### PR TITLE
docs: convert LINUX_PROGRAMMING markdown to HTML

### DIFF
--- a/LINUX_PROGRAMMING.md
+++ b/LINUX_PROGRAMMING.md
@@ -130,7 +130,7 @@ Un processo è un'istanza di un programma: un file eseguibile presente sul disco
 Ciascun processo in Linux è identificato da un identificatore univoco detto <em>process ID</em> o <strong>PID</strong>. Un <strong>PID</strong> è rappresentato con 16 bit ($s^{16}=65536$). Ciascun processo ha un processo padre, tranne il processo che viene creato per primo all'avvio del sistema operativo, detto processo <strong>init</strong>, che ha <strong>PID</strong> 1 e nessun padre. Il process ID del processo padre è anche detto <strong>PPID</strong>. I processi nei sistemi Linux sono quindi rappresentabili attraverso un albero dove la radice è il processo <strong>init</strong>. Quando in C si vuole rappresentare il <strong>PID</strong> di un processo si usa il tipo <code>pid_t</code> definito in <code>&lt;sys/types.h&gt;</code>. Per ottenere il proprio <strong>PID</strong> si richiama la system call <code>getpid()</code>, allo stesso modo per ottenere il <strong>PPID</strong> si richiama la <code>getppid()</code>. Vediamo un esempio:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -154,7 +154,7 @@ int main ()
 Il comando <strong>ps</strong> mostra i processi attivi sul sistema.
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/0_processes$ ps
     PID TTY          TIME CMD
    1331 pts/0    00:00:00 bash
@@ -165,7 +165,7 @@ vagrant@ubuntu2204:/lab2/0_processes$ ps
 Sembra che ci siano due processi attivi sul sistema: il primo è <strong>bash</strong> e il secondo è <strong>ps</strong>, che abbiamo lanciato. La prima colonna mostra il <strong>PID</strong> dei processi attivi. Per maggiori dettagli possiamo digitare:
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 ps -e -o pid,ppid,command
 </code></pre>
 
@@ -200,7 +200,7 @@ ps -e -o pid,ppid,command
   </tbody>
 </table>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/0_processes$ ps -e -o pid,ppid,command
     PID    PPID COMMAND
       1       0 /sbin/init =
@@ -324,7 +324,7 @@ Ci sono due modi per creare un processo: il primo è relativamente semplice ma i
 La funzione <code>system()</code> è fornita nella libreria standard del linguaggio C e permette di eseguire un comando all'interno di un programma come se fosse stato digitato direttamente in una shell. La funzione <code>system()</code> crea un sottoprocesso lanciando <code>/bin/sh</code>. Per esempio, il codice seguente invoca il comando <code>ls</code> per mostrare il contenuto della root directory come se si fosse digitato <code>ls -l /</code> direttamente dalla shell.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -351,7 +351,7 @@ La system call <code>fork()</code> crea un nuovo processo che è la copia del pr
 Per distinguere il padre dal figlio, la funzione <code>fork()</code> restituisce un intero: in particolare restituisce zero al processo figlio e il <strong>PID</strong> del processo figlio al processo padre.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -406,7 +406,7 @@ La system call <code>exec()</code> sostituisce il programma in esecuzione nel pr
   </li>
 </ul>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -466,7 +466,7 @@ int main ()
 Eseguendo il programma ti accorgerai che il processo padre termina immediatamente ("done with the main program") successivamente viene stampato il prompt e poco dopo l'output del processo figlio sporca il terminale perché continua a scrivere sullo stdout. In generale non è possibile sapere quale processo tra il padre ed il figlio concluda per primo ma vedremo che è possibile sincronizzare l'esecuzione dei due processi facendo in modo che il processo padre attenda la terminazione dei suoi figli prima di concludere la propria esecuzione.
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/0_processes$ bin/3_fork_exec
 done with main program
 vagrant@ubuntu2204:/lab2/0_processes$ total 2097224
@@ -597,7 +597,7 @@ La <strong>sigaction</strong> può essere usata per impostare il comportamento d
   </li>
 </ol>
    
-<pre><code class="language-c">
+<pre lang="c"><code>
 int sigaction(int signum,
                      const struct sigaction *_Nullable restrict act,
                      struct sigaction *_Nullable restrict oldact);
