### PR TITLE
docs: add lab output generation workflow

### DIFF
--- a/.github/workflows/lab-outputs.yml
+++ b/.github/workflows/lab-outputs.yml
@@ -1,14 +1,30 @@
+# Verifica che gli output testuali dei laboratori configurati siano aggiornati.
+#
+# La Action non modifica il repository: esegue lo script in modalita --check.
+# Se un output non e aggiornato, la PR fallisce e va rigenerata localmente con:
+#
+#   python scripts/update_lab_outputs.py
+#
 name: Check lab outputs
 
 on:
+  # pull_request: esegue il controllo nelle PR quando cambiano i sorgenti lab,
+  # il manifest, gli output versionati, lo script o questo workflow.
   pull_request:
     paths:
+      # Sorgenti C dei laboratori.
       - "lab/**/*.c"
+      # Header C dei laboratori.
       - "lab/**/*.h"
+      # Manifest JSON, in particolare lab/lab_outputs.json.
       - "lab/**/*.json"
+      # Output generati e versionati accanto ai laboratori.
       - "lab/**/output/*.txt"
+      # Script che genera o controlla gli output.
       - "scripts/update_lab_outputs.py"
+      # Questo workflow: se cambia, va rieseguito.
       - ".github/workflows/lab-outputs.yml"
+  # push su main: mantiene protetto anche il ramo principale dopo i merge.
   push:
     branches:
       - main
@@ -22,18 +38,24 @@ on:
 
 jobs:
   check-lab-outputs:
+    # Runner Linux coerente con l'ambiente dei laboratori C.
     runs-on: ubuntu-latest
     steps:
+      # Scarica il repository nel runner.
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Installa Python per eseguire scripts/update_lab_outputs.py.
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
+      # Installa gcc e toolchain C essenziale per compilare i lab.
       - name: Install C build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential
 
+      # Rigenera gli output in memoria e li confronta con i file committati.
+      # In caso di differenza fallisce, chiedendo di eseguire lo script localmente.
       - name: Verify generated lab outputs
         run: python scripts/update_lab_outputs.py --check

