### PR TITLE
Correzione grammaticale: Implementazione Thread GNU/Linux

### DIFF
--- a/LINUX_PROGRAMMING.md
+++ b/LINUX_PROGRAMMING.md
@@ -2138,7 +2138,7 @@ I deadlock possono verificarsi quando due (o più) thread sono bloccati, in atte
 
 ### Implementazione dei Thread in GNU/Linux
 
-L'implementazione dei thread POSIX su GNU/Linux differisce dall'implementa zione dei thread su molti altri sistemi simili a UNIX in un modo importante: su GNU/Linux, **i thread sono implementati come processi**. Ogni volta che chiami pthread_create per creare un nuovo thread, Linux crea un nuovo processo che esegue quel thread. Tuttavia, questo processo non è lo stesso di un processo che creeresti con fork; in particolare, condivide lo stesso spazio di indirizzamento e le stesse risorse del processo originale anziché ricevere copie. Il programma mostrato sotto lo dimostra. Il programma crea un thread; sia il thread originale che quello nuovo chiamano la funzione getpid e stampano i rispettivi ID di processo e quindi ruotano all'infinito.
+L'implementazione dei thread POSIX su GNU/Linux differisce dall'implementazione dei thread su molti altri sistemi simili a UNIX in un modo importante: su GNU/Linux, **i thread sono implementati come processi**. Ogni volta che chiami pthread_create per creare un nuovo thread, Linux crea un nuovo processo che esegue quel thread. Tuttavia, questo processo non è lo stesso di un processo che creeresti con fork; in particolare, condivide lo stesso spazio di indirizzamento e le stesse risorse del processo originale invece di ricevere copie. Il programma mostrato sotto lo dimostra. Il programma crea un thread; sia il thread originale che quello nuovo chiamano la funzione getpid e stampano i rispettivi ID di processo e quindi ruotano all'infinito.
 
 ```c
 /***********************************************************************


### PR DESCRIPTION
Correzione grammaticale del paragrafo `### Implementazione dei Thread in GNU/Linux` in LINUX_PROGRAMMING.md.

Closes #186.
Riferimento issue madre: #162.