@@ -607,7 +607,7 @@ int sigaction(int signum,
 La struct <code>sigaction</code> ha questa forma:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 struct sigaction {
                void     (*sa_handler)(int);
                void     (*sa_sigaction)(int, siginfo_t *, void *);
@@ -651,7 +651,7 @@ Un altro aspetto da tenere in considerazione è rendere le proprie istruzioni (v
 Vediamo un esempio di <strong>signal-handler</strong> per la gestione del segnale <strong>SIGUSR1</strong>, uno dei due segnali riservati all'uso da parte dei programmi applicativi.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -695,7 +695,7 @@ int main ()
 In un primo terminale esegui il programma che resterà in esecuzione per 5 minuti; alla fine dell'esecuzione stamperà il numero di volte che il segnale <code>SIGUSR1</code> è stato ricevuto.
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/0_processes$ bin/4_sigusr1
 ***************************************************
 **************************SIGUSR1 was raised 6 times
@@ -705,7 +705,7 @@ vagrant@ubuntu2204:/lab2/0_processes$ bin/4_sigusr1
 Per inviare il segnale <code>SIGUSR1</code> basta usare il comando <code>kill</code>, con il <strong>PID</strong> del processo recuperabile in questo esempio con il comando <code>ps</code>.
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:~$ ps -e|grep 4_sigusr1
    1642 pts/0    00:01:17 4_sigusr1
 
@@ -726,7 +726,7 @@ Un processo termina o attraverso la chiamata alla funzione <code>exit()</code> o
 Tutti questi segnali ed anche altri possono essere inviati con il comando <code>kill</code> specificando quale segnale inviare come parametro. Per inviare un <code>SIGKILL</code> fai in questo modo:
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 kill -KILL pid
 </code></pre>
 
@@ -734,7 +734,7 @@ kill -KILL pid
 Esiste anche la funzione <code>kill()</code> per inviare un segnale dal codice ed ha questo prototipo:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int kill(pid_t pid, int sig);
 </code></pre>
 
@@ -767,7 +767,7 @@ Devi includere <code>&lt;sys/types.h&gt;</code> e <code>&lt;signal.h&gt;</code> 
 Puoi leggere l'<strong>exit code</strong> dell'ultimo programma lanciato sulla shell stampando il contenuto della variabile <code>$?</code> per esempio.
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/0_processes$ ls
 0_print_pid.c  1_system.c  2_fork.c  3_fork_exec.c  4_sigusr1.c  bin
 vagrant@ubuntu2204:/lab2/0_processes$ echo $?
@@ -790,7 +790,7 @@ La <code>wait()</code> sospende l'esecuzione del processo padre finché uno dei 
 Vediamo un esempio:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -859,7 +859,7 @@ int main ()
 Come mostrato nell'esempio seguente, il terminale visualizza prima l'output del processo figlio (<code>ls -l</code>), mentre successivamente il processo padre termina stampando a schermo (<code>done with the main program</code>).
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/0_processes$ bin/5_fork_exec_wait
 total 2097224
 lrwxrwxrwx   1 root    root             7 Aug 10  2023 bin -&gt; usr/bin
@@ -898,7 +898,7 @@ done with main program
 Quando un processo figlio termina e il processo padre ha chiamato la <code>wait()</code>, le informazioni sulla sua terminazione passano al padre attraverso la <code>wait()</code>. Se il padre non chiama la <code>wait()</code>, queste informazioni vanno perse? In questo caso il processo figlio diventa un processo <strong>zombie</strong>. Un processo <strong>zombie</strong> è un processo che ha terminato la propria esecuzione ma non è stato ancora ripulito; è quindi compito del processo padre ripulire il figlio. Il compito della <code>wait()</code> è proprio questo: una volta che il processo figlio termina, questo diventa uno zombie e poi la <code>wait()</code> estrae lo stato di uscita del figlio, cosicché il processo figlio può essere eliminato. Se il processo padre non chiama la <code>wait()</code>, il figlio resta nello stato di zombie, vediamo un esempio:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -931,14 +931,14 @@ int main ()
 Lancia il programma da un terminale in questo modo:
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/0_processes$ bin/6_zombie
 </code></pre>
 <p align="justify">
 Ed usa, su un altro terminale, il comando <code>ps</code> in questo modo:
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:~$ ps -e -o pid,ppid,stat,cmd|grep 6_zombie
    2317    1331 S+   bin/6_zombie
    2318    2317 Z+   [6_zombie] &lt;defunct&gt;
@@ -957,7 +957,7 @@ Il processo padre ha pid <code>2317</code> ed è in stato <code>S+</code>; il pr
 La <code>wait()</code> ci permette di attendere (nel codice del padre) la terminazione del figlio. Il problema è che la chiamata alla <code>wait()</code> è bloccante, quindi il codice del padre rimane (appeso) all'istruzione di <code>wait</code> fino a quando il figlio non termina. Se si vuole che il padre continui la propria elaborazione mentre si attende che il figlio completi, è possibile controllare periodicamente la terminazione del figlio chiamando <code>wait3()</code> o <code>wait4()</code> (flag <code>WNOHANG</code>) in modo asincrono nel codice del padre. Una soluzione migliore è usare il segnale <code>SIGCHLD</code>, che Linux invia al padre ogni volta che uno dei suoi figli termina. Vediamo un esempio:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1036,7 +1036,7 @@ int main ()
 }
 </code></pre>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/0_processes$ bin/7_sigchld
 Child 3099 created
 Child 3100 created
@@ -1073,7 +1073,7 @@ I thread, come i processi, sono un meccanismo per permettere a un programma di s
 Ad ogni thread è associato un ID univoco di tipo <code>pthread_t</code>. Una volta creato, un thread esegue una semplice funzione che contiene il codice che il thread deve eseguire. Quando questa funzione termina, anche il thread termina la propria esecuzione. Questa funzione riceve in ingresso un puntatore a void <code>void *</code> e ritorna sempre un altro puntatore a void <code>void *</code>. Per creare un nuovo thread bisogna usare la funzione <code>pthread_create()</code>. Questo è il suo prototipo:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_create(pthread_t *restrict thread,
                           const pthread_attr_t *restrict attr,
                           void *(*start_routine)(void *),
@@ -1107,7 +1107,7 @@ int pthread_create(pthread_t *restrict thread,
 Vediamo un esempio di creazione di un thread:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1151,7 +1151,7 @@ Il thread termina quando termina la funzione del thread <code>print_xs</code>, u
 Per passare argomenti a un thread basta usare il quarto argomento della <code>pthread_create()</code>. Per farlo basta solo dichiarare una struttura o un array e passare il puntatore alla <code>pthread_create()</code>. L'unica accortezza da tenere in considerazione è quella di effettuare il cast corretto del parametro in ingresso alla funzione del thread. Vediamo un esempio:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1218,7 +1218,7 @@ Il problema in questo codice è che le due variabili locali (automatiche) <code>
 Per fare in modo che il <code>main()</code> attenda la terminazione dei thread è possibile usare la funzione <code>pthread_join()</code>. Questo è il suo prototipo:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_join(pthread_t thread, void **retval);
 </code></pre>
 
@@ -1239,7 +1239,7 @@ int pthread_join(pthread_t thread, void **retval);
 Vediamo come risolvere il bug dell'esempio precedente usando la <code>pthread_join()</code> per attendere il completamento dei thread creati nel <code>main()</code>
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1308,7 +1308,7 @@ int main ()
 Se il secondo parametro in ingresso alla <code>pthread_join()</code> non è <code>NULL</code> allora il valore di ritorno del thread verrà salvato nella locazione di memoria puntata da quell'argomento. Il valore di ritorno del thread è di tipo puntatore a <code>void</code>: <code>void *</code>, quindi è necessario castare l'indirizzo della variabile intera <code>prime</code> a <code>void *</code> nella chiamata alla <code>pthread_join()</code>.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1364,7 +1364,7 @@ int main ()
 }
 </code></pre>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/1_threads$ bin/3_primes
 The 5000th prime number is 48611.
 </code></pre>
@@ -1375,7 +1375,7 @@ The 5000th prime number is 48611.
 <code>pthread_self()</code> ritorna il thread id del thread corrente che la sta eseguendo. Questo è il suo prototipo:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 pthread_t pthread_self(void);
 </code></pre>
 
@@ -1383,7 +1383,7 @@ pthread_t pthread_self(void);
 <code>pthread_equal()</code> confronta due thread id(s): ritorna zero se i due ID sono uguali. Questo è il suo prototipo:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_equal(pthread_t t1, pthread_t t2);
 </code></pre>
 
@@ -1391,7 +1391,7 @@ int pthread_equal(pthread_t t1, pthread_t t2);
 Queste due funzioni possono essere utili per controllare se un certo ID corrisponde a quello del thread corrente per esempio prima di chiamare una <code>pthread_join()</code> in quanto aspettare la terminazione di se stessi è un grosso errore. Sotto un esempio:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 if (!pthread_equal (pthread_self (), other_thread))
   pthread_join (other_thread, NULL);
 </code></pre>
@@ -1438,7 +1438,7 @@ Un singolo oggetto attributo thread può essere utilizzato per inizializzare div
 Per impostare lo stato detached in un oggetto attributo thread, basta utilizzare <code>pthread_attr_setdetachstate()</code>. Questo è il suo prototipo:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate);
 </code></pre>
 
@@ -1446,7 +1446,7 @@ int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate);
 Il primo argomento è un puntatore all'oggetto attributo thread (<code>pthread_attr_t *</code>) e il secondo è lo stato detached desiderato. Poiché lo stato joinable è quello predefinito, è necessario chiamare questo solo per creare detached thread passando <code>PTHREAD_CREATE_DETACHED</code> come secondo argomento. Il codice seguente crea un detached thread impostando l'attributo thread a <code>PTHREAD_CREATE_DETACHED</code>.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1482,7 +1482,7 @@ int main ()
 Anche se un thread è stato creato con stato joinable può essere impostato in un secondo momento nello stato detached, per fare questo basta usare la funzione <code>pthread_detach()</code>. Questo è il suo prototipo:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_detach(pthread_t thread);
 </code></pre>
 
@@ -1524,7 +1524,7 @@ Spesso un thread può eseguire codice in cui tutte le istruzioni devono essere t
 Un thread cancellabile in modo asincrono può essere annullato in qualsiasi momento della sua esecuzione. Un thread cancellabile in modo sincrono, al contrario, può essere cancellato solo in determinati punti della sua esecuzione. Questi punti sono chiamati punti di annullamento. Il thread metterà in coda una richiesta di annullamento finché non raggiunge il punto di annullamento successivo. Per rendere un thread cancellabile in modo asincrono, utilizzare <code>pthread_setcanceltype()</code>. Questo è il suo prototipo:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_setcanceltype(int type, int *oldtype);
 </code></pre>
 
@@ -1532,7 +1532,7 @@ int pthread_setcanceltype(int type, int *oldtype);
 Il primo argomento dovrebbe essere <code>PTHREAD_CANCEL_ASYNCHRONOUS</code> per rendere il thread cancellabile in modo asincrono o <code>PTHREAD_CANCEL_DEFERRED</code> per riportarlo allo stato cancellabile in modo sincrono. Il secondo argomento, se non è nullo, è un puntatore a una variabile che riceverà il tipo di annullamento precedente per il thread. Questa chiamata, ad esempio, rende il thread chiamante cancellabile in modo asincrono.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 pthread_setcanceltype (PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 </code></pre>
 
@@ -1540,7 +1540,7 @@ pthread_setcanceltype (PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 Cosa costituisce un punto di annullamento e dove dovrebbero essere posizionati? Il modo più diretto per creare un punto di annullamento è chiamare <code>pthread_testcancel()</code>.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 void pthread_testcancel(void);
 </code></pre>
 <p align="justify">
@@ -1554,7 +1554,7 @@ Questa funzione non fa altro che elaborare un annullamento in sospeso in un thre
 Un thread può disabilitare del tutto la cancellazione di se stesso con la funzione <code>pthread_setcancelstate()</code>.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_setcancelstate(int state, int *oldstate);
 </code></pre>
 
@@ -1562,7 +1562,7 @@ int pthread_setcancelstate(int state, int *oldstate);
 Il primo argomento è <code>PTHREAD_CANCEL_DISABLE</code> per disabilitare la cancellazione o <code>PTHREAD_CANCEL_ENABLE</code> per riabilitare la cancellazione. Il secondo argomento, se non è nullo, punta a una variabile che riceverà lo stato di cancellazione precedente. Questa chiamata, ad esempio, disabilita l'annullamento del thread nel thread chiamante.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 pthread_setcancelstate (PTHREAD_CANCEL_DISABLE, NULL);
 </code></pre>
 
@@ -1570,7 +1570,7 @@ pthread_setcancelstate (PTHREAD_CANCEL_DISABLE, NULL);
 <strong>L'utilizzo di <code>pthread_setcancelstate()</code> consente di implementare sezioni critiche</strong>. Una <strong>sezione critica</strong> è una sequenza di codice che deve essere eseguita per intero o per niente; in altre parole, se un thread inizia a eseguire la sezione critica, deve continuare fino alla fine della sezione critica senza essere annullato. Ad esempio, supponiamo che tu stia scrivendo una routine per un programma bancario che trasferisce denaro da un conto a un altro. Per fare ciò, devi aggiungere valore al saldo di un conto e detrarre lo stesso valore dal saldo di un altro conto. Se il thread che esegue la tua routine venisse annullato proprio nel momento sbagliato tra queste due operazioni, il programma avrebbe aumentato in modo ingiusto i depositi totali della banca non riuscendo a completare la transazione. Per evitare questa possibilità, inserisci le due operazioni in una sezione critica. Potresti implementare il trasferimento con una funzione come <code>process_transaction()</code>, riportata nel paragrafo seguente. Questa funzione disabilita l'annullamento del thread per avviare una sezione critica prima che modifichi il saldo di uno dei due conti.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1657,7 +1657,7 @@ int main() {
 }
 </code></pre>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
 vagrant@ubuntu2204:/lab2/1_threads$ bin/5_critical_section
 [0] 100$
 [1] 67$
@@ -1703,7 +1703,7 @@ A differenza dei processi, <strong>tutti i thread in un singolo programma condiv
 Puoi creare tutti gli elementi dati specifici del thread che vuoi, ognuno di tipo <code>void *</code>. Ogni elemento è identificato da una chiave. Per creare una nuova chiave, e quindi un nuovo elemento dati per ogni thread, usa <strong>pthread_key_create()</strong>.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_key_create(pthread_key_t *key, void (*destructor)(void*));
 </code></pre>
 
@@ -1711,7 +1711,7 @@ int pthread_key_create(pthread_key_t *key, void (*destructor)(void*));
 Il primo argomento è un puntatore a una variabile di tipo <strong>pthread_key_t</strong>. Quel valore chiave può essere usato da ogni thread per accedere alla propria copia dell'elemento dati corrispondente. Il secondo argomento dopo <code>pthread_key_t</code> è una funzione di pulizia (cleanup function). Se passi un puntatore a funzione qui, GNU/Linux chiama automaticamente quella funzione quando il thread esce, passando il valore specifico del thread corrispondente a quella chiave. Ciò è particolarmente utile perché la funzione di pulizia viene chiamata anche se il thread viene annullato in un punto arbitrario della sua esecuzione. Se il valore specifico del thread è <code>NULL</code>, la funzione di pulizia del thread non viene chiamata. Se non hai bisogno di una funzione di pulizia, puoi passare <code>NULL</code> invece di un puntatore a funzione. <strong>Dopo aver creato una chiave</strong>, <strong>ogni thread può impostare il suo valore specifico del thread corrispondente a quella chiave</strong> chiamando <strong>pthread_setspecific()</strong>.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_setspecific(pthread_key_t key, const void *value);
 </code></pre>
 
@@ -1719,7 +1719,7 @@ int pthread_setspecific(pthread_key_t key, const void *value);
 Il primo argomento è la chiave e il secondo è il valore specifico del thread (di tipo void*) da memorizzare. Per recuperare un elemento dati specifico del thread, chiama <strong>pthread_getspecific()</strong>, passando la chiave come argomento.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 void *pthread_getspecific(pthread_key_t key);
 </code></pre>
 
@@ -1728,7 +1728,7 @@ Supponiamo, ad esempio, che l'applicazione divida un'attività tra più thread. 
 </p>
 
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1812,11 +1812,11 @@ Si noti che <strong>thread_function()</strong> non ha bisogno di chiudere il fil
 Le funzioni di pulizia per chiavi dati specifiche del thread possono essere molto utili per garantire che le risorse non vengano perse quando un thread esce o viene annullato. A volte, tuttavia, è utile poter specificare funzioni di pulizia senza creare un nuovo elemento dati specifico del thread duplicato per ogni thread. GNU/Linux fornisce gestori di pulizia a questo scopo. <strong>Un gestore di pulizia è semplicemente una funzione che dovrebbe essere chiamata quando un thread esce</strong>. Il gestore accetta un singolo parametro <code>void *</code> e il suo valore di argomento viene fornito quando il gestore viene registrato; questo semplifica l'utilizzo della stessa funzione di pulizia per gestire più istanze di risorse. <strong>Un gestore di pulizia è una misura temporanea</strong>, <strong>utilizzata per deallocare una risorsa solo se il thread esce o viene annullato</strong> anziché terminare l'esecuzione di una particolare regione di codice. <strong>In circostanze normali, quando il thread non esce e non viene annullato, la risorsa dovrebbe essere deallocata in modo esplicito</strong> e il gestore di pulizia dovrebbe essere rimosso. Per registrare un gestore di pulizia, chiama <strong>pthread_cleanup_push()</strong>, passando un puntatore alla funzione di pulizia e il valore del suo argomento <code>void *</code>. La chiamata a pthread_cleanup_push deve essere bilanciata da una chiamata corrispondente a pthread_cleanup_pop, che annulla la registrazione del gestore di pulizia.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 void pthread_cleanup_push(void (*routine)(void *), void *arg);
 </code></pre>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 void pthread_cleanup_pop(int execute);
 </code></pre>
 
@@ -1824,7 +1824,7 @@ void pthread_cleanup_pop(int execute);
 Per comodità, <code>pthread_cleanup_pop()</code> accetta un argomento flag int; se il flag è diverso da zero, l'azione di pulizia viene effettivamente eseguita. Il frammento di programma seguente mostra come è possibile utilizzare un gestore di pulizia per assicurarsi che un buffer allocato dinamicamente venga ripulito se il thread termina.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 ***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1897,7 +1897,7 @@ Supponiamo che il tuo programma abbia una serie di lavori in coda che vengono el
 Ora supponiamo che due thread finiscano un lavoro più o meno nello stesso momento, ma che solo un lavoro rimanga nella coda. Il primo thread controlla se job_queue è nullo; scoprendo che non lo è, il thread entra nel ciclo e memorizza il puntatore all'oggetto lavoro in next_job. A questo punto, Linux interrompe il primo thread e pianifica il secondo. Anche il secondo thread controlla job_queue e, trovandolo non nullo, assegna lo stesso puntatore lavoro a next_job. Per una sfortunata coincidenza, ora abbiamo due thread che eseguono lo stesso lavoro. A peggiorare le cose, un thread scollegherà l'oggetto lavoro dalla coda, lasciando job_queue contenente <code>NULL</code>. Quando l'altro thread valuta job_queue->next, si verificherà un errore di segmentazione. Questo è un esempio di condizione di gara. In circostanze fortunate, questa particolare pianificazione dei due thread potrebbe non verificarsi mai e la condizione di gara potrebbe non manifestarsi mai. In circostanze diverse, magari quando si esegue su un sistema pesantemente caricato (o sul nuovo server multiprocessore di un cliente importante!), il bug può manifestarsi. Per eliminare le <strong>race conditions</strong>, è necessario un modo per <strong>rendere le operazioni atomiche</strong>. <strong>Un'operazione atomica è indivisibile e ininterrotta; una volta avviata, non verrà messa in pausa o interrotta fino al suo completamento e nel frattempo non verrà eseguita nessun'altra operazione</strong>. In questo particolare esempio, si desidera controllare job_queue: se non è vuoto, si rimuove il primo lavoro, il tutto come un'unica operazione atomica.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -1977,7 +1977,7 @@ int main(void){
 La soluzione al problema della race condition della coda dei lavori consiste nel consentire a un solo thread alla volta di accedere alla coda dei lavori. Una volta che un thread inizia a guardare la coda, nessun altro thread dovrebbe essere in grado di accedervi finché il primo thread non ha deciso se elaborare un lavoro e, in tal caso, lo ha rimosso dall'elenco. L'implementazione richiede il supporto del sistema operativo. GNU/Linux fornisce i <strong>mutex</strong>, abbreviazione di blocchi MUTual EXclusion. Un mutex è un blocco speciale che solo un thread può bloccare alla volta. Se un thread blocca un mutex e poi un secondo thread tenta di bloccare lo stesso mutex, il secondo thread viene bloccato o messo in attesa. Solo quando il primo thread sblocca il mutex, il secondo thread viene sbloccato, ovvero può riprendere l'esecuzione. GNU/Linux garantisce che non si verifichino condizioni di gara tra thread che tentano di bloccare un mutex; solo un thread otterrà il blocco e tutti gli altri thread verranno bloccati. Pensa a un mutex come alla serratura di una porta del bagno. Chi arriva per primo entra nel bagno e chiude a chiave la porta. Se qualcun altro tenta di entrare nel bagno mentre è occupato, quella persona troverà la porta chiusa a chiave e sarà costretta ad aspettare fuori finché l'occupante non esce. Per creare un mutex, crea una variabile di tipo <strong>pthread_mutex_t</strong> e passa un puntatore a <strong>pthread_mutex_init()</strong>. Il secondo argomento di <code>pthread_mutex_init()</code> è un puntatore a un oggetto attributo mutex, che specifica gli attributi del mutex.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_mutex_init(pthread_mutex_t *restrict mutex, const pthread_mutexattr_t *restrict attr);
 </code></pre>
 
@@ -1985,7 +1985,7 @@ int pthread_mutex_init(pthread_mutex_t *restrict mutex, const pthread_mutexattr_
 Come con <code>pthread_create()</code>, se il puntatore dell'attributo è <code>NULL</code>, vengono assunti gli attributi predefiniti. La variabile mutex dovrebbe essere inizializzata solo una volta. Questo frammento di codice dimostra la dichiarazione e l'inizializzazione di una variabile mutex.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 pthread_mutex_t mutex;
 pthread_mutex_init (&amp;mutex, NULL);
 </code></pre>
@@ -1994,7 +1994,7 @@ pthread_mutex_init (&amp;mutex, NULL);
 Un altro modo più semplice per creare un mutex con attributi predefiniti è inizializzarlo con il valore speciale <code>PTHREAD_MUTEX_INITIALIZER</code>. Non è necessaria alcuna chiamata aggiuntiva a pthread_mutex_init. Ciò è particolarmente comodo per le variabili globali (e, in C++, i membri dati statici). Il frammento di codice precedente avrebbe potuto essere scritto in modo equivalente così:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 </code></pre>
 
@@ -2019,7 +2019,7 @@ Un thread può tentare di bloccare un mutex chiamando <strong>pthread_mutex_lock
 Più di un thread può essere bloccato su un mutex bloccato contemporaneamente. Quando il mutex viene sbloccato, solo uno dei thread bloccati (scelto in modo imprevedibile) viene sbloccato e gli viene consentito di bloccare il mutex; gli altri thread rimangono bloccati. Una chiamata a <strong>pthread_mutex_unlock()</strong> sblocca un mutex. Questa funzione dovrebbe essere sempre chiamata dallo stesso thread che ha bloccato il mutex. L'esempio seguente mostra un'altra versione dell'esempio di coda di lavoro. Ora la coda è protetta da un mutex. Prima di accedere alla coda (sia per lettura che per scrittura), ogni thread blocca prima un mutex. Solo quando l'intera sequenza di controllo della coda e rimozione di un lavoro è completa, il mutex viene sbloccato. Ciò impedisce la race condition descritta in precedenza.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -2118,7 +2118,7 @@ Tutti gli accessi a job_queue (il puntatore dati condiviso) avvengono tra la chi
 </p>
 
 
-<pre><code class="language-c">
+<pre lang="c"><code>
  void enqueue_job (struct job* new_job)
  {
    pthread_mutex_lock (&amp;job_queue_mutex);
@@ -2161,7 +2161,7 @@ mai essere rilasciato.
 Per impostazione predefinita, un mutex GNU/Linux è del tipo veloce. Per creare un mutex di uno degli altri due tipi, crea prima un oggetto attributo mutex dichiarando una variabile <strong>pthread_mutexattr_t</strong> e chiamando <strong>pthread_mutexattr_init()</strong>. Poi imposta il tipo di mutex chiamando  <strong>pthread_mutexattr_setkind_np()</strong>.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int pthread_mutexattr_setkind_np(pthread_mutexattr_t *attr, int kind);
 </code></pre>
 
@@ -2169,7 +2169,7 @@ int pthread_mutexattr_setkind_np(pthread_mutexattr_t *attr, int kind);
 Il primo argomento è un puntatore all'oggetto attributo mutex, e il secondo è <code>PTHREAD_MUTEX_RECURSIVE_NP</code> per un mutex ricorsivo, o <code>PTHREAD_MUTEX_ERRORCHECK_NP</code> per uno di controllo degli errori. Passa un puntatore a questo oggetto attributo a <strong>pthread_mutex_init()</strong> per creare un mutex di questo tipo, quindi distruggi l'oggetto attributo con <strong>pthread_mutexattr_destroy()</strong>. Questa sequenza di codice illustra la creazione di un mutex di controllo degli errori, ad esempio:
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
  pthread_mutexattr_t attr;
  pthread_mutex_t mutex;
  pthread_mutexattr_init (&amp;attr);
@@ -2211,7 +2211,7 @@ Nell'esempio precedente, in cui diversi thread elaborano i lavori da una coda, l
 Nota che GNU/Linux fornisce due implementazioni di semafori leggermente diverse. Quella che descriviamo qui è l'implementazione standard del semaforo POSIX. Usa questi semafori quando comunichi tra thread. L'altra implementazione, usata per la comunicazione tra processi, verrà descritta nel prossimo capitolo. Se usi i semafori, includi <code>&lt;semaphore.h&gt;</code>. Un semaforo è rappresentato da una variabile <strong>sem_t</strong>. Prima di usarla, devi inizializzarla usando la funzione <strong>sem_init()</strong>, passando un puntatore alla variabile sem_t. Il secondo parametro dovrebbe essere zero (Un valore diverso da zero indicherebbe un semaforo che può essere condiviso tra i processi, il che non è supportato da GNU/Linux per questo tipo di semaforo) e il terzo parametro è il valore iniziale del semaforo.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int sem_init(sem_t *sem, int pshared, unsigned int value);
 </code></pre>
 
@@ -2224,7 +2224,7 @@ Se non hai più bisogno di un semaforo, è bene deallocarlo con <strong>sem_dest
 Per attendere un semaforo, usa <strong>sem_wait()</strong>.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int sem_wait(sem_t *sem);
 </code></pre>
 
@@ -2232,7 +2232,7 @@ int sem_wait(sem_t *sem);
 Per inviare a un semaforo, usa <strong>sem_post()</strong>.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int sem_post(sem_t *sem);
 </code></pre>
 
@@ -2240,7 +2240,7 @@ int sem_post(sem_t *sem);
 Viene fornita anche una funzione di attesa non bloccante, <strong>sem_trywait()</strong>. è simile a pthread_mutex_trylock: se l'attesa si fosse bloccata perché il valore del semaforo era zero, la funzione restituisce immediatamente, con il valore di errore <code>EAGAIN</code>, invece di bloccare.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int sem_trywait(sem_t *sem);
 </code></pre>
 
@@ -2248,7 +2248,7 @@ int sem_trywait(sem_t *sem);
 GNU/Linux fornisce anche una funzione per recuperare il valore corrente di un semaforo, <strong>sem_getvalue()</strong>, che inserisce il valore nella variabile int puntata dal suo secondo argomento.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 int sem_getvalue(sem_t *sem, int *sval);
 </code></pre>
 
@@ -2256,7 +2256,7 @@ int sem_getvalue(sem_t *sem, int *sval);
 Tuttavia, non dovresti usare il valore del semaforo che ottieni da questa funzione per prendere una decisione se inviare o attendere il semaforo. Ciò potrebbe portare a una race condition: un altro thread potrebbe modificare il valore del semaforo tra la chiamata a sem_getvalue e la chiamata a un'altra funzione del semaforo. Utilizza invece le funzioni atomiche di post e attesa. Tornando al nostro esempio di coda di lavoro, possiamo usare un semaforo per contare il numero di lavori in attesa nella coda. L'esempio seguente controlla la coda con un semaforo. La funzione enqueue_job aggiunge un nuovo job alla coda.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -2396,7 +2396,7 @@ Prima di prendere un lavoro dalla parte anteriore della coda, ogni thread attend
 Abbiamo mostrato come usare un mutex per proteggere una variabile dall'accesso simultaneo da due thread e come usare i semafori per implementare un contatore condiviso. Una <strong>variabile di condizione</strong> è un terzo dispositivo di sincronizzazione fornito da GNU/Linux; con essa, puoi implementare condizioni più complesse in base alle quali i thread vengono eseguiti. Supponiamo di scrivere una funzione thread che esegue un ciclo all'infinito, eseguendo un po' di lavoro a ogni iterazione. Il ciclo thread, tuttavia, deve essere controllato da un flag: il ciclo viene eseguito solo quando il flag è impostato; quando il flag non è impostato, il ciclo si interrompe. Durante ogni iterazione del ciclo, la funzione thread verifica che il flag sia impostato. Poiché il flag è accessibile da più thread, è protetto da un mutex. Questa implementazione potrebbe essere corretta, ma non è efficiente. La funzione thread impiegherà molta CPU ogni volta che il flag non è impostato, controllando e ricontrollando il flag, ogni volta bloccando e sbloccando il mutex. Ciò che si desidera realmente è un modo per mettere il thread in modalità sleep quando il flag non è impostato, finché non cambiano alcune circostanze che potrebbero causare l'impostazione del flag.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -2504,7 +2504,7 @@ Una variabile di condizione è rappresentata da un'istanza di <strong>pthread_co
 <p align="justify">
 Il mutex deve essere inizializzato separatamente
 </p>
-<pre><code class="language-c">
+<pre lang="c"><code>
    int pthread_cond_init(pthread_cond_t *restrict cond, const pthread_condattr_t *restrict attr);
 </code></pre>
 <ul>
@@ -2518,11 +2518,11 @@ Il mutex deve essere inizializzato separatamente
 pthread_cond_t. Una chiamata simile, <strong>pthread_cond_broadcast()</strong>, sblocca tutti i thread bloccati sulla variabile di condizione, invece di uno solo.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
   int pthread_cond_signal(pthread_cond_t *cond);
 </code></pre>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
   int pthread_cond_broadcast(pthread_cond_t *cond);
 </code></pre>
 <ul>
@@ -2532,7 +2532,7 @@ pthread_cond_t. Una chiamata simile, <strong>pthread_cond_broadcast()</strong>, 
     </p>
   </li>
 </ul>
-<pre><code class="language-c">
+<pre lang="c"><code>
   int pthread_cond_wait(pthread_cond_t *restrict cond, pthread_mutex_t *restrict mutex);
 </code></pre>
   
@@ -2567,7 +2567,7 @@ Ogni volta che il programma esegue un'azione che potrebbe cambiare il senso dell
 Il codice seguente mostra di nuovo l'esempio precedente, che ora utilizza una variabile di condizione per proteggere il flag del thread. In <code>thread_function</code>, un blocco sul mutex viene mantenuto prima di controllare il valore di <code>thread_flag</code>. Tale blocco viene automaticamente rilasciato da <code>pthread_cond_wait</code> prima dell'attesa e riacquisito subito dopo. Notare inoltre che <code>set_thread_flag</code> blocca il mutex prima di impostare il valore di <code>thread_flag</code> e di segnalare il mutex.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
@@ -2649,7 +2649,7 @@ I deadlock possono verificarsi quando due (o più) thread sono bloccati, in atte
 L'implementazione dei thread POSIX su GNU/Linux differisce dall'implementazione dei thread su molti altri sistemi simili a UNIX in un modo importante: su GNU/Linux, <strong>i thread sono implementati come processi</strong>. Ogni volta che chiami <code>pthread_create</code> per creare un nuovo thread, Linux crea un nuovo processo che esegue quel thread. Tuttavia, questo processo non è lo stesso di un processo che creeresti con <code>fork</code>; in particolare, condivide lo stesso spazio di indirizzamento e le stesse risorse del processo originale invece di ricevere copie. Il codice seguente lo dimostra. Il programma crea un thread; sia il thread originale che quello nuovo chiamano la funzione <code>getpid</code> e stampano i rispettivi ID di processo e quindi restano in attesa all'infinito.
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
@@ -2683,7 +2683,7 @@ int main ()
 Esegui il programma in background, quindi richiama <code>ps x</code> per visualizzare i processi in esecuzione. Non dimenticare di terminare il programma thread-pid in seguito: consuma molta CPU senza fare nulla. Ecco come potrebbe apparire l'output:
 </p>
 
-<pre><code class="language-bash">
+<pre lang="bash"><code>
  % gcc -o thread-pid thread-pid.c -lpthread
 
  % ./thread-pid &amp;
@@ -2724,7 +2724,7 @@ Nota che ci sono tre processi che eseguono il programma thread-pid. Il primo di 
 Supponiamo che un programma multithread riceva un segnale. In quale thread viene invocato il gestore del segnale? Il comportamento dell'interazione tra segnali e thread varia da un sistema UNIX a un altro. In GNU/Linux, il comportamento è dettato dal fatto che i thread sono implementati come processi. Poiché ogni thread è un processo separato e poiché un segnale viene inviato a un processo particolare, non vi è ambiguità su quale thread riceva il segnale. In genere, i segnali inviati dall'esterno del programma vengono inviati al processo corrispondente al thread principale del programma. Ad esempio, se un programma si biforca e il processo figlio esegue un programma multithread, il processo padre conterrà l'ID processo del thread principale del programma del processo figlio e utilizzerà tale ID processo per inviare segnali al suo figlio. Questa è in genere una buona convenzione da seguire quando si inviano segnali a un programma multithread. Si noti che questo aspetto dell'implementazione di pthreads di GNU/Linux è in contrasto con lo standard di thread POSIX. Non fare affidamento su questo comportamento in programmi che sono pensati per essere portabili. All'interno di un programma multithread, è possibile che un thread invii un segnale specificamente a un altro thread. Utilizzare la funzione <strong>pthread_kill()</strong> per farlo. Il suo primo parametro è un ID thread e il suo secondo parametro è il numero del segnale
 </p>
 
-<pre><code class="language-c">
+<pre lang="c"><code>
 pthread_kill(pthread_t thread, int sig);
 </code></pre>
 

--- a/LINUX_PROGRAMMING.md
+++ b/LINUX_PROGRAMMING.md
@@ -1,4 +1,4 @@
-## Indice
+﻿## Indice
 
 * [Controllo dei processi](#controllo-dei-processi)
 * [Linux Programming](#linux-programming)
@@ -1879,25 +1879,33 @@ int main(void){
 
 ### Sincronizzazione e Sezioni Critiche
 
+<p align="justify">
 La programmazione con i thread è molto complicata perché la maggior parte dei programmi con thread è composta da programmi concorrenti. In particolare, non c'è modo di sapere quando il sistema pianificherà l'esecuzione di un thread e quando ne eseguirà un altro. Un thread potrebbe essere eseguito per un tempo molto lungo o il sistema potrebbe passare da un thread all'altro molto rapidamente. Su un sistema con più processori, il sistema potrebbe persino pianificare l'esecuzione di più thread letteralmente nello stesso momento. Il debug di un programma con thread è difficile perché non è sempre possibile riprodurre facilmente il comportamento che ha causato il problema. Potresti eseguire il programma una volta e far funzionare tutto correttamente; la volta successiva che lo esegui, potrebbe bloccarsi. Non c'è modo di far pianificare i thread esattamente nello stesso modo in cui lo faceva prima.
+</p>
 
-La causa ultima della maggior parte dei bug che coinvolgono i thread è che **i thread accedono agli stessi dati**. Come accennato in precedenza, questo è uno degli aspetti più potenti dei thread, ma può anche essere pericoloso. Se un thread è solo a metà dell'aggiornamento di una struttura dati quando un altro thread accede alla stessa struttura dati, è probabile che si verifichi il caos. Spesso, i programmi con thread buggati contengono un codice che funzionerà solo se un thread viene pianificato più spesso, o prima, di un altro thread. Questi bug sono chiamati **race conditions**; i thread sono in competizione tra loro per modificare la stessa struttura dati.
+<p align="justify">
+La causa ultima della maggior parte dei bug che coinvolgono i thread è che <strong>i thread accedono agli stessi dati</strong>. Come accennato in precedenza, questo è uno degli aspetti più potenti dei thread, ma può anche essere pericoloso. Se un thread è solo a metà dell'aggiornamento di una struttura dati quando un altro thread accede alla stessa struttura dati, è probabile che si verifichi il caos. Spesso, i programmi con thread buggati contengono un codice che funzionerà solo se un thread viene pianificato più spesso, o prima, di un altro thread. Questi bug sono chiamati <strong>race conditions</strong>; i thread sono in competizione tra loro per modificare la stessa struttura dati.
+</p>
 
 #### Race Conditions
 
-Supponiamo che il tuo programma abbia una serie di lavori in coda che vengono elaborati da diversi thread simultanei. La coda dei lavori è rappresentata da una lista di oggetti struct job. Dopo che ogni thread termina un'operazione, controlla la coda per vedere se è disponibile un lavoro aggiuntivo. Se job_queue è diverso da `NULL`, il thread rimuove la testa dell'elenco collegato e imposta job_queue sul lavoro successivo nell'elenco.
+<p align="justify">
+Supponiamo che il tuo programma abbia una serie di lavori in coda che vengono elaborati da diversi thread simultanei. La coda dei lavori è rappresentata da una lista di oggetti struct job. Dopo che ogni thread termina un'operazione, controlla la coda per vedere se è disponibile un lavoro aggiuntivo. Se job_queue è diverso da <code>NULL</code>, il thread rimuove la testa dell'elenco collegato e imposta job_queue sul lavoro successivo nell'elenco.
+</p>
 
-Ora supponiamo che due thread finiscano un lavoro più o meno nello stesso momento, ma che solo un lavoro rimanga nella coda. Il primo thread controlla se job_queue è nullo; scoprendo che non lo è, il thread entra nel ciclo e memorizza il puntatore all'oggetto lavoro in next_job. A questo punto, Linux interrompe il primo thread e pianifica il secondo. Anche il secondo thread controlla job_queue e, trovandolo non nullo, assegna lo stesso puntatore lavoro a next_job. Per una sfortunata coincidenza, ora abbiamo due thread che eseguono lo stesso lavoro. A peggiorare le cose, un thread scollegherà l'oggetto lavoro dalla coda, lasciando job_queue contenente `NULL`. Quando l'altro thread valuta job_queue->next, si verificherà un errore di segmentazione. Questo è un esempio di condizione di gara. In circostanze fortunate, questa particolare pianificazione dei due thread potrebbe non verificarsi mai e la condizione di gara potrebbe non manifestarsi mai. In circostanze diverse, magari quando si esegue su un sistema pesantemente caricato (o sul nuovo server multiprocessore di un cliente importante!), il bug può manifestarsi. Per eliminare le **race conditions**, è necessario un modo per **rendere le operazioni atomiche**. **Un'operazione atomica è indivisibile e ininterrotta; una volta avviata, non verrà messa in pausa o interrotta fino al suo completamento e nel frattempo non verrà eseguita nessun'altra operazione**. In questo particolare esempio, si desidera controllare job_queue: se non è vuoto, si rimuove il primo lavoro, il tutto come un'unica operazione atomica.
+<p align="justify">
+Ora supponiamo che due thread finiscano un lavoro più o meno nello stesso momento, ma che solo un lavoro rimanga nella coda. Il primo thread controlla se job_queue è nullo; scoprendo che non lo è, il thread entra nel ciclo e memorizza il puntatore all'oggetto lavoro in next_job. A questo punto, Linux interrompe il primo thread e pianifica il secondo. Anche il secondo thread controlla job_queue e, trovandolo non nullo, assegna lo stesso puntatore lavoro a next_job. Per una sfortunata coincidenza, ora abbiamo due thread che eseguono lo stesso lavoro. A peggiorare le cose, un thread scollegherà l'oggetto lavoro dalla coda, lasciando job_queue contenente <code>NULL</code>. Quando l'altro thread valuta job_queue->next, si verificherà un errore di segmentazione. Questo è un esempio di condizione di gara. In circostanze fortunate, questa particolare pianificazione dei due thread potrebbe non verificarsi mai e la condizione di gara potrebbe non manifestarsi mai. In circostanze diverse, magari quando si esegue su un sistema pesantemente caricato (o sul nuovo server multiprocessore di un cliente importante!), il bug può manifestarsi. Per eliminare le <strong>race conditions</strong>, è necessario un modo per <strong>rendere le operazioni atomiche</strong>. <strong>Un'operazione atomica è indivisibile e ininterrotta; una volta avviata, non verrà messa in pausa o interrotta fino al suo completamento e nel frattempo non verrà eseguita nessun'altra operazione</strong>. In questo particolare esempio, si desidera controllare job_queue: se non è vuoto, si rimuove il primo lavoro, il tutto come un'unica operazione atomica.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <malloc.h>
-#include <pthread.h>
+#include &lt;malloc.h&gt;
+#include &lt;pthread.h&gt;
 
 struct job {
   /* Link field for linked list.  */
@@ -1911,7 +1919,7 @@ struct job* job_queue;
 
 void process_job (struct job* tmp){
   char print_me[20];
-  printf("Thread %ld completed job %s \n", pthread_self(), tmp->message);
+  printf("Thread %ld completed job %s \n", pthread_self(), tmp-&gt;message);
 }
 
 /* Process queued jobs until the queue is empty.  */
@@ -1922,7 +1930,7 @@ void* thread_function (void* arg)
     /* Get the next available job.  */
     struct job* next_job = job_queue;
     /* Remove this job from the list.  */
-    job_queue = job_queue->next;
+    job_queue = job_queue-&gt;next;
     /* Carry out the work.  */
     process_job (next_job);
     /* Clean up.  */
@@ -1936,74 +1944,90 @@ int main(void){
   struct job *two   = (struct job *) malloc(sizeof(struct job));
   struct job *three = (struct job *) malloc(sizeof(struct job));
 
-  one->message   = "1";
-  two->message   = "2";
-  three->message = "3";
+  one-&gt;message   = "1";
+  two-&gt;message   = "2";
+  three-&gt;message = "3";
 
   job_queue = (struct job *) malloc(sizeof(struct job));
-  job_queue->message = "4";
-  job_queue->next = three;
+  job_queue-&gt;message = "4";
+  job_queue-&gt;next = three;
 
-  three->next = two;
-  two->next = one;
-  one->next = NULL;
+  three-&gt;next = two;
+  two-&gt;next = one;
+  one-&gt;next = NULL;
 
 
   pthread_t first;
   pthread_t second;
 
-  pthread_create(&first, NULL, thread_function, NULL);
-  pthread_create(&second, NULL, thread_function, NULL);
+  pthread_create(&amp;first, NULL, thread_function, NULL);
+  pthread_create(&amp;second, NULL, thread_function, NULL);
 
   pthread_join(first, NULL);
   pthread_join(second, NULL);
 
   return 0;
 }
-```
+</code></pre>
 
 
 ### Mutex
 
-La soluzione al problema della race condition della coda dei lavori consiste nel consentire a un solo thread alla volta di accedere alla coda dei lavori. Una volta che un thread inizia a guardare la coda, nessun altro thread dovrebbe essere in grado di accedervi finché il primo thread non ha deciso se elaborare un lavoro e, in tal caso, lo ha rimosso dall'elenco. L'implementazione richiede il supporto del sistema operativo. GNU/Linux fornisce i **mutex**, abbreviazione di blocchi MUTual EXclusion. Un mutex è un blocco speciale che solo un thread può bloccare alla volta. Se un thread blocca un mutex e poi un secondo thread tenta di bloccare lo stesso mutex, il secondo thread viene bloccato o messo in attesa. Solo quando il primo thread sblocca il mutex, il secondo thread viene sbloccato, ovvero può riprendere l'esecuzione. GNU/Linux garantisce che non si verifichino condizioni di gara tra thread che tentano di bloccare un mutex; solo un thread otterrà il blocco e tutti gli altri thread verranno bloccati. Pensa a un mutex come alla serratura di una porta del bagno. Chi arriva per primo entra nel bagno e chiude a chiave la porta. Se qualcun altro tenta di entrare nel bagno mentre è occupato, quella persona troverà la porta chiusa a chiave e sarà costretta ad aspettare fuori finché l'occupante non esce. Per creare un mutex, crea una variabile di tipo **pthread_mutex_t** e passa un puntatore a **pthread_mutex_init()**. Il secondo argomento di `pthread_mutex_init()` è un puntatore a un oggetto attributo mutex, che specifica gli attributi del mutex.
+<p align="justify">
+La soluzione al problema della race condition della coda dei lavori consiste nel consentire a un solo thread alla volta di accedere alla coda dei lavori. Una volta che un thread inizia a guardare la coda, nessun altro thread dovrebbe essere in grado di accedervi finché il primo thread non ha deciso se elaborare un lavoro e, in tal caso, lo ha rimosso dall'elenco. L'implementazione richiede il supporto del sistema operativo. GNU/Linux fornisce i <strong>mutex</strong>, abbreviazione di blocchi MUTual EXclusion. Un mutex è un blocco speciale che solo un thread può bloccare alla volta. Se un thread blocca un mutex e poi un secondo thread tenta di bloccare lo stesso mutex, il secondo thread viene bloccato o messo in attesa. Solo quando il primo thread sblocca il mutex, il secondo thread viene sbloccato, ovvero può riprendere l'esecuzione. GNU/Linux garantisce che non si verifichino condizioni di gara tra thread che tentano di bloccare un mutex; solo un thread otterrà il blocco e tutti gli altri thread verranno bloccati. Pensa a un mutex come alla serratura di una porta del bagno. Chi arriva per primo entra nel bagno e chiude a chiave la porta. Se qualcun altro tenta di entrare nel bagno mentre è occupato, quella persona troverà la porta chiusa a chiave e sarà costretta ad aspettare fuori finché l'occupante non esce. Per creare un mutex, crea una variabile di tipo <strong>pthread_mutex_t</strong> e passa un puntatore a <strong>pthread_mutex_init()</strong>. Il secondo argomento di <code>pthread_mutex_init()</code> è un puntatore a un oggetto attributo mutex, che specifica gli attributi del mutex.
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_mutex_init(pthread_mutex_t *restrict mutex, const pthread_mutexattr_t *restrict attr);
-```
+</code></pre>
 
-Come con `pthread_create()`, se il puntatore dell'attributo è `NULL`, vengono assunti gli attributi predefiniti. La variabile mutex dovrebbe essere inizializzata solo una volta. Questo frammento di codice dimostra la dichiarazione e l'inizializzazione di una variabile mutex.
+<p align="justify">
+Come con <code>pthread_create()</code>, se il puntatore dell'attributo è <code>NULL</code>, vengono assunti gli attributi predefiniti. La variabile mutex dovrebbe essere inizializzata solo una volta. Questo frammento di codice dimostra la dichiarazione e l'inizializzazione di una variabile mutex.
+</p>
 
-```c
+<pre><code class="language-c">
 pthread_mutex_t mutex;
-pthread_mutex_init (&mutex, NULL);
-```
+pthread_mutex_init (&amp;mutex, NULL);
+</code></pre>
 
-Un altro modo più semplice per creare un mutex con attributi predefiniti è inizializzarlo con il valore speciale `PTHREAD_MUTEX_INITIALIZER`. Non è necessaria alcuna chiamata aggiuntiva a pthread_mutex_init. Ciò è particolarmente comodo per le variabili globali
-(e, in C++, i membri dati statici). Il frammento di codice precedente avrebbe potuto essere scritto in modo equivalente così:
+<p align="justify">
+Un altro modo più semplice per creare un mutex con attributi predefiniti è inizializzarlo con il valore speciale <code>PTHREAD_MUTEX_INITIALIZER</code>. Non è necessaria alcuna chiamata aggiuntiva a pthread_mutex_init. Ciò è particolarmente comodo per le variabili globali (e, in C++, i membri dati statici). Il frammento di codice precedente avrebbe potuto essere scritto in modo equivalente così:
+</p>
 
-```c
+<pre><code class="language-c">
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-```
+</code></pre>
 
-Un thread può tentare di bloccare un mutex chiamando **pthread_mutex_lock()** su di esso. 
+<p align="justify">
+Un thread può tentare di bloccare un mutex chiamando <strong>pthread_mutex_lock()</strong> su di esso.
+</p>
 
-* **Se il mutex è in stato sbloccato, diventa bloccato e la funzione ritorna immediatamente**
-* **Se il mutex è in stato bloccato da un altro thread, pthread_mutex_lock blocca l'esecuzione e restituisce solo alla fine quando il mutex viene sbloccato dall'altro thread**.
+<ul>
+  <li>
+    <p align="justify">
+    <strong>Se il mutex è in stato sbloccato, diventa bloccato e la funzione ritorna immediatamente</strong>
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    <strong>Se il mutex è in stato bloccato da un altro thread, pthread_mutex_lock blocca l'esecuzione e restituisce solo alla fine quando il mutex viene sbloccato dall'altro thread</strong>.
+    </p>
+  </li>
+</ul>
 
-Più di un thread può essere bloccato su un mutex bloccato contemporaneamente. Quando il mutex viene sbloccato, solo uno dei thread bloccati (scelto in modo imprevedibile) viene sbloccato e gli viene consentito di bloccare il mutex; gli altri thread rimangono bloccati.
-Una chiamata a **pthread_mutex_unlock()** sblocca un mutex. Questa funzione dovrebbe essere sempre chiamata dallo stesso thread che ha bloccato il mutex.
-L'esempio seguente mostra un'altra versione dell'esempio di coda di lavoro. Ora la coda è protetta da un mutex. Prima di accedere alla coda (sia per lettura che per scrittura), ogni thread blocca prima un mutex. Solo quando l'intera sequenza di controllo della coda e
-rimozione di un lavoro è completa, il mutex viene sbloccato. Ciò impedisce la race condition descritta in precedenza.
+<p align="justify">
+Più di un thread può essere bloccato su un mutex bloccato contemporaneamente. Quando il mutex viene sbloccato, solo uno dei thread bloccati (scelto in modo imprevedibile) viene sbloccato e gli viene consentito di bloccare il mutex; gli altri thread rimangono bloccati. Una chiamata a <strong>pthread_mutex_unlock()</strong> sblocca un mutex. Questa funzione dovrebbe essere sempre chiamata dallo stesso thread che ha bloccato il mutex. L'esempio seguente mostra un'altra versione dell'esempio di coda di lavoro. Ora la coda è protetta da un mutex. Prima di accedere alla coda (sia per lettura che per scrittura), ogni thread blocca prima un mutex. Solo quando l'intera sequenza di controllo della coda e rimozione di un lavoro è completa, il mutex viene sbloccato. Ciò impedisce la race condition descritta in precedenza.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <malloc.h>
-#include <pthread.h>
+#include &lt;malloc.h&gt;
+#include &lt;pthread.h&gt;
 
 struct job {
   /* Link field for linked list.  */
@@ -2017,7 +2041,7 @@ struct job* job_queue;
 
 void process_job (struct job* tmp){
   char print_me[20];
-  printf("Thread %ld completed job %s \n", pthread_self(), tmp->message);
+  printf("Thread %ld completed job %s \n", pthread_self(), tmp-&gt;message);
 }
 
 /* A mutex protecting job_queue.  */
@@ -2031,7 +2055,7 @@ void* thread_function (void* arg)
     struct job* next_job;
 
     /* Lock the mutex on the job queue.  */
-    pthread_mutex_lock (&job_queue_mutex);
+    pthread_mutex_lock (&amp;job_queue_mutex);
     /* Now it's safe to check if the queue is empty.  */
     if (job_queue == NULL)
       next_job = NULL;
@@ -2039,11 +2063,11 @@ void* thread_function (void* arg)
       /* Get the next available job.  */
       next_job = job_queue;
       /* Remove this job from the list.  */
-      job_queue = job_queue->next;
+      job_queue = job_queue-&gt;next;
     }
     /* Unlock the mutex on the job queue, since we're done with the
        queue for now.  */
-    pthread_mutex_unlock (&job_queue_mutex);
+    pthread_mutex_unlock (&amp;job_queue_mutex);
 
     /* Was the queue empty?  If so, end the thread.  */
     if (next_job == NULL)
@@ -2063,138 +2087,186 @@ int main(void){
   struct job *two   = (struct job *) malloc(sizeof(struct job));
   struct job *three = (struct job *) malloc(sizeof(struct job));
 
-  one->message   = "1";
-  two->message   = "2";
-  three->message = "3";
+  one-&gt;message   = "1";
+  two-&gt;message   = "2";
+  three-&gt;message = "3";
 
   job_queue = (struct job *) malloc(sizeof(struct job));
-  job_queue->message = "4";
-  job_queue->next = three;
+  job_queue-&gt;message = "4";
+  job_queue-&gt;next = three;
 
-  three->next = two;
-  two->next = one;
-  one->next = NULL;
+  three-&gt;next = two;
+  two-&gt;next = one;
+  one-&gt;next = NULL;
 
 
   pthread_t first;
   pthread_t second;
 
-  pthread_create(&first, NULL, thread_function, NULL);
-  pthread_create(&second, NULL, thread_function, NULL);
+  pthread_create(&amp;first, NULL, thread_function, NULL);
+  pthread_create(&amp;second, NULL, thread_function, NULL);
 
   pthread_join(first, NULL);
   pthread_join(second, NULL);
 
   return 0;
 }
-```
+</code></pre>
 
+<p align="justify">
 Tutti gli accessi a job_queue (il puntatore dati condiviso) avvengono tra la chiamata a pthread_mutex_lock e la chiamata a pthread_mutex_unlock. Un oggetto job, memorizzato in next_job, è accessibile al di fuori di questa regione solo dopo che l'oggetto è stato rimosso dalla coda ed è quindi inaccessibile ad altri thread. Nota che se la coda è vuota (ovvero, job_queue è null), non usciamo immediatamente dal ciclo perché ciò lascerebbe il mutex bloccato in modo permanente e impedirebbe a qualsiasi altro thread di accedere di nuovo alla coda job. Invece, ricordiamo questo fatto impostando next_job su null ed usciamo solo dopo aver sbloccato il mutex. L'uso del mutex per bloccare job_queue non è automatico; spetta a te aggiungere codice per bloccare il mutex prima di accedere a quella variabile e quindi sbloccarlo in seguito. Ad esempio, una funzione per aggiungere un job alla coda job potrebbe apparire così:
+</p>
 
 
-```c
+<pre><code class="language-c">
  void enqueue_job (struct job* new_job)
  {
-   pthread_mutex_lock (&job_queue_mutex);
-   new_job->next = job_queue;
+   pthread_mutex_lock (&amp;job_queue_mutex);
+   new_job-&gt;next = job_queue;
    job_queue = new_job;
-   pthread_mutex_unlock (&job_queue_mutex);
+   pthread_mutex_unlock (&amp;job_queue_mutex);
 }
-```
+</code></pre>
 
 ### Mutex Deadlocks
 
-I mutex forniscono un meccanismo per consentire a un thread di bloccare l'esecuzione di un altro. Ciò apre la possibilità di **una nuova classe di bug**, chiamata **deadlock**. **Un deadlock si verifica quando uno o più thread sono bloccati in attesa di qualcosa che non si verificherà mai. Un semplice deadlock può verificarsi quando lo stesso thread tenta di bloccare un mutex due volte di seguito. Il comportamento in questo caso dipende dal tipo di mutex utilizzato. Esistono tre tipi di mutex:
+<p align="justify">
+I mutex forniscono un meccanismo per consentire a un thread di bloccare l'esecuzione di un altro. Ciò apre la possibilità di <strong>una nuova classe di bug</strong>, chiamata <strong>deadlock</strong>. **Un deadlock si verifica quando uno o più thread sono bloccati in attesa di qualcosa che non si verificherà mai. Un semplice deadlock può verificarsi quando lo stesso thread tenta di bloccare un mutex due volte di seguito. Il comportamento in questo caso dipende dal tipo di mutex utilizzato. Esistono tre tipi di mutex:
+</p>
 
-* Il blocco di un mutex veloce (il tipo predefinito) causerà il verificarsi di un deadlock. Il tentativo di bloccare il mutex resta in attesa finché il mutex non viene sbloccato. Ma poiché il thread che ha bloccato il mutex è bloccato sullo stesso mutex, il blocco non può
+<ul>
+  <li>
+    <p align="justify">
+    Il blocco di un mutex veloce (il tipo predefinito) causerà il verificarsi di un deadlock. Il tentativo di bloccare il mutex resta in attesa finché il mutex non viene sbloccato. Ma poiché il thread che ha bloccato il mutex è bloccato sullo stesso mutex, il blocco non può
+    </p>
+  </li>
+</ul>
+<p align="justify">
 mai essere rilasciato.
-* Il blocco di un mutex ricorsivo non causa un deadlock. Un mutex ricorsivo può essere bloccato in modo sicuro più volte dallo stesso thread. Il mutex ricorda quante volte pthread_mutex_lock è stato chiamato su di esso dal thread che detiene il blocco; quel thread deve effettuare lo stesso numero di chiamate a pthread_mutex_unlock prima che il mutex venga effettivamente sbloccato e un altro thread possa bloccarlo.
-* GNU/Linux rileverà e contrassegnerà un doppio blocco su un mutex di controllo degli errori che altrimenti causerebbe un deadlock. La seconda chiamata consecutiva a pthread_mutex_lock restituisce il codice di errore `EDEADLK`.
+</p>
+<ul>
+  <li>
+    <p align="justify">
+    Il blocco di un mutex ricorsivo non causa un deadlock. Un mutex ricorsivo può essere bloccato in modo sicuro più volte dallo stesso thread. Il mutex ricorda quante volte pthread_mutex_lock è stato chiamato su di esso dal thread che detiene il blocco; quel thread deve effettuare lo stesso numero di chiamate a pthread_mutex_unlock prima che il mutex venga effettivamente sbloccato e un altro thread possa bloccarlo.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    GNU/Linux rileverà e contrassegnerà un doppio blocco su un mutex di controllo degli errori che altrimenti causerebbe un deadlock. La seconda chiamata consecutiva a pthread_mutex_lock restituisce il codice di errore <code>EDEADLK</code>.
+    </p>
+  </li>
+</ul>
 
-Per impostazione predefinita, un mutex GNU/Linux è del tipo veloce. Per creare un mutex di uno degli altri due tipi, crea prima un oggetto attributo mutex dichiarando una variabile **pthread_mutexattr_t** e chiamando **pthread_mutexattr_init()**.
-Poi imposta il tipo di mutex chiamando  **pthread_mutexattr_setkind_np()**.
+<p align="justify">
+Per impostazione predefinita, un mutex GNU/Linux è del tipo veloce. Per creare un mutex di uno degli altri due tipi, crea prima un oggetto attributo mutex dichiarando una variabile <strong>pthread_mutexattr_t</strong> e chiamando <strong>pthread_mutexattr_init()</strong>. Poi imposta il tipo di mutex chiamando  <strong>pthread_mutexattr_setkind_np()</strong>.
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_mutexattr_setkind_np(pthread_mutexattr_t *attr, int kind);
-```
+</code></pre>
 
-Il primo argomento è un puntatore all'oggetto attributo mutex, e il secondo è `PTHREAD_MUTEX_RECURSIVE_NP` per un mutex ricorsivo, o `PTHREAD_MUTEX_ERRORCHECK_NP` per uno di controllo degli errori. Passa un puntatore a questo oggetto attributo a
-**pthread_mutex_init()** per creare un mutex di questo tipo, quindi distruggi l'oggetto attributo con **pthread_mutexattr_destroy()**. Questa sequenza di codice illustra la creazione di un mutex di controllo degli errori, ad esempio:
+<p align="justify">
+Il primo argomento è un puntatore all'oggetto attributo mutex, e il secondo è <code>PTHREAD_MUTEX_RECURSIVE_NP</code> per un mutex ricorsivo, o <code>PTHREAD_MUTEX_ERRORCHECK_NP</code> per uno di controllo degli errori. Passa un puntatore a questo oggetto attributo a <strong>pthread_mutex_init()</strong> per creare un mutex di questo tipo, quindi distruggi l'oggetto attributo con <strong>pthread_mutexattr_destroy()</strong>. Questa sequenza di codice illustra la creazione di un mutex di controllo degli errori, ad esempio:
+</p>
 
-```c
+<pre><code class="language-c">
  pthread_mutexattr_t attr;
  pthread_mutex_t mutex;
- pthread_mutexattr_init (&attr);
- pthread_mutexattr_setkind_np (&attr, PTHREAD_MUTEX_ERRORCHECK_NP);
- pthread_mutex_init (&mutex, &attr);
- pthread_mutexattr_destroy (&attr);
-```
+ pthread_mutexattr_init (&amp;attr);
+ pthread_mutexattr_setkind_np (&amp;attr, PTHREAD_MUTEX_ERRORCHECK_NP);
+ pthread_mutex_init (&amp;mutex, &amp;attr);
+ pthread_mutexattr_destroy (&amp;attr);
+</code></pre>
 
+<p align="justify">
 Come suggerito dal suffisso "np", i tipi di mutex ricorsivi e di controllo degli errori sono specifici di GNU/Linux e non sono portabili. Pertanto, in genere non è consigliabile utilizzarli nei programmi. (Tuttavia, i mutex di controllo degli errori possono essere utili durante il debug.)
+</p>
 
 ### Test Mutex non bloccanti
 
-A volte, è utile verificare se un mutex è bloccato senza effettivamente bloccarlo. Ad esempio, un thread potrebbe dover verificare un mutex ma potrebbe avere altro lavoro da fare anziché attendere, se il mutex è già bloccato. Poiché **pthread_mutex_lock()** non
-tornerà finché il mutex non sarà sbloccato, è necessaria un'altra funzione. GNU/Linux fornisce **pthread_mutex_trylock()** per questo scopo. Se chiami pthread_mutex_trylock su un mutex sbloccato, bloccherai il mutex come se avessi chiamato pthread_mutex_lock e pthread_mutex_trylock restituirà zero. Tuttavia, se il mutex è già bloccato da un altro thread, pthread_mutex_trylock non bloccherà. Invece, tornerà immediatamente con il codice di errore `EBUSY`. Il mutex mantenuto dall'altro thread non è coinvolto. Puoi provare di nuovo più tardi a bloccare il mutex.
+<p align="justify">
+A volte, è utile verificare se un mutex è bloccato senza effettivamente bloccarlo. Ad esempio, un thread potrebbe dover verificare un mutex ma potrebbe avere altro lavoro da fare anziché attendere, se il mutex è già bloccato. Poiché <strong>pthread_mutex_lock()</strong> non tornerà finché il mutex non sarà sbloccato, è necessaria un'altra funzione. GNU/Linux fornisce <strong>pthread_mutex_trylock()</strong> per questo scopo. Se chiami pthread_mutex_trylock su un mutex sbloccato, bloccherai il mutex come se avessi chiamato pthread_mutex_lock e pthread_mutex_trylock restituirà zero. Tuttavia, se il mutex è già bloccato da un altro thread, pthread_mutex_trylock non bloccherà. Invece, tornerà immediatamente con il codice di errore <code>EBUSY</code>. Il mutex mantenuto dall'altro thread non è coinvolto. Puoi provare di nuovo più tardi a bloccare il mutex.
+</p>
 
 ### Semafori
 
-Nell'esempio precedente, in cui diversi thread elaborano i lavori da una coda, la funzione thread principale dei thread esegue il lavoro successivo finché non ci sono più lavori e quindi esce dal thread. Questo schema funziona se tutti i lavori vengono messi in coda in anticipo o se i nuovi lavori vengono messi in coda almeno con la stessa rapidità con cui i thread li elaborano. Tuttavia, se i thread lavorano troppo velocemente, la coda dei lavori si svuoterà e i thread usciranno. Se in seguito vengono messi in coda nuovi lavori, non ci saranno più thread che li elaborino. Ciò che potremmo invece desiderare è un meccanismo per bloccare i thread quando la coda si svuota finché non diventano disponibili nuovi lavori. Un semaforo fornisce un metodo conveniente per farlo. **Un semaforo è un contatore** che può essere **utilizzato per sincronizzare più thread**. Come con un mutex, GNU/Linux garantisce che il controllo o la modifica del valore di un semaforo può essere eseguito in modo sicuro, senza creare una condizione di competizione. **Ogni semaforo ha un valore contatore**, che è **un intero non negativo**. Un semaforo supporta due operazioni di base:
+<p align="justify">
+Nell'esempio precedente, in cui diversi thread elaborano i lavori da una coda, la funzione thread principale dei thread esegue il lavoro successivo finché non ci sono più lavori e quindi esce dal thread. Questo schema funziona se tutti i lavori vengono messi in coda in anticipo o se i nuovi lavori vengono messi in coda almeno con la stessa rapidità con cui i thread li elaborano. Tuttavia, se i thread lavorano troppo velocemente, la coda dei lavori si svuoterà e i thread usciranno. Se in seguito vengono messi in coda nuovi lavori, non ci saranno più thread che li elaborino. Ciò che potremmo invece desiderare è un meccanismo per bloccare i thread quando la coda si svuota finché non diventano disponibili nuovi lavori. Un semaforo fornisce un metodo conveniente per farlo. <strong>Un semaforo è un contatore</strong> che può essere <strong>utilizzato per sincronizzare più thread</strong>. Come con un mutex, GNU/Linux garantisce che il controllo o la modifica del valore di un semaforo può essere eseguito in modo sicuro, senza creare una condizione di competizione. <strong>Ogni semaforo ha un valore contatore</strong>, che è <strong>un intero non negativo</strong>. Un semaforo supporta due operazioni di base:
+</p>
 
-* Un'operazione di attesa decrementa il valore del semaforo di 1. Se il valore è già zero, l'operazione si blocca finché il valore del semaforo non diventa positivo (a causa dell'azione di un altro thread). Quando il valore del semaforo diventa positivo, viene decrementato di 1 e l'operazione di attesa ritorna.
-* Un'operazione di post incrementa il valore del semaforo di 1. Se il semaforo era precedentemente zero e altri thread sono bloccati in un'operazione di attesa su quel semaforo, uno di quei thread viene sbloccato e la sua operazione di attesa viene completata (il che riporta il valore del semaforo a zero)
+<ul>
+  <li>
+    <p align="justify">
+    Un'operazione di attesa decrementa il valore del semaforo di 1. Se il valore è già zero, l'operazione si blocca finché il valore del semaforo non diventa positivo (a causa dell'azione di un altro thread). Quando il valore del semaforo diventa positivo, viene decrementato di 1 e l'operazione di attesa ritorna.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Un'operazione di post incrementa il valore del semaforo di 1. Se il semaforo era precedentemente zero e altri thread sono bloccati in un'operazione di attesa su quel semaforo, uno di quei thread viene sbloccato e la sua operazione di attesa viene completata (il che riporta il valore del semaforo a zero)
+    </p>
+  </li>
+</ul>
 
-Nota che GNU/Linux fornisce due implementazioni di semafori leggermente diverse. Quella che descriviamo qui è l'implementazione standard del semaforo POSIX. Usa questi semafori quando comunichi tra thread.
-L'altra implementazione, usata per la comunicazione tra processi, verrà descritta nel prossimo capitolo. Se usi i semafori, includi **<semaphore.h>**.
-Un semaforo è rappresentato da una variabile **sem_t**. Prima di usarla, devi inizializzarla usando la funzione **sem_init()**, passando un puntatore alla variabile sem_t. Il secondo parametro dovrebbe essere zero (Un valore diverso da zero indicherebbe un semaforo che può essere condiviso tra i processi, il che non è supportato da GNU/Linux per questo tipo di semaforo) e il terzo parametro è il valore iniziale del semaforo. 
+<p align="justify">
+Nota che GNU/Linux fornisce due implementazioni di semafori leggermente diverse. Quella che descriviamo qui è l'implementazione standard del semaforo POSIX. Usa questi semafori quando comunichi tra thread. L'altra implementazione, usata per la comunicazione tra processi, verrà descritta nel prossimo capitolo. Se usi i semafori, includi <code>&lt;semaphore.h&gt;</code>. Un semaforo è rappresentato da una variabile <strong>sem_t</strong>. Prima di usarla, devi inizializzarla usando la funzione <strong>sem_init()</strong>, passando un puntatore alla variabile sem_t. Il secondo parametro dovrebbe essere zero (Un valore diverso da zero indicherebbe un semaforo che può essere condiviso tra i processi, il che non è supportato da GNU/Linux per questo tipo di semaforo) e il terzo parametro è il valore iniziale del semaforo.
+</p>
 
-```c
+<pre><code class="language-c">
 int sem_init(sem_t *sem, int pshared, unsigned int value);
-```
+</code></pre>
 
-Se non hai più bisogno di un semaforo, è bene deallocarlo con **sem_destroy()**.
+<p align="justify">
+Se non hai più bisogno di un semaforo, è bene deallocarlo con <strong>sem_destroy()</strong>.
+</p>
 
 
-Per attendere un semaforo, usa **sem_wait()**. 
+<p align="justify">
+Per attendere un semaforo, usa <strong>sem_wait()</strong>.
+</p>
 
-```c
+<pre><code class="language-c">
 int sem_wait(sem_t *sem);
-```
+</code></pre>
 
-Per inviare a un semaforo, usa **sem_post()**.
+<p align="justify">
+Per inviare a un semaforo, usa <strong>sem_post()</strong>.
+</p>
 
-```c
+<pre><code class="language-c">
 int sem_post(sem_t *sem);
-```
+</code></pre>
 
-Viene fornita anche una funzione di attesa non bloccante, **sem_trywait()**. è simile a pthread_mutex_trylock: se l'attesa si fosse bloccata perché il valore del semaforo era zero, la funzione restituisce immediatamente, con il valore di errore `EAGAIN`, invece di
-bloccare.
+<p align="justify">
+Viene fornita anche una funzione di attesa non bloccante, <strong>sem_trywait()</strong>. è simile a pthread_mutex_trylock: se l'attesa si fosse bloccata perché il valore del semaforo era zero, la funzione restituisce immediatamente, con il valore di errore <code>EAGAIN</code>, invece di bloccare.
+</p>
 
-```c
+<pre><code class="language-c">
 int sem_trywait(sem_t *sem);
-```
+</code></pre>
 
-GNU/Linux fornisce anche una funzione per recuperare il valore corrente di un semaforo, **sem_getvalue()**, che inserisce il valore nella variabile int puntata dal suo secondo argomento. 
+<p align="justify">
+GNU/Linux fornisce anche una funzione per recuperare il valore corrente di un semaforo, <strong>sem_getvalue()</strong>, che inserisce il valore nella variabile int puntata dal suo secondo argomento.
+</p>
 
-```c
+<pre><code class="language-c">
 int sem_getvalue(sem_t *sem, int *sval);
-```
+</code></pre>
 
-Tuttavia, non dovresti usare il valore del semaforo che ottieni da questa funzione per prendere una decisione se inviare o attendere il semaforo. Ciò potrebbe portare
-a una race condition: un altro thread potrebbe modificare il valore del semaforo tra la chiamata a sem_getvalue e la chiamata a un'altra funzione del semaforo. Utilizza invece le funzioni atomiche di post e attesa.
-Tornando al nostro esempio di coda di lavoro, possiamo usare un semaforo per contare il numero di lavori in attesa nella coda. L'esempio seguente controlla la coda con un semaforo. La funzione enqueue_job aggiunge un nuovo job alla coda.
+<p align="justify">
+Tuttavia, non dovresti usare il valore del semaforo che ottieni da questa funzione per prendere una decisione se inviare o attendere il semaforo. Ciò potrebbe portare a una race condition: un altro thread potrebbe modificare il valore del semaforo tra la chiamata a sem_getvalue e la chiamata a un'altra funzione del semaforo. Utilizza invece le funzioni atomiche di post e attesa. Tornando al nostro esempio di coda di lavoro, possiamo usare un semaforo per contare il numero di lavori in attesa nella coda. L'esempio seguente controlla la coda con un semaforo. La funzione enqueue_job aggiunge un nuovo job alla coda.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <malloc.h>
-#include <pthread.h>
-#include <semaphore.h>
-#include <unistd.h> // sleep
+#include &lt;malloc.h&gt;
+#include &lt;pthread.h&gt;
+#include &lt;semaphore.h&gt;
+#include &lt;unistd.h&gt; // sleep
 
 struct job {
   /* Link field for linked list.  */
@@ -2208,7 +2280,7 @@ struct job* job_queue;
 
 void process_job (struct job* tmp){
   char print_me[20];
-  printf("Thread %ld completed job %s \n", pthread_self(), tmp->message);
+  printf("Thread %ld completed job %s \n", pthread_self(), tmp-&gt;message);
 }
 
 /* A mutex protecting job_queue.  */
@@ -2225,7 +2297,7 @@ void initialize_job_queue ()
   job_queue = NULL;
   /* Initialize the semaphore which counts jobs in the queue.  Its
      initial value should be zero.  */
-  sem_init (&job_queue_count, 0, 0);
+  sem_init (&amp;job_queue_count, 0, 0);
 }
 
 /* Process queued jobs until the queue is empty.  */
@@ -2238,18 +2310,18 @@ void* thread_function (void* arg)
     /* Wait on the job queue semaphore.  If its value is positive,
        indicating that the queue is not empty, decrement the count by
        one.  If the queue is empty, block until a new job is enqueued.  */
-    sem_wait (&job_queue_count);
+    sem_wait (&amp;job_queue_count);
 
     /* Lock the mutex on the job queue.  */
-    pthread_mutex_lock (&job_queue_mutex);
+    pthread_mutex_lock (&amp;job_queue_mutex);
     /* Because of the semaphore, we know the queue is not empty.  Get
        the next available job.  */
     next_job = job_queue;
     /* Remove this job from the list.  */
-    job_queue = job_queue->next;
+    job_queue = job_queue-&gt;next;
     /* Unlock the mutex on the job queue, since we're done with the
        queue for now.  */
-    pthread_mutex_unlock (&job_queue_mutex);
+    pthread_mutex_unlock (&amp;job_queue_mutex);
 
     /* Carry out the work.  */
     process_job (next_job);
@@ -2268,21 +2340,21 @@ void enqueue_job (char *message)
   /* Allocate a new job object.  */
   new_job = (struct job*) malloc (sizeof (struct job));
   /* Set the other fields of the job struct here...  */
-  new_job->message = message;
+  new_job-&gt;message = message;
 
   /* Lock the mutex on the job queue before accessing it.  */
-  pthread_mutex_lock (&job_queue_mutex);
+  pthread_mutex_lock (&amp;job_queue_mutex);
   /* Place the new job at the head of the queue.  */
-  new_job->next = job_queue;
+  new_job-&gt;next = job_queue;
   job_queue = new_job;
 
   /* Post to the semaphore to indicate another job is available.  If
      threads are blocked, waiting on the semaphore, one will become
      unblocked so it can process the job.  */
-  sem_post (&job_queue_count);
+  sem_post (&amp;job_queue_count);
 
   /* Unlock the job queue mutex.  */
-  pthread_mutex_unlock (&job_queue_mutex);
+  pthread_mutex_unlock (&amp;job_queue_mutex);
 }
 
 
@@ -2296,8 +2368,8 @@ int main(void){
   pthread_t first;
   pthread_t second;
 
-  pthread_create(&first, NULL, thread_function, NULL);
-  pthread_create(&second, NULL, thread_function, NULL);
+  pthread_create(&amp;first, NULL, thread_function, NULL);
+  pthread_create(&amp;second, NULL, thread_function, NULL);
 
   sleep(60);
 
@@ -2312,24 +2384,26 @@ int main(void){
 
   return 0;
 }
-```
+</code></pre>
 
+<p align="justify">
 Prima di prendere un lavoro dalla parte anteriore della coda, ogni thread attenderà prima sul semaforo. Se il valore del semaforo è zero, indicando che la coda è vuota, il thread si bloccherà semplicemente finché il valore del semaforo non diventerà positivo, indicando che un lavoro è stato aggiunto alla coda. La funzione enqueue_job aggiunge un lavoro alla coda. Proprio come thread_function, deve bloccare il mutex della coda prima di modificare la coda. Dopo aver aggiunto un lavoro alla coda, invia un post al semaforo, indicando che un nuovo lavoro è disponibile. In questa implementazione i thread che elaborano i lavori non escono mai; se nessun lavoro è disponibile per un po', tutti i thread si bloccano semplicemente in sem_wait.
+</p>
 
 ### Variabili di condizione
 
-Abbiamo mostrato come usare un mutex per proteggere una variabile dall'accesso simultaneo da due thread e come usare i semafori per implementare un contatore condiviso. Una **variabile di condizione** è un terzo dispositivo di sincronizzazione fornito da GNU/Linux; con essa, puoi implementare condizioni più complesse in base alle quali i thread vengono eseguiti. Supponiamo di scrivere una funzione thread che esegue un ciclo all'infinito, eseguendo un po' di lavoro a ogni iterazione. Il ciclo thread, tuttavia, deve essere controllato da un flag: il ciclo viene eseguito solo quando il flag è impostato; quando il flag non è impostato, il ciclo si interrompe.
-Durante ogni iterazione del ciclo, la funzione thread verifica che il flag sia impostato. Poiché il flag è accessibile da più thread, è protetto da un mutex. Questa implementazione potrebbe essere corretta, ma non è efficiente. La funzione thread impiegherà molta CPU
-ogni volta che il flag non è impostato, controllando e ricontrollando il flag, ogni volta bloccando e sbloccando il mutex. Ciò che si desidera realmente è un modo per mettere il thread in modalità sleep quando il flag non è impostato, finché non cambiano alcune circostanze che potrebbero causare l'impostazione del flag.
+<p align="justify">
+Abbiamo mostrato come usare un mutex per proteggere una variabile dall'accesso simultaneo da due thread e come usare i semafori per implementare un contatore condiviso. Una <strong>variabile di condizione</strong> è un terzo dispositivo di sincronizzazione fornito da GNU/Linux; con essa, puoi implementare condizioni più complesse in base alle quali i thread vengono eseguiti. Supponiamo di scrivere una funzione thread che esegue un ciclo all'infinito, eseguendo un po' di lavoro a ogni iterazione. Il ciclo thread, tuttavia, deve essere controllato da un flag: il ciclo viene eseguito solo quando il flag è impostato; quando il flag non è impostato, il ciclo si interrompe. Durante ogni iterazione del ciclo, la funzione thread verifica che il flag sia impostato. Poiché il flag è accessibile da più thread, è protetto da un mutex. Questa implementazione potrebbe essere corretta, ma non è efficiente. La funzione thread impiegherà molta CPU ogni volta che il flag non è impostato, controllando e ricontrollando il flag, ogni volta bloccando e sbloccando il mutex. Ciò che si desidera realmente è un modo per mettere il thread in modalità sleep quando il flag non è impostato, finché non cambiano alcune circostanze che potrebbero causare l'impostazione del flag.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <pthread.h>
+#include &lt;pthread.h&gt;
 
 extern void do_work ();
 
@@ -2338,7 +2412,7 @@ pthread_mutex_t thread_flag_mutex;
 
 void initialize_flag ()
 {
-  pthread_mutex_init (&thread_flag_mutex, NULL);
+  pthread_mutex_init (&amp;thread_flag_mutex, NULL);
   thread_flag = 0;
 }
 
@@ -2351,9 +2425,9 @@ void* thread_function (void* thread_arg)
     int flag_is_set;
 
     /* Protect the flag with a mutex lock.  */
-    pthread_mutex_lock (&thread_flag_mutex);
+    pthread_mutex_lock (&amp;thread_flag_mutex);
     flag_is_set = thread_flag;
-    pthread_mutex_unlock (&thread_flag_mutex);
+    pthread_mutex_unlock (&amp;thread_flag_mutex);
 
     if (flag_is_set)
       do_work ();
@@ -2367,59 +2441,133 @@ void* thread_function (void* thread_arg)
 void set_thread_flag (int flag_value)
 {
   /* Protect the flag with a mutex lock.  */
-  pthread_mutex_lock (&thread_flag_mutex);
+  pthread_mutex_lock (&amp;thread_flag_mutex);
   thread_flag = flag_value;
-  pthread_mutex_unlock (&thread_flag_mutex);
+  pthread_mutex_unlock (&amp;thread_flag_mutex);
 }
-```
+</code></pre>
 
+<p align="justify">
 Una variabile di condizione consente di implementare una condizione in base alla quale un thread viene eseguito e, inversamente, la condizione in base alla quale il thread viene bloccato. Finché ogni thread che potenzialmente modifica il senso della condizione utilizza la variabile di condizione correttamente, Linux garantisce che i thread bloccati sulla condizione verranno sbloccati quando la condizione cambia. Come con un semaforo, un thread può attendere una variabile di condizione. Se il thread A attende una variabile di condizione, viene bloccato finché un altro thread, il thread B, segnala la stessa variabile di condizione. A differenza di un semaforo, una variabile di condizione non ha un contatore o una memoria; il thread A deve attendere la variabile di condizione prima che il thread B la segnali. Se il thread B segnala la variabile di condizione prima che il thread A la attenda, il segnale viene perso e il thread A si blocca finché un altro thread non segnala di nuovo la variabile di condizione. Ecco come utilizzeresti una variabile di condizione per rendere più efficiente l'esempio precedente:
+</p>
 
-* Il ciclo in **thread_function** controlla il flag. Se il flag non è impostato, il thread attende la variabile di condizione.
-* La funzione **set_thread_flag** segnala la variabile di condizione dopo aver modificato il valore del flag. In questo modo, se thread_function è bloccato sulla variabile di condizione, verrà sbloccato e controllerà di nuovo la condizione.
+<ul>
+  <li>
+    <p align="justify">
+    Il ciclo in <strong>thread_function</strong> controlla il flag. Se il flag non è impostato, il thread attende la variabile di condizione.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    La funzione <strong>set_thread_flag</strong> segnala la variabile di condizione dopo aver modificato il valore del flag. In questo modo, se thread_function è bloccato sulla variabile di condizione, verrà sbloccato e controllerà di nuovo la condizione.
+    </p>
+  </li>
+</ul>
 
+<p align="justify">
 C'è un problema con questo: c'è una condizione di competizione tra il controllo del valore del flag e la segnalazione o l'attesa della variabile di condizione. Supponiamo che thread_function abbia controllato il flag e abbia scoperto che non era impostato. In quel momento, lo scheduler di Linux ha messo in pausa quel thread e ha ripreso quello principale. Per una coincidenza, il thread principale è in set_thread_flag. Imposta il flag e quindi segnala la variabile di condizione. Poiché nessun thread è in attesa della variabile di condizione in quel momento (ricorda che thread_function è stato messo in pausa prima di poter attendere la variabile di condizione), il segnale viene perso. Ora, quando Linux riprogramma l'altro thread, inizia ad attendere la variabile di condizione e potrebbe finire bloccato per sempre. Per risolvere questo problema, abbiamo bisogno di un modo per bloccare il flag e la variabile di condizione insieme con un singolo mutex. Fortunatamente, GNU/Linux fornisce esattamente questo meccanismo. Ogni variabile di condizione deve essere utilizzata insieme a un mutex, per impedire questo tipo di race condition. Utilizzando questo schema, la funzione thread segue questi passaggi:
+</p>
 
-1. Il ciclo in thread_function blocca il mutex e legge il valore del flag.
-2. Se il flag è impostato, sblocca il mutex ed esegue la funzione di lavoro.
-3. Se il flag non è impostato, sblocca atomicamente il mutex e attende la variabile di condizione.
+<ol>
+  <li>
+    <p align="justify">
+    Il ciclo in thread_function blocca il mutex e legge il valore del flag.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Se il flag è impostato, sblocca il mutex ed esegue la funzione di lavoro.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Se il flag non è impostato, sblocca atomicamente il mutex e attende la variabile di condizione.
+    </p>
+  </li>
+</ol>
 
-Il punto critico qui è nel passaggio 3, in cui GNU/Linux consente di sbloccare il mutex e attendere la variabile di condizione in modo atomico, senza la possibilità che un altro thread intervenga. Ciò elimina la possibilità che un altro thread possa
-modificare il valore del flag e segnalare la variabile di condizione tra il test del valore del flag e l'attesa della variabile di condizione di thread_function.
+<p align="justify">
+Il punto critico qui è nel passaggio 3, in cui GNU/Linux consente di sbloccare il mutex e attendere la variabile di condizione in modo atomico, senza la possibilità che un altro thread intervenga. Ciò elimina la possibilità che un altro thread possa modificare il valore del flag e segnalare la variabile di condizione tra il test del valore del flag e l'attesa della variabile di condizione di thread_function.
+</p>
 
-Una variabile di condizione è rappresentata da un'istanza di **pthread_cond_t**. Ricorda che **ogni variabile di condizione deve essere accompagnata da un mutex**. Queste sono le funzioni che manipolano le variabili di condizione:
+<p align="justify">
+Una variabile di condizione è rappresentata da un'istanza di <strong>pthread_cond_t</strong>. Ricorda che <strong>ogni variabile di condizione deve essere accompagnata da un mutex</strong>. Queste sono le funzioni che manipolano le variabili di condizione:
+</p>
 
-* **pthread_cond_init()** inizializza una variabile di condizione. Il primo argomento è un puntatore a un'istanza di pthread_cond_t. Il secondo argomento, un puntatore a un oggetto attributo di variabile di condizione, viene ignorato in GNU/Linux.
-   Il mutex deve essere inizializzato separatamente
-   ```c
+<ul>
+  <li>
+    <p align="justify">
+    <strong>pthread_cond_init()</strong> inizializza una variabile di condizione. Il primo argomento è un puntatore a un'istanza di pthread_cond_t. Il secondo argomento, un puntatore a un oggetto attributo di variabile di condizione, viene ignorato in GNU/Linux.
+    </p>
+  </li>
+</ul>
+<p align="justify">
+Il mutex deve essere inizializzato separatamente
+</p>
+<pre><code class="language-c">
    int pthread_cond_init(pthread_cond_t *restrict cond, const pthread_condattr_t *restrict attr);
-   ```
-* **pthread_cond_signal()** segnala una variabile di condizione. Un singolo thread bloccato sulla variabile di condizione verrà sbloccato. Se nessun altro thread è bloccato sulla variabile di condizione, il segnale viene ignorato. L'argomento è un puntatore all'istanza di
-  pthread_cond_t. Una chiamata simile, **pthread_cond_broadcast()**, sblocca tutti i thread bloccati sulla variabile di condizione, invece di uno solo.
+</code></pre>
+<ul>
+  <li>
+    <p align="justify">
+    <strong>pthread_cond_signal()</strong> segnala una variabile di condizione. Un singolo thread bloccato sulla variabile di condizione verrà sbloccato. Se nessun altro thread è bloccato sulla variabile di condizione, il segnale viene ignorato. L'argomento è un puntatore all'istanza di
+    </p>
+  </li>
+</ul>
+<p align="justify">
+pthread_cond_t. Una chiamata simile, <strong>pthread_cond_broadcast()</strong>, sblocca tutti i thread bloccati sulla variabile di condizione, invece di uno solo.
+</p>
 
-  ```c
+<pre><code class="language-c">
   int pthread_cond_signal(pthread_cond_t *cond);
-  ```
+</code></pre>
 
-  ```c
+<pre><code class="language-c">
   int pthread_cond_broadcast(pthread_cond_t *cond);
-  ```
-* **pthread_cond_wait()** blocca il thread chiamante finché la variabile di condizione non viene segnalata. L'argomento è un puntatore all'istanza pthread_cond_t. Il secondo argomento è un puntatore all'istanza del mutex pthread_mutex_t. Quando viene chiamata pthread_cond_wait, il mutex deve essere già bloccato dal thread chiamante. Quella funzione sblocca atomicamente il mutex e blocca la variabile di condizione. Quando la variabile di condizione viene segnalata e il thread chiamante si sblocca, pthread_cond_wait riacquisisce automaticamente un blocco sul mutex.
-  ```c
+</code></pre>
+<ul>
+  <li>
+    <p align="justify">
+    <strong>pthread_cond_wait()</strong> blocca il thread chiamante finché la variabile di condizione non viene segnalata. L'argomento è un puntatore all'istanza pthread_cond_t. Il secondo argomento è un puntatore all'istanza del mutex pthread_mutex_t. Quando viene chiamata pthread_cond_wait, il mutex deve essere già bloccato dal thread chiamante. Quella funzione sblocca atomicamente il mutex e blocca la variabile di condizione. Quando la variabile di condizione viene segnalata e il thread chiamante si sblocca, pthread_cond_wait riacquisisce automaticamente un blocco sul mutex.
+    </p>
+  </li>
+</ul>
+<pre><code class="language-c">
   int pthread_cond_wait(pthread_cond_t *restrict cond, pthread_mutex_t *restrict mutex);
-  ```
+</code></pre>
   
-Ogni volta che il programma esegue un'azione che potrebbe cambiare il senso della condizione che stai proteggendo con la variabile di condizione, dovrebbe eseguire questi passaggi. (Nel
-nostro esempio, la condizione è lo stato del flag del thread, quindi questi passaggi devono essere eseguiti ogni volta che il flag viene modificato.)
+<p align="justify">
+Ogni volta che il programma esegue un'azione che potrebbe cambiare il senso della condizione che stai proteggendo con la variabile di condizione, dovrebbe eseguire questi passaggi. (Nel nostro esempio, la condizione è lo stato del flag del thread, quindi questi passaggi devono essere eseguiti ogni volta che il flag viene modificato.)
+</p>
 
-1. Bloccare il mutex che accompagna la variabile di condizione.
-2. Eseguire l'azione che potrebbe modificare il senso della condizione (nel nostro esempio, impostare il flag).
-3. Segnalare o trasmettere la variabile di condizione, a seconda del comportamento desiderato.
-4. Sbloccare il mutex che accompagna la variabile di condizione.
+<ol>
+  <li>
+    <p align="justify">
+    Bloccare il mutex che accompagna la variabile di condizione.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Eseguire l'azione che potrebbe modificare il senso della condizione (nel nostro esempio, impostare il flag).
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Segnalare o trasmettere la variabile di condizione, a seconda del comportamento desiderato.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Sbloccare il mutex che accompagna la variabile di condizione.
+    </p>
+  </li>
+</ol>
 
-Il codice seguente mostra di nuovo l'esempio precedente, che ora utilizza una variabile di condizione per proteggere il flag del thread. In `thread_function`, un blocco sul mutex viene mantenuto prima di controllare il valore di `thread_flag`. Tale blocco viene automaticamente rilasciato da `pthread_cond_wait` prima dell'attesa e riacquisito subito dopo. Notare inoltre che `set_thread_flag` blocca il mutex prima di impostare il valore di `thread_flag` e di segnalare il mutex.
+<p align="justify">
+Il codice seguente mostra di nuovo l'esempio precedente, che ora utilizza una variabile di condizione per proteggere il flag del thread. In <code>thread_function</code>, un blocco sul mutex viene mantenuto prima di controllare il valore di <code>thread_flag</code>. Tale blocco viene automaticamente rilasciato da <code>pthread_cond_wait</code> prima dell'attesa e riacquisito subito dopo. Notare inoltre che <code>set_thread_flag</code> blocca il mutex prima di impostare il valore di <code>thread_flag</code> e di segnalare il mutex.
+</p>
 
-```c
+<pre><code class="language-c">
 
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
@@ -2427,7 +2575,7 @@ Il codice seguente mostra di nuovo l'esempio precedente, che ora utilizza una va
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <pthread.h>
+#include &lt;pthread.h&gt;
 
 extern void do_work ();
 
@@ -2438,8 +2586,8 @@ pthread_mutex_t thread_flag_mutex;
 void initialize_flag ()
 {
   /* Initialize the mutex and condition variable.  */
-  pthread_mutex_init (&thread_flag_mutex, NULL);
-  pthread_cond_init (&thread_flag_cv, NULL);
+  pthread_mutex_init (&amp;thread_flag_mutex, NULL);
+  pthread_cond_init (&amp;thread_flag_cv, NULL);
   /* Initialize the flag value.  */
   thread_flag = 0;
 }
@@ -2452,16 +2600,16 @@ void* thread_function (void* thread_arg)
   /* Loop infinitely.  */
   while (1) {
     /* Lock the mutex before accessing the flag value.  */
-    pthread_mutex_lock (&thread_flag_mutex);
+    pthread_mutex_lock (&amp;thread_flag_mutex);
     while (!thread_flag) 
       /* The flag is clear.  Wait for a signal on the condition
 	 variable, indicating the flag value has changed.  When the
 	 signal arrives and this thread unblocks, loop and check the
 	 flag again.  */
-      pthread_cond_wait (&thread_flag_cv, &thread_flag_mutex);
+      pthread_cond_wait (&amp;thread_flag_cv, &amp;thread_flag_mutex);
     /* When we've gotten here, we know the flag must be set.  Unlock
        the mutex.  */
-    pthread_mutex_unlock (&thread_flag_mutex);
+    pthread_mutex_unlock (&amp;thread_flag_mutex);
     /* Do some work.  */
     do_work ();
   }
@@ -2473,38 +2621,44 @@ void* thread_function (void* thread_arg)
 void set_thread_flag (int flag_value)
 {
   /* Lock the mutex before accessing the flag value.  */
-  pthread_mutex_lock (&thread_flag_mutex);
+  pthread_mutex_lock (&amp;thread_flag_mutex);
   /* Set the flag value, and then signal in case thread_function is
      blocked, waiting for the flag to become set.  However,
      thread_function can't actually check the flag until the mutex is
      unlocked.  */
   thread_flag = flag_value;
-  pthread_cond_signal (&thread_flag_cv);
+  pthread_cond_signal (&amp;thread_flag_cv);
   /* Unlock the mutex.  */
-  pthread_mutex_unlock (&thread_flag_mutex);
+  pthread_mutex_unlock (&amp;thread_flag_mutex);
 }
-```
+</code></pre>
 
+<p align="justify">
 La condizione protetta da una variabile di condizione può essere arbitrariamente complessa. Tuttavia, prima di eseguire qualsiasi operazione che possa modificare il senso della condizione, dovrebbe essere richiesto un blocco mutex e la variabile di condizione dovrebbe essere segnalata in seguito. Una variabile di condizione può anche essere utilizzata senza una condizione, semplicemente come meccanismo per bloccare un thread finché un altro thread non lo "sveglia". Anche un semaforo può essere utilizzato a tale scopo. La differenza principale è che un semaforo "ricorda" la chiamata di sveglia anche se nessun thread è stato bloccato su di esso in quel momento, mentre una variabile di condizione scarta la chiamata di sveglia a meno che un thread non sia effettivamente bloccato su di essa in quel momento. Inoltre, un semaforo fornisce solo una singola sveglia per post; con pthread_cond_broadcast, un numero arbitrario e sconosciuto di thread bloccati può essere risvegliato contemporaneamente.
+</p>
 
 ### Deadlocks con due o più Thread
 
-I deadlock possono verificarsi quando due (o più) thread sono bloccati, in attesa che si verifichi una condizione che solo l'altro può causare. Ad esempio, se il thread A è bloccato su una variabile di condizione in attesa che il thread B lo segnali, e il thread B è bloccato su una variabile di condizione in attesa che il thread A lo segnali, si è verificato un deadlock perché nessuno dei due thread segnalerà mai l'altro. Dovresti fare attenzione a evitare la possibilità di tali situazioni perché sono piuttosto difficili da rilevare. Un errore comune che può causare un deadlock riguarda un problema in cui più thread stanno tentando di bloccare lo stesso set di oggetti. Ad esempio, considera un programma in cui due thread diversi, che eseguono due funzioni di thread diverse, devono bloccare gli stessi due mutex. Supponiamo che il thread A blocchi il mutex 1 e poi il mutex 2, e che il thread B blocchi il mutex 2 prima del mutex 1. In uno scenario di pianificazione sufficientemente sfortunato, Linux potrebbe pianificare il thread A abbastanza a lungo da bloccare il mutex 1, e quindi pianificare il thread B, che blocca prontamente il mutex 2. Ora nessuno dei due thread può procedere perché ognuno è bloccato su un mutex che l'altro thread tiene bloccato. Questo è un esempio di un problema di deadlock più generale, che può coinvolgere non solo oggetti di sincronizzazione come i mutex, ma anche altre risorse, come blocchi su file o dispositivi. Il problema si verifica quando più thread tentano di bloccare lo stesso set di risorse in ordini diversi. **La soluzione è assicurarsi che tutti i thread che bloccano più risorse le blocchino nello stesso ordine**.
+<p align="justify">
+I deadlock possono verificarsi quando due (o più) thread sono bloccati, in attesa che si verifichi una condizione che solo l'altro può causare. Ad esempio, se il thread A è bloccato su una variabile di condizione in attesa che il thread B lo segnali, e il thread B è bloccato su una variabile di condizione in attesa che il thread A lo segnali, si è verificato un deadlock perché nessuno dei due thread segnalerà mai l'altro. Dovresti fare attenzione a evitare la possibilità di tali situazioni perché sono piuttosto difficili da rilevare. Un errore comune che può causare un deadlock riguarda un problema in cui più thread stanno tentando di bloccare lo stesso set di oggetti. Ad esempio, considera un programma in cui due thread diversi, che eseguono due funzioni di thread diverse, devono bloccare gli stessi due mutex. Supponiamo che il thread A blocchi il mutex 1 e poi il mutex 2, e che il thread B blocchi il mutex 2 prima del mutex 1. In uno scenario di pianificazione sufficientemente sfortunato, Linux potrebbe pianificare il thread A abbastanza a lungo da bloccare il mutex 1, e quindi pianificare il thread B, che blocca prontamente il mutex 2. Ora nessuno dei due thread può procedere perché ognuno è bloccato su un mutex che l'altro thread tiene bloccato. Questo è un esempio di un problema di deadlock più generale, che può coinvolgere non solo oggetti di sincronizzazione come i mutex, ma anche altre risorse, come blocchi su file o dispositivi. Il problema si verifica quando più thread tentano di bloccare lo stesso set di risorse in ordini diversi. <strong>La soluzione è assicurarsi che tutti i thread che bloccano più risorse le blocchino nello stesso ordine</strong>.
+</p>
 
 ### Implementazione dei Thread in GNU/Linux
 
-L'implementazione dei thread POSIX su GNU/Linux differisce dall'implementazione dei thread su molti altri sistemi simili a UNIX in un modo importante: su GNU/Linux, **i thread sono implementati come processi**. Ogni volta che chiami `pthread_create` per creare un nuovo thread, Linux crea un nuovo processo che esegue quel thread. Tuttavia, questo processo non è lo stesso di un processo che creeresti con `fork`; in particolare, condivide lo stesso spazio di indirizzamento e le stesse risorse del processo originale invece di ricevere copie. Il codice seguente lo dimostra. Il programma crea un thread; sia il thread originale che quello nuovo chiamano la funzione `getpid` e stampano i rispettivi ID di processo e quindi restano in attesa all'infinito.
+<p align="justify">
+L'implementazione dei thread POSIX su GNU/Linux differisce dall'implementazione dei thread su molti altri sistemi simili a UNIX in un modo importante: su GNU/Linux, <strong>i thread sono implementati come processi</strong>. Ogni volta che chiami <code>pthread_create</code> per creare un nuovo thread, Linux crea un nuovo processo che esegue quel thread. Tuttavia, questo processo non è lo stesso di un processo che creeresti con <code>fork</code>; in particolare, condivide lo stesso spazio di indirizzamento e le stesse risorse del processo originale invece di ricevere copie. Il codice seguente lo dimostra. Il programma crea un thread; sia il thread originale che quello nuovo chiamano la funzione <code>getpid</code> e stampano i rispettivi ID di processo e quindi restano in attesa all'infinito.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <pthread.h>
-#include <stdio.h>
-#include <unistd.h>
+#include &lt;pthread.h&gt;
+#include &lt;stdio.h&gt;
+#include &lt;unistd.h&gt;
 
 void* thread_function (void* arg)
 {
@@ -2518,19 +2672,21 @@ int main ()
 {
   pthread_t thread;
   fprintf (stderr, "main thread pid is %d\n", (int) getpid ());
-  pthread_create (&thread, NULL, &thread_function, NULL);
+  pthread_create (&amp;thread, NULL, &amp;thread_function, NULL);
   /* Spin forever.  */
   while (1);
   return 0;
 }
-```
+</code></pre>
 
-Esegui il programma in background, quindi richiama `ps x` per visualizzare i processi in esecuzione. Non dimenticare di terminare il programma thread-pid in seguito: consuma molta CPU senza fare nulla. Ecco come potrebbe apparire l'output:
+<p align="justify">
+Esegui il programma in background, quindi richiama <code>ps x</code> per visualizzare i processi in esecuzione. Non dimenticare di terminare il programma thread-pid in seguito: consuma molta CPU senza fare nulla. Ecco come potrebbe apparire l'output:
+</p>
 
-```bash
+<pre><code class="language-bash">
  % gcc -o thread-pid thread-pid.c -lpthread
 
- % ./thread-pid &
+ % ./thread-pid &amp;
  [1] 14608
  main thread pid is 14608
  child thread pid is 14610
@@ -2545,37 +2701,80 @@ Esegui il programma in background, quindi richiama `ps x` per visualizzare i pro
 
  % kill 14608
  [1]+  Terminated              ./thread-pid
-```
+</code></pre>
 
-> [!NOTE]
-> Notifica del controllo del job nella shell
-> Le righe che iniziano con [1] provengono dalla shell. Quando esegui un programma in background, la shell gli assegna un numero di job, in questo caso 1, e stampa il pid del programma. Se un job in background termina, la shell segnala tale fatto la volta successiva che invochi un comando
+<table align="center">
+	<td>:pill: <b>Nota</b>
+`t<p align=justify>
+ Notifica del controllo del job nella shell
+`t</p>
+`t<p align=justify>
+ Le righe che iniziano con [1] provengono dalla shell. Quando esegui un programma in background, la shell gli assegna un numero di job, in questo caso 1, e stampa il pid del programma. Se un job in background termina, la shell segnala tale fatto la volta successiva che invochi un comando
+`t</p>
+`t</td>
+</table>
 
+<p align="justify">
 Nota che ci sono tre processi che eseguono il programma thread-pid. Il primo di questi, con pid 14608, è il thread principale nel programma; il terzo, con pid 14610, è il thread che abbiamo creato per eseguire thread_function. E il secondo thread, con pid 14609? Questo è il "thread del gestore", che fa parte dell'implementazione interna dei thread GNU/Linux. Il thread del gestore viene creato la prima volta che un programma chiama pthread_create per creare un nuovo thread.
+</p>
 
 ### Signal Handling
 
-Supponiamo che un programma multithread riceva un segnale. In quale thread viene invocato il gestore del segnale? Il comportamento dell'interazione tra segnali e thread varia da un sistema UNIX a un altro. In GNU/Linux, il comportamento è dettato dal fatto che i thread sono implementati come processi. Poiché ogni thread è un processo separato e poiché un segnale viene inviato a un processo particolare, non vi è ambiguità su quale thread riceva il segnale. In genere, i segnali inviati dall'esterno del programma vengono inviati al processo corrispondente al thread principale del programma. Ad esempio, se un programma si biforca e il processo figlio esegue un programma multithread, il processo padre conterrà l'ID processo del thread principale del programma del processo figlio e utilizzerà tale ID processo per inviare segnali al suo figlio. Questa è in genere una buona convenzione da seguire quando si inviano segnali a un programma multithread. Si noti che questo aspetto dell'implementazione di pthreads di GNU/Linux è in contrasto
-con lo standard di thread POSIX. Non fare affidamento su questo comportamento in programmi che sono
-pensati per essere portabili. All'interno di un programma multithread, è possibile che un thread invii un segnale specificamente a un altro thread. Utilizzare la funzione **pthread_kill()** per farlo. Il suo primo parametro è un ID thread e il suo secondo parametro è il numero del segnale
+<p align="justify">
+Supponiamo che un programma multithread riceva un segnale. In quale thread viene invocato il gestore del segnale? Il comportamento dell'interazione tra segnali e thread varia da un sistema UNIX a un altro. In GNU/Linux, il comportamento è dettato dal fatto che i thread sono implementati come processi. Poiché ogni thread è un processo separato e poiché un segnale viene inviato a un processo particolare, non vi è ambiguità su quale thread riceva il segnale. In genere, i segnali inviati dall'esterno del programma vengono inviati al processo corrispondente al thread principale del programma. Ad esempio, se un programma si biforca e il processo figlio esegue un programma multithread, il processo padre conterrà l'ID processo del thread principale del programma del processo figlio e utilizzerà tale ID processo per inviare segnali al suo figlio. Questa è in genere una buona convenzione da seguire quando si inviano segnali a un programma multithread. Si noti che questo aspetto dell'implementazione di pthreads di GNU/Linux è in contrasto con lo standard di thread POSIX. Non fare affidamento su questo comportamento in programmi che sono pensati per essere portabili. All'interno di un programma multithread, è possibile che un thread invii un segnale specificamente a un altro thread. Utilizzare la funzione <strong>pthread_kill()</strong> per farlo. Il suo primo parametro è un ID thread e il suo secondo parametro è il numero del segnale
+</p>
 
-```c
+<pre><code class="language-c">
 pthread_kill(pthread_t thread, int sig);
-```
+</code></pre>
 
 ### La chiamata di sistema Clone()
-Sebbene i thread GNU/Linux creati nello stesso programma siano implementati come processi separati, condividono il loro spazio di memoria virtuale e altre risorse. Un processo figlio creato con `fork()`, tuttavia, ottiene copie di questi elementi. Come viene creato il primo tipo di processo? La chiamata di sistema `clone()` di Linux è una forma generalizzata di `fork()` e `pthread_create()` che consente al chiamante di specificare quali risorse sono condivise tra il processo chiamante e il processo appena creato. Inoltre, `clone()` richiede di specificare la regione di memoria per lo stack di esecuzione che il nuovo processo utilizzerà. Sebbene menzioniamo `clone()` qui per soddisfare la curiosità del lettore, quella chiamata di sistema non dovrebbe essere normalmente utilizzata nei programmi. Utilizzare `fork()` per creare nuovi processi o `pthread_create()` per creare thread.
+<p align="justify">
+Sebbene i thread GNU/Linux creati nello stesso programma siano implementati come processi separati, condividono il loro spazio di memoria virtuale e altre risorse. Un processo figlio creato con <code>fork()</code>, tuttavia, ottiene copie di questi elementi. Come viene creato il primo tipo di processo? La chiamata di sistema <code>clone()</code> di Linux è una forma generalizzata di <code>fork()</code> e <code>pthread_create()</code> che consente al chiamante di specificare quali risorse sono condivise tra il processo chiamante e il processo appena creato. Inoltre, <code>clone()</code> richiede di specificare la regione di memoria per lo stack di esecuzione che il nuovo processo utilizzerà. Sebbene menzioniamo <code>clone()</code> qui per soddisfare la curiosità del lettore, quella chiamata di sistema non dovrebbe essere normalmente utilizzata nei programmi. Utilizzare <code>fork()</code> per creare nuovi processi o <code>pthread_create()</code> per creare thread.
+</p>
 
 ### Processi vs Thread
 
+<p align="justify">
 Per alcuni programmi che traggono vantaggio dalla concorrenza, la decisione se utilizzare processi o thread può essere difficile. Ecco alcune linee guida per aiutarti a decidere quale modello di concorrenza si adatta meglio al tuo programma:
+</p>
 
-* Tutti i thread in un programma devono eseguire lo stesso eseguibile. Un processo figlio, d'altra parte, può eseguire un eseguibile diverso chiamando una funzione exec.
-* Un thread difettoso può danneggiare altri thread nello stesso processo perché i thread condividono lo stesso spazio di memoria virtuale e altre risorse. Ad esempio, una scrittura di memoria selvaggia tramite un puntatore non inizializzato in un thread può danneggiare
+<ul>
+  <li>
+    <p align="justify">
+    Tutti i thread in un programma devono eseguire lo stesso eseguibile. Un processo figlio, d'altra parte, può eseguire un eseguibile diverso chiamando una funzione exec.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Un thread difettoso può danneggiare altri thread nello stesso processo perché i thread condividono lo stesso spazio di memoria virtuale e altre risorse. Ad esempio, una scrittura di memoria selvaggia tramite un puntatore non inizializzato in un thread può danneggiare
+    </p>
+  </li>
+</ul>
+<p align="justify">
 la memoria visibile a un altro thread. Un processo separato, d'altra parte, non può farlo perché ogni processo ha una copia dello spazio di memoria del programma.
-* La copia della memoria per un nuovo processo aggiunge un ulteriore sovraccarico di prestazioni rispetto alla creazione di un nuovo thread. Tuttavia, la copia viene eseguita solo quando la memoria viene modificata, quindi la penalità è minima se il processo figlio legge solo
+</p>
+<ul>
+  <li>
+    <p align="justify">
+    La copia della memoria per un nuovo processo aggiunge un ulteriore sovraccarico di prestazioni rispetto alla creazione di un nuovo thread. Tuttavia, la copia viene eseguita solo quando la memoria viene modificata, quindi la penalità è minima se il processo figlio legge solo
+    </p>
+  </li>
+</ul>
+<p align="justify">
 la memoria.
-* I thread dovrebbero essere utilizzati per i programmi che necessitano di un parallelismo a grana fine. Ad esempio, se un problema può essere suddiviso in più attività quasi identiche, i thread potrebbero essere una buona scelta. I processi dovrebbero essere utilizzati per i programmi che necessitano di un parallelismo più grossolano.
-* La condivisione dei dati tra thread è banale perché i thread condividono la stessa memoria. (Tuttavia, è necessario prestare molta attenzione per evitare race condition, come descritto in precedenza.) La condivisione dei dati tra processi richiede l'uso di meccanismi IPC. Ciò può essere più macchinoso, ma rende i processi multipli meno inclini a soffrire di bug di concorrenza
+</p>
+<ul>
+  <li>
+    <p align="justify">
+    I thread dovrebbero essere utilizzati per i programmi che necessitano di un parallelismo a grana fine. Ad esempio, se un problema può essere suddiviso in più attività quasi identiche, i thread potrebbero essere una buona scelta. I processi dovrebbero essere utilizzati per i programmi che necessitano di un parallelismo più grossolano.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    La condivisione dei dati tra thread è banale perché i thread condividono la stessa memoria. (Tuttavia, è necessario prestare molta attenzione per evitare race condition, come descritto in precedenza.) La condivisione dei dati tra processi richiede l'uso di meccanismi IPC. Ciò può essere più macchinoso, ma rende i processi multipli meno inclini a soffrire di bug di concorrenza
+    </p>
+  </li>
+</ul>
 
 

--- a/LINUX_PROGRAMMING.md
+++ b/LINUX_PROGRAMMING.md
@@ -150,30 +150,57 @@ int main ()
 
 ### Vedere i processi attivi
 
-Il comando **ps** mostra i processi attivi sul sistema.
+<p align="justify">
+Il comando <strong>ps</strong> mostra i processi attivi sul sistema.
+</p>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/0_processes$ ps
     PID TTY          TIME CMD
    1331 pts/0    00:00:00 bash
    1421 pts/0    00:00:00 ps
- ```
+</code></pre>
 
-Sembra che ci siano due processi attivi sul sistema: il primo è **bash** e il secondo è **ps**, che abbiamo lanciato. La prima colonna mostra il **PID** dei processi attivi. Per maggiori dettagli possiamo digitare:
+<p align="justify">
+Sembra che ci siano due processi attivi sul sistema: il primo è <strong>bash</strong> e il secondo è <strong>ps</strong>, che abbiamo lanciato. La prima colonna mostra il <strong>PID</strong> dei processi attivi. Per maggiori dettagli possiamo digitare:
+</p>
 
-```bash
+<pre><code class="language-bash">
 ps -e -o pid,ppid,command
-```
+</code></pre>
 
-| Opzione  | Significato |
-| ------------- | ------------- |
-| `-e`  | mostra tutti i processi attivi sul sistema non solo quelli dell'utente corrente  |
-| `-o`  | specifica quali informazioni mostrare per il singolo processo  |
-| `pid`  | mostra il **pid**  |
-| `ppid`  | mostra il **ppid**  |
-| `command`  | mostra il programma eseguito dal processo |
+<table align="center">
+  <thead>
+    <tr>
+      <th>Opzione</th>
+      <th>Significato</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>-e</code></td>
+      <td>mostra tutti i processi attivi sul sistema non solo quelli dell'utente corrente</td>
+    </tr>
+    <tr>
+      <td><code>-o</code></td>
+      <td>specifica quali informazioni mostrare per il singolo processo</td>
+    </tr>
+    <tr>
+      <td><code>pid</code></td>
+      <td>mostra il <strong>pid</strong></td>
+    </tr>
+    <tr>
+      <td><code>ppid</code></td>
+      <td>mostra il <strong>ppid</strong></td>
+    </tr>
+    <tr>
+      <td><code>command</code></td>
+      <td>mostra il programma eseguito dal processo</td>
+    </tr>
+  </tbody>
+</table>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/0_processes$ ps -e -o pid,ppid,command
     PID    PPID COMMAND
       1       0 /sbin/init =
@@ -277,28 +304,34 @@ vagrant@ubuntu2204:/lab2/0_processes$ ps -e -o pid,ppid,command
    1429       2 [kworker/1:3-events]
    1453       2 [kworker/u4:0-events_unbound]
    1455    1331 ps -e -o pid,ppid,command
-```
+</code></pre>
 
 ### Uccidere un processo
 
-è possibile uccidere un processo con il comando `kill`. Indica sulla riga di comando il PID del processo che deve essere terminato. Il comando `kill` invia al processo un segnale `SIGTERM`. La ricezione di questo segnale determina (a meno che il processo non gestisca il segnale o lo ignori) la sua terminazione.
+<p align="justify">
+è possibile uccidere un processo con il comando <code>kill</code>. Indica sulla riga di comando il PID del processo che deve essere terminato. Il comando <code>kill</code> invia al processo un segnale <code>SIGTERM</code>. La ricezione di questo segnale determina (a meno che il processo non gestisca il segnale o lo ignori) la sua terminazione.
+</p>
 
 ### Creare un processo
 
+<p align="justify">
 Ci sono due modi per creare un processo: il primo è relativamente semplice ma inefficiente e rischioso dal punto di vista della sicurezza; il secondo è più complesso ma fornisce maggiore sicurezza e flessibilità.
+</p>
 
 #### `system()`
 
-La funzione `system()` è fornita nella libreria standard del linguaggio C e permette di eseguire un comando all'interno di un programma come se fosse stato digitato direttamente in una shell. La funzione `system()` crea un sottoprocesso lanciando `/bin/sh`. Per esempio, il codice seguente invoca il comando `ls` per mostrare il contenuto della root directory come se si fosse digitato `ls -l /` direttamente dalla shell.
+<p align="justify">
+La funzione <code>system()</code> è fornita nella libreria standard del linguaggio C e permette di eseguire un comando all'interno di un programma come se fosse stato digitato direttamente in una shell. La funzione <code>system()</code> crea un sottoprocesso lanciando <code>/bin/sh</code>. Per esempio, il codice seguente invoca il comando <code>ls</code> per mostrare il contenuto della root directory come se si fosse digitato <code>ls -l /</code> direttamente dalla shell.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <stdlib.h>
+#include &lt;stdlib.h&gt;
 
 int main ()
 {
@@ -306,24 +339,28 @@ int main ()
   return_value = system ("ls -l /");
   return return_value;
 }
-```
+</code></pre>
 
 ### `fork()` `exec()`
 
-La system call `fork()` crea un nuovo processo che è la copia del processo padre. La `exec()` permette di sostituire il processo figlio con un nuovo programma nel processo appena creato da `fork()`.
+<p align="justify">
+La system call <code>fork()</code> crea un nuovo processo che è la copia del processo padre. La <code>exec()</code> permette di sostituire il processo figlio con un nuovo programma nel processo appena creato da <code>fork()</code>.
+</p>
 
-Per distinguere il padre dal figlio, la funzione `fork()` restituisce un intero: in particolare restituisce zero al processo figlio e il **PID** del processo figlio al processo padre.
+<p align="justify">
+Per distinguere il padre dal figlio, la funzione <code>fork()</code> restituisce un intero: in particolare restituisce zero al processo figlio e il <strong>PID</strong> del processo figlio al processo padre.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <stdio.h>
-#include <sys/types.h>
-#include <unistd.h>
+#include &lt;stdio.h&gt;
+#include &lt;sys/types.h&gt;
+#include &lt;unistd.h&gt;
 
 int main ()
 {
@@ -341,28 +378,45 @@ int main ()
 
   return 0;
 }
-```
+</code></pre>
 
-Nota che il codice all'interno del blocco `if` è eseguito solo dal processo padre, mentre il codice dentro il blocco `else` è eseguito dal processo figlio.
+<p align="justify">
+Nota che il codice all'interno del blocco <code>if</code> è eseguito solo dal processo padre, mentre il codice dentro il blocco <code>else</code> è eseguito dal processo figlio.
+</p>
 
-La system call `exec()` sostituisce il programma in esecuzione nel processo con un nuovo programma. Quando un programma richiama la `exec()`, il processo smette immediatamente di eseguire il programma precedente e inizia l'esecuzione del nuovo programma richiamato dalla `exec()`.
-Ci sono diverse versioni della `exec()`:
+<p align="justify">
+La system call <code>exec()</code> sostituisce il programma in esecuzione nel processo con un nuovo programma. Quando un programma richiama la <code>exec()</code>, il processo smette immediatamente di eseguire il programma precedente e inizia l'esecuzione del nuovo programma richiamato dalla <code>exec()</code>. Ci sono diverse versioni della <code>exec()</code>:
+</p>
 
-* Le funzioni che contengono la lettera `p` nel nome (`execvp`, `execlp`) accettano il nome del programma e lo cercano nel sistema; le funzioni che non contengono la `p` nel nome necessitano del percorso assoluto del programma da eseguire.
-* Le funzioni che contengono la lettera `v` nel nome (`execv`, `execvp`, `execve`) accettano una lista di argomenti da passare in ingresso al nuovo programma come un array di puntatori a caratteri terminati da `NULL`. Le funzioni che contengono la lettera `l` (`execl`, `execlp`, `execle`) accettano una lista di argomenti in ingresso secondo il meccanismo delle variadic del linguaggio C.
-* Le funzioni che contengono la lettera `e` nel nome (`execve`, `execle`) accettano un argomento in più: un array di variabili d'ambiente. L'argomento dovrebbe essere un array di puntatori a caratteri terminato da `NULL`, e ciascuna stringa dovrebbe essere nella forma `VARIABILE=valore`.
+<ul>
+  <li>
+    <p align="justify">
+    Le funzioni che contengono la lettera <code>p</code> nel nome (<code>execvp</code>, <code>execlp</code>) accettano il nome del programma e lo cercano nel sistema; le funzioni che non contengono la <code>p</code> nel nome necessitano del percorso assoluto del programma da eseguire.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Le funzioni che contengono la lettera <code>v</code> nel nome (<code>execv</code>, <code>execvp</code>, <code>execve</code>) accettano una lista di argomenti da passare in ingresso al nuovo programma come un array di puntatori a caratteri terminati da <code>NULL</code>. Le funzioni che contengono la lettera <code>l</code> (<code>execl</code>, <code>execlp</code>, <code>execle</code>) accettano una lista di argomenti in ingresso secondo il meccanismo delle variadic del linguaggio C.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Le funzioni che contengono la lettera <code>e</code> nel nome (<code>execve</code>, <code>execle</code>) accettano un argomento in più: un array di variabili d'ambiente. L'argomento dovrebbe essere un array di puntatori a caratteri terminato da <code>NULL</code>, e ciascuna stringa dovrebbe essere nella forma <code>VARIABILE=valore</code>.
+    </p>
+  </li>
+</ul>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/types.h>
-#include <unistd.h>
+#include &lt;stdio.h&gt;
+#include &lt;stdlib.h&gt;
+#include &lt;sys/types.h&gt;
+#include &lt;unistd.h&gt;
 
 /* Spawn a child process running a new program.  PROGRAM is the name
    of the program to run; the path will be searched for this program.
@@ -406,25 +460,27 @@ int main ()
 
   return 0;
 }
-```
+</code></pre>
 
+<p align="justify">
 Eseguendo il programma ti accorgerai che il processo padre termina immediatamente ("done with the main program") successivamente viene stampato il prompt e poco dopo l'output del processo figlio sporca il terminale perché continua a scrivere sullo stdout. In generale non è possibile sapere quale processo tra il padre ed il figlio concluda per primo ma vedremo che è possibile sincronizzare l'esecuzione dei due processi facendo in modo che il processo padre attenda la terminazione dei suoi figli prima di concludere la propria esecuzione.
+</p>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/0_processes$ bin/3_fork_exec
 done with main program
 vagrant@ubuntu2204:/lab2/0_processes$ total 2097224
-lrwxrwxrwx   1 root    root             7 Aug 10  2023 bin -> usr/bin
+lrwxrwxrwx   1 root    root             7 Aug 10  2023 bin -&gt; usr/bin
 drwxr-xr-x   4 root    root          4096 Jan 11  2024 boot
 drwxr-xr-x  19 root    root          3980 Aug 12 08:33 dev
 drwxr-xr-x 104 root    root          4096 Aug 12 08:33 etc
 drwxr-xr-x   3 root    root          4096 Jan 10  2024 home
 drwxrwxrwx   1 vagrant vagrant       4096 Aug  9 07:23 lab
 drwxrwxrwx   1 vagrant vagrant          0 Aug 12 08:30 lab2
-lrwxrwxrwx   1 root    root             7 Aug 10  2023 lib -> usr/lib
-lrwxrwxrwx   1 root    root             9 Aug 10  2023 lib32 -> usr/lib32
-lrwxrwxrwx   1 root    root             9 Aug 10  2023 lib64 -> usr/lib64
-lrwxrwxrwx   1 root    root            10 Aug 10  2023 libx32 -> usr/libx32
+lrwxrwxrwx   1 root    root             7 Aug 10  2023 lib -&gt; usr/lib
+lrwxrwxrwx   1 root    root             9 Aug 10  2023 lib32 -&gt; usr/lib32
+lrwxrwxrwx   1 root    root             9 Aug 10  2023 lib64 -&gt; usr/lib64
+lrwxrwxrwx   1 root    root            10 Aug 10  2023 libx32 -&gt; usr/libx32
 drwx------   2 root    root         16384 Jan 10  2024 lost+found
 drwxr-xr-x   2 root    root          4096 Aug 10  2023 media
 drwxr-xr-x   2 root    root          4096 Aug 10  2023 mnt
@@ -432,7 +488,7 @@ drwxr-xr-x   2 root    root          4096 Aug 10  2023 opt
 dr-xr-xr-x 162 root    root             0 Aug 12 08:32 proc
 drwx------   5 root    root          4096 Jan 11  2024 root
 drwxr-xr-x  28 root    root           840 Aug 12 10:37 run
-lrwxrwxrwx   1 root    root             8 Aug 10  2023 sbin -> usr/sbin
+lrwxrwxrwx   1 root    root             8 Aug 10  2023 sbin -&gt; usr/sbin
 drwxr-xr-x   6 root    root          4096 Jul  7 07:31 snap
 drwxr-xr-x   2 root    root          4096 Aug 10  2023 srv
 -rw-------   1 root    root    2147483648 Jan 10  2024 swap.img
@@ -440,49 +496,118 @@ dr-xr-xr-x  13 root    root             0 Aug 12 08:32 sys
 drwxrwxrwt  12 root    root          4096 Aug 12 16:36 tmp
 drwxr-xr-x  14 root    root          4096 Aug 10  2023 usr
 drwxr-xr-x  13 root    root          4096 Aug 10  2023 var
-```
+</code></pre>
 
 #### Segnali
 
-I segnali sono un meccanismo per comunicare e manipolare i processi in Linux. Un segnale è semplicemente un messaggio inviato a un processo. In Linux sono definiti in `/usr/include/bits/signum.h`, ma per usarli basta includere `<signal.h>` nel codice sorgente.
+<p align="justify">
+I segnali sono un meccanismo per comunicare e manipolare i processi in Linux. Un segnale è semplicemente un messaggio inviato a un processo. In Linux sono definiti in <code>/usr/include/bits/signum.h</code>, ma per usarli basta includere <code>&lt;signal.h&gt;</code> nel codice sorgente.
+</p>
 
+<p align="justify">
 Quando un processo riceve un segnale può comportarsi in modi differenti sulla base della disposizione di default, che stabilisce cosa accade se il programma non specifica un comportamento specifico per quel segnale. Per ciascun segnale, un programma può:
-1. Specificare un comportamento diverso dalla disposizione di default
-2. Ignorare il segnale
-3. Chiamare una funzione, detta **signal-handler**, per rispondere in modo personalizzato al segnale
+</p>
+<ol>
+  <li>
+    <p align="justify">
+    Specificare un comportamento diverso dalla disposizione di default
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Ignorare il segnale
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Chiamare una funzione, detta <strong>signal-handler</strong>, per rispondere in modo personalizzato al segnale
+    </p>
+  </li>
+</ol>
 
-Se una funzione **signal-handler** viene usata, l'esecuzione del programma è messa in pausa e il gestore viene eseguito immediatamente. Solo dopo che questa termina l'esecuzione del programma riprende nel punto in cui si era interrotta.
+<p align="justify">
+Se una funzione <strong>signal-handler</strong> viene usata, l'esecuzione del programma è messa in pausa e il gestore viene eseguito immediatamente. Solo dopo che questa termina l'esecuzione del programma riprende nel punto in cui si era interrotta.
+</p>
 
+<p align="justify">
 Alcuni esempi di segnali sono:
+</p>
 
-| Segnale  | Significato | Disposizione |
-| ------------- | ------------- |------------- |
-| `SIGSEGV`  | segmentation fault  | termina il processo |
-| `SIGTERM`  | chiede al processo di terminare, il processo potrebbe ignorare il segnale di terminazione  | termina il processo |
-| `SIGKILL`  | termina il processo immediatamente, il processo non può ignorare questo segnale  | termina il processo |
-| `SIGUSR1`  | Definito dall'utente  |
-| `SIGUSR2`  | Definito dall'utente  |
-| `SIGHUP`   | Risveglia un processo o lo mette in sleep o lo costringe a rileggere la sua configurazione |
+<table align="center">
+  <thead>
+    <tr>
+      <th>Segnale</th>
+      <th>Significato</th>
+      <th>Disposizione</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>SIGSEGV</code></td>
+      <td>segmentation fault</td>
+      <td>termina il processo</td>
+    </tr>
+    <tr>
+      <td><code>SIGTERM</code></td>
+      <td>chiede al processo di terminare, il processo potrebbe ignorare il segnale di terminazione</td>
+      <td>termina il processo</td>
+    </tr>
+    <tr>
+      <td><code>SIGKILL</code></td>
+      <td>termina il processo immediatamente, il processo non può ignorare questo segnale</td>
+      <td>termina il processo</td>
+    </tr>
+    <tr>
+      <td><code>SIGUSR1</code></td>
+      <td>Definito dall'utente</td>
+    </tr>
+    <tr>
+      <td><code>SIGUSR2</code></td>
+      <td>Definito dall'utente</td>
+    </tr>
+    <tr>
+      <td><code>SIGHUP</code></td>
+      <td>Risveglia un processo o lo mette in sleep o lo costringe a rileggere la sua configurazione</td>
+    </tr>
+  </tbody>
+</table>
 
 
 #### sigaction
 
-La **sigaction** può essere usata per impostare il comportamento di default di un segnale.
-Essa riceve in ingresso tre parametri:
+<p align="justify">
+La <strong>sigaction</strong> può essere usata per impostare il comportamento di default di un segnale. Essa riceve in ingresso tre parametri:
+</p>
 
-1. `int`: il numero del segnale
-2. `const struct sigaction *`: la disposizione desiderata per il segnale
-3. `struct sigaction *`: la precedente disposizione per il segnale
+<ol>
+  <li>
+    <p align="justify">
+    <code>int</code>: il numero del segnale
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    <code>const struct sigaction *</code>: la disposizione desiderata per il segnale
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    <code>struct sigaction *</code>: la precedente disposizione per il segnale
+    </p>
+  </li>
+</ol>
    
-```c
+<pre><code class="language-c">
 int sigaction(int signum,
                      const struct sigaction *_Nullable restrict act,
                      struct sigaction *_Nullable restrict oldact);
-```
+</code></pre>
 
-La struct `sigaction` ha questa forma:
+<p align="justify">
+La struct <code>sigaction</code> ha questa forma:
+</p>
 
-```c
+<pre><code class="language-c">
 struct sigaction {
                void     (*sa_handler)(int);
                void     (*sa_sigaction)(int, siginfo_t *, void *);
@@ -490,33 +615,55 @@ struct sigaction {
                int        sa_flags;
                void     (*sa_restorer)(void);
            };
-```
+</code></pre>
 
-Il campo più importante in questa struttura è `sa_handler` che può assumere uno di questi tre valori:
+<p align="justify">
+Il campo più importante in questa struttura è <code>sa_handler</code> che può assumere uno di questi tre valori:
+</p>
 
-* **SIG_DFL**
-* **SIG_IGN**
-* Un puntatore alla funzione **signal-handler**. La funzione dovrebbe accettare un parametro (il numero del segnale) e restituire `void`.
+<ul>
+  <li>
+    <p align="justify">
+    <strong>SIG_DFL</strong>
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    <strong>SIG_IGN</strong>
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Un puntatore alla funzione <strong>signal-handler</strong>. La funzione dovrebbe accettare un parametro (il numero del segnale) e restituire <code>void</code>.
+    </p>
+  </li>
+</ul>
 
-Quando il segnale viene processato dal programma questo può essere in uno stato altamente instabile (quindi durante l'esecuzione di un **signal-handler**). All'interno di una funzione **signal-handler** bisogna svolgere solo i task strettamente necessari per gestire e rispondere al segnale ed evitare operazioni di I/O o richiamare librerie esterne o del linguaggio. Può accadere che un **signal-handler** sia interrotto a causa della ricezione di un altro segnale e questo è un problema molto complicato da diagnosticare e debuggare, quindi bisogna essere molto cauti su cosa fare dentro un **signal-handler**.
+<p align="justify">
+Quando il segnale viene processato dal programma questo può essere in uno stato altamente instabile (quindi durante l'esecuzione di un <strong>signal-handler</strong>). All'interno di una funzione <strong>signal-handler</strong> bisogna svolgere solo i task strettamente necessari per gestire e rispondere al segnale ed evitare operazioni di I/O o richiamare librerie esterne o del linguaggio. Può accadere che un <strong>signal-handler</strong> sia interrotto a causa della ricezione di un altro segnale e questo è un problema molto complicato da diagnosticare e debuggare, quindi bisogna essere molto cauti su cosa fare dentro un <strong>signal-handler</strong>.
+</p>
 
-Un altro aspetto da tenere in considerazione è rendere le proprie istruzioni (variabili globali) atomiche usando il tipo `sig_atomic_t`. Linux garantisce che l'assegnazione di variabili di questo tipo avvenga in modo atomico e non possa essere interrotta dall'arrivo di un nuovo segnale.
+<p align="justify">
+Un altro aspetto da tenere in considerazione è rendere le proprie istruzioni (variabili globali) atomiche usando il tipo <code>sig_atomic_t</code>. Linux garantisce che l'assegnazione di variabili di questo tipo avvenga in modo atomico e non possa essere interrotta dall'arrivo di un nuovo segnale.
+</p>
 
-Vediamo un esempio di **signal-handler** per la gestione del segnale **SIGUSR1**, uno dei due segnali riservati all'uso da parte dei programmi applicativi.
+<p align="justify">
+Vediamo un esempio di <strong>signal-handler</strong> per la gestione del segnale <strong>SIGUSR1</strong>, uno dei due segnali riservati all'uso da parte dei programmi applicativi.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <signal.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <time.h>
+#include &lt;signal.h&gt;
+#include &lt;stdio.h&gt;
+#include &lt;string.h&gt;
+#include &lt;sys/types.h&gt;
+#include &lt;unistd.h&gt;
+#include &lt;time.h&gt;
 
 #define SOME_MINUTES 5
 #define SECONDS_PER_MINUTE 60
@@ -531,30 +678,34 @@ void handler (int signal_number)
 int main ()
 {
   struct sigaction sa;
-  memset (&sa, 0, sizeof (sa));
-  sa.sa_handler = &handler;
-  sigaction (SIGUSR1, &sa, NULL);
+  memset (&amp;sa, 0, sizeof (sa));
+  sa.sa_handler = &amp;handler;
+  sigaction (SIGUSR1, &amp;sa, NULL);
 
   time_t start = time(NULL);
-  while (time(NULL) - start < (time_t) (SOME_MINUTES * SECONDS_PER_MINUTE)) {
+  while (time(NULL) - start &lt; (time_t) (SOME_MINUTES * SECONDS_PER_MINUTE)) {
     printf("*");
   }
   printf ("SIGUSR1 was raised %d times\n", sigusr1_count);
   return 0;
 }
-```
+</code></pre>
 
-In un primo terminale esegui il programma che resterà in esecuzione per 5 minuti; alla fine dell'esecuzione stamperà il numero di volte che il segnale `SIGUSR1` è stato ricevuto.
+<p align="justify">
+In un primo terminale esegui il programma che resterà in esecuzione per 5 minuti; alla fine dell'esecuzione stamperà il numero di volte che il segnale <code>SIGUSR1</code> è stato ricevuto.
+</p>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/0_processes$ bin/4_sigusr1
 ***************************************************
 **************************SIGUSR1 was raised 6 times
-```
+</code></pre>
 
-Per inviare il segnale `SIGUSR1` basta usare il comando `kill`, con il **PID** del processo recuperabile in questo esempio con il comando `ps`.
+<p align="justify">
+Per inviare il segnale <code>SIGUSR1</code> basta usare il comando <code>kill</code>, con il <strong>PID</strong> del processo recuperabile in questo esempio con il comando <code>ps</code>.
+</p>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:~$ ps -e|grep 4_sigusr1
    1642 pts/0    00:01:17 4_sigusr1
 
@@ -564,62 +715,93 @@ vagrant@ubuntu2204:~$ kill -SIGUSR1 1642
 vagrant@ubuntu2204:~$ kill -SIGUSR1 1642
 vagrant@ubuntu2204:~$ kill -SIGUSR1 1642
 vagrant@ubuntu2204:~$ kill -SIGUSR1 1642
-```
+</code></pre>
 #### Terminare un processo
 
-Un processo termina o attraverso la chiamata alla funzione `exit()` o quando termina la funzione `main()` del programma (attraverso `return` o perché raggiunge l'ultima istruzione della funzione `main()`). Il valore intero ritornato attraverso `return` o come parametro in input alla `exit()` è detto **exit code**. Un processo può anche terminare in risposta a un segnale (`SIGSEGV`, `SIGKILL` ecc.). Altri segnali per terminare un processo sono `SIGINT`, inviato quando si preme la combinazione di tasti `CTRL+C` nel terminale attivo del programma. Un altro segnale che termina un processo è `SIGABRT`: oltre a terminare il processo genera un core file; è possibile inviare questo segnale attraverso la chiamata `abort()`. Il modo più rapido per terminare un processo è quello di inviare il segnale `SIGKILL`, che termina immediatamente il processo e non può essere ignorato o bloccato.
+<p align="justify">
+Un processo termina o attraverso la chiamata alla funzione <code>exit()</code> o quando termina la funzione <code>main()</code> del programma (attraverso <code>return</code> o perché raggiunge l'ultima istruzione della funzione <code>main()</code>). Il valore intero ritornato attraverso <code>return</code> o come parametro in input alla <code>exit()</code> è detto <strong>exit code</strong>. Un processo può anche terminare in risposta a un segnale (<code>SIGSEGV</code>, <code>SIGKILL</code> ecc.). Altri segnali per terminare un processo sono <code>SIGINT</code>, inviato quando si preme la combinazione di tasti <code>CTRL+C</code> nel terminale attivo del programma. Un altro segnale che termina un processo è <code>SIGABRT</code>: oltre a terminare il processo genera un core file; è possibile inviare questo segnale attraverso la chiamata <code>abort()</code>. Il modo più rapido per terminare un processo è quello di inviare il segnale <code>SIGKILL</code>, che termina immediatamente il processo e non può essere ignorato o bloccato.
+</p>
 
-Tutti questi segnali ed anche altri possono essere inviati con il comando `kill` specificando quale segnale inviare come parametro. Per inviare un `SIGKILL` fai in questo modo:
+<p align="justify">
+Tutti questi segnali ed anche altri possono essere inviati con il comando <code>kill</code> specificando quale segnale inviare come parametro. Per inviare un <code>SIGKILL</code> fai in questo modo:
+</p>
 
-```bash
+<pre><code class="language-bash">
 kill -KILL pid
-```
+</code></pre>
 
-Esiste anche la funzione `kill()` per inviare un segnale dal codice ed ha questo prototipo:
+<p align="justify">
+Esiste anche la funzione <code>kill()</code> per inviare un segnale dal codice ed ha questo prototipo:
+</p>
 
-```c
+<pre><code class="language-c">
 int kill(pid_t pid, int sig);
-```
+</code></pre>
 
-1. `pid_t pid`: il PID del processo
-2. `int sig`: segnale da inviare
+<ol>
+  <li>
+    <p align="justify">
+    <code>pid_t pid</code>: il PID del processo
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    <code>int sig</code>: segnale da inviare
+    </p>
+  </li>
+</ol>
 
-Devi includere `<sys/types.h>` e `<signal.h>` per utilizzare la funzione `kill()`.
+<p align="justify">
+Devi includere <code>&lt;sys/types.h&gt;</code> e <code>&lt;signal.h&gt;</code> per utilizzare la funzione <code>kill()</code>.
+</p>
 
-> [!IMPORTANT]
-> Per convenzione, **exit code** è usato per indicare se il programma ha terminato la sua esecuzione correttamente o con degli errori. Un valore pari a zero indica una corretta esecuzione, mentre valori diversi da zero indicano che il processo ha terminato con qualche errore. è importante seguire questa convenzione se vuoi usare gli operatori logici della shell (`&&` `||`) per concatenare più programmi tra loro.
+<table align="center">
+	<td>:exclamation: <b>Importante</b>
+`t<p align=justify>
+ Per convenzione, <strong>exit code</strong> è usato per indicare se il programma ha terminato la sua esecuzione correttamente o con degli errori. Un valore pari a zero indica una corretta esecuzione, mentre valori diversi da zero indicano che il processo ha terminato con qualche errore. è importante seguire questa convenzione se vuoi usare gli operatori logici della shell (<code>&amp;&amp;</code> <code>||</code>) per concatenare più programmi tra loro.
+`t</p>
+`t</td>
+</table>
 
-Puoi leggere l'**exit code** dell'ultimo programma lanciato sulla shell stampando il contenuto della variabile `$?` per esempio.
+<p align="justify">
+Puoi leggere l'<strong>exit code</strong> dell'ultimo programma lanciato sulla shell stampando il contenuto della variabile <code>$?</code> per esempio.
+</p>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/0_processes$ ls
 0_print_pid.c  1_system.c  2_fork.c  3_fork_exec.c  4_sigusr1.c  bin
 vagrant@ubuntu2204:/lab2/0_processes$ echo $?
 0
-```
+</code></pre>
 
 #### Aspettare la terminazione di un processo
 
-Quando si esegue la coppia di chiamate `fork()` ed `exec()` per creare un processo figlio siamo in grado, all'interno dello stesso codice, di differenziare quali istruzioni saranno eseguite dal padre e quali dal processo figlio sfruttando il valore di ritorno della chiamata `fork()`. Nulla però ci assicura che il padre termini prima del figlio, l'ordine di terminazione dipende dal numero di istruzioni dei due processi e soprattutto da come il sistema operativo andrà a schedulare i due processi nell'assegnazione dei tempi di CPU. Quando è necessario che per la correttezza del nostro programma il padre termini soltanto al termine dell'esecuzione del processo figlio, è obbligatorio usare la funzione `wait()`.
+<p align="justify">
+Quando si esegue la coppia di chiamate <code>fork()</code> ed <code>exec()</code> per creare un processo figlio siamo in grado, all'interno dello stesso codice, di differenziare quali istruzioni saranno eseguite dal padre e quali dal processo figlio sfruttando il valore di ritorno della chiamata <code>fork()</code>. Nulla però ci assicura che il padre termini prima del figlio, l'ordine di terminazione dipende dal numero di istruzioni dei due processi e soprattutto da come il sistema operativo andrà a schedulare i due processi nell'assegnazione dei tempi di CPU. Quando è necessario che per la correttezza del nostro programma il padre termini soltanto al termine dell'esecuzione del processo figlio, è obbligatorio usare la funzione <code>wait()</code>.
+</p>
 
 #### wait()
 
-La `wait()` sospende l'esecuzione del processo padre finché uno dei suoi figli è terminato (anche con un errore, non importa). Inoltre la `wait()` ritorna uno status code (codice di stato, **exit code**) dal quale estrarre informazioni su come il processo figlio ha terminato l'esecuzione. Ad esempio la macro `WEXITSTATUS` contiene l'**exit code** del processo figlio.
+<p align="justify">
+La <code>wait()</code> sospende l'esecuzione del processo padre finché uno dei suoi figli è terminato (anche con un errore, non importa). Inoltre la <code>wait()</code> ritorna uno status code (codice di stato, <strong>exit code</strong>) dal quale estrarre informazioni su come il processo figlio ha terminato l'esecuzione. Ad esempio la macro <code>WEXITSTATUS</code> contiene l'<strong>exit code</strong> del processo figlio.
+</p>
 
+<p align="justify">
 Vediamo un esempio:
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
+#include &lt;stdio.h&gt;
+#include &lt;stdlib.h&gt;
+#include &lt;sys/types.h&gt;
+#include &lt;sys/wait.h&gt;
+#include &lt;unistd.h&gt;
 
 /* Spawn a child process running a new program.  PROGRAM is the name
    of the program to run; the path will be searched for this program.
@@ -661,7 +843,7 @@ int main ()
   spawn ("ls", arg_list);
 
   /* Wait for the child process to complete. */
-  wait(&child_status);
+  wait(&amp;child_status);
   if (WIFEXITED(child_status))
    printf("the child process exited normally, with exit code %d\n", WEXITSTATUS(child_status));
   else
@@ -671,24 +853,26 @@ int main ()
 
   return 0;
 }                                                                                          
-```
+</code></pre>
 
-Come mostrato nell'esempio seguente, il terminale visualizza prima l'output del processo figlio (`ls -l`), mentre successivamente il processo padre termina stampando a schermo (`done with the main program`).
+<p align="justify">
+Come mostrato nell'esempio seguente, il terminale visualizza prima l'output del processo figlio (<code>ls -l</code>), mentre successivamente il processo padre termina stampando a schermo (<code>done with the main program</code>).
+</p>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/0_processes$ bin/5_fork_exec_wait
 total 2097224
-lrwxrwxrwx   1 root    root             7 Aug 10  2023 bin -> usr/bin
+lrwxrwxrwx   1 root    root             7 Aug 10  2023 bin -&gt; usr/bin
 drwxr-xr-x   4 root    root          4096 Jan 11  2024 boot
 drwxr-xr-x  19 root    root          3980 Aug 12 08:33 dev
 drwxr-xr-x 104 root    root          4096 Aug 12 08:33 etc
 drwxr-xr-x   3 root    root          4096 Jan 10  2024 home
 drwxrwxrwx   1 vagrant vagrant       4096 Aug  9 07:23 lab
 drwxrwxrwx   1 vagrant vagrant          0 Aug 12 08:30 lab2
-lrwxrwxrwx   1 root    root             7 Aug 10  2023 lib -> usr/lib
-lrwxrwxrwx   1 root    root             9 Aug 10  2023 lib32 -> usr/lib32
-lrwxrwxrwx   1 root    root             9 Aug 10  2023 lib64 -> usr/lib64
-lrwxrwxrwx   1 root    root            10 Aug 10  2023 libx32 -> usr/libx32
+lrwxrwxrwx   1 root    root             7 Aug 10  2023 lib -&gt; usr/lib
+lrwxrwxrwx   1 root    root             9 Aug 10  2023 lib32 -&gt; usr/lib32
+lrwxrwxrwx   1 root    root             9 Aug 10  2023 lib64 -&gt; usr/lib64
+lrwxrwxrwx   1 root    root            10 Aug 10  2023 libx32 -&gt; usr/libx32
 drwx------   2 root    root         16384 Jan 10  2024 lost+found
 drwxr-xr-x   2 root    root          4096 Aug 10  2023 media
 drwxr-xr-x   2 root    root          4096 Aug 10  2023 mnt
@@ -696,7 +880,7 @@ drwxr-xr-x   2 root    root          4096 Aug 10  2023 opt
 dr-xr-xr-x 163 root    root             0 Aug 12 08:32 proc
 drwx------   5 root    root          4096 Jan 11  2024 root
 drwxr-xr-x  28 root    root           840 Aug 12  10:37 run
-lrwxrwxrwx   1 root    root             8 Aug 10  2023 sbin -> usr/sbin
+lrwxrwxrwx   1 root    root             8 Aug 10  2023 sbin -&gt; usr/sbin
 drwxr-xr-x   6 root    root          4096 Jul  7 07:31 snap
 drwxr-xr-x   2 root    root          4096 Aug 10  2023 srv
 -rw-------   1 root    root    2147483648 Jan 10  2024 swap.img
@@ -706,23 +890,24 @@ drwxr-xr-x  14 root    root          4096 Aug 10  2023 usr
 drwxr-xr-x  13 root    root          4096 Aug 10  2023 var
 the child process exited normally, with exit code 0
 done with main program
-```
+</code></pre>
 
 #### Processi zombie
 
-Quando un processo figlio termina e il processo padre ha chiamato la `wait()`, le informazioni sulla sua terminazione passano al padre attraverso la `wait()`. Se il padre non chiama la `wait()`, queste informazioni vanno perse? In questo caso il processo figlio diventa un processo **zombie**.
-Un processo **zombie** è un processo che ha terminato la propria esecuzione ma non è stato ancora ripulito; è quindi compito del processo padre ripulire il figlio. Il compito della `wait()` è proprio questo: una volta che il processo figlio termina, questo diventa uno zombie e poi la `wait()` estrae lo stato di uscita del figlio, cosicché il processo figlio può essere eliminato. Se il processo padre non chiama la `wait()`, il figlio resta nello stato di zombie, vediamo un esempio:
+<p align="justify">
+Quando un processo figlio termina e il processo padre ha chiamato la <code>wait()</code>, le informazioni sulla sua terminazione passano al padre attraverso la <code>wait()</code>. Se il padre non chiama la <code>wait()</code>, queste informazioni vanno perse? In questo caso il processo figlio diventa un processo <strong>zombie</strong>. Un processo <strong>zombie</strong> è un processo che ha terminato la propria esecuzione ma non è stato ancora ripulito; è quindi compito del processo padre ripulire il figlio. Il compito della <code>wait()</code> è proprio questo: una volta che il processo figlio termina, questo diventa uno zombie e poi la <code>wait()</code> estrae lo stato di uscita del figlio, cosicché il processo figlio può essere eliminato. Se il processo padre non chiama la <code>wait()</code>, il figlio resta nello stato di zombie, vediamo un esempio:
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <stdlib.h>
-#include <sys/types.h>
-#include <unistd.h>
+#include &lt;stdlib.h&gt;
+#include &lt;sys/types.h&gt;
+#include &lt;unistd.h&gt;
 
 int main ()
 {
@@ -730,7 +915,7 @@ int main ()
 
   /* Create a child process.  */
   child_pid = fork ();
-  if (child_pid > 0) {
+  if (child_pid &gt; 0) {
     /* This is the parent process.  Sleep for a minute.  */
     sleep (60);
   }
@@ -740,46 +925,53 @@ int main ()
   }
   return 0;
 }
-```
+</code></pre>
 
+<p align="justify">
 Lancia il programma da un terminale in questo modo:
+</p>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/0_processes$ bin/6_zombie
-```
-Ed usa, su un altro terminale, il comando `ps` in questo modo:
+</code></pre>
+<p align="justify">
+Ed usa, su un altro terminale, il comando <code>ps</code> in questo modo:
+</p>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:~$ ps -e -o pid,ppid,stat,cmd|grep 6_zombie
    2317    1331 S+   bin/6_zombie
-   2318    2317 Z+   [6_zombie] <defunct>
+   2318    2317 Z+   [6_zombie] &lt;defunct&gt;
    2325    2301 S+   grep --color=auto 6_zombie
-```
+</code></pre>
 
-Il processo padre ha pid `2317` ed è in stato `S+`; il processo figlio è `<defunct>` ed è uno zombie `Z+`.
-Quando il processo padre termina prima del figlio senza chiamare la `wait()`, chi si occupa di ripulire il processo figlio e riportarlo dallo stato di zombie a terminato? Il processo **init**, che è il padre di tutti i processi (init infatti ha PID=1), eredita tutti i figli rimasti orfani del proprio padre. Se rilanci `ps` dopo un po' di tempo, vedrai che il processo figlio con pid `2318` non esiste più perché è stato ripulito da init.
+<p align="justify">
+Il processo padre ha pid <code>2317</code> ed è in stato <code>S+</code>; il processo figlio è <code>&lt;defunct&gt;</code> ed è uno zombie <code>Z+</code>. Quando il processo padre termina prima del figlio senza chiamare la <code>wait()</code>, chi si occupa di ripulire il processo figlio e riportarlo dallo stato di zombie a terminato? Il processo <strong>init</strong>, che è il padre di tutti i processi (init infatti ha PID=1), eredita tutti i figli rimasti orfani del proprio padre. Se rilanci <code>ps</code> dopo un po' di tempo, vedrai che il processo figlio con pid <code>2318</code> non esiste più perché è stato ripulito da init.
+</p>
 
 
 
 ### Ripulire il figlio in modo asincrono
 
-La `wait()` ci permette di attendere (nel codice del padre) la terminazione del figlio. Il problema è che la chiamata alla `wait()` è bloccante, quindi il codice del padre rimane (appeso) all'istruzione di `wait` fino a quando il figlio non termina. Se si vuole che il padre continui la propria elaborazione mentre si attende che il figlio completi, è possibile controllare periodicamente la terminazione del figlio chiamando `wait3()` o `wait4()` (flag `WNOHANG`) in modo asincrono nel codice del padre. Una soluzione migliore è usare il segnale `SIGCHLD`, che Linux invia al padre ogni volta che uno dei suoi figli termina. Vediamo un esempio:
+<p align="justify">
+La <code>wait()</code> ci permette di attendere (nel codice del padre) la terminazione del figlio. Il problema è che la chiamata alla <code>wait()</code> è bloccante, quindi il codice del padre rimane (appeso) all'istruzione di <code>wait</code> fino a quando il figlio non termina. Se si vuole che il padre continui la propria elaborazione mentre si attende che il figlio completi, è possibile controllare periodicamente la terminazione del figlio chiamando <code>wait3()</code> o <code>wait4()</code> (flag <code>WNOHANG</code>) in modo asincrono nel codice del padre. Una soluzione migliore è usare il segnale <code>SIGCHLD</code>, che Linux invia al padre ogni volta che uno dei suoi figli termina. Vediamo un esempio:
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <signal.h>     // sigaction
-#include <string.h>     // memset()
-#include <stdio.h>      // fprintf()
-#include <stdlib.h>     // abort()
-#include <sys/types.h>  // pid_t
-#include <sys/wait.h>   // wait()
-#include <unistd.h>     // fork() exec()
-#include <time.h>       // time()
+#include &lt;signal.h&gt;     // sigaction
+#include &lt;string.h&gt;     // memset()
+#include &lt;stdio.h&gt;      // fprintf()
+#include &lt;stdlib.h&gt;     // abort()
+#include &lt;sys/types.h&gt;  // pid_t
+#include &lt;sys/wait.h&gt;   // wait()
+#include &lt;unistd.h&gt;     // fork() exec()
+#include &lt;time.h&gt;       // time()
 
 #define N_CHILDS 10
 
@@ -792,7 +984,7 @@ void clean_up_child_process (int signal_number)
 {
   /* Clean up the child process.  */
   int status;
-  wait (&status);
+  wait (&amp;status);
   /* Store its exit status in a global variable.  */
   child_exit_status = status;
   fprintf (stdout, "Child exit with %d status\n", status);
@@ -821,9 +1013,9 @@ int main ()
 {
   /* Handle SIGCHLD by calling clean_up_child_process.  */
   struct sigaction sigchld_action;
-  memset (&sigchld_action, 0, sizeof (sigchld_action));
-  sigchld_action.sa_handler = &clean_up_child_process;
-  sigaction (SIGCHLD, &sigchld_action, NULL);
+  memset (&amp;sigchld_action, 0, sizeof (sigchld_action));
+  sigchld_action.sa_handler = &amp;clean_up_child_process;
+  sigaction (SIGCHLD, &amp;sigchld_action, NULL);
 
   /* Now do things, including forking a child process.  */
   /* The argument list to pass to the "ls" command.  */
@@ -833,18 +1025,18 @@ int main ()
     NULL      /* The argument list must end with a NULL.  */
   };
 
-  for(int i=0; i<N_CHILDS; i++)
+  for(int i=0; i&lt;N_CHILDS; i++)
      spawn ("sleep", arg_list);
 
   time_t start = time(NULL);
-  while (time(NULL) - start < (time_t) (SOME_MINUTES * SECONDS_PER_MINUTE));
+  while (time(NULL) - start &lt; (time_t) (SOME_MINUTES * SECONDS_PER_MINUTE));
   fprintf (stdout, "Father's quitting\n");
 
   return 0;
 }
-```
+</code></pre>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/0_processes$ bin/7_sigchld
 Child 3099 created
 Child 3100 created
@@ -867,7 +1059,7 @@ Child exit with 0 status
 Child exit with 0 status
 
 Father's quitting
-```
+</code></pre>
 
 ### I Thread
 

--- a/LINUX_PROGRAMMING.md
+++ b/LINUX_PROGRAMMING.md
@@ -1063,39 +1063,59 @@ Father's quitting
 
 ### I Thread
 
-I thread, come i processi, sono un meccanismo per permettere a un programma di svolgere più compiti contemporaneamente. Come i processi, anche i thread si contendono la CPU per l'esecuzione. Da un punto di vista teorico, un thread esiste all'interno di un processo: quando viene invocato un programma, Linux crea un nuovo processo e, al suo interno, anche un singolo thread che esegue il programma in modo sequenziale. Questo thread può creare altri thread che eseguono lo stesso programma nello stesso processo, ma ciascun thread può eseguire una parte diversa del programma in qualunque momento.
-Abbiamo visto come un processo può forkare un processo figlio. Il processo figlio inizialmente esegue il programma del padre come una copia della memoria virtuale del processo padre, i descrittori dei file e così via. Il processo figlio può modificare la sua memoria, chiudere i descrittori dei file ecc., senza alterare quelli del padre. Quando un thread crea un nuovo thread nulla è copiato. Il thread padre e il thread figlio condividono la stessa memoria, i descrittori dei file e tutte le altre risorse. Se un thread cambia il valore di una variabile, anche l'altro thread vedrà questa modifica; se un thread chiude un descrittore di un file, gli altri thread potrebbero non poter più leggere o scrivere su quel descrittore. Siccome un processo e tutti i suoi thread possono eseguire un solo programma alla volta, se un thread richiama la `exec()` tutti i thread verranno terminati.
-Linux implementa le API POSIX per i thread (conosciuto come **pthread**). Tutte le funzioni per i thread sono definite nel file d'intestazione `<pthread.h>` che non è inclusa nella libreria standard fornita dal linguaggio C. La libreria è fornita in `libpthread.so` ed è necessario passare il parametro `-lpthread` a gcc per linkarla al momento della compilazione.
+<p align="justify">
+I thread, come i processi, sono un meccanismo per permettere a un programma di svolgere più compiti contemporaneamente. Come i processi, anche i thread si contendono la CPU per l'esecuzione. Da un punto di vista teorico, un thread esiste all'interno di un processo: quando viene invocato un programma, Linux crea un nuovo processo e, al suo interno, anche un singolo thread che esegue il programma in modo sequenziale. Questo thread può creare altri thread che eseguono lo stesso programma nello stesso processo, ma ciascun thread può eseguire una parte diversa del programma in qualunque momento. Abbiamo visto come un processo può forkare un processo figlio. Il processo figlio inizialmente esegue il programma del padre come una copia della memoria virtuale del processo padre, i descrittori dei file e così via. Il processo figlio può modificare la sua memoria, chiudere i descrittori dei file ecc., senza alterare quelli del padre. Quando un thread crea un nuovo thread nulla è copiato. Il thread padre e il thread figlio condividono la stessa memoria, i descrittori dei file e tutte le altre risorse. Se un thread cambia il valore di una variabile, anche l'altro thread vedrà questa modifica; se un thread chiude un descrittore di un file, gli altri thread potrebbero non poter più leggere o scrivere su quel descrittore. Siccome un processo e tutti i suoi thread possono eseguire un solo programma alla volta, se un thread richiama la <code>exec()</code> tutti i thread verranno terminati. Linux implementa le API POSIX per i thread (conosciuto come <strong>pthread</strong>). Tutte le funzioni per i thread sono definite nel file d'intestazione <code>&lt;pthread.h&gt;</code> che non è inclusa nella libreria standard fornita dal linguaggio C. La libreria è fornita in <code>libpthread.so</code> ed è necessario passare il parametro <code>-lpthread</code> a gcc per linkarla al momento della compilazione.
+</p>
 
 #### Creazione di un thread
 
-Ad ogni thread è associato un ID univoco di tipo `pthread_t`.
-Una volta creato, un thread esegue una semplice funzione che contiene il codice che il thread deve eseguire. Quando questa funzione termina, anche il thread termina la propria esecuzione. Questa funzione riceve in ingresso un puntatore a void `void *` e ritorna sempre un altro puntatore a void `void *`.
-Per creare un nuovo thread bisogna usare la funzione `pthread_create()`. Questo è il suo prototipo:
+<p align="justify">
+Ad ogni thread è associato un ID univoco di tipo <code>pthread_t</code>. Una volta creato, un thread esegue una semplice funzione che contiene il codice che il thread deve eseguire. Quando questa funzione termina, anche il thread termina la propria esecuzione. Questa funzione riceve in ingresso un puntatore a void <code>void *</code> e ritorna sempre un altro puntatore a void <code>void *</code>. Per creare un nuovo thread bisogna usare la funzione <code>pthread_create()</code>. Questo è il suo prototipo:
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_create(pthread_t *restrict thread,
                           const pthread_attr_t *restrict attr,
                           void *(*start_routine)(void *),
                           void *restrict arg);
-```
+</code></pre>
 
-1. `pthread_t thread`: un identificatore di thread
-2. `const pthread_attr_t *`: un puntatore all'oggetto contenente gli attributi del thread: questo oggetto controlla i dettagli di come il thread interagisce con il resto del programma. Se passi `NULL` come attributo del thread, il thread sarà creato con gli attributi di default.
-3. `void* (*) (void*)`: un puntatore alla funzione del thread, questo è un semplice puntatore a funzione
-4. `void *`: l'argomento in ingresso da passare alla funzione del thread di tipo `void *`
+<ol>
+  <li>
+    <p align="justify">
+    <code>pthread_t thread</code>: un identificatore di thread
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    <code>const pthread_attr_t *</code>: un puntatore all'oggetto contenente gli attributi del thread: questo oggetto controlla i dettagli di come il thread interagisce con il resto del programma. Se passi <code>NULL</code> come attributo del thread, il thread sarà creato con gli attributi di default.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    <code>void* (*) (void*)</code>: un puntatore alla funzione del thread, questo è un semplice puntatore a funzione
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    <code>void *</code>: l'argomento in ingresso da passare alla funzione del thread di tipo <code>void *</code>
+    </p>
+  </li>
+</ol>
 
+<p align="justify">
 Vediamo un esempio di creazione di un thread:
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <pthread.h>
-#include <stdio.h>
+#include &lt;pthread.h&gt;
+#include &lt;stdio.h&gt;
 
 /* Prints x's to stderr.  The parameter is unused.  Does not return.  */
 
@@ -1113,31 +1133,33 @@ int main ()
   pthread_t thread_id;
   /* Create a new thread.  The new thread will run the print_xs
      function.  */
-  pthread_create (&thread_id, NULL, &print_xs, NULL);
+  pthread_create (&amp;thread_id, NULL, &amp;print_xs, NULL);
   /* Print o's continuously to stderr.  */
   while (1)
     fputc ('o', stderr);
   return 0;
 }
-```
+</code></pre>
 
-Il thread termina quando termina la funzione del thread `print_xs`, un thread può ritornare anche richiamando la funzione `pthread_exit()`.
+<p align="justify">
+Il thread termina quando termina la funzione del thread <code>print_xs</code>, un thread può ritornare anche richiamando la funzione <code>pthread_exit()</code>.
+</p>
 
 #### Passare dati a un thread
 
-Per passare argomenti a un thread basta usare il quarto argomento della `pthread_create()`. Per farlo basta solo dichiarare una struttura o un array e passare il puntatore alla `pthread_create()`.
-L'unica accortezza da tenere in considerazione è quella di effettuare il cast corretto del parametro in ingresso alla funzione del thread.
-Vediamo un esempio:
+<p align="justify">
+Per passare argomenti a un thread basta usare il quarto argomento della <code>pthread_create()</code>. Per farlo basta solo dichiarare una struttura o un array e passare il puntatore alla <code>pthread_create()</code>. L'unica accortezza da tenere in considerazione è quella di effettuare il cast corretto del parametro in ingresso alla funzione del thread. Vediamo un esempio:
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <pthread.h>
-#include <stdio.h>
+#include &lt;pthread.h&gt;
+#include &lt;stdio.h&gt;
 
 /* Parameters to print_function.  */
 
@@ -1158,8 +1180,8 @@ void* char_print (void* parameters)
   struct char_print_parms* p = (struct char_print_parms*) parameters;
   int i;
 
-  for (i = 0; i < p->count; ++i)
-    fputc (p->character, stderr);
+  for (i = 0; i &lt; p-&gt;count; ++i)
+    fputc (p-&gt;character, stderr);
   return NULL;
 }
 
@@ -1175,41 +1197,57 @@ int main ()
   /* Create a new thread to print 30000 x's.  */
   thread1_args.character = 'x';
   thread1_args.count = 30000;
-  pthread_create (&thread1_id, NULL, &char_print, &thread1_args);
+  pthread_create (&amp;thread1_id, NULL, &amp;char_print, &amp;thread1_args);
 
   /* Create a new thread to print 20000 o's.  */
   thread2_args.character = 'o';
   thread2_args.count = 20000;
-  pthread_create (&thread2_id, NULL, &char_print, &thread2_args);
+  pthread_create (&amp;thread2_id, NULL, &amp;char_print, &amp;thread2_args);
 
   return 0;
 }
-```
+</code></pre>
 
-Il problema in questo codice è che le due variabili locali (automatiche) `thread1_args` e `thread2_args` che contengono i parametri da passare ai due thread sono dichiarate nel processo padre, il processo padre termina immediatamente e tutte le sue variabili verranno deallocate, comprese quelle passate come argomenti ai thread che accederanno quindi a locazioni di memoria non valide. Per risolvere questo problema dovremmo fare in modo che il processo padre attenda la terminazione dei thread nello stesso modo con cui attraverso la `wait()` attendeva la terminazione del processo figlio.
+<p align="justify">
+Il problema in questo codice è che le due variabili locali (automatiche) <code>thread1_args</code> e <code>thread2_args</code> che contengono i parametri da passare ai due thread sono dichiarate nel processo padre, il processo padre termina immediatamente e tutte le sue variabili verranno deallocate, comprese quelle passate come argomenti ai thread che accederanno quindi a locazioni di memoria non valide. Per risolvere questo problema dovremmo fare in modo che il processo padre attenda la terminazione dei thread nello stesso modo con cui attraverso la <code>wait()</code> attendeva la terminazione del processo figlio.
+</p>
 
 #### Attendere la terminazione dei thread
 
-Per fare in modo che il `main()` attenda la terminazione dei thread è possibile usare la funzione `pthread_join()`. Questo è il suo prototipo:
+<p align="justify">
+Per fare in modo che il <code>main()</code> attenda la terminazione dei thread è possibile usare la funzione <code>pthread_join()</code>. Questo è il suo prototipo:
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_join(pthread_t thread, void **retval);
-```
+</code></pre>
 
-1. `pthread_t`: id del thread di cui si vuole attendere il completamento
-2. `void *`: puntatore a void per il valore di ritorno del thread. Se non sei interessato al valore di ritorno passa `NULL` a questo parametro.
+<ol>
+  <li>
+    <p align="justify">
+    <code>pthread_t</code>: id del thread di cui si vuole attendere il completamento
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    <code>void *</code>: puntatore a void per il valore di ritorno del thread. Se non sei interessato al valore di ritorno passa <code>NULL</code> a questo parametro.
+    </p>
+  </li>
+</ol>
 
-Vediamo come risolvere il bug dell'esempio precedente usando la `pthread_join()` per attendere il completamento dei thread creati nel `main()`
+<p align="justify">
+Vediamo come risolvere il bug dell'esempio precedente usando la <code>pthread_join()</code> per attendere il completamento dei thread creati nel <code>main()</code>
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <pthread.h>
-#include <stdio.h>
+#include &lt;pthread.h&gt;
+#include &lt;stdio.h&gt;
 
 /* Parameters to print_function.  */
 
@@ -1230,8 +1268,8 @@ void* char_print (void* parameters)
   struct char_print_parms* p = (struct char_print_parms*) parameters;
   int i;
 
-  for (i = 0; i < p->count; ++i)
-    fputc (p->character, stderr);
+  for (i = 0; i &lt; p-&gt;count; ++i)
+    fputc (p-&gt;character, stderr);
   return NULL;
 }
 
@@ -1247,12 +1285,12 @@ int main ()
   /* Create a new thread to print 30000 x's.  */
   thread1_args.character = 'x';
   thread1_args.count = 30000;
-  pthread_create (&thread1_id, NULL, &char_print, &thread1_args);
+  pthread_create (&amp;thread1_id, NULL, &amp;char_print, &amp;thread1_args);
 
   /* Create a new thread to print 20000 o's.  */
   thread2_args.character = 'o';
   thread2_args.count = 20000;
-  pthread_create (&thread2_id, NULL, &char_print, &thread2_args);
+  pthread_create (&amp;thread2_id, NULL, &amp;char_print, &amp;thread2_args);
 
   /* Make sure the first thread has finished.  */
   pthread_join (thread1_id, NULL);
@@ -1262,21 +1300,23 @@ int main ()
   /* Now we can safely return.  */
   return 0;
 }
-```
+</code></pre>
 
 #### Il valore di ritorno dei thread
 
-Se il secondo parametro in ingresso alla `pthread_join()` non è `NULL` allora il valore di ritorno del thread verrà salvato nella locazione di memoria puntata da quell'argomento. Il valore di ritorno del thread è di tipo puntatore a `void`: `void *`, quindi è necessario castare l'indirizzo della variabile intera `prime` a `void *` nella chiamata alla `pthread_join()`.
+<p align="justify">
+Se il secondo parametro in ingresso alla <code>pthread_join()</code> non è <code>NULL</code> allora il valore di ritorno del thread verrà salvato nella locazione di memoria puntata da quell'argomento. Il valore di ritorno del thread è di tipo puntatore a <code>void</code>: <code>void *</code>, quindi è necessario castare l'indirizzo della variabile intera <code>prime</code> a <code>void *</code> nella chiamata alla <code>pthread_join()</code>.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <pthread.h>
-#include <stdio.h>
+#include &lt;pthread.h&gt;
+#include &lt;stdio.h&gt;
 
 /* Compute successive prime numbers (very inefficiently).  Return the
    Nth prime number, where N is the value pointed to by *ARG.  */
@@ -1291,7 +1331,7 @@ void* compute_prime (void* arg)
     int is_prime = 1;
 
     /* Test primality by successive division.  */
-    for (factor = 2; factor < candidate; ++factor)
+    for (factor = 2; factor &lt; candidate; ++factor)
       if (candidate % factor == 0) {
         is_prime = 0;
         break;
@@ -1314,74 +1354,106 @@ int main ()
   int prime;
 
   /* Start the computing thread, up to the 5000th prime number.  */
-  pthread_create (&thread, NULL, &compute_prime, &which_prime);
+  pthread_create (&amp;thread, NULL, &amp;compute_prime, &amp;which_prime);
   /* Do some other work here...  */
   /* Wait for the prime number thread to complete, and get the result.  */
-  pthread_join (thread, (void*) &prime);
+  pthread_join (thread, (void*) &amp;prime);
   /* Print the largest prime it computed.  */
   printf("The %dth prime number is %d.\n", which_prime, prime);
   return 0;
 }
-```
+</code></pre>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/1_threads$ bin/3_primes
 The 5000th prime number is 48611.
-```
+</code></pre>
 
 #### `pthread_self()` e `pthread_equal()`
 
-`pthread_self()` ritorna il thread id del thread corrente che la sta eseguendo. Questo è il suo prototipo:
+<p align="justify">
+<code>pthread_self()</code> ritorna il thread id del thread corrente che la sta eseguendo. Questo è il suo prototipo:
+</p>
 
-```c
+<pre><code class="language-c">
 pthread_t pthread_self(void);
-```
+</code></pre>
 
-`pthread_equal()` confronta due thread id(s): ritorna zero se i due ID sono uguali. Questo è il suo prototipo:
+<p align="justify">
+<code>pthread_equal()</code> confronta due thread id(s): ritorna zero se i due ID sono uguali. Questo è il suo prototipo:
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_equal(pthread_t t1, pthread_t t2);
-```
+</code></pre>
 
-Queste due funzioni possono essere utili per controllare se un certo ID corrisponde a quello del thread corrente per esempio prima di chiamare una `pthread_join()` in quanto aspettare la terminazione di se stessi è un grosso errore. Sotto un esempio:
+<p align="justify">
+Queste due funzioni possono essere utili per controllare se un certo ID corrisponde a quello del thread corrente per esempio prima di chiamare una <code>pthread_join()</code> in quanto aspettare la terminazione di se stessi è un grosso errore. Sotto un esempio:
+</p>
 
-```c
+<pre><code class="language-c">
 if (!pthread_equal (pthread_self (), other_thread))
   pthread_join (other_thread, NULL);
-```
+</code></pre>
 
 #### Gli attributi dei thread
 
-Gli attributi del thread forniscono un meccanismo per la messa a punto del comportamento dei singoli thread. Abbiamo visto come la `pthread_create()` accetta un argomento che è un puntatore a un oggetto attributo del thread. Se passi un puntatore nullo a questo argomento, gli attributi predefiniti vengono utilizzati per configurare il nuovo thread. Tuttavia, puoi creare e personalizzare un oggetto attributo thread per specificare altri valori per gli attributi. Per specificare attributi thread personalizzati, devi seguire questi passaggi: 
+<p align="justify">
+Gli attributi del thread forniscono un meccanismo per la messa a punto del comportamento dei singoli thread. Abbiamo visto come la <code>pthread_create()</code> accetta un argomento che è un puntatore a un oggetto attributo del thread. Se passi un puntatore nullo a questo argomento, gli attributi predefiniti vengono utilizzati per configurare il nuovo thread. Tuttavia, puoi creare e personalizzare un oggetto attributo thread per specificare altri valori per gli attributi. Per specificare attributi thread personalizzati, devi seguire questi passaggi:
+</p>
 
-1. Crea un oggetto `pthread_attr_t`. Il modo più semplice per farlo è dichiarare una variabile automatica di questo tipo.
-2. Chiama la funzione `pthread_attr_init()`, passando un puntatore a questo oggetto. Ciò inizializza gli attributi ai loro valori predefiniti.
-3. Modifica l'oggetto attributo per contenere i valori attributo desiderati.
-4. Passa un puntatore all'oggetto attributo che hai valorizzato al punto precedente quando richiami la `pthread_create()`.
-5. Chiama la `pthread_attr_destroy()` per rilasciare l'oggetto attributo. La variabile `pthread_attr_t` non viene deallocata; può essere reinizializzata con `pthread_attr_init()`
+<ol>
+  <li>
+    <p align="justify">
+    Crea un oggetto <code>pthread_attr_t</code>. Il modo più semplice per farlo è dichiarare una variabile automatica di questo tipo.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Chiama la funzione <code>pthread_attr_init()</code>, passando un puntatore a questo oggetto. Ciò inizializza gli attributi ai loro valori predefiniti.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Modifica l'oggetto attributo per contenere i valori attributo desiderati.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Passa un puntatore all'oggetto attributo che hai valorizzato al punto precedente quando richiami la <code>pthread_create()</code>.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Chiama la <code>pthread_attr_destroy()</code> per rilasciare l'oggetto attributo. La variabile <code>pthread_attr_t</code> non viene deallocata; può essere reinizializzata con <code>pthread_attr_init()</code>
+    </p>
+  </li>
+</ol>
   
-Un singolo oggetto attributo thread può essere utilizzato per inizializzare diversi thread. Non è necessario mantenere l'oggetto attributo thread dopo che i thread sono stati creati.
-Per la maggior parte delle attività di programmazione delle applicazioni GNU/Linux, un solo attributo thread è in genere di interesse (gli altri attributi disponibili sono principalmente per la programmazione in tempo reale).
-Questo attributo è il **detach state** del thread. Un thread può essere creato come un thread **joinable** (l'impostazione predefinita) o come un **detached** thread. Un joinable thread, come un processo, non viene automaticamente ripulito da GNU/Linux quando termina e lo stato di uscita del thread rimane sospeso nel sistema (un po' come un processo zombie) finché un altro thread non richiama la `pthread_join()` per ottenere il suo valore di ritorno. **Solo allora le sue risorse vengono rilasciate**. Un **detached** thread, al contrario, viene ripulito automaticamente quando termina. Poiché un detached thread viene immediatamente ripulito, un altro thread potrebbe non sincronizzarsi al suo completamento tramite `pthread_join()` o ottenere il suo valore di ritorno.
+<p align="justify">
+Un singolo oggetto attributo thread può essere utilizzato per inizializzare diversi thread. Non è necessario mantenere l'oggetto attributo thread dopo che i thread sono stati creati. Per la maggior parte delle attività di programmazione delle applicazioni GNU/Linux, un solo attributo thread è in genere di interesse (gli altri attributi disponibili sono principalmente per la programmazione in tempo reale). Questo attributo è il <strong>detach state</strong> del thread. Un thread può essere creato come un thread <strong>joinable</strong> (l'impostazione predefinita) o come un <strong>detached</strong> thread. Un joinable thread, come un processo, non viene automaticamente ripulito da GNU/Linux quando termina e lo stato di uscita del thread rimane sospeso nel sistema (un po' come un processo zombie) finché un altro thread non richiama la <code>pthread_join()</code> per ottenere il suo valore di ritorno. <strong>Solo allora le sue risorse vengono rilasciate</strong>. Un <strong>detached</strong> thread, al contrario, viene ripulito automaticamente quando termina. Poiché un detached thread viene immediatamente ripulito, un altro thread potrebbe non sincronizzarsi al suo completamento tramite <code>pthread_join()</code> o ottenere il suo valore di ritorno.
+</p>
 
-Per impostare lo stato detached in un oggetto attributo thread, basta utilizzare `pthread_attr_setdetachstate()`.
-Questo è il suo prototipo:
+<p align="justify">
+Per impostare lo stato detached in un oggetto attributo thread, basta utilizzare <code>pthread_attr_setdetachstate()</code>. Questo è il suo prototipo:
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate);
-```
+</code></pre>
 
-Il primo argomento è un puntatore all'oggetto attributo thread (`pthread_attr_t *`) e il secondo è lo stato detached desiderato. Poiché lo stato joinable è quello predefinito, è necessario chiamare questo solo per creare detached thread passando `PTHREAD_CREATE_DETACHED` come secondo argomento.
-Il codice seguente crea un detached thread impostando l'attributo thread a `PTHREAD_CREATE_DETACHED`.
+<p align="justify">
+Il primo argomento è un puntatore all'oggetto attributo thread (<code>pthread_attr_t *</code>) e il secondo è lo stato detached desiderato. Poiché lo stato joinable è quello predefinito, è necessario chiamare questo solo per creare detached thread passando <code>PTHREAD_CREATE_DETACHED</code> come secondo argomento. Il codice seguente crea un detached thread impostando l'attributo thread a <code>PTHREAD_CREATE_DETACHED</code>.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <pthread.h>
+#include &lt;pthread.h&gt;
 
 void* thread_function (void* thread_arg)
 {
@@ -1394,86 +1466,121 @@ int main ()
   pthread_attr_t attr;
   pthread_t thread;
 
-  pthread_attr_init (&attr);
-  pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_DETACHED);
-  pthread_create (&thread, &attr, &thread_function, NULL);
-  pthread_attr_destroy (&attr);
+  pthread_attr_init (&amp;attr);
+  pthread_attr_setdetachstate (&amp;attr, PTHREAD_CREATE_DETACHED);
+  pthread_create (&amp;thread, &amp;attr, &amp;thread_function, NULL);
+  pthread_attr_destroy (&amp;attr);
 
   /* Do work here...  */
 
   /* No need to join the second thread.  */
   return 0;
 }
-```
+</code></pre>
 
-Anche se un thread è stato creato con stato joinable può essere impostato in un secondo momento nello stato detached, per fare questo basta usare la funzione `pthread_detach()`. Questo è il suo prototipo:
+<p align="justify">
+Anche se un thread è stato creato con stato joinable può essere impostato in un secondo momento nello stato detached, per fare questo basta usare la funzione <code>pthread_detach()</code>. Questo è il suo prototipo:
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_detach(pthread_t thread);
-```
+</code></pre>
 
 #### Cancellazione del thread
 
-In circostanze normali, un thread termina quando conclude la propria funzione o chiamando la `pthread_exit()`. Tuttavia, è possibile che un thread richieda la terminazione di un altro thread. Questo meccanismo si chiama cancellamento di un thread. Per cancellare un thread, chiama la `pthread_cancel()`, passando l'ID del thread da cancellare. è possibile richiamare la `pthread_join()` su un thread cancellato (di tipo joinable, non è possibile per un thread in stato detached) per liberarne le risorse. Il valore di ritorno di un thread cancellato è il valore speciale `PTHREAD_CANCELED`.
+<p align="justify">
+In circostanze normali, un thread termina quando conclude la propria funzione o chiamando la <code>pthread_exit()</code>. Tuttavia, è possibile che un thread richieda la terminazione di un altro thread. Questo meccanismo si chiama cancellamento di un thread. Per cancellare un thread, chiama la <code>pthread_cancel()</code>, passando l'ID del thread da cancellare. è possibile richiamare la <code>pthread_join()</code> su un thread cancellato (di tipo joinable, non è possibile per un thread in stato detached) per liberarne le risorse. Il valore di ritorno di un thread cancellato è il valore speciale <code>PTHREAD_CANCELED</code>.
+</p>
 
+<p align="justify">
 Spesso un thread può eseguire codice in cui tutte le istruzioni devono essere trattate in modo atomico. Ad esempio, il thread può allocare alcune risorse, usarle e quindi deallocarle. Se il thread viene annullato nel mezzo di questo codice, potrebbe non avere l'opportunità di deallocare le risorse, e quindi le risorse saranno perse. Per contrastare questa possibilità, un thread può controllare se e quando può essere annullato. Un thread può trovarsi in uno dei tre stati per quanto riguarda la cancellazione del thread:
+</p>
 
-* Il thread può essere **cancellabile in modo asincrono**. Il thread può essere annullato in qualsiasi momento della sua esecuzione.
-* Il thread può essere **cancellabile in modo sincrono**. Il thread può essere annullato, ma non in qualsiasi momento della sua esecuzione. Invece, le richieste di annullamento vengono messe in coda e il thread viene cancellato solo quando raggiunge punti specifici della sua esecuzione.
-* Un thread può essere **non cancellabile**. I tentativi di cancellare il thread vengono ignorati silenziosamente.
+<ul>
+  <li>
+    <p align="justify">
+    Il thread può essere <strong>cancellabile in modo asincrono</strong>. Il thread può essere annullato in qualsiasi momento della sua esecuzione.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Il thread può essere <strong>cancellabile in modo sincrono</strong>. Il thread può essere annullato, ma non in qualsiasi momento della sua esecuzione. Invece, le richieste di annullamento vengono messe in coda e il thread viene cancellato solo quando raggiunge punti specifici della sua esecuzione.
+    </p>
+  </li>
+  <li>
+    <p align="justify">
+    Un thread può essere <strong>non cancellabile</strong>. I tentativi di cancellare il thread vengono ignorati silenziosamente.
+    </p>
+  </li>
+</ul>
 
-**Quando viene creato inizialmente, un thread è cancellabile in modo sincrono**
+<p align="justify">
+<strong>Quando viene creato inizialmente, un thread è cancellabile in modo sincrono</strong>
+</p>
 
 #### Thread sincroni ed asincroni
 
-Un thread cancellabile in modo asincrono può essere annullato in qualsiasi momento della sua esecuzione. Un thread cancellabile in modo sincrono, al contrario, può essere cancellato solo in determinati punti della sua esecuzione. Questi punti sono chiamati punti di annullamento. Il thread metterà in coda una richiesta di annullamento finché non raggiunge il punto di annullamento successivo. Per rendere un thread cancellabile in modo asincrono, utilizzare `pthread_setcanceltype()`. Questo è il suo prototipo:
+<p align="justify">
+Un thread cancellabile in modo asincrono può essere annullato in qualsiasi momento della sua esecuzione. Un thread cancellabile in modo sincrono, al contrario, può essere cancellato solo in determinati punti della sua esecuzione. Questi punti sono chiamati punti di annullamento. Il thread metterà in coda una richiesta di annullamento finché non raggiunge il punto di annullamento successivo. Per rendere un thread cancellabile in modo asincrono, utilizzare <code>pthread_setcanceltype()</code>. Questo è il suo prototipo:
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_setcanceltype(int type, int *oldtype);
-```
+</code></pre>
 
-Il primo argomento dovrebbe essere `PTHREAD_CANCEL_ASYNCHRONOUS` per rendere il thread cancellabile in modo asincrono o `PTHREAD_CANCEL_DEFERRED` per riportarlo allo stato cancellabile in modo sincrono. Il secondo argomento, se non è nullo, è un puntatore a una variabile che riceverà il tipo di annullamento precedente per il thread. Questa chiamata, ad esempio, rende il thread chiamante cancellabile in modo asincrono.
+<p align="justify">
+Il primo argomento dovrebbe essere <code>PTHREAD_CANCEL_ASYNCHRONOUS</code> per rendere il thread cancellabile in modo asincrono o <code>PTHREAD_CANCEL_DEFERRED</code> per riportarlo allo stato cancellabile in modo sincrono. Il secondo argomento, se non è nullo, è un puntatore a una variabile che riceverà il tipo di annullamento precedente per il thread. Questa chiamata, ad esempio, rende il thread chiamante cancellabile in modo asincrono.
+</p>
 
-```c
+<pre><code class="language-c">
 pthread_setcanceltype (PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
-```
+</code></pre>
 
-Cosa costituisce un punto di annullamento e dove dovrebbero essere posizionati? Il modo più diretto per creare un punto di annullamento è chiamare `pthread_testcancel()`. 
+<p align="justify">
+Cosa costituisce un punto di annullamento e dove dovrebbero essere posizionati? Il modo più diretto per creare un punto di annullamento è chiamare <code>pthread_testcancel()</code>.
+</p>
 
-```c
+<pre><code class="language-c">
 void pthread_testcancel(void);
-```
-Questa funzione non fa altro che elaborare un annullamento in sospeso in un thread cancellabile in modo sincrono. Dovresti chiamare `pthread_testcancel()` periodicamente durante i calcoli lunghi in una funzione thread, nei punti in cui il thread può essere annullato senza perdere risorse o produrre altri effetti negativi. Anche alcune altre funzioni sono implicitamente punti di annullamento. Sono elencate nella pagina man di `pthread_cancel()`. Nota che altre funzioni possono utilizzare queste funzioni internamente e quindi saranno indirettamente punti di annullamento.		
+</code></pre>
+<p align="justify">
+Questa funzione non fa altro che elaborare un annullamento in sospeso in un thread cancellabile in modo sincrono. Dovresti chiamare <code>pthread_testcancel()</code> periodicamente durante i calcoli lunghi in una funzione thread, nei punti in cui il thread può essere annullato senza perdere risorse o produrre altri effetti negativi. Anche alcune altre funzioni sono implicitamente punti di annullamento. Sono elencate nella pagina man di <code>pthread_cancel()</code>. Nota che altre funzioni possono utilizzare queste funzioni internamente e quindi saranno indirettamente punti di annullamento.
+</p>
 
 
 #### Sezioni critiche non cancellabili
 
-Un thread può disabilitare del tutto la cancellazione di se stesso con la funzione `pthread_setcancelstate()`. 
+<p align="justify">
+Un thread può disabilitare del tutto la cancellazione di se stesso con la funzione <code>pthread_setcancelstate()</code>.
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_setcancelstate(int state, int *oldstate);
-```
+</code></pre>
 
-Il primo argomento è `PTHREAD_CANCEL_DISABLE` per disabilitare la cancellazione o `PTHREAD_CANCEL_ENABLE` per riabilitare la cancellazione. Il secondo argomento, se non è nullo,
-punta a una variabile che riceverà lo stato di cancellazione precedente. Questa chiamata, ad esempio, disabilita l'annullamento del thread nel thread chiamante.
+<p align="justify">
+Il primo argomento è <code>PTHREAD_CANCEL_DISABLE</code> per disabilitare la cancellazione o <code>PTHREAD_CANCEL_ENABLE</code> per riabilitare la cancellazione. Il secondo argomento, se non è nullo, punta a una variabile che riceverà lo stato di cancellazione precedente. Questa chiamata, ad esempio, disabilita l'annullamento del thread nel thread chiamante.
+</p>
 
-```c
+<pre><code class="language-c">
 pthread_setcancelstate (PTHREAD_CANCEL_DISABLE, NULL);
-```
+</code></pre>
 
-**L'utilizzo di `pthread_setcancelstate()` consente di implementare sezioni critiche**. Una **sezione critica** è una sequenza di codice che deve essere eseguita per intero o per niente; in altre parole, se un thread inizia a eseguire la sezione critica, deve continuare fino alla fine della sezione critica senza essere annullato. Ad esempio, supponiamo che tu stia scrivendo una routine per un programma bancario che trasferisce denaro da un conto a un altro. Per fare ciò, devi aggiungere valore al saldo di un conto e detrarre lo stesso valore dal saldo di un altro conto. Se il thread che esegue la tua routine venisse annullato proprio nel momento sbagliato tra queste due operazioni, il programma avrebbe aumentato in modo ingiusto i depositi totali della banca non riuscendo a completare la transazione. Per evitare questa possibilità, inserisci le due operazioni in una sezione critica. Potresti implementare il trasferimento con una funzione come `process_transaction()`, riportata nel paragrafo seguente. Questa funzione disabilita l'annullamento del thread per avviare una sezione critica prima che modifichi il saldo di uno dei due conti.
+<p align="justify">
+<strong>L'utilizzo di <code>pthread_setcancelstate()</code> consente di implementare sezioni critiche</strong>. Una <strong>sezione critica</strong> è una sequenza di codice che deve essere eseguita per intero o per niente; in altre parole, se un thread inizia a eseguire la sezione critica, deve continuare fino alla fine della sezione critica senza essere annullato. Ad esempio, supponiamo che tu stia scrivendo una routine per un programma bancario che trasferisce denaro da un conto a un altro. Per fare ciò, devi aggiungere valore al saldo di un conto e detrarre lo stesso valore dal saldo di un altro conto. Se il thread che esegue la tua routine venisse annullato proprio nel momento sbagliato tra queste due operazioni, il programma avrebbe aumentato in modo ingiusto i depositi totali della banca non riuscendo a completare la transazione. Per evitare questa possibilità, inserisci le due operazioni in una sezione critica. Potresti implementare il trasferimento con una funzione come <code>process_transaction()</code>, riportata nel paragrafo seguente. Questa funzione disabilita l'annullamento del thread per avviare una sezione critica prima che modifichi il saldo di uno dei due conti.
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <pthread.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
+#include &lt;pthread.h&gt;
+#include &lt;stdio.h&gt;
+#include &lt;string.h&gt;
+#include &lt;stdlib.h&gt;
 
 /* Parameters to process_transaction function.  */
 
@@ -1494,18 +1601,18 @@ float* account_balances;
 void* process_transaction (void *args)
 {
   struct thread_params *p= (struct thread_params *)args;
-  int from_acct = p->from;
-  int to_acct = p->to;
-  float dollars = p->dollars;
+  int from_acct = p-&gt;from;
+  int to_acct = p-&gt;to;
+  float dollars = p-&gt;dollars;
 
   int old_cancel_state;
 
   /* Check the balance in FROM_ACCT.  */
-  if (account_balances[from_acct] < dollars)
+  if (account_balances[from_acct] &lt; dollars)
     return (void *)1;
 
   /* Begin critical section.  */
-  pthread_setcancelstate (PTHREAD_CANCEL_DISABLE, &old_cancel_state);
+  pthread_setcancelstate (PTHREAD_CANCEL_DISABLE, &amp;old_cancel_state);
   /* Move the money.  */
   account_balances[to_acct] += dollars;
   account_balances[from_acct] -= dollars;
@@ -1536,21 +1643,21 @@ int main() {
   account_balances[8] = 34;
   account_balances[9] = 13;
 
-  for(int i=0; i< 10; i++)
+  for(int i=0; i&lt; 10; i++)
     printf("[%d] %1.f$\n", i, account_balances[i]);
 
-  pthread_create (&thread_id, NULL, &process_transaction, &p);
-  pthread_join (thread_id, (void *) &thread_return_value);
+  pthread_create (&amp;thread_id, NULL, &amp;process_transaction, &amp;p);
+  pthread_join (thread_id, (void *) &amp;thread_return_value);
 
   printf("\n");
-  for(int i=0; i< 10; i++)
+  for(int i=0; i&lt; 10; i++)
     printf("[%d] %1.f$\n", i, account_balances[i]);
 
   return 0;
 }
-```
+</code></pre>
 
-```bash
+<pre><code class="language-bash">
 vagrant@ubuntu2204:/lab2/1_threads$ bin/5_critical_section
 [0] 100$
 [1] 67$
@@ -1573,53 +1680,64 @@ vagrant@ubuntu2204:/lab2/1_threads$ bin/5_critical_section
 [7] 90$
 [8] 34$
 [9] 13$
-```
+</code></pre>
 
-Si noti che è importante ripristinare il vecchio stato di annullamento alla fine della sezione critica piuttosto che impostarlo incondizionatamente su `PTHREAD_CANCEL_ENABLE`. Ciò consente di chiamare la funzione `process_transaction()` in modo sicuro da un'altra sezione critica, in quel caso la funzione setterà lo stato di annullamento nello stesso modo in cui lo ha trovato.
+<p align="justify">
+Si noti che è importante ripristinare il vecchio stato di annullamento alla fine della sezione critica piuttosto che impostarlo incondizionatamente su <code>PTHREAD_CANCEL_ENABLE</code>. Ciò consente di chiamare la funzione <code>process_transaction()</code> in modo sicuro da un'altra sezione critica, in quel caso la funzione setterà lo stato di annullamento nello stesso modo in cui lo ha trovato.
+</p>
 
 
 #### Quando usare la cancellazione del thread
 
+<p align="justify">
 In generale, è una buona idea non usare la cancellazione del thread per terminare l'esecuzione di un thread, tranne in circostanze insolite. Durante il normale funzionamento, una strategia migliore è quella di indicare al thread che dovrebbe uscire e quindi attendere che il thread esca da solo in modo ordinato. Per far questo è necessario conoscere le tecniche di IPC (Interprocess Communication).
+</p>
 
 ### Dati specifici del thread
 
-A differenza dei processi, **tutti i thread in un singolo programma condividono lo stesso spazio di indirizzamento**. Ciò significa che se un thread modifica una posizione nella memoria (ad esempio, una variabile globale), la modifica è visibile a tutti gli altri thread. Ciò consente a più thread di operare sugli stessi dati senza utilizzare meccanismi di comunicazione tra processi. Tuttavia, ogni thread ha il proprio stack di chiamate. Ciò consente a ogni thread di eseguire codice diverso e di chiamare e restituire da subroutine nel modo consueto. Come in un programma a thread singolo, ogni invocazione di una subroutine in ogni thread ha il proprio set di variabili locali, che vengono memorizzate nello stack per quel thread. A volte, tuttavia, è desiderabile duplicare una determinata variabile in modo che ogni thread abbia una copia separata. GNU/Linux supporta ciò **fornendo a ogni thread un'area dati specifica per il thread**. Le variabili memorizzate in quest'area vengono duplicate per ogni thread e ogni thread può modificare la propria copia di una variabile senza influenzare gli altri thread. Poiché tutti i thread condividono lo stesso spazio di memoria, **i dati specifici del thread potrebbero non essere accessibili tramite normali riferimenti alle variabili**. GNU/Linux fornisce funzioni speciali per impostare e recuperare valori dall'area dati specifica del thread.
+<p align="justify">
+A differenza dei processi, <strong>tutti i thread in un singolo programma condividono lo stesso spazio di indirizzamento</strong>. Ciò significa che se un thread modifica una posizione nella memoria (ad esempio, una variabile globale), la modifica è visibile a tutti gli altri thread. Ciò consente a più thread di operare sugli stessi dati senza utilizzare meccanismi di comunicazione tra processi. Tuttavia, ogni thread ha il proprio stack di chiamate. Ciò consente a ogni thread di eseguire codice diverso e di chiamare e restituire da subroutine nel modo consueto. Come in un programma a thread singolo, ogni invocazione di una subroutine in ogni thread ha il proprio set di variabili locali, che vengono memorizzate nello stack per quel thread. A volte, tuttavia, è desiderabile duplicare una determinata variabile in modo che ogni thread abbia una copia separata. GNU/Linux supporta ciò <strong>fornendo a ogni thread un'area dati specifica per il thread</strong>. Le variabili memorizzate in quest'area vengono duplicate per ogni thread e ogni thread può modificare la propria copia di una variabile senza influenzare gli altri thread. Poiché tutti i thread condividono lo stesso spazio di memoria, <strong>i dati specifici del thread potrebbero non essere accessibili tramite normali riferimenti alle variabili</strong>. GNU/Linux fornisce funzioni speciali per impostare e recuperare valori dall'area dati specifica del thread.
+</p>
 
-Puoi creare tutti gli elementi dati specifici del thread che vuoi, ognuno di tipo `void *`.
-Ogni elemento è identificato da una chiave. Per creare una nuova chiave, e quindi un nuovo elemento dati per ogni thread, usa **pthread_key_create()**. 
+<p align="justify">
+Puoi creare tutti gli elementi dati specifici del thread che vuoi, ognuno di tipo <code>void *</code>. Ogni elemento è identificato da una chiave. Per creare una nuova chiave, e quindi un nuovo elemento dati per ogni thread, usa <strong>pthread_key_create()</strong>.
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_key_create(pthread_key_t *key, void (*destructor)(void*));
-```
+</code></pre>
 
-Il primo argomento è un puntatore a una variabile di tipo **pthread_key_t**. Quel valore chiave può essere usato da ogni thread per accedere alla propria copia dell'elemento dati corrispondente.
-Il secondo argomento dopo `pthread_key_t` è una funzione di pulizia (cleanup function). Se passi un puntatore a funzione qui, GNU/Linux chiama automaticamente quella funzione quando il thread esce, passando il valore specifico del thread corrispondente
-a quella chiave. Ciò è particolarmente utile perché la funzione di pulizia viene chiamata anche se il thread viene annullato in un punto arbitrario della sua esecuzione. Se il valore specifico del thread è `NULL`, la funzione di pulizia del thread non viene chiamata. Se non hai bisogno di una funzione di pulizia, puoi passare `NULL` invece di un puntatore a funzione. **Dopo aver creato una chiave**, **ogni thread può impostare il suo valore specifico del thread corrispondente a quella chiave** chiamando **pthread_setspecific()**.
+<p align="justify">
+Il primo argomento è un puntatore a una variabile di tipo <strong>pthread_key_t</strong>. Quel valore chiave può essere usato da ogni thread per accedere alla propria copia dell'elemento dati corrispondente. Il secondo argomento dopo <code>pthread_key_t</code> è una funzione di pulizia (cleanup function). Se passi un puntatore a funzione qui, GNU/Linux chiama automaticamente quella funzione quando il thread esce, passando il valore specifico del thread corrispondente a quella chiave. Ciò è particolarmente utile perché la funzione di pulizia viene chiamata anche se il thread viene annullato in un punto arbitrario della sua esecuzione. Se il valore specifico del thread è <code>NULL</code>, la funzione di pulizia del thread non viene chiamata. Se non hai bisogno di una funzione di pulizia, puoi passare <code>NULL</code> invece di un puntatore a funzione. <strong>Dopo aver creato una chiave</strong>, <strong>ogni thread può impostare il suo valore specifico del thread corrispondente a quella chiave</strong> chiamando <strong>pthread_setspecific()</strong>.
+</p>
 
-```c
+<pre><code class="language-c">
 int pthread_setspecific(pthread_key_t key, const void *value);
-```
+</code></pre>
 
-Il primo argomento è la chiave e il secondo è il valore specifico del thread (di tipo void*) da memorizzare. Per recuperare un elemento dati specifico del thread, chiama **pthread_getspecific()**, passando la chiave come argomento. 
+<p align="justify">
+Il primo argomento è la chiave e il secondo è il valore specifico del thread (di tipo void*) da memorizzare. Per recuperare un elemento dati specifico del thread, chiama <strong>pthread_getspecific()</strong>, passando la chiave come argomento.
+</p>
 
-```c
+<pre><code class="language-c">
 void *pthread_getspecific(pthread_key_t key);
-```
+</code></pre>
 
-Supponiamo, ad esempio, che l'applicazione divida un'attività tra più thread. Ogni thread deve avere un file di registro separato, in cui vengono registrati i messaggi di avanzamento per le attività di quel thread. L'area dati specifica del thread è un posto comodo per memorizzare il puntatore al file di registro di ogni singolo thread. 
+<p align="justify">
+Supponiamo, ad esempio, che l'applicazione divida un'attività tra più thread. Ogni thread deve avere un file di registro separato, in cui vengono registrati i messaggi di avanzamento per le attività di quel thread. L'area dati specifica del thread è un posto comodo per memorizzare il puntatore al file di registro di ogni singolo thread.
+</p>
 
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <malloc.h>
-#include <pthread.h>
-#include <stdio.h>
+#include &lt;malloc.h&gt;
+#include &lt;pthread.h&gt;
+#include &lt;stdio.h&gt;
 
 /* The key used to associate a log file pointer with each thread.  */
 static pthread_key_t thread_log_key;
@@ -1668,45 +1786,53 @@ int main ()
   /* Create a key to associate thread log file pointers in
      thread-specific data.  Use close_thread_log to clean up the file
      pointers.  */
-  pthread_key_create (&thread_log_key, close_thread_log);
+  pthread_key_create (&amp;thread_log_key, close_thread_log);
   /* Create threads to do the work.  */
-  for (i = 0; i < 5; ++i)
-    pthread_create (&(threads[i]), NULL, thread_function, NULL);
+  for (i = 0; i &lt; 5; ++i)
+    pthread_create (&amp;(threads[i]), NULL, thread_function, NULL);
   /* Wait for all threads to finish.  */
-  for (i = 0; i < 5; ++i)
+  for (i = 0; i &lt; 5; ++i)
     pthread_join (threads[i], NULL);
   return 0;
 }
-```
+</code></pre>
 
 
-La funzione principale in questo programma di esempio crea una chiave per memorizzare il puntatore del file specifico del thread e quindi lo memorizza in **thread_log_key**. Poiché si tratta di una variabile globale, è condivisa da tutti i thread. Quando ogni thread inizia a eseguire la sua funzione thread, apre un file di registro e memorizza il relativo puntatore del file associato a quella chiave. In seguito, uno qualsiasi di questi thread può chiamare **write_to_thread_log()** per scrivere un messaggio nel file di registro specifico del thread. Tale funzione recupera il puntatore del file per il file di registro del thread dai dati specifici del thread e scrive il messaggio.
+<p align="justify">
+La funzione principale in questo programma di esempio crea una chiave per memorizzare il puntatore del file specifico del thread e quindi lo memorizza in <strong>thread_log_key</strong>. Poiché si tratta di una variabile globale, è condivisa da tutti i thread. Quando ogni thread inizia a eseguire la sua funzione thread, apre un file di registro e memorizza il relativo puntatore del file associato a quella chiave. In seguito, uno qualsiasi di questi thread può chiamare <strong>write_to_thread_log()</strong> per scrivere un messaggio nel file di registro specifico del thread. Tale funzione recupera il puntatore del file per il file di registro del thread dai dati specifici del thread e scrive il messaggio.
+</p>
 
-Si noti che **thread_function()** non ha bisogno di chiudere il file di registro. Questo perché quando è stata creata la chiave del file di registro, **close_thread_log()** è stato specificato come funzione di pulizia per quella chiave. Ogni volta che un thread esce, GNU/Linux chiama quella funzione, passando il valore specifico del thread per la chiave del registro del thread. Questa funzione si occupa di chiudere il file di registro.
+<p align="justify">
+Si noti che <strong>thread_function()</strong> non ha bisogno di chiudere il file di registro. Questo perché quando è stata creata la chiave del file di registro, <strong>close_thread_log()</strong> è stato specificato come funzione di pulizia per quella chiave. Ogni volta che un thread esce, GNU/Linux chiama quella funzione, passando il valore specifico del thread per la chiave del registro del thread. Questa funzione si occupa di chiudere il file di registro.
+</p>
 
 ### Gestori di pulizia (Cleanup Handler)
 
-Le funzioni di pulizia per chiavi dati specifiche del thread possono essere molto utili per garantire che le risorse non vengano perse quando un thread esce o viene annullato. A volte, tuttavia, è utile poter specificare funzioni di pulizia senza creare un nuovo elemento dati specifico del thread duplicato per ogni thread. GNU/Linux fornisce gestori di pulizia a questo scopo. **Un gestore di pulizia è semplicemente una funzione che dovrebbe essere chiamata quando un thread esce**. Il gestore accetta un singolo parametro `void *` e il suo valore di argomento viene fornito quando il gestore viene registrato; questo semplifica l'utilizzo della stessa funzione di pulizia per gestire più istanze di risorse. **Un gestore di pulizia è una misura temporanea**, **utilizzata per deallocare una risorsa solo se il thread esce o viene annullato** anziché terminare l'esecuzione di una particolare regione di codice. **In circostanze normali, quando il thread non esce e non viene annullato, la risorsa dovrebbe essere deallocata in modo esplicito** e il gestore di pulizia dovrebbe essere rimosso. Per registrare un gestore di pulizia, chiama **pthread_cleanup_push()**, passando un puntatore alla funzione di pulizia e il valore del suo argomento `void *`. La chiamata a pthread_cleanup_push deve essere bilanciata da una chiamata corrispondente a pthread_cleanup_pop, che annulla la registrazione del gestore di pulizia. 
+<p align="justify">
+Le funzioni di pulizia per chiavi dati specifiche del thread possono essere molto utili per garantire che le risorse non vengano perse quando un thread esce o viene annullato. A volte, tuttavia, è utile poter specificare funzioni di pulizia senza creare un nuovo elemento dati specifico del thread duplicato per ogni thread. GNU/Linux fornisce gestori di pulizia a questo scopo. <strong>Un gestore di pulizia è semplicemente una funzione che dovrebbe essere chiamata quando un thread esce</strong>. Il gestore accetta un singolo parametro <code>void *</code> e il suo valore di argomento viene fornito quando il gestore viene registrato; questo semplifica l'utilizzo della stessa funzione di pulizia per gestire più istanze di risorse. <strong>Un gestore di pulizia è una misura temporanea</strong>, <strong>utilizzata per deallocare una risorsa solo se il thread esce o viene annullato</strong> anziché terminare l'esecuzione di una particolare regione di codice. <strong>In circostanze normali, quando il thread non esce e non viene annullato, la risorsa dovrebbe essere deallocata in modo esplicito</strong> e il gestore di pulizia dovrebbe essere rimosso. Per registrare un gestore di pulizia, chiama <strong>pthread_cleanup_push()</strong>, passando un puntatore alla funzione di pulizia e il valore del suo argomento <code>void *</code>. La chiamata a pthread_cleanup_push deve essere bilanciata da una chiamata corrispondente a pthread_cleanup_pop, che annulla la registrazione del gestore di pulizia.
+</p>
 
-```c
+<pre><code class="language-c">
 void pthread_cleanup_push(void (*routine)(void *), void *arg);
-```
+</code></pre>
 
-```c
+<pre><code class="language-c">
 void pthread_cleanup_pop(int execute);
-```
+</code></pre>
 
-Per comodità, `pthread_cleanup_pop()` accetta un argomento flag int; se il flag è diverso da zero, l'azione di pulizia viene effettivamente eseguita. Il frammento di programma seguente mostra come è possibile utilizzare un gestore di pulizia per assicurarsi che un buffer allocato dinamicamente venga ripulito se il thread termina.
+<p align="justify">
+Per comodità, <code>pthread_cleanup_pop()</code> accetta un argomento flag int; se il flag è diverso da zero, l'azione di pulizia viene effettivamente eseguita. Il frammento di programma seguente mostra come è possibile utilizzare un gestore di pulizia per assicurarsi che un buffer allocato dinamicamente venga ripulito se il thread termina.
+</p>
 
-```c
+<pre><code class="language-c">
 ***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
-#include <stdio.h>
-#include <malloc.h>
-#include <pthread.h>
+#include &lt;stdio.h&gt;
+#include &lt;malloc.h&gt;
+#include &lt;pthread.h&gt;
 
 /* Allocate a temporary buffer.  */
 
@@ -1744,12 +1870,12 @@ void* do_some_work ()
 
 int main(void){
   pthread_t allocator_thread;
-  pthread_create(&allocator_thread, NULL, do_some_work, NULL);
+  pthread_create(&amp;allocator_thread, NULL, do_some_work, NULL);
   pthread_join(allocator_thread, NULL);
   return 0;
 
 }
-```
+</code></pre>
 
 ### Sincronizzazione e Sezioni Critiche
 

--- a/LINUX_PROGRAMMING.md
+++ b/LINUX_PROGRAMMING.md
@@ -120,24 +120,25 @@
 
 ### Processi
 
-Un processo è un'istanza di un programma: un file eseguibile presente sul disco che viene caricato in memoria.
-Quando dalla riga di comando invochiamo il nome di un programma o clicchiamo sull'icona presente sulla scrivania, il file eseguibile viene caricato in memoria ed ha inizio la sua esecuzione in un nuovo processo. Un singolo programma può fare uso di più processi contemporaneamente per svolgere più operazioni allo stesso tempo. La maggior parte delle funzioni per la manipolazione dei processi richiede l'inclusione del file header `<unistd.h>`.
+<p align="justify">
+Un processo è un'istanza di un programma: un file eseguibile presente sul disco che viene caricato in memoria. Quando dalla riga di comando invochiamo il nome di un programma o clicchiamo sull'icona presente sulla scrivania, il file eseguibile viene caricato in memoria ed ha inizio la sua esecuzione in un nuovo processo. Un singolo programma può fare uso di più processi contemporaneamente per svolgere più operazioni allo stesso tempo. La maggior parte delle funzioni per la manipolazione dei processi richiede l'inclusione del file header <code>&lt;unistd.h&gt;</code>.
+</p>
 
 #### Process IDs
 
-Ciascun processo in Linux è identificato da un identificatore univoco detto *process ID* o **PID**. Un **PID** è rappresentato con 16 bit ($s^{16}=65536$). Ciascun processo ha un processo padre, tranne il processo che viene creato per primo all'avvio del sistema operativo, detto processo **init**, che ha **PID** 1 e nessun padre.
-Il process ID del processo padre è anche detto **PPID**. I processi nei sistemi Linux sono quindi rappresentabili attraverso un albero dove la radice è il processo **init**.
-Quando in C si vuole rappresentare il **PID** di un processo si usa il tipo `pid_t` definito in `<sys/types.h>`. Per ottenere il proprio **PID** si richiama la system call `getpid()`, allo stesso modo per ottenere il **PPID** si richiama la `getppid()`. Vediamo un esempio:
+<p align="justify">
+Ciascun processo in Linux è identificato da un identificatore univoco detto <em>process ID</em> o <strong>PID</strong>. Un <strong>PID</strong> è rappresentato con 16 bit ($s^{16}=65536$). Ciascun processo ha un processo padre, tranne il processo che viene creato per primo all'avvio del sistema operativo, detto processo <strong>init</strong>, che ha <strong>PID</strong> 1 e nessun padre. Il process ID del processo padre è anche detto <strong>PPID</strong>. I processi nei sistemi Linux sono quindi rappresentabili attraverso un albero dove la radice è il processo <strong>init</strong>. Quando in C si vuole rappresentare il <strong>PID</strong> di un processo si usa il tipo <code>pid_t</code> definito in <code>&lt;sys/types.h&gt;</code>. Per ottenere il proprio <strong>PID</strong> si richiama la system call <code>getpid()</code>, allo stesso modo per ottenere il <strong>PPID</strong> si richiama la <code>getppid()</code>. Vediamo un esempio:
+</p>
 
-```c
+<pre><code class="language-c">
 /***********************************************************************
 * Code listing from "Advanced Linux Programming," by CodeSourcery LLC  *
 * Copyright (C) 2001 by New Riders Publishing                          *
 * See COPYRIGHT for license information.                               *
 ***********************************************************************/
 
-#include <stdio.h>
-#include <unistd.h>
+#include &lt;stdio.h&gt;
+#include &lt;unistd.h&gt;
 
 int main ()
 {
@@ -145,7 +146,7 @@ int main ()
   printf ("The parent process id is %d\n", (int) getppid ());
   return 0;
 }
-```
+</code></pre>
 
 ### Vedere i processi attivi
 

--- a/LINUX_PROGRAMMING.md
+++ b/LINUX_PROGRAMMING.md
@@ -44,41 +44,77 @@
 
 ## Controllo dei processi
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.01.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.01.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.02.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.02.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.03.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.03.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.04.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.04.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.05.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.05.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.06.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.06.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.07.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.07.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.08.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.08.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.09.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.09.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.10.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.10.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.11.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.11.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.12.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.12.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.13.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.13.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.14.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.14.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.15.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.15.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.16.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.16.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.17.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.17.png" alt="">
+</div>
 
-![](https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.18.png)
+<div align="center">
+  <img src="https://github.com/kinderp/2cornot2c/blob/main/images/controllo_dei_processi/controllo_dei_processi.18.png" alt="">
+</div>
 
 ## Linux Programming
 


### PR DESCRIPTION
## Summary
- Center process-control images in LINUX_PROGRAMMING.md
- Convert prose paragraphs to justified HTML paragraphs
- Convert Markdown code blocks, lists, tables, images, inline code, emphasis, links, and callouts to HTML where needed

## Notes
- Changes are split into atomic documentation commits by section/macro-section
- TEMPLATES.md is intentionally left untracked and not included