### PR TITLE
README: Correzione Passs commento

### DIFF
--- a/README.md
+++ b/README.md
@@ -15161,7 +15161,7 @@ diskhelp:
     cmp rax,0           ; A returned null indicates error or EOF
     jle .done           ; If we get 0 in rax, close up & return
     mov rdi,HelpLine    ; Pass address of help line in rdi
-    xor rax,rax         ; Passs 0 to show there will be no fp registers    
+    xor rax,rax         ; Pass 0 to show there will be no fp registers    
     call printf         ; Call printf to display help line
     jmp .rdln
 


### PR DESCRIPTION
Corregge Passs 0 in Pass 0 nel commento printf della funzione diskhelp.\n\nIssue figlia: #199\nIssue madre: #194