### PR TITLE
docs: add outputs for preprocessor labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3681,6 +3681,18 @@ int main(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/2_preprocessor/output/macro.txt" -->
+<pre lang="text"><code>Inserisci il primo operando
+Inserisci il secondo operando
+s)Somma d)Differenza m)Moltiplicazione D)Divisione
+Il risultato e': 6
+</code></pre>
+<!-- lab-output:end -->
 </details>
 </td>
 </tr>
@@ -3884,6 +3896,15 @@ int main(void){
 	
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/2_preprocessor/output/direttiva_if.txt" -->
+<pre lang="text"><code>DEBUG is OFF
+</code></pre>
+<!-- lab-output:end -->
 </details>
 
 <details>
@@ -3943,6 +3964,15 @@ int main(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/2_preprocessor/output/direttiva_ifdef.txt" -->
+<pre lang="text"><code>DEBUG is not defined
+</code></pre>
+<!-- lab-output:end -->
 </details>
 
 <details>
@@ -4002,6 +4032,15 @@ int main(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/2_preprocessor/output/direttiva_ifndef.txt" -->
+<pre lang="text"><code>DEBUG is not defined
+</code></pre>
+<!-- lab-output:end -->
 </details>
 </td>
 </tr>
@@ -4127,6 +4166,15 @@ int main(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/2_preprocessor/output/eliminazione_temporanea_codice.txt" -->
+<pre lang="text"><code>int i = &lt;indefinito&gt;
+</code></pre>
+<!-- lab-output:end -->
 </details>
 </td>
 </tr>

--- a/lab/2_preprocessor/output/direttiva_if.txt
+++ b/lab/2_preprocessor/output/direttiva_if.txt
@@ -1,0 +1,1 @@
+DEBUG is OFF

--- a/lab/2_preprocessor/output/direttiva_ifdef.txt
+++ b/lab/2_preprocessor/output/direttiva_ifdef.txt
@@ -1,0 +1,1 @@
+DEBUG is not defined

--- a/lab/2_preprocessor/output/direttiva_ifndef.txt
+++ b/lab/2_preprocessor/output/direttiva_ifndef.txt
@@ -1,0 +1,1 @@
+DEBUG is not defined

--- a/lab/2_preprocessor/output/eliminazione_temporanea_codice.txt
+++ b/lab/2_preprocessor/output/eliminazione_temporanea_codice.txt
@@ -1,0 +1,1 @@
+int i = <indefinito>

--- a/lab/2_preprocessor/output/macro.txt
+++ b/lab/2_preprocessor/output/macro.txt
@@ -1,0 +1,4 @@
+Inserisci il primo operando
+Inserisci il secondo operando
+s)Somma d)Differenza m)Moltiplicazione D)Divisione
+Il risultato e': 6

--- a/lab/lab_outputs.json
+++ b/lab/lab_outputs.json
@@ -200,6 +200,93 @@
       "stdin": "3\n5\n0\n",
       "output": "lab/1_variables/output/4_global_external_internal.txt",
       "timeout_seconds": 5
+    },
+    {
+      "name": "macro",
+      "path": "lab/2_preprocessor/macro.c",
+      "workdir": "lab/2_preprocessor",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/macro",
+        "macro.c"
+      ],
+      "run": [
+        "bin/macro"
+      ],
+      "stdin": "4\n2\ns\n",
+      "output": "lab/2_preprocessor/output/macro.txt",
+      "timeout_seconds": 5
+    },
+    {
+      "name": "direttiva_if",
+      "path": "lab/2_preprocessor/direttiva_if.c",
+      "workdir": "lab/2_preprocessor",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/direttiva_if",
+        "direttiva_if.c"
+      ],
+      "run": [
+        "bin/direttiva_if"
+      ],
+      "output": "lab/2_preprocessor/output/direttiva_if.txt",
+      "timeout_seconds": 5
+    },
+    {
+      "name": "direttiva_ifdef",
+      "path": "lab/2_preprocessor/direttiva_ifdef.c",
+      "workdir": "lab/2_preprocessor",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/direttiva_ifdef",
+        "direttiva_ifdef.c"
+      ],
+      "run": [
+        "bin/direttiva_ifdef"
+      ],
+      "output": "lab/2_preprocessor/output/direttiva_ifdef.txt",
+      "timeout_seconds": 5
+    },
+    {
+      "name": "direttiva_ifndef",
+      "path": "lab/2_preprocessor/direttiva_ifndef.c",
+      "workdir": "lab/2_preprocessor",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/direttiva_ifndef",
+        "direttiva_ifndef.c"
+      ],
+      "run": [
+        "bin/direttiva_ifndef"
+      ],
+      "output": "lab/2_preprocessor/output/direttiva_ifndef.txt",
+      "timeout_seconds": 5
+    },
+    {
+      "name": "eliminazione_temporanea_codice",
+      "path": "lab/2_preprocessor/eliminazione_temporanea_codice.c",
+      "workdir": "lab/2_preprocessor",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/eliminazione_temporanea_codice",
+        "eliminazione_temporanea_codice.c"
+      ],
+      "run": [
+        "bin/eliminazione_temporanea_codice"
+      ],
+      "output": "lab/2_preprocessor/output/eliminazione_temporanea_codice.txt",
+      "timeout_seconds": 5,
+      "normalize": [
+        {
+          "pattern": "(?m)^int i = -?\\d+",
+          "replacement": "int i = <indefinito>"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Cosa cambia
- aggiunge gli output versionati per i lab di `lab/2_preprocessor`
- configura i nuovi lab in `lab/lab_outputs.json`
- inserisce i blocchi `Output` nel README

## Note
- `macro.c` usa input deterministico `4`, `2`, `s`
- `eliminazione_temporanea_codice.c` normalizza il valore non inizializzato di `i` con `<indefinito>`