### PR TITLE
docs: add didactic frame template

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,36 @@ Ogni lab contiene al suo interno una cartella bin destinata a ospitare i file es
 
 ## Il processo di compilazione
 
+<table align="center">
+<tr>
+<td>
+<details>
+<summary>&#129517; <strong>Orientamento della sezione</strong></summary>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128506;</span> Contesto:</strong>
+Iniziamo dal passaggio piu concreto: trasformare un file sorgente C in un programma eseguibile. Questo crea il ponte tra il codice che scriviamo e il binario che la macchina puo eseguire.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128736;</span> Prerequisiti:</strong>
+Saper accedere all'ambiente Linux del corso e creare un file di testo.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#127919;</span> Obiettivi:</strong>
+Alla fine di questa sezione saprai compilare un file <code>.c</code> con <code>gcc</code>, distinguere sorgente ed eseguibile e riconoscere le fasi principali del processo di compilazione.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#10145;</span> Prossimo passo:</strong>
+Dopo aver capito come nasce un eseguibile, leggeremo la struttura minima di un programma C nella sezione <a href="#il-primo-programma-in-c">Il primo programma in C</a>.
+</p>
+</details>
+</td>
+</tr>
+</table>
+
 <p align="justify">
 I programmi sono scritti in un qualche linguaggio di programmazione; il programmatore scrive il codice sorgente. Nel caso del linguaggio C, i file sorgente hanno estensione .c o .h. Il codice sorgente contiene tutte le istruzioni che il programma dovrà eseguire. Le istruzioni all'interno del codice sorgente, scritte in un qualsiasi linguaggio di programmazione, devono essere tradotte in una sequenza di bit (in altri termini, nel linguaggio macchina) perché la CPU è in grado di comprendere solo il linguaggio macchina, esclusivamente sequenze di bit e nient'altro. In sintesi si dice che il programma sorgente deve essere trasformato in un file eseguibile (file binario) che contiene le istruzioni (sequenze di bit) per la specifica architettura del nostro processore.
 Questo processo di trasformazione del sorgente in binario è detto processo di compilazione ed è svolto dal compilatore. In realtà questo processo è articolato in vari step e non coinvolge solo il compilatore. Vediamo brevemente di studiarne le fasi.
