### PR TITLE
tools: add course design board MVP

### DIFF
--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -1,0 +1,37 @@
+﻿# Course Design Board
+
+La board e uno strumento locale per progettare il percorso didattico senza modificare manualmente tabelle Markdown grandi.
+
+## Avvio
+
+Dalla root del repository:
+
+```bash
+python scripts/course_board_server.py
+```
+
+Poi apri nel browser:
+
+```text
+http://127.0.0.1:8765/tools/course_board.html
+```
+
+## Cosa fa questa prima versione
+
+- legge gli heading da `README.md` e `LINUX_PROGRAMMING.md`;
+- mostra i paragrafi e sottoparagrafi disponibili nella colonna sinistra;
+- mostra anni, UDA e settimane nella colonna destra;
+- permette di trascinare un paragrafo dentro una UDA;
+- permette di riordinare e rimuovere gli elementi assegnati;
+- salva la struttura in `doc/course_design.json`.
+
+## Cosa non fa ancora
+
+Questa e una prima versione MVP. Non genera ancora automaticamente:
+
+- `doc/PERCORSO_DIDATTICO.md`;
+- le cornici `Orientamento della sezione` dentro il README;
+- report dei TODO;
+- report dei paragrafi non assegnati.
+
+Queste funzioni saranno aggiunte dopo aver stabilizzato il modello dati.

