### PR TITLE
docs: improve lab template snippets

### DIFF
--- a/.github/workflows/lab-snippets.yml
+++ b/.github/workflows/lab-snippets.yml
@@ -1,0 +1,34 @@
+name: Check lab snippets
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+      - "TEMPLATES.md"
+      - "lab/**"
+      - "scripts/update_lab_snippets.py"
+      - ".github/workflows/lab-snippets.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "README.md"
+      - "TEMPLATES.md"
+      - "lab/**"
+      - "scripts/update_lab_snippets.py"
+      - ".github/workflows/lab-snippets.yml"
+
+jobs:
+  check-lab-snippets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Verify generated lab snippets
+        run: python scripts/update_lab_snippets.py --check

--- a/LAB_SNIPPETS.md
+++ b/LAB_SNIPPETS.md
@@ -1,0 +1,250 @@
+# Lab snippets: template, script e GitHub Action
+
+Questo documento spiega come funzionano i blocchi lab generati automaticamente nel README o in altri file Markdown del repository.
+
+L'obiettivo e semplice: mostrare nel README il codice reale degli esercizi presenti in `lab/`, senza copiarlo a mano ogni volta.
+
+## Perche usare gli snippet automatici
+
+Quando un esercizio in `lab/` cambia, il codice copiato manualmente nel README rischia di diventare vecchio.
+
+Per evitare questo problema usiamo:
+
+- un template HTML/Markdown per presentare il laboratorio;
+- due marker HTML che delimitano il codice generato;
+- lo script `scripts/update_lab_snippets.py`, che legge il file reale in `lab/` e aggiorna lo snippet;
+- una GitHub Action che controlla nelle PR se gli snippet sono aggiornati.
+
+## Struttura consigliata di un blocco lab
+
+Esempio:
+
+```html
+<details>
+<summary>💻 <code>/lab/0_intro/0_hello.c</code></summary>
+
+<table align="center">
+  <tr>
+    <td>
+      <p align="justify">
+        <strong>Descrizione breve:</strong>
+        Primo programma C.
+      </p>
+
+      <p align="justify">
+        <strong>Descrizione lunga:</strong>
+        Questo laboratorio mostra come includere un header standard, definire
+        la funzione <code>main()</code>, compilare il sorgente ed eseguire il binario.
+      </p>
+
+      <p align="justify">
+        <strong>Sorgente:</strong>
+        <a href="https://github.com/TheBitPoets/2cornot2c/blob/main/lab/0_intro/0_hello.c">
+          /lab/0_intro/0_hello.c
+        </a>
+      </p>
+
+<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
+<pre lang="c"><code>/* codice generato automaticamente */
+</code></pre>
+<!-- lab-snippet:end -->
+    </td>
+  </tr>
+</table>
+
+</details>
+```
+
+La parte importante e questa:
+
+```html
+<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
+...
+<!-- lab-snippet:end -->
+```
+
+Lo script sostituisce tutto quello che si trova tra questi due marker.
+
+## Come usare lo script
+
+Per aggiornare gli snippet in `README.md` e `TEMPLATES.md`:
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+Per aggiornare solo un file specifico:
+
+```bash
+python scripts/update_lab_snippets.py README.md
+```
+
+oppure:
+
+```bash
+python scripts/update_lab_snippets.py TEMPLATES.md
+```
+
+Lo script:
+
+- cerca tutti i marker `lab-snippet:start` / `lab-snippet:end`;
+- legge il file indicato nell'attributo `path`;
+- converte i caratteri speciali in entita HTML;
+- inserisce il codice dentro un blocco `<pre lang="..."><code>...</code></pre>`;
+- sceglie il linguaggio in base all'estensione del file.
+
+Esempi:
+
+| Estensione | Linguaggio usato nel blocco |
+|---|---|
+| `.c` | `c` |
+| `.h` | `c` |
+| `.asm` | `asm` |
+| `.s` | `asm` |
+| `.sh` | `bash` |
+| `.py` | `python` |
+
+## Modalita controllo
+
+Per controllare se gli snippet sono aggiornati senza volerli modificare intenzionalmente:
+
+```bash
+python scripts/update_lab_snippets.py --check
+```
+
+Se tutto e aggiornato, il comando termina correttamente.
+
+Se qualche snippet e vecchio, il comando fallisce e stampa un messaggio simile:
+
+```text
+Lab snippets are not up to date:
+- README.md
+Run: python scripts/update_lab_snippets.py
+```
+
+In quel caso basta eseguire:
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+poi committare i file aggiornati.
+
+## Come funziona la GitHub Action
+
+Il workflow si trova in:
+
+```text
+.github/workflows/lab-snippets.yml
+```
+
+La Action parte quando in una PR o su `main` cambiano file come:
+
+```text
+README.md
+TEMPLATES.md
+lab/**
+scripts/update_lab_snippets.py
+.github/workflows/lab-snippets.yml
+```
+
+La Action esegue:
+
+```bash
+python scripts/update_lab_snippets.py --check
+```
+
+Quindi non modifica automaticamente il repository.
+
+Serve solo come controllo di sicurezza: se un file in `lab/` cambia ma lo snippet nel README non e stato rigenerato, la PR fallisce e segnala cosa fare.
+
+## Workflow consigliato
+
+Quando aggiungi o modifichi un esercizio in `lab/`:
+
+1. Modifica il file sorgente in `lab/`.
+2. Aggiungi o aggiorna il blocco lab nel README, se necessario.
+3. Esegui:
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+4. Controlla le modifiche generate.
+5. Committa insieme:
+
+```text
+lab/...
+README.md
+```
+
+oppure, se stai aggiornando solo il template:
+
+```text
+TEMPLATES.md
+```
+
+## Cosa non modificare a mano
+
+Non modificare a mano il codice dentro questi marker:
+
+```html
+<!-- lab-snippet:start path="..." -->
+...
+<!-- lab-snippet:end -->
+```
+
+Qualunque modifica manuale dentro i marker verra sovrascritta dallo script.
+
+Puoi invece modificare liberamente:
+
+- il `<summary>`;
+- la descrizione breve;
+- la descrizione lunga;
+- il link al sorgente;
+- i comandi di compilazione;
+- tutto il testo fuori dai marker.
+
+## Link al sorgente
+
+Per i link ai file lab e preferibile usare `blob/main`, per esempio:
+
+```html
+<a href="https://github.com/TheBitPoets/2cornot2c/blob/main/lab/0_intro/0_hello.c">
+  /lab/0_intro/0_hello.c
+</a>
+```
+
+Evita link con hash di commit vecchi, perche puntano a una versione congelata del file.
+
+## Troubleshooting
+
+### La Action fallisce dicendo che gli snippet non sono aggiornati
+
+Esegui localmente:
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+poi committa i file modificati.
+
+### Lo script dice che il file sorgente non esiste
+
+Controlla il path nel marker:
+
+```html
+<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
+```
+
+Il path deve essere relativo alla root del repository e deve puntare a un file esistente.
+
+### Il codice appare senza syntax highlighting
+
+Controlla l'estensione del file sorgente. Lo script usa l'estensione per decidere il linguaggio del blocco `<pre lang="...">`.
+
+Per file C e header il risultato atteso e:
+
+```html
+<pre lang="c"><code>...</code></pre>
+```

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1,0 +1,113 @@
+## Lab
+
+<details>
+<summary>💻 <code>/lab/0_intro/0_hello.c</code></summary>
+
+<table align="center">
+  <tr>
+    <td>
+      <p align="justify">
+        <strong>Descrizione breve:</strong>
+        Primo programma C: stampa un messaggio a schermo e introduce la struttura minima di un programma.
+      </p>
+
+      <p align="justify">
+        <strong>Descrizione lunga:</strong>
+        Questo laboratorio mostra come includere un header standard, definire la funzione <code>main()</code>,
+        chiamare <code>printf()</code>, compilare il sorgente con <code>gcc</code> ed eseguire il binario prodotto.
+        È il punto di partenza per collegare codice sorgente, compilazione ed esecuzione.
+      </p>
+
+      <p align="justify">
+        <strong>Sorgente:</strong>
+        <a href="https://github.com/TheBitPoets/2cornot2c/blob/main/lab/0_intro/0_hello.c">
+          /lab/0_intro/0_hello.c
+        </a>
+      </p>
+
+      <p align="justify">
+        <strong>Compilazione ed esecuzione:</strong>
+      </p>
+
+<pre lang="bash"><code>cd /lab/0_intro
+gcc -o bin/0_hello 0_hello.c
+bin/0_hello</code></pre>
+
+      <p align="justify">
+        <strong>Codice:</strong>
+      </p>
+
+<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
+<pre lang="c"><code>/*
+ * 0_intro -- Primo esempio di programma in c
+ *
+ * Cosa imparerai:
+ *	*) Cosa sono gli header files
+ *      *) Concetto di funzione e chiamata di funzione
+ *	*) Processo di creazione di un file eseguibile (binario)
+ *
+ * Utilizzo:
+ *      gcc -o bin/0_hello 0_hello.c
+ *      bin/0_hello	      
+ */
+
+#include &lt;stdio.h&gt;
+
+int main(void){
+	printf("Hello World\n");
+	return 0;
+}
+</code></pre>
+<!-- lab-snippet:end -->
+    </td>
+  </tr>
+</table>
+
+</details>
+
+## Lab
+
+<details>
+<summary>/lab/0_intro/0_hello.c</summary>
+<a href="https://github.com/kinderp/2cornot2c/blob/18b60e866c1e0e22c59835fe953cbe3c534e7422/lab/0_intro/0_hello.c">/lab/0_intro/0_hello.c</a>
+	<ul>
+		<li>Entra nella macchina Linux con <code>vagrant ssh</code></li>
+		<li>Spostati nella cartella <code>lab/0_intro</code></li>
+		<li>Compila il file <code>0_hello.c</code>. L'eseguibile finale deve avere nome <code>bin/0_hello</code></li>
+	</ul>
+</details>
+
+
+## Importante
+
+<table align="center">
+	<td>:exclamation: <b>Importante</b>
+	<p align=justify>
+ Una <b>variabile</b> è una locazione di memoria a cui è stato associato un <b>identificatore</b>, cioè un nome per referenziare nel codice quella cella di memoria.
+	</p>
+	</td>
+</table>
+
+## Attenzione
+
+<table align="center">
+	<td>&#9888; <b>Attenzione</b>
+	<p align=justify>
+Le variabili possono essere sia dichiarate che definite e spesso i due termini sono usati per esprimere la stessa cosa. è prematuro spiegarne la lieve differenza, ma tieni a mente per adesso che i due termini non sono la stessa cosa.
+	</p>
+	</td>
+</table>
+
+## Nota
+
+<table align="center">
+	<td>:pill: <b>Nota</b>
+	<p align=justify>
+ Storicamente le variabili con <b>block scope</b> dovevano essere dichiarate all'inizio del blocco.
+	</p>
+	<p align=justify>
+Dal C99 è possibile dichiarare le variabili all'interno del blocco in qualsiasi posizione al suo interno.
+Questo è utile soprattutto per le variabili indice di un ciclo o per documentare meglio il proprio codice, dichiarando le variabili il più vicino possibile alla riga che ne fa effettivamente uso.
+	</p>
+	</td>
+</table>