@@ -679,6 +709,36 @@ il linker (ld) ha il compito di aggregare in un unico file oggetto (il file eseg
 
 ## Introduzione
 
+<table align="center">
+<tr>
+<td>
+<details>
+<summary>&#129517; <strong>Orientamento della sezione</strong></summary>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128506;</span> Contesto:</strong>
+Dopo aver visto come compilare un programma, facciamo una prima mappa dei mattoni che incontreremo spesso nel codice C: variabili, costanti, funzioni e preprocessore.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128736;</span> Prerequisiti:</strong>
+<a href="#il-processo-di-compilazione">Il processo di compilazione</a>.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#127919;</span> Obiettivi:</strong>
+Alla fine di questa sezione saprai riconoscere i componenti principali di un programma C, anche se alcuni saranno approfonditi solo piu avanti.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#10145;</span> Prossimo passo:</strong>
+Useremo questa mappa per leggere il codice della sezione <a href="#il-primo-programma-in-c">Il primo programma in C</a>.
+</p>
+</details>
+</td>
+</tr>
+</table>
+
 <p align=justify>
 Un programma C è di fatto una collezione di:
 </p>
@@ -763,6 +823,41 @@ Il preprocessore viene richiamato dal compilatore come primo step nel processo d
 </table>
 
 ## Il primo programma in C
+
+<table align="center">
+<tr>
+<td>
+<details>
+<summary>&#129517; <strong>Orientamento della sezione</strong></summary>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128506;</span> Contesto:</strong>
+Ora osserviamo il primo programma completo. Non serve capire ogni dettaglio in profondita: l'obiettivo e vedere una forma minima che possiamo compilare ed eseguire.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128736;</span> Prerequisiti:</strong>
+<a href="#il-processo-di-compilazione">Il processo di compilazione</a> e <a href="#introduzione-1">Introduzione</a>.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#127919;</span> Obiettivi:</strong>
+Alla fine di questa sezione saprai individuare <code>#include</code>, la funzione <code>main</code>, una chiamata a <code>printf</code> e il valore restituito dal programma.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128064;</span> Anticipazione:</strong>
+Qui compaiono le funzioni e il preprocessore. Per ora ti basta riconoscere che <code>printf</code> e una funzione gia pronta e che <code>#include &lt;stdio.h&gt;</code> permette al compilatore di conoscerla; li studieremo meglio nelle sezioni <a href="#funzioni">Funzioni</a> e <a href="#il-preprocessore">Il preprocessore</a>.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#10145;</span> Prossimo passo:</strong>
+Dopo aver letto un programma minimo, inizieremo a salvare e modificare valori nella sezione <a href="#variabili">Variabili</a>.
+</p>
+</details>
+</td>
+</tr>
+</table>
 
 <!-- lab-exercises:start heading="Il primo programma in C" -->
 
@@ -1150,6 +1245,41 @@ Come spiegato ampiamente in precedenza, facciamo uso anche della funzione printf
 
 
 ## Variabili
+
+<table align="center">
+<tr>
+<td>
+<details>
+<summary>&#129517; <strong>Orientamento della sezione</strong></summary>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128506;</span> Contesto:</strong>
+Dopo il primo programma, abbiamo bisogno di un modo per conservare dati durante l'esecuzione. Le variabili sono il primo strumento per dare un nome a una porzione di memoria e usarla nel codice.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128736;</span> Prerequisiti:</strong>
+<a href="#il-primo-programma-in-c">Il primo programma in C</a>.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#127919;</span> Obiettivi:</strong>
+Alla fine di questa sezione saprai distinguere dichiarazione, inizializzazione e assegnamento; riconoscere il ruolo del tipo; leggere esempi semplici con variabili locali e globali.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128064;</span> Anticipazione:</strong>
+Nel codice dei lab compaiono funzioni, scope e variabili globali. Per ora concentrati sul fatto che una variabile ha un nome, un tipo e un valore; scope e classi di memorizzazione saranno ripresi piu avanti.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#10145;</span> Prossimo passo:</strong>
+Per scegliere bene una variabile dobbiamo capire come il C rappresenta le informazioni e quali tipi mette a disposizione.
+</p>
+</details>
+</td>
+</tr>
+</table>
 
 <!-- lab-exercises:start heading="Variabili" -->
 
@@ -4525,6 +4655,36 @@ int main(void){
 ```
 ## Rappresentazione delle informazioni
 
+<table align="center">
+<tr>
+<td>
+<details>
+<summary>&#129517; <strong>Orientamento della sezione</strong></summary>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128506;</span> Contesto:</strong>
+Abbiamo introdotto le variabili come nomi associati a locazioni di memoria. Ora guardiamo il livello sottostante: ogni informazione viene rappresentata come sequenza di bit.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128736;</span> Prerequisiti:</strong>
+<a href="#variabili">Variabili</a> e uso elementare delle potenze di 2.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#127919;</span> Obiettivi:</strong>
+Alla fine di questa sezione saprai spiegare perche il computer usa bit e byte, leggere rappresentazioni binarie/esadecimali semplici e distinguere numeri con e senza segno.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#10145;</span> Prossimo passo:</strong>
+Questa base serve per capire i <a href="#tipi-di-dato">Tipi di dato</a>, in particolare <code>int</code> e <code>char</code>.
+</p>
+</details>
+</td>
+</tr>
+</table>
+
 <p align="justify">
 <b>Le informazioni di seguito riportate sono solo un aiuto per fissare i concetti e vedere un'applicazione pratica in un linguaggio di programmazione dei contenuti teorici presentati a lezione e non sostituiscono in alcun modo lo studio del materiale teorico</b>
 </p>
@@ -4980,6 +5140,41 @@ Per esempio:
 </p>
 
 ### Tipi di dato
+
+<table align="center">
+<tr>
+<td>
+<details>
+<summary>&#129517; <strong>Orientamento della sezione</strong></summary>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128506;</span> Contesto:</strong>
+Dopo aver visto che le informazioni sono bit, torniamo al codice C: il tipo dice come interpretare quei bit e quanto spazio occupa il dato.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128736;</span> Prerequisiti:</strong>
+<a href="#variabili">Variabili</a> e <a href="#rappresentazione-delle-informazioni">Rappresentazione delle informazioni</a>.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#127919;</span> Obiettivi:</strong>
+Alla fine di questa sezione saprai riconoscere le keyword dei tipi principali, distinguere interi, caratteri e reali, e capire perche la dimensione del tipo influenza il range dei valori rappresentabili.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#128064;</span> Anticipazione:</strong>
+Alcuni dettagli su cast, overflow e conversioni saranno ripresi nelle sezioni successive. Qui ci interessa costruire la mappa dei tipi di base.
+</p>
+
+<p align="justify">
+<strong><span style="font-size: 1.15em;">&#10145;</span> Prossimo passo:</strong>
+Approfondiremo prima <a href="#int"><code>int</code></a> e poi <a href="#char"><code>char</code></a>.
+</p>
+</details>
+</td>
+</tr>
+</table>
 
 ```c
 int main(void){

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4,7 +4,7 @@
 <tr>
 <td>
 <details>
-<summary><span style="font-size: 1.25em;">&#129517;</span> <strong>Cornice didattica</strong></summary>
+<summary>&#129517; <strong>Orientamento della sezione</strong></summary>
 
 <p align="justify">
 <strong><span style="font-size: 1.15em;">&#128506;</span> Contesto:</strong>

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3,6 +3,9 @@
 <table align="center">
 <tr>
 <td>
+<details>
+<summary>&#128506; Cornice didattica</summary>
+
 <p align="justify">
 <strong>&#128506; Contesto:</strong>
 Qui spiega in due o tre frasi da quale punto del percorso arriva lo studente. Il testo deve aiutare la lettura sequenziale: "finora abbiamo visto...", "adesso facciamo un passo in piu...", "questo argomento serve per...".
@@ -23,6 +26,7 @@ Alla fine di questa sezione saprai descrivere il concetto principale, riconoscer
 <strong>&#10145; Prossimo passo:</strong>
 Qui spiega dove porta naturalmente la sezione successiva. Il testo deve mantenere il filo narrativo per chi legge la dispensa dall'inizio alla fine.
 </p>
+</details>
 </td>
 </tr>
 </table>

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4,23 +4,23 @@
 <tr>
 <td>
 <p align="justify">
-<strong>Contesto:</strong>
+<strong>&#128506; Contesto:</strong>
 Qui spiega in due o tre frasi da quale punto del percorso arriva lo studente. Il testo deve aiutare la lettura sequenziale: "finora abbiamo visto...", "adesso facciamo un passo in piu...", "questo argomento serve per...".
 </p>
 
 <p align="justify">
-<strong>Prerequisiti:</strong>
+<strong>&#128736; Prerequisiti:</strong>
 <a href="#sezione-precedente">Nome sezione precedente</a>,
 <a href="#altra-sezione">Nome altra sezione</a>.
 </p>
 
 <p align="justify">
-<strong>Obiettivi:</strong>
+<strong>&#127919; Obiettivi:</strong>
 Alla fine di questa sezione saprai descrivere il concetto principale, riconoscere gli errori piu comuni e applicare il meccanismo in un piccolo programma.
 </p>
 
 <p align="justify">
-<strong>Prossimo passo:</strong>
+<strong>&#10145; Prossimo passo:</strong>
 Qui spiega dove porta naturalmente la sezione successiva. Il testo deve mantenere il filo narrativo per chi legge la dispensa dall'inizio alla fine.
 </p>
 </td>
@@ -33,7 +33,7 @@ Qui spiega dove porta naturalmente la sezione successiva. Il testo deve mantener
 <tr>
 <td>
 <p align="justify">
-<strong>Richiamo:</strong>
+<strong>&#128257; Richiamo:</strong>
 Questo concetto e stato introdotto nella sezione <a href="#sezione-gia-vista">Nome sezione gia vista</a>. Qui lo riprendiamo solo per usarlo nel nuovo contesto.
 </p>
 </td>
@@ -46,7 +46,7 @@ Questo concetto e stato introdotto nella sezione <a href="#sezione-gia-vista">No
 <tr>
 <td>
 <p align="justify">
-<strong>Anticipazione:</strong>
+<strong>&#128064; Anticipazione:</strong>
 Qui compare il concetto di <code>concetto futuro</code>. Per ora ti basta sapere che ... Lo studieremo in dettaglio nella sezione <a href="#sezione-futura">Nome sezione futura</a>.
 </p>
 </td>
@@ -59,7 +59,7 @@ Qui compare il concetto di <code>concetto futuro</code>. Per ora ti basta sapere
 <tr>
 <td>
 <p align="justify">
-<strong>Rimando:</strong>
+<strong>&#128279; Rimando:</strong>
 Questo dettaglio sara ripreso piu avanti nella sezione <a href="#sezione-futura">Nome sezione futura</a>. Per ora puoi ignorarlo senza perdere il filo principale.
 </p>
 </td>

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4,26 +4,26 @@
 <tr>
 <td>
 <details>
-<summary>&#128506; Cornice didattica</summary>
+<summary><span style="font-size: 1.25em;">&#129517;</span> <strong>Cornice didattica</strong></summary>
 
 <p align="justify">
-<strong>&#128506; Contesto:</strong>
+<strong><span style="font-size: 1.15em;">&#128506;</span> Contesto:</strong>
 Qui spiega in due o tre frasi da quale punto del percorso arriva lo studente. Il testo deve aiutare la lettura sequenziale: "finora abbiamo visto...", "adesso facciamo un passo in piu...", "questo argomento serve per...".
 </p>
 
 <p align="justify">
-<strong>&#128736; Prerequisiti:</strong>
+<strong><span style="font-size: 1.15em;">&#128736;</span> Prerequisiti:</strong>
 <a href="#sezione-precedente">Nome sezione precedente</a>,
 <a href="#altra-sezione">Nome altra sezione</a>.
 </p>
 
 <p align="justify">
-<strong>&#127919; Obiettivi:</strong>
+<strong><span style="font-size: 1.15em;">&#127919;</span> Obiettivi:</strong>
 Alla fine di questa sezione saprai descrivere il concetto principale, riconoscere gli errori piu comuni e applicare il meccanismo in un piccolo programma.
 </p>
 
 <p align="justify">
-<strong>&#10145; Prossimo passo:</strong>
+<strong><span style="font-size: 1.15em;">&#10145;</span> Prossimo passo:</strong>
 Qui spiega dove porta naturalmente la sezione successiva. Il testo deve mantenere il filo narrativo per chi legge la dispensa dall'inizio alla fine.
 </p>
 </details>
@@ -37,7 +37,7 @@ Qui spiega dove porta naturalmente la sezione successiva. Il testo deve mantener
 <tr>
 <td>
 <p align="justify">
-<strong>&#128257; Richiamo:</strong>
+<strong><span style="font-size: 1.15em;">&#128257;</span> Richiamo:</strong>
 Questo concetto e stato introdotto nella sezione <a href="#sezione-gia-vista">Nome sezione gia vista</a>. Qui lo riprendiamo solo per usarlo nel nuovo contesto.
 </p>
 </td>
@@ -50,7 +50,7 @@ Questo concetto e stato introdotto nella sezione <a href="#sezione-gia-vista">No
 <tr>
 <td>
 <p align="justify">
-<strong>&#128064; Anticipazione:</strong>
+<strong><span style="font-size: 1.15em;">&#128064;</span> Anticipazione:</strong>
 Qui compare il concetto di <code>concetto futuro</code>. Per ora ti basta sapere che ... Lo studieremo in dettaglio nella sezione <a href="#sezione-futura">Nome sezione futura</a>.
 </p>
 </td>
@@ -63,7 +63,7 @@ Qui compare il concetto di <code>concetto futuro</code>. Per ora ti basta sapere
 <tr>
 <td>
 <p align="justify">
-<strong>&#128279; Rimando:</strong>
+<strong><span style="font-size: 1.15em;">&#128279;</span> Rimando:</strong>
 Questo dettaglio sara ripreso piu avanti nella sezione <a href="#sezione-futura">Nome sezione futura</a>. Per ora puoi ignorarlo senza perdere il filo principale.
 </p>
 </td>

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1,3 +1,71 @@
+## Cornice didattica
+
+<table align="center">
+<tr>
+<td>
+<p align="justify">
+<strong>Contesto:</strong>
+Qui spiega in due o tre frasi da quale punto del percorso arriva lo studente. Il testo deve aiutare la lettura sequenziale: "finora abbiamo visto...", "adesso facciamo un passo in piu...", "questo argomento serve per...".
+</p>
+
+<p align="justify">
+<strong>Prerequisiti:</strong>
+<a href="#sezione-precedente">Nome sezione precedente</a>,
+<a href="#altra-sezione">Nome altra sezione</a>.
+</p>
+
+<p align="justify">
+<strong>Obiettivi:</strong>
+Alla fine di questa sezione saprai descrivere il concetto principale, riconoscere gli errori piu comuni e applicare il meccanismo in un piccolo programma.
+</p>
+
+<p align="justify">
+<strong>Prossimo passo:</strong>
+Qui spiega dove porta naturalmente la sezione successiva. Il testo deve mantenere il filo narrativo per chi legge la dispensa dall'inizio alla fine.
+</p>
+</td>
+</tr>
+</table>
+
+## Richiamo
+
+<table align="center">
+<tr>
+<td>
+<p align="justify">
+<strong>Richiamo:</strong>
+Questo concetto e stato introdotto nella sezione <a href="#sezione-gia-vista">Nome sezione gia vista</a>. Qui lo riprendiamo solo per usarlo nel nuovo contesto.
+</p>
+</td>
+</tr>
+</table>
+
+## Anticipazione
+
+<table align="center">
+<tr>
+<td>
+<p align="justify">
+<strong>Anticipazione:</strong>
+Qui compare il concetto di <code>concetto futuro</code>. Per ora ti basta sapere che ... Lo studieremo in dettaglio nella sezione <a href="#sezione-futura">Nome sezione futura</a>.
+</p>
+</td>
+</tr>
+</table>
+
+## Rimando
+
+<table align="center">
+<tr>
+<td>
+<p align="justify">
+<strong>Rimando:</strong>
+Questo dettaglio sara ripreso piu avanti nella sezione <a href="#sezione-futura">Nome sezione futura</a>. Per ora puoi ignorarlo senza perdere il filo principale.
+</p>
+</td>
+</tr>
+</table>
+
 ## Lab
 
 <table align="center">

--- a/doc/PERCORSO_DIDATTICO.md
+++ b/doc/PERCORSO_DIDATTICO.md
@@ -27,7 +27,7 @@ Le dispense sono nate per una lettura sequenziale, ma la schedule permette anche
 | Lettura sequenziale | Il testo continua a raccontare un percorso progressivo: da dove veniamo, cosa impariamo ora, dove andremo dopo. |
 | Lettura modulare | Chi arriva da una UDA o da una tabella capisce subito prerequisiti, obiettivi, concetti anticipati e link utili. |
 
-Per ottenere questo equilibrio, ogni sezione importante dovrebbe iniziare con una cornice didattica leggera e richiudibile, costruita con una linguetta `<details>` come i blocchi dei lab. In questo modo chi legge in sequenza non viene interrotto da un blocco troppo grande, mentre chi arriva dalla schedule puo aprire la cornice e orientarsi subito. Il template operativo si trova in `TEMPLATES.md`, nella sezione `Cornice didattica`.
+Per ottenere questo equilibrio, ogni sezione importante dovrebbe iniziare con una cornice didattica leggera e richiudibile, costruita con una linguetta `<details>` come i blocchi dei lab. La linguetta usa l'icona bussola per richiamare l'idea di orientamento. In questo modo chi legge in sequenza non viene interrotto da un blocco troppo grande, mentre chi arriva dalla schedule puo aprire la cornice e orientarsi subito. Il template operativo si trova in `TEMPLATES.md`, nella sezione `Cornice didattica`.
 
 La cornice didattica contiene:
 

--- a/doc/PERCORSO_DIDATTICO.md
+++ b/doc/PERCORSO_DIDATTICO.md
@@ -18,6 +18,36 @@ La struttura didattica del corso segue tre livelli:
 | UDA | Unita didattica autonoma, con prerequisiti, obiettivi, lezioni, lab ed esercizi. |
 | Lezione | Singolo blocco settimanale di lavoro, organizzato sulle 3 ore disponibili. |
 
+## Lettura sequenziale e lettura modulare
+
+Le dispense sono nate per una lettura sequenziale, ma la schedule permette anche di arrivare direttamente a un paragrafo specifico. Per ridurre l'accoppiamento implicito tra paragrafi senza perdere il filo narrativo, ogni sezione importante dovrebbe funzionare in due modi:
+
+| Modalita | Obiettivo |
+|---|---|
+| Lettura sequenziale | Il testo continua a raccontare un percorso progressivo: da dove veniamo, cosa impariamo ora, dove andremo dopo. |
+| Lettura modulare | Chi arriva da una UDA o da una tabella capisce subito prerequisiti, obiettivi, concetti anticipati e link utili. |
+
+Per ottenere questo equilibrio, ogni sezione importante dovrebbe iniziare con una cornice didattica leggera. Il template operativo si trova in `TEMPLATES.md`, nella sezione `Cornice didattica`.
+
+La cornice didattica contiene:
+
+| Campo | Funzione |
+|---|---|
+| Contesto | Mantiene il filo della lettura sequenziale. |
+| Prerequisiti | Esplicita cosa serve sapere prima di leggere la sezione. |
+| Obiettivi | Chiarisce cosa lo studente deve saper fare alla fine. |
+| Prossimo passo | Collega la sezione alla progressione successiva. |
+
+Nel corpo dei paragrafi useremo tre tipi di raccordo:
+
+| Tipo | Quando usarlo | Effetto didattico |
+|---|---|---|
+| Richiamo | Quando un concetto e gia stato spiegato. | Riduce ripetizioni e offre un link rapido. |
+| Anticipazione | Quando un concetto futuro e necessario per capire il minimo indispensabile. | Permette di procedere senza aprire una digressione lunga. |
+| Rimando | Quando un concetto futuro compare ma non serve capirlo subito. | Abbassa il carico cognitivo: lo studente sa che puo ignorarlo per ora. |
+
+Se una sezione della schedule non ha ancora un paragrafo adatto nel README o in un documento dedicato, il materiale resta marcato come `TODO`. Questo serve a distinguere cio che esiste gia da cio che va ancora scritto.
+
 Ogni settimana prevede 3 ore di TPSI. La divisione naturale e 2 ore di teoria e 1 ora di laboratorio, ma i portatili permettono di trasformare anche parte della teoria in attivita pratica breve. Per questo la scansione sotto distingue:
 
 | Blocco | Uso consigliato |

--- a/doc/PERCORSO_DIDATTICO.md
+++ b/doc/PERCORSO_DIDATTICO.md
@@ -27,7 +27,7 @@ Le dispense sono nate per una lettura sequenziale, ma la schedule permette anche
 | Lettura sequenziale | Il testo continua a raccontare un percorso progressivo: da dove veniamo, cosa impariamo ora, dove andremo dopo. |
 | Lettura modulare | Chi arriva da una UDA o da una tabella capisce subito prerequisiti, obiettivi, concetti anticipati e link utili. |
 
-Per ottenere questo equilibrio, ogni sezione importante dovrebbe iniziare con una cornice didattica leggera e richiudibile, costruita con una linguetta `<details>` come i blocchi dei lab. La linguetta usa l'icona bussola per richiamare l'idea di orientamento. In questo modo chi legge in sequenza non viene interrotto da un blocco troppo grande, mentre chi arriva dalla schedule puo aprire la cornice e orientarsi subito. Il template operativo si trova in `TEMPLATES.md`, nella sezione `Cornice didattica`.
+Per ottenere questo equilibrio, ogni sezione importante dovrebbe iniziare con una cornice didattica leggera e richiudibile, costruita con una linguetta `<details>` come i blocchi dei lab. La linguetta si chiama `Orientamento della sezione` e usa l'icona bussola per richiamare l'idea di orientamento. In questo modo chi legge in sequenza non viene interrotto da un blocco troppo grande, mentre chi arriva dalla schedule puo aprire la cornice e orientarsi subito. Il template operativo si trova in `TEMPLATES.md`, nella sezione `Cornice didattica`.
 
 La cornice didattica contiene:
 

--- a/doc/PERCORSO_DIDATTICO.md
+++ b/doc/PERCORSO_DIDATTICO.md
@@ -33,18 +33,18 @@ La cornice didattica contiene:
 
 | Campo | Funzione |
 |---|---|
-| Contesto | Mantiene il filo della lettura sequenziale. |
-| Prerequisiti | Esplicita cosa serve sapere prima di leggere la sezione. |
-| Obiettivi | Chiarisce cosa lo studente deve saper fare alla fine. |
-| Prossimo passo | Collega la sezione alla progressione successiva. |
+| &#128506; Contesto | Mantiene il filo della lettura sequenziale. |
+| &#128736; Prerequisiti | Esplicita cosa serve sapere prima di leggere la sezione. |
+| &#127919; Obiettivi | Chiarisce cosa lo studente deve saper fare alla fine. |
+| &#10145; Prossimo passo | Collega la sezione alla progressione successiva. |
 
 Nel corpo dei paragrafi useremo tre tipi di raccordo:
 
 | Tipo | Quando usarlo | Effetto didattico |
 |---|---|---|
-| Richiamo | Quando un concetto e gia stato spiegato. | Riduce ripetizioni e offre un link rapido. |
-| Anticipazione | Quando un concetto futuro e necessario per capire il minimo indispensabile. | Permette di procedere senza aprire una digressione lunga. |
-| Rimando | Quando un concetto futuro compare ma non serve capirlo subito. | Abbassa il carico cognitivo: lo studente sa che puo ignorarlo per ora. |
+| &#128257; Richiamo | Quando un concetto e gia stato spiegato. | Riduce ripetizioni e offre un link rapido. |
+| &#128064; Anticipazione | Quando un concetto futuro e necessario per capire il minimo indispensabile. | Permette di procedere senza aprire una digressione lunga. |
+| &#128279; Rimando | Quando un concetto futuro compare ma non serve capirlo subito. | Abbassa il carico cognitivo: lo studente sa che puo ignorarlo per ora. |
 
 Se una sezione della schedule non ha ancora un paragrafo adatto nel README o in un documento dedicato, il materiale resta marcato come `TODO`. Questo serve a distinguere cio che esiste gia da cio che va ancora scritto.
 

--- a/doc/PERCORSO_DIDATTICO.md
+++ b/doc/PERCORSO_DIDATTICO.md
@@ -27,7 +27,7 @@ Le dispense sono nate per una lettura sequenziale, ma la schedule permette anche
 | Lettura sequenziale | Il testo continua a raccontare un percorso progressivo: da dove veniamo, cosa impariamo ora, dove andremo dopo. |
 | Lettura modulare | Chi arriva da una UDA o da una tabella capisce subito prerequisiti, obiettivi, concetti anticipati e link utili. |
 
-Per ottenere questo equilibrio, ogni sezione importante dovrebbe iniziare con una cornice didattica leggera. Il template operativo si trova in `TEMPLATES.md`, nella sezione `Cornice didattica`.
+Per ottenere questo equilibrio, ogni sezione importante dovrebbe iniziare con una cornice didattica leggera e richiudibile, costruita con una linguetta `<details>` come i blocchi dei lab. In questo modo chi legge in sequenza non viene interrotto da un blocco troppo grande, mentre chi arriva dalla schedule puo aprire la cornice e orientarsi subito. Il template operativo si trova in `TEMPLATES.md`, nella sezione `Cornice didattica`.
 
 La cornice didattica contiene:
 


### PR DESCRIPTION
## Cosa cambia

Aggiunge un modello operativo per ridurre l'accoppiamento tra paragrafi senza perdere la lettura sequenziale della dispensa.

## Dettagli

- Aggiunge in `TEMPLATES.md` il template `Cornice didattica` con:
  - Contesto;
  - Prerequisiti;
  - Obiettivi;
  - Prossimo passo.
- Aggiunge anche template per:
  - Richiamo;
  - Anticipazione;
  - Rimando.
- Documenta in `doc/PERCORSO_DIDATTICO.md` la regola di doppia lettura:
  - lettura sequenziale;
  - lettura modulare da UDA/schedule.

## Nota

Questa PR non applica ancora la cornice ai paragrafi del README. Serve come base condivisa prima di lavorare sulle UDA una per volta.