--- a/.github/workflows/lab-outputs.yml
+++ b/.github/workflows/lab-outputs.yml
@@ -1,0 +1,39 @@
+name: Check lab outputs
+
+on:
+  pull_request:
+    paths:
+      - "lab/**/*.c"
+      - "lab/**/*.h"
+      - "lab/**/*.json"
+      - "lab/**/output/*.txt"
+      - "scripts/update_lab_outputs.py"
+      - ".github/workflows/lab-outputs.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "lab/**/*.c"
+      - "lab/**/*.h"
+      - "lab/**/*.json"
+      - "lab/**/output/*.txt"
+      - "scripts/update_lab_outputs.py"
+      - ".github/workflows/lab-outputs.yml"
+
+jobs:
+  check-lab-outputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install C build tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+
+      - name: Verify generated lab outputs
+        run: python scripts/update_lab_outputs.py --check

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -59,6 +59,15 @@ int main(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/0_intro/output/0_hello.txt" -->
+<pre lang="text"><code>Hello World
+</code></pre>
+<!-- lab-output:end -->
 </details>
 </td>
 </tr>

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -24,6 +24,244 @@ python scripts/update_lab_snippets.py
 
 5. Committa insieme sorgente, manifest, output e README/template aggiornati.
 
+## Flusso manuale: aggiungere un nuovo lab al README con output
+
+Questo esempio descrive il caso piu comune: hai creato un nuovo file sorgente e vuoi mostrarlo nel README insieme al suo output.
+
+Immaginiamo di aver creato questo nuovo laboratorio:
+
+```text
+lab/0_intro/6_esempio.c
+```
+
+### 1. Crea o modifica il sorgente del lab
+
+Scrivi il file sorgente nella cartella corretta:
+
+```text
+lab/0_intro/6_esempio.c
+```
+
+Esempio:
+
+```c
+#include <stdio.h>
+
+int main(void) {
+    printf("Esempio nuovo lab\n");
+    return 0;
+}
+```
+
+### 2. Verifica manualmente compilazione ed esecuzione
+
+Prima di integrare il lab nella documentazione, provalo a mano:
+
+```bash
+cd lab/0_intro
+gcc -o bin/6_esempio 6_esempio.c
+bin/6_esempio
+```
+
+Se il programma richiede input, annota esattamente cosa hai digitato: lo userai nel campo `stdin` del manifest.
+
+### 3. Aggiungi il lab a `lab/lab_outputs.json`
+
+Apri `lab/lab_outputs.json` e aggiungi una nuova voce dentro l'array `labs`.
+
+Esempio senza input:
+
+```json
+{
+  "name": "6_esempio",
+  "path": "lab/0_intro/6_esempio.c",
+  "workdir": "lab/0_intro",
+  "compile": ["gcc", "-o", "bin/6_esempio", "6_esempio.c"],
+  "run": ["bin/6_esempio"],
+  "output": "lab/0_intro/output/6_esempio.txt",
+  "timeout_seconds": 5
+}
+```
+
+Esempio con input:
+
+```json
+{
+  "name": "2_variabili",
+  "path": "lab/0_intro/2_variabili.c",
+  "workdir": "lab/0_intro",
+  "compile": ["gcc", "-o", "bin/2_variabili", "2_variabili.c"],
+  "run": ["bin/2_variabili"],
+  "stdin": "4\n2\ns\n",
+  "output": "lab/0_intro/output/2_variabili.txt",
+  "timeout_seconds": 5
+}
+```
+
+### 4. Genera il file output
+
+Torna nella root del repository ed esegui:
+
+```bash
+python scripts/update_lab_outputs.py
+```
+
+Lo script crea o aggiorna:
+
+```text
+lab/0_intro/output/6_esempio.txt
+```
+
+### 5. Inserisci il blocco lab nel README
+
+Nel punto giusto del README, aggiungi un blocco lab seguendo il template.
+
+La parte importante per il codice e:
+
+```html
+<p align="justify">
+<strong>Codice:</strong>
+</p>
+
+<!-- lab-snippet:start path="lab/0_intro/6_esempio.c" -->
+<pre lang="c"><code></code></pre>
+<!-- lab-snippet:end -->
+```
+
+La parte importante per l'output e:
+
+```html
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/0_intro/output/6_esempio.txt" -->
+<pre lang="text"><code></code></pre>
+<!-- lab-output:end -->
+```
+
+Non serve incollare codice o output a mano: i marker verranno riempiti dallo script.
+
+### 6. Rigenera codice e output dentro README/template
+
+Esegui:
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+Questo aggiorna:
+
+- il codice tra `lab-snippet:start` e `lab-snippet:end`;
+- l'output tra `lab-output:start` e `lab-output:end`.
+
+### 7. Controlla cosa e cambiato
+
+Controlla le modifiche generate:
+
+```bash
+git diff
+```
+
+Verifica che siano presenti:
+
+```text
+lab/0_intro/6_esempio.c
+lab/0_intro/output/6_esempio.txt
+lab/lab_outputs.json
+README.md
+```
+
+### 8. Prima della PR, esegui i controlli locali
+
+```bash
+python scripts/update_lab_outputs.py --check
+python scripts/update_lab_snippets.py --check
+```
+
+Se entrambi i comandi terminano senza errori, la Action dovrebbe passare.
+
+### 9. Committa tutto insieme
+
+```bash
+git add lab/0_intro/6_esempio.c
+git add lab/0_intro/output/6_esempio.txt
+git add lab/lab_outputs.json
+git add README.md
+git commit -m "docs: add output for 6_esempio lab"
+```
+
+Se hai modificato anche `TEMPLATES.md`, aggiungilo allo stesso commit o a un commit dedicato.
+
+## Flusso manuale: modificare un lab gia integrato
+
+Questo e il caso in cui il lab e gia presente nel README e in `lab/lab_outputs.json`, ma cambi il sorgente.
+
+### 1. Modifica il sorgente
+
+Esempio:
+
+```text
+lab/0_intro/0_hello.c
+```
+
+### 2. Rigenera l'output
+
+```bash
+python scripts/update_lab_outputs.py
+```
+
+Se l'output del programma cambia, verra aggiornato il file:
+
+```text
+lab/0_intro/output/0_hello.txt
+```
+
+### 3. Rigenera README/template
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+Questo aggiorna nel README:
+
+- il codice sorgente mostrato nella linguetta;
+- l'output mostrato nella linguetta, se presente.
+
+### 4. Controlla il diff
+
+```bash
+git diff
+```
+
+Di solito dovresti vedere modifiche a:
+
+```text
+lab/0_intro/0_hello.c
+lab/0_intro/output/0_hello.txt
+README.md
+```
+
+Se hai cambiato solo il codice ma l'output non cambia, il file `output/*.txt` potrebbe restare invariato.
+
+### 5. Esegui i controlli
+
+```bash
+python scripts/update_lab_outputs.py --check
+python scripts/update_lab_snippets.py --check
+```
+
+### 6. Committa
+
+```bash
+git add lab/0_intro/0_hello.c
+git add lab/0_intro/output/0_hello.txt
+git add README.md
+git commit -m "docs: update 0_hello lab output"
+```
+
+Se un file non e cambiato, `git add` semplicemente non aggiungera nulla per quel file.
+
 ## File coinvolti
 
 | File | Ruolo |

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -1,0 +1,126 @@
+# Output automatici dei laboratori
+
+Questo documento spiega come compilare ed eseguire i laboratori configurati in `lab/` e come salvare il loro output in file versionati.
+
+L'obiettivo e avere, per ogni esercizio didattico, un output riproducibile che possa essere mostrato nel README insieme al codice sorgente.
+
+## File coinvolti
+
+| File | Ruolo |
+|---|---|
+| `lab/lab_outputs.json` | Manifest dei laboratori da compilare, eseguire e salvare |
+| `scripts/update_lab_outputs.py` | Script che genera o controlla gli output |
+| `.github/workflows/lab-outputs.yml` | GitHub Action che controlla gli output in PR |
+| `lab/<cartella>/output/<nome>.txt` | Output generato per uno specifico esercizio |
+
+## Struttura degli output
+
+Gli output vengono salvati nella stessa cartella logica del laboratorio, dentro una sottocartella `output`.
+
+Esempio:
+
+```text
+lab/0_intro/0_hello.c
+lab/0_intro/output/0_hello.txt
+```
+
+## Manifest `lab/lab_outputs.json`
+
+Ogni laboratorio configurato ha una voce nel manifest.
+
+Esempio:
+
+```json
+{
+  "name": "0_hello",
+  "path": "lab/0_intro/0_hello.c",
+  "workdir": "lab/0_intro",
+  "compile": ["gcc", "-o", "bin/0_hello", "0_hello.c"],
+  "run": ["bin/0_hello"],
+  "output": "lab/0_intro/output/0_hello.txt",
+  "timeout_seconds": 5
+}
+```
+
+Campi principali:
+
+| Campo | Significato |
+|---|---|
+| `name` | Nome leggibile del laboratorio |
+| `path` | Sorgente principale del laboratorio |
+| `workdir` | Cartella da cui eseguire compilazione e programma |
+| `compile` | Comando di compilazione espresso come array |
+| `run` | Comando di esecuzione espresso come array |
+| `stdin` | Input opzionale da passare al programma |
+| `output` | File `.txt` in cui salvare stdout/stderr |
+| `timeout_seconds` | Tempo massimo di compilazione/esecuzione |
+| `allow_failure` | Se `true`, permette programmi che falliscono intenzionalmente |
+
+## Aggiornare gli output localmente
+
+Per rigenerare gli output:
+
+```bash
+python scripts/update_lab_outputs.py
+```
+
+Lo script compila ed esegue ogni lab configurato nel manifest e aggiorna i file `output/*.txt`.
+
+## Controllare gli output senza modificarli
+
+Per verificare che gli output committati siano aggiornati:
+
+```bash
+python scripts/update_lab_outputs.py --check
+```
+
+Se un output e diverso da quello generato, lo script fallisce e suggerisce di rigenerarlo.
+
+## GitHub Action
+
+La Action `Check lab outputs` parte quando cambiano:
+
+```text
+lab/**/*.c
+lab/**/*.h
+lab/**/*.json
+lab/**/output/*.txt
+scripts/update_lab_outputs.py
+.github/workflows/lab-outputs.yml
+```
+
+In PR esegue:
+
+```bash
+python scripts/update_lab_outputs.py --check
+```
+
+Quindi la Action non committa nulla automaticamente: verifica solo che gli output siano aggiornati.
+
+## Laboratori interattivi o non deterministici
+
+Alcuni esercizi richiedono input, producono indirizzi di memoria variabili, oppure mostrano errori intenzionali.
+
+Per questi casi:
+
+- usare `stdin` se il programma richiede input;
+- usare `timeout_seconds` per evitare blocchi;
+- usare `allow_failure: true` solo se il fallimento e parte dell'esercizio;
+- evitare di configurare subito esercizi con output non deterministico finche non sono stati normalizzati.
+
+## Collegamento con il README
+
+Il passo successivo e usare marker dedicati per incollare anche l'output nel README, per esempio:
+
+```html
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/0_intro/output/0_hello.txt" -->
+<pre lang="text"><code>Hello World
+</code></pre>
+<!-- lab-output:end -->
+```
+
+Lo script `scripts/update_lab_snippets.py` supporta questi marker e puo aggiornare sia codice sia output.

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -1,8 +1,28 @@
 # Output automatici dei laboratori
 
-Questo documento spiega come compilare ed eseguire i laboratori configurati in `lab/` e come salvare il loro output in file versionati.
+Questo documento spiega come compilare ed eseguire i laboratori configurati in `lab/`, salvare il loro output in file versionati e mostrare tale output nei blocchi lab del README.
 
-L'obiettivo e avere, per ogni esercizio didattico, un output riproducibile che possa essere mostrato nel README insieme al codice sorgente.
+L'obiettivo e avere, per ogni esercizio didattico configurato, un output riproducibile e controllato dalla CI.
+
+## Flusso completo
+
+Quando aggiungi o modifichi un laboratorio con output:
+
+1. Modifica il sorgente, per esempio `lab/0_intro/0_hello.c`.
+2. Aggiungi o aggiorna la voce corrispondente in `lab/lab_outputs.json`.
+3. Rigenera gli output:
+
+```bash
+python scripts/update_lab_outputs.py
+```
+
+4. Se nel README o nel template esiste un marker `lab-output`, rigenera anche i blocchi Markdown:
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+5. Committa insieme sorgente, manifest, output e README/template aggiornati.
 
 ## File coinvolti
 
@@ -10,8 +30,9 @@ L'obiettivo e avere, per ogni esercizio didattico, un output riproducibile che p
 |---|---|
 | `lab/lab_outputs.json` | Manifest dei laboratori da compilare, eseguire e salvare |
 | `scripts/update_lab_outputs.py` | Script che genera o controlla gli output |
-| `.github/workflows/lab-outputs.yml` | GitHub Action che controlla gli output in PR |
+| `.github/workflows/lab-outputs.yml` | GitHub Action che controlla gli output in PR e su `main` |
 | `lab/<cartella>/output/<nome>.txt` | Output generato per uno specifico esercizio |
+| `scripts/update_lab_snippets.py` | Script che incolla nel README sia sorgenti sia output generati |
 
 ## Struttura degli output
 
@@ -24,37 +45,98 @@ lab/0_intro/0_hello.c
 lab/0_intro/output/0_hello.txt
 ```
 
+Questa struttura tiene vicino il sorgente e il risultato atteso, senza mescolare gli output ai file `.c`.
+
 ## Manifest `lab/lab_outputs.json`
 
-Ogni laboratorio configurato ha una voce nel manifest.
+Il manifest e un JSON versionato che dice allo script quali esercizi compilare ed eseguire.
 
-Esempio:
+Esempio completo:
 
 ```json
 {
-  "name": "0_hello",
-  "path": "lab/0_intro/0_hello.c",
+  "version": 1,
+  "labs": [
+    {
+      "name": "0_hello",
+      "path": "lab/0_intro/0_hello.c",
+      "workdir": "lab/0_intro",
+      "compile": ["gcc", "-o", "bin/0_hello", "0_hello.c"],
+      "run": ["bin/0_hello"],
+      "output": "lab/0_intro/output/0_hello.txt",
+      "timeout_seconds": 5
+    }
+  ]
+}
+```
+
+## Significato dei campi del manifest
+
+| Campo | Obbligatorio | Significato |
+|---|---|---|
+| `version` | Si | Versione del formato del manifest. Al momento vale `1`. |
+| `labs` | Si | Lista dei laboratori gestiti dallo script. |
+| `name` | Consigliato | Nome leggibile del laboratorio usato nei messaggi di errore. |
+| `path` | Si | Sorgente principale del laboratorio, relativo alla root del repository. |
+| `workdir` | Si | Cartella da cui lanciare compilazione ed esecuzione. |
+| `compile` | Si | Comando di compilazione come array, senza shell implicita. |
+| `run` | Si | Comando di esecuzione come array, senza shell implicita. |
+| `stdin` | No | Testo da passare allo stdin del programma, utile per esercizi interattivi. |
+| `output` | Si | File `.txt` generato dallo script. |
+| `timeout_seconds` | No | Timeout per compilazione/esecuzione. Default: `10`. |
+| `allow_failure` | No | Se `true`, permette exit code non zero per esercizi che falliscono apposta. |
+
+## Esempio con input da tastiera
+
+Per un programma che legge tre valori da `scanf`, puoi usare `stdin`:
+
+```json
+{
+  "name": "2_variabili",
+  "path": "lab/0_intro/2_variabili.c",
   "workdir": "lab/0_intro",
-  "compile": ["gcc", "-o", "bin/0_hello", "0_hello.c"],
-  "run": ["bin/0_hello"],
-  "output": "lab/0_intro/output/0_hello.txt",
+  "compile": ["gcc", "-o", "bin/2_variabili", "2_variabili.c"],
+  "run": ["bin/2_variabili"],
+  "stdin": "4\n2\ns\n",
+  "output": "lab/0_intro/output/2_variabili.txt",
   "timeout_seconds": 5
 }
 ```
 
-Campi principali:
+## Esempio multi-file
 
-| Campo | Significato |
-|---|---|
-| `name` | Nome leggibile del laboratorio |
-| `path` | Sorgente principale del laboratorio |
-| `workdir` | Cartella da cui eseguire compilazione e programma |
-| `compile` | Comando di compilazione espresso come array |
-| `run` | Comando di esecuzione espresso come array |
-| `stdin` | Input opzionale da passare al programma |
-| `output` | File `.txt` in cui salvare stdout/stderr |
-| `timeout_seconds` | Tempo massimo di compilazione/esecuzione |
-| `allow_failure` | Se `true`, permette programmi che falliscono intenzionalmente |
+Per un laboratorio composto da piu sorgenti:
+
+```json
+{
+  "name": "5_variabili",
+  "path": "lab/0_intro/5_variabili_main.c",
+  "workdir": "lab/0_intro",
+  "compile": ["gcc", "-o", "bin/5_variabili", "5_variabili_main.c", "5_variabili.c"],
+  "run": ["bin/5_variabili"],
+  "output": "lab/0_intro/output/5_variabili.txt",
+  "timeout_seconds": 5
+}
+```
+
+## Esempio con fallimento intenzionale
+
+Alcuni esercizi possono dimostrare un errore o un comportamento non sicuro. In quel caso puoi usare `allow_failure`:
+
+```json
+{
+  "name": "esempio_fallimento",
+  "path": "lab/esempio/fallimento.c",
+  "workdir": "lab/esempio",
+  "compile": ["gcc", "-o", "bin/fallimento", "fallimento.c"],
+  "run": ["bin/fallimento"],
+  "output": "lab/esempio/output/fallimento.txt",
+  "allow_failure": true,
+  "timeout_seconds": 5
+}
+```
+
+Usalo solo quando il fallimento e parte dell'esercizio.
 
 ## Aggiornare gli output localmente
 
@@ -64,7 +146,13 @@ Per rigenerare gli output:
 python scripts/update_lab_outputs.py
 ```
 
-Lo script compila ed esegue ogni lab configurato nel manifest e aggiorna i file `output/*.txt`.
+Lo script:
+
+1. legge `lab/lab_outputs.json`;
+2. compila ogni lab nella sua `workdir`;
+3. esegue il binario;
+4. cattura stdout e stderr;
+5. scrive il risultato nel file `output` configurato.
 
 ## Controllare gli output senza modificarli
 
@@ -74,43 +162,16 @@ Per verificare che gli output committati siano aggiornati:
 python scripts/update_lab_outputs.py --check
 ```
 
-Se un output e diverso da quello generato, lo script fallisce e suggerisce di rigenerarlo.
-
-## GitHub Action
-
-La Action `Check lab outputs` parte quando cambiano:
+Se un output e diverso da quello generato, lo script fallisce e stampa un messaggio simile:
 
 ```text
-lab/**/*.c
-lab/**/*.h
-lab/**/*.json
-lab/**/output/*.txt
-scripts/update_lab_outputs.py
-.github/workflows/lab-outputs.yml
+Output is not up to date for 0_hello: lab/0_intro/output/0_hello.txt
+Run: python scripts/update_lab_outputs.py
 ```
-
-In PR esegue:
-
-```bash
-python scripts/update_lab_outputs.py --check
-```
-
-Quindi la Action non committa nulla automaticamente: verifica solo che gli output siano aggiornati.
-
-## Laboratori interattivi o non deterministici
-
-Alcuni esercizi richiedono input, producono indirizzi di memoria variabili, oppure mostrano errori intenzionali.
-
-Per questi casi:
-
-- usare `stdin` se il programma richiede input;
-- usare `timeout_seconds` per evitare blocchi;
-- usare `allow_failure: true` solo se il fallimento e parte dell'esercizio;
-- evitare di configurare subito esercizi con output non deterministico finche non sono stati normalizzati.
 
 ## Collegamento con il README
 
-Il passo successivo e usare marker dedicati per incollare anche l'output nel README, per esempio:
+Dopo aver generato gli output, puoi mostrarli nei blocchi lab con marker dedicati:
 
 ```html
 <p align="justify">
@@ -123,4 +184,109 @@ Il passo successivo e usare marker dedicati per incollare anche l'output nel REA
 <!-- lab-output:end -->
 ```
 
-Lo script `scripts/update_lab_snippets.py` supporta questi marker e puo aggiornare sia codice sia output.
+Per aggiornare questi marker:
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+Lo script aggiorna sia:
+
+- `lab-snippet`, cioe il codice sorgente;
+- `lab-output`, cioe l'output generato.
+
+## GitHub Action: file YAML
+
+Il workflow e definito in:
+
+```text
+.github/workflows/lab-outputs.yml
+```
+
+La Action usa questo schema:
+
+```yaml
+name: Check lab outputs
+```
+
+`name` e il nome mostrato da GitHub nella lista dei check.
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - "lab/**/*.c"
+```
+
+`on.pull_request.paths` limita l'esecuzione alle PR che modificano file rilevanti. In questo modo non facciamo partire la compilazione dei lab quando cambia documentazione non collegata.
+
+```yaml
+  push:
+    branches:
+      - main
+```
+
+`on.push.branches` ripete il controllo su `main` dopo il merge.
+
+```yaml
+jobs:
+  check-lab-outputs:
+    runs-on: ubuntu-latest
+```
+
+`jobs` contiene i lavori eseguiti dalla Action. `runs-on: ubuntu-latest` sceglie un runner Linux, coerente con i laboratori C.
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+```
+
+`checkout` scarica il repository nel runner.
+
+```yaml
+  - uses: actions/setup-python@v5
+    with:
+      python-version: "3.x"
+```
+
+`setup-python` installa una versione recente di Python.
+
+```yaml
+  - run: sudo apt-get update && sudo apt-get install -y build-essential
+```
+
+Installa `gcc`, linker e tool essenziali per compilare i laboratori.
+
+```yaml
+  - run: python scripts/update_lab_outputs.py --check
+```
+
+Esegue lo script in modalita controllo. Se gli output sono vecchi, la Action fallisce.
+
+## Laboratori interattivi o non deterministici
+
+Alcuni esercizi richiedono input, producono indirizzi di memoria variabili, oppure mostrano errori intenzionali.
+
+Per questi casi:
+
+- usa `stdin` se il programma richiede input;
+- usa `timeout_seconds` per evitare blocchi;
+- usa `allow_failure: true` solo se il fallimento e parte dell'esercizio;
+- evita di configurare subito esercizi con output non deterministico finche non sono stati normalizzati.
+
+## Sequenza consigliata in PR
+
+Quando cambi un lab configurato:
+
+```bash
+python scripts/update_lab_outputs.py
+python scripts/update_lab_snippets.py
+```
+
+Poi committa insieme:
+
+```text
+lab/.../*.c
+lab/.../output/*.txt
+README.md o TEMPLATES.md, se contengono marker output aggiornati
+```

--- a/doc/LAB_SNIPPETS.md
+++ b/doc/LAB_SNIPPETS.md
@@ -1,99 +1,78 @@
-# Frammenti di codice dei laboratori: template, script e GitHub Action
+# Frammenti di codice e output dei laboratori
 
 Questo documento spiega come funzionano i blocchi lab generati automaticamente nel README o in altri file Markdown del repository.
 
-L'obiettivo e semplice: mostrare nel README il codice reale degli esercizi presenti in `lab/`, senza copiarlo a mano ogni volta.
+L'obiettivo e mostrare nel README il codice reale degli esercizi presenti in `lab/`, e quando disponibile anche l'output generato dal programma, senza copiarli a mano ogni volta.
 
-## Perche usare gli frammento automatici
+## Perche usare i frammenti automatici
 
 Quando un esercizio in `lab/` cambia, il codice copiato manualmente nel README rischia di diventare vecchio.
 
 Per evitare questo problema usiamo:
 
 - un template HTML/Markdown per presentare il laboratorio;
-- due marker HTML che delimitano il codice generato;
-- lo script `scripts/update_lab_frammentos.py`, che legge il file reale in `lab/` e aggiorna lo frammento;
-- una GitHub Action che controlla nelle PR se gli frammento sono aggiornati.
+- marker HTML che delimitano il codice generato;
+- marker HTML che delimitano l'output generato;
+- lo script `scripts/update_lab_snippets.py`, che aggiorna i marker leggendo i file reali;
+- GitHub Actions che controllano in PR se codice e output sono aggiornati.
 
-## Struttura consigliata di un blocco lab
+## Marker codice sorgente
 
-Esempio:
+Un blocco codice viene delimitato cosi:
 
 ```html
-<details>
-<summary>💻 <code>/lab/0_intro/0_hello.c</code></summary>
-
-<table align="center">
-  <tr>
-    <td>
-      <p align="justify">
-        <strong>Descrizione breve:</strong>
-        Primo programma C.
-      </p>
-
-      <p align="justify">
-        <strong>Descrizione lunga:</strong>
-        Questo laboratorio mostra come includere un header standard, definire
-        la funzione <code>main()</code>, compilare il sorgente ed eseguire il binario.
-      </p>
-
-      <p align="justify">
-        <strong>Sorgente:</strong>
-        <a href="https://github.com/TheBitPoets/2cornot2c/blob/main/lab/0_intro/0_hello.c">
-          /lab/0_intro/0_hello.c
-        </a>
-      </p>
-
-<!-- lab-frammento:start path="lab/0_intro/0_hello.c" -->
+<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
 <pre lang="c"><code>/* codice generato automaticamente */
 </code></pre>
-<!-- lab-frammento:end -->
-    </td>
-  </tr>
-</table>
-
-</details>
+<!-- lab-snippet:end -->
 ```
 
-La parte importante e questa:
+Lo script sostituisce tutto quello che si trova tra i due marker.
+
+Il path deve essere relativo alla root del repository.
+
+## Marker output
+
+Un blocco output viene delimitato cosi:
 
 ```html
-<!-- lab-frammento:start path="lab/0_intro/0_hello.c" -->
-...
-<!-- lab-frammento:end -->
+<!-- lab-output:start path="lab/0_intro/output/0_hello.txt" -->
+<pre lang="text"><code>Hello World
+</code></pre>
+<!-- lab-output:end -->
 ```
 
-Lo script sostituisce tutto quello che si trova tra questi due marker.
+Lo script legge il file indicato in `path` e lo inserisce come testo preformattato.
 
 ## Come usare lo script
 
-Per aggiornare gli frammento in `README.md` e `TEMPLATES.md`:
+Per aggiornare codice e output in `README.md` e `TEMPLATES.md`:
 
 ```bash
-python scripts/update_lab_frammentos.py
+python scripts/update_lab_snippets.py
 ```
 
 Per aggiornare solo un file specifico:
 
 ```bash
-python scripts/update_lab_frammentos.py README.md
+python scripts/update_lab_snippets.py README.md
 ```
 
 oppure:
 
 ```bash
-python scripts/update_lab_frammentos.py TEMPLATES.md
+python scripts/update_lab_snippets.py TEMPLATES.md
 ```
 
 Lo script:
 
-- cerca tutti i marker `lab-frammento:start` / `lab-frammento:end`;
+- cerca tutti i marker `lab-snippet:start` / `lab-snippet:end`;
+- cerca tutti i marker `lab-output:start` / `lab-output:end`;
 - legge il file indicato nell'attributo `path`;
 - converte i caratteri speciali in entita HTML;
-- inserisce il codice dentro un blocco `<pre lang="..."><code>...</code></pre>`;
-- sceglie il linguaggio in base all'estensione del file.
+- inserisce codice e output dentro blocchi `<pre><code>`.
 
-Esempi:
+## Linguaggi supportati per il codice
 
 | Estensione | Linguaggio usato nel blocco |
 |---|---|
@@ -104,31 +83,18 @@ Esempi:
 | `.sh` | `bash` |
 | `.py` | `python` |
 
-
-## Frammenti di output dei laboratori
-
-Lo stesso script aggiorna anche i blocchi output delimitati da questi marker:
-
-```html
-<!-- lab-output:start path="lab/0_intro/output/0_hello.txt" -->
-...
-<!-- lab-output:end -->
-```
-
-Il contenuto viene letto dal file indicato in `path` e inserito come blocco:
+Gli output usano sempre:
 
 ```html
 <pre lang="text"><code>...</code></pre>
 ```
 
-Gli output vengono generati e controllati con `scripts/update_lab_outputs.py`. La procedura completa e documentata in `doc/LAB_OUTPUTS.md`.
-
 ## Modalita controllo
 
-Per controllare se gli frammento sono aggiornati senza volerli modificare intenzionalmente:
+Per controllare se i frammenti sono aggiornati senza modificarli:
 
 ```bash
-python scripts/update_lab_frammentos.py --check
+python scripts/update_lab_snippets.py --check
 ```
 
 Se tutto e aggiornato, il comando termina correttamente.
@@ -136,81 +102,107 @@ Se tutto e aggiornato, il comando termina correttamente.
 Se qualche frammento e vecchio, il comando fallisce e stampa un messaggio simile:
 
 ```text
-I frammenti di codice dei laboratori non sono aggiornati:
+Lab snippets are not up to date:
 - README.md
-Esegui: python scripts/update_lab_frammentos.py
+Run: python scripts/update_lab_snippets.py
 ```
 
 In quel caso basta eseguire:
 
 ```bash
-python scripts/update_lab_frammentos.py
+python scripts/update_lab_snippets.py
 ```
 
 poi committare i file aggiornati.
 
-## Come funziona la GitHub Action
+## Flusso completo codice + output
 
-Il workflow si trova in:
+Quando aggiungi o modifichi un esercizio con output:
 
-```text
-.github/workflows/lab-frammentos.yml
+1. Modifica il sorgente in `lab/`.
+2. Aggiorna `lab/lab_outputs.json`, se l'esercizio deve produrre output versionato.
+3. Rigenera gli output:
+
+```bash
+python scripts/update_lab_outputs.py
 ```
 
-La Action parte quando in una PR o su `main` cambiano file come:
+4. Rigenera README/template:
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+5. Committa insieme sorgente, output e Markdown aggiornato.
+
+## Esempio pratico
+
+Template di un lab con codice e output:
+
+```html
+<p align="justify">
+<strong>Codice:</strong>
+</p>
+
+<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
+<pre lang="c"><code>/* generato */
+</code></pre>
+<!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/0_intro/output/0_hello.txt" -->
+<pre lang="text"><code>Hello World
+</code></pre>
+<!-- lab-output:end -->
+```
+
+## GitHub Action dei frammenti
+
+Il workflow dei frammenti si trova in:
 
 ```text
-README.md
-TEMPLATES.md
-lab/**
-scripts/update_lab_frammentos.py
-.github/workflows/lab-frammentos.yml
+.github/workflows/lab-snippets.yml
 ```
 
 La Action esegue:
 
 ```bash
-python scripts/update_lab_frammentos.py --check
+python scripts/update_lab_snippets.py --check
 ```
 
-Quindi non modifica automaticamente il repository.
+Quindi non modifica automaticamente il repository. Fallisce solo se i marker nel README o nel template non sono aggiornati.
 
-Serve solo come controllo di sicurezza: se un file in `lab/` cambia ma lo frammento nel README non e stato rigenerato, la PR fallisce e segnala cosa fare.
+## Collegamento con gli output
 
-## Flusso di lavoro consigliato
-
-Quando aggiungi o modifichi un esercizio in `lab/`:
-
-1. Modifica il file sorgente in `lab/`.
-2. Aggiungi o aggiorna il blocco lab nel README, se necessario.
-3. Esegui:
+Gli output vengono generati da:
 
 ```bash
-python scripts/update_lab_frammentos.py
+python scripts/update_lab_outputs.py
 ```
 
-4. Controlla le modifiche generate.
-5. Committa insieme:
+La procedura completa sugli output e documentata in:
 
 ```text
-lab/...
-README.md
-```
-
-oppure, se stai aggiornando solo il template:
-
-```text
-TEMPLATES.md
+doc/LAB_OUTPUTS.md
 ```
 
 ## Cosa non modificare a mano
 
-Non modificare a mano il codice dentro questi marker:
+Non modificare manualmente il contenuto dentro questi marker:
 
 ```html
-<!-- lab-frammento:start path="..." -->
+<!-- lab-snippet:start path="..." -->
 ...
-<!-- lab-frammento:end -->
+<!-- lab-snippet:end -->
+```
+
+```html
+<!-- lab-output:start path="..." -->
+...
+<!-- lab-output:end -->
 ```
 
 Qualunque modifica manuale dentro i marker verra sovrascritta dallo script.
@@ -224,46 +216,30 @@ Puoi invece modificare liberamente:
 - i comandi di compilazione;
 - tutto il testo fuori dai marker.
 
-## Collegamento al sorgente
-
-Per i link ai file lab e preferibile usare `blob/main`, per esempio:
-
-```html
-<a href="https://github.com/TheBitPoets/2cornot2c/blob/main/lab/0_intro/0_hello.c">
-  /lab/0_intro/0_hello.c
-</a>
-```
-
-Evita link con hash di commit vecchi, perche puntano a una versione congelata del file.
-
 ## Risoluzione dei problemi
-
-### La Action fallisce dicendo che gli frammento non sono aggiornati
-
-Esegui localmente:
-
-```bash
-python scripts/update_lab_frammentos.py
-```
-
-poi committa i file modificati.
 
 ### Lo script dice che il file sorgente non esiste
 
 Controlla il path nel marker:
 
 ```html
-<!-- lab-frammento:start path="lab/0_intro/0_hello.c" -->
+<!-- lab-snippet:start path="lab/0_intro/0_hello.c" -->
 ```
 
-Il path deve essere relativo alla root del repository e deve puntare a un file esistente.
+### Lo script dice che il file output non esiste
+
+Prima genera gli output:
+
+```bash
+python scripts/update_lab_outputs.py
+```
+
+Poi aggiorna i marker:
+
+```bash
+python scripts/update_lab_snippets.py
+```
 
 ### Il codice appare senza evidenziazione della sintassi
 
 Controlla l'estensione del file sorgente. Lo script usa l'estensione per decidere il linguaggio del blocco `<pre lang="...">`.
-
-Per file C e header il risultato atteso e:
-
-```html
-<pre lang="c"><code>...</code></pre>
-```

--- a/doc/LAB_SNIPPETS.md
+++ b/doc/LAB_SNIPPETS.md
@@ -135,6 +135,12 @@ python scripts/update_lab_snippets.py
 
 5. Committa insieme sorgente, output e Markdown aggiornato.
 
+Per una procedura manuale dettagliata, con esempio di nuovo lab e caso di modifica di un lab esistente, vedi:
+
+```text
+doc/LAB_OUTPUTS.md
+```
+
 ## Esempio pratico
 
 Template di un lab con codice e output:

--- a/doc/LAB_SNIPPETS.md
+++ b/doc/LAB_SNIPPETS.md
@@ -104,6 +104,25 @@ Esempi:
 | `.sh` | `bash` |
 | `.py` | `python` |
 
+
+## Frammenti di output dei laboratori
+
+Lo stesso script aggiorna anche i blocchi output delimitati da questi marker:
+
+```html
+<!-- lab-output:start path="lab/0_intro/output/0_hello.txt" -->
+...
+<!-- lab-output:end -->
+```
+
+Il contenuto viene letto dal file indicato in `path` e inserito come blocco:
+
+```html
+<pre lang="text"><code>...</code></pre>
+```
+
+Gli output vengono generati e controllati con `scripts/update_lab_outputs.py`. La procedura completa e documentata in `doc/LAB_OUTPUTS.md`.
+
 ## Modalita controllo
 
 Per controllare se gli frammento sono aggiornati senza volerli modificare intenzionalmente:

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,129 @@
+﻿# Indice della documentazione del repository
+
+Questa cartella raccoglie la documentazione tecnica di supporto alla manutenzione del README, dei template e dei laboratori.
+
+Usa questo file come punto di partenza per capire quale documento leggere in base al lavoro che devi fare.
+
+## Percorso consigliato
+
+Se devi lavorare sui blocchi lab nel README, leggi i documenti in questo ordine:
+
+1. [`LAB_SNIPPETS.md`](LAB_SNIPPETS.md)
+2. [`LAB_OUTPUTS.md`](LAB_OUTPUTS.md)
+
+`LAB_SNIPPETS.md` spiega come il README viene aggiornato con codice sorgente e output generati.
+
+`LAB_OUTPUTS.md` spiega come compilare i laboratori, generare i file `output/*.txt` e far passare la GitHub Action.
+
+## Mappa rapida
+
+| Documento | Quando leggerlo |
+|---|---|
+| [`LAB_SNIPPETS.md`](LAB_SNIPPETS.md) | Quando devi modificare i blocchi lab nel README o nel template |
+| [`LAB_OUTPUTS.md`](LAB_OUTPUTS.md) | Quando devi aggiungere o aggiornare l'output di un laboratorio |
+
+## Script collegati
+
+| Script | Scopo | Documento |
+|---|---|---|
+| `scripts/update_lab_snippets.py` | Aggiorna nel README/template il codice dei lab e gli output generati | [`LAB_SNIPPETS.md`](LAB_SNIPPETS.md) |
+| `scripts/update_lab_outputs.py` | Compila/esegue i lab configurati e aggiorna `lab/**/output/*.txt` | [`LAB_OUTPUTS.md`](LAB_OUTPUTS.md) |
+
+## GitHub Actions collegate
+
+| Workflow | Scopo | Documento |
+|---|---|---|
+| `.github/workflows/lab-snippets.yml` | Controlla che snippet e output inseriti nel README/template siano aggiornati | [`LAB_SNIPPETS.md`](LAB_SNIPPETS.md) |
+| `.github/workflows/lab-outputs.yml` | Controlla che gli output dei lab configurati siano aggiornati | [`LAB_OUTPUTS.md`](LAB_OUTPUTS.md) |
+
+## Casi d'uso comuni
+
+### Voglio aggiungere un nuovo lab al README
+
+Leggi:
+
+```text
+doc/LAB_OUTPUTS.md
+```
+
+Sezione utile:
+
+```text
+Flusso manuale: aggiungere un nuovo lab al README con output
+```
+
+### Ho modificato un lab gia presente nel README
+
+Leggi:
+
+```text
+doc/LAB_OUTPUTS.md
+```
+
+Sezione utile:
+
+```text
+Flusso manuale: modificare un lab gia integrato
+```
+
+### Ho cambiato solo il codice di un lab, ma non il README
+
+Esegui comunque:
+
+```bash
+python scripts/update_lab_outputs.py
+python scripts/update_lab_snippets.py
+```
+
+Poi controlla:
+
+```bash
+git diff
+```
+
+Se il codice mostrato nel README o l'output sono cambiati, committa anche quei file.
+
+### Ho cambiato solo testo descrittivo fuori dai marker
+
+Se non hai toccato sorgenti in `lab/` e non hai modificato contenuti dentro i marker, in genere non serve rigenerare nulla.
+
+I marker da non modificare a mano sono:
+
+```html
+<!-- lab-snippet:start path="..." -->
+...
+<!-- lab-snippet:end -->
+```
+
+```html
+<!-- lab-output:start path="..." -->
+...
+<!-- lab-output:end -->
+```
+
+### La GitHub Action fallisce
+
+Se fallisce il controllo output:
+
+```bash
+python scripts/update_lab_outputs.py
+python scripts/update_lab_snippets.py
+```
+
+Se fallisce il controllo snippet:
+
+```bash
+python scripts/update_lab_snippets.py
+```
+
+Poi committa i file modificati.
+
+## Regola pratica
+
+Quando lavori sui laboratori, pensa a tre livelli:
+
+1. Sorgente del lab: `lab/**/*.c` e `lab/**/*.h`
+2. Output generato: `lab/**/output/*.txt`
+3. Documentazione renderizzata: `README.md` o `TEMPLATES.md`
+
+Se cambi un livello, chiediti sempre se anche i livelli successivi devono essere rigenerati.

--- a/lab/0_intro/output/0_hello.txt
+++ b/lab/0_intro/output/0_hello.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/lab/lab_outputs.json
+++ b/lab/lab_outputs.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "labs": [
+    {
+      "name": "0_hello",
+      "path": "lab/0_intro/0_hello.c",
+      "workdir": "lab/0_intro",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/0_hello",
+        "0_hello.c"
+      ],
+      "run": [
+        "bin/0_hello"
+      ],
+      "output": "lab/0_intro/output/0_hello.txt",
+      "timeout_seconds": 5
+    }
+  ]
+}

--- a/scripts/update_lab_outputs.py
+++ b/scripts/update_lab_outputs.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Compile and run configured lab exercises, then update their output files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = ROOT / "lab" / "lab_outputs.json"
+
+
+def repo_path(value: str) -> pathlib.Path:
+    path = (ROOT / value).resolve()
+    try:
+        path.relative_to(ROOT)
+    except ValueError as exc:
+        raise ValueError(f"path escapes repository root: {value}") from exc
+    return path
+
+
+def load_config(path: pathlib.Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_command(command: list[str], cwd: pathlib.Path, timeout: int, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        input=stdin,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def format_output(compile_result: subprocess.CompletedProcess[str], run_result: subprocess.CompletedProcess[str]) -> str:
+    sections: list[str] = []
+    if compile_result.stdout.strip():
+        sections.append("[compile stdout]\n" + compile_result.stdout.rstrip())
+    if compile_result.stderr.strip():
+        sections.append("[compile stderr]\n" + compile_result.stderr.rstrip())
+    if run_result.stdout.strip():
+        sections.append(run_result.stdout.rstrip())
+    if run_result.stderr.strip():
+        sections.append("[stderr]\n" + run_result.stderr.rstrip())
+    if not sections:
+        return ""
+    return "\n".join(sections) + "\n"
+
+
+def process_lab(entry: dict[str, Any], check: bool) -> bool:
+    name = entry.get("name") or entry["path"]
+    cwd = repo_path(entry.get("workdir", str(pathlib.Path(entry["path"]).parent)))
+    timeout = int(entry.get("timeout_seconds", 10))
+    compile_cmd = entry["compile"]
+    run_cmd = entry["run"]
+    stdin = entry.get("stdin")
+    allow_failure = bool(entry.get("allow_failure", False))
+    output_path = repo_path(entry["output"])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    compile_result = run_command(compile_cmd, cwd=cwd, timeout=timeout)
+    if compile_result.returncode != 0 and not allow_failure:
+        sys.stderr.write(f"Compilation failed for {name}\n")
+        sys.stderr.write(compile_result.stdout)
+        sys.stderr.write(compile_result.stderr)
+        return False
+
+    run_result = run_command(run_cmd, cwd=cwd, timeout=timeout, stdin=stdin)
+    if run_result.returncode != 0 and not allow_failure:
+        sys.stderr.write(f"Execution failed for {name}\n")
+        sys.stderr.write(run_result.stdout)
+        sys.stderr.write(run_result.stderr)
+        return False
+
+    generated = format_output(compile_result, run_result)
+    if check:
+        current = output_path.read_text(encoding="utf-8") if output_path.exists() else None
+        if current != generated:
+            sys.stderr.write(f"Output is not up to date for {name}: {output_path.relative_to(ROOT)}\n")
+            return False
+    else:
+        output_path.write_text(generated, encoding="utf-8", newline="\n")
+        print(f"updated {output_path.relative_to(ROOT)}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to the lab output manifest.")
+    parser.add_argument("--check", action="store_true", help="Fail if generated outputs differ from committed files.")
+    args = parser.parse_args()
+
+    config = load_config(repo_path(args.config))
+    ok = True
+    for entry in config.get("labs", []):
+        ok = process_lab(entry, check=args.check) and ok
+    if not ok:
+        if args.check:
+            sys.stderr.write("Run: python scripts/update_lab_outputs.py\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_lab_outputs.py
+++ b/scripts/update_lab_outputs.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
-"""Compile and run configured lab exercises, then update their output files."""
+"""Generate and verify output files for configured C lab exercises.
+
+This script is intentionally manifest-driven: it does not try to discover and
+run every file under ``lab/`` automatically, because several exercises are
+interactive, intentionally fail, or produce non-deterministic output.  Each lab
+that should have a committed output file is listed in ``lab/lab_outputs.json``.
+
+Typical usage:
+
+    python scripts/update_lab_outputs.py
+    python scripts/update_lab_outputs.py --check
+
+The first command rewrites ``lab/**/output/*.txt`` files.  The second command is
+used by GitHub Actions and fails when the committed output files are stale.
+"""
 
 from __future__ import annotations
 
@@ -15,6 +29,13 @@ DEFAULT_CONFIG = ROOT / "lab" / "lab_outputs.json"
 
 
 def repo_path(value: str) -> pathlib.Path:
+    """Return an absolute repository-local path and reject path traversal.
+
+    Manifest paths are intentionally written relative to the repository root.
+    This helper resolves them and prevents accidental values such as
+    ``../../somewhere`` from escaping the repository workspace.
+    """
+
     path = (ROOT / value).resolve()
     try:
         path.relative_to(ROOT)
@@ -24,10 +45,23 @@ def repo_path(value: str) -> pathlib.Path:
 
 
 def load_config(path: pathlib.Path) -> dict[str, Any]:
+    """Load the JSON manifest that lists the labs to compile and execute."""
+
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def run_command(command: list[str], cwd: pathlib.Path, timeout: int, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+def run_command(
+    command: list[str],
+    cwd: pathlib.Path,
+    timeout: int,
+    stdin: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command in a lab directory and capture stdout/stderr.
+
+    ``check=False`` is deliberate: the caller decides whether a non-zero exit
+    code is acceptable by reading the lab entry's ``allow_failure`` field.
+    """
+
     return subprocess.run(
         command,
         cwd=cwd,
@@ -39,7 +73,17 @@ def run_command(command: list[str], cwd: pathlib.Path, timeout: int, stdin: str 
     )
 
 
-def format_output(compile_result: subprocess.CompletedProcess[str], run_result: subprocess.CompletedProcess[str]) -> str:
+def format_output(
+    compile_result: subprocess.CompletedProcess[str],
+    run_result: subprocess.CompletedProcess[str],
+) -> str:
+    """Build the text that will be committed as the lab output artifact.
+
+    Normal program stdout is written plainly.  Compiler stdout/stderr and runtime
+    stderr are preserved in labelled sections only when they contain text, so the
+    common clean case remains easy to read.
+    """
+
     sections: list[str] = []
     if compile_result.stdout.strip():
         sections.append("[compile stdout]\n" + compile_result.stdout.rstrip())
@@ -55,6 +99,13 @@ def format_output(compile_result: subprocess.CompletedProcess[str], run_result: 
 
 
 def process_lab(entry: dict[str, Any], check: bool) -> bool:
+    """Compile, run, and either update or verify one manifest entry.
+
+    Returns ``True`` when the entry succeeds.  In update mode the generated text
+    is written to ``entry['output']``.  In check mode the generated text is
+    compared with the committed output file and no files are modified.
+    """
+
     name = entry.get("name") or entry["path"]
     cwd = repo_path(entry.get("workdir", str(pathlib.Path(entry["path"]).parent)))
     timeout = int(entry.get("timeout_seconds", 10))
@@ -92,6 +143,8 @@ def process_lab(entry: dict[str, Any], check: bool) -> bool:
 
 
 def main() -> int:
+    """Parse CLI flags and process every configured lab entry."""
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to the lab output manifest.")
     parser.add_argument("--check", action="store_true", help="Fail if generated outputs differ from committed files.")

--- a/scripts/update_lab_snippets.py
+++ b/scripts/update_lab_snippets.py
@@ -9,6 +9,12 @@ The script replaces every block delimited by these markers:
 
 with the current content of the referenced file, escaped for HTML and wrapped in
 <pre lang="..."><code>...</code></pre>.
+
+It also replaces lab output blocks delimited by these markers:
+
+<!-- lab-output:start path="lab/0_intro/output/0_hello.txt" -->
+...
+<!-- lab-output:end -->
 """
 
 from __future__ import annotations
@@ -37,6 +43,13 @@ SNIPPET_RE = re.compile(
     re.DOTALL,
 )
 
+OUTPUT_RE = re.compile(
+    r'<!-- lab-output:start\s+path="(?P<path>[^"]+)"\s*-->'
+    r'.*?'
+    r'<!-- lab-output:end -->',
+    re.DOTALL,
+)
+
 
 def language_for(path: pathlib.Path) -> str:
     return LANG_BY_SUFFIX.get(path.suffix.lower(), "text")
@@ -60,13 +73,34 @@ def render_snippet(relative_path: str) -> str:
     )
 
 
+def render_output(relative_path: str) -> str:
+    output_path = (ROOT / relative_path).resolve()
+    try:
+        output_path.relative_to(ROOT)
+    except ValueError as exc:
+        raise ValueError(f"path escapes repository root: {relative_path}") from exc
+    if not output_path.is_file():
+        raise FileNotFoundError(f"lab output not found: {relative_path}")
+    output = output_path.read_text(encoding="utf-8")
+    escaped = html.escape(output, quote=False)
+    return (
+        f'<!-- lab-output:start path="{relative_path}" -->\n'
+        f'<pre lang="text"><code>{escaped}</code></pre>\n'
+        '<!-- lab-output:end -->'
+    )
+
+
 def update_file(path: pathlib.Path) -> bool:
     original = path.read_text(encoding="utf-8")
 
     def replace(match: re.Match[str]) -> str:
         return render_snippet(match.group("path"))
 
+    def replace_output(match: re.Match[str]) -> str:
+        return render_output(match.group("path"))
+
     updated = SNIPPET_RE.sub(replace, original)
+    updated = OUTPUT_RE.sub(replace_output, updated)
     if updated == original:
         return False
     path.write_text(updated, encoding="utf-8", newline="\n")

--- a/scripts/update_lab_snippets.py
+++ b/scripts/update_lab_snippets.py
@@ -52,10 +52,14 @@ OUTPUT_RE = re.compile(
 
 
 def language_for(path: pathlib.Path) -> str:
+    """Return the syntax-highlighting language for a source file path."""
+
     return LANG_BY_SUFFIX.get(path.suffix.lower(), "text")
 
 
 def render_snippet(relative_path: str) -> str:
+    """Render one lab source marker as an escaped HTML code block."""
+
     source_path = (ROOT / relative_path).resolve()
     try:
         source_path.relative_to(ROOT)
@@ -74,6 +78,8 @@ def render_snippet(relative_path: str) -> str:
 
 
 def render_output(relative_path: str) -> str:
+    """Render one lab output marker as an escaped plain-text block."""
+
     output_path = (ROOT / relative_path).resolve()
     try:
         output_path.relative_to(ROOT)
@@ -91,6 +97,8 @@ def render_output(relative_path: str) -> str:
 
 
 def update_file(path: pathlib.Path) -> bool:
+    """Update all lab source and output markers in one Markdown file."""
+
     original = path.read_text(encoding="utf-8")
 
     def replace(match: re.Match[str]) -> str:
@@ -108,6 +116,8 @@ def update_file(path: pathlib.Path) -> bool:
 
 
 def main() -> int:
+    """Parse CLI flags and update or check the requested Markdown files."""
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "targets",


### PR DESCRIPTION
## Summary
- Add a manifest-driven script to compile/run configured labs and save outputs under lab/**/output
- Add a GitHub Action that checks generated lab outputs when lab code changes
- Extend lab snippet generation to support lab-output markers
- Document the output workflow in doc/LAB_OUTPUTS.md and cross-link it from doc/LAB_SNIPPETS.md
- Add the first configured output example for lab/0_intro/0_hello.c

## Notes
- The manifest starts with one deterministic lab; interactive or intentionally failing labs can be added progressively with stdin, timeout_seconds, and allow_failure metadata