--- a/doc/LAB_SNIPPETS.md
+++ b/doc/LAB_SNIPPETS.md
@@ -1,10 +1,10 @@
-# Lab snippets: template, script e GitHub Action
+# Frammenti di codice dei laboratori: template, script e GitHub Action
 
 Questo documento spiega come funzionano i blocchi lab generati automaticamente nel README o in altri file Markdown del repository.
 
 L'obiettivo e semplice: mostrare nel README il codice reale degli esercizi presenti in `lab/`, senza copiarlo a mano ogni volta.
 
-## Perche usare gli snippet automatici
+## Perche usare gli frammento automatici
 
 Quando un esercizio in `lab/` cambia, il codice copiato manualmente nel README rischia di diventare vecchio.
 
@@ -12,8 +12,8 @@ Per evitare questo problema usiamo:
 
 - un template HTML/Markdown per presentare il laboratorio;
 - due marker HTML che delimitano il codice generato;
-- lo script `scripts/update_lab_snippets.py`, che legge il file reale in `lab/` e aggiorna lo snippet;
-- una GitHub Action che controlla nelle PR se gli snippet sono aggiornati.
+- lo script `scripts/update_lab_frammentos.py`, che legge il file reale in `lab/` e aggiorna lo frammento;
+- una GitHub Action che controlla nelle PR se gli frammento sono aggiornati.
 
 ## Struttura consigliata di un blocco lab
 
