### PR TITLE
Correzione grammaticale: variabili statiche locali

### DIFF
--- a/README.md
+++ b/README.md
@@ -1476,13 +1476,13 @@ int main(void){
 int uno(register int a);
 ```
 
-## Varabili statiche locali (static variables with block scope)
+## Variabili statiche locali (static variables with block scope)
 
 <p align="justify">
-Una variabile con block scope ha visibilità limitata all'interno del blocco in cui è dichiarata ed ovviamente nessun linkage (non è visibile alle altre funzioni nel file corrente e negli altri file). Lo storage duration è limitato al tempo di esecuzione del blocco in cui è dichiarata; la variabile è allocata in memoria appena si entra nel blocco e deallocata all'uscita. Queste variabili sono le variaili locali. Rendere statica una variabile locale significa modificare il suo storage duration in modo da farlo coincidere con il tempo di esecuzione del programma e non più con il tempo di esecuzione del blocco; in altre parole la variabile sarà allocata quando il programma verrà eseguito e deallocata alla sua terminazione. Ovviamente lo scope resta di tipo block quindi anche se la variabile non viene deallocata all'uscita del blocco il suo identificatore non è più visibile e quindi non è possibile accedere alla locazione di memoria. Quando il flusso di esecuzione rientrerà nel blocco il valore precedetemente conservato sarà disponibile attraverso l'identificatore. Per dichiarare statica una variabile locale si usa la <i>keyword</i> <b>static</b>, vediamo un esempio:
+Una variabile con block scope ha visibilità limitata all'interno del blocco in cui è dichiarata e ovviamente nessun linkage (non è visibile alle altre funzioni nel file corrente e negli altri file). Lo storage duration è limitato al tempo di esecuzione del blocco in cui è dichiarata; la variabile è allocata in memoria appena si entra nel blocco e deallocata all'uscita. Queste variabili sono le variabili locali. Rendere statica una variabile locale significa modificare il suo storage duration in modo da farlo coincidere con il tempo di esecuzione del programma e non più con il tempo di esecuzione del blocco; in altre parole, la variabile sarà allocata quando il programma verrà eseguito e deallocata alla sua terminazione. Ovviamente lo scope resta di tipo block, quindi, anche se la variabile non viene deallocata all'uscita del blocco, il suo identificatore non è più visibile e quindi non è possibile accedere alla locazione di memoria. Quando il flusso di esecuzione rientrerà nel blocco, il valore precedentemente conservato sarà disponibile attraverso l'identificatore. Per dichiarare statica una variabile locale si usa la <i>keyword</i> <b>static</b>. Vediamo un esempio:
 </p>
 
-La funzione `example_static_var` dichiara due variabili: `a` di tipo automatica e `b` statica (con block scope). Vediamo le differenze pratiche:
+La funzione `example_static_var` dichiara due variabili: `a` di tipo automatico e `b` statica (con block scope). Vediamo le differenze pratiche:
 
 ```c
 #include<stdio.h>
@@ -1490,16 +1490,17 @@ La funzione `example_static_var` dichiara due variabili: `a` di tipo automatica 
 void example_static_var(void);
 
 int main(void){
-        /* Richiamiamo cinque volte la funzione example_static_var: la variabile a ad ogni
+        /* Richiamiamo cinque volte la funzione example_static_var: la variabile a, a ogni
 	 * nuova chiamata verrà prima allocata poi inizializzata a zero, incrementata di 1
-	 * e poi deallocata. una successiva chiamata alla funzione example_static_var rial
-	 * -locherà spazio in memoria per la variabile e la inizializzerà a 0 e  così via.
-	 * Al  massimo  la variabile a potrà valere 1. Al contrario la variabile di nome b
-	 * viene allocata una sola volta all' esecuzione e deallocata  alla  terminazione,
-	 * quindi il suo valore sarà conservato  tra due chiamate successive alla funzione
-	 * example_static_var, il valore di b infatti  sarà incrementato cinque volte,  un
-	 * valore pari al numero di chiamate alla funzione example_static_var   
-         
+	 * e poi deallocata. Una successiva chiamata alla funzione example_static_var
+	 * riallocherà spazio in memoria per la variabile e la inizializzerà a 0, e così via.
+	 * Al massimo la variabile a potrà valere 1. Al contrario, la variabile di nome b
+	 * viene allocata una sola volta all'esecuzione e deallocata alla terminazione;
+	 * quindi il suo valore sarà conservato tra due chiamate successive alla funzione
+	 * example_static_var. Il valore di b, infatti, sarà incrementato cinque volte,
+	 * un valore pari al numero di chiamate alla funzione example_static_var.
+	 */
+
         example_static_var();
         example_static_var();
         example_static_var();
@@ -1509,25 +1510,25 @@ int main(void){
 }
 
 void example_static_var(void){
-        int a = 0;     /* variabile automatica: viene allocata all' entrata del  blocco e
-			* deallocata  all' uscita perdendo il  valore  in  esso contenuto
+        int a = 0;     /* variabile automatica: viene allocata all'entrata del blocco e
+			* deallocata all'uscita, perdendo il valore in essa contenuto
 			*/
-        static int b;  /* variabile locale statica: viene  allocata  una  sola volta all'
-			* esecuzione del programma e deallocata alla terminazione, mantie
-			* -ne il valore  in essa contenuto  anche  se  si esce dal blocco
-			* Non abbiamo  inizializzato la  variabile  esplicitamente a zero
-			* in quanto è statica: le variabili  statiche  non  inizializzate
+        static int b;  /* variabile locale statica: viene allocata una sola volta
+			* all'esecuzione del programma e deallocata alla terminazione.
+			* Mantiene il valore in essa contenuto anche se si esce dal blocco.
+			* Non abbiamo inizializzato la variabile esplicitamente a zero
+			* in quanto è statica: le variabili statiche non inizializzate
 			* esplicitamente sono poste a zero dal compilatore.
  			*/
 
         a = a + 1;     // a ora vale 1
-        b = b + 1;     // b ora  vale b + 1, il valore di b  dipende  da quante volte  la
+        b = b + 1;     // b ora vale b + 1, il valore di b dipende da quante volte la
 		       // funzione è stata richiamata nel programma fino a questo momento
         printf("a=%d, b=%d\n", a, b);
 }
 ```
 
-Come puoi vedere dall'output del programma compilato
+Come puoi vedere dall'output del programma compilato:
 
 ```bash
 vagrant@ubuntu2204:~$ ./static_variable
@@ -1538,7 +1539,7 @@ a=1, b=4
 a=1, b=5
 ```
 
-Infine, i parametri formali di una funzione non posso essere dichiarati static, non puoi fare questo:
+Infine, i parametri formali di una funzione non possono essere dichiarati static, quindi non puoi fare questo:
 
 ```c
 int no_possible_static_parameter(static int a); /* ERRORE */


### PR DESCRIPTION
## Cosa cambia

- Corregge il titolo `Varabili statiche locali` in `Variabili statiche locali`.
- Corregge refusi, accenti, punteggiatura e concordanze nella spiegazione del block scope statico.
- Sistema i commenti dell'esempio C, inclusa la chiusura del commento introduttivo.

## Ambito

Il lavoro è limitato alla sezione `Variabili statiche locali (static variables with block scope)`, fino a prima di `Differenza tra definzione e dichiarazione di variabile`.

Closes #28

## Verifiche

- `git diff --check -- README.md`