### PR TITLE
docs: add outputs for variables labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2165,13 +2165,13 @@ void print_var(void){
 
 <!-- lab-output:start path="lab/1_variables/output/0_local.txt" -->
 <pre lang="text"><code>local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;base+0x0&gt;
-init_local_var=0 	 &amp;init_local_var=&lt;base-0x4&gt;
+init_local_var=0 	 &amp;init_local_var=&lt;base+0x4&gt;
 
 local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;base+0x0&gt;
-init_local_var=0 	 &amp;init_local_var=&lt;base-0x4&gt;
+init_local_var=0 	 &amp;init_local_var=&lt;base+0x4&gt;
 
 local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;base+0x0&gt;
-init_local_var=0 	 &amp;init_local_var=&lt;base-0x4&gt;
+init_local_var=0 	 &amp;init_local_var=&lt;base+0x4&gt;
 </code></pre>
 <!-- lab-output:end -->
 </details>

--- a/README.md
+++ b/README.md
@@ -2164,14 +2164,14 @@ void print_var(void){
 </p>
 
 <!-- lab-output:start path="lab/1_variables/output/0_local.txt" -->
-<pre lang="text"><code>local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;indirizzo&gt;
-init_local_var=0 	 &amp;init_local_var=&lt;indirizzo&gt;
+<pre lang="text"><code>local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;base+0x0&gt;
+init_local_var=0 	 &amp;init_local_var=&lt;base-0x4&gt;
 
-local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;indirizzo&gt;
-init_local_var=0 	 &amp;init_local_var=&lt;indirizzo&gt;
+local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;base+0x0&gt;
+init_local_var=0 	 &amp;init_local_var=&lt;base-0x4&gt;
 
-local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;indirizzo&gt;
-init_local_var=0 	 &amp;init_local_var=&lt;indirizzo&gt;
+local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;base+0x0&gt;
+init_local_var=0 	 &amp;init_local_var=&lt;base-0x4&gt;
 </code></pre>
 <!-- lab-output:end -->
 </details>
@@ -2358,24 +2358,24 @@ void call_me(void){
 </p>
 
 <!-- lab-output:start path="lab/1_variables/output/1_static_local.txt" -->
-<pre lang="text"><code>count=1 	 &amp;count=&lt;indirizzo&gt;
-bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+<pre lang="text"><code>count=1 	 &amp;count=&lt;static+0x0&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;stack+0x0&gt;
 You call me 1 times
 
-count=2 	 &amp;count=&lt;indirizzo&gt;
-bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+count=2 	 &amp;count=&lt;static+0x0&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;stack+0x0&gt;
 You call me 2 times
 
-count=3 	 &amp;count=&lt;indirizzo&gt;
-bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+count=3 	 &amp;count=&lt;static+0x0&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;stack+0x0&gt;
 You call me 3 times
 
-count=4 	 &amp;count=&lt;indirizzo&gt;
-bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+count=4 	 &amp;count=&lt;static+0x0&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;stack+0x0&gt;
 You call me 4 times
 
-count=5 	 &amp;count=&lt;indirizzo&gt;
-bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+count=5 	 &amp;count=&lt;static+0x0&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;stack+0x0&gt;
 You call me 5 times
 </code></pre>
 <!-- lab-output:end -->

--- a/README.md
+++ b/README.md
@@ -1921,6 +1921,18 @@ void three(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/1_variables/output/2_global.txt" -->
+<pre lang="text"><code>global=0
+global=1
+global=2
+global=3
+</code></pre>
+<!-- lab-output:end -->
 </details>
 </td>
 </tr>
@@ -2146,6 +2158,22 @@ void print_var(void){
 
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/1_variables/output/0_local.txt" -->
+<pre lang="text"><code>local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;indirizzo&gt;
+init_local_var=0 	 &amp;init_local_var=&lt;indirizzo&gt;
+
+local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;indirizzo&gt;
+init_local_var=0 	 &amp;init_local_var=&lt;indirizzo&gt;
+
+local_var=&lt;indefinito&gt; 		 &amp;local_var=&lt;indirizzo&gt;
+init_local_var=0 	 &amp;init_local_var=&lt;indirizzo&gt;
+</code></pre>
+<!-- lab-output:end -->
 </details>
 </td>
 </tr>
@@ -2324,6 +2352,33 @@ void call_me(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/1_variables/output/1_static_local.txt" -->
+<pre lang="text"><code>count=1 	 &amp;count=&lt;indirizzo&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+You call me 1 times
+
+count=2 	 &amp;count=&lt;indirizzo&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+You call me 2 times
+
+count=3 	 &amp;count=&lt;indirizzo&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+You call me 3 times
+
+count=4 	 &amp;count=&lt;indirizzo&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+You call me 4 times
+
+count=5 	 &amp;count=&lt;indirizzo&gt;
+bad_count=1 	 &amp;bad_coubt=&lt;indirizzo&gt;
+You call me 5 times
+</code></pre>
+<!-- lab-output:end -->
 </details>
 </td>
 </tr>
@@ -2542,6 +2597,22 @@ int main(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/1_variables/output/4_global_external_internal.txt" -->
+<pre lang="text"><code>Get me an integer &gt; 0 (0 to quit)
+You call me 1 times 
+Subtotal = 3
+Get me an integer &gt; 0 (0 to quit)
+You call me 2 times 
+Subtotal = 8
+Get me an integer &gt; 0 (0 to quit)
+total=8
+</code></pre>
+<!-- lab-output:end -->
 </details>
 
 <details>
@@ -2841,6 +2912,17 @@ void two(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/1_variables/output/3_global_internal.txt" -->
+<pre lang="text"><code>global_internal=0
+global_internal=1
+global_internal=2
+</code></pre>
+<!-- lab-output:end -->
 </details>
 </td>
 </tr>

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -526,21 +526,21 @@ Esempio reale possibile:
 
 ```text
 local_var=123          &local_var=0x7ffca000
-init_local_var=0       &init_local_var=0x7ffc9ffc
+init_local_var=0       &init_local_var=0x7ffca004
 ```
 
 Lo script prende `0x7ffca000` come base e calcola:
 
 ```text
 0x7ffca000 - 0x7ffca000 = 0x0
-0x7ffc9ffc - 0x7ffca000 = -0x4
+0x7ffca004 - 0x7ffca000 = -0x4
 ```
 
 L'output normalizzato diventa:
 
 ```text
 local_var=<indefinito>          &local_var=<base+0x0>
-init_local_var=0                &init_local_var=<base-0x4>
+init_local_var=0                &init_local_var=<base+0x4>
 ```
 
 In questo modo l'indirizzo assoluto non dipende dal runner, ma il delta di `0x4` byte resta visibile nel README.
@@ -565,10 +565,10 @@ diventa:
 
 ```text
 local_var=<indefinito>          &local_var=<base+0x0>
-init_local_var=0                &init_local_var=<base-0x4>
+init_local_var=0                &init_local_var=<base+0x4>
 
 local_var=<indefinito>          &local_var=<base+0x0>
-init_local_var=0                &init_local_var=<base-0x4>
+init_local_var=0                &init_local_var=<base+0x4>
 ```
 
 Non confrontiamo gli indirizzi assoluti tra chiamate diverse. Conserviamo invece la relazione tra variabili nello stesso blocco, che e la parte utile per spiegare il layout locale.
@@ -600,7 +600,7 @@ L'output mostrato nel README diventa:
 
 ```text
 local_var=<indefinito>          &local_var=<base+0x0>
-init_local_var=0                &init_local_var=<base-0x4>
+init_local_var=0                &init_local_var=<base+0x4>
 ```
 
 Cosa comunica:
@@ -608,7 +608,7 @@ Cosa comunica:
 - `local_var=<indefinito>` indica che la variabile locale non inizializzata non ha un valore affidabile;
 - `init_local_var=0` mostra che la variabile inizializzata vale davvero zero;
 - `<base+0x0>` indica il primo indirizzo del blocco;
-- `<base-0x4>` indica un indirizzo distante quattro byte dalla base, espresso in esadecimale.
+- `<base+0x4>` indica un indirizzo distante quattro byte dalla base, espresso in esadecimale.
 
 ### Caso `1_static_local.c`
 
@@ -689,7 +689,7 @@ Il README mostrera quindi offset esadecimali relativi, per esempio:
 
 ```text
 &local_var=<base+0x0>
-&init_local_var=<base-0x4>
+&init_local_var=<base+0x4>
 ```
 
 Se invece trova indirizzi appartenenti a zone diverse, per esempio `static` e stack, aggiunge sostituzioni semantiche:

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -24,6 +24,53 @@ python scripts/update_lab_snippets.py
 
 5. Committa insieme sorgente, manifest, output e README/template aggiornati.
 
+## Scorciatoia: aggiornare il manifest senza ricordare tutti i campi
+
+Per aggiungere o aggiornare una voce in `lab/lab_outputs.json` puoi usare:
+
+```bash
+python scripts/upsert_lab_output_manifest.py lab/1_variables/0_local.c
+```
+
+Lo script inferisce automaticamente:
+
+- `name`;
+- `path`;
+- `workdir`;
+- comando `compile`;
+- comando `run`;
+- file `output`;
+- normalizzazioni comuni per indirizzi e valori instabili.
+
+Se il lab e gia presente nel manifest, la voce viene aggiornata. Se non e presente, viene aggiunta.
+
+Per vedere cosa verrebbe scritto senza modificare il manifest:
+
+```bash
+python scripts/upsert_lab_output_manifest.py lab/1_variables/0_local.c --dry-run
+```
+
+Per un programma interattivo:
+
+```bash
+python scripts/upsert_lab_output_manifest.py lab/0_intro/2_variabili.c --stdin "4\n2\ns\n"
+```
+
+Per un lab composto da piu file:
+
+```bash
+python scripts/upsert_lab_output_manifest.py lab/1_variables/4_global_external_internal_a.c --extra-source lab/1_variables/4_global_external_internal_b.c
+```
+
+Dopo aver aggiornato il manifest, rigenera output e README:
+
+```bash
+python scripts/update_lab_outputs.py
+python scripts/update_lab_snippets.py
+```
+
+Lo script e pensato come assistente, non come oracolo: per casi molto particolari puoi ancora modificare manualmente la voce generata.
+
 ## Flusso manuale: aggiungere un nuovo lab al README con output
 
 Questo esempio descrive il caso piu comune: hai creato un nuovo file sorgente e vuoi mostrarlo nel README insieme al suo output.
@@ -271,6 +318,7 @@ Se un file non e cambiato, `git add` semplicemente non aggiungera nulla per quel
 | `.github/workflows/lab-outputs.yml` | GitHub Action che controlla gli output in PR e su `main` |
 | `lab/<cartella>/output/<nome>.txt` | Output generato per uno specifico esercizio |
 | `scripts/update_lab_snippets.py` | Script che incolla nel README sia sorgenti sia output generati |
+| `scripts/upsert_lab_output_manifest.py` | Script che aggiunge o aggiorna una voce del manifest inferendo i campi piu comuni |
 
 ## Struttura degli output
 
@@ -574,6 +622,44 @@ global=3
 puo essere salvato direttamente senza `normalize` e senza `normalize_addresses`.
 
 In sintesi: usa `normalize` per sostituire valori instabili o semanticamente inutili; usa `normalize_addresses: "paragraph"` quando vuoi mantenere il delta in byte tra indirizzi dello stesso blocco logico.
+
+## Come lo script inferisce le normalizzazioni
+
+`scripts/upsert_lab_output_manifest.py` legge il sorgente C e cerca i casi piu frequenti.
+
+Se trova una variabile automatica `int` dichiarata senza inizializzazione e stampata con una forma come:
+
+```c
+printf("local_var=%d", local_var);
+```
+
+aggiunge una regola `normalize` che trasforma il valore numerico in:
+
+```text
+local_var=<indefinito>
+```
+
+Se trova piu indirizzi stampati con `%p` e tutti appartengono a variabili automatiche locali, aggiunge:
+
+```json
+"normalize_addresses": "paragraph"
+```
+
+Il README mostrera quindi offset esadecimali relativi, per esempio:
+
+```text
+&local_var=<base+0x0>
+&init_local_var=<base-0x4>
+```
+
+Se invece trova indirizzi appartenenti a zone diverse, per esempio `static` e stack, aggiunge sostituzioni semantiche:
+
+```text
+&count=<static+0x0>
+&bad_count=<stack+0x0>
+```
+
+Questa scelta evita di mostrare delta assoluti tra aree di memoria diverse, che potrebbero cambiare per ASLR o layout del processo.
 
 ## Aggiornare gli output localmente
 

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -324,6 +324,7 @@ Esempio completo:
 | `timeout_seconds` | No | Timeout per compilazione/esecuzione. Default: `10`. |
 | `allow_failure` | No | Se `true`, permette exit code non zero per esercizi che falliscono apposta. |
 | `normalize` | No | Lista di sostituzioni regex da applicare all'output generato prima di salvarlo o confrontarlo. |
+| `normalize_addresses` | No | Se vale `"paragraph"`, trasforma gli indirizzi esadecimali di ogni blocco in offset relativi, preservando i delta in byte. |
 
 ## Esempio con input da tastiera
 
@@ -383,7 +384,9 @@ Alcuni programmi didattici stampano valori che cambiano a ogni esecuzione, per e
 
 In questi casi puoi usare il campo `normalize` per sostituire le parti variabili con segnaposto stabili.
 
-Esempio:
+Quando gli indirizzi appartengono allo stesso blocco logico, per esempio variabili locali stampate nello stesso frame, conviene usare `normalize_addresses`.
+
+Esempio con delta preservati:
 
 ```json
 {
@@ -393,19 +396,34 @@ Esempio:
   "compile": ["gcc", "-o", "bin/0_local", "0_local.c"],
   "run": ["bin/0_local"],
   "output": "lab/1_variables/output/0_local.txt",
+  "normalize_addresses": "paragraph",
   "timeout_seconds": 5,
   "normalize": [
     {
       "pattern": "(?m)^local_var=-?\\d+",
       "replacement": "local_var=<indefinito>"
-    },
-    {
-      "pattern": "0x[0-9a-fA-F]+",
-      "replacement": "<indirizzo>"
     }
   ]
 }
 ```
+
+Un output reale come:
+
+```text
+&local_var=0x7ffca000
+&init_local_var=0x7ffc9ffc
+```
+
+diventa:
+
+```text
+&local_var=<base+0x0>
+&init_local_var=<base-0x4>
+```
+
+In questo modo l'indirizzo assoluto non dipende dal runner, ma il delta di `0x4` byte resta visibile.
+
+Se invece gli indirizzi appartengono a zone diverse, per esempio una variabile `static` e una variabile sullo stack, il delta assoluto puo dipendere da ASLR e dal layout del processo. In quel caso e meglio usare `normalize` con sostituzioni mirate, per esempio `<static+0x0>` e `<stack+0x0>`.
 
 Lo script esegue comunque il programma reale. La normalizzazione avviene solo dopo la cattura dell'output, prima di scrivere il file `output/*.txt` o prima del confronto in modalita `--check`.
 

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -24,9 +24,48 @@ python scripts/update_lab_snippets.py
 
 5. Committa insieme sorgente, manifest, output e README/template aggiornati.
 
-## Scorciatoia: aggiornare il manifest senza ricordare tutti i campi
+## Scorciatoia: wizard guidato per tutto il flusso
 
-Per aggiungere o aggiornare una voce in `lab/lab_outputs.json` puoi usare:
+Se vuoi essere guidato passo passo senza ricordare la procedura, usa il wizard:
+
+```bash
+python scripts/lab_output_wizard.py
+```
+
+Il wizard chiede:
+
+- path del sorgente principale;
+- eventuali sorgenti aggiuntivi;
+- eventuale input da passare a `stdin`;
+- conferma della voce manifest inferita;
+- se generare subito gli output;
+- se aggiornare subito README/template.
+
+Se il blocco lab esiste gia nel README, il wizard aggiunge automaticamente il marker `Output`.
+
+Se il blocco lab non esiste ancora, il wizard stampa un blocco pronto da inserire manualmente nel paragrafo didattico corretto. Questa scelta resta manuale perche lo script non puo sapere con certezza dove un nuovo esercizio sia piu utile dal punto di vista pedagogico.
+
+Puoi anche avviarlo passando direttamente il sorgente:
+
+```bash
+python scripts/lab_output_wizard.py lab/1_variables/0_local.c
+```
+
+Per un programma interattivo:
+
+```bash
+python scripts/lab_output_wizard.py lab/0_intro/2_variabili.c --stdin "4\n2\ns\n"
+```
+
+Per un lab multi-file:
+
+```bash
+python scripts/lab_output_wizard.py lab/1_variables/4_global_external_internal_a.c --extra-source lab/1_variables/4_global_external_internal_b.c
+```
+
+## Scorciatoia tecnica: aggiornare solo il manifest
+
+Se vuoi solo aggiungere o aggiornare una voce in `lab/lab_outputs.json`, senza l'intero flusso guidato, puoi usare:
 
 ```bash
 python scripts/upsert_lab_output_manifest.py lab/1_variables/0_local.c
@@ -319,6 +358,7 @@ Se un file non e cambiato, `git add` semplicemente non aggiungera nulla per quel
 | `lab/<cartella>/output/<nome>.txt` | Output generato per uno specifico esercizio |
 | `scripts/update_lab_snippets.py` | Script che incolla nel README sia sorgenti sia output generati |
 | `scripts/upsert_lab_output_manifest.py` | Script che aggiunge o aggiorna una voce del manifest inferendo i campi piu comuni |
+| `scripts/lab_output_wizard.py` | Procedura guidata interattiva per manifest, output e marker README |
 
 ## Struttura degli output
 
@@ -625,7 +665,7 @@ In sintesi: usa `normalize` per sostituire valori instabili o semanticamente inu
 
 ## Come lo script inferisce le normalizzazioni
 
-`scripts/upsert_lab_output_manifest.py` legge il sorgente C e cerca i casi piu frequenti.
+`scripts/upsert_lab_output_manifest.py` e `scripts/lab_output_wizard.py` leggono il sorgente C e cercano i casi piu frequenti.
 
 Se trova una variabile automatica `int` dichiarata senza inizializzazione e stampata con una forma come:
 

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -717,6 +717,8 @@ Lo script:
 4. cattura stdout e stderr;
 5. scrive il risultato nel file `output` configurato.
 
+Se il comando di compilazione usa `-o bin/nome_lab`, lo script crea automaticamente la cartella `bin` prima di lanciare `gcc`. Non serve quindi versionare una cartella `bin` vuota per ogni directory di laboratorio.
+
 ## Controllare gli output senza modificarli
 
 Per verificare che gli output committati siano aggiornati:

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -378,15 +378,116 @@ Alcuni esercizi possono dimostrare un errore o un comportamento non sicuro. In q
 
 Usalo solo quando il fallimento e parte dell'esercizio.
 
-## Esempio con output non deterministico
+## Output non deterministico e normalizzazione
 
 Alcuni programmi didattici stampano valori che cambiano a ogni esecuzione, per esempio indirizzi di memoria o valori di variabili automatiche non inizializzate.
 
-In questi casi puoi usare il campo `normalize` per sostituire le parti variabili con segnaposto stabili.
+In questi casi lo script deve continuare a compilare ed eseguire il programma reale, ma l'output salvato deve essere stabile. Per questo il manifest supporta due forme di normalizzazione:
 
-Quando gli indirizzi appartengono allo stesso blocco logico, per esempio variabili locali stampate nello stesso frame, conviene usare `normalize_addresses`.
+- `normalize`, per sostituzioni testuali tramite regex;
+- `normalize_addresses`, per trasformare indirizzi esadecimali in offset relativi.
 
-Esempio con delta preservati:
+La sequenza resta sempre questa:
+
+1. lo script compila il programma;
+2. lo script esegue il programma;
+3. lo script cattura stdout e stderr;
+4. lo script applica le normalizzazioni configurate;
+5. lo script salva o confronta il file `output/*.txt`.
+
+La normalizzazione non cambia il programma e non cambia quello che viene eseguito. Cambia solo il testo finale usato come output versionato.
+
+### Sostituzioni semplici con `normalize`
+
+Il campo `normalize` contiene una lista di regole regex:
+
+```json
+"normalize": [
+  {
+    "pattern": "(?m)^local_var=-?\\d+",
+    "replacement": "local_var=<indefinito>"
+  }
+]
+```
+
+Questa regola trasforma un valore reale ma instabile come:
+
+```text
+local_var=32764
+```
+
+in:
+
+```text
+local_var=<indefinito>
+```
+
+Questo e utile quando il numero stampato non ha significato didattico stabile. Nel caso di una variabile automatica non inizializzata, il valore non va interpretato come risultato affidabile: il segnaposto `<indefinito>` comunica meglio il concetto.
+
+### Indirizzi con delta preservati
+
+Quando gli indirizzi appartengono allo stesso blocco logico, per esempio variabili locali stampate nello stesso frame, conviene usare:
+
+```json
+"normalize_addresses": "paragraph"
+```
+
+Con questa opzione, ogni blocco separato da una riga vuota viene trattato separatamente. Dentro ogni blocco, il primo indirizzo esadecimale diventa la base e tutti gli altri indirizzi vengono convertiti in offset rispetto a quella base.
+
+Esempio reale possibile:
+
+```text
+local_var=123          &local_var=0x7ffca000
+init_local_var=0       &init_local_var=0x7ffc9ffc
+```
+
+Lo script prende `0x7ffca000` come base e calcola:
+
+```text
+0x7ffca000 - 0x7ffca000 = 0x0
+0x7ffc9ffc - 0x7ffca000 = -0x4
+```
+
+L'output normalizzato diventa:
+
+```text
+local_var=<indefinito>          &local_var=<base+0x0>
+init_local_var=0                &init_local_var=<base-0x4>
+```
+
+In questo modo l'indirizzo assoluto non dipende dal runner, ma il delta di `0x4` byte resta visibile nel README.
+
+### Perche `"paragraph"`
+
+Il valore `"paragraph"` significa che la base viene ricalcolata per ogni paragrafo, cioe per ogni blocco separato da una riga vuota.
+
+Questo e utile per programmi come `0_local.c`, dove la stessa funzione viene chiamata piu volte e ogni chiamata stampa un blocco autonomo.
+
+Esempio:
+
+```text
+local_var=123          &local_var=0xaaa0
+init_local_var=0       &init_local_var=0xaa9c
+
+local_var=456          &local_var=0xbbb0
+init_local_var=0       &init_local_var=0xbbac
+```
+
+diventa:
+
+```text
+local_var=<indefinito>          &local_var=<base+0x0>
+init_local_var=0                &init_local_var=<base-0x4>
+
+local_var=<indefinito>          &local_var=<base+0x0>
+init_local_var=0                &init_local_var=<base-0x4>
+```
+
+Non confrontiamo gli indirizzi assoluti tra chiamate diverse. Conserviamo invece la relazione tra variabili nello stesso blocco, che e la parte utile per spiegare il layout locale.
+
+### Caso `0_local.c`
+
+Nel lab `0_local.c` usiamo insieme `normalize_addresses` e `normalize`:
 
 ```json
 {
@@ -407,25 +508,72 @@ Esempio con delta preservati:
 }
 ```
 
-Un output reale come:
+L'output mostrato nel README diventa:
 
 ```text
-&local_var=0x7ffca000
-&init_local_var=0x7ffc9ffc
+local_var=<indefinito>          &local_var=<base+0x0>
+init_local_var=0                &init_local_var=<base-0x4>
 ```
 
-diventa:
+Cosa comunica:
+
+- `local_var=<indefinito>` indica che la variabile locale non inizializzata non ha un valore affidabile;
+- `init_local_var=0` mostra che la variabile inizializzata vale davvero zero;
+- `<base+0x0>` indica il primo indirizzo del blocco;
+- `<base-0x4>` indica un indirizzo distante quattro byte dalla base, espresso in esadecimale.
+
+### Caso `1_static_local.c`
+
+Nel lab `1_static_local.c` il programma stampa l'indirizzo di una variabile `static` locale e quello di una variabile automatica locale.
+
+Questi due indirizzi appartengono a zone di memoria concettualmente diverse:
+
+- `count` e `static`, quindi vive in storage statico;
+- `bad_count` e automatica, quindi vive nello stack.
+
+Il delta assoluto tra area statica e stack puo cambiare a causa di ASLR e del layout del processo. In questo caso conservare un delta numerico sarebbe fragile e potenzialmente fuorviante.
+
+Per questo usiamo sostituzioni semantiche:
+
+```json
+"normalize": [
+  {
+    "pattern": "&count=0x[0-9a-fA-F]+",
+    "replacement": "&count=<static+0x0>"
+  },
+  {
+    "pattern": "&bad_coubt=0x[0-9a-fA-F]+",
+    "replacement": "&bad_coubt=<stack+0x0>"
+  }
+]
+```
+
+L'output mostrato diventa:
 
 ```text
-&local_var=<base+0x0>
-&init_local_var=<base-0x4>
+count=1      &count=<static+0x0>
+bad_count=1  &bad_coubt=<stack+0x0>
+You call me 1 times
 ```
 
-In questo modo l'indirizzo assoluto non dipende dal runner, ma il delta di `0x4` byte resta visibile.
+Qui il punto didattico non e la distanza tra i due indirizzi, ma il fatto che le due variabili hanno durata e collocazione concettuale diverse.
 
-Se invece gli indirizzi appartengono a zone diverse, per esempio una variabile `static` e una variabile sullo stack, il delta assoluto puo dipendere da ASLR e dal layout del processo. In quel caso e meglio usare `normalize` con sostituzioni mirate, per esempio `<static+0x0>` e `<stack+0x0>`.
+### Casi senza normalizzazione
 
-Lo script esegue comunque il programma reale. La normalizzazione avviene solo dopo la cattura dell'output, prima di scrivere il file `output/*.txt` o prima del confronto in modalita `--check`.
+Se l'output e gia stabile, non serve configurare nulla.
+
+Per esempio un lab che stampa:
+
+```text
+global=0
+global=1
+global=2
+global=3
+```
+
+puo essere salvato direttamente senza `normalize` e senza `normalize_addresses`.
+
+In sintesi: usa `normalize` per sostituire valori instabili o semanticamente inutili; usa `normalize_addresses: "paragraph"` quando vuoi mantenere il delta in byte tra indirizzi dello stesso blocco logico.
 
 ## Aggiornare gli output localmente
 

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -323,6 +323,7 @@ Esempio completo:
 | `output` | Si | File `.txt` generato dallo script. |
 | `timeout_seconds` | No | Timeout per compilazione/esecuzione. Default: `10`. |
 | `allow_failure` | No | Se `true`, permette exit code non zero per esercizi che falliscono apposta. |
+| `normalize` | No | Lista di sostituzioni regex da applicare all'output generato prima di salvarlo o confrontarlo. |
 
 ## Esempio con input da tastiera
 
@@ -375,6 +376,38 @@ Alcuni esercizi possono dimostrare un errore o un comportamento non sicuro. In q
 ```
 
 Usalo solo quando il fallimento e parte dell'esercizio.
+
+## Esempio con output non deterministico
+
+Alcuni programmi didattici stampano valori che cambiano a ogni esecuzione, per esempio indirizzi di memoria o valori di variabili automatiche non inizializzate.
+
+In questi casi puoi usare il campo `normalize` per sostituire le parti variabili con segnaposto stabili.
+
+Esempio:
+
+```json
+{
+  "name": "0_local",
+  "path": "lab/1_variables/0_local.c",
+  "workdir": "lab/1_variables",
+  "compile": ["gcc", "-o", "bin/0_local", "0_local.c"],
+  "run": ["bin/0_local"],
+  "output": "lab/1_variables/output/0_local.txt",
+  "timeout_seconds": 5,
+  "normalize": [
+    {
+      "pattern": "(?m)^local_var=-?\\d+",
+      "replacement": "local_var=<indefinito>"
+    },
+    {
+      "pattern": "0x[0-9a-fA-F]+",
+      "replacement": "<indirizzo>"
+    }
+  ]
+}
+```
+
+Lo script esegue comunque il programma reale. La normalizzazione avviene solo dopo la cattura dell'output, prima di scrivere il file `output/*.txt` o prima del confronto in modalita `--check`.
 
 ## Aggiornare gli output localmente
 
@@ -510,7 +543,7 @@ Per questi casi:
 - usa `stdin` se il programma richiede input;
 - usa `timeout_seconds` per evitare blocchi;
 - usa `allow_failure: true` solo se il fallimento e parte dell'esercizio;
-- evita di configurare subito esercizi con output non deterministico finche non sono stati normalizzati.
+- usa `normalize` quando l'esercizio stampa valori non deterministici ma il comportamento generale deve restare verificabile.
 
 ## Sequenza consigliata in PR
 

--- a/lab/1_variables/output/0_local.txt
+++ b/lab/1_variables/output/0_local.txt
@@ -1,8 +1,8 @@
 local_var=<indefinito> 		 &local_var=<base+0x0>
-init_local_var=0 	 &init_local_var=<base-0x4>
+init_local_var=0 	 &init_local_var=<base+0x4>
 
 local_var=<indefinito> 		 &local_var=<base+0x0>
-init_local_var=0 	 &init_local_var=<base-0x4>
+init_local_var=0 	 &init_local_var=<base+0x4>
 
 local_var=<indefinito> 		 &local_var=<base+0x0>
-init_local_var=0 	 &init_local_var=<base-0x4>
+init_local_var=0 	 &init_local_var=<base+0x4>

--- a/lab/1_variables/output/0_local.txt
+++ b/lab/1_variables/output/0_local.txt
@@ -1,0 +1,8 @@
+local_var=<indefinito> 		 &local_var=<indirizzo>
+init_local_var=0 	 &init_local_var=<indirizzo>
+
+local_var=<indefinito> 		 &local_var=<indirizzo>
+init_local_var=0 	 &init_local_var=<indirizzo>
+
+local_var=<indefinito> 		 &local_var=<indirizzo>
+init_local_var=0 	 &init_local_var=<indirizzo>

--- a/lab/1_variables/output/0_local.txt
+++ b/lab/1_variables/output/0_local.txt
@@ -1,8 +1,8 @@
-local_var=<indefinito> 		 &local_var=<indirizzo>
-init_local_var=0 	 &init_local_var=<indirizzo>
+local_var=<indefinito> 		 &local_var=<base+0x0>
+init_local_var=0 	 &init_local_var=<base-0x4>
 
-local_var=<indefinito> 		 &local_var=<indirizzo>
-init_local_var=0 	 &init_local_var=<indirizzo>
+local_var=<indefinito> 		 &local_var=<base+0x0>
+init_local_var=0 	 &init_local_var=<base-0x4>
 
-local_var=<indefinito> 		 &local_var=<indirizzo>
-init_local_var=0 	 &init_local_var=<indirizzo>
+local_var=<indefinito> 		 &local_var=<base+0x0>
+init_local_var=0 	 &init_local_var=<base-0x4>

--- a/lab/1_variables/output/1_static_local.txt
+++ b/lab/1_variables/output/1_static_local.txt
@@ -1,19 +1,19 @@
-count=1 	 &count=<indirizzo>
-bad_count=1 	 &bad_coubt=<indirizzo>
+count=1 	 &count=<static+0x0>
+bad_count=1 	 &bad_coubt=<stack+0x0>
 You call me 1 times
 
-count=2 	 &count=<indirizzo>
-bad_count=1 	 &bad_coubt=<indirizzo>
+count=2 	 &count=<static+0x0>
+bad_count=1 	 &bad_coubt=<stack+0x0>
 You call me 2 times
 
-count=3 	 &count=<indirizzo>
-bad_count=1 	 &bad_coubt=<indirizzo>
+count=3 	 &count=<static+0x0>
+bad_count=1 	 &bad_coubt=<stack+0x0>
 You call me 3 times
 
-count=4 	 &count=<indirizzo>
-bad_count=1 	 &bad_coubt=<indirizzo>
+count=4 	 &count=<static+0x0>
+bad_count=1 	 &bad_coubt=<stack+0x0>
 You call me 4 times
 
-count=5 	 &count=<indirizzo>
-bad_count=1 	 &bad_coubt=<indirizzo>
+count=5 	 &count=<static+0x0>
+bad_count=1 	 &bad_coubt=<stack+0x0>
 You call me 5 times

--- a/lab/1_variables/output/1_static_local.txt
+++ b/lab/1_variables/output/1_static_local.txt
@@ -1,0 +1,19 @@
+count=1 	 &count=<indirizzo>
+bad_count=1 	 &bad_coubt=<indirizzo>
+You call me 1 times
+
+count=2 	 &count=<indirizzo>
+bad_count=1 	 &bad_coubt=<indirizzo>
+You call me 2 times
+
+count=3 	 &count=<indirizzo>
+bad_count=1 	 &bad_coubt=<indirizzo>
+You call me 3 times
+
+count=4 	 &count=<indirizzo>
+bad_count=1 	 &bad_coubt=<indirizzo>
+You call me 4 times
+
+count=5 	 &count=<indirizzo>
+bad_count=1 	 &bad_coubt=<indirizzo>
+You call me 5 times

--- a/lab/1_variables/output/2_global.txt
+++ b/lab/1_variables/output/2_global.txt
@@ -1,0 +1,4 @@
+global=0
+global=1
+global=2
+global=3

--- a/lab/1_variables/output/3_global_internal.txt
+++ b/lab/1_variables/output/3_global_internal.txt
@@ -1,0 +1,3 @@
+global_internal=0
+global_internal=1
+global_internal=2

--- a/lab/1_variables/output/4_global_external_internal.txt
+++ b/lab/1_variables/output/4_global_external_internal.txt
@@ -1,0 +1,8 @@
+Get me an integer > 0 (0 to quit)
+You call me 1 times 
+Subtotal = 3
+Get me an integer > 0 (0 to quit)
+You call me 2 times 
+Subtotal = 8
+Get me an integer > 0 (0 to quit)
+total=8

--- a/lab/lab_outputs.json
+++ b/lab/lab_outputs.json
@@ -121,12 +121,9 @@
         {
           "pattern": "(?m)^local_var=-?\\d+",
           "replacement": "local_var=<indefinito>"
-        },
-        {
-          "pattern": "0x[0-9a-fA-F]+",
-          "replacement": "<indirizzo>"
         }
-      ]
+      ],
+      "normalize_addresses": "paragraph"
     },
     {
       "name": "1_static_local",
@@ -145,8 +142,12 @@
       "timeout_seconds": 5,
       "normalize": [
         {
-          "pattern": "0x[0-9a-fA-F]+",
-          "replacement": "<indirizzo>"
+          "pattern": "&count=0x[0-9a-fA-F]+",
+          "replacement": "&count=<static+0x0>"
+        },
+        {
+          "pattern": "&bad_coubt=0x[0-9a-fA-F]+",
+          "replacement": "&bad_coubt=<stack+0x0>"
         }
       ]
     },

--- a/lab/lab_outputs.json
+++ b/lab/lab_outputs.json
@@ -101,6 +101,104 @@
       "stdin": "4\n2\ns\n8\n2\nD\n",
       "output": "lab/0_intro/output/5_variabili.txt",
       "timeout_seconds": 5
+    },
+    {
+      "name": "0_local",
+      "path": "lab/1_variables/0_local.c",
+      "workdir": "lab/1_variables",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/0_local",
+        "0_local.c"
+      ],
+      "run": [
+        "bin/0_local"
+      ],
+      "output": "lab/1_variables/output/0_local.txt",
+      "timeout_seconds": 5,
+      "normalize": [
+        {
+          "pattern": "(?m)^local_var=-?\\d+",
+          "replacement": "local_var=<indefinito>"
+        },
+        {
+          "pattern": "0x[0-9a-fA-F]+",
+          "replacement": "<indirizzo>"
+        }
+      ]
+    },
+    {
+      "name": "1_static_local",
+      "path": "lab/1_variables/1_static_local.c",
+      "workdir": "lab/1_variables",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/1_static_local",
+        "1_static_local.c"
+      ],
+      "run": [
+        "bin/1_static_local"
+      ],
+      "output": "lab/1_variables/output/1_static_local.txt",
+      "timeout_seconds": 5,
+      "normalize": [
+        {
+          "pattern": "0x[0-9a-fA-F]+",
+          "replacement": "<indirizzo>"
+        }
+      ]
+    },
+    {
+      "name": "2_global",
+      "path": "lab/1_variables/2_global.c",
+      "workdir": "lab/1_variables",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/2_global",
+        "2_global.c"
+      ],
+      "run": [
+        "bin/2_global"
+      ],
+      "output": "lab/1_variables/output/2_global.txt",
+      "timeout_seconds": 5
+    },
+    {
+      "name": "3_global_internal",
+      "path": "lab/1_variables/3_global_internal.c",
+      "workdir": "lab/1_variables",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/3_global_internal",
+        "3_global_internal.c"
+      ],
+      "run": [
+        "bin/3_global_internal"
+      ],
+      "output": "lab/1_variables/output/3_global_internal.txt",
+      "timeout_seconds": 5
+    },
+    {
+      "name": "4_global_external_internal",
+      "path": "lab/1_variables/4_global_external_internal_a.c",
+      "workdir": "lab/1_variables",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/4_global_external_internal",
+        "4_global_external_internal_a.c",
+        "4_global_external_internal_b.c"
+      ],
+      "run": [
+        "bin/4_global_external_internal"
+      ],
+      "stdin": "3\n5\n0\n",
+      "output": "lab/1_variables/output/4_global_external_internal.txt",
+      "timeout_seconds": 5
     }
   ]
 }

--- a/scripts/lab_output_wizard.py
+++ b/scripts/lab_output_wizard.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Guided workflow for adding or updating lab outputs.
+
+Run this script when you do not want to remember the full lab-output procedure.
+It guides you through:
+
+1. choosing the lab source;
+2. updating ``lab/lab_outputs.json``;
+3. adding an output marker to README when the lab block already exists;
+4. reminding you which generation commands to run next.
+
+The script deliberately does not guess the pedagogical position of a brand-new
+lab inside README.  When the lab snippet is missing, it prints a ready-to-paste
+block so you can place it in the right paragraph.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+from upsert_lab_output_manifest import (
+    DEFAULT_CONFIG,
+    ROOT,
+    build_entry,
+    load_config,
+    relative_repo_path,
+    repo_path,
+    save_config,
+    upsert_entry,
+)
+
+
+README = ROOT / "README.md"
+
+
+def ask(prompt: str, default: str | None = None) -> str:
+    """Ask one interactive question and return the user's answer."""
+
+    suffix = f" [{default}]" if default is not None else ""
+    answer = input(f"{prompt}{suffix}: ").strip()
+    return answer if answer else (default or "")
+
+
+def ask_yes_no(prompt: str, default: bool = True) -> bool:
+    """Ask a yes/no question with a default."""
+
+    default_label = "S/n" if default else "s/N"
+    answer = input(f"{prompt} [{default_label}]: ").strip().lower()
+    if not answer:
+        return default
+    return answer in {"s", "si", "sì", "y", "yes"}
+
+
+def parse_list(value: str) -> list[str]:
+    """Parse a comma-separated list typed by the user."""
+
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def decode_stdin(value: str) -> str | None:
+    """Decode a CLI-friendly stdin string such as ``4\\n2\\ns\\n``."""
+
+    if not value:
+        return None
+    return value.encode("utf-8").decode("unicode_escape")
+
+
+def namespace_from_answers(
+    source: str,
+    extra_sources: list[str],
+    stdin: str | None,
+    timeout_seconds: int,
+) -> argparse.Namespace:
+    """Build the argument namespace expected by the manifest helper."""
+
+    return argparse.Namespace(
+        source=source,
+        config=str(DEFAULT_CONFIG.relative_to(ROOT)),
+        name=None,
+        output_name=None,
+        workdir=None,
+        extra_source=extra_sources,
+        stdin=stdin,
+        timeout_seconds=timeout_seconds,
+        dry_run=False,
+    )
+
+
+def render_lab_block(entry: dict[str, Any]) -> str:
+    """Return a ready-to-paste README lab block for a new exercise."""
+
+    source = entry["path"]
+    output = entry["output"]
+    return f"""<tr>
+<td>
+<p align="center"><strong>Esercizi collegati</strong></p>
+
+<details>
+<summary>&#128187; /{source}</summary>
+
+<p align="justify">
+<strong>Descrizione breve:</strong>
+TODO: aggiungi una descrizione breve dell'esercizio.
+</p>
+
+<p align="justify">
+<strong>Descrizione lunga:</strong>
+TODO: spiega cosa mostra il lab e perche e collegato a questo paragrafo.
+</p>
+
+<p align="justify">
+<strong>Sorgente:</strong>
+<a href="https://github.com/TheBitPoets/2cornot2c/blob/main/{source}">/{source}</a>
+</p>
+
+<p align="justify">
+<strong>Compilazione ed esecuzione:</strong>
+</p>
+
+<pre lang="bash"><code>cd /{entry["workdir"]}
+{" ".join(entry["compile"])}
+{" ".join(entry["run"])}</code></pre>
+
+<p align="justify">
+<strong>Codice:</strong>
+</p>
+
+<!-- lab-snippet:start path="{source}" -->
+<pre lang="c"><code></code></pre>
+<!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="{output}" -->
+<pre lang="text"><code></code></pre>
+<!-- lab-output:end -->
+
+</details>
+</td>
+</tr>"""
+
+
+def ensure_readme_output_marker(entry: dict[str, Any]) -> str:
+    """Insert the output marker after an existing README lab snippet if possible."""
+
+    if not README.exists():
+        return "missing-readme"
+
+    readme = README.read_text(encoding="utf-8")
+    output_marker = f'<!-- lab-output:start path="{entry["output"]}" -->'
+    if output_marker in readme:
+        return "already-present"
+
+    snippet_marker = f'<!-- lab-snippet:start path="{entry["path"]}" -->'
+    snippet_start = readme.find(snippet_marker)
+    if snippet_start == -1:
+        return "missing-snippet"
+
+    snippet_end_marker = "<!-- lab-snippet:end -->"
+    snippet_end = readme.find(snippet_end_marker, snippet_start)
+    if snippet_end == -1:
+        return "missing-snippet-end"
+
+    insert_at = snippet_end + len(snippet_end_marker)
+    output_block = (
+        '\n\n<p align="justify">\n'
+        "<strong>Output:</strong>\n"
+        "</p>\n\n"
+        f'<!-- lab-output:start path="{entry["output"]}" -->\n'
+        '<pre lang="text"><code></code></pre>\n'
+        "<!-- lab-output:end -->"
+    )
+    README.write_text(readme[:insert_at] + output_block + readme[insert_at:], encoding="utf-8", newline="\n")
+    return "inserted"
+
+
+def run_command(command: list[str]) -> int:
+    """Run a command and stream its output to the terminal."""
+
+    print("\n$ " + " ".join(command))
+    return subprocess.run(command, cwd=ROOT, check=False).returncode
+
+
+def print_entry(entry: dict[str, Any]) -> None:
+    """Print the inferred manifest entry in readable JSON."""
+
+    print("\nVoce manifest inferita:")
+    print(json.dumps(entry, ensure_ascii=False, indent=2))
+
+
+def guided_flow(args: argparse.Namespace) -> int:
+    """Run the interactive guided workflow."""
+
+    print("Workflow guidato per output lab\n")
+    source = args.source or ask("Path del sorgente principale, relativo alla root")
+    if not source:
+        print("Nessun sorgente indicato.", file=sys.stderr)
+        return 1
+
+    repo_path(source)
+    extra_sources = args.extra_source or parse_list(ask("Altri sorgenti da compilare, separati da virgola", ""))
+    stdin = decode_stdin(args.stdin) if args.stdin is not None else decode_stdin(ask("Input stdin, usa \\\\n per andare a capo", ""))
+    timeout_seconds = args.timeout_seconds
+
+    helper_args = namespace_from_answers(source, extra_sources, stdin, timeout_seconds)
+    entry = build_entry(helper_args)
+    print_entry(entry)
+
+    if not ask_yes_no("Aggiorno lab/lab_outputs.json?", True):
+        print("Manifest non modificato.")
+        return 0
+
+    config = load_config(DEFAULT_CONFIG)
+    action = upsert_entry(config, entry)
+    save_config(DEFAULT_CONFIG, config)
+    print(f"\nManifest {action}: {entry['name']}")
+
+    marker_status = ensure_readme_output_marker(entry)
+    if marker_status == "inserted":
+        print("README aggiornato: marker Output inserito nel blocco lab esistente.")
+    elif marker_status == "already-present":
+        print("README gia aggiornato: marker Output gia presente.")
+    elif marker_status == "missing-snippet":
+        print("\nNon ho trovato il blocco lab nel README.")
+        print("Inserisci manualmente questo blocco nel paragrafo didattico corretto:")
+        print("\n" + render_lab_block(entry))
+    else:
+        print(f"README non aggiornato automaticamente: {marker_status}.")
+
+    if ask_yes_no("Vuoi lanciare ora la generazione degli output?", True):
+        output_status = run_command([sys.executable, "scripts/update_lab_outputs.py"])
+        if output_status != 0:
+            print("Generazione output non completata. Controlla l'errore sopra e rilancia lo script.")
+            return output_status
+
+    if ask_yes_no("Vuoi aggiornare ora snippet e output nel README/template?", True):
+        snippet_status = run_command([sys.executable, "scripts/update_lab_snippets.py"])
+        if snippet_status != 0:
+            print("Aggiornamento snippet non completato. Controlla l'errore sopra e rilancia lo script.")
+            return snippet_status
+
+    print("\nFlusso completato. Prima della PR controlla il diff e committa manifest, output e Markdown aggiornati.")
+    return 0
+
+
+def main() -> int:
+    """Parse CLI arguments and run the guided workflow."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", nargs="?", help="Main C source file, relative to the repository root.")
+    parser.add_argument("--extra-source", action="append", default=[], help="Additional C source file to compile.")
+    parser.add_argument("--stdin", help="Text passed to stdin, for example: '4\\n2\\ns\\n'.")
+    parser.add_argument("--timeout-seconds", type=int, default=5, help="Compile/run timeout. Default: 5.")
+    args = parser.parse_args()
+    return guided_flow(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_lab_outputs.py
+++ b/scripts/update_lab_outputs.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import re
 import subprocess
 import sys
 from typing import Any
@@ -98,6 +99,22 @@ def format_output(
     return "\n".join(sections) + "\n"
 
 
+def apply_normalizations(generated: str, entry: dict[str, Any]) -> str:
+    """Apply optional regex replacements to make expected output stable.
+
+    Some didactic programs intentionally print values that change between runs,
+    such as stack addresses or uninitialized automatic variables.  The manifest
+    can define a ``normalize`` list with ``pattern`` and ``replacement`` fields;
+    each item is applied with ``re.sub`` before the output file is written or
+    compared in ``--check`` mode.
+    """
+
+    normalized = generated
+    for rule in entry.get("normalize", []):
+        normalized = re.sub(rule["pattern"], rule["replacement"], normalized)
+    return normalized
+
+
 def process_lab(entry: dict[str, Any], check: bool) -> bool:
     """Compile, run, and either update or verify one manifest entry.
 
@@ -130,7 +147,7 @@ def process_lab(entry: dict[str, Any], check: bool) -> bool:
         sys.stderr.write(run_result.stderr)
         return False
 
-    generated = format_output(compile_result, run_result)
+    generated = apply_normalizations(format_output(compile_result, run_result), entry)
     if check:
         current = output_path.read_text(encoding="utf-8") if output_path.exists() else None
         if current != generated:

--- a/scripts/update_lab_outputs.py
+++ b/scripts/update_lab_outputs.py
@@ -74,6 +74,27 @@ def run_command(
     )
 
 
+def ensure_compile_output_dir(command: list[str], cwd: pathlib.Path) -> None:
+    """Create the parent directory of a GCC ``-o`` output path when needed.
+
+    Lab manifests commonly compile to paths such as ``bin/0_hello``.  Git does
+    not track empty directories, so a fresh checkout may not contain that
+    ``bin`` directory yet.  Creating it here keeps manifests simple and avoids
+    requiring ``.gitkeep`` files in every lab folder.
+    """
+
+    try:
+        output_index = command.index("-o") + 1
+    except ValueError:
+        return
+    if output_index >= len(command):
+        return
+    output_path = pathlib.Path(command[output_index])
+    parent = output_path.parent
+    if str(parent) != ".":
+        (cwd / parent).mkdir(parents=True, exist_ok=True)
+
+
 def format_output(
     compile_result: subprocess.CompletedProcess[str],
     run_result: subprocess.CompletedProcess[str],
@@ -166,6 +187,7 @@ def process_lab(entry: dict[str, Any], check: bool) -> bool:
     output_path = repo_path(entry["output"])
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
+    ensure_compile_output_dir(compile_cmd, cwd)
     compile_result = run_command(compile_cmd, cwd=cwd, timeout=timeout)
     if compile_result.returncode != 0 and not allow_failure:
         sys.stderr.write(f"Compilation failed for {name}\n")

--- a/scripts/update_lab_outputs.py
+++ b/scripts/update_lab_outputs.py
@@ -104,15 +104,48 @@ def apply_normalizations(generated: str, entry: dict[str, Any]) -> str:
 
     Some didactic programs intentionally print values that change between runs,
     such as stack addresses or uninitialized automatic variables.  The manifest
-    can define a ``normalize`` list with ``pattern`` and ``replacement`` fields;
-    each item is applied with ``re.sub`` before the output file is written or
-    compared in ``--check`` mode.
+    can define ``normalize_addresses: "paragraph"`` to replace hexadecimal
+    addresses inside each blank-line-separated output block with offsets from
+    the first address in that block.  It can also define a ``normalize`` list
+    with ``pattern`` and ``replacement`` fields; each item is applied with
+    ``re.sub`` before the output file is written or compared in ``--check``
+    mode.
     """
 
-    normalized = generated
+    normalized = normalize_addresses(generated, entry)
     for rule in entry.get("normalize", []):
         normalized = re.sub(rule["pattern"], rule["replacement"], normalized)
     return normalized
+
+
+def normalize_addresses(generated: str, entry: dict[str, Any]) -> str:
+    """Normalize hexadecimal addresses while preserving local byte deltas.
+
+    With ``normalize_addresses: "paragraph"``, every paragraph uses its first
+    hexadecimal address as ``base``.  Later addresses become values such as
+    ``<base+0x4>`` or ``<base-0x4>``.  This keeps stack-frame relationships
+    visible without committing ASLR-dependent absolute addresses.
+    """
+
+    if entry.get("normalize_addresses") != "paragraph":
+        return generated
+
+    address_re = re.compile(r"0x[0-9a-fA-F]+")
+
+    def replace_paragraph(paragraph: str) -> str:
+        matches = list(address_re.finditer(paragraph))
+        if not matches:
+            return paragraph
+        base = int(matches[0].group(0), 16)
+
+        def replace_address(match: re.Match[str]) -> str:
+            delta = int(match.group(0), 16) - base
+            sign = "+" if delta >= 0 else "-"
+            return f"<base{sign}0x{abs(delta):x}>"
+
+        return address_re.sub(replace_address, paragraph)
+
+    return "\n\n".join(replace_paragraph(part) for part in generated.split("\n\n"))
 
 
 def process_lab(entry: dict[str, Any], check: bool) -> bool:

--- a/scripts/upsert_lab_output_manifest.py
+++ b/scripts/upsert_lab_output_manifest.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Add or update one lab entry in lab/lab_outputs.json.
+
+The script infers the common manifest fields from a C source file and adds the
+normalization rules needed by frequent didactic cases:
+
+- automatic local variables printed before initialization;
+- hexadecimal addresses printed with ``%p``;
+- address deltas inside one stack frame;
+- semantic placeholders for addresses from different storage areas.
+
+It is intentionally conservative.  For multi-file labs or interactive programs,
+pass the missing information explicitly with ``--extra-source`` and ``--stdin``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = ROOT / "lab" / "lab_outputs.json"
+
+
+def repo_path(value: str) -> pathlib.Path:
+    """Return an absolute repository-local path and reject path traversal."""
+
+    path = (ROOT / value).resolve()
+    try:
+        path.relative_to(ROOT)
+    except ValueError as exc:
+        raise ValueError(f"path escapes repository root: {value}") from exc
+    return path
+
+
+def relative_repo_path(path: pathlib.Path) -> str:
+    """Return a POSIX-style path relative to the repository root."""
+
+    return path.resolve().relative_to(ROOT).as_posix()
+
+
+def load_config(path: pathlib.Path) -> dict[str, Any]:
+    """Load the output manifest, creating an empty structure when missing."""
+
+    if not path.exists():
+        return {"version": 1, "labs": []}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_config(path: pathlib.Path, config: dict[str, Any]) -> None:
+    """Write the manifest with stable formatting."""
+
+    path.write_text(json.dumps(config, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def infer_name(source: pathlib.Path, explicit_name: str | None) -> str:
+    """Infer the lab name used for binary and output paths."""
+
+    if explicit_name:
+        return explicit_name
+    name = source.stem
+    if name.endswith("_main"):
+        name = name.removesuffix("_main")
+    return name
+
+
+def classify_symbol(source: str, symbol: str) -> str:
+    """Classify a C symbol into a coarse storage area label."""
+
+    declaration = rf"(?:^|[;\n{{])\s*(?P<static>static\s+)?(?:const\s+)?(?:unsigned\s+|signed\s+)?(?:char|short|int|long|float|double|void\s*\*|[A-Za-z_]\w+\s*\*)\s+{re.escape(symbol)}\b"
+    match = re.search(declaration, source)
+    if match and match.group("static"):
+        return "static"
+    if match:
+        return "stack"
+    extern_declaration = rf"\bextern\s+.*\b{re.escape(symbol)}\b"
+    if re.search(extern_declaration, source):
+        return "extern"
+    return "address"
+
+
+def find_uninitialized_prints(source: str) -> list[dict[str, str]]:
+    """Return regex replacements for printed uninitialized automatic ints."""
+
+    rules: list[dict[str, str]] = []
+    declared = set(re.findall(r"(?:^|[;\n{])\s*int\s+([A-Za-z_]\w*)\s*;", source))
+    for symbol in sorted(declared):
+        printed_as_decimal = re.search(rf'printf\s*\(\s*"[^"]*{re.escape(symbol)}=%d[^"]*"\s*,\s*{re.escape(symbol)}\b', source)
+        if printed_as_decimal:
+            rules.append(
+                {
+                    "pattern": rf"(?m)^{re.escape(symbol)}=-?\d+",
+                    "replacement": f"{symbol}=<indefinito>",
+                }
+            )
+    return rules
+
+
+def find_printed_addresses(source: str) -> list[tuple[str, str, str]]:
+    """Return tuples of output label, C symbol, and storage class for %p prints."""
+
+    printed: list[tuple[str, str, str]] = []
+    printf_re = re.compile(r'printf\s*\(\s*"(?P<format>(?:\\.|[^"])*)"\s*,(?P<args>.*?)\);', re.DOTALL)
+    for match in printf_re.finditer(source):
+        fmt = match.group("format")
+        args = match.group("args")
+        if "%p" not in fmt:
+            continue
+        labels = re.findall(r"&([A-Za-z_]\w*)=%p", fmt)
+        symbols = re.findall(r"&\s*([A-Za-z_]\w*)", args)
+        for index, symbol in enumerate(symbols):
+            label = labels[index] if index < len(labels) else symbol
+            printed.append((label, symbol, classify_symbol(source, symbol)))
+    return printed
+
+
+def infer_normalization(source: str) -> dict[str, Any]:
+    """Infer address and value normalization settings for a manifest entry."""
+
+    inferred: dict[str, Any] = {}
+    rules = find_uninitialized_prints(source)
+    addresses = find_printed_addresses(source)
+    if addresses:
+        classes = {storage for _, _, storage in addresses}
+        if classes == {"stack"} and len(addresses) > 1:
+            inferred["normalize_addresses"] = "paragraph"
+        else:
+            for label, _, storage in addresses:
+                rules.append(
+                    {
+                        "pattern": rf"&{re.escape(label)}=0x[0-9a-fA-F]+",
+                        "replacement": f"&{label}=<{storage}+0x0>",
+                    }
+                )
+    if rules:
+        inferred["normalize"] = rules
+    return inferred
+
+
+def build_entry(args: argparse.Namespace) -> dict[str, Any]:
+    """Build one manifest entry from CLI arguments and source inspection."""
+
+    source = repo_path(args.source)
+    source_text = source.read_text(encoding="utf-8")
+    workdir = repo_path(args.workdir) if args.workdir else source.parent
+    name = infer_name(source, args.name)
+    output_name = args.output_name or name
+    extra_sources = [repo_path(value) for value in args.extra_source]
+    compile_sources = [source.name] + [path.name if path.parent == workdir else relative_repo_path(path) for path in extra_sources]
+
+    entry: dict[str, Any] = {
+        "name": name,
+        "path": relative_repo_path(source),
+        "workdir": relative_repo_path(workdir),
+        "compile": ["gcc", "-o", f"bin/{name}", *compile_sources],
+        "run": [f"bin/{name}"],
+        "output": f"{relative_repo_path(workdir)}/output/{output_name}.txt",
+        "timeout_seconds": args.timeout_seconds,
+    }
+    if args.stdin is not None:
+        entry["stdin"] = args.stdin
+    entry.update(infer_normalization(source_text))
+    return entry
+
+
+def upsert_entry(config: dict[str, Any], entry: dict[str, Any]) -> str:
+    """Insert or replace an entry matching the same name or source path."""
+
+    labs = config.setdefault("labs", [])
+    for index, current in enumerate(labs):
+        if current.get("name") == entry["name"] or current.get("path") == entry["path"]:
+            labs[index] = entry
+            return "updated"
+    labs.append(entry)
+    return "added"
+
+
+def main() -> int:
+    """Parse CLI arguments and update the manifest."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", help="Main C source file, relative to the repository root.")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG.relative_to(ROOT)), help="Manifest path.")
+    parser.add_argument("--name", help="Manifest name and binary name. Defaults to the source stem.")
+    parser.add_argument("--output-name", help="Output file stem. Defaults to the manifest name.")
+    parser.add_argument("--workdir", help="Compilation/execution directory. Defaults to the source directory.")
+    parser.add_argument("--extra-source", action="append", default=[], help="Additional C source file to compile.")
+    parser.add_argument("--stdin", help="Text passed to stdin, for example: '4\\n2\\ns\\n'.")
+    parser.add_argument("--timeout-seconds", type=int, default=5, help="Compile/run timeout. Default: 5.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the inferred entry without changing the manifest.")
+    args = parser.parse_args()
+
+    config_path = repo_path(args.config)
+    entry = build_entry(args)
+    if args.dry_run:
+        print(json.dumps(entry, ensure_ascii=False, indent=2))
+        return 0
+
+    config = load_config(config_path)
+    action = upsert_entry(config, entry)
+    save_config(config_path, config)
+    print(f"{action} {entry['name']} in {relative_repo_path(config_path)}")
+    if entry.get("normalize") or entry.get("normalize_addresses"):
+        print("normalization inferred:")
+        if entry.get("normalize_addresses"):
+            print(f"- normalize_addresses: {entry['normalize_addresses']}")
+        for rule in entry.get("normalize", []):
+            print(f"- {rule['pattern']} -> {rule['replacement']}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Cosa cambia
- aggiunge gli output versionati per i lab di `lab/1_variables`
- inserisce i blocchi `Output` nel README per gli esercizi collegati
- aggiunge il campo opzionale `normalize` al generatore output per rendere stabili indirizzi e valori non deterministici
- documenta l'uso di `normalize` in `doc/LAB_OUTPUTS.md`

## Note
- `0_local.c` stampa una variabile non inizializzata e indirizzi: l'output viene normalizzato con `<indefinito>` e `<indirizzo>`
- `1_static_local.c` stampa indirizzi: l'output viene normalizzato con `<indirizzo>`
- la GitHub Action compilera' ed eseguira' i lab su Ubuntu