@@ -44,10 +44,10 @@ Esempio:
         </a>
       </p>
 
-<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
+<!-- lab-frammento:start path="lab/0_intro/0_hello.c" -->
 <pre lang="c"><code>/* codice generato automaticamente */
 </code></pre>
-<!-- lab-snippet:end -->
+<!-- lab-frammento:end -->
     </td>
   </tr>
 </table>
@@ -58,36 +58,36 @@ Esempio:
 La parte importante e questa:
 
 ```html
-<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
+<!-- lab-frammento:start path="lab/0_intro/0_hello.c" -->
 ...
-<!-- lab-snippet:end -->
+<!-- lab-frammento:end -->
 ```
 
 Lo script sostituisce tutto quello che si trova tra questi due marker.
 
 ## Come usare lo script
 
-Per aggiornare gli snippet in `README.md` e `TEMPLATES.md`:
+Per aggiornare gli frammento in `README.md` e `TEMPLATES.md`:
 
 ```bash
-python scripts/update_lab_snippets.py
+python scripts/update_lab_frammentos.py
 ```
 
 Per aggiornare solo un file specifico:
 
 ```bash
-python scripts/update_lab_snippets.py README.md
+python scripts/update_lab_frammentos.py README.md
 ```
 
 oppure:
 
 ```bash
-python scripts/update_lab_snippets.py TEMPLATES.md
+python scripts/update_lab_frammentos.py TEMPLATES.md
 ```
 
 Lo script:
 