--- a/doc/course_design.json
+++ b/doc/course_design.json
@@ -1,0 +1,43 @@
+﻿{
+  "version": 1,
+  "source_files": [
+    "README.md",
+    "LINUX_PROGRAMMING.md"
+  ],
+  "years": [
+    {
+      "id": "terzo-anno",
+      "title": "Terzo anno",
+      "description": "C base e intermedio",
+      "weekly_hours": 3,
+      "weeks": 33,
+      "udas": [
+        { "id": "uda-1", "title": "Strumenti, primo programma e rappresentazione", "path": "Base", "weeks": "1-3", "items": [] },
+        { "id": "uda-2", "title": "Operatori, condizioni e selezione", "path": "Base", "weeks": "4-6", "items": [] },
+        { "id": "uda-3", "title": "Cicli e funzioni", "path": "Base", "weeks": "7-10", "items": [] },
+        { "id": "uda-4", "title": "Array e stringhe semplici", "path": "Base", "weeks": "11-14", "items": [] },
+        { "id": "uda-5", "title": "Struct e consolidamento", "path": "Base", "weeks": "15-17", "items": [] },
+        { "id": "uda-6", "title": "Puntatori, array e indirizzi", "path": "Intermedio", "weeks": "18-21", "items": [] },
+        { "id": "uda-7", "title": "Memoria automatica, statica e dinamica", "path": "Intermedio", "weeks": "22-25", "items": [] },
+        { "id": "uda-8", "title": "Preprocessore, header e compilazione separata", "path": "Intermedio", "weeks": "26-28", "items": [] },
+        { "id": "uda-9", "title": "File, Makefile, debugging e progetto", "path": "Intermedio", "weeks": "29-33", "items": [] }
+      ]
+    },
+    {
+      "id": "quarto-anno",
+      "title": "Quarto anno",
+      "description": "Linux programming, processi e thread",
+      "weekly_hours": 3,
+      "weeks": 33,
+      "udas": [
+        { "id": "uda-10", "title": "Ripartenza C/Linux, API e qualita", "path": "Avanzato", "weeks": "1-5", "items": [] },
+        { "id": "uda-11", "title": "Processi", "path": "Avanzato", "weeks": "6-12", "items": [] },
+        { "id": "uda-12", "title": "Segnali e progetto processi", "path": "Avanzato", "weeks": "13-15", "items": [] },
+        { "id": "uda-13", "title": "Thread", "path": "Avanzato", "weeks": "16-20", "items": [] },
+        { "id": "uda-14", "title": "Sincronizzazione", "path": "Avanzato", "weeks": "21-25", "items": [] },
+        { "id": "uda-15", "title": "I/O, processi e socket intro", "path": "Avanzato", "weeks": "26-28", "items": [] },
+        { "id": "uda-16", "title": "Sicurezza, CI, manutenzione e progetto finale", "path": "Avanzato", "weeks": "29-33", "items": [] }
+      ]
+    }
+  ]
+}

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1,0 +1,175 @@
+﻿#!/usr/bin/env python3
+"""Serve the local course design board and save course_design.json.
+
+Usage:
+
+    python scripts/course_board_server.py
+
+Then open:
+
+    http://localhost:8765/tools/course_board.html
+
+The server uses only the Python standard library.  It exposes a tiny local API
+for reading Markdown headings, loading/saving doc/course_design.json, and
+serving static files from the repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import re
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+DESIGN_PATH = ROOT / "doc" / "course_design.json"
+DEFAULT_SOURCES = ["README.md", "LINUX_PROGRAMMING.md"]
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+TAG_RE = re.compile(r"<[^>]+>")
+PUNCT_RE = re.compile(r"[^\w\s-]", re.UNICODE)
+SPACE_RE = re.compile(r"[\s_]+")
+
+
+def github_anchor(title: str, seen: dict[str, int]) -> str:
+    """Return a GitHub-like Markdown anchor for a heading title."""
+
+    plain = TAG_RE.sub("", title).strip().lower()
+    plain = plain.replace("`", "")
+    plain = PUNCT_RE.sub("", plain)
+    base = SPACE_RE.sub("-", plain).strip("-") or "section"
+    count = seen.get(base, 0)
+    seen[base] = count + 1
+    if count == 0:
+        return base
+    return f"{base}-{count}"
+
+
+def read_design() -> dict:
+    """Load the course design JSON file, creating a minimal shape if missing."""
+
+    if DESIGN_PATH.exists():
+        return json.loads(DESIGN_PATH.read_text(encoding="utf-8-sig"))
+    return {"version": 1, "source_files": DEFAULT_SOURCES, "years": []}
+
+
+def write_design(payload: dict) -> None:
+    """Persist the course design JSON with stable formatting."""
+
+    DESIGN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    DESIGN_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def extract_headings() -> list[dict]:
+    """Extract headings from configured Markdown sources."""
+
+    design = read_design()
+    sources = design.get("source_files") or DEFAULT_SOURCES
+    headings: list[dict] = []
+    for source in sources:
+        path = (ROOT / source).resolve()
+        try:
+            path.relative_to(ROOT)
+        except ValueError:
+            continue
+        if not path.is_file():
+            continue
+        seen: dict[str, int] = {}
+        for lineno, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), start=1):
+            match = HEADING_RE.match(line)
+            if not match:
+                continue
+            title = match.group(2).strip()
+            if not title or title.startswith("0 \""):
+                continue
+            anchor = github_anchor(title, seen)
+            headings.append(
+                {
+                    "id": f"{source}#{anchor}",
+                    "source": source,
+                    "level": len(match.group(1)),
+                    "title": TAG_RE.sub("", title).strip(),
+                    "anchor": anchor,
+                    "href": f"../{source}#{anchor}",
+                    "line": lineno,
+                }
+            )
+    return headings
+
+
+class CourseBoardHandler(BaseHTTPRequestHandler):
+    """HTTP handler for the local board and its JSON API."""
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/headings":
+            self.write_json({"headings": extract_headings()})
+            return
+        if parsed.path == "/api/course-design":
+            self.write_json(read_design())
+            return
+        self.serve_static(parsed.path)
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path != "/api/course-design":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        write_design(payload)
+        self.write_json({"ok": True, "path": str(DESIGN_PATH.relative_to(ROOT))})
+
+    def write_json(self, payload: dict) -> None:
+        body = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def serve_static(self, request_path: str) -> None:
+        relative = unquote(request_path.lstrip("/")) or "tools/course_board.html"
+        target = (ROOT / relative).resolve()
+        try:
+            target.relative_to(ROOT)
+        except ValueError:
+            self.send_error(403)
+            return
+        if target.is_dir():
+            target = target / "index.html"
+        if not target.is_file():
+            self.send_error(404)
+            return
+        body = target.read_bytes()
+        content_type = mimetypes.guess_type(str(target))[0] or "application/octet-stream"
+        if target.suffix in {".html", ".css", ".js"}:
+            content_type += "; charset=utf-8"
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), CourseBoardHandler)
+    print(f"Course board: http://{args.host}:{args.port}/tools/course_board.html")
+    print("Premi Ctrl+C per fermare il server.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nServer fermato.")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -1,13 +1,14 @@
-﻿:root {
-  --ink: #1f2933;
-  --muted: #687385;
-  --paper: #f7f1e6;
-  --panel: #fffaf0;
-  --line: #ddc9aa;
-  --accent: #0f766e;
-  --accent-dark: #115e59;
-  --warm: #b45309;
-  --shadow: 0 18px 45px rgba(58, 41, 20, 0.14);
+:root {
+  --ink: #111111;
+  --muted: #666666;
+  --paper: #f6f6f6;
+  --panel: #ffffff;
+  --line: #d7d7d7;
+  --accent: #111111;
+  --accent-dark: #000000;
+  --warm: #3f3f46;
+  --shadow: 0 18px 42px rgba(0, 0, 0, 0.08);
+  --mono: "Cascadia Code", "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, monospace;
 }
 
 * { box-sizing: border-box; }
@@ -17,9 +18,11 @@ body {
   min-height: 100vh;
   color: var(--ink);
   background:
-    radial-gradient(circle at top left, rgba(20, 184, 166, 0.18), transparent 34rem),
-    linear-gradient(135deg, #f5ead7 0%, #f9f4ea 46%, #e7f2ef 100%);
-  font-family: Georgia, "Times New Roman", serif;
+    linear-gradient(rgba(0, 0, 0, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.025) 1px, transparent 1px),
+    #f7f7f7;
+  background-size: 24px 24px;
+  font-family: var(--mono);
 }
 
 .hero {
@@ -33,7 +36,7 @@ body {
 .eyebrow {
   margin: 0 0 .35rem;
   color: var(--warm);
-  font: 700 .76rem/1.2 Verdana, sans-serif;
+  font: 700 .76rem/1.2 var(--mono);
   letter-spacing: .18em;
   text-transform: uppercase;
 }
@@ -59,15 +62,15 @@ h1 {
 button, select, input {
   border: 1px solid var(--line);
   border-radius: 999px;
-  background: #fffdf7;
+  background: #ffffff;
   color: var(--ink);
-  font: 700 .88rem/1.2 Verdana, sans-serif;
+  font: 700 .88rem/1.2 var(--mono);
 }
 
 button {
   cursor: pointer;
   padding: .72rem 1rem;
-  box-shadow: 0 8px 20px rgba(58, 41, 20, 0.08);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
 }
 
 button.primary { background: var(--accent); border-color: var(--accent); color: white; }
@@ -82,9 +85,9 @@ button:hover { transform: translateY(-1px); }
 
 .panel {
   min-height: calc(100vh - 10rem);
-  border: 1px solid rgba(122, 91, 52, .22);
+  border: 1px solid rgba(17, 17, 17, .16);
   border-radius: 28px;
-  background: rgba(255, 250, 240, .82);
+  background: rgba(255, 255, 255, .92);
   box-shadow: var(--shadow);
   backdrop-filter: blur(10px);
   overflow: hidden;
@@ -93,7 +96,7 @@ button:hover { transform: translateY(-1px); }
 .panelHead {
   padding: 1.1rem;
   border-bottom: 1px solid var(--line);
-  background: rgba(255, 255, 255, .45);
+  background: rgba(255, 255, 255, .72);
 }
 
 .panelHead h2 { margin-bottom: .75rem; font-size: 1.25rem; }
@@ -105,7 +108,7 @@ button:hover { transform: translateY(-1px); }
   grid-template-columns: 1fr 8rem;
   gap: .5rem;
   padding: .85rem 1.1rem;
-  border-bottom: 1px solid rgba(221, 201, 170, .6);
+  border-bottom: 1px solid rgba(215, 215, 215, .8);
 }
 
 input, select { width: 100%; padding: .72rem .9rem; }
@@ -117,9 +120,9 @@ input, select { width: 100%; padding: .72rem .9rem; }
 }
 
 .headingCard, .item {
-  border: 1px solid rgba(15, 118, 110, .22);
+  border: 1px solid rgba(17, 17, 17, .16);
   border-radius: 18px;
-  background: #fffdf8;
+  background: #ffffff;
   padding: .62rem .72rem;
   margin-bottom: .4rem;
 }
@@ -137,23 +140,23 @@ input, select { width: 100%; padding: .72rem .9rem; }
   top: -.45rem;
   bottom: -.45rem;
   width: 1px;
-  background: rgba(180, 83, 9, .18);
+  background: rgba(17, 17, 17, .16);
 }
 
 .headingCard.level-1 {
-  border-color: rgba(180, 83, 9, .48);
-  background: #fff4dd;
+  border-color: rgba(17, 17, 17, .38);
+  background: #eeeeee;
 }
 
 .headingCard.level-2 {
-  border-color: rgba(15, 118, 110, .34);
+  border-color: rgba(17, 17, 17, .24);
 }
 
 .headingCard.level-3,
 .headingCard.level-4,
 .headingCard.level-5,
 .headingCard.level-6 {
-  background: rgba(255, 253, 248, .82);
+  background: rgba(255, 255, 255, .84);
 }
 
 .headingCard.level-3 .headingTitle::before,
@@ -177,7 +180,7 @@ input, select { width: 100%; padding: .72rem .9rem; }
 }
 
 .headingTitle { font-size: .92rem; font-weight: 700; line-height: 1.18; }
-.headingMeta { margin-top: .24rem; color: var(--muted); font: .68rem/1.35 Verdana, sans-serif; }
+.headingMeta { margin-top: .24rem; color: var(--muted); font: .68rem/1.35 var(--mono); }
 
 .courseTree {
   height: calc(100vh - 14rem);
@@ -186,9 +189,9 @@ input, select { width: 100%; padding: .72rem .9rem; }
 }
 
 .year {
-  border: 1px solid rgba(180, 83, 9, .25);
+  border: 1px solid rgba(17, 17, 17, .16);
   border-radius: 24px;
-  background: rgba(255, 255, 255, .45);
+  background: rgba(255, 255, 255, .72);
   padding: 1rem;
   margin-bottom: 1rem;
 }
@@ -204,10 +207,10 @@ input, select { width: 100%; padding: .72rem .9rem; }
 .yearMeta { color: var(--muted); font-size: .9rem; }
 
 .uda {
-  border: 1px dashed rgba(104, 115, 133, .38);
+  border: 1px dashed rgba(17, 17, 17, .24);
   border-radius: 20px;
   margin-top: .85rem;
-  background: rgba(255, 250, 240, .74);
+  background: rgba(250, 250, 250, .82);
   overflow: hidden;
 }
 
@@ -217,15 +220,15 @@ input, select { width: 100%; padding: .72rem .9rem; }
   font-weight: 700;
 }
 
-.udaMeta { color: var(--muted); font: .78rem/1.2 Verdana, sans-serif; margin-left: .4rem; }
+.udaMeta { color: var(--muted); font: .78rem/1.2 var(--mono); margin-left: .4rem; }
 
 .dropzone {
   min-height: 4.2rem;
   padding: .85rem;
-  border-top: 1px solid rgba(221, 201, 170, .72);
+  border-top: 1px solid rgba(215, 215, 215, .9);
 }
 
-.dropzone.dragOver { background: rgba(20, 184, 166, .12); }
+.dropzone.dragOver { background: rgba(0, 0, 0, .06); }
 
 .item {
   display: grid;
@@ -235,7 +238,7 @@ input, select { width: 100%; padding: .72rem .9rem; }
 }
 
 .itemTitle { font-weight: 700; }
-.itemMeta { color: var(--muted); font: .76rem/1.35 Verdana, sans-serif; }
+.itemMeta { color: var(--muted); font: .76rem/1.35 var(--mono); }
 .itemActions { display: flex; gap: .25rem; }
 .itemActions button { padding: .35rem .5rem; font-size: .72rem; }
 

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -213,7 +213,37 @@ input, select { width: 100%; padding: .72rem .9rem; }
   text-decoration-thickness: 1px;
 }
 
-.headingTitle { font-size: .92rem; font-weight: 700; line-height: 1.18; }
+.headingTitle {
+  display: flex;
+  align-items: flex-start;
+  gap: .42rem;
+  font-size: .92rem;
+  font-weight: 700;
+  line-height: 1.18;
+}
+
+.treeToggle,
+.treeToggleSpacer {
+  flex: 0 0 1.15rem;
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.treeToggle {
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+  border-radius: .34rem;
+  font-size: .78rem;
+  line-height: 1;
+  box-shadow: none;
+}
+
+.treeToggle:hover {
+  transform: none;
+  background: #f1f1f1;
+}
+
 .headingMeta { margin-top: .24rem; color: var(--muted); font: .68rem/1.35 var(--mono); }
 
 .courseTree {

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -1,0 +1,204 @@
+﻿:root {
+  --ink: #1f2933;
+  --muted: #687385;
+  --paper: #f7f1e6;
+  --panel: #fffaf0;
+  --line: #ddc9aa;
+  --accent: #0f766e;
+  --accent-dark: #115e59;
+  --warm: #b45309;
+  --shadow: 0 18px 45px rgba(58, 41, 20, 0.14);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(20, 184, 166, 0.18), transparent 34rem),
+    linear-gradient(135deg, #f5ead7 0%, #f9f4ea 46%, #e7f2ef 100%);
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+.hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2rem clamp(1rem, 3vw, 3rem) 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 .35rem;
+  color: var(--warm);
+  font: 700 .76rem/1.2 Verdana, sans-serif;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+}
+
+h1, h2, h3, p { margin-top: 0; }
+
+h1 {
+  margin-bottom: .35rem;
+  font-size: clamp(2rem, 5vw, 4.6rem);
+  line-height: .92;
+  letter-spacing: -.06em;
+}
+
+.subtitle {
+  max-width: 52rem;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.actions { display: flex; gap: .75rem; flex-wrap: wrap; }
+
+button, select, input {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #fffdf7;
+  color: var(--ink);
+  font: 700 .88rem/1.2 Verdana, sans-serif;
+}
+
+button {
+  cursor: pointer;
+  padding: .72rem 1rem;
+  box-shadow: 0 8px 20px rgba(58, 41, 20, 0.08);
+}
+
+button.primary { background: var(--accent); border-color: var(--accent); color: white; }
+button:hover { transform: translateY(-1px); }
+
+.board {
+  display: grid;
+  grid-template-columns: minmax(19rem, 28rem) minmax(0, 1fr);
+  gap: 1rem;
+  padding: 0 clamp(1rem, 3vw, 3rem) 2rem;
+}
+
+.panel {
+  min-height: calc(100vh - 10rem);
+  border: 1px solid rgba(122, 91, 52, .22);
+  border-radius: 28px;
+  background: rgba(255, 250, 240, .82);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+  overflow: hidden;
+}
+
+.panelHead {
+  padding: 1.1rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, .45);
+}
+
+.panelHead h2 { margin-bottom: .75rem; font-size: 1.25rem; }
+
+.status { margin: 0; color: var(--muted); font-size: .9rem; }
+
+.filters {
+  display: grid;
+  grid-template-columns: 1fr 8rem;
+  gap: .5rem;
+  padding: .85rem 1.1rem;
+  border-bottom: 1px solid rgba(221, 201, 170, .6);
+}
+
+input, select { width: 100%; padding: .72rem .9rem; }
+
+.headingList {
+  height: calc(100vh - 18.5rem);
+  overflow: auto;
+  padding: .8rem;
+}
+
+.headingCard, .item {
+  border: 1px solid rgba(15, 118, 110, .22);
+  border-radius: 18px;
+  background: #fffdf8;
+  padding: .78rem .85rem;
+  margin-bottom: .55rem;
+}
+
+.headingCard { cursor: grab; }
+.headingCard:active { cursor: grabbing; }
+
+.headingTitle { font-weight: 700; }
+.headingMeta { margin-top: .35rem; color: var(--muted); font: .76rem/1.4 Verdana, sans-serif; }
+
+.courseTree {
+  height: calc(100vh - 14rem);
+  overflow: auto;
+  padding: 1rem;
+}
+
+.year {
+  border: 1px solid rgba(180, 83, 9, .25);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, .45);
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.yearHead {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.year h3 { margin-bottom: .2rem; font-size: 1.45rem; }
+.yearMeta { color: var(--muted); font-size: .9rem; }
+
+.uda {
+  border: 1px dashed rgba(104, 115, 133, .38);
+  border-radius: 20px;
+  margin-top: .85rem;
+  background: rgba(255, 250, 240, .74);
+  overflow: hidden;
+}
+
+.uda summary {
+  cursor: pointer;
+  padding: .85rem 1rem;
+  font-weight: 700;
+}
+
+.udaMeta { color: var(--muted); font: .78rem/1.2 Verdana, sans-serif; margin-left: .4rem; }
+
+.dropzone {
+  min-height: 4.2rem;
+  padding: .85rem;
+  border-top: 1px solid rgba(221, 201, 170, .72);
+}
+
+.dropzone.dragOver { background: rgba(20, 184, 166, .12); }
+
+.item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: .75rem;
+  align-items: center;
+}
+
+.itemTitle { font-weight: 700; }
+.itemMeta { color: var(--muted); font: .76rem/1.35 Verdana, sans-serif; }
+.itemActions { display: flex; gap: .25rem; }
+.itemActions button { padding: .35rem .5rem; font-size: .72rem; }
+
+.empty {
+  color: var(--muted);
+  font-style: italic;
+  padding: .8rem;
+}
+
+@media (max-width: 860px) {
+  .hero { align-items: flex-start; flex-direction: column; }
+  .board { grid-template-columns: 1fr; }
+  .panel { min-height: auto; }
+  .headingList, .courseTree { height: auto; max-height: 60vh; }
+}

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -127,13 +127,13 @@ input, select { width: 100%; padding: .72rem .9rem; }
 .headingCard {
   position: relative;
   cursor: grab;
-  margin-left: calc(var(--depth, 0) * 1.15rem);
+  margin-left: calc(var(--depth, 0) * 2.3rem);
 }
 
 .headingCard::before {
   content: "";
   position: absolute;
-  left: calc(var(--depth, 0) * -1.15rem + .28rem);
+  left: calc(var(--depth, 0) * -2.3rem + .42rem);
   top: -.45rem;
   bottom: -.45rem;
   width: 1px;

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -124,7 +124,46 @@ input, select { width: 100%; padding: .72rem .9rem; }
   margin-bottom: .55rem;
 }
 
-.headingCard { cursor: grab; }
+.headingCard {
+  position: relative;
+  cursor: grab;
+  margin-left: calc(var(--depth, 0) * .82rem);
+}
+
+.headingCard::before {
+  content: "";
+  position: absolute;
+  left: calc(var(--depth, 0) * -.82rem + .2rem);
+  top: -.6rem;
+  bottom: -.6rem;
+  width: 1px;
+  background: rgba(180, 83, 9, .18);
+}
+
+.headingCard.level-1 {
+  border-color: rgba(180, 83, 9, .48);
+  background: #fff4dd;
+}
+
+.headingCard.level-2 {
+  border-color: rgba(15, 118, 110, .34);
+}
+
+.headingCard.level-3,
+.headingCard.level-4,
+.headingCard.level-5,
+.headingCard.level-6 {
+  background: rgba(255, 253, 248, .82);
+}
+
+.headingCard.level-3 .headingTitle::before,
+.headingCard.level-4 .headingTitle::before,
+.headingCard.level-5 .headingTitle::before,
+.headingCard.level-6 .headingTitle::before {
+  content: "↳ ";
+  color: var(--warm);
+}
+
 .headingCard:active { cursor: grabbing; }
 
 .headingTitle { font-weight: 700; }

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -295,16 +295,32 @@ input, select { width: 100%; padding: .72rem .9rem; }
 .dropzone.dragOver { background: rgba(0, 0, 0, .06); }
 
 .item {
+  margin-left: calc(var(--item-depth, 0) * 1.35rem);
+}
+
+.itemRow {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: .75rem;
   align-items: center;
 }
 
-.itemTitle { font-weight: 700; }
+.itemTitle {
+  display: flex;
+  align-items: flex-start;
+  gap: .42rem;
+  font-weight: 700;
+}
+
 .itemMeta { color: var(--muted); font: .76rem/1.35 var(--mono); }
 .itemActions { display: flex; gap: .25rem; }
 .itemActions button { padding: .35rem .5rem; font-size: .72rem; }
+
+.itemChildren {
+  margin-top: .5rem;
+  padding-top: .5rem;
+  border-top: 1px solid rgba(17, 17, 17, .08);
+}
 
 .empty {
   color: var(--muted);

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -57,6 +57,79 @@ h1 {
   font-size: 1.05rem;
 }
 
+.heroTools {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.orgBadge {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 4.3rem;
+  height: 4.3rem;
+  border: 1px solid rgba(17, 17, 17, .18);
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, .9);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, .08);
+  overflow: visible;
+  isolation: isolate;
+}
+
+.orgBadge img {
+  width: 3.3rem;
+  height: 3.3rem;
+  border-radius: 1rem;
+  display: block;
+  position: relative;
+  z-index: 2;
+}
+
+.paintDrip {
+  position: absolute;
+  top: 3.15rem;
+  width: .42rem;
+  height: 1.55rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #111111, #7a7a7a);
+  opacity: .7;
+  transform-origin: top;
+  animation: drip 2.8s ease-in-out infinite;
+  z-index: 1;
+}
+
+.paintDrip::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -.22rem;
+  width: .62rem;
+  height: .62rem;
+  border-radius: 50%;
+  background: #111111;
+  transform: translateX(-50%);
+}
+
+.paintDripOne {
+  right: 1.05rem;
+}
+
+.paintDripTwo {
+  right: 2rem;
+  height: 1.05rem;
+  opacity: .45;
+  animation-delay: .7s;
+}
+
+@keyframes drip {
+  0%, 100% { transform: scaleY(.58); opacity: .25; }
+  45% { transform: scaleY(1); opacity: .75; }
+  70% { transform: translateY(.28rem) scaleY(.86); opacity: .58; }
+}
+
 .actions { display: flex; gap: .75rem; flex-wrap: wrap; }
 
 button, select, input {

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -69,65 +69,26 @@ h1 {
   position: relative;
   display: grid;
   place-items: center;
-  width: 4.3rem;
-  height: 4.3rem;
-  border: 1px solid rgba(17, 17, 17, .18);
-  border-radius: 1.25rem;
-  background: rgba(255, 255, 255, .9);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, .08);
-  overflow: visible;
-  isolation: isolate;
+  width: 3.9rem;
+  height: 3.9rem;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, .82);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, .06);
+  transition: transform .16s ease, box-shadow .16s ease, border-color .16s ease;
+}
+
+.orgBadge:hover {
+  border-color: rgba(17, 17, 17, .26);
+  box-shadow: 0 14px 32px rgba(0, 0, 0, .1);
+  transform: translateY(-1px);
 }
 
 .orgBadge img {
-  width: 3.3rem;
-  height: 3.3rem;
-  border-radius: 1rem;
+  width: 2.9rem;
+  height: 2.9rem;
+  border-radius: .78rem;
   display: block;
-  position: relative;
-  z-index: 2;
-}
-
-.paintDrip {
-  position: absolute;
-  top: 3.15rem;
-  width: .42rem;
-  height: 1.55rem;
-  border-radius: 999px;
-  background: linear-gradient(180deg, #111111, #7a7a7a);
-  opacity: .7;
-  transform-origin: top;
-  animation: drip 2.8s ease-in-out infinite;
-  z-index: 1;
-}
-
-.paintDrip::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  bottom: -.22rem;
-  width: .62rem;
-  height: .62rem;
-  border-radius: 50%;
-  background: #111111;
-  transform: translateX(-50%);
-}
-
-.paintDripOne {
-  right: 1.05rem;
-}
-
-.paintDripTwo {
-  right: 2rem;
-  height: 1.05rem;
-  opacity: .45;
-  animation-delay: .7s;
-}
-
-@keyframes drip {
-  0%, 100% { transform: scaleY(.58); opacity: .25; }
-  45% { transform: scaleY(1); opacity: .75; }
-  70% { transform: translateY(.28rem) scaleY(.86); opacity: .58; }
 }
 
 .actions { display: flex; gap: .75rem; flex-wrap: wrap; }

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -113,29 +113,29 @@ input, select { width: 100%; padding: .72rem .9rem; }
 .headingList {
   height: calc(100vh - 18.5rem);
   overflow: auto;
-  padding: .8rem;
+  padding: .65rem;
 }
 
 .headingCard, .item {
   border: 1px solid rgba(15, 118, 110, .22);
   border-radius: 18px;
   background: #fffdf8;
-  padding: .78rem .85rem;
-  margin-bottom: .55rem;
+  padding: .62rem .72rem;
+  margin-bottom: .4rem;
 }
 
 .headingCard {
   position: relative;
   cursor: grab;
-  margin-left: calc(var(--depth, 0) * .82rem);
+  margin-left: calc(var(--depth, 0) * 1.15rem);
 }
 
 .headingCard::before {
   content: "";
   position: absolute;
-  left: calc(var(--depth, 0) * -.82rem + .2rem);
-  top: -.6rem;
-  bottom: -.6rem;
+  left: calc(var(--depth, 0) * -1.15rem + .28rem);
+  top: -.45rem;
+  bottom: -.45rem;
   width: 1px;
   background: rgba(180, 83, 9, .18);
 }
@@ -166,8 +166,18 @@ input, select { width: 100%; padding: .72rem .9rem; }
 
 .headingCard:active { cursor: grabbing; }
 
-.headingTitle { font-weight: 700; }
-.headingMeta { margin-top: .35rem; color: var(--muted); font: .76rem/1.4 Verdana, sans-serif; }
+.headingCard.assigned {
+  opacity: .48;
+  filter: grayscale(.7);
+}
+
+.headingCard.assigned .headingTitle {
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+
+.headingTitle { font-size: .92rem; font-weight: 700; line-height: 1.18; }
+.headingMeta { margin-top: .24rem; color: var(--muted); font: .68rem/1.35 Verdana, sans-serif; }
 
 .courseTree {
   height: calc(100vh - 14rem);

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -1,0 +1,58 @@
+﻿<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Course Design Board</title>
+  <link rel="stylesheet" href="course_board.css">
+</head>
+<body>
+  <header class="hero">
+    <div>
+      <p class="eyebrow">2cornot2c</p>
+      <h1>Course Design Board</h1>
+      <p class="subtitle">Costruisci percorsi, UDA e settimane partendo dai paragrafi reali delle dispense.</p>
+    </div>
+    <div class="actions">
+      <button id="reloadBtn" type="button">Ricarica</button>
+      <button id="saveBtn" type="button" class="primary">Salva JSON</button>
+    </div>
+  </header>
+
+  <main class="board">
+    <section class="panel library">
+      <div class="panelHead">
+        <h2>Paragrafi disponibili</h2>
+        <input id="searchInput" type="search" placeholder="Cerca: puntatori, malloc, fork...">
+      </div>
+      <div class="filters">
+        <select id="sourceFilter" aria-label="Filtro sorgente"></select>
+        <select id="levelFilter" aria-label="Filtro livello">
+          <option value="">Tutti i livelli</option>
+          <option value="2">H2</option>
+          <option value="3">H3</option>
+          <option value="4">H4</option>
+        </select>
+      </div>
+      <div id="headingList" class="headingList"></div>
+    </section>
+
+    <section class="panel planner">
+      <div class="panelHead">
+        <h2>Percorso didattico</h2>
+        <p id="status" class="status">Pronto.</p>
+      </div>
+      <div id="courseTree" class="courseTree"></div>
+    </section>
+  </main>
+
+  <template id="headingTemplate">
+    <article class="headingCard" draggable="true">
+      <div class="headingTitle"></div>
+      <div class="headingMeta"></div>
+    </article>
+  </template>
+
+  <script src="course_board.js"></script>
+</body>
+</html>

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -15,8 +15,6 @@
     </div>
     <div class="heroTools">
       <a class="orgBadge" href="https://github.com/TheBitPoets" target="_blank" rel="noreferrer" aria-label="Apri TheBitPoets su GitHub">
-        <span class="paintDrip paintDripOne"></span>
-        <span class="paintDrip paintDripTwo"></span>
         <img src="https://github.com/TheBitPoets.png" alt="TheBitPoets">
       </a>
       <div class="actions">

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -13,9 +13,16 @@
       <h1>Course Design Board</h1>
       <p class="subtitle">Costruisci percorsi, UDA e settimane partendo dai paragrafi reali delle dispense.</p>
     </div>
-    <div class="actions">
-      <button id="reloadBtn" type="button">Ricarica</button>
-      <button id="saveBtn" type="button" class="primary">Salva JSON</button>
+    <div class="heroTools">
+      <a class="orgBadge" href="https://github.com/TheBitPoets" target="_blank" rel="noreferrer" aria-label="Apri TheBitPoets su GitHub">
+        <span class="paintDrip paintDripOne"></span>
+        <span class="paintDrip paintDripTwo"></span>
+        <img src="https://github.com/TheBitPoets.png" alt="TheBitPoets">
+      </a>
+      <div class="actions">
+        <button id="reloadBtn" type="button">Ricarica</button>
+        <button id="saveBtn" type="button" class="primary">Salva JSON</button>
+      </div>
     </div>
   </header>
 

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -2,6 +2,7 @@
   headings: [],
   design: null,
   draggedHeading: null,
+  collapsedHeadingIds: new Set(),
 };
 
 const els = {
@@ -82,6 +83,7 @@ function renderHeadings() {
   const headings = state.headings.filter((heading) => {
     if (source && heading.source !== source) return false;
     if (level && String(heading.level) !== level) return false;
+    if (!query && isHiddenByCollapsedParent(heading)) return false;
     if (query && !`${heading.title} ${heading.source}`.toLowerCase().includes(query)) return false;
     return true;
   });
@@ -91,12 +93,33 @@ function renderHeadings() {
     node.dataset.id = heading.id;
     const depth = Math.max(0, heading.level - 1);
     const usedInYears = used.get(heading.id) || new Set();
+    const hasChildren = headingHasChildren(heading);
     node.classList.add(`level-${heading.level}`);
     if (usedInYears.size) {
       node.classList.add("assigned");
     }
     node.style.setProperty("--depth", depth);
-    node.querySelector(".headingTitle").textContent = heading.title;
+    const title = node.querySelector(".headingTitle");
+    title.innerHTML = "";
+    if (hasChildren) {
+      const toggle = document.createElement("button");
+      toggle.className = "treeToggle";
+      toggle.type = "button";
+      toggle.textContent = state.collapsedHeadingIds.has(heading.id) ? "+" : "-";
+      toggle.setAttribute("aria-label", state.collapsedHeadingIds.has(heading.id) ? "Mostra sottoparagrafi" : "Nascondi sottoparagrafi");
+      toggle.addEventListener("click", (event) => {
+        event.stopPropagation();
+        toggleHeading(heading.id);
+      });
+      title.append(toggle);
+    } else {
+      const spacer = document.createElement("span");
+      spacer.className = "treeToggleSpacer";
+      title.append(spacer);
+    }
+    const titleText = document.createElement("span");
+    titleText.textContent = heading.title;
+    title.append(titleText);
     const usedLabel = usedInYears.size ? ` · inserito in ${[...usedInYears].join(", ")}` : "";
     node.querySelector(".headingMeta").textContent = `${heading.source}:${heading.line} · H${heading.level}${usedLabel}`;
     node.addEventListener("dragstart", () => {
@@ -109,6 +132,38 @@ function renderHeadings() {
   if (!headings.length) {
     els.headingList.innerHTML = '<p class="empty">Nessun paragrafo trovato.</p>';
   }
+}
+
+function headingHasChildren(heading) {
+  const index = state.headings.findIndex((candidate) => candidate.id === heading.id);
+  if (index < 0) return false;
+  for (const candidate of state.headings.slice(index + 1)) {
+    if (candidate.source !== heading.source) break;
+    if (candidate.level <= heading.level) return false;
+    return true;
+  }
+  return false;
+}
+
+function isHiddenByCollapsedParent(heading) {
+  const index = state.headings.findIndex((candidate) => candidate.id === heading.id);
+  if (index < 0) return false;
+  for (let i = index - 1; i >= 0; i -= 1) {
+    const candidate = state.headings[i];
+    if (candidate.source !== heading.source) break;
+    if (candidate.level < heading.level && state.collapsedHeadingIds.has(candidate.id)) return true;
+    if (candidate.level < heading.level) continue;
+  }
+  return false;
+}
+
+function toggleHeading(headingId) {
+  if (state.collapsedHeadingIds.has(headingId)) {
+    state.collapsedHeadingIds.delete(headingId);
+  } else {
+    state.collapsedHeadingIds.add(headingId);
+  }
+  renderHeadings();
 }
 
 function addToFirstUda(heading) {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -58,12 +58,14 @@ function populateFilters() {
   els.sourceFilter.value = selected;
 }
 
-function assignedIds() {
-  const ids = new Set();
+function assignedYearsById() {
+  const ids = new Map();
   for (const year of state.design.years || []) {
     for (const uda of year.udas || []) {
       for (const item of uda.items || []) {
-        if (item.id) ids.add(item.id);
+        if (!item.id) continue;
+        if (!ids.has(item.id)) ids.set(item.id, new Set());
+        ids.get(item.id).add(year.id);
       }
     }
   }
@@ -74,7 +76,7 @@ function renderHeadings() {
   const source = els.sourceFilter.value;
   const level = els.levelFilter.value;
   const query = els.searchInput.value.trim().toLowerCase();
-  const used = assignedIds();
+  const used = assignedYearsById();
   els.headingList.innerHTML = "";
 
   const headings = state.headings.filter((heading) => {
@@ -88,10 +90,15 @@ function renderHeadings() {
     const node = els.headingTemplate.content.firstElementChild.cloneNode(true);
     node.dataset.id = heading.id;
     const depth = Math.max(0, heading.level - 1);
+    const usedInYears = used.get(heading.id) || new Set();
     node.classList.add(`level-${heading.level}`);
+    if (usedInYears.size) {
+      node.classList.add("assigned");
+    }
     node.style.setProperty("--depth", depth);
     node.querySelector(".headingTitle").textContent = heading.title;
-    node.querySelector(".headingMeta").textContent = `${heading.source}:${heading.line} · H${heading.level}${used.has(heading.id) ? " · gia assegnato" : ""}`;
+    const usedLabel = usedInYears.size ? ` · inserito in ${[...usedInYears].join(", ")}` : "";
+    node.querySelector(".headingMeta").textContent = `${heading.source}:${heading.line} · H${heading.level}${usedLabel}`;
     node.addEventListener("dragstart", () => {
       state.draggedHeading = heading;
     });
@@ -143,13 +150,13 @@ function renderCourse() {
     `;
 
     for (const uda of year.udas || []) {
-      yearNode.append(renderUda(uda));
+      yearNode.append(renderUda(year, uda));
     }
     els.courseTree.append(yearNode);
   }
 }
 
-function renderUda(uda) {
+function renderUda(year, uda) {
   const details = document.createElement("details");
   details.className = "uda";
   details.open = true;
@@ -167,6 +174,11 @@ function renderUda(uda) {
     event.preventDefault();
     dropzone.classList.remove("dragOver");
     if (!state.draggedHeading) return;
+    if (isAssignedToYear(state.draggedHeading.id, year.id)) {
+      setStatus(`"${state.draggedHeading.title}" e gia presente in ${year.title}.`);
+      state.draggedHeading = null;
+      return;
+    }
     uda.items ||= [];
     uda.items.push(itemFromHeading(state.draggedHeading));
     state.draggedHeading = null;
@@ -182,6 +194,12 @@ function renderUda(uda) {
   }
   details.append(dropzone);
   return details;
+}
+
+function isAssignedToYear(itemId, yearId) {
+  const year = (state.design.years || []).find((candidate) => candidate.id === yearId);
+  if (!year) return false;
+  return (year.udas || []).some((uda) => (uda.items || []).some((item) => item.id === itemId));
 }
 
 function renderItem(uda, item, index) {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -3,6 +3,7 @@
   design: null,
   draggedHeading: null,
   collapsedHeadingIds: new Set(),
+  collapsedCourseItemIds: new Set(),
 };
 
 const els = {
@@ -61,12 +62,18 @@ function populateFilters() {
 
 function assignedYearsById() {
   const ids = new Map();
+  const collect = (item, yearId) => {
+    if (!item.id) return;
+    if (!ids.has(item.id)) ids.set(item.id, new Set());
+    ids.get(item.id).add(yearId);
+    for (const child of item.children || []) {
+      collect(child, yearId);
+    }
+  };
   for (const year of state.design.years || []) {
     for (const uda of year.udas || []) {
       for (const item of uda.items || []) {
-        if (!item.id) continue;
-        if (!ids.has(item.id)) ids.set(item.id, new Set());
-        ids.get(item.id).add(year.id);
+        collect(item, year.id);
       }
     }
   }
@@ -177,7 +184,7 @@ function addToFirstUda(heading) {
 }
 
 function itemFromHeading(heading) {
-  return {
+  const item = {
     id: heading.id,
     title: heading.title,
     source: heading.source,
@@ -188,6 +195,44 @@ function itemFromHeading(heading) {
       status: "todo"
     }
   };
+  const children = childItemsFromHeading(heading);
+  if (children.length) item.children = children;
+  return item;
+}
+
+function childItemsFromHeading(parentHeading) {
+  const parentIndex = state.headings.findIndex((candidate) => candidate.id === parentHeading.id);
+  if (parentIndex < 0) return [];
+  const roots = [];
+  const stack = [{ level: parentHeading.level, children: roots }];
+
+  for (const heading of state.headings.slice(parentIndex + 1)) {
+    if (heading.source !== parentHeading.source || heading.level <= parentHeading.level) break;
+    const item = {
+      id: heading.id,
+      title: heading.title,
+      source: heading.source,
+      href: heading.href,
+      level: heading.level,
+      line: heading.line,
+      frame: {
+        status: "todo"
+      }
+    };
+    while (stack.length && heading.level <= stack.at(-1).level) {
+      stack.pop();
+    }
+    stack.at(-1).children.push(item);
+    item.children = [];
+    stack.push(item);
+  }
+
+  const pruneEmptyChildren = (item) => {
+    item.children.forEach(pruneEmptyChildren);
+    if (!item.children.length) delete item.children;
+  };
+  roots.forEach(pruneEmptyChildren);
+  return roots;
 }
 
 function renderCourse() {
@@ -229,8 +274,8 @@ function renderUda(year, uda) {
     event.preventDefault();
     dropzone.classList.remove("dragOver");
     if (!state.draggedHeading) return;
-    if (isAssignedToYear(state.draggedHeading.id, year.id)) {
-      setStatus(`"${state.draggedHeading.title}" e gia presente in ${year.title}.`);
+    if (isHeadingTreeAssignedToYear(state.draggedHeading, year.id)) {
+      setStatus(`"${state.draggedHeading.title}" o un suo sottoparagrafo e gia presente in ${year.title}.`);
       state.draggedHeading = null;
       return;
     }
@@ -245,7 +290,7 @@ function renderUda(year, uda) {
   if (!items.length) {
     dropzone.innerHTML = '<p class="empty">Trascina qui paragrafi o sottoparagrafi.</p>';
   } else {
-    items.forEach((item, index) => dropzone.append(renderItem(uda, item, index)));
+    items.forEach((item, index) => dropzone.append(renderItem(uda, uda.items, item, index, 0)));
   }
   details.append(dropzone);
   return details;
@@ -254,41 +299,97 @@ function renderUda(year, uda) {
 function isAssignedToYear(itemId, yearId) {
   const year = (state.design.years || []).find((candidate) => candidate.id === yearId);
   if (!year) return false;
-  return (year.udas || []).some((uda) => (uda.items || []).some((item) => item.id === itemId));
+  const contains = (item) => item.id === itemId || (item.children || []).some(contains);
+  return (year.udas || []).some((uda) => (uda.items || []).some(contains));
 }
 
-function renderItem(uda, item, index) {
+function isHeadingTreeAssignedToYear(heading, yearId) {
+  return headingTreeIds(heading).some((id) => isAssignedToYear(id, yearId));
+}
+
+function headingTreeIds(heading) {
+  const ids = [heading.id];
+  const parentIndex = state.headings.findIndex((candidate) => candidate.id === heading.id);
+  if (parentIndex < 0) return ids;
+  for (const candidate of state.headings.slice(parentIndex + 1)) {
+    if (candidate.source !== heading.source || candidate.level <= heading.level) break;
+    ids.push(candidate.id);
+  }
+  return ids;
+}
+
+function renderItem(uda, siblings, item, index, depth) {
   const node = document.createElement("article");
   node.className = "item";
+  node.style.setProperty("--item-depth", depth);
+  const children = item.children || [];
+  const collapseKey = `${uda.id}:${item.id}`;
+  const isCollapsed = state.collapsedCourseItemIds.has(collapseKey);
   node.innerHTML = `
-    <div>
-      <div class="itemTitle">${escapeHtml(item.title)}</div>
-      <div class="itemMeta">${escapeHtml(item.source)} · H${item.level || "?"} · ${escapeHtml(item.frame?.status || "ok")}</div>
-    </div>
-    <div class="itemActions">
-      <button type="button" data-action="up">Su</button>
-      <button type="button" data-action="down">Giu</button>
-      <button type="button" data-action="remove">Rimuovi</button>
+    <div class="itemRow">
+      <div>
+        <div class="itemTitle"></div>
+        <div class="itemMeta">${escapeHtml(item.source)} · H${item.level || "?"} · ${escapeHtml(item.frame?.status || "ok")}</div>
+      </div>
+      <div class="itemActions">
+        <button type="button" data-action="up">Su</button>
+        <button type="button" data-action="down">Giu</button>
+        <button type="button" data-action="remove">Rimuovi</button>
+      </div>
     </div>
   `;
-  node.querySelector('[data-action="up"]').addEventListener("click", () => moveItem(uda, index, -1));
-  node.querySelector('[data-action="down"]').addEventListener("click", () => moveItem(uda, index, 1));
-  node.querySelector('[data-action="remove"]').addEventListener("click", () => removeItem(uda, index));
+  const title = node.querySelector(".itemTitle");
+  if (children.length) {
+    const toggle = document.createElement("button");
+    toggle.className = "treeToggle";
+    toggle.type = "button";
+    toggle.textContent = isCollapsed ? "+" : "-";
+    toggle.setAttribute("aria-label", isCollapsed ? "Mostra sottoparagrafi" : "Nascondi sottoparagrafi");
+    toggle.addEventListener("click", (event) => {
+      event.stopPropagation();
+      toggleCourseItem(collapseKey);
+    });
+    title.append(toggle);
+  } else {
+    const spacer = document.createElement("span");
+    spacer.className = "treeToggleSpacer";
+    title.append(spacer);
+  }
+  const titleText = document.createElement("span");
+  titleText.textContent = item.title;
+  title.append(titleText);
+  node.querySelector('[data-action="up"]').addEventListener("click", () => moveItem(siblings, index, -1));
+  node.querySelector('[data-action="down"]').addEventListener("click", () => moveItem(siblings, index, 1));
+  node.querySelector('[data-action="remove"]').addEventListener("click", () => removeItem(siblings, index));
+  if (children.length && !isCollapsed) {
+    const childList = document.createElement("div");
+    childList.className = "itemChildren";
+    children.forEach((child, childIndex) => childList.append(renderItem(uda, children, child, childIndex, depth + 1)));
+    node.append(childList);
+  }
   return node;
 }
 
-function moveItem(uda, index, delta) {
-  const items = uda.items || [];
+function moveItem(items, index, delta) {
   const target = index + delta;
   if (target < 0 || target >= items.length) return;
   [items[index], items[target]] = [items[target], items[index]];
   renderCourse();
 }
 
-function removeItem(uda, index) {
-  uda.items.splice(index, 1);
+function removeItem(items, index) {
+  items.splice(index, 1);
   renderCourse();
   renderHeadings();
+}
+
+function toggleCourseItem(collapseKey) {
+  if (state.collapsedCourseItemIds.has(collapseKey)) {
+    state.collapsedCourseItemIds.delete(collapseKey);
+  } else {
+    state.collapsedCourseItemIds.add(collapseKey);
+  }
+  renderCourse();
 }
 
 async function saveDesign() {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1,0 +1,244 @@
+﻿const state = {
+  headings: [],
+  design: null,
+  draggedHeading: null,
+};
+
+const els = {
+  headingList: document.querySelector("#headingList"),
+  headingTemplate: document.querySelector("#headingTemplate"),
+  sourceFilter: document.querySelector("#sourceFilter"),
+  levelFilter: document.querySelector("#levelFilter"),
+  searchInput: document.querySelector("#searchInput"),
+  courseTree: document.querySelector("#courseTree"),
+  status: document.querySelector("#status"),
+  reloadBtn: document.querySelector("#reloadBtn"),
+  saveBtn: document.querySelector("#saveBtn"),
+};
+
+function setStatus(message) {
+  els.status.textContent = message;
+}
+
+async function api(path, options = {}) {
+  const response = await fetch(path, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+async function loadAll() {
+  setStatus("Caricamento...");
+  const [headingsPayload, design] = await Promise.all([
+    api("/api/headings"),
+    api("/api/course-design"),
+  ]);
+  state.headings = headingsPayload.headings;
+  state.design = design;
+  populateFilters();
+  renderHeadings();
+  renderCourse();
+  setStatus("Pronto.");
+}
+
+function populateFilters() {
+  const selected = els.sourceFilter.value;
+  const sources = [...new Set(state.headings.map((heading) => heading.source))];
+  els.sourceFilter.innerHTML = '<option value="">Tutte le sorgenti</option>';
+  for (const source of sources) {
+    const option = document.createElement("option");
+    option.value = source;
+    option.textContent = source;
+    els.sourceFilter.append(option);
+  }
+  els.sourceFilter.value = selected;
+}
+
+function assignedIds() {
+  const ids = new Set();
+  for (const year of state.design.years || []) {
+    for (const uda of year.udas || []) {
+      for (const item of uda.items || []) {
+        if (item.id) ids.add(item.id);
+      }
+    }
+  }
+  return ids;
+}
+
+function renderHeadings() {
+  const source = els.sourceFilter.value;
+  const level = els.levelFilter.value;
+  const query = els.searchInput.value.trim().toLowerCase();
+  const used = assignedIds();
+  els.headingList.innerHTML = "";
+
+  const headings = state.headings.filter((heading) => {
+    if (source && heading.source !== source) return false;
+    if (level && String(heading.level) !== level) return false;
+    if (query && !`${heading.title} ${heading.source}`.toLowerCase().includes(query)) return false;
+    return true;
+  });
+
+  for (const heading of headings) {
+    const node = els.headingTemplate.content.firstElementChild.cloneNode(true);
+    node.dataset.id = heading.id;
+    node.querySelector(".headingTitle").textContent = `${"  ".repeat(Math.max(0, heading.level - 2))}${heading.title}`;
+    node.querySelector(".headingMeta").textContent = `${heading.source}:${heading.line} · H${heading.level}${used.has(heading.id) ? " · gia assegnato" : ""}`;
+    node.addEventListener("dragstart", () => {
+      state.draggedHeading = heading;
+    });
+    node.addEventListener("dblclick", () => addToFirstUda(heading));
+    els.headingList.append(node);
+  }
+
+  if (!headings.length) {
+    els.headingList.innerHTML = '<p class="empty">Nessun paragrafo trovato.</p>';
+  }
+}
+
+function addToFirstUda(heading) {
+  const firstYear = state.design.years?.[0];
+  const firstUda = firstYear?.udas?.[0];
+  if (!firstUda) return;
+  firstUda.items ||= [];
+  firstUda.items.push(itemFromHeading(heading));
+  renderCourse();
+  renderHeadings();
+}
+
+function itemFromHeading(heading) {
+  return {
+    id: heading.id,
+    title: heading.title,
+    source: heading.source,
+    href: heading.href,
+    level: heading.level,
+    line: heading.line,
+    frame: {
+      status: "todo"
+    }
+  };
+}
+
+function renderCourse() {
+  els.courseTree.innerHTML = "";
+  for (const year of state.design.years || []) {
+    const yearNode = document.createElement("section");
+    yearNode.className = "year";
+    yearNode.innerHTML = `
+      <div class="yearHead">
+        <div>
+          <h3>${escapeHtml(year.title)}</h3>
+          <div class="yearMeta">${escapeHtml(year.description || "")} · ${year.weeks || "?"} settimane · ${year.weekly_hours || "?"} ore/settimana</div>
+        </div>
+      </div>
+    `;
+
+    for (const uda of year.udas || []) {
+      yearNode.append(renderUda(uda));
+    }
+    els.courseTree.append(yearNode);
+  }
+}
+
+function renderUda(uda) {
+  const details = document.createElement("details");
+  details.className = "uda";
+  details.open = true;
+  details.innerHTML = `
+    <summary>${escapeHtml(uda.id.toUpperCase())}: ${escapeHtml(uda.title)} <span class="udaMeta">${escapeHtml(uda.path || "")} · settimane ${escapeHtml(uda.weeks || "?")}</span></summary>
+  `;
+  const dropzone = document.createElement("div");
+  dropzone.className = "dropzone";
+  dropzone.addEventListener("dragover", (event) => {
+    event.preventDefault();
+    dropzone.classList.add("dragOver");
+  });
+  dropzone.addEventListener("dragleave", () => dropzone.classList.remove("dragOver"));
+  dropzone.addEventListener("drop", (event) => {
+    event.preventDefault();
+    dropzone.classList.remove("dragOver");
+    if (!state.draggedHeading) return;
+    uda.items ||= [];
+    uda.items.push(itemFromHeading(state.draggedHeading));
+    state.draggedHeading = null;
+    renderCourse();
+    renderHeadings();
+  });
+
+  const items = uda.items || [];
+  if (!items.length) {
+    dropzone.innerHTML = '<p class="empty">Trascina qui paragrafi o sottoparagrafi.</p>';
+  } else {
+    items.forEach((item, index) => dropzone.append(renderItem(uda, item, index)));
+  }
+  details.append(dropzone);
+  return details;
+}
+
+function renderItem(uda, item, index) {
+  const node = document.createElement("article");
+  node.className = "item";
+  node.innerHTML = `
+    <div>
+      <div class="itemTitle">${escapeHtml(item.title)}</div>
+      <div class="itemMeta">${escapeHtml(item.source)} · H${item.level || "?"} · ${escapeHtml(item.frame?.status || "ok")}</div>
+    </div>
+    <div class="itemActions">
+      <button type="button" data-action="up">Su</button>
+      <button type="button" data-action="down">Giu</button>
+      <button type="button" data-action="remove">Rimuovi</button>
+    </div>
+  `;
+  node.querySelector('[data-action="up"]').addEventListener("click", () => moveItem(uda, index, -1));
+  node.querySelector('[data-action="down"]').addEventListener("click", () => moveItem(uda, index, 1));
+  node.querySelector('[data-action="remove"]').addEventListener("click", () => removeItem(uda, index));
+  return node;
+}
+
+function moveItem(uda, index, delta) {
+  const items = uda.items || [];
+  const target = index + delta;
+  if (target < 0 || target >= items.length) return;
+  [items[index], items[target]] = [items[target], items[index]];
+  renderCourse();
+}
+
+function removeItem(uda, index) {
+  uda.items.splice(index, 1);
+  renderCourse();
+  renderHeadings();
+}
+
+async function saveDesign() {
+  setStatus("Salvataggio...");
+  await api("/api/course-design", {
+    method: "POST",
+    body: JSON.stringify(state.design),
+  });
+  setStatus("Salvato in doc/course_design.json.");
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+els.reloadBtn.addEventListener("click", loadAll);
+els.saveBtn.addEventListener("click", saveDesign);
+els.sourceFilter.addEventListener("change", renderHeadings);
+els.levelFilter.addEventListener("change", renderHeadings);
+els.searchInput.addEventListener("input", renderHeadings);
+
+loadAll().catch((error) => {
+  console.error(error);
+  setStatus(`Errore: ${error.message}`);
+});

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -87,7 +87,10 @@ function renderHeadings() {
   for (const heading of headings) {
     const node = els.headingTemplate.content.firstElementChild.cloneNode(true);
     node.dataset.id = heading.id;
-    node.querySelector(".headingTitle").textContent = `${"  ".repeat(Math.max(0, heading.level - 2))}${heading.title}`;
+    const depth = Math.max(0, heading.level - 1);
+    node.classList.add(`level-${heading.level}`);
+    node.style.setProperty("--depth", depth);
+    node.querySelector(".headingTitle").textContent = heading.title;
     node.querySelector(".headingMeta").textContent = `${heading.source}:${heading.line} · H${heading.level}${used.has(heading.id) ? " · gia assegnato" : ""}`;
     node.addEventListener("dragstart", () => {
       state.draggedHeading = heading;


### PR DESCRIPTION
## Cosa cambia

Aggiunge una prima versione locale della Course Design Board per progettare il percorso didattico senza modificare manualmente grandi tabelle Markdown.

## File aggiunti

- `doc/course_design.json`: modello dati iniziale con terzo/quarto anno e UDA.
- `scripts/course_board_server.py`: piccolo server locale Python, solo standard library.
- `tools/course_board.html`: interfaccia della board.
- `tools/course_board.css`: stile della board.
- `tools/course_board.js`: logica client, drag and drop, salvataggio.
- `doc/COURSE_BOARD.md`: istruzioni di utilizzo.

## Funzioni MVP

- Legge gli heading da `README.md` e `LINUX_PROGRAMMING.md`.
- Mostra paragrafi/sottoparagrafi disponibili a sinistra.
- Mostra anni, UDA e settimane a destra.
- Permette drag and drop dei paragrafi dentro le UDA.
- Permette riordino e rimozione degli elementi assegnati.
- Salva la struttura in `doc/course_design.json`.

## Come provarla

```bash
python scripts/course_board_server.py
```

Poi aprire:

```text
http://127.0.0.1:8765/tools/course_board.html
```

## Non incluso in questa PR

Questa PR non genera ancora automaticamente:

- `doc/PERCORSO_DIDATTICO.md`;
- le cornici `Orientamento della sezione` nel README;
- report TODO;
- report paragrafi non assegnati.

Queste parti saranno lo step successivo dopo aver validato il modello dati e l'esperienza della board.