### PR TITLE
fix: show configured lab stdin in outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1238,7 +1238,12 @@ int moltiplicazione(){
 </p>
 
 <!-- lab-output:start path="lab/0_intro/output/2_variabili.txt" -->
-<pre lang="text"><code>Inserisci il primo operando
+<pre lang="text"><code>[stdin]
+4
+2
+s
+
+Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazine
 Il risultato e': 6
@@ -1332,7 +1337,12 @@ int moltiplicazione(int primo_fattore, int secondo_fattore){
 </p>
 
 <!-- lab-output:start path="lab/0_intro/output/3_variabili.txt" -->
-<pre lang="text"><code>Inserisci il primo operando
+<pre lang="text"><code>[stdin]
+4
+2
+s
+
+Inserisci il primo operando
 Insesci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione
 Il risultato e': 6
@@ -2603,7 +2613,12 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/1_variables/output/4_global_external_internal.txt" -->
-<pre lang="text"><code>Get me an integer &gt; 0 (0 to quit)
+<pre lang="text"><code>[stdin]
+3
+5
+0
+
+Get me an integer &gt; 0 (0 to quit)
 You call me 1 times 
 Subtotal = 3
 Get me an integer &gt; 0 (0 to quit)
@@ -3171,7 +3186,15 @@ int divisione(int dividendo, int divisore){
 </p>
 
 <!-- lab-output:start path="lab/0_intro/output/4_variabili.txt" -->
-<pre lang="text"><code>Inserisci il primo operando
+<pre lang="text"><code>[stdin]
+4
+2
+s
+8
+2
+D
+
+Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione
 Il risultato e': 6
@@ -3295,7 +3318,15 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/0_intro/output/5_variabili.txt" -->
-<pre lang="text"><code>Inserisci il primo operando
+<pre lang="text"><code>[stdin]
+4
+2
+s
+8
+2
+D
+
+Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione
 Il risultato e': 6
@@ -3687,7 +3718,12 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/2_preprocessor/output/macro.txt" -->
-<pre lang="text"><code>Inserisci il primo operando
+<pre lang="text"><code>[stdin]
+4
+2
+s
+
+Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione
 Il risultato e': 6
@@ -7118,7 +7154,10 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/4_operators/output/op_modulo.txt" -->
-<pre lang="text"><code>Inserisci un numero tra 1 e 10
+<pre lang="text"><code>[stdin]
+4
+
+Inserisci un numero tra 1 e 10
 4 e' pari
 </code></pre>
 <!-- lab-output:end -->
@@ -7491,7 +7530,10 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/5_control_statements/output/if.txt" -->
-<pre lang="text"><code>Inserisci un numero tra 1 e 10
+<pre lang="text"><code>[stdin]
+4
+
+Inserisci un numero tra 1 e 10
 4 e' pari
 </code></pre>
 <!-- lab-output:end -->
@@ -7639,7 +7681,11 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/5_control_statements/output/logical_relational_operators.txt" -->
-<pre lang="text"><code>Inserisci la tua eta'
+<pre lang="text"><code>[stdin]
+35
+S
+
+Inserisci la tua eta'
 Hai la laurea?
 [S]ì 	 [N]o
 Hai la laurea, il tuo stipendio e' 3000
@@ -8059,7 +8105,10 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/5_control_statements/output/switch.txt" -->
-<pre lang="text"><code>a=&lt;indefinito&gt; 	 b=&lt;indefinito&gt; 	 c=&lt;indefinito&gt; 	 other=&lt;indefinito&gt;
+<pre lang="text"><code>[stdin]
+a
+
+a=&lt;indefinito&gt; 	 b=&lt;indefinito&gt; 	 c=&lt;indefinito&gt; 	 other=&lt;indefinito&gt;
 Quale variabile vuoi incrementare?
 [a-A]	[b-B]	[c-C]
 a=&lt;indefinito&gt; 	 b=&lt;indefinito&gt; 	 c=&lt;indefinito&gt; 	 other=&lt;indefinito&gt;
@@ -8362,7 +8411,10 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/6_pointers/output/0_pointers.txt" -->
-<pre lang="text"><code>i = 42, &amp;i = &lt;addr_i&gt;
+<pre lang="text"><code>[stdin]
+&lt;INVIO&gt;
+
+i = 42, &amp;i = &lt;addr_i&gt;
 j = 107, &amp;j = &lt;addr_j&gt;
 *p = 42, p = &lt;addr_i&gt;
 *q = 107, p = &lt;addr_j&gt;
@@ -8430,7 +8482,10 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/6_pointers/output/1_pointers.txt" -->
-<pre lang="text"><code>i = 42, &amp;i = &lt;addr_i&gt;
+<pre lang="text"><code>[stdin]
+&lt;INVIO&gt;
+
+i = 42, &amp;i = &lt;addr_i&gt;
 j = 107, &amp;j = &lt;addr_j&gt;
 *p = 42, p = &lt;addr_i&gt;
 *q = 107, p = &lt;addr_j&gt;
@@ -11771,7 +11826,10 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/10_dynamic_memory/output/0_malloc.txt" -->
-<pre lang="text"><code>Quanti elementi per il vettore?
+<pre lang="text"><code>[stdin]
+15
+
+Quanti elementi per il vettore?
 statico : 0 1 2 3 4 5 6 7 8 9 
 dinamico: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
 </code></pre>
@@ -12170,7 +12228,10 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/6_pointers/output/9_pointers.txt" -->
-<pre lang="text"><code>Inserisci un numero da 1 a 12
+<pre lang="text"><code>[stdin]
+7
+
+Inserisci un numero da 1 a 12
 7 -&gt; Luglio
 </code></pre>
 <!-- lab-output:end -->
@@ -12298,7 +12359,10 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/6_pointers/output/11_pointers.txt" -->
-<pre lang="text"><code>Inserisci un numero da 1 a 12
+<pre lang="text"><code>[stdin]
+7
+
+Inserisci un numero da 1 a 12
 7 -&gt; Luglio
 7 -&gt; Luglio
 7 -&gt; Luglio
@@ -12404,7 +12468,10 @@ int main(void){
 </p>
 
 <!-- lab-output:start path="lab/6_pointers/output/10_pointers.txt" -->
-<pre lang="text"><code>Inserisci un numero da 1 a 12
+<pre lang="text"><code>[stdin]
+7
+
+Inserisci un numero da 1 a 12
 7 -&gt; Luglio
 7 -&gt; Luglio
 </code></pre>

--- a/README.md
+++ b/README.md
@@ -1242,7 +1242,6 @@ int moltiplicazione(){
 4
 2
 s
-
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazine
@@ -1341,7 +1340,6 @@ int moltiplicazione(int primo_fattore, int secondo_fattore){
 4
 2
 s
-
 Inserisci il primo operando
 Insesci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione
@@ -2617,7 +2615,6 @@ int main(void){
 3
 5
 0
-
 Get me an integer &gt; 0 (0 to quit)
 You call me 1 times 
 Subtotal = 3
@@ -3193,7 +3190,6 @@ s
 8
 2
 D
-
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione
@@ -3325,7 +3321,6 @@ s
 8
 2
 D
-
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione
@@ -3722,7 +3717,6 @@ int main(void){
 4
 2
 s
-
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione
@@ -7156,7 +7150,6 @@ int main(void){
 <!-- lab-output:start path="lab/4_operators/output/op_modulo.txt" -->
 <pre lang="text"><code>[stdin]
 4
-
 Inserisci un numero tra 1 e 10
 4 e' pari
 </code></pre>
@@ -7532,7 +7525,6 @@ int main(void){
 <!-- lab-output:start path="lab/5_control_statements/output/if.txt" -->
 <pre lang="text"><code>[stdin]
 4
-
 Inserisci un numero tra 1 e 10
 4 e' pari
 </code></pre>
@@ -7684,7 +7676,6 @@ int main(void){
 <pre lang="text"><code>[stdin]
 35
 S
-
 Inserisci la tua eta'
 Hai la laurea?
 [S]ì 	 [N]o
@@ -8107,7 +8098,6 @@ int main(void){
 <!-- lab-output:start path="lab/5_control_statements/output/switch.txt" -->
 <pre lang="text"><code>[stdin]
 a
-
 a=&lt;indefinito&gt; 	 b=&lt;indefinito&gt; 	 c=&lt;indefinito&gt; 	 other=&lt;indefinito&gt;
 Quale variabile vuoi incrementare?
 [a-A]	[b-B]	[c-C]
@@ -8413,7 +8403,6 @@ int main(void){
 <!-- lab-output:start path="lab/6_pointers/output/0_pointers.txt" -->
 <pre lang="text"><code>[stdin]
 &lt;INVIO&gt;
-
 i = 42, &amp;i = &lt;addr_i&gt;
 j = 107, &amp;j = &lt;addr_j&gt;
 *p = 42, p = &lt;addr_i&gt;
@@ -8484,7 +8473,6 @@ int main(void){
 <!-- lab-output:start path="lab/6_pointers/output/1_pointers.txt" -->
 <pre lang="text"><code>[stdin]
 &lt;INVIO&gt;
-
 i = 42, &amp;i = &lt;addr_i&gt;
 j = 107, &amp;j = &lt;addr_j&gt;
 *p = 42, p = &lt;addr_i&gt;
@@ -11828,7 +11816,6 @@ int main(void){
 <!-- lab-output:start path="lab/10_dynamic_memory/output/0_malloc.txt" -->
 <pre lang="text"><code>[stdin]
 15
-
 Quanti elementi per il vettore?
 statico : 0 1 2 3 4 5 6 7 8 9 
 dinamico: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
@@ -12230,7 +12217,6 @@ int main(void){
 <!-- lab-output:start path="lab/6_pointers/output/9_pointers.txt" -->
 <pre lang="text"><code>[stdin]
 7
-
 Inserisci un numero da 1 a 12
 7 -&gt; Luglio
 </code></pre>
@@ -12361,7 +12347,6 @@ int main(void){
 <!-- lab-output:start path="lab/6_pointers/output/11_pointers.txt" -->
 <pre lang="text"><code>[stdin]
 7
-
 Inserisci un numero da 1 a 12
 7 -&gt; Luglio
 7 -&gt; Luglio
@@ -12470,7 +12455,6 @@ int main(void){
 <!-- lab-output:start path="lab/6_pointers/output/10_pointers.txt" -->
 <pre lang="text"><code>[stdin]
 7
-
 Inserisci un numero da 1 a 12
 7 -&gt; Luglio
 7 -&gt; Luglio

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -438,7 +438,6 @@ Quando `stdin` e presente, il file `output/*.txt` mostra prima gli input simulat
 4
 2
 s
-
 Risultato del programma...
 ```
 

--- a/doc/LAB_OUTPUTS.md
+++ b/doc/LAB_OUTPUTS.md
@@ -407,7 +407,7 @@ Esempio completo:
 | `workdir` | Si | Cartella da cui lanciare compilazione ed esecuzione. |
 | `compile` | Si | Comando di compilazione come array, senza shell implicita. |
 | `run` | Si | Comando di esecuzione come array, senza shell implicita. |
-| `stdin` | No | Testo da passare allo stdin del programma, utile per esercizi interattivi. |
+| `stdin` | No | Testo da passare allo stdin del programma, utile per esercizi interattivi. Se presente, viene mostrato anche nell'output generato. |
 | `output` | Si | File `.txt` generato dallo script. |
 | `timeout_seconds` | No | Timeout per compilazione/esecuzione. Default: `10`. |
 | `allow_failure` | No | Se `true`, permette exit code non zero per esercizi che falliscono apposta. |
@@ -430,6 +430,34 @@ Per un programma che legge tre valori da `scanf`, puoi usare `stdin`:
   "timeout_seconds": 5
 }
 ```
+
+Quando `stdin` e presente, il file `output/*.txt` mostra prima gli input simulati e poi l'output del programma:
+
+```text
+[stdin]
+4
+2
+s
+
+Risultato del programma...
+```
+
+Questo evita un'ambiguita didattica: nel README non si vede solo il risultato finale, ma anche i valori che hanno prodotto quel risultato.
+
+Se l'input e una riga vuota, per esempio un programma che aspetta solo la pressione di Invio:
+
+```json
+"stdin": "\n"
+```
+
+lo script salva:
+
+```text
+[stdin]
+<INVIO>
+```
+
+In questo modo l'azione dell'utente resta visibile anche quando non c'e un carattere stampabile da mostrare.
 
 ## Esempio multi-file
 
@@ -718,8 +746,9 @@ Lo script:
 1. legge `lab/lab_outputs.json`;
 2. compila ogni lab nella sua `workdir`;
 3. esegue il binario;
-4. cattura stdout e stderr;
-5. scrive il risultato nel file `output` configurato.
+4. passa al programma l'eventuale `stdin` configurato;
+5. cattura stdout e stderr;
+6. scrive nel file `output` configurato gli input simulati, l'output del programma e gli eventuali errori.
 
 Se il comando di compilazione usa `-o bin/nome_lab`, lo script crea automaticamente la cartella `bin` prima di lanciare `gcc`. Non serve quindi versionare una cartella `bin` vuota per ogni directory di laboratorio.
 

--- a/lab/0_intro/output/2_variabili.txt
+++ b/lab/0_intro/output/2_variabili.txt
@@ -1,3 +1,8 @@
+[stdin]
+4
+2
+s
+
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazine

--- a/lab/0_intro/output/2_variabili.txt
+++ b/lab/0_intro/output/2_variabili.txt
@@ -2,7 +2,6 @@
 4
 2
 s
-
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazine

--- a/lab/0_intro/output/3_variabili.txt
+++ b/lab/0_intro/output/3_variabili.txt
@@ -2,7 +2,6 @@
 4
 2
 s
-
 Inserisci il primo operando
 Insesci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione

--- a/lab/0_intro/output/3_variabili.txt
+++ b/lab/0_intro/output/3_variabili.txt
@@ -1,3 +1,8 @@
+[stdin]
+4
+2
+s
+
 Inserisci il primo operando
 Insesci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione

--- a/lab/0_intro/output/4_variabili.txt
+++ b/lab/0_intro/output/4_variabili.txt
@@ -1,3 +1,11 @@
+[stdin]
+4
+2
+s
+8
+2
+D
+
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione

--- a/lab/0_intro/output/4_variabili.txt
+++ b/lab/0_intro/output/4_variabili.txt
@@ -5,7 +5,6 @@ s
 8
 2
 D
-
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione

--- a/lab/0_intro/output/5_variabili.txt
+++ b/lab/0_intro/output/5_variabili.txt
@@ -1,3 +1,11 @@
+[stdin]
+4
+2
+s
+8
+2
+D
+
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione

--- a/lab/0_intro/output/5_variabili.txt
+++ b/lab/0_intro/output/5_variabili.txt
@@ -5,7 +5,6 @@ s
 8
 2
 D
-
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione

--- a/lab/10_dynamic_memory/output/0_malloc.txt
+++ b/lab/10_dynamic_memory/output/0_malloc.txt
@@ -1,6 +1,5 @@
 [stdin]
 15
-
 Quanti elementi per il vettore?
 statico : 0 1 2 3 4 5 6 7 8 9 
 dinamico: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14

--- a/lab/10_dynamic_memory/output/0_malloc.txt
+++ b/lab/10_dynamic_memory/output/0_malloc.txt
@@ -1,3 +1,6 @@
+[stdin]
+15
+
 Quanti elementi per il vettore?
 statico : 0 1 2 3 4 5 6 7 8 9 
 dinamico: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14

--- a/lab/1_variables/output/4_global_external_internal.txt
+++ b/lab/1_variables/output/4_global_external_internal.txt
@@ -1,3 +1,8 @@
+[stdin]
+3
+5
+0
+
 Get me an integer > 0 (0 to quit)
 You call me 1 times 
 Subtotal = 3

--- a/lab/1_variables/output/4_global_external_internal.txt
+++ b/lab/1_variables/output/4_global_external_internal.txt
@@ -2,7 +2,6 @@
 3
 5
 0
-
 Get me an integer > 0 (0 to quit)
 You call me 1 times 
 Subtotal = 3

--- a/lab/2_preprocessor/output/macro.txt
+++ b/lab/2_preprocessor/output/macro.txt
@@ -1,3 +1,8 @@
+[stdin]
+4
+2
+s
+
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione

--- a/lab/2_preprocessor/output/macro.txt
+++ b/lab/2_preprocessor/output/macro.txt
@@ -2,7 +2,6 @@
 4
 2
 s
-
 Inserisci il primo operando
 Inserisci il secondo operando
 s)Somma d)Differenza m)Moltiplicazione D)Divisione

--- a/lab/4_operators/output/op_modulo.txt
+++ b/lab/4_operators/output/op_modulo.txt
@@ -1,5 +1,4 @@
 [stdin]
 4
-
 Inserisci un numero tra 1 e 10
 4 e' pari

--- a/lab/4_operators/output/op_modulo.txt
+++ b/lab/4_operators/output/op_modulo.txt
@@ -1,2 +1,5 @@
+[stdin]
+4
+
 Inserisci un numero tra 1 e 10
 4 e' pari

--- a/lab/5_control_statements/output/if.txt
+++ b/lab/5_control_statements/output/if.txt
@@ -1,5 +1,4 @@
 [stdin]
 4
-
 Inserisci un numero tra 1 e 10
 4 e' pari

--- a/lab/5_control_statements/output/if.txt
+++ b/lab/5_control_statements/output/if.txt
@@ -1,2 +1,5 @@
+[stdin]
+4
+
 Inserisci un numero tra 1 e 10
 4 e' pari

--- a/lab/5_control_statements/output/logical_relational_operators.txt
+++ b/lab/5_control_statements/output/logical_relational_operators.txt
@@ -1,3 +1,7 @@
+[stdin]
+35
+S
+
 Inserisci la tua eta'
 Hai la laurea?
 [S]ì 	 [N]o

--- a/lab/5_control_statements/output/logical_relational_operators.txt
+++ b/lab/5_control_statements/output/logical_relational_operators.txt
@@ -1,7 +1,6 @@
 [stdin]
 35
 S
-
 Inserisci la tua eta'
 Hai la laurea?
 [S]ì 	 [N]o

--- a/lab/5_control_statements/output/switch.txt
+++ b/lab/5_control_statements/output/switch.txt
@@ -1,3 +1,6 @@
+[stdin]
+a
+
 a=<indefinito> 	 b=<indefinito> 	 c=<indefinito> 	 other=<indefinito>
 Quale variabile vuoi incrementare?
 [a-A]	[b-B]	[c-C]

--- a/lab/5_control_statements/output/switch.txt
+++ b/lab/5_control_statements/output/switch.txt
@@ -1,6 +1,5 @@
 [stdin]
 a
-
 a=<indefinito> 	 b=<indefinito> 	 c=<indefinito> 	 other=<indefinito>
 Quale variabile vuoi incrementare?
 [a-A]	[b-B]	[c-C]

--- a/lab/6_pointers/output/0_pointers.txt
+++ b/lab/6_pointers/output/0_pointers.txt
@@ -1,6 +1,5 @@
 [stdin]
 <INVIO>
-
 i = 42, &i = <addr_i>
 j = 107, &j = <addr_j>
 *p = 42, p = <addr_i>

--- a/lab/6_pointers/output/0_pointers.txt
+++ b/lab/6_pointers/output/0_pointers.txt
@@ -1,3 +1,6 @@
+[stdin]
+<INVIO>
+
 i = 42, &i = <addr_i>
 j = 107, &j = <addr_j>
 *p = 42, p = <addr_i>

--- a/lab/6_pointers/output/10_pointers.txt
+++ b/lab/6_pointers/output/10_pointers.txt
@@ -1,3 +1,6 @@
+[stdin]
+7
+
 Inserisci un numero da 1 a 12
 7 -> Luglio
 7 -> Luglio

--- a/lab/6_pointers/output/10_pointers.txt
+++ b/lab/6_pointers/output/10_pointers.txt
@@ -1,6 +1,5 @@
 [stdin]
 7
-
 Inserisci un numero da 1 a 12
 7 -> Luglio
 7 -> Luglio

--- a/lab/6_pointers/output/11_pointers.txt
+++ b/lab/6_pointers/output/11_pointers.txt
@@ -1,3 +1,6 @@
+[stdin]
+7
+
 Inserisci un numero da 1 a 12
 7 -> Luglio
 7 -> Luglio

--- a/lab/6_pointers/output/11_pointers.txt
+++ b/lab/6_pointers/output/11_pointers.txt
@@ -1,6 +1,5 @@
 [stdin]
 7
-
 Inserisci un numero da 1 a 12
 7 -> Luglio
 7 -> Luglio

--- a/lab/6_pointers/output/1_pointers.txt
+++ b/lab/6_pointers/output/1_pointers.txt
@@ -1,6 +1,5 @@
 [stdin]
 <INVIO>
-
 i = 42, &i = <addr_i>
 j = 107, &j = <addr_j>
 *p = 42, p = <addr_i>

--- a/lab/6_pointers/output/1_pointers.txt
+++ b/lab/6_pointers/output/1_pointers.txt
@@ -1,3 +1,6 @@
+[stdin]
+<INVIO>
+
 i = 42, &i = <addr_i>
 j = 107, &j = <addr_j>
 *p = 42, p = <addr_i>

--- a/lab/6_pointers/output/9_pointers.txt
+++ b/lab/6_pointers/output/9_pointers.txt
@@ -1,5 +1,4 @@
 [stdin]
 7
-
 Inserisci un numero da 1 a 12
 7 -> Luglio

--- a/lab/6_pointers/output/9_pointers.txt
+++ b/lab/6_pointers/output/9_pointers.txt
@@ -1,2 +1,5 @@
+[stdin]
+7
+
 Inserisci un numero da 1 a 12
 7 -> Luglio

--- a/scripts/update_lab_outputs.py
+++ b/scripts/update_lab_outputs.py
@@ -106,9 +106,30 @@ def ensure_compile_output_dir(command: list[str], cwd: pathlib.Path) -> None:
         (cwd / parent).mkdir(parents=True, exist_ok=True)
 
 
+def format_stdin(stdin: str | None) -> str | None:
+    """Return a readable representation of the configured program input.
+
+    When an interactive lab receives input through the manifest's ``stdin``
+    field, saving only program stdout hides what the simulated user typed.
+    Normal lines are preserved as text; empty submitted lines are rendered as
+    ``<INVIO>`` so an exercise that waits for a plain Enter key remains visible
+    in the generated output artifact.
+    """
+
+    if stdin is None:
+        return None
+    lines = stdin.split("\n")
+    if stdin.endswith("\n"):
+        lines = lines[:-1]
+    if not lines:
+        return ""
+    return "\n".join(line if line else "<INVIO>" for line in lines).rstrip()
+
+
 def format_output(
     compile_result: subprocess.CompletedProcess[str],
     run_result: subprocess.CompletedProcess[str],
+    stdin: str | None = None,
 ) -> str:
     """Build the text that will be committed as the lab output artifact.
 
@@ -118,6 +139,9 @@ def format_output(
     """
 
     sections: list[str] = []
+    formatted_stdin = format_stdin(stdin)
+    if formatted_stdin is not None:
+        sections.append("[stdin]\n" + formatted_stdin)
     if compile_result.stdout.strip():
         sections.append("[compile stdout]\n" + compile_result.stdout.rstrip())
     if compile_result.returncode != 0 and compile_result.stderr.strip():
@@ -210,7 +234,7 @@ def process_lab(entry: dict[str, Any], check: bool) -> bool:
             sys.stderr.write(compile_result.stdout)
             sys.stderr.write(compile_result.stderr)
             return False
-        generated = apply_normalizations(format_output(compile_result, subprocess.CompletedProcess(run_cmd, 0, "", "")), entry)
+        generated = apply_normalizations(format_output(compile_result, subprocess.CompletedProcess(run_cmd, 0, "", ""), stdin), entry)
         if check:
             current = output_path.read_text(encoding="utf-8") if output_path.exists() else None
             if current != generated:
@@ -228,7 +252,7 @@ def process_lab(entry: dict[str, Any], check: bool) -> bool:
         sys.stderr.write(run_result.stderr)
         return False
 
-    generated = apply_normalizations(format_output(compile_result, run_result), entry)
+    generated = apply_normalizations(format_output(compile_result, run_result, stdin), entry)
     if check:
         current = output_path.read_text(encoding="utf-8") if output_path.exists() else None
         if current != generated:


### PR DESCRIPTION
## Cosa cambia

- Aggiunge una sezione `[stdin]` agli output generati quando una voce del manifest definisce `stdin`.
- Rende visibili nel README gli input simulati per i lab interattivi.
- Mostra `<INVIO>` quando l'input configurato e una riga vuota, cosi anche la pressione di Enter resta leggibile.
- Aggiorna la documentazione del flusso output per spiegare il nuovo comportamento.

## Perche

Prima gli input venivano passati correttamente ai programmi, ma non venivano salvati negli output versionati. Nei lab interattivi questo rendeva il risultato meno didattico: si vedeva l'esito, ma non i valori inseriti che lo avevano prodotto.

## Validazione

- Non ho eseguito la compilazione locale perche in questo ambiente non e disponibile `gcc`.
- Ho aggiornato gli output esistenti in modo deterministico partendo da `lab/lab_outputs.json` e poi ho rigenerato i marker del README con `scripts/update_lab_snippets.py`.