-- cerca tutti i marker `lab-snippet:start` / `lab-snippet:end`;
+- cerca tutti i marker `lab-frammento:start` / `lab-frammento:end`;
 - legge il file indicato nell'attributo `path`;
 - converte i caratteri speciali in entita HTML;
 - inserisce il codice dentro un blocco `<pre lang="..."><code>...</code></pre>`;
@@ -106,26 +106,26 @@ Esempi:
 
 ## Modalita controllo
 
-Per controllare se gli snippet sono aggiornati senza volerli modificare intenzionalmente:
+Per controllare se gli frammento sono aggiornati senza volerli modificare intenzionalmente:
 
 ```bash
-python scripts/update_lab_snippets.py --check
+python scripts/update_lab_frammentos.py --check
 ```
 
 Se tutto e aggiornato, il comando termina correttamente.
 
-Se qualche snippet e vecchio, il comando fallisce e stampa un messaggio simile:
+Se qualche frammento e vecchio, il comando fallisce e stampa un messaggio simile:
 
 ```text
-Lab snippets are not up to date:
+I frammenti di codice dei laboratori non sono aggiornati:
 - README.md
-Run: python scripts/update_lab_snippets.py
+Esegui: python scripts/update_lab_frammentos.py
 ```
 
 In quel caso basta eseguire:
 
 ```bash
-python scripts/update_lab_snippets.py
+python scripts/update_lab_frammentos.py
 ```
 
 poi committare i file aggiornati.
@@ -135,7 +135,7 @@ poi committare i file aggiornati.
 Il workflow si trova in:
 
 ```text
-.github/workflows/lab-snippets.yml
+.github/workflows/lab-frammentos.yml
 ```
 
 La Action parte quando in una PR o su `main` cambiano file come:
@@ -144,21 +144,21 @@ La Action parte quando in una PR o su `main` cambiano file come:
 README.md
 TEMPLATES.md
 lab/**
-scripts/update_lab_snippets.py
-.github/workflows/lab-snippets.yml
+scripts/update_lab_frammentos.py
+.github/workflows/lab-frammentos.yml
 ```
 
 La Action esegue:
 
 ```bash
-python scripts/update_lab_snippets.py --check
+python scripts/update_lab_frammentos.py --check
 ```
 
 Quindi non modifica automaticamente il repository.
 
-Serve solo come controllo di sicurezza: se un file in `lab/` cambia ma lo snippet nel README non e stato rigenerato, la PR fallisce e segnala cosa fare.
+Serve solo come controllo di sicurezza: se un file in `lab/` cambia ma lo frammento nel README non e stato rigenerato, la PR fallisce e segnala cosa fare.
 
-## Workflow consigliato
+## Flusso di lavoro consigliato
 
 Quando aggiungi o modifichi un esercizio in `lab/`:
 
@@ -167,7 +167,7 @@ Quando aggiungi o modifichi un esercizio in `lab/`:
 3. Esegui:
 
 ```bash
-python scripts/update_lab_snippets.py
+python scripts/update_lab_frammentos.py
 ```
 
 4. Controlla le modifiche generate.
@@ -189,9 +189,9 @@ TEMPLATES.md
 Non modificare a mano il codice dentro questi marker:
 
 ```html
-<!-- lab-snippet:start path="..." -->
+<!-- lab-frammento:start path="..." -->
 ...
-<!-- lab-snippet:end -->
+<!-- lab-frammento:end -->
 ```
 
 Qualunque modifica manuale dentro i marker verra sovrascritta dallo script.
@@ -205,7 +205,7 @@ Puoi invece modificare liberamente:
 - i comandi di compilazione;
 - tutto il testo fuori dai marker.
 
-## Link al sorgente
+## Collegamento al sorgente
 
 Per i link ai file lab e preferibile usare `blob/main`, per esempio:
 
@@ -217,14 +217,14 @@ Per i link ai file lab e preferibile usare `blob/main`, per esempio:
 
 Evita link con hash di commit vecchi, perche puntano a una versione congelata del file.
 
-## Troubleshooting
+## Risoluzione dei problemi
 
-### La Action fallisce dicendo che gli snippet non sono aggiornati
+### La Action fallisce dicendo che gli frammento non sono aggiornati
 
 Esegui localmente:
 
 ```bash
-python scripts/update_lab_snippets.py
+python scripts/update_lab_frammentos.py
 ```
 
 poi committa i file modificati.
@@ -234,12 +234,12 @@ poi committa i file modificati.
 Controlla il path nel marker:
 
 ```html
-<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
+<!-- lab-frammento:start path="lab/0_intro/0_hello.c" -->
 ```
 
 Il path deve essere relativo alla root del repository e deve puntare a un file esistente.
 
-### Il codice appare senza syntax highlighting
+### Il codice appare senza evidenziazione della sintassi
 
 Controlla l'estensione del file sorgente. Lo script usa l'estensione per decidere il linguaggio del blocco `<pre lang="...">`.
 

--- a/scripts/update_lab_snippets.py
+++ b/scripts/update_lab_snippets.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Update embedded lab code snippets in Markdown files.
+
+The script replaces every block delimited by these markers:
+
+<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
+...
+<!-- lab-snippet:end -->
+
+with the current content of the referenced file, escaped for HTML and wrapped in
+<pre lang="..."><code>...</code></pre>.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_TARGETS = ["README.md", "TEMPLATES.md"]
+LANG_BY_SUFFIX = {
+    ".c": "c",
+    ".h": "c",
+    ".s": "asm",
+    ".asm": "asm",
+    ".sh": "bash",
+    ".py": "python",
+}
+
+SNIPPET_RE = re.compile(
+    r'<!-- lab-snippet:start\s+path="(?P<path>[^"]+)"\s*-->'
+    r'.*?'
+    r'<!-- lab-snippet:end -->',
+    re.DOTALL,
+)
+
+
+def language_for(path: pathlib.Path) -> str:
+    return LANG_BY_SUFFIX.get(path.suffix.lower(), "text")
+
+
+def render_snippet(relative_path: str) -> str:
+    source_path = (ROOT / relative_path).resolve()
+    try:
+        source_path.relative_to(ROOT)
+    except ValueError as exc:
+        raise ValueError(f"path escapes repository root: {relative_path}") from exc
+    if not source_path.is_file():
+        raise FileNotFoundError(f"lab snippet source not found: {relative_path}")
+    code = source_path.read_text(encoding="utf-8")
+    escaped = html.escape(code, quote=False)
+    lang = language_for(source_path)
+    return (
+        f'<!-- lab-snippet:start path="{relative_path}" -->\n'
+        f'<pre lang="{lang}"><code>{escaped}</code></pre>\n'
+        '<!-- lab-snippet:end -->'
+    )
+
+
+def update_file(path: pathlib.Path) -> bool:
+    original = path.read_text(encoding="utf-8")
+
+    def replace(match: re.Match[str]) -> str:
+        return render_snippet(match.group("path"))
+
+    updated = SNIPPET_RE.sub(replace, original)
+    if updated == original:
+        return False
+    path.write_text(updated, encoding="utf-8", newline="\n")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        default=DEFAULT_TARGETS,
+        help="Markdown files to update. Defaults to README.md and TEMPLATES.md.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if any target would change.",
+    )
+    args = parser.parse_args()
+
+    changed: list[pathlib.Path] = []
+    for target in args.targets:
+        target_path = ROOT / target
+        if not target_path.exists():
+            continue
+        if update_file(target_path):
+            changed.append(target_path.relative_to(ROOT))
+
+    if args.check and changed:
+        print("Lab snippets are not up to date:", file=sys.stderr)
+        for path in changed:
+            print(f"- {path}", file=sys.stderr)
+        print("Run: python scripts/update_lab_snippets.py", file=sys.stderr)
+        return 1
+
+    for path in changed:
+        print(f"updated {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a richer lab template with laptop summary, short/long descriptions, source link, commands, and embedded code
- Add scripts/update_lab_snippets.py to refresh embedded lab code from files under lab/
- Add a GitHub Actions check to fail when generated lab snippets are stale

## Notes
- The embedded code is delimited by lab-snippet markers so only the generated snippet is replaced