### PR TITLE
docs: add output for dynamic memory lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -11734,6 +11734,17 @@ int main(void){
 }
 </code></pre>
 <!-- lab-snippet:end -->
+
+<p align="justify">
+<strong>Output:</strong>
+</p>
+
+<!-- lab-output:start path="lab/10_dynamic_memory/output/0_malloc.txt" -->
+<pre lang="text"><code>Quanti elementi per il vettore?
+statico : 0 1 2 3 4 5 6 7 8 9 
+dinamico: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+</code></pre>
+<!-- lab-output:end -->
 </details>
 </td>
 </tr>

--- a/lab/10_dynamic_memory/output/0_malloc.txt
+++ b/lab/10_dynamic_memory/output/0_malloc.txt
@@ -1,0 +1,3 @@
+Quanti elementi per il vettore?
+statico : 0 1 2 3 4 5 6 7 8 9 
+dinamico: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14

--- a/lab/lab_outputs.json
+++ b/lab/lab_outputs.json
@@ -1263,6 +1263,23 @@
       ],
       "output": "lab/9_functions/output/3_functions.txt",
       "timeout_seconds": 5
+    },
+    {
+      "name": "0_malloc",
+      "path": "lab/10_dynamic_memory/0_malloc.c",
+      "workdir": "lab/10_dynamic_memory",
+      "compile": [
+        "gcc",
+        "-o",
+        "bin/0_malloc",
+        "0_malloc.c"
+      ],
+      "run": [
+        "bin/0_malloc"
+      ],
+      "stdin": "15\n",
+      "output": "lab/10_dynamic_memory/output/0_malloc.txt",
+      "timeout_seconds": 5
     }
   ]
 }


### PR DESCRIPTION
## Cosa cambia
- aggiunge output versionato per `lab/10_dynamic_memory/0_malloc.c`
- configura il lab in `lab/lab_outputs.json`
- inserisce il blocco `Output` nel README

## Note
- usa input deterministico `15`, coerente con l'esempio didattico nel testo