### PR TITLE
[codex] Add didactic frame fields to course board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *~
 .vagrant
 *.log
+.secrets/
+*.secret

--- a/config/ai_providers.yaml
+++ b/config/ai_providers.yaml
@@ -1,0 +1,49 @@
+﻿providers:
+  openai:
+    label: OpenAI
+    secret_key: OPENAI_API_KEY
+    default_model: gpt-5.5
+    billing_note: OpenAI API usa quota/billing API separati da ChatGPT Free/Plus.
+    models:
+      - id: gpt-5.5
+        label: GPT-5.5
+        tier: paid
+      - id: gpt-5-mini
+        label: GPT-5 Mini
+        tier: paid-low-cost
+  gemini:
+    label: Gemini
+    secret_key: GEMINI_API_KEY
+    default_model: gemini-2.5-flash
+    billing_note: Gemini puo avere free tier su Google AI Studio, ma quota e limiti dipendono dall'account.
+    models:
+      - id: gemini-2.5-flash
+        label: Gemini 2.5 Flash
+        tier: free-or-low-cost
+      - id: gemini-3-flash-preview
+        label: Gemini 3 Flash Preview
+        tier: free-or-low-cost
+  groq:
+    label: Groq
+    secret_key: GROQ_API_KEY
+    default_model: llama-3.3-70b-versatile
+    billing_note: Groq offre piani free/dev con rate limit; disponibilita e limiti dipendono dall'account.
+    models:
+      - id: llama-3.3-70b-versatile
+        label: Llama 3.3 70B Versatile
+        tier: free-or-low-cost
+      - id: qwen/qwen3-32b
+        label: Qwen3 32B
+        tier: free-or-low-cost
+  openrouter:
+    label: OpenRouter
+    secret_key: OPENROUTER_API_KEY
+    default_model: openrouter/free
+    billing_note: OpenRouter espone modelli free, ma limiti e fallback dipendono dall'account e dal modello scelto.
+    models:
+      - id: openrouter/free
+        label: Free Models Router
+        tier: free
+      - id: meta-llama/llama-3.3-70b-instruct:free
+        label: Llama 3.3 70B Instruct Free
+        tier: free

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -261,25 +261,35 @@ Il flusso e sempre lo stesso:
 7. controlli il testo generato;
 8. clicchi `Salva JSON`.
 
-La board supporta questi provider:
+La board supporta questi provider dichiarati in `config/ai_providers.yaml`:
 
 | Provider | Variabile provider | Variabile API key | Variabile modello opzionale |
 | --- | --- | --- | --- |
 | OpenAI | `AI_PROVIDER=openai` | `OPENAI_API_KEY` | `OPENAI_MODEL` |
 | Gemini | `AI_PROVIDER=gemini` | `GEMINI_API_KEY` | `GEMINI_MODEL` |
+| Groq | `AI_PROVIDER=groq` | `GROQ_API_KEY` | `GROQ_MODEL` |
+| OpenRouter | `AI_PROVIDER=openrouter` | `OPENROUTER_API_KEY` | `OPENROUTER_MODEL` |
 
 Se non imposti `AI_PROVIDER`, il server usa `openai`.
 
 `ChatGPT Free` non e un provider API per automazioni locali: e l'interfaccia web/app di ChatGPT. Per questo non viene usato direttamente dalla board, perche richiederebbe automazioni fragili del browser e non una integrazione API pulita.
 
-La board mostra nella sezione `Percorso didattico` la configurazione AI attiva e permette di cambiare provider tramite select:
+La board mostra nella sezione `Percorso didattico` la configurazione AI attiva e permette di cambiare provider e modello tramite select:
 
 - provider selezionato;
 - modello selezionato;
 - presenza o assenza della API key;
 - nota su quota, billing o free tier.
 
-Il cambio provider funziona solo se la API key del provider scelto e gia presente nelle variabili d'ambiente del server locale. Se scegli un provider non configurato, la board mantiene il provider precedente e mostra un messaggio di errore.
+Il cambio provider funziona solo se la API key del provider scelto e gia presente nelle variabili d'ambiente del server locale oppure nel file locale `.secrets/ai.secret`. Se scegli un provider non configurato, la board mantiene il provider precedente e mostra un messaggio di errore.
+
+Il cambio modello funziona dalla UI senza riavviare il server, purche il modello sia dichiarato in:
+
+```text
+config/ai_providers.yaml
+```
+
+Questo e utile per passare rapidamente da un modello gratuito o low-cost a un altro quando un modello e saturo o ha esaurito temporaneamente la quota.
 
 La board non mostra mai il valore della API key. Inoltre non puo sapere con certezza se il tuo account stia usando un piano gratuito, credito residuo o billing a pagamento: puo solo mostrare il provider configurato e una nota orientativa.
 
@@ -293,7 +303,73 @@ Non scrivere mai una API key dentro:
 - file `.html`;
 - commit Git.
 
-La API key deve stare solo nella shell, in una variabile d'ambiente locale.
+La API key deve stare solo nella shell, in una variabile d'ambiente locale, oppure nel file locale non versionato:
+
+```text
+.secrets/ai.secret
+```
+
+Il server legge prima le variabili d'ambiente e poi `.secrets/ai.secret`.
+
+Esempio:
+
+```text
+OPENAI_API_KEY=sk-...
+GEMINI_API_KEY=...
+```
+
+La cartella `.secrets/` e ignorata da Git.
+
+### Configurazione dei provider e dei modelli
+
+I provider e i modelli disponibili nella UI sono definiti in:
+
+```text
+config/ai_providers.yaml
+```
+
+Esempio concettuale:
+
+```yaml
+providers:
+  gemini:
+    label: Gemini
+    secret_key: GEMINI_API_KEY
+    default_model: gemini-2.5-flash
+    models:
+      - id: gemini-2.5-flash
+        label: Gemini 2.5 Flash
+        tier: free-or-low-cost
+```
+
+Il campo `tier` e una nota orientativa per la UI. Non verifica in tempo reale se hai credito gratuito residuo.
+
+### Provider free o low-cost
+
+Anche quando un provider offre modelli gratuiti o free tier, serve comunque una API key.
+
+La API key non implica necessariamente pagamento: spesso serve solo a identificare account, quota e rate limit.
+
+Provider utili:
+
+- `gemini`: consigliato come prima opzione free/low-cost;
+- `groq`: utile per modelli open veloci, con rate limit da account;
+- `openrouter`: utile come router di modelli free, ma bisogna controllare bene modello e fallback;
+- `openai`: qualita alta, ma API separata da ChatGPT/Codex Pro e non gratuita di default.
+
+Per Groq aggiungi nel secret:
+
+```text
+GROQ_API_KEY=...
+```
+
+Per OpenRouter aggiungi:
+
+```text
+OPENROUTER_API_KEY=...
+```
+
+Poi riavvia il server.
 
 ### Guida OpenAI
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -50,6 +50,8 @@ Questo flusso e diverso dalla generazione della cornice didattica:
 
 La proposta non viene applicata automaticamente. Questo evita che la AI sovrascriva il percorso senza revisione docente.
 
+Durante la generazione compare un indicatore `AI assisted in corso` con messaggi progressivi e percentuale. La percentuale e una stima di attesa lato interfaccia: serve a farti capire che la richiesta e ancora in corso, non rappresenta il progresso reale interno del provider AI.
+
 ### Brief modificabile
 
 Il brief viene precompilato a partire dai dati dell'anno presenti nel JSON.
@@ -337,6 +339,8 @@ http://127.0.0.1:8765/tools/course_board.html
 5. Clicca `Salva JSON` per rendere persistenti i campi generati.
 
 Il modello deve restituire dati strutturati; la board accetta solo i campi previsti dalla cornice didattica.
+
+Anche in questo caso compare l'indicatore di lavoro `AI assisted in corso`. Se la risposta impiega tempo, lascia aperta la finestra: il provider potrebbe richiedere diversi secondi per leggere il contesto e produrre il JSON strutturato.
 
 ### Come funziona la chiamata AI
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -25,6 +25,7 @@ http://127.0.0.1:8765/tools/course_board.html
 - permette di riordinare e rimuovere gli elementi assegnati;
 - permette di compilare una cornice didattica per ogni argomento assegnato;
 - permette di generare una proposta di percorso annuale con `AI assisted percorso`;
+- permette di generare le cornici didattiche per tutto il percorso;
 - permette di archiviare e ricaricare piu versioni del percorso didattico;
 - salva la struttura in `doc/course_design.json`;
 - genera `doc/PERCORSO_DIDATTICO.md` a partire dal JSON della board.
@@ -234,6 +235,13 @@ Nel file `doc/course_design.json` questi dati vengono salvati dentro il campo `f
 
 Nel documento generato `doc/PERCORSO_DIDATTICO.md` vengono mostrati solo i campi compilati, cosi la bozza resta leggibile anche quando molte cornici sono ancora vuote.
 
+Nella board la linguetta `Cornice didattica` cambia colore:
+
+- grigio: cornice ancora vuota;
+- verde: almeno un campo della cornice e stato compilato.
+
+In questo modo puoi capire quali argomenti sono gia stati lavorati senza aprire tutte le linguette.
+
 ## Compilazione AI assisted della cornice
 
 La board puo chiedere a un servizio AI di compilare automaticamente la cornice didattica di un argomento.
@@ -407,6 +415,31 @@ Il modello deve restituire dati strutturati; la board accetta solo i campi previ
 Anche in questo caso compare l'indicatore di lavoro `AI assisted in corso`. Se la risposta impiega tempo, lascia aperta la finestra: il provider potrebbe richiedere diversi secondi per leggere il contesto e produrre il JSON strutturato.
 
 La generazione della cornice del singolo argomento e di solito piu rapida del percorso annuale, perche usa solo il contesto ravvicinato dell'argomento.
+
+Se la richiesta fallisce, la board mostra il dettaglio restituito dal server o dal provider AI. Per esempio:
+
+- quota insufficiente;
+- modello temporaneamente non disponibile;
+- timeout;
+- API key mancante;
+- errore interno del server.
+
+### Generare le cornici di tutto il percorso
+
+Il bottone `Genera cornici` prova a generare le cornici didattiche per tutti gli argomenti presenti nel percorso corrente.
+
+Il processo e ricorsivo:
+
+- visita tutte le UDA;
+- visita tutti gli argomenti;
+- visita tutti i sottoparagrafi annidati, anche a piu livelli;
+- genera una cornice per ogni nodo dell'albero.
+
+Questo significa che, se nel percorso sono presenti argomenti H1, H2, H3, H4, H5 o H6, la board puo generare la cornice anche per i livelli piu profondi.
+
+La generazione avviene in sequenza, una cornice alla volta. Se un provider restituisce errore, la generazione si interrompe e la board mostra il dettaglio dell'errore.
+
+Prima di usare questo comando su un percorso grande, considera che puo consumare molte chiamate API.
 
 ### Come funziona la chiamata AI
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -25,8 +25,59 @@ http://127.0.0.1:8765/tools/course_board.html
 - permette di riordinare e rimuovere gli elementi assegnati;
 - permette di compilare una cornice didattica per ogni argomento assegnato;
 - permette di generare una proposta di percorso annuale con `AI assisted percorso`;
+- permette di archiviare e ricaricare piu versioni del percorso didattico;
 - salva la struttura in `doc/course_design.json`;
 - genera `doc/PERCORSO_DIDATTICO.md` a partire dal JSON della board.
+
+## Archivio dei percorsi didattici
+
+La board usa `doc/course_design.json` come percorso didattico corrente.
+
+Per conservare versioni diverse, per esempio per anni scolastici differenti, puoi usare l'archivio:
+
+```text
+doc/course_designs/
+```
+
+Esempi di nomi:
+
+```text
+course_design_as_24_25.json
+course_design_as_25_26.json
+```
+
+### Salvare una versione in archivio
+
+1. Modifica la board.
+2. Clicca `Salva archivio`.
+3. Inserisci un nome file `.json`.
+4. La board salva una copia in `doc/course_designs/`.
+
+Il nome puo contenere solo lettere, numeri, trattino, underscore, punto e deve terminare con `.json`.
+
+### Caricare una versione salvata
+
+1. Scegli un file dal select `Percorsi salvati`.
+2. Clicca `Carica`.
+3. La board sostituisce la vista corrente con il JSON archiviato.
+4. Modifica il percorso normalmente.
+5. Usa `Salva archivio` per aggiornare il file archiviato oppure `Salva JSON` per renderlo il percorso corrente.
+
+### Differenza tra Salva JSON e Salva archivio
+
+`Salva JSON` aggiorna:
+
+```text
+doc/course_design.json
+```
+
+`Salva archivio` aggiorna o crea un file dentro:
+
+```text
+doc/course_designs/
+```
+
+In questo modo puoi mantenere piu percorsi didattici storici o alternativi senza sovrascrivere sempre il percorso corrente.
 
 ## Generazione AI assisted del percorso annuale
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -23,8 +23,28 @@ http://127.0.0.1:8765/tools/course_board.html
 - mostra anni, UDA e settimane nella colonna destra;
 - permette di trascinare un paragrafo dentro una UDA;
 - permette di riordinare e rimuovere gli elementi assegnati;
+- permette di compilare una cornice didattica per ogni argomento assegnato;
 - salva la struttura in `doc/course_design.json`;
 - genera `doc/PERCORSO_DIDATTICO.md` a partire dal JSON della board.
+
+## Cornice didattica degli argomenti
+
+Ogni argomento inserito in una UDA puo avere una cornice didattica compilabile dalla board.
+
+I campi disponibili sono:
+
+- `Stato`: avanzamento della progettazione dell'argomento (`todo`, `draft`, `review`, `done`);
+- `Contesto`: dove si colloca l'argomento nel percorso;
+- `Prerequisiti`: cosa gli studenti devono gia sapere;
+- `Obiettivi`: cosa devono saper fare alla fine;
+- `Richiamo`: collegamenti a concetti gia incontrati;
+- `Anticipazione`: concetti che verranno ripresi piu avanti;
+- `Prossimo passo`: cosa studiare o fare subito dopo;
+- `Rimando`: link o riferimenti utili.
+
+Nel file `doc/course_design.json` questi dati vengono salvati dentro il campo `frame` di ogni item.
+
+Nel documento generato `doc/PERCORSO_DIDATTICO.md` vengono mostrati solo i campi compilati, cosi la bozza resta leggibile anche quando molte cornici sono ancora vuote.
 
 ## Generazione del percorso didattico
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -24,8 +24,141 @@ http://127.0.0.1:8765/tools/course_board.html
 - permette di trascinare un paragrafo dentro una UDA;
 - permette di riordinare e rimuovere gli elementi assegnati;
 - permette di compilare una cornice didattica per ogni argomento assegnato;
+- permette di generare una proposta di percorso annuale con `AI assisted percorso`;
 - salva la struttura in `doc/course_design.json`;
 - genera `doc/PERCORSO_DIDATTICO.md` a partire dal JSON della board.
+
+## Generazione AI assisted del percorso annuale
+
+La board puo chiedere alla AI di proporre la struttura di un intero anno scolastico.
+
+Questo flusso e diverso dalla generazione della cornice didattica:
+
+- `AI assisted percorso`: costruisce una proposta di UDA e argomenti per un anno;
+- `AI assisted`: compila la cornice didattica di un singolo argomento gia inserito.
+
+### Flusso consigliato
+
+1. Clicca `AI assisted percorso` sull'anno da progettare.
+2. Si apre un brief didattico modificabile.
+3. Controlla e modifica il brief prima di inviarlo.
+4. Clicca `Genera proposta`.
+5. La board mostra una preview della proposta.
+6. Se la proposta ti convince, clicca `Applica proposta`.
+7. Controlla manualmente la struttura con drag and drop.
+8. Clicca `Salva JSON`.
+
+La proposta non viene applicata automaticamente. Questo evita che la AI sovrascriva il percorso senza revisione docente.
+
+### Brief modificabile
+
+Il brief viene precompilato a partire dai dati dell'anno presenti nel JSON.
+
+Puoi modificare:
+
+- materia;
+- anno;
+- descrizione;
+- ore settimanali;
+- numero di settimane;
+- ore totali;
+- obiettivi didattici;
+- vincoli;
+- preferenze.
+
+Esempi di vincoli utili:
+
+```text
+Usa solo argomenti presenti tra i paragrafi disponibili.
+Non duplicare argomenti nello stesso anno.
+Non inserire argomenti Linux/processi/thread nel terzo anno.
+Non inserire assembly in questa fase.
+Mantieni una progressione dal semplice al complesso.
+Lascia tra i non assegnati gli argomenti non coerenti.
+```
+
+Esempi di preferenze utili:
+
+```text
+Preferire UDA da 3-5 settimane.
+Alternare spiegazione teorica e laboratorio.
+Mettere i puntatori dopo funzioni, array e stringhe.
+Produrre una proposta modificabile, non una soluzione definitiva.
+```
+
+Il brief viene salvato nel JSON dentro il campo `ai_brief` dell'anno quando applichi la proposta e salvi il JSON.
+
+### Cosa viene mandato alla AI per generare il percorso
+
+Per la generazione del percorso annuale il server manda:
+
+- brief modificato dal docente;
+- id dell'anno target;
+- struttura corrente del corso;
+- elenco completo dei paragrafi e sottoparagrafi disponibili;
+- id stabile di ogni paragrafo;
+- titolo;
+- sorgente;
+- livello heading;
+- link relativo;
+- breve estratto locale del testo del paragrafo;
+- vincoli tecnici: usare solo id reali, non duplicare, restituire item come id.
+
+Non viene mandato tutto il testo completo di tutti i paragrafi, per evitare richieste troppo grandi. Per questa fase basta una mappa ragionata degli argomenti con estratti brevi. Il testo completo viene usato invece nella generazione della cornice didattica del singolo argomento.
+
+### Risposta attesa dalla AI
+
+La AI deve restituire una proposta strutturata:
+
+```json
+{
+  "year_id": "terzo-anno",
+  "title": "Terzo anno",
+  "description": "C base e intermedio",
+  "udas": [
+    {
+      "id": "uda-1",
+      "title": "Strumenti e primo programma",
+      "path": "Base",
+      "weeks": "1-3",
+      "items": [
+        "README.md#introduzione",
+        "README.md#variabili"
+      ]
+    }
+  ],
+  "unplaced_topics": [
+    {
+      "id": "README.md#argomento-non-usato",
+      "reason": "Non coerente con i vincoli del terzo anno."
+    }
+  ],
+  "notes": "Note sintetiche sulla proposta."
+}
+```
+
+La AI restituisce solo gli id degli argomenti. Il server poi:
+
+- verifica che ogni id esista davvero;
+- scarta id inventati;
+- evita duplicati;
+- ricostruisce gli item completi per la board;
+- mantiene i sottoparagrafi quando viene scelto un paragrafo padre;
+- produce una preview da revisionare prima dell'applicazione.
+
+### Preview e applicazione
+
+Dopo `Genera proposta`, la board mostra:
+
+- numero di UDA;
+- argomenti assegnati;
+- argomenti non assegnati;
+- tabella con UDA, percorso, settimane e numero di argomenti;
+- eventuali note della AI.
+
+Solo cliccando `Applica proposta` la struttura dell'anno viene sostituita nella UI.
+
+La modifica diventa persistente solo dopo `Salva JSON`.
 
 ## Cornice didattica degli argomenti
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -205,6 +205,159 @@ http://127.0.0.1:8765/tools/course_board.html
 
 Il modello deve restituire dati strutturati; la board accetta solo i campi previsti dalla cornice didattica.
 
+### Come funziona la chiamata AI
+
+Quando clicchi `AI assisted`, la board non manda al modello solo una frase generica.
+
+Il server costruisce un prompt composto da:
+
+- una istruzione di ruolo;
+- il percorso didattico corrente;
+- la UDA corrente;
+- l'argomento target;
+- gli argomenti immediatamente precedenti;
+- gli argomenti immediatamente successivi;
+- i sottoparagrafi dell'argomento target;
+- la posizione dell'argomento nella UDA;
+- il testo reale dei paragrafi estratto dai file locali;
+- i link GitHub ai paragrafi, usati come riferimento.
+
+L'istruzione di ruolo dice al modello di comportarsi come un docente di TPSI e programmazione C, di produrre una cornice didattica in italiano, di non inventare link e di non perdere il contenuto tecnico.
+
+Il modello deve rispondere con una struttura JSON che contiene solo i campi previsti:
+
+```json
+{
+  "context": "...",
+  "prerequisites": "...",
+  "objectives": "...",
+  "recall": "...",
+  "preview": "...",
+  "next_step": "...",
+  "references": "..."
+}
+```
+
+La board prende questa risposta e aggiorna il campo `frame` dell'argomento.
+
+### Perche non basta passare un link GitHub
+
+Un link GitHub e utile per la tracciabilita, ma non garantisce che il modello lo apra e lo legga.
+
+Per questo il server fa una cosa piu affidabile:
+
+1. legge localmente `README.md` o `LINUX_PROGRAMMING.md`;
+2. trova la riga dell'heading dell'argomento;
+3. estrae il testo fino al prossimo heading dello stesso livello o superiore;
+4. ripete l'operazione per i paragrafi vicini;
+5. passa alla AI sia il testo reale sia il link GitHub.
+
+In questo modo la AI non lavora solo sul titolo del paragrafo, ma legge anche il contenuto tecnico effettivo della dispensa.
+
+Per evitare richieste troppo grandi, ogni sezione estratta viene tagliata se supera un limite interno di caratteri.
+
+### Quale contesto viene mandato alla AI
+
+Il payload contiene due blocchi principali:
+
+```json
+{
+  "course": {
+    "years": []
+  },
+  "target": {
+    "year": {},
+    "uda": {},
+    "position": {},
+    "previous_topics": [],
+    "target_topic": {},
+    "next_topics": []
+  }
+}
+```
+
+`course` contiene la struttura sintetica del percorso: anni, UDA, settimane, titoli e argomenti assegnati.
+
+`target` contiene il contesto ravvicinato:
+
+- anno corrente;
+- UDA corrente;
+- posizione dell'argomento nella UDA;
+- fino a due argomenti precedenti;
+- argomento target con testo locale;
+- fino a due argomenti successivi;
+- sottoparagrafi del target.
+
+Il blocco `position` contiene informazioni come:
+
+```json
+{
+  "index_in_uda": 3,
+  "total_items_in_uda": 7,
+  "previous_topics_available": 2,
+  "next_topics_available": 4,
+  "has_subtopics": true,
+  "context_quality": "good"
+}
+```
+
+`context_quality` puo valere:
+
+- `weak`: l'argomento e quasi isolato;
+- `medium`: esiste almeno un vicino o l'argomento ha sottoparagrafi;
+- `good`: esistono argomenti sia prima sia dopo.
+
+### Comportamento migliore per ottenere buone risposte
+
+Il comportamento consigliato e:
+
+1. costruisci prima una piccola sequenza coerente nella UDA;
+2. inserisci almeno un argomento precedente e uno successivo quando possibile;
+3. poi clicca `AI assisted` sull'argomento target;
+4. rileggi la cornice generata;
+5. correggi eventuali anticipazioni, semplificazioni o collegamenti troppo forzati;
+6. clicca `Salva JSON`.
+
+Esempio di sequenza utile:
+
+```text
+Variabili
+Operatori
+If
+Cicli
+Funzioni
+```
+
+Se generi la cornice su `If`, il modello puo capire che:
+
+- prima sono stati introdotti variabili e operatori;
+- dopo verranno introdotti i cicli;
+- l'argomento deve fare da ponte tra espressioni booleane e controllo del flusso.
+
+Se invece l'argomento e da solo nella UDA, la AI puo comunque generare una bozza, ma sara piu generica.
+
+### Indicatore di contesto nella UI
+
+Accanto al bottone `AI assisted` la board mostra un piccolo indicatore:
+
+- `poco contesto`: l'argomento e isolato;
+- `contesto medio`: esiste un vicino oppure ci sono sottoparagrafi;
+- `contesto buono`: ci sono argomenti sia prima sia dopo.
+
+Il bottone non viene mai bloccato. L'indicatore serve solo a suggerire quando conviene costruire meglio la UDA prima di chiedere aiuto alla AI.
+
+### Regola didattica importante
+
+La AI produce una bozza, non una decisione definitiva.
+
+Prima di salvare definitivamente il JSON, controlla sempre che:
+
+- non abbia inventato prerequisiti non affrontati;
+- non abbia anticipato concetti che nel percorso arrivano molto dopo;
+- non abbia perso dettagli tecnici importanti;
+- non abbia creato rimandi generici o inutili;
+- il linguaggio sia adatto alla classe reale.
+
 ### Errori comuni
 
 Se vedi un errore nella barra di stato della board:

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -46,10 +46,10 @@ course_design_as_24_25.json
 course_design_as_25_26.json
 ```
 
-### Salvare una versione in archivio
+### Salvare o aggiornare una versione in archivio
 
 1. Modifica la board.
-2. Clicca `Salva archivio`.
+2. Clicca `Aggiorna archivio`.
 3. Inserisci un nome file `.json`.
 4. La board salva una copia in `doc/course_designs/`.
 
@@ -58,20 +58,20 @@ Il nome puo contenere solo lettere, numeri, trattino, underscore, punto e deve t
 ### Caricare una versione salvata
 
 1. Scegli un file dal select `Percorsi salvati`.
-2. Clicca `Carica`.
+2. Clicca `Carica archiviato`.
 3. La board sostituisce la vista corrente con il JSON archiviato.
 4. Modifica il percorso normalmente.
-5. Usa `Salva archivio` per aggiornare il file archiviato oppure `Salva JSON` per renderlo il percorso corrente.
+5. Usa `Aggiorna archivio` per aggiornare il file archiviato oppure `Imposta corrente` per renderlo il percorso corrente.
 
-### Differenza tra Salva JSON e Salva archivio
+### Differenza tra Imposta corrente e Aggiorna archivio
 
-`Salva JSON` aggiorna:
+`Imposta corrente` aggiorna:
 
 ```text
 doc/course_design.json
 ```
 
-`Salva archivio` aggiorna o crea un file dentro:
+`Aggiorna archivio` aggiorna o crea un file dentro:
 
 ```text
 doc/course_designs/

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -612,6 +612,15 @@ http://127.0.0.1:8765/tools/course_board.html
 
 Il modello deve restituire dati strutturati; la board accetta solo i campi previsti dalla cornice didattica.
 
+Se l'argomento contiene sottoparagrafi, il bottone `AI assisted` apre una coda di generazione per l'intero sottoalbero:
+
+- `Genera prossimo`: genera la cornice del prossimo paragrafo o sottoparagrafo;
+- `Genera tutti`: genera in sequenza tutte le cornici del paragrafo e dei suoi sottoparagrafi;
+- `Chiudi`: termina la coda mantenendo le cornici gia generate nella board;
+- `Annulla`: ripristina le cornici allo stato precedente all'apertura della coda.
+
+La modifica diventa definitiva solo quando clicchi `Salva JSON` o `Imposta corrente`, quindi puoi provare una generazione parziale senza compromettere subito il file.
+
 Anche in questo caso compare l'indicatore di lavoro `AI assisted in corso`. Se la risposta impiega tempo, lascia aperta la finestra: il provider potrebbe richiedere diversi secondi per leggere il contesto e produrre il JSON strutturato.
 
 La generazione della cornice del singolo argomento e di solito piu rapida del percorso annuale, perche usa solo il contesto ravvicinato dell'argomento.

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -46,6 +46,47 @@ Nel file `doc/course_design.json` questi dati vengono salvati dentro il campo `f
 
 Nel documento generato `doc/PERCORSO_DIDATTICO.md` vengono mostrati solo i campi compilati, cosi la bozza resta leggibile anche quando molte cornici sono ancora vuote.
 
+## Compilazione AI assisted della cornice
+
+La board puo chiedere a un servizio AI di compilare automaticamente la cornice didattica di un argomento.
+
+Il browser non chiama direttamente il servizio cloud: la richiesta passa dal server locale `scripts/course_board_server.py`, cosi la chiave API resta nella shell e non viene esposta nel frontend.
+
+### Configurazione OpenAI
+
+Prima di avviare la board, configura la variabile d'ambiente:
+
+```powershell
+$env:OPENAI_API_KEY="sk-..."
+```
+
+Se vuoi scegliere un modello diverso da quello predefinito:
+
+```powershell
+$env:OPENAI_MODEL="gpt-5.5"
+```
+
+Poi avvia normalmente la board:
+
+```bash
+python scripts/course_board_server.py
+```
+
+### Uso nella board
+
+1. Trascina un paragrafo dentro una UDA.
+2. Clicca `AI assisted` sull'argomento assegnato.
+3. Il server invia al modello:
+   - struttura completa del percorso;
+   - anno e UDA corrente;
+   - argomento target;
+   - argomenti immediatamente precedenti e successivi nella stessa UDA;
+   - eventuali sottoparagrafi dell'argomento.
+4. La risposta riempie i campi della cornice didattica e imposta lo stato a `draft`.
+5. Clicca `Salva JSON` per rendere persistenti i campi generati.
+
+Il modello deve restituire dati strutturati; la board accetta solo i campi previsti dalla cornice didattica.
+
 ## Generazione del percorso didattico
 
 Dopo aver modificato e salvato la board, rigenera il documento Markdown:

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -270,6 +270,35 @@ La board supporta questi provider dichiarati in `config/ai_providers.yaml`:
 | Groq | `AI_PROVIDER=groq` | `GROQ_API_KEY` | `GROQ_MODEL` |
 | OpenRouter | `AI_PROVIDER=openrouter` | `OPENROUTER_API_KEY` | `OPENROUTER_MODEL` |
 
+### Quale provider conviene usare
+
+L'ordine consigliato, per il lavoro sulla cornice didattica, e questo:
+
+| Priorita | Provider | Quando usarlo | Perche |
+| --- | --- | --- | --- |
+| 1 | Groq | Cornici singole o code di sottoparagrafi | E veloce, nel test ha retto il contesto compatto piu ampio e ha prodotto JSON utilizzabile. Il limite principale e il TPM: troppe richieste ravvicinate possono generare `429`. |
+| 2 | Gemini | Quando serve una risposta piu ragionata e il free tier e disponibile | Tende a essere buono nella qualita didattica e nel JSON strutturato. Il limite principale e la quota free: quando finisce, risponde con `429` o errori temporanei. |
+| 3 | OpenAI | Quando vuoi massima stabilita e accetti il costo API | E il provider piu adatto se vuoi affidabilita, contesto ricco e meno rumore da free tier. Attenzione: il billing API e separato da ChatGPT/Codex. |
+| 4 | OpenRouter free | Solo come fallback leggero | Il router gratuito puo cambiare modello a monte, restituire JSON instabile o andare in rate limit upstream. Nei test e risultato il meno prevedibile. |
+
+In pratica:
+
+- per lavorare tutti i giorni sulla board, parti da `Groq`;
+- se Groq va in TPM, aspetta un minuto o passa temporaneamente a `Gemini`;
+- se Gemini ha quota esaurita, torna a `Groq`;
+- usa `OpenRouter free` solo per prove leggere;
+- usa `OpenAI` se vuoi privilegiare stabilita e qualita rispetto al costo.
+
+I valori compatti consigliati dai test locali sono:
+
+```text
+GROQ_COMPACT_TEXT_CHARS=6360
+GEMINI_COMPACT_TEXT_CHARS=3022
+OPENROUTER_COMPACT_TEXT_CHARS=404
+```
+
+Questi numeri non sono assoluti: dipendono dal modello, dal piano, dai rate limit e dal carico del provider. Sono valori prudenti per evitare di mandare payload troppo grandi durante la generazione delle cornici.
+
 Se non imposti `AI_PROVIDER`, il server usa `openai`.
 
 `ChatGPT Free` non e un provider API per automazioni locali: e l'interfaccia web/app di ChatGPT. Per questo non viene usato direttamente dalla board, perche richiederebbe automazioni fragili del browser e non una integrazione API pulita.

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -473,6 +473,130 @@ Nel browser apri:
 http://127.0.0.1:8765/tools/course_board.html
 ```
 
+### Guida Groq
+
+Groq puo essere utile come provider veloce per modelli open, con piani free/dev soggetti a rate limit dell'account.
+
+#### 1. Recupera la API key Groq
+
+1. Apri `https://console.groq.com/`.
+2. Accedi o crea un account.
+3. Vai nella sezione API keys.
+4. Crea una nuova API key.
+5. Copiala e conservala in un posto sicuro.
+
+#### 2. Configura le variabili su Windows PowerShell
+
+Queste variabili valgono solo per la finestra PowerShell corrente:
+
+```powershell
+$env:AI_PROVIDER="groq"
+$env:GROQ_API_KEY="..."
+$env:GROQ_MODEL="llama-3.3-70b-versatile"
+```
+
+Poi avvia il server:
+
+```powershell
+python scripts/course_board_server.py
+```
+
+#### 3. Configura le variabili su Linux/macOS
+
+Queste variabili valgono solo per il terminale corrente:
+
+```bash
+export AI_PROVIDER="groq"
+export GROQ_API_KEY="..."
+export GROQ_MODEL="llama-3.3-70b-versatile"
+```
+
+Poi avvia il server:
+
+```bash
+python scripts/course_board_server.py
+```
+
+#### 4. Configurazione tramite `.secrets/ai.secret`
+
+In alternativa puoi salvare la chiave nel file locale non versionato:
+
+```text
+GROQ_API_KEY=...
+```
+
+Poi riavvia il server.
+
+#### 5. Apri la board
+
+Nel browser apri:
+
+```text
+http://127.0.0.1:8765/tools/course_board.html
+```
+
+### Guida OpenRouter
+
+OpenRouter puo essere utile come router di modelli gratuiti o low-cost. E importante controllare il modello scelto, per evitare fallback non desiderati.
+
+#### 1. Recupera la API key OpenRouter
+
+1. Apri `https://openrouter.ai/`.
+2. Accedi o crea un account.
+3. Vai nella sezione Keys.
+4. Crea una nuova API key.
+5. Copiala e conservala in un posto sicuro.
+
+#### 2. Configura le variabili su Windows PowerShell
+
+Queste variabili valgono solo per la finestra PowerShell corrente:
+
+```powershell
+$env:AI_PROVIDER="openrouter"
+$env:OPENROUTER_API_KEY="..."
+$env:OPENROUTER_MODEL="openrouter/free"
+```
+
+Poi avvia il server:
+
+```powershell
+python scripts/course_board_server.py
+```
+
+#### 3. Configura le variabili su Linux/macOS
+
+Queste variabili valgono solo per il terminale corrente:
+
+```bash
+export AI_PROVIDER="openrouter"
+export OPENROUTER_API_KEY="..."
+export OPENROUTER_MODEL="openrouter/free"
+```
+
+Poi avvia il server:
+
+```bash
+python scripts/course_board_server.py
+```
+
+#### 4. Configurazione tramite `.secrets/ai.secret`
+
+In alternativa puoi salvare la chiave nel file locale non versionato:
+
+```text
+OPENROUTER_API_KEY=...
+```
+
+Poi riavvia il server.
+
+#### 5. Apri la board
+
+Nel browser apri:
+
+```text
+http://127.0.0.1:8765/tools/course_board.html
+```
+
 ### Uso di AI assisted nella board
 
 1. Trascina un paragrafo dentro una UDA.

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -732,6 +732,50 @@ Per evitare errori di quota o limiti di token, Groq e OpenRouter ricevono una ve
 
 OpenAI e Gemini ricevono invece il contesto piu esteso. In pratica Groq e OpenRouter sono utili per prove rapide e modelli free/low-cost, mentre OpenAI e Gemini possono dare risposte piu contestualizzate quando il testo e lungo.
 
+Il limite di testo usato per il contesto compatto e configurabile:
+
+```text
+GROQ_COMPACT_TEXT_CHARS=1200
+OPENROUTER_COMPACT_TEXT_CHARS=1200
+```
+
+Puoi inserire questi valori come variabili d'ambiente oppure nel file locale `.secrets/ai.secret`.
+
+### Calibrare il payload massimo per Groq e OpenRouter
+
+Groq e OpenRouter non hanno un limite pratico unico valido per sempre: il massimo dipende da provider, modello, account, free tier, rate limit e richieste gia inviate nell'ultimo minuto.
+
+Per trovare un valore piu ricco ma ancora sicuro puoi usare:
+
+```powershell
+python scripts/probe_ai_payload_limit.py --provider groq --max-chars 8000
+```
+
+Oppure:
+
+```powershell
+python scripts/probe_ai_payload_limit.py --provider openrouter --max-chars 12000
+```
+
+Lo script:
+
+1. legge la API key da variabili d'ambiente o `.secrets/ai.secret`;
+2. costruisce un payload simile a quello della cornice didattica;
+3. prova dimensioni crescenti con ricerca binaria;
+4. stampa il massimo riuscito;
+5. propone un valore consigliato con margine di sicurezza.
+
+Esempio di risultato:
+
+```text
+Risultato
+- massimo riuscito: 4200 caratteri target
+- valore consigliato con safety 0.80: 3360
+- variabile da impostare: GROQ_COMPACT_TEXT_CHARS=3360
+```
+
+Se ricevi errori di tipo TPM, attendi circa un minuto prima di rilanciare il probe: il provider potrebbe aver contato anche le richieste precedenti.
+
 Il blocco `position` contiene informazioni come:
 
 ```json

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -211,12 +211,14 @@ Se non imposti `AI_PROVIDER`, il server usa `openai`.
 
 `ChatGPT Free` non e un provider API per automazioni locali: e l'interfaccia web/app di ChatGPT. Per questo non viene usato direttamente dalla board, perche richiederebbe automazioni fragili del browser e non una integrazione API pulita.
 
-La board mostra nella sezione `Percorso didattico` la configurazione AI attiva:
+La board mostra nella sezione `Percorso didattico` la configurazione AI attiva e permette di cambiare provider tramite select:
 
 - provider selezionato;
 - modello selezionato;
 - presenza o assenza della API key;
 - nota su quota, billing o free tier.
+
+Il cambio provider funziona solo se la API key del provider scelto e gia presente nelle variabili d'ambiente del server locale. Se scegli un provider non configurato, la board mantiene il provider precedente e mostra un messaggio di errore.
 
 La board non mostra mai il valore della API key. Inoltre non puo sapere con certezza se il tuo account stia usando un piano gratuito, credito residuo o billing a pagamento: puo solo mostrare il provider configurato e una nota orientativa.
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -52,54 +52,145 @@ La board puo chiedere a un servizio AI di compilare automaticamente la cornice d
 
 Il browser non chiama direttamente il servizio cloud: la richiesta passa dal server locale `scripts/course_board_server.py`, cosi la chiave API resta nella shell e non viene esposta nel frontend.
 
-### Provider supportati
+### Idea generale
+
+Il flusso e sempre lo stesso:
+
+1. scegli un provider AI;
+2. recuperi una API key dal sito del provider;
+3. imposti le variabili d'ambiente nella shell;
+4. avvii il server locale della board;
+5. apri la board nel browser;
+6. clicchi `AI assisted` su un argomento assegnato a una UDA;
+7. controlli il testo generato;
+8. clicchi `Salva JSON`.
 
 La board supporta questi provider:
 
-- `openai`: usa OpenAI API e la variabile `OPENAI_API_KEY`;
-- `gemini`: usa Gemini API e la variabile `GEMINI_API_KEY`.
+| Provider | Variabile provider | Variabile API key | Variabile modello opzionale |
+| --- | --- | --- | --- |
+| OpenAI | `AI_PROVIDER=openai` | `OPENAI_API_KEY` | `OPENAI_MODEL` |
+| Gemini | `AI_PROVIDER=gemini` | `GEMINI_API_KEY` | `GEMINI_MODEL` |
+
+Se non imposti `AI_PROVIDER`, il server usa `openai`.
 
 `ChatGPT Free` non e un provider API per automazioni locali: e l'interfaccia web/app di ChatGPT. Per questo non viene usato direttamente dalla board, perche richiederebbe automazioni fragili del browser e non una integrazione API pulita.
 
-### Configurazione OpenAI
+### Regola di sicurezza importante
 
-Prima di avviare la board, configura la variabile d'ambiente:
+Non scrivere mai una API key dentro:
+
+- `README.md`;
+- `doc/course_design.json`;
+- file `.js`;
+- file `.html`;
+- commit Git.
+
+La API key deve stare solo nella shell, in una variabile d'ambiente locale.
+
+### Guida OpenAI
+
+#### 1. Recupera la API key OpenAI
+
+1. Apri `https://platform.openai.com/`.
+2. Accedi con il tuo account.
+3. Vai nella sezione delle API keys.
+4. Crea una nuova secret key.
+5. Copiala subito e conservala in un posto sicuro, perche di solito viene mostrata una sola volta.
+
+#### 2. Configura le variabili su Windows PowerShell
+
+Queste variabili valgono solo per la finestra PowerShell corrente:
 
 ```powershell
 $env:AI_PROVIDER="openai"
 $env:OPENAI_API_KEY="sk-..."
-```
-
-Se vuoi scegliere un modello diverso da quello predefinito:
-
-```powershell
 $env:OPENAI_MODEL="gpt-5.5"
 ```
 
-### Configurazione Gemini
-
-Gemini puo essere utile per prove a costo zero o a basso costo, in base ai limiti del free tier disponibili sul tuo account Google AI Studio.
-
-Configura:
+Poi avvia il server:
 
 ```powershell
-$env:AI_PROVIDER="gemini"
-$env:GEMINI_API_KEY="..."
+python scripts/course_board_server.py
 ```
 
-Se vuoi scegliere un modello diverso da quello predefinito:
+#### 3. Configura le variabili su Linux/macOS
 
-```powershell
-$env:GEMINI_MODEL="gemini-3-flash-preview"
+Queste variabili valgono solo per il terminale corrente:
+
+```bash
+export AI_PROVIDER="openai"
+export OPENAI_API_KEY="sk-..."
+export OPENAI_MODEL="gpt-5.5"
 ```
 
-Poi avvia normalmente la board:
+Poi avvia il server:
 
 ```bash
 python scripts/course_board_server.py
 ```
 
-### Uso nella board
+#### 4. Apri la board
+
+Nel browser apri:
+
+```text
+http://127.0.0.1:8765/tools/course_board.html
+```
+
+### Guida Gemini
+
+Gemini puo essere utile per prove a costo zero o a basso costo, in base ai limiti del free tier disponibili sul tuo account Google AI Studio.
+
+#### 1. Recupera la API key Gemini
+
+1. Apri `https://aistudio.google.com/`.
+2. Accedi con il tuo account Google.
+3. Vai nella sezione API keys.
+4. Crea una nuova API key.
+5. Copiala e conservala in un posto sicuro.
+
+#### 2. Configura le variabili su Windows PowerShell
+
+Queste variabili valgono solo per la finestra PowerShell corrente:
+
+```powershell
+$env:AI_PROVIDER="gemini"
+$env:GEMINI_API_KEY="..."
+$env:GEMINI_MODEL="gemini-3-flash-preview"
+```
+
+Poi avvia il server:
+
+```powershell
+python scripts/course_board_server.py
+```
+
+#### 3. Configura le variabili su Linux/macOS
+
+Queste variabili valgono solo per il terminale corrente:
+
+```bash
+export AI_PROVIDER="gemini"
+export GEMINI_API_KEY="..."
+export GEMINI_MODEL="gemini-3-flash-preview"
+```
+
+Poi avvia il server:
+
+```bash
+python scripts/course_board_server.py
+```
+
+#### 4. Apri la board
+
+Nel browser apri:
+
+```text
+http://127.0.0.1:8765/tools/course_board.html
+```
+
+### Uso di AI assisted nella board
 
 1. Trascina un paragrafo dentro una UDA.
 2. Clicca `AI assisted` sull'argomento assegnato.
@@ -113,6 +204,17 @@ python scripts/course_board_server.py
 5. Clicca `Salva JSON` per rendere persistenti i campi generati.
 
 Il modello deve restituire dati strutturati; la board accetta solo i campi previsti dalla cornice didattica.
+
+### Errori comuni
+
+Se vedi un errore nella barra di stato della board:
+
+- `Configura OPENAI_API_KEY`: hai scelto OpenAI ma non hai impostato la chiave;
+- `Configura GEMINI_API_KEY`: hai scelto Gemini ma non hai impostato la chiave;
+- `Provider AI non supportato`: `AI_PROVIDER` contiene un valore diverso da `openai` o `gemini`;
+- errore `401` o `403`: chiave non valida, scaduta o non autorizzata;
+- errore `429`: quota o rate limit superato;
+- errore `500`: controlla il terminale dove e avviato il server, perche li trovi il dettaglio tecnico.
 
 ## Generazione del percorso didattico
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -802,7 +802,9 @@ Se vedi un errore nella barra di stato della board:
 - `Configura GEMINI_API_KEY`: hai scelto Gemini ma non hai impostato la chiave;
 - `Provider AI non supportato`: `AI_PROVIDER` contiene un valore diverso da `openai` o `gemini`;
 - errore `401` o `403`: chiave non valida, scaduta o non autorizzata;
+- errore Groq `403` con codice `1010`: probabile blocco lato Groq/Cloudflare/rete/account, non errore della board;
 - errore `429`: quota o rate limit superato;
+- messaggio `non ha compilato nessun campo`: il provider ha risposto con JSON vuoto o non compatibile; prova un altro modello o provider;
 - errore `500`: controlla il terminale dove e avviato il server, perche li trovi il dettaglio tecnico.
 
 ## Generazione del percorso didattico

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -159,6 +159,8 @@ Per la generazione del percorso annuale il server manda:
 
 Non viene mandato tutto il testo completo di tutti i paragrafi, per evitare richieste troppo grandi. Per questa fase basta una mappa ragionata degli argomenti con estratti brevi. Il testo completo viene usato invece nella generazione della cornice didattica del singolo argomento.
 
+La generazione del percorso annuale e piu pesante della generazione della singola cornice: puo richiedere anche 1-3 minuti, soprattutto con modelli gratuiti o molto richiesti. Il server usa un timeout piu lungo per questa operazione e invia estratti brevi dei paragrafi per ridurre tempi e costo.
+
 ### Risposta attesa dalla AI
 
 La AI deve restituire una proposta strutturata:
@@ -403,6 +405,8 @@ http://127.0.0.1:8765/tools/course_board.html
 Il modello deve restituire dati strutturati; la board accetta solo i campi previsti dalla cornice didattica.
 
 Anche in questo caso compare l'indicatore di lavoro `AI assisted in corso`. Se la risposta impiega tempo, lascia aperta la finestra: il provider potrebbe richiedere diversi secondi per leggere il contesto e produrre il JSON strutturato.
+
+La generazione della cornice del singolo argomento e di solito piu rapida del percorso annuale, perche usa solo il contesto ravvicinato dell'argomento.
 
 ### Come funziona la chiamata AI
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -744,17 +744,26 @@ OpenAI e Gemini ricevono invece il contesto piu esteso. In pratica Groq e OpenRo
 Il limite di testo usato per il contesto compatto e configurabile:
 
 ```text
-GROQ_COMPACT_TEXT_CHARS=1200
-OPENROUTER_COMPACT_TEXT_CHARS=1200
+GEMINI_COMPACT_TEXT_CHARS=3022
+GROQ_COMPACT_TEXT_CHARS=6360
+OPENROUTER_COMPACT_TEXT_CHARS=404
 ```
 
 Puoi inserire questi valori come variabili d'ambiente oppure nel file locale `.secrets/ai.secret`.
 
-### Calibrare il payload massimo per Groq e OpenRouter
+Per Gemini il contesto compatto viene usato solo se imposti esplicitamente `GEMINI_COMPACT_TEXT_CHARS`. Se non la imposti, Gemini continua a ricevere il contesto esteso.
 
-Groq e OpenRouter non hanno un limite pratico unico valido per sempre: il massimo dipende da provider, modello, account, free tier, rate limit e richieste gia inviate nell'ultimo minuto.
+### Calibrare il payload massimo per Gemini, Groq e OpenRouter
+
+Gemini, Groq e OpenRouter non hanno un limite pratico unico valido per sempre: il massimo dipende da provider, modello, account, free tier, rate limit e richieste gia inviate nell'ultimo minuto.
 
 Per trovare un valore piu ricco ma ancora sicuro puoi usare:
+
+```powershell
+python scripts/probe_ai_payload_limit.py --provider gemini --model gemini-3-flash-preview --max-chars 12000
+```
+
+Oppure:
 
 ```powershell
 python scripts/probe_ai_payload_limit.py --provider groq --max-chars 8000

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -211,6 +211,15 @@ Se non imposti `AI_PROVIDER`, il server usa `openai`.
 
 `ChatGPT Free` non e un provider API per automazioni locali: e l'interfaccia web/app di ChatGPT. Per questo non viene usato direttamente dalla board, perche richiederebbe automazioni fragili del browser e non una integrazione API pulita.
 
+La board mostra nella sezione `Percorso didattico` la configurazione AI attiva:
+
+- provider selezionato;
+- modello selezionato;
+- presenza o assenza della API key;
+- nota su quota, billing o free tier.
+
+La board non mostra mai il valore della API key. Inoltre non puo sapere con certezza se il tuo account stia usando un piano gratuito, credito residuo o billing a pagamento: puo solo mostrare il provider configurato e una nota orientativa.
+
 ### Regola di sicurezza importante
 
 Non scrivere mai una API key dentro:

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -724,6 +724,14 @@ Il payload contiene due blocchi principali:
 - fino a due argomenti successivi;
 - sottoparagrafi del target.
 
+Per evitare errori di quota o limiti di token, Groq e OpenRouter ricevono una versione compatta del contesto quando generano la cornice didattica:
+
+- mantengono anno, UDA, posizione dell'argomento, titoli precedenti, titolo corrente, titoli successivi e sottoparagrafi;
+- includono il testo dell'argomento corrente, ma lo tagliano se e troppo lungo;
+- non includono il testo completo degli argomenti vicini.
+
+OpenAI e Gemini ricevono invece il contesto piu esteso. In pratica Groq e OpenRouter sono utili per prove rapide e modelli free/low-cost, mentre OpenAI e Gemini possono dare risposte piu contestualizzate quando il testo e lungo.
+
 Il blocco `position` contiene informazioni come:
 
 ```json

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -52,11 +52,21 @@ La board puo chiedere a un servizio AI di compilare automaticamente la cornice d
 
 Il browser non chiama direttamente il servizio cloud: la richiesta passa dal server locale `scripts/course_board_server.py`, cosi la chiave API resta nella shell e non viene esposta nel frontend.
 
+### Provider supportati
+
+La board supporta questi provider:
+
+- `openai`: usa OpenAI API e la variabile `OPENAI_API_KEY`;
+- `gemini`: usa Gemini API e la variabile `GEMINI_API_KEY`.
+
+`ChatGPT Free` non e un provider API per automazioni locali: e l'interfaccia web/app di ChatGPT. Per questo non viene usato direttamente dalla board, perche richiederebbe automazioni fragili del browser e non una integrazione API pulita.
+
 ### Configurazione OpenAI
 
 Prima di avviare la board, configura la variabile d'ambiente:
 
 ```powershell
+$env:AI_PROVIDER="openai"
 $env:OPENAI_API_KEY="sk-..."
 ```
 
@@ -64,6 +74,23 @@ Se vuoi scegliere un modello diverso da quello predefinito:
 
 ```powershell
 $env:OPENAI_MODEL="gpt-5.5"
+```
+
+### Configurazione Gemini
+
+Gemini puo essere utile per prove a costo zero o a basso costo, in base ai limiti del free tier disponibili sul tuo account Google AI Studio.
+
+Configura:
+
+```powershell
+$env:AI_PROVIDER="gemini"
+$env:GEMINI_API_KEY="..."
+```
+
+Se vuoi scegliere un modello diverso da quello predefinito:
+
+```powershell
+$env:GEMINI_MODEL="gemini-3-flash-preview"
 ```
 
 Poi avvia normalmente la board:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -151,6 +151,18 @@ def secret_value(key: str) -> str:
     return os.environ.get(key, "") or read_secret_env().get(key, "")
 
 
+def secret_int_value(key: str, default: int) -> int:
+    """Return an integer setting from environment or local secret file."""
+
+    raw_value = secret_value(key)
+    if not raw_value:
+        return default
+    try:
+        return int(raw_value)
+    except ValueError:
+        return default
+
+
 def parse_ai_providers_yaml() -> dict:
     """Parse the small YAML subset used by config/ai_providers.yaml."""
 
@@ -911,6 +923,7 @@ def compact_frame_payload(payload: dict) -> dict:
 def compact_topic(topic: dict, include_text: bool) -> dict:
     """Return a compact topic with optional truncated text and child titles."""
 
+    text_limit = secret_int_value(f"{ACTIVE_AI_PROVIDER.upper()}_COMPACT_TEXT_CHARS", COMPACT_TEXT_CHARS)
     compact = {
         "title": topic.get("title", ""),
         "source": topic.get("source", ""),
@@ -927,8 +940,8 @@ def compact_topic(topic: dict, include_text: bool) -> dict:
     }
     if include_text:
         text = str(topic.get("text", ""))
-        compact["text"] = text[:COMPACT_TEXT_CHARS].rstrip()
-        if len(text) > COMPACT_TEXT_CHARS:
+        compact["text"] = text[:text_limit].rstrip()
+        if len(text) > text_limit:
             compact["text"] += "\n[contenuto tagliato per provider con limite token]"
     return compact
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -772,6 +772,27 @@ def call_ai_course_plan(payload: dict) -> dict:
     raise RuntimeError(f"Provider AI non supportato: {provider}. Usa AI_PROVIDER=openai oppure AI_PROVIDER=gemini.")
 
 
+def ai_config() -> dict:
+    """Return safe AI provider configuration for the board UI."""
+
+    provider = os.environ.get("AI_PROVIDER", "openai").strip().lower()
+    if provider == "gemini":
+      model = os.environ.get("GEMINI_MODEL") or os.environ.get("AI_MODEL", "gemini-3-flash-preview")
+      return {
+          "provider": "gemini",
+          "model": model,
+          "api_key_configured": bool(os.environ.get("GEMINI_API_KEY")),
+          "billing_note": "Gemini puo avere free tier su Google AI Studio, ma quota e limiti dipendono dall'account.",
+      }
+    model = os.environ.get("OPENAI_MODEL") or os.environ.get("AI_MODEL", "gpt-5.5")
+    return {
+        "provider": provider,
+        "model": model,
+        "api_key_configured": bool(os.environ.get("OPENAI_API_KEY")),
+        "billing_note": "OpenAI API usa quota/billing API separati da ChatGPT Free/Plus.",
+    }
+
+
 class CourseBoardHandler(BaseHTTPRequestHandler):
     """HTTP handler for the local board and its JSON API."""
 
@@ -782,6 +803,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/api/course-design":
             self.write_json(read_design())
+            return
+        if parsed.path == "/api/ai-config":
+            self.write_json(ai_config())
             return
         self.serve_static(parsed.path)
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -346,30 +346,42 @@ def target_context(design: dict, year_id: str, uda_id: str, item_id: str) -> dic
         for uda in year.get("udas", []):
             if uda.get("id") != uda_id:
                 continue
-            items = uda.get("items", [])
-            for index, item in enumerate(items):
-                if item.get("id") == item_id:
-                    previous_topics = items[max(0, index - 2):index]
-                    next_topics = items[index + 1:index + 3]
-                    return {
-                        "year": {key: year.get(key, "") for key in ["id", "title", "description"]},
-                        "uda": {key: uda.get(key, "") for key in ["id", "title", "path", "weeks"]},
-                        "position": topic_position(index, items, item),
-                        "previous_topics": [
-                            topic_summary(candidate, include_text=True)
-                            for candidate in previous_topics
-                        ],
-                        "target_topic": topic_summary(
-                            item,
-                            include_text=True,
-                            child_text_budget=MAX_CHILDREN_WITH_TEXT,
-                        ),
-                        "next_topics": [
-                            topic_summary(candidate, include_text=True)
-                            for candidate in next_topics
-                        ],
-                    }
+            found = find_item_context(uda.get("items", []), item_id)
+            if found:
+                index, siblings, item = found
+                previous_topics = siblings[max(0, index - 2):index]
+                next_topics = siblings[index + 1:index + 3]
+                return {
+                    "year": {key: year.get(key, "") for key in ["id", "title", "description"]},
+                    "uda": {key: uda.get(key, "") for key in ["id", "title", "path", "weeks"]},
+                    "position": topic_position(index, siblings, item),
+                    "previous_topics": [
+                        topic_summary(candidate, include_text=True)
+                        for candidate in previous_topics
+                    ],
+                    "target_topic": topic_summary(
+                        item,
+                        include_text=True,
+                        child_text_budget=MAX_CHILDREN_WITH_TEXT,
+                    ),
+                    "next_topics": [
+                        topic_summary(candidate, include_text=True)
+                        for candidate in next_topics
+                    ],
+                }
     raise ValueError("Argomento non trovato nel percorso didattico corrente.")
+
+
+def find_item_context(items: list[dict], item_id: str) -> tuple[int, list[dict], dict] | None:
+    """Find an item at any nesting level, returning its index and siblings."""
+
+    for index, item in enumerate(items):
+        if item.get("id") == item_id:
+            return index, items, item
+        found = find_item_context(item.get("children", []), item_id)
+        if found:
+            return found
+    return None
 
 
 def topic_position(index: int, items: list[dict], item: dict) -> dict:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -30,6 +30,7 @@ from urllib.parse import unquote, urlparse
 ROOT = Path(__file__).resolve().parents[1]
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 DEFAULT_SOURCES = ["README.md", "LINUX_PROGRAMMING.md"]
+ACTIVE_AI_PROVIDER = os.environ.get("AI_PROVIDER", "openai").strip().lower()
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 TAG_RE = re.compile(r"<[^>]+>")
 PUNCT_RE = re.compile(r"[^\w\s-]", re.UNICODE)
@@ -664,7 +665,7 @@ def call_gemini_didactic_frame(payload: dict) -> dict:
 def call_ai_didactic_frame(payload: dict) -> dict:
     """Route didactic-frame generation to the configured AI provider."""
 
-    provider = os.environ.get("AI_PROVIDER", "openai").strip().lower()
+    provider = ACTIVE_AI_PROVIDER
     if provider == "openai":
         return call_openai_didactic_frame(payload)
     if provider == "gemini":
@@ -764,7 +765,7 @@ def call_gemini_course_plan(payload: dict) -> dict:
 def call_ai_course_plan(payload: dict) -> dict:
     """Route annual course-plan generation to the configured AI provider."""
 
-    provider = os.environ.get("AI_PROVIDER", "openai").strip().lower()
+    provider = ACTIVE_AI_PROVIDER
     if provider == "openai":
         return call_openai_course_plan(payload)
     if provider == "gemini":
@@ -775,22 +776,50 @@ def call_ai_course_plan(payload: dict) -> dict:
 def ai_config() -> dict:
     """Return safe AI provider configuration for the board UI."""
 
-    provider = os.environ.get("AI_PROVIDER", "openai").strip().lower()
-    if provider == "gemini":
-      model = os.environ.get("GEMINI_MODEL") or os.environ.get("AI_MODEL", "gemini-3-flash-preview")
-      return {
-          "provider": "gemini",
-          "model": model,
-          "api_key_configured": bool(os.environ.get("GEMINI_API_KEY")),
-          "billing_note": "Gemini puo avere free tier su Google AI Studio, ma quota e limiti dipendono dall'account.",
-      }
-    model = os.environ.get("OPENAI_MODEL") or os.environ.get("AI_MODEL", "gpt-5.5")
+    providers = ai_providers()
+    active = providers.get(ACTIVE_AI_PROVIDER) or providers["openai"]
     return {
-        "provider": provider,
-        "model": model,
-        "api_key_configured": bool(os.environ.get("OPENAI_API_KEY")),
-        "billing_note": "OpenAI API usa quota/billing API separati da ChatGPT Free/Plus.",
+        "provider": active["id"],
+        "model": active["model"],
+        "api_key_configured": active["api_key_configured"],
+        "billing_note": active["billing_note"],
+        "providers": list(providers.values()),
     }
+
+
+def ai_providers() -> dict:
+    """Return all server-supported providers with safe configuration status."""
+
+    return {
+        "openai": {
+            "id": "openai",
+            "label": "OpenAI",
+            "model": os.environ.get("OPENAI_MODEL") or os.environ.get("AI_MODEL", "gpt-5.5"),
+            "api_key_configured": bool(os.environ.get("OPENAI_API_KEY")),
+            "billing_note": "OpenAI API usa quota/billing API separati da ChatGPT Free/Plus.",
+        },
+        "gemini": {
+            "id": "gemini",
+            "label": "Gemini",
+            "model": os.environ.get("GEMINI_MODEL") or os.environ.get("AI_MODEL", "gemini-3-flash-preview"),
+            "api_key_configured": bool(os.environ.get("GEMINI_API_KEY")),
+            "billing_note": "Gemini puo avere free tier su Google AI Studio, ma quota e limiti dipendono dall'account.",
+        },
+    }
+
+
+def set_ai_provider(provider: str) -> dict:
+    """Set the active provider only when the server has its API key."""
+
+    global ACTIVE_AI_PROVIDER
+    provider = provider.strip().lower()
+    providers = ai_providers()
+    if provider not in providers:
+        raise RuntimeError(f"Provider AI non supportato: {provider}.")
+    if not providers[provider]["api_key_configured"]:
+        raise RuntimeError(f"Provider {providers[provider]['label']} non configurato: API key mancante.")
+    ACTIVE_AI_PROVIDER = provider
+    return ai_config()
 
 
 class CourseBoardHandler(BaseHTTPRequestHandler):
@@ -816,6 +845,15 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/course-design":
             write_design(payload)
             self.write_json({"ok": True, "path": str(DESIGN_PATH.relative_to(ROOT))})
+            return
+        if parsed.path == "/api/ai-config":
+            try:
+                self.write_json(set_ai_provider(payload.get("provider", "")))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
             return
         if parsed.path == "/api/ai-frame":
             try:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -629,7 +629,15 @@ def course_plan_system_prompt() -> str:
 def normalize_frame(result: dict) -> dict:
     """Keep only the expected didactic-frame fields as stripped strings."""
 
-    return {field: str(result.get(field, "")).strip() for field in AI_FRAME_FIELDS}
+    if isinstance(result.get("frame"), dict):
+        result = result["frame"]
+    frame = {field: str(result.get(field, "")).strip() for field in AI_FRAME_FIELDS}
+    if not any(frame.values()):
+        raise RuntimeError(
+            "Il provider AI ha risposto correttamente, ma non ha compilato nessun campo della cornice didattica. "
+            "Prova un modello diverso o un provider diverso."
+        )
+    return frame
 
 
 def normalize_course_plan(raw: dict, design: dict, year_id: str) -> dict:
@@ -858,7 +866,7 @@ def call_groq_didactic_frame(payload: dict) -> dict:
         "https://api.groq.com/openai/v1/chat/completions",
         api_key,
         active_ai_model(),
-        didactic_frame_system_prompt() + " Restituisci solo JSON con i campi richiesti.",
+        didactic_frame_system_prompt() + " Restituisci solo JSON con questi campi top-level: context, prerequisites, objectives, recall, preview, next_step, references.",
         payload,
     )
     return normalize_frame(result)
@@ -875,7 +883,7 @@ def call_openrouter_didactic_frame(payload: dict) -> dict:
         "https://openrouter.ai/api/v1/chat/completions",
         api_key,
         active_ai_model(),
-        didactic_frame_system_prompt() + " Restituisci solo JSON con i campi richiesti.",
+        didactic_frame_system_prompt() + " Restituisci solo JSON con questi campi top-level: context, prerequisites, objectives, recall, preview, next_step, references.",
         payload,
     )
     return normalize_frame(result)

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -803,7 +803,7 @@ def call_gemini_didactic_frame(payload: dict) -> dict:
         "contents": [
             {
                 "role": "user",
-                "parts": [{"text": json.dumps(payload, ensure_ascii=False, indent=2)}],
+                "parts": [{"text": json.dumps(gemini_frame_payload(payload), ensure_ascii=False, indent=2)}],
             }
         ],
         "generationConfig": {
@@ -830,6 +830,14 @@ def call_gemini_didactic_frame(payload: dict) -> dict:
         raise RuntimeError("La risposta Gemini non contiene testo utilizzabile.") from error
 
     return normalize_frame(json.loads(output_text))
+
+
+def gemini_frame_payload(payload: dict) -> dict:
+    """Use compact Gemini context only when explicitly configured."""
+
+    if secret_value("GEMINI_COMPACT_TEXT_CHARS"):
+        return compact_frame_payload(payload)
+    return payload
 
 
 def call_chat_completions_json(provider_name: str, url: str, api_key: str, model: str, system_prompt: str, payload: dict) -> dict:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -55,6 +55,7 @@ MAX_CHILDREN_WITH_TEXT = 8
 MAX_CATALOG_EXCERPT_CHARS = 400
 AI_FRAME_TIMEOUT_SECONDS = 120
 AI_COURSE_PLAN_TIMEOUT_SECONDS = 240
+COMPACT_TEXT_CHARS = 1200
 
 
 def github_anchor(title: str, seen: dict[str, int]) -> str:
@@ -873,6 +874,65 @@ def parse_json_object(text: str) -> dict:
     return json.loads(text)
 
 
+def compact_frame_payload(payload: dict) -> dict:
+    """Reduce frame-generation context for providers with strict token limits."""
+
+    target = payload.get("target", {})
+    return {
+        "course": {
+            "years": [
+                {
+                    "title": year.get("title", ""),
+                    "description": year.get("description", ""),
+                    "udas": [
+                        {
+                            "title": uda.get("title", ""),
+                            "path": uda.get("path", ""),
+                            "weeks": uda.get("weeks", ""),
+                        }
+                        for uda in year.get("udas", [])
+                    ],
+                }
+                for year in payload.get("course", {}).get("years", [])
+            ]
+        },
+        "target": {
+            "year": target.get("year", {}),
+            "uda": target.get("uda", {}),
+            "position": target.get("position", {}),
+            "previous_topics": [compact_topic(topic, include_text=False) for topic in target.get("previous_topics", [])],
+            "target_topic": compact_topic(target.get("target_topic", {}), include_text=True),
+            "next_topics": [compact_topic(topic, include_text=False) for topic in target.get("next_topics", [])],
+        },
+        "context_mode": "compact",
+    }
+
+
+def compact_topic(topic: dict, include_text: bool) -> dict:
+    """Return a compact topic with optional truncated text and child titles."""
+
+    compact = {
+        "title": topic.get("title", ""),
+        "source": topic.get("source", ""),
+        "level": topic.get("level", ""),
+        "href": topic.get("href", ""),
+        "children": [
+            {
+                "title": child.get("title", ""),
+                "source": child.get("source", ""),
+                "level": child.get("level", ""),
+            }
+            for child in topic.get("children", [])
+        ],
+    }
+    if include_text:
+        text = str(topic.get("text", ""))
+        compact["text"] = text[:COMPACT_TEXT_CHARS].rstrip()
+        if len(text) > COMPACT_TEXT_CHARS:
+            compact["text"] += "\n[contenuto tagliato per provider con limite token]"
+    return compact
+
+
 def call_groq_didactic_frame(payload: dict) -> dict:
     """Ask Groq to draft didactic-frame fields."""
 
@@ -885,7 +945,7 @@ def call_groq_didactic_frame(payload: dict) -> dict:
         api_key,
         active_ai_model(),
         didactic_frame_system_prompt() + " Restituisci solo JSON con questi campi top-level: context, prerequisites, objectives, recall, preview, next_step, references.",
-        payload,
+        compact_frame_payload(payload),
     )
     return normalize_frame(result)
 
@@ -902,7 +962,7 @@ def call_openrouter_didactic_frame(payload: dict) -> dict:
         api_key,
         active_ai_model(),
         didactic_frame_system_prompt() + " Restituisci solo JSON con questi campi top-level: context, prerequisites, objectives, recall, preview, next_step, references.",
-        payload,
+        compact_frame_payload(payload),
     )
     return normalize_frame(result)
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 import argparse
 import json
 import mimetypes
+import os
 import re
+import urllib.error
+import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import unquote, urlparse
@@ -31,6 +34,15 @@ HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 TAG_RE = re.compile(r"<[^>]+>")
 PUNCT_RE = re.compile(r"[^\w\s-]", re.UNICODE)
 SPACE_RE = re.compile(r"[\s_]+")
+AI_FRAME_FIELDS = [
+    "context",
+    "prerequisites",
+    "objectives",
+    "recall",
+    "preview",
+    "next_step",
+    "references",
+]
 
 
 def github_anchor(title: str, seen: dict[str, int]) -> str:
@@ -99,6 +111,147 @@ def extract_headings() -> list[dict]:
     return headings
 
 
+def topic_summary(item: dict) -> dict:
+    """Return a compact recursive topic summary for the AI prompt."""
+
+    return {
+        "title": item.get("title", ""),
+        "source": item.get("source", ""),
+        "level": item.get("level", ""),
+        "href": item.get("href", ""),
+        "children": [topic_summary(child) for child in item.get("children", [])],
+    }
+
+
+def compact_design(design: dict) -> dict:
+    """Return the full course structure without verbose frame text."""
+
+    return {
+        "years": [
+            {
+                "id": year.get("id", ""),
+                "title": year.get("title", ""),
+                "description": year.get("description", ""),
+                "udas": [
+                    {
+                        "id": uda.get("id", ""),
+                        "title": uda.get("title", ""),
+                        "path": uda.get("path", ""),
+                        "weeks": uda.get("weeks", ""),
+                        "items": [topic_summary(item) for item in uda.get("items", [])],
+                    }
+                    for uda in year.get("udas", [])
+                ],
+            }
+            for year in design.get("years", [])
+        ]
+    }
+
+
+def target_context(design: dict, year_id: str, uda_id: str, item_id: str) -> dict:
+    """Collect the target item plus local before/after context inside its UDA."""
+
+    for year in design.get("years", []):
+        if year.get("id") != year_id:
+            continue
+        for uda in year.get("udas", []):
+            if uda.get("id") != uda_id:
+                continue
+            items = uda.get("items", [])
+            for index, item in enumerate(items):
+                if item.get("id") == item_id:
+                    return {
+                        "year": {key: year.get(key, "") for key in ["id", "title", "description"]},
+                        "uda": {key: uda.get(key, "") for key in ["id", "title", "path", "weeks"]},
+                        "previous_topics": [topic_summary(candidate) for candidate in items[max(0, index - 2):index]],
+                        "target_topic": topic_summary(item),
+                        "next_topics": [topic_summary(candidate) for candidate in items[index + 1:index + 3]],
+                    }
+    raise ValueError("Argomento non trovato nel percorso didattico corrente.")
+
+
+def call_openai_didactic_frame(payload: dict) -> dict:
+    """Ask OpenAI to draft didactic-frame fields for one course topic."""
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Configura OPENAI_API_KEY prima di usare AI assisted.")
+
+    model = os.environ.get("OPENAI_MODEL", "gpt-5.5")
+    schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": AI_FRAME_FIELDS,
+        "properties": {field: {"type": "string"} for field in AI_FRAME_FIELDS},
+    }
+    body = {
+        "model": model,
+        "input": [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "Sei un docente di TPSI e programmazione C. "
+                            "Compila una cornice didattica in italiano per un argomento del corso. "
+                            "Sii concreto, fluido e didattico; non inventare link; non perdere il contenuto tecnico."
+                        ),
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": json.dumps(payload, ensure_ascii=False, indent=2),
+                    }
+                ],
+            },
+        ],
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "didactic_frame",
+                "schema": schema,
+                "strict": True,
+            }
+        },
+        "store": False,
+    }
+    request = urllib.request.Request(
+        "https://api.openai.com/v1/responses",
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=90) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Errore OpenAI API {error.code}: {detail}") from error
+
+    output_text = data.get("output_text")
+    if not output_text:
+        for output in data.get("output", []):
+            for content in output.get("content", []):
+                if content.get("type") == "output_text":
+                    output_text = content.get("text")
+                    break
+            if output_text:
+                break
+    if not output_text:
+        raise RuntimeError("La risposta AI non contiene testo utilizzabile.")
+
+    result = json.loads(output_text)
+    return {field: str(result.get(field, "")).strip() for field in AI_FRAME_FIELDS}
+
+
 class CourseBoardHandler(BaseHTTPRequestHandler):
     """HTTP handler for the local board and its JSON API."""
 
@@ -114,13 +267,31 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
-        if parsed.path != "/api/course-design":
-            self.send_error(404)
-            return
         length = int(self.headers.get("Content-Length", "0"))
         payload = json.loads(self.rfile.read(length).decode("utf-8"))
-        write_design(payload)
-        self.write_json({"ok": True, "path": str(DESIGN_PATH.relative_to(ROOT))})
+        if parsed.path == "/api/course-design":
+            write_design(payload)
+            self.write_json({"ok": True, "path": str(DESIGN_PATH.relative_to(ROOT))})
+            return
+        if parsed.path == "/api/ai-frame":
+            try:
+                context = {
+                    "course": compact_design(payload.get("design", {})),
+                    "target": target_context(
+                        payload.get("design", {}),
+                        payload.get("year_id", ""),
+                        payload.get("uda_id", ""),
+                        payload.get("item_id", ""),
+                    ),
+                }
+                self.write_json({"frame": call_openai_didactic_frame(context)})
+            except Exception as error:  # noqa: BLE001
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        self.send_error(404)
 
     def write_json(self, payload: dict) -> None:
         body = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -170,6 +170,43 @@ def target_context(design: dict, year_id: str, uda_id: str, item_id: str) -> dic
     raise ValueError("Argomento non trovato nel percorso didattico corrente.")
 
 
+def didactic_frame_schema_openai() -> dict:
+    """Return the JSON Schema shape expected from OpenAI."""
+
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": AI_FRAME_FIELDS,
+        "properties": {field: {"type": "string"} for field in AI_FRAME_FIELDS},
+    }
+
+
+def didactic_frame_schema_gemini() -> dict:
+    """Return the JSON Schema shape expected from Gemini generateContent."""
+
+    return {
+        "type": "OBJECT",
+        "required": AI_FRAME_FIELDS,
+        "properties": {field: {"type": "STRING"} for field in AI_FRAME_FIELDS},
+    }
+
+
+def didactic_frame_system_prompt() -> str:
+    """Return the shared provider-independent instruction."""
+
+    return (
+        "Sei un docente di TPSI e programmazione C. "
+        "Compila una cornice didattica in italiano per un argomento del corso. "
+        "Sii concreto, fluido e didattico; non inventare link; non perdere il contenuto tecnico."
+    )
+
+
+def normalize_frame(result: dict) -> dict:
+    """Keep only the expected didactic-frame fields as stripped strings."""
+
+    return {field: str(result.get(field, "")).strip() for field in AI_FRAME_FIELDS}
+
+
 def call_openai_didactic_frame(payload: dict) -> dict:
     """Ask OpenAI to draft didactic-frame fields for one course topic."""
 
@@ -177,13 +214,7 @@ def call_openai_didactic_frame(payload: dict) -> dict:
     if not api_key:
         raise RuntimeError("Configura OPENAI_API_KEY prima di usare AI assisted.")
 
-    model = os.environ.get("OPENAI_MODEL", "gpt-5.5")
-    schema = {
-        "type": "object",
-        "additionalProperties": False,
-        "required": AI_FRAME_FIELDS,
-        "properties": {field: {"type": "string"} for field in AI_FRAME_FIELDS},
-    }
+    model = os.environ.get("OPENAI_MODEL") or os.environ.get("AI_MODEL", "gpt-5.5")
     body = {
         "model": model,
         "input": [
@@ -192,11 +223,7 @@ def call_openai_didactic_frame(payload: dict) -> dict:
                 "content": [
                     {
                         "type": "input_text",
-                        "text": (
-                            "Sei un docente di TPSI e programmazione C. "
-                            "Compila una cornice didattica in italiano per un argomento del corso. "
-                            "Sii concreto, fluido e didattico; non inventare link; non perdere il contenuto tecnico."
-                        ),
+                        "text": didactic_frame_system_prompt(),
                     }
                 ],
             },
@@ -214,7 +241,7 @@ def call_openai_didactic_frame(payload: dict) -> dict:
             "format": {
                 "type": "json_schema",
                 "name": "didactic_frame",
-                "schema": schema,
+                "schema": didactic_frame_schema_openai(),
                 "strict": True,
             }
         },
@@ -249,7 +276,62 @@ def call_openai_didactic_frame(payload: dict) -> dict:
         raise RuntimeError("La risposta AI non contiene testo utilizzabile.")
 
     result = json.loads(output_text)
-    return {field: str(result.get(field, "")).strip() for field in AI_FRAME_FIELDS}
+    return normalize_frame(result)
+
+
+def call_gemini_didactic_frame(payload: dict) -> dict:
+    """Ask Gemini to draft didactic-frame fields for one course topic."""
+
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Configura GEMINI_API_KEY prima di usare AI assisted con Gemini.")
+
+    model = os.environ.get("GEMINI_MODEL") or os.environ.get("AI_MODEL", "gemini-3-flash-preview")
+    body = {
+        "systemInstruction": {
+            "parts": [{"text": didactic_frame_system_prompt()}],
+        },
+        "contents": [
+            {
+                "role": "user",
+                "parts": [{"text": json.dumps(payload, ensure_ascii=False, indent=2)}],
+            }
+        ],
+        "generationConfig": {
+            "responseMimeType": "application/json",
+            "responseSchema": didactic_frame_schema_gemini(),
+        },
+    }
+    request = urllib.request.Request(
+        f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=90) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Errore Gemini API {error.code}: {detail}") from error
+
+    try:
+        output_text = data["candidates"][0]["content"]["parts"][0]["text"]
+    except (KeyError, IndexError) as error:
+        raise RuntimeError("La risposta Gemini non contiene testo utilizzabile.") from error
+
+    return normalize_frame(json.loads(output_text))
+
+
+def call_ai_didactic_frame(payload: dict) -> dict:
+    """Route didactic-frame generation to the configured AI provider."""
+
+    provider = os.environ.get("AI_PROVIDER", "openai").strip().lower()
+    if provider == "openai":
+        return call_openai_didactic_frame(payload)
+    if provider == "gemini":
+        return call_gemini_didactic_frame(payload)
+    raise RuntimeError(f"Provider AI non supportato: {provider}. Usa AI_PROVIDER=openai oppure AI_PROVIDER=gemini.")
 
 
 class CourseBoardHandler(BaseHTTPRequestHandler):
@@ -284,7 +366,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                         payload.get("item_id", ""),
                     ),
                 }
-                self.write_json({"frame": call_openai_didactic_frame(context)})
+                self.write_json({"frame": call_ai_didactic_frame(context)})
             except Exception as error:  # noqa: BLE001
                 self.send_response(500)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -30,8 +30,11 @@ from urllib.parse import unquote, urlparse
 ROOT = Path(__file__).resolve().parents[1]
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
+AI_PROVIDERS_PATH = ROOT / "config" / "ai_providers.yaml"
+AI_SECRET_PATH = ROOT / ".secrets" / "ai.secret"
 DEFAULT_SOURCES = ["README.md", "LINUX_PROGRAMMING.md"]
 ACTIVE_AI_PROVIDER = os.environ.get("AI_PROVIDER", "openai").strip().lower()
+ACTIVE_AI_MODEL = os.environ.get("AI_MODEL", "").strip()
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 TAG_RE = re.compile(r"<[^>]+>")
 PUNCT_RE = re.compile(r"[^\w\s-]", re.UNICODE)
@@ -124,6 +127,93 @@ def write_saved_design(name: str, payload: dict) -> dict:
     path = saved_design_path(name)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return {"name": path.name, "path": str(path.relative_to(ROOT))}
+
+
+def read_secret_env() -> dict[str, str]:
+    """Read local secret values from .secrets/ai.secret."""
+
+    values: dict[str, str] = {}
+    if not AI_SECRET_PATH.is_file():
+        return values
+    for line in AI_SECRET_PATH.read_text(encoding="utf-8-sig").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def secret_value(key: str) -> str:
+    """Return a secret from environment first, then local secret file."""
+
+    return os.environ.get(key, "") or read_secret_env().get(key, "")
+
+
+def parse_ai_providers_yaml() -> dict:
+    """Parse the small YAML subset used by config/ai_providers.yaml."""
+
+    if not AI_PROVIDERS_PATH.is_file():
+        return default_ai_provider_config()
+    providers: dict[str, dict] = {}
+    current_provider: str | None = None
+    current_model: dict | None = None
+    in_models = False
+    for raw in AI_PROVIDERS_PATH.read_text(encoding="utf-8-sig").splitlines():
+        if not raw.strip() or raw.strip().startswith("#") or raw.strip() == "providers:":
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        line = raw.strip()
+        if indent == 2 and line.endswith(":"):
+            current_provider = line[:-1]
+            providers[current_provider] = {"id": current_provider, "models": []}
+            in_models = False
+            current_model = None
+            continue
+        if not current_provider:
+            continue
+        if indent == 4 and line == "models:":
+            in_models = True
+            continue
+        if in_models and indent == 6 and line.startswith("- "):
+            current_model = {}
+            providers[current_provider]["models"].append(current_model)
+            key, value = line[2:].split(":", 1)
+            current_model[key.strip()] = value.strip()
+            continue
+        if in_models and indent == 8 and current_model and ":" in line:
+            key, value = line.split(":", 1)
+            current_model[key.strip()] = value.strip()
+            continue
+        if indent == 4 and ":" in line:
+            key, value = line.split(":", 1)
+            providers[current_provider][key.strip()] = value.strip()
+    return {"providers": providers}
+
+
+def default_ai_provider_config() -> dict:
+    """Return built-in AI provider config when YAML is missing."""
+
+    return {
+        "providers": {
+            "openai": {
+                "id": "openai",
+                "label": "OpenAI",
+                "secret_key": "OPENAI_API_KEY",
+                "default_model": "gpt-5.5",
+                "billing_note": "OpenAI API usa quota/billing API separati da ChatGPT Free/Plus.",
+                "models": [{"id": "gpt-5.5", "label": "GPT-5.5", "tier": "paid"}],
+            },
+            "gemini": {
+                "id": "gemini",
+                "label": "Gemini",
+                "secret_key": "GEMINI_API_KEY",
+                "default_model": "gemini-2.5-flash",
+                "billing_note": "Gemini puo avere free tier su Google AI Studio, ma quota e limiti dipendono dall'account.",
+                "models": [{"id": "gemini-2.5-flash", "label": "Gemini 2.5 Flash", "tier": "free-or-low-cost"}],
+            },
+        }
+    }
 
 
 def extract_headings() -> list[dict]:
@@ -608,11 +698,11 @@ def count_item_tree(item: dict) -> int:
 def call_openai_didactic_frame(payload: dict) -> dict:
     """Ask OpenAI to draft didactic-frame fields for one course topic."""
 
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = secret_value("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("Configura OPENAI_API_KEY prima di usare AI assisted.")
 
-    model = os.environ.get("OPENAI_MODEL") or os.environ.get("AI_MODEL", "gpt-5.5")
+    model = active_ai_model()
     body = {
         "model": model,
         "input": [
@@ -680,11 +770,11 @@ def call_openai_didactic_frame(payload: dict) -> dict:
 def call_gemini_didactic_frame(payload: dict) -> dict:
     """Ask Gemini to draft didactic-frame fields for one course topic."""
 
-    api_key = os.environ.get("GEMINI_API_KEY")
+    api_key = secret_value("GEMINI_API_KEY")
     if not api_key:
         raise RuntimeError("Configura GEMINI_API_KEY prima di usare AI assisted con Gemini.")
 
-    model = os.environ.get("GEMINI_MODEL") or os.environ.get("AI_MODEL", "gemini-3-flash-preview")
+    model = active_ai_model()
     body = {
         "systemInstruction": {
             "parts": [{"text": didactic_frame_system_prompt()}],
@@ -721,6 +811,76 @@ def call_gemini_didactic_frame(payload: dict) -> dict:
     return normalize_frame(json.loads(output_text))
 
 
+def call_chat_completions_json(provider_name: str, url: str, api_key: str, model: str, system_prompt: str, payload: dict) -> dict:
+    """Call an OpenAI-compatible chat completions endpoint and parse JSON content."""
+
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": json.dumps(payload, ensure_ascii=False, indent=2)},
+        ],
+        "response_format": {"type": "json_object"},
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    if provider_name == "OpenRouter":
+        headers["HTTP-Referer"] = "https://github.com/TheBitPoets/2cornot2c"
+        headers["X-Title"] = "2cornot2c Course Design Board"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=AI_COURSE_PLAN_TIMEOUT_SECONDS) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Errore {provider_name} API {error.code}: {detail}") from error
+    try:
+        return json.loads(data["choices"][0]["message"]["content"])
+    except (KeyError, IndexError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"La risposta {provider_name} non contiene JSON utilizzabile.") from error
+
+
+def call_groq_didactic_frame(payload: dict) -> dict:
+    """Ask Groq to draft didactic-frame fields."""
+
+    api_key = secret_value("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError("Configura GROQ_API_KEY prima di usare AI assisted con Groq.")
+    result = call_chat_completions_json(
+        "Groq",
+        "https://api.groq.com/openai/v1/chat/completions",
+        api_key,
+        active_ai_model(),
+        didactic_frame_system_prompt() + " Restituisci solo JSON con i campi richiesti.",
+        payload,
+    )
+    return normalize_frame(result)
+
+
+def call_openrouter_didactic_frame(payload: dict) -> dict:
+    """Ask OpenRouter to draft didactic-frame fields."""
+
+    api_key = secret_value("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError("Configura OPENROUTER_API_KEY prima di usare AI assisted con OpenRouter.")
+    result = call_chat_completions_json(
+        "OpenRouter",
+        "https://openrouter.ai/api/v1/chat/completions",
+        api_key,
+        active_ai_model(),
+        didactic_frame_system_prompt() + " Restituisci solo JSON con i campi richiesti.",
+        payload,
+    )
+    return normalize_frame(result)
+
+
 def call_ai_didactic_frame(payload: dict) -> dict:
     """Route didactic-frame generation to the configured AI provider."""
 
@@ -729,16 +889,20 @@ def call_ai_didactic_frame(payload: dict) -> dict:
         return call_openai_didactic_frame(payload)
     if provider == "gemini":
         return call_gemini_didactic_frame(payload)
-    raise RuntimeError(f"Provider AI non supportato: {provider}. Usa AI_PROVIDER=openai oppure AI_PROVIDER=gemini.")
+    if provider == "groq":
+        return call_groq_didactic_frame(payload)
+    if provider == "openrouter":
+        return call_openrouter_didactic_frame(payload)
+    raise RuntimeError(f"Provider AI non supportato: {provider}. Usa un provider dichiarato in config/ai_providers.yaml.")
 
 
 def call_openai_course_plan(payload: dict) -> dict:
     """Ask OpenAI to draft an annual course plan."""
 
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = secret_value("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("Configura OPENAI_API_KEY prima di usare AI assisted percorso.")
-    model = os.environ.get("OPENAI_MODEL") or os.environ.get("AI_MODEL", "gpt-5.5")
+    model = active_ai_model()
     body = {
         "model": model,
         "input": [
@@ -790,10 +954,10 @@ def call_openai_course_plan(payload: dict) -> dict:
 def call_gemini_course_plan(payload: dict) -> dict:
     """Ask Gemini to draft an annual course plan."""
 
-    api_key = os.environ.get("GEMINI_API_KEY")
+    api_key = secret_value("GEMINI_API_KEY")
     if not api_key:
         raise RuntimeError("Configura GEMINI_API_KEY prima di usare AI assisted percorso con Gemini.")
-    model = os.environ.get("GEMINI_MODEL") or os.environ.get("AI_MODEL", "gemini-3-flash-preview")
+    model = active_ai_model()
     body = {
         "systemInstruction": {"parts": [{"text": course_plan_system_prompt()}]},
         "contents": [{"role": "user", "parts": [{"text": json.dumps(payload, ensure_ascii=False, indent=2)}]}],
@@ -821,6 +985,38 @@ def call_gemini_course_plan(payload: dict) -> dict:
     return json.loads(output_text)
 
 
+def call_groq_course_plan(payload: dict) -> dict:
+    """Ask Groq to draft an annual course plan."""
+
+    api_key = secret_value("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError("Configura GROQ_API_KEY prima di usare AI assisted percorso con Groq.")
+    return call_chat_completions_json(
+        "Groq",
+        "https://api.groq.com/openai/v1/chat/completions",
+        api_key,
+        active_ai_model(),
+        course_plan_system_prompt(),
+        payload,
+    )
+
+
+def call_openrouter_course_plan(payload: dict) -> dict:
+    """Ask OpenRouter to draft an annual course plan."""
+
+    api_key = secret_value("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError("Configura OPENROUTER_API_KEY prima di usare AI assisted percorso con OpenRouter.")
+    return call_chat_completions_json(
+        "OpenRouter",
+        "https://openrouter.ai/api/v1/chat/completions",
+        api_key,
+        active_ai_model(),
+        course_plan_system_prompt(),
+        payload,
+    )
+
+
 def call_ai_course_plan(payload: dict) -> dict:
     """Route annual course-plan generation to the configured AI provider."""
 
@@ -829,7 +1025,11 @@ def call_ai_course_plan(payload: dict) -> dict:
         return call_openai_course_plan(payload)
     if provider == "gemini":
         return call_gemini_course_plan(payload)
-    raise RuntimeError(f"Provider AI non supportato: {provider}. Usa AI_PROVIDER=openai oppure AI_PROVIDER=gemini.")
+    if provider == "groq":
+        return call_groq_course_plan(payload)
+    if provider == "openrouter":
+        return call_openrouter_course_plan(payload)
+    raise RuntimeError(f"Provider AI non supportato: {provider}. Usa un provider dichiarato in config/ai_providers.yaml.")
 
 
 def ai_config() -> dict:
@@ -839,7 +1039,7 @@ def ai_config() -> dict:
     active = providers.get(ACTIVE_AI_PROVIDER) or providers["openai"]
     return {
         "provider": active["id"],
-        "model": active["model"],
+        "model": active_ai_model(),
         "api_key_configured": active["api_key_configured"],
         "billing_note": active["billing_note"],
         "providers": list(providers.values()),
@@ -849,35 +1049,50 @@ def ai_config() -> dict:
 def ai_providers() -> dict:
     """Return all server-supported providers with safe configuration status."""
 
-    return {
-        "openai": {
-            "id": "openai",
-            "label": "OpenAI",
-            "model": os.environ.get("OPENAI_MODEL") or os.environ.get("AI_MODEL", "gpt-5.5"),
-            "api_key_configured": bool(os.environ.get("OPENAI_API_KEY")),
-            "billing_note": "OpenAI API usa quota/billing API separati da ChatGPT Free/Plus.",
-        },
-        "gemini": {
-            "id": "gemini",
-            "label": "Gemini",
-            "model": os.environ.get("GEMINI_MODEL") or os.environ.get("AI_MODEL", "gemini-3-flash-preview"),
-            "api_key_configured": bool(os.environ.get("GEMINI_API_KEY")),
-            "billing_note": "Gemini puo avere free tier su Google AI Studio, ma quota e limiti dipendono dall'account.",
-        },
-    }
+    config = parse_ai_providers_yaml()["providers"]
+    providers: dict[str, dict] = {}
+    for provider_id, provider in config.items():
+        secret_key = provider.get("secret_key", "")
+        default_model = provider.get("default_model", "")
+        env_model = os.environ.get(f"{provider_id.upper()}_MODEL", "")
+        model = env_model or (ACTIVE_AI_MODEL if ACTIVE_AI_PROVIDER == provider_id else "") or default_model
+        models = provider.get("models", [])
+        providers[provider_id] = {
+            "id": provider_id,
+            "label": provider.get("label", provider_id),
+            "model": model,
+            "default_model": default_model,
+            "api_key_configured": bool(secret_value(secret_key)),
+            "billing_note": provider.get("billing_note", ""),
+            "models": models,
+        }
+    return providers
 
 
-def set_ai_provider(provider: str) -> dict:
-    """Set the active provider only when the server has its API key."""
+def active_ai_model() -> str:
+    """Return the currently selected model for the active provider."""
 
-    global ACTIVE_AI_PROVIDER
+    providers = ai_providers()
+    active = providers.get(ACTIVE_AI_PROVIDER) or providers["openai"]
+    return ACTIVE_AI_MODEL or active.get("model") or active.get("default_model", "")
+
+
+def set_ai_provider(provider: str, model: str = "") -> dict:
+    """Set the active provider/model only when the server has its API key."""
+
+    global ACTIVE_AI_PROVIDER, ACTIVE_AI_MODEL
     provider = provider.strip().lower()
     providers = ai_providers()
     if provider not in providers:
         raise RuntimeError(f"Provider AI non supportato: {provider}.")
     if not providers[provider]["api_key_configured"]:
         raise RuntimeError(f"Provider {providers[provider]['label']} non configurato: API key mancante.")
+    model_ids = {candidate.get("id") for candidate in providers[provider].get("models", [])}
+    selected_model = model.strip() or providers[provider].get("model") or providers[provider].get("default_model", "")
+    if model_ids and selected_model not in model_ids:
+        raise RuntimeError(f"Modello non supportato per {providers[provider]['label']}: {selected_model}.")
     ACTIVE_AI_PROVIDER = provider
+    ACTIVE_AI_MODEL = selected_model
     return ai_config()
 
 
@@ -929,7 +1144,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/api/ai-config":
             try:
-                self.write_json(set_ai_provider(payload.get("provider", "")))
+                self.write_json(set_ai_provider(payload.get("provider", ""), payload.get("model", "")))
             except Exception as error:  # noqa: BLE001
                 self.send_response(400)
                 self.send_header("Content-Type", "application/json; charset=utf-8")
@@ -1031,3 +1246,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -43,8 +43,10 @@ AI_FRAME_FIELDS = [
     "next_step",
     "references",
 ]
+COURSE_PLAN_REQUIRED_FIELDS = ["year_id", "title", "description", "udas", "unplaced_topics", "notes"]
 MAX_SECTION_CHARS = 6000
 MAX_CHILDREN_WITH_TEXT = 8
+MAX_CATALOG_EXCERPT_CHARS = 900
 
 
 def github_anchor(title: str, seen: dict[str, int]) -> str:
@@ -152,6 +154,51 @@ def section_text(source: str, line: int | str, level: int | str) -> str:
     return text
 
 
+def section_excerpt(heading: dict) -> str:
+    """Return a short local excerpt for course-plan generation."""
+
+    text = section_text(heading.get("source", ""), heading.get("line", ""), heading.get("level", ""))
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > MAX_CATALOG_EXCERPT_CHARS:
+        return text[:MAX_CATALOG_EXCERPT_CHARS].rstrip() + "..."
+    return text
+
+
+def heading_catalog_tree() -> list[dict]:
+    """Return all available headings as a tree with compact excerpts."""
+
+    roots: list[dict] = []
+    stack: list[dict] = []
+    for heading in extract_headings():
+        node = {
+            "id": heading["id"],
+            "title": heading["title"],
+            "source": heading["source"],
+            "level": heading["level"],
+            "href": heading["href"],
+            "excerpt": section_excerpt(heading),
+            "children": [],
+        }
+        while stack and heading["level"] <= stack[-1]["level"]:
+            stack.pop()
+        if stack:
+            stack[-1]["children"].append(node)
+        else:
+            roots.append(node)
+        stack.append(node)
+    prune_empty_children(roots)
+    return roots
+
+
+def prune_empty_children(items: list[dict]) -> None:
+    """Remove empty children arrays recursively."""
+
+    for item in items:
+        prune_empty_children(item.get("children", []))
+        if not item.get("children"):
+            item.pop("children", None)
+
+
 def topic_summary(item: dict, include_text: bool = False, child_text_budget: int = 0) -> dict:
     """Return a compact recursive topic summary for the AI prompt."""
 
@@ -170,6 +217,51 @@ def topic_summary(item: dict, include_text: bool = False, child_text_budget: int
     if include_text:
         summary["text"] = section_text(item.get("source", ""), item.get("line", ""), item.get("level", ""))
     return summary
+
+
+def heading_by_id() -> dict[str, dict]:
+    """Return available headings indexed by stable id."""
+
+    return {heading["id"]: heading for heading in extract_headings()}
+
+
+def item_from_heading_id(heading_id: str, headings: list[dict]) -> dict | None:
+    """Build a board item from a heading id, preserving its subtree."""
+
+    index = next((i for i, heading in enumerate(headings) if heading["id"] == heading_id), None)
+    if index is None:
+        return None
+    heading = headings[index]
+    item = board_item_from_heading(heading)
+    roots: list[dict] = []
+    stack: list[dict] = [{"level": heading["level"], "children": roots}]
+    for child in headings[index + 1:]:
+        if child["source"] != heading["source"] or child["level"] <= heading["level"]:
+            break
+        child_item = board_item_from_heading(child)
+        child_item["children"] = []
+        while stack and child["level"] <= stack[-1]["level"]:
+            stack.pop()
+        stack[-1]["children"].append(child_item)
+        stack.append({"level": child["level"], "children": child_item["children"]})
+    prune_empty_children(roots)
+    if roots:
+        item["children"] = roots
+    return item
+
+
+def board_item_from_heading(heading: dict) -> dict:
+    """Return the JSON item shape consumed by the course board."""
+
+    return {
+        "id": heading["id"],
+        "title": heading["title"],
+        "source": heading["source"],
+        "href": heading["href"],
+        "level": heading["level"],
+        "line": heading["line"],
+        "frame": {"status": "todo"},
+    }
 
 
 def compact_design(design: dict) -> dict:
@@ -275,6 +367,89 @@ def didactic_frame_schema_gemini() -> dict:
     }
 
 
+def course_plan_schema_openai() -> dict:
+    """Return the JSON Schema expected from OpenAI for a course proposal."""
+
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": COURSE_PLAN_REQUIRED_FIELDS,
+        "properties": {
+            "year_id": {"type": "string"},
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "udas": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["id", "title", "path", "weeks", "items"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "title": {"type": "string"},
+                        "path": {"type": "string"},
+                        "weeks": {"type": "string"},
+                        "items": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+            },
+            "unplaced_topics": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["id", "reason"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                },
+            },
+            "notes": {"type": "string"},
+        },
+    }
+
+
+def course_plan_schema_gemini() -> dict:
+    """Return the JSON Schema expected from Gemini for a course proposal."""
+
+    return {
+        "type": "OBJECT",
+        "required": COURSE_PLAN_REQUIRED_FIELDS,
+        "properties": {
+            "year_id": {"type": "STRING"},
+            "title": {"type": "STRING"},
+            "description": {"type": "STRING"},
+            "udas": {
+                "type": "ARRAY",
+                "items": {
+                    "type": "OBJECT",
+                    "required": ["id", "title", "path", "weeks", "items"],
+                    "properties": {
+                        "id": {"type": "STRING"},
+                        "title": {"type": "STRING"},
+                        "path": {"type": "STRING"},
+                        "weeks": {"type": "STRING"},
+                        "items": {"type": "ARRAY", "items": {"type": "STRING"}},
+                    },
+                },
+            },
+            "unplaced_topics": {
+                "type": "ARRAY",
+                "items": {
+                    "type": "OBJECT",
+                    "required": ["id", "reason"],
+                    "properties": {
+                        "id": {"type": "STRING"},
+                        "reason": {"type": "STRING"},
+                    },
+                },
+            },
+            "notes": {"type": "STRING"},
+        },
+    }
+
+
 def didactic_frame_system_prompt() -> str:
     """Return the shared provider-independent instruction."""
 
@@ -288,10 +463,86 @@ def didactic_frame_system_prompt() -> str:
     )
 
 
+def course_plan_system_prompt() -> str:
+    """Return the provider-independent instruction for course-plan generation."""
+
+    return (
+        "Sei un docente esperto di TPSI e progettazione didattica. "
+        "Devi costruire una proposta di percorso annuale usando solo gli id degli argomenti disponibili. "
+        "Rispetta il brief del docente, la progressione didattica, il numero di settimane e gli obiettivi. "
+        "Non inventare id. Non duplicare argomenti nello stesso anno. "
+        "Se un argomento non e coerente con il brief, lascialo tra gli unplaced_topics spiegando il motivo. "
+        "Restituisci solo JSON valido secondo lo schema richiesto."
+    )
+
+
 def normalize_frame(result: dict) -> dict:
     """Keep only the expected didactic-frame fields as stripped strings."""
 
     return {field: str(result.get(field, "")).strip() for field in AI_FRAME_FIELDS}
+
+
+def normalize_course_plan(raw: dict, design: dict, year_id: str) -> dict:
+    """Validate a raw AI proposal and hydrate item ids into board items."""
+
+    headings = extract_headings()
+    valid_ids = {heading["id"] for heading in headings}
+    year = next((candidate for candidate in design.get("years", []) if candidate.get("id") == year_id), {})
+    used: set[str] = set()
+    hydrated_udas: list[dict] = []
+
+    for index, uda in enumerate(raw.get("udas", []), start=1):
+        hydrated_items: list[dict] = []
+        for heading_id in uda.get("items", []):
+            if heading_id not in valid_ids or heading_id in used:
+                continue
+            item = item_from_heading_id(heading_id, headings)
+            if item:
+                hydrated_items.append(item)
+                used.update(collect_item_ids(item))
+        hydrated_udas.append(
+            {
+                "id": str(uda.get("id") or f"uda-{index}"),
+                "title": str(uda.get("title") or f"UDA {index}"),
+                "path": str(uda.get("path") or "Da definire"),
+                "weeks": str(uda.get("weeks") or "?"),
+                "items": hydrated_items,
+            }
+        )
+
+    unplaced = []
+    for topic in raw.get("unplaced_topics", []):
+        heading_id = str(topic.get("id", ""))
+        if heading_id in valid_ids:
+            unplaced.append({"id": heading_id, "reason": str(topic.get("reason", ""))})
+
+    return {
+        "year_id": year_id,
+        "title": str(raw.get("title") or year.get("title", "")),
+        "description": str(raw.get("description") or year.get("description", "")),
+        "udas": hydrated_udas,
+        "unplaced_topics": unplaced,
+        "notes": str(raw.get("notes", "")),
+        "stats": {
+            "assigned_topics": sum(count_item_tree(item) for uda in hydrated_udas for item in uda["items"]),
+            "root_topics": sum(len(uda["items"]) for uda in hydrated_udas),
+        },
+    }
+
+
+def collect_item_ids(item: dict) -> set[str]:
+    """Collect ids from a board item subtree."""
+
+    ids = {item.get("id", "")}
+    for child in item.get("children", []):
+        ids.update(collect_item_ids(child))
+    return {item_id for item_id in ids if item_id}
+
+
+def count_item_tree(item: dict) -> int:
+    """Count a board item subtree."""
+
+    return 1 + sum(count_item_tree(child) for child in item.get("children", []))
 
 
 def call_openai_didactic_frame(payload: dict) -> dict:
@@ -421,6 +672,106 @@ def call_ai_didactic_frame(payload: dict) -> dict:
     raise RuntimeError(f"Provider AI non supportato: {provider}. Usa AI_PROVIDER=openai oppure AI_PROVIDER=gemini.")
 
 
+def call_openai_course_plan(payload: dict) -> dict:
+    """Ask OpenAI to draft an annual course plan."""
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Configura OPENAI_API_KEY prima di usare AI assisted percorso.")
+    model = os.environ.get("OPENAI_MODEL") or os.environ.get("AI_MODEL", "gpt-5.5")
+    body = {
+        "model": model,
+        "input": [
+            {
+                "role": "system",
+                "content": [{"type": "input_text", "text": course_plan_system_prompt()}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": json.dumps(payload, ensure_ascii=False, indent=2)}],
+            },
+        ],
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "course_plan_proposal",
+                "schema": course_plan_schema_openai(),
+                "strict": True,
+            }
+        },
+        "store": False,
+    }
+    request = urllib.request.Request(
+        "https://api.openai.com/v1/responses",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Errore OpenAI API {error.code}: {detail}") from error
+    output_text = data.get("output_text")
+    if not output_text:
+        for output in data.get("output", []):
+            for content in output.get("content", []):
+                if content.get("type") == "output_text":
+                    output_text = content.get("text")
+                    break
+            if output_text:
+                break
+    if not output_text:
+        raise RuntimeError("La risposta AI non contiene una proposta utilizzabile.")
+    return json.loads(output_text)
+
+
+def call_gemini_course_plan(payload: dict) -> dict:
+    """Ask Gemini to draft an annual course plan."""
+
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Configura GEMINI_API_KEY prima di usare AI assisted percorso con Gemini.")
+    model = os.environ.get("GEMINI_MODEL") or os.environ.get("AI_MODEL", "gemini-3-flash-preview")
+    body = {
+        "systemInstruction": {"parts": [{"text": course_plan_system_prompt()}]},
+        "contents": [{"role": "user", "parts": [{"text": json.dumps(payload, ensure_ascii=False, indent=2)}]}],
+        "generationConfig": {
+            "responseMimeType": "application/json",
+            "responseSchema": course_plan_schema_gemini(),
+        },
+    }
+    request = urllib.request.Request(
+        f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Errore Gemini API {error.code}: {detail}") from error
+    try:
+        output_text = data["candidates"][0]["content"]["parts"][0]["text"]
+    except (KeyError, IndexError) as error:
+        raise RuntimeError("La risposta Gemini non contiene una proposta utilizzabile.") from error
+    return json.loads(output_text)
+
+
+def call_ai_course_plan(payload: dict) -> dict:
+    """Route annual course-plan generation to the configured AI provider."""
+
+    provider = os.environ.get("AI_PROVIDER", "openai").strip().lower()
+    if provider == "openai":
+        return call_openai_course_plan(payload)
+    if provider == "gemini":
+        return call_gemini_course_plan(payload)
+    raise RuntimeError(f"Provider AI non supportato: {provider}. Usa AI_PROVIDER=openai oppure AI_PROVIDER=gemini.")
+
+
 class CourseBoardHandler(BaseHTTPRequestHandler):
     """HTTP handler for the local board and its JSON API."""
 
@@ -454,6 +805,30 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                     ),
                 }
                 self.write_json({"frame": call_ai_didactic_frame(context)})
+            except Exception as error:  # noqa: BLE001
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/ai-course-plan":
+            try:
+                design = payload.get("design", {})
+                year_id = payload.get("year_id", "")
+                ai_payload = {
+                    "brief": payload.get("brief", {}),
+                    "target_year_id": year_id,
+                    "current_course": compact_design(design),
+                    "available_topics": heading_catalog_tree(),
+                    "constraints": {
+                        "use_only_available_topic_ids": True,
+                        "do_not_duplicate_topics": True,
+                        "return_items_as_topic_ids": True,
+                        "teacher_must_review_before_apply": True,
+                    },
+                }
+                raw = call_ai_course_plan(ai_payload)
+                self.write_json({"proposal": normalize_course_plan(raw, design, year_id)})
             except Exception as error:  # noqa: BLE001
                 self.send_response(500)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -828,7 +828,6 @@ def call_chat_completions_json(provider_name: str, url: str, api_key: str, model
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": json.dumps(payload, ensure_ascii=False, indent=2)},
         ],
-        "response_format": {"type": "json_object"},
     }
     headers = {
         "Authorization": f"Bearer {api_key}",
@@ -850,9 +849,24 @@ def call_chat_completions_json(provider_name: str, url: str, api_key: str, model
         detail = error.read().decode("utf-8", errors="replace")
         raise RuntimeError(f"Errore {provider_name} API {error.code}: {detail}") from error
     try:
-        return json.loads(data["choices"][0]["message"]["content"])
+        return parse_json_object(data["choices"][0]["message"]["content"])
     except (KeyError, IndexError, json.JSONDecodeError) as error:
         raise RuntimeError(f"La risposta {provider_name} non contiene JSON utilizzabile.") from error
+
+
+def parse_json_object(text: str) -> dict:
+    """Parse a JSON object, tolerating markdown fences around it."""
+
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?", "", text).strip()
+        text = re.sub(r"```$", "", text).strip()
+    if not text.startswith("{"):
+        start = text.find("{")
+        end = text.rfind("}")
+        if start >= 0 and end > start:
+            text = text[start:end + 1]
+    return json.loads(text)
 
 
 def call_groq_didactic_frame(payload: dict) -> dict:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -29,12 +29,14 @@ from urllib.parse import unquote, urlparse
 
 ROOT = Path(__file__).resolve().parents[1]
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
+COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
 DEFAULT_SOURCES = ["README.md", "LINUX_PROGRAMMING.md"]
 ACTIVE_AI_PROVIDER = os.environ.get("AI_PROVIDER", "openai").strip().lower()
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 TAG_RE = re.compile(r"<[^>]+>")
 PUNCT_RE = re.compile(r"[^\w\s-]", re.UNICODE)
 SPACE_RE = re.compile(r"[\s_]+")
+DESIGN_NAME_RE = re.compile(r"^[a-zA-Z0-9_.-]+\.json$")
 AI_FRAME_FIELDS = [
     "context",
     "prerequisites",
@@ -77,6 +79,49 @@ def write_design(payload: dict) -> None:
 
     DESIGN_PATH.parent.mkdir(parents=True, exist_ok=True)
     DESIGN_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def safe_design_name(name: str) -> str:
+    """Validate a saved course-design filename."""
+
+    name = name.strip()
+    if not DESIGN_NAME_RE.match(name):
+        raise ValueError("Nome non valido. Usa solo lettere, numeri, trattino, underscore, punto e suffisso .json.")
+    return name
+
+
+def saved_design_path(name: str) -> Path:
+    """Return the safe path for a saved course design."""
+
+    return COURSE_DESIGNS_DIR / safe_design_name(name)
+
+
+def list_saved_designs() -> list[dict]:
+    """List saved course designs stored in doc/course_designs."""
+
+    COURSE_DESIGNS_DIR.mkdir(parents=True, exist_ok=True)
+    designs = []
+    for path in sorted(COURSE_DESIGNS_DIR.glob("*.json")):
+        designs.append({"name": path.name, "path": str(path.relative_to(ROOT))})
+    return designs
+
+
+def read_saved_design(name: str) -> dict:
+    """Read a saved course design by filename."""
+
+    path = saved_design_path(name)
+    if not path.is_file():
+        raise FileNotFoundError(f"Percorso salvato non trovato: {name}")
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_saved_design(name: str, payload: dict) -> dict:
+    """Persist a named course design in the archive folder."""
+
+    COURSE_DESIGNS_DIR.mkdir(parents=True, exist_ok=True)
+    path = saved_design_path(name)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return {"name": path.name, "path": str(path.relative_to(ROOT))}
 
 
 def extract_headings() -> list[dict]:
@@ -833,6 +878,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/course-design":
             self.write_json(read_design())
             return
+        if parsed.path == "/api/saved-designs":
+            self.write_json({"designs": list_saved_designs()})
+            return
         if parsed.path == "/api/ai-config":
             self.write_json(ai_config())
             return
@@ -845,6 +893,25 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/course-design":
             write_design(payload)
             self.write_json({"ok": True, "path": str(DESIGN_PATH.relative_to(ROOT))})
+            return
+        if parsed.path == "/api/saved-designs/load":
+            try:
+                self.write_json({"design": read_saved_design(payload.get("name", ""))})
+            except Exception as error:  # noqa: BLE001
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/saved-designs/save":
+            try:
+                saved = write_saved_design(payload.get("name", ""), payload.get("design", {}))
+                self.write_json({"ok": True, "saved": saved, "designs": list_saved_designs()})
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
             return
         if parsed.path == "/api/ai-config":
             try:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -49,7 +49,9 @@ AI_FRAME_FIELDS = [
 COURSE_PLAN_REQUIRED_FIELDS = ["year_id", "title", "description", "udas", "unplaced_topics", "notes"]
 MAX_SECTION_CHARS = 6000
 MAX_CHILDREN_WITH_TEXT = 8
-MAX_CATALOG_EXCERPT_CHARS = 900
+MAX_CATALOG_EXCERPT_CHARS = 400
+AI_FRAME_TIMEOUT_SECONDS = 120
+AI_COURSE_PLAN_TIMEOUT_SECONDS = 240
 
 
 def github_anchor(title: str, seen: dict[str, int]) -> str:
@@ -641,7 +643,7 @@ def call_openai_didactic_frame(payload: dict) -> dict:
         method="POST",
     )
     try:
-        with urllib.request.urlopen(request, timeout=90) as response:
+        with urllib.request.urlopen(request, timeout=AI_FRAME_TIMEOUT_SECONDS) as response:
             data = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace")
@@ -693,7 +695,7 @@ def call_gemini_didactic_frame(payload: dict) -> dict:
         method="POST",
     )
     try:
-        with urllib.request.urlopen(request, timeout=90) as response:
+        with urllib.request.urlopen(request, timeout=AI_FRAME_TIMEOUT_SECONDS) as response:
             data = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace")
@@ -754,7 +756,7 @@ def call_openai_course_plan(payload: dict) -> dict:
         method="POST",
     )
     try:
-        with urllib.request.urlopen(request, timeout=120) as response:
+        with urllib.request.urlopen(request, timeout=AI_COURSE_PLAN_TIMEOUT_SECONDS) as response:
             data = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace")
@@ -795,7 +797,7 @@ def call_gemini_course_plan(payload: dict) -> dict:
         method="POST",
     )
     try:
-        with urllib.request.urlopen(request, timeout=120) as response:
+        with urllib.request.urlopen(request, timeout=AI_COURSE_PLAN_TIMEOUT_SECONDS) as response:
             data = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -43,6 +43,8 @@ AI_FRAME_FIELDS = [
     "next_step",
     "references",
 ]
+MAX_SECTION_CHARS = 6000
+MAX_CHILDREN_WITH_TEXT = 8
 
 
 def github_anchor(title: str, seen: dict[str, int]) -> str:
@@ -111,16 +113,63 @@ def extract_headings() -> list[dict]:
     return headings
 
 
-def topic_summary(item: dict) -> dict:
+def github_blob_url(source: str, anchor: str = "") -> str:
+    """Return a GitHub URL for a source file and optional anchor."""
+
+    base = f"https://github.com/TheBitPoets/2cornot2c/blob/main/{source}"
+    return f"{base}#{anchor}" if anchor else base
+
+
+def section_text(source: str, line: int | str, level: int | str) -> str:
+    """Extract local Markdown text for one heading section."""
+
+    try:
+        start_line = int(line)
+        start_level = int(level)
+    except (TypeError, ValueError):
+        return ""
+    path = (ROOT / source).resolve()
+    try:
+        path.relative_to(ROOT)
+    except ValueError:
+        return ""
+    if not path.is_file():
+        return ""
+
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    if start_line < 1 or start_line > len(lines):
+        return ""
+
+    section: list[str] = []
+    for current in lines[start_line:]:
+        match = HEADING_RE.match(current)
+        if match and len(match.group(1)) <= start_level:
+            break
+        section.append(current)
+    text = "\n".join(section).strip()
+    if len(text) > MAX_SECTION_CHARS:
+        return text[:MAX_SECTION_CHARS].rstrip() + "\n\n[contenuto tagliato per limite di contesto]"
+    return text
+
+
+def topic_summary(item: dict, include_text: bool = False, child_text_budget: int = 0) -> dict:
     """Return a compact recursive topic summary for the AI prompt."""
 
-    return {
+    anchor = str(item.get("href", "")).split("#", 1)[-1] if "#" in str(item.get("href", "")) else ""
+    summary = {
         "title": item.get("title", ""),
         "source": item.get("source", ""),
         "level": item.get("level", ""),
         "href": item.get("href", ""),
-        "children": [topic_summary(child) for child in item.get("children", [])],
+        "github_url": github_blob_url(item.get("source", ""), anchor),
+        "children": [
+            topic_summary(child, include_text=include_text and index < child_text_budget)
+            for index, child in enumerate(item.get("children", []))
+        ],
     }
+    if include_text:
+        summary["text"] = section_text(item.get("source", ""), item.get("line", ""), item.get("level", ""))
+    return summary
 
 
 def compact_design(design: dict) -> dict:
@@ -160,14 +209,49 @@ def target_context(design: dict, year_id: str, uda_id: str, item_id: str) -> dic
             items = uda.get("items", [])
             for index, item in enumerate(items):
                 if item.get("id") == item_id:
+                    previous_topics = items[max(0, index - 2):index]
+                    next_topics = items[index + 1:index + 3]
                     return {
                         "year": {key: year.get(key, "") for key in ["id", "title", "description"]},
                         "uda": {key: uda.get(key, "") for key in ["id", "title", "path", "weeks"]},
-                        "previous_topics": [topic_summary(candidate) for candidate in items[max(0, index - 2):index]],
-                        "target_topic": topic_summary(item),
-                        "next_topics": [topic_summary(candidate) for candidate in items[index + 1:index + 3]],
+                        "position": topic_position(index, items, item),
+                        "previous_topics": [
+                            topic_summary(candidate, include_text=True)
+                            for candidate in previous_topics
+                        ],
+                        "target_topic": topic_summary(
+                            item,
+                            include_text=True,
+                            child_text_budget=MAX_CHILDREN_WITH_TEXT,
+                        ),
+                        "next_topics": [
+                            topic_summary(candidate, include_text=True)
+                            for candidate in next_topics
+                        ],
                     }
     raise ValueError("Argomento non trovato nel percorso didattico corrente.")
+
+
+def topic_position(index: int, items: list[dict], item: dict) -> dict:
+    """Describe how much local didactic context surrounds a topic."""
+
+    previous_count = index
+    next_count = max(0, len(items) - index - 1)
+    has_children = bool(item.get("children"))
+    if previous_count and next_count:
+        quality = "good"
+    elif previous_count or next_count or has_children:
+        quality = "medium"
+    else:
+        quality = "weak"
+    return {
+        "index_in_uda": index + 1,
+        "total_items_in_uda": len(items),
+        "previous_topics_available": previous_count,
+        "next_topics_available": next_count,
+        "has_subtopics": has_children,
+        "context_quality": quality,
+    }
 
 
 def didactic_frame_schema_openai() -> dict:
@@ -197,7 +281,10 @@ def didactic_frame_system_prompt() -> str:
     return (
         "Sei un docente di TPSI e programmazione C. "
         "Compila una cornice didattica in italiano per un argomento del corso. "
-        "Sii concreto, fluido e didattico; non inventare link; non perdere il contenuto tecnico."
+        "Usa prima di tutto il testo locale dei paragrafi forniti nel payload. "
+        "Sii concreto, fluido e didattico; non inventare link; non perdere il contenuto tecnico. "
+        "Se la qualita del contesto e weak, resta prudente e non inventare una progressione didattica. "
+        "Se la qualita del contesto e medium o good, collega l'argomento ai paragrafi precedenti e successivi."
     )
 
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -828,10 +828,14 @@ def call_chat_completions_json(provider_name: str, url: str, api_key: str, model
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": json.dumps(payload, ensure_ascii=False, indent=2)},
         ],
+        "response_format": {"type": "json_object"},
     }
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "2cornot2c-course-board/1.0",
+        "Connection": "close",
     }
     if provider_name == "OpenRouter":
         headers["HTTP-Referer"] = "https://github.com/TheBitPoets/2cornot2c"

--- a/scripts/generate_course_plan.py
+++ b/scripts/generate_course_plan.py
@@ -8,6 +8,15 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_INPUT = ROOT / "doc" / "course_design.json"
 DEFAULT_OUTPUT = ROOT / "doc" / "PERCORSO_DIDATTICO.md"
+FRAME_FIELDS = [
+    ("context", "Contesto"),
+    ("prerequisites", "Prerequisiti"),
+    ("objectives", "Obiettivi"),
+    ("recall", "Richiamo"),
+    ("preview", "Anticipazione"),
+    ("next_step", "Prossimo passo"),
+    ("references", "Rimando"),
+]
 
 
 def load_design(path: Path) -> dict[str, Any]:
@@ -42,7 +51,20 @@ def render_items(items: list[dict[str, Any]], depth: int = 0) -> list[str]:
         level = item.get("level", "?")
         status = item.get("frame", {}).get("status", "todo")
         lines.append(f"{indent}- {title} `{source}` H{level} `{status}`")
+        lines.extend(render_frame(item.get("frame", {}), depth + 1))
         lines.extend(render_items(item.get("children", []), depth + 1))
+    return lines
+
+
+def render_frame(frame: dict[str, Any], depth: int) -> list[str]:
+    """Render filled didactic-frame fields below a topic."""
+    lines: list[str] = []
+    indent = "  " * depth
+    for key, label in FRAME_FIELDS:
+        value = str(frame.get(key, "")).strip()
+        if not value:
+            continue
+        lines.append(f"{indent}- **{label}:** {value}")
     return lines
 
 

--- a/scripts/probe_ai_payload_limit.py
+++ b/scripts/probe_ai_payload_limit.py
@@ -153,7 +153,7 @@ def call_provider(provider_id: str, model: str, api_key: str, text_chars: int, t
             {"role": "user", "content": json.dumps(payload, ensure_ascii=False, indent=2)},
         ],
         "response_format": {"type": "json_object"},
-        "max_tokens": 180,
+        "max_tokens": 700,
     }
     encoded = json.dumps(body).encode("utf-8")
     headers = {

--- a/scripts/probe_ai_payload_limit.py
+++ b/scripts/probe_ai_payload_limit.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Probe practical AI payload limits for OpenAI-compatible providers.
+
+The Course Design Board sends didactic-frame requests to providers such as
+Groq and OpenRouter. Some free or low-cost models reject large requests because
+of context limits, token-per-minute limits, or provider-specific quotas.
+
+This script sends small JSON-only chat-completion requests with an increasingly
+large `target_topic.text` field and reports a safe value for:
+
+- GROQ_COMPACT_TEXT_CHARS
+- OPENROUTER_COMPACT_TEXT_CHARS
+
+The result is empirical: provider limits can change by model, account, time,
+and requests already sent in the current minute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SECRET_PATH = ROOT / ".secrets" / "ai.secret"
+
+PROVIDERS = {
+    "groq": {
+        "label": "Groq",
+        "url": "https://api.groq.com/openai/v1/chat/completions",
+        "secret_key": "GROQ_API_KEY",
+        "model_key": "GROQ_MODEL",
+        "default_model": "llama-3.3-70b-versatile",
+    },
+    "openrouter": {
+        "label": "OpenRouter",
+        "url": "https://openrouter.ai/api/v1/chat/completions",
+        "secret_key": "OPENROUTER_API_KEY",
+        "model_key": "OPENROUTER_MODEL",
+        "default_model": "openrouter/free",
+    },
+}
+
+
+def read_secret_env() -> dict[str, str]:
+    """Read local key-value pairs from .secrets/ai.secret."""
+
+    values: dict[str, str] = {}
+    if not SECRET_PATH.is_file():
+        return values
+    for line in SECRET_PATH.read_text(encoding="utf-8-sig").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def secret_value(key: str) -> str:
+    """Return a value from the environment first, then .secrets/ai.secret."""
+
+    return os.environ.get(key, "") or read_secret_env().get(key, "")
+
+
+def build_payload(text_chars: int) -> dict:
+    """Build a didactic-frame-like payload with controlled text size."""
+
+    repeated_text = (
+        "Questo e un testo didattico sintetico usato solo per misurare il limite "
+        "pratico del payload. "
+    )
+    target_text = (repeated_text * ((text_chars // len(repeated_text)) + 1))[:text_chars]
+    return {
+        "course": {
+            "years": [
+                {
+                    "title": "Terzo anno TPSI",
+                    "description": "C base e intermedio",
+                    "udas": [
+                        {
+                            "title": "UDA di prova",
+                            "path": "Base",
+                            "weeks": "1-3",
+                        }
+                    ],
+                }
+            ]
+        },
+        "target": {
+            "year": {"title": "Terzo anno TPSI"},
+            "uda": {"title": "UDA di prova", "path": "Base", "weeks": "1-3"},
+            "position": {"index": 1, "total": 3},
+            "previous_topics": [
+                {"title": "Variabili", "source": "README.md", "level": 2},
+                {"title": "Operatori", "source": "README.md", "level": 2},
+            ],
+            "target_topic": {
+                "title": "Puntatori",
+                "source": "README.md",
+                "level": 2,
+                "href": "README.md#puntatori",
+                "text": target_text,
+                "children": [
+                    {"title": "Indirizzi", "source": "README.md", "level": 3},
+                    {"title": "Dereferenziazione", "source": "README.md", "level": 3},
+                ],
+            },
+            "next_topics": [
+                {"title": "Array", "source": "README.md", "level": 2},
+                {"title": "Stringhe", "source": "README.md", "level": 2},
+            ],
+        },
+        "context_mode": "probe",
+    }
+
+
+def parse_json_object(text: str) -> dict:
+    """Parse JSON even when the provider wraps it in markdown fences."""
+
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?", "", text).strip()
+        text = re.sub(r"```$", "", text).strip()
+    if not text.startswith("{"):
+        start = text.find("{")
+        end = text.rfind("}")
+        if start >= 0 and end > start:
+            text = text[start:end + 1]
+    return json.loads(text)
+
+
+def call_provider(provider_id: str, model: str, api_key: str, text_chars: int, timeout: int) -> tuple[bool, str, int]:
+    """Send one probe request and return success, detail, and request bytes."""
+
+    provider = PROVIDERS[provider_id]
+    payload = build_payload(text_chars)
+    system_prompt = (
+        "Rispondi solo con JSON valido. Compila in italiano questi campi: "
+        "context, prerequisites, objectives, recall, preview, next_step, references."
+    )
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": json.dumps(payload, ensure_ascii=False, indent=2)},
+        ],
+        "response_format": {"type": "json_object"},
+        "max_tokens": 180,
+    }
+    encoded = json.dumps(body).encode("utf-8")
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "2cornot2c-course-board/1.0",
+        "Connection": "close",
+    }
+    if provider_id == "openrouter":
+        headers["HTTP-Referer"] = "https://github.com/TheBitPoets/2cornot2c"
+        headers["X-Title"] = "2cornot2c Course Design Board"
+    request = urllib.request.Request(provider["url"], data=encoded, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+        parse_json_object(data["choices"][0]["message"]["content"])
+        return True, "ok", len(encoded)
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        return False, f"HTTP {error.code}: {detail}", len(encoded)
+    except Exception as error:  # noqa: BLE001 - this is a diagnostic CLI.
+        return False, f"{type(error).__name__}: {error}", len(encoded)
+
+
+def main() -> int:
+    """Run a bounded binary search for the practical provider payload limit."""
+
+    parser = argparse.ArgumentParser(description="Probe AI payload limits for Course Design Board providers.")
+    parser.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    parser.add_argument("--model", default="", help="Model id. Defaults to provider env/config default.")
+    parser.add_argument("--min-chars", type=int, default=500)
+    parser.add_argument("--max-chars", type=int, default=8000)
+    parser.add_argument("--safety", type=float, default=0.8, help="Safety factor for the recommended value.")
+    parser.add_argument("--sleep", type=float, default=2.0, help="Seconds between requests to reduce rate-limit noise.")
+    parser.add_argument("--timeout", type=int, default=120)
+    args = parser.parse_args()
+
+    provider = PROVIDERS[args.provider]
+    api_key = secret_value(provider["secret_key"])
+    if not api_key:
+        print(f"Errore: manca {provider['secret_key']} in ambiente o in .secrets/ai.secret.", file=sys.stderr)
+        return 2
+
+    model = args.model or secret_value(provider["model_key"]) or provider["default_model"]
+    low = max(0, args.min_chars)
+    high = max(low, args.max_chars)
+    best = 0
+    best_bytes = 0
+    last_error = ""
+
+    print(f"Provider: {provider['label']}")
+    print(f"Modello: {model}")
+    print(f"Ricerca: {low}..{high} caratteri di testo target")
+    print("Nota: se il provider ha un limite TPM, attendi 60 secondi prima di ripetere il probe.\n")
+
+    while low <= high:
+        mid = (low + high) // 2
+        ok, detail, request_bytes = call_provider(args.provider, model, api_key, mid, args.timeout)
+        status = "OK" if ok else "FAIL"
+        print(f"{status} text_chars={mid} request_bytes={request_bytes}")
+        if ok:
+            best = mid
+            best_bytes = request_bytes
+            low = mid + 1
+        else:
+            last_error = detail
+            high = mid - 1
+            print(f"  dettaglio: {detail[:500]}")
+        if low <= high and args.sleep > 0:
+            time.sleep(args.sleep)
+
+    recommended = int(best * args.safety)
+    env_name = f"{args.provider.upper()}_COMPACT_TEXT_CHARS"
+    print("\nRisultato")
+    print(f"- massimo riuscito: {best} caratteri target ({best_bytes} byte circa di richiesta)")
+    print(f"- valore consigliato con safety {args.safety:.2f}: {recommended}")
+    print(f"- variabile da impostare: {env_name}={recommended}")
+    if last_error:
+        print(f"- ultimo errore osservato: {last_error[:500]}")
+    return 0 if best else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_ai_payload_limit.py
+++ b/scripts/probe_ai_payload_limit.py
@@ -32,6 +32,13 @@ ROOT = Path(__file__).resolve().parents[1]
 SECRET_PATH = ROOT / ".secrets" / "ai.secret"
 
 PROVIDERS = {
+    "gemini": {
+        "label": "Gemini",
+        "url": "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}",
+        "secret_key": "GEMINI_API_KEY",
+        "model_key": "GEMINI_MODEL",
+        "default_model": "gemini-3-flash-preview",
+    },
     "groq": {
         "label": "Groq",
         "url": "https://api.groq.com/openai/v1/chat/completions",
@@ -140,6 +147,14 @@ def parse_json_object(text: str) -> dict:
 def call_provider(provider_id: str, model: str, api_key: str, text_chars: int, timeout: int) -> tuple[bool, str, int]:
     """Send one probe request and return success, detail, and request bytes."""
 
+    if provider_id == "gemini":
+        return call_gemini_provider(model, api_key, text_chars, timeout)
+    return call_chat_completions_provider(provider_id, model, api_key, text_chars, timeout)
+
+
+def call_chat_completions_provider(provider_id: str, model: str, api_key: str, text_chars: int, timeout: int) -> tuple[bool, str, int]:
+    """Send one probe request to an OpenAI-compatible provider."""
+
     provider = PROVIDERS[provider_id]
     payload = build_payload(text_chars)
     system_prompt = (
@@ -171,6 +186,52 @@ def call_provider(provider_id: str, model: str, api_key: str, text_chars: int, t
         with urllib.request.urlopen(request, timeout=timeout) as response:
             data = json.loads(response.read().decode("utf-8"))
         parse_json_object(data["choices"][0]["message"]["content"])
+        return True, "ok", len(encoded)
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        return False, f"HTTP {error.code}: {detail}", len(encoded)
+    except Exception as error:  # noqa: BLE001 - this is a diagnostic CLI.
+        return False, f"{type(error).__name__}: {error}", len(encoded)
+
+
+def call_gemini_provider(model: str, api_key: str, text_chars: int, timeout: int) -> tuple[bool, str, int]:
+    """Send one probe request to Gemini."""
+
+    payload = build_payload(text_chars)
+    body = {
+        "systemInstruction": {
+            "parts": [
+                {
+                    "text": (
+                        "Rispondi solo con JSON valido. Compila in italiano questi campi: "
+                        "context, prerequisites, objectives, recall, preview, next_step, references."
+                    )
+                }
+            ],
+        },
+        "contents": [
+            {
+                "role": "user",
+                "parts": [{"text": json.dumps(payload, ensure_ascii=False, indent=2)}],
+            }
+        ],
+        "generationConfig": {
+            "responseMimeType": "application/json",
+            "maxOutputTokens": 900,
+        },
+    }
+    encoded = json.dumps(body).encode("utf-8")
+    url = PROVIDERS["gemini"]["url"].format(model=model, api_key=api_key)
+    request = urllib.request.Request(
+        url,
+        data=encoded,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+        parse_json_object(data["candidates"][0]["content"]["parts"][0]["text"])
         return True, "ok", len(encoded)
     except urllib.error.HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace")

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -279,6 +279,15 @@ input, select { width: 100%; padding: .72rem .9rem; }
   align-items: baseline;
 }
 
+.yearHead [data-action="ai-course"] {
+  flex: 0 0 auto;
+  border-color: rgba(17, 17, 17, .32);
+  background: #111111;
+  color: #ffffff;
+  padding: .55rem .75rem;
+  font-size: .76rem;
+}
+
 .year h3 { margin-bottom: .2rem; font-size: 1.45rem; }
 .yearMeta { color: var(--muted); font-size: .9rem; }
 
@@ -393,10 +402,79 @@ input, select { width: 100%; padding: .72rem .9rem; }
   padding: .8rem;
 }
 
+.courseAiDialog {
+  width: min(72rem, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  border: 1px solid rgba(17, 17, 17, .2);
+  border-radius: 24px;
+  background: #ffffff;
+  color: var(--ink);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, .22);
+  padding: 0;
+}
+
+.courseAiDialog::backdrop {
+  background: rgba(0, 0, 0, .34);
+}
+
+.courseAiPanel {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+}
+
+.courseAiHead,
+.courseAiActions {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.briefGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: .75rem;
+}
+
+.briefGrid label,
+.wideField {
+  display: grid;
+  gap: .32rem;
+  color: var(--muted);
+  font-size: .76rem;
+  font-weight: 700;
+}
+
+.courseAiPreview {
+  max-height: 22rem;
+  overflow: auto;
+  border: 1px solid rgba(17, 17, 17, .12);
+  border-radius: 18px;
+  background: #fafafa;
+  padding: .85rem;
+}
+
+.courseAiPreview table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .78rem;
+}
+
+.courseAiPreview th,
+.courseAiPreview td {
+  border-bottom: 1px solid rgba(17, 17, 17, .1);
+  padding: .45rem;
+  text-align: left;
+  vertical-align: top;
+}
+
 @media (max-width: 860px) {
   .hero { align-items: flex-start; flex-direction: column; }
   .board { grid-template-columns: 1fr; }
   .panel { min-height: auto; }
   .headingList, .courseTree { height: auto; max-height: 60vh; }
   .frameGrid { grid-template-columns: 1fr; }
+  .briefGrid { grid-template-columns: 1fr; }
+  .courseAiHead, .courseAiActions { align-items: flex-start; flex-direction: column; }
 }

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -150,14 +150,32 @@ button:hover { transform: translateY(-1px); }
 .status { margin: 0; color: var(--muted); font-size: .9rem; }
 
 .aiConfig {
+  display: flex;
+  align-items: center;
+  gap: .55rem;
+  flex-wrap: wrap;
   margin: .35rem 0 0;
   border: 1px solid rgba(17, 17, 17, .1);
-  border-radius: 999px;
+  border-radius: 1rem;
   background: #f5f5f5;
   color: var(--muted);
   font-size: .72rem;
   line-height: 1.35;
   padding: .42rem .65rem;
+}
+
+.aiConfig label {
+  display: flex;
+  align-items: center;
+  gap: .45rem;
+  font-weight: 700;
+}
+
+.aiConfig select {
+  width: auto;
+  min-width: 16rem;
+  padding: .42rem .65rem;
+  font-size: .72rem;
 }
 
 .filters {

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -91,7 +91,17 @@ h1 {
   display: block;
 }
 
-.actions { display: flex; gap: .75rem; flex-wrap: wrap; }
+.actions {
+  display: flex;
+  gap: .55rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.actions select {
+  width: auto;
+  min-width: 13rem;
+}
 
 button, select, input {
   border: 1px solid var(--line);

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -577,6 +577,20 @@ input, select { width: 100%; padding: .72rem .9rem; }
   transition: width .35s ease;
 }
 
+.aiBusyControls {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  gap: .4rem;
+  flex-wrap: wrap;
+  margin-top: .35rem;
+}
+
+.aiBusyControls button {
+  padding: .38rem .58rem;
+  font-size: .72rem;
+}
+
 @media (max-width: 860px) {
   .hero { align-items: flex-start; flex-direction: column; }
   .board { grid-template-columns: 1fr; }

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -469,6 +469,58 @@ input, select { width: 100%; padding: .72rem .9rem; }
   vertical-align: top;
 }
 
+.aiBusy {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  z-index: 20;
+  width: min(28rem, calc(100vw - 2.5rem));
+}
+
+.aiBusyCard {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: .75rem;
+  border: 1px solid rgba(17, 17, 17, .18);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, .96);
+  box-shadow: 0 22px 58px rgba(0, 0, 0, .18);
+  padding: 1rem;
+}
+
+.aiBusyCard p {
+  margin: .25rem 0 0;
+  color: var(--muted);
+  font-size: .82rem;
+}
+
+.aiBusyPercent {
+  align-self: start;
+  border: 1px solid rgba(17, 17, 17, .12);
+  border-radius: 999px;
+  background: #f4f4f4;
+  color: var(--ink);
+  font-weight: 700;
+  padding: .38rem .55rem;
+}
+
+.aiBusyBar {
+  grid-column: 1 / -1;
+  height: .45rem;
+  border-radius: 999px;
+  background: #ececec;
+  overflow: hidden;
+}
+
+.aiBusyBar span {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #111111, #707070);
+  transition: width .35s ease;
+}
+
 @media (max-width: 860px) {
   .hero { align-items: flex-start; flex-direction: column; }
   .board { grid-template-columns: 1fr; }

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -101,6 +101,18 @@ button, select, input {
   font: 700 .88rem/1.2 var(--mono);
 }
 
+textarea {
+  width: 100%;
+  min-height: 4.2rem;
+  resize: vertical;
+  border: 1px solid var(--line);
+  border-radius: .9rem;
+  background: #ffffff;
+  color: var(--ink);
+  font: .78rem/1.45 var(--mono);
+  padding: .65rem .75rem;
+}
+
 button {
   cursor: pointer;
   padding: .72rem 1rem;
@@ -322,6 +334,42 @@ input, select { width: 100%; padding: .72rem .9rem; }
   border-top: 1px solid rgba(17, 17, 17, .08);
 }
 
+.frameEditor {
+  margin-top: .55rem;
+  border-top: 1px solid rgba(17, 17, 17, .08);
+  padding-top: .55rem;
+}
+
+.frameEditor summary {
+  cursor: pointer;
+  color: var(--muted);
+  font-size: .75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+}
+
+.frameGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .65rem;
+  margin-top: .7rem;
+}
+
+.frameGrid label {
+  display: grid;
+  gap: .28rem;
+  color: var(--muted);
+  font-size: .72rem;
+  font-weight: 700;
+}
+
+.frameGrid select {
+  width: 100%;
+  padding: .55rem .7rem;
+  font-size: .76rem;
+}
+
 .empty {
   color: var(--muted);
   font-style: italic;
@@ -333,4 +381,5 @@ input, select { width: 100%; padding: .72rem .9rem; }
   .board { grid-template-columns: 1fr; }
   .panel { min-height: auto; }
   .headingList, .courseTree { height: auto; max-height: 60vh; }
+  .frameGrid { grid-template-columns: 1fr; }
 }

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -333,6 +333,18 @@ input, select { width: 100%; padding: .72rem .9rem; }
   color: #ffffff;
 }
 
+.contextBadge {
+  align-self: center;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 999px;
+  background: #f4f4f4;
+  color: var(--muted);
+  font-size: .66rem;
+  font-weight: 700;
+  padding: .28rem .5rem;
+  white-space: nowrap;
+}
+
 .itemChildren {
   margin-top: .5rem;
   padding-top: .5rem;

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -149,6 +149,17 @@ button:hover { transform: translateY(-1px); }
 
 .status { margin: 0; color: var(--muted); font-size: .9rem; }
 
+.aiConfig {
+  margin: .35rem 0 0;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-radius: 999px;
+  background: #f5f5f5;
+  color: var(--muted);
+  font-size: .72rem;
+  line-height: 1.35;
+  padding: .42rem .65rem;
+}
+
 .filters {
   display: grid;
   grid-template-columns: 1fr 8rem;

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -327,6 +327,11 @@ input, select { width: 100%; padding: .72rem .9rem; }
 .itemMeta { color: var(--muted); font: .76rem/1.35 var(--mono); }
 .itemActions { display: flex; gap: .25rem; }
 .itemActions button { padding: .35rem .5rem; font-size: .72rem; }
+.itemActions [data-action="ai"] {
+  border-color: rgba(17, 17, 17, .32);
+  background: #111111;
+  color: #ffffff;
+}
 
 .itemChildren {
   margin-top: .5rem;

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -414,6 +414,18 @@ input, select { width: 100%; padding: .72rem .9rem; }
   letter-spacing: .08em;
 }
 
+.frameEditor.frameEmpty summary {
+  color: #8a8a8a;
+}
+
+.frameEditor.frameReady summary {
+  color: #0f5132;
+}
+
+.frameEditor.frameReady {
+  border-top-color: rgba(15, 81, 50, .24);
+}
+
 .frameGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -183,9 +183,14 @@ button:hover { transform: translateY(-1px); }
 
 .aiConfig select {
   width: auto;
-  min-width: 16rem;
+  min-width: 12rem;
   padding: .42rem .65rem;
   font-size: .72rem;
+}
+
+.aiConfig select:disabled {
+  opacity: .48;
+  cursor: not-allowed;
 }
 
 .filters {

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -58,6 +58,67 @@
     </article>
   </template>
 
+  <dialog id="courseAiDialog" class="courseAiDialog">
+    <form method="dialog" class="courseAiPanel">
+      <header class="courseAiHead">
+        <div>
+          <p class="eyebrow">AI assisted percorso</p>
+          <h2 id="courseAiTitle">Genera percorso</h2>
+        </div>
+        <button id="courseAiCloseBtn" type="button">Chiudi</button>
+      </header>
+
+      <div class="briefGrid">
+        <label>
+          <span>Materia</span>
+          <input id="briefSubject" type="text">
+        </label>
+        <label>
+          <span>Anno</span>
+          <input id="briefYearTitle" type="text">
+        </label>
+        <label>
+          <span>Descrizione</span>
+          <input id="briefDescription" type="text">
+        </label>
+        <label>
+          <span>Ore/settimana</span>
+          <input id="briefWeeklyHours" type="number" min="1">
+        </label>
+        <label>
+          <span>Settimane</span>
+          <input id="briefWeeks" type="number" min="1">
+        </label>
+        <label>
+          <span>Ore totali</span>
+          <input id="briefTotalHours" type="number" min="1">
+        </label>
+      </div>
+
+      <label class="wideField">
+        <span>Obiettivi didattici</span>
+        <textarea id="briefGoals" rows="5"></textarea>
+      </label>
+      <label class="wideField">
+        <span>Vincoli</span>
+        <textarea id="briefConstraints" rows="5"></textarea>
+      </label>
+      <label class="wideField">
+        <span>Preferenze</span>
+        <textarea id="briefPreferences" rows="5"></textarea>
+      </label>
+
+      <div class="courseAiActions">
+        <button id="courseAiGenerateBtn" type="button" class="primary">Genera proposta</button>
+        <button id="courseAiApplyBtn" type="button" disabled>Applica proposta</button>
+      </div>
+
+      <section id="courseAiPreview" class="courseAiPreview">
+        <p class="empty">Nessuna proposta generata.</p>
+      </section>
+    </form>
+  </dialog>
+
   <script src="course_board.js"></script>
 </body>
 </html>

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -51,6 +51,19 @@
     </section>
   </main>
 
+  <div id="aiBusy" class="aiBusy" hidden>
+    <div class="aiBusyCard">
+      <div>
+        <strong id="aiBusyTitle">AI assisted in corso</strong>
+        <p id="aiBusyMessage">Preparo la richiesta...</p>
+      </div>
+      <div class="aiBusyPercent" id="aiBusyPercent">0%</div>
+      <div class="aiBusyBar" aria-hidden="true">
+        <span id="aiBusyBarFill"></span>
+      </div>
+    </div>
+  </div>
+
   <template id="headingTemplate">
     <article class="headingCard" draggable="true">
       <div class="headingTitle"></div>

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -46,6 +46,7 @@
       <div class="panelHead">
         <h2>Percorso didattico</h2>
         <p id="status" class="status">Pronto.</p>
+        <p id="aiConfig" class="aiConfig">AI: configurazione non caricata.</p>
       </div>
       <div id="courseTree" class="courseTree"></div>
     </section>

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -18,6 +18,11 @@
         <img src="https://github.com/TheBitPoets.png" alt="TheBitPoets">
       </a>
       <div class="actions">
+        <select id="savedDesignSelect" aria-label="Percorsi didattici salvati">
+          <option value="">Percorsi salvati</option>
+        </select>
+        <button id="loadSavedDesignBtn" type="button">Carica</button>
+        <button id="saveArchiveBtn" type="button">Salva archivio</button>
         <button id="reloadBtn" type="button">Ricarica</button>
         <button id="saveBtn" type="button" class="primary">Salva JSON</button>
       </div>

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -23,6 +23,7 @@
         </select>
         <button id="loadSavedDesignBtn" type="button">Carica archiviato</button>
         <button id="saveArchiveBtn" type="button">Aggiorna archivio</button>
+        <button id="generateAllFramesBtn" type="button">Genera cornici</button>
         <button id="reloadBtn" type="button">Ricarica</button>
         <button id="saveBtn" type="button" class="primary">Imposta corrente</button>
       </div>

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -21,10 +21,10 @@
         <select id="savedDesignSelect" aria-label="Percorsi didattici salvati">
           <option value="">Percorsi salvati</option>
         </select>
-        <button id="loadSavedDesignBtn" type="button">Carica</button>
-        <button id="saveArchiveBtn" type="button">Salva archivio</button>
+        <button id="loadSavedDesignBtn" type="button">Carica archiviato</button>
+        <button id="saveArchiveBtn" type="button">Aggiorna archivio</button>
         <button id="reloadBtn" type="button">Ricarica</button>
-        <button id="saveBtn" type="button" class="primary">Salva JSON</button>
+        <button id="saveBtn" type="button" class="primary">Imposta corrente</button>
       </div>
     </div>
   </header>

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -68,6 +68,12 @@
       <div class="aiBusyBar" aria-hidden="true">
         <span id="aiBusyBarFill"></span>
       </div>
+      <div id="aiBusyControls" class="aiBusyControls" hidden>
+        <button id="aiBusyNextBtn" type="button">Genera prossimo</button>
+        <button id="aiBusyAllBtn" type="button" class="primary">Genera tutti</button>
+        <button id="aiBusyCloseBtn" type="button">Chiudi</button>
+        <button id="aiBusyCancelBtn" type="button">Annulla</button>
+      </div>
     </div>
   </div>
 

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -180,7 +180,7 @@ async function loadSavedDesign() {
   state.activeSavedDesign = name;
   renderHeadings();
   renderCourse();
-  setStatus(`Percorso "${name}" caricato. Usa "Salva JSON" o "Salva archivio" per persistere modifiche.`);
+  setStatus(`Percorso "${name}" caricato. Usa "Imposta corrente" o "Aggiorna archivio" per persistere modifiche.`);
 }
 
 async function saveArchiveDesign() {
@@ -817,7 +817,7 @@ async function saveDesign() {
     method: "POST",
     body: JSON.stringify(state.design),
   });
-  setStatus("Salvato in doc/course_design.json.");
+  setStatus("Percorso impostato come corrente in doc/course_design.json.");
 }
 
 function escapeHtml(value) {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -55,9 +55,20 @@ async function api(path, options = {}) {
     ...options,
   });
   if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
+    throw new Error(await responseErrorMessage(response));
   }
   return response.json();
+}
+
+async function responseErrorMessage(response) {
+  const fallback = `${response.status} ${response.statusText}`;
+  try {
+    const payload = await response.json();
+    if (payload.error) return `${fallback}: ${payload.error}`;
+  } catch {
+    return fallback;
+  }
+  return fallback;
 }
 
 async function loadAll() {
@@ -501,7 +512,7 @@ async function generateCourseAiProposal() {
     setStatus(`Proposta percorso generata per ${year.title}.`);
   } catch (error) {
     els.courseAiPreview.innerHTML = `<p class="empty">Errore: ${escapeHtml(error.message)}</p>`;
-    setStatus(`AI assisted percorso non riuscito: ${error.message}`);
+    setStatus(`AI assisted percorso non riuscito. Dettaglio provider/server: ${error.message}`);
   } finally {
     els.courseAiGenerateBtn.disabled = false;
   }
@@ -576,7 +587,7 @@ async function fillFrameWithAi(year, uda, item) {
     renderCourse();
     setStatus(`Cornice didattica generata per "${item.title}".`);
   } catch (error) {
-    setStatus(`AI assisted non riuscito: ${error.message}`);
+    setStatus(`AI assisted non riuscito. Dettaglio provider/server: ${error.message}`);
   }
 }
 
@@ -673,3 +684,4 @@ loadAll().catch((error) => {
   console.error(error);
   setStatus(`Errore: ${error.message}`);
 });
+

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -149,8 +149,37 @@ function renderAiConfig() {
     els.aiConfig.textContent = "AI: configurazione non caricata.";
     return;
   }
+  const providers = state.aiConfig.providers || [];
+  const options = providers.map((provider) => {
+    const configured = provider.api_key_configured ? "configurato" : "non configurato";
+    const selected = provider.id === state.aiConfig.provider ? "selected" : "";
+    return `<option value="${escapeHtml(provider.id)}" ${selected}>${escapeHtml(provider.label)} · ${escapeHtml(provider.model)} · ${configured}</option>`;
+  }).join("");
   const keyStatus = state.aiConfig.api_key_configured ? "API key impostata" : "API key non impostata";
-  els.aiConfig.textContent = `AI: ${state.aiConfig.provider} · modello ${state.aiConfig.model} · ${keyStatus} · ${state.aiConfig.billing_note}`;
+  els.aiConfig.innerHTML = `
+    <label>
+      <span>AI provider</span>
+      <select id="aiProviderSelect">${options}</select>
+    </label>
+    <span>${escapeHtml(keyStatus)} · ${escapeHtml(state.aiConfig.billing_note)}</span>
+  `;
+  els.aiConfig.querySelector("#aiProviderSelect").addEventListener("change", switchAiProvider);
+}
+
+async function switchAiProvider(event) {
+  const provider = event.target.value;
+  setStatus(`Cambio provider AI in ${provider}...`);
+  try {
+    state.aiConfig = await api("/api/ai-config", {
+      method: "POST",
+      body: JSON.stringify({ provider }),
+    });
+    renderAiConfig();
+    setStatus(`Provider AI attivo: ${state.aiConfig.provider}.`);
+  } catch (error) {
+    renderAiConfig();
+    setStatus(`Cambio provider AI non riuscito. Dettaglio: ${error.message}`);
+  }
 }
 
 function populateFilters() {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1,6 +1,8 @@
 ﻿const state = {
   headings: [],
   design: null,
+  savedDesigns: [],
+  activeSavedDesign: "",
   aiConfig: null,
   draggedHeading: null,
   collapsedHeadingIds: new Set(),
@@ -18,6 +20,9 @@ const els = {
   courseTree: document.querySelector("#courseTree"),
   status: document.querySelector("#status"),
   aiConfig: document.querySelector("#aiConfig"),
+  savedDesignSelect: document.querySelector("#savedDesignSelect"),
+  loadSavedDesignBtn: document.querySelector("#loadSavedDesignBtn"),
+  saveArchiveBtn: document.querySelector("#saveArchiveBtn"),
   reloadBtn: document.querySelector("#reloadBtn"),
   saveBtn: document.querySelector("#saveBtn"),
   courseAiDialog: document.querySelector("#courseAiDialog"),
@@ -129,19 +134,68 @@ async function responseErrorMessage(response) {
 
 async function loadAll() {
   setStatus("Caricamento...");
-  const [headingsPayload, design, aiConfig] = await Promise.all([
+  const [headingsPayload, design, aiConfig, savedDesigns] = await Promise.all([
     api("/api/headings"),
     api("/api/course-design"),
     api("/api/ai-config"),
+    api("/api/saved-designs"),
   ]);
   state.headings = headingsPayload.headings;
   state.design = design;
   state.aiConfig = aiConfig;
+  state.savedDesigns = savedDesigns.designs || [];
   populateFilters();
   renderAiConfig();
+  renderSavedDesigns();
   renderHeadings();
   renderCourse();
   setStatus("Pronto.");
+}
+
+function renderSavedDesigns() {
+  const selected = state.activeSavedDesign || els.savedDesignSelect.value;
+  els.savedDesignSelect.innerHTML = '<option value="">Percorsi salvati</option>';
+  for (const design of state.savedDesigns) {
+    const option = document.createElement("option");
+    option.value = design.name;
+    option.textContent = design.name;
+    els.savedDesignSelect.append(option);
+  }
+  els.savedDesignSelect.value = selected;
+}
+
+async function loadSavedDesign() {
+  const name = els.savedDesignSelect.value;
+  if (!name) {
+    setStatus("Seleziona un percorso salvato da caricare.");
+    return;
+  }
+  if (!confirm(`Caricare "${name}" nella board? Le modifiche non salvate nella vista corrente saranno perse.`)) return;
+  setStatus(`Caricamento percorso salvato "${name}"...`);
+  const payload = await api("/api/saved-designs/load", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+  state.design = payload.design;
+  state.activeSavedDesign = name;
+  renderHeadings();
+  renderCourse();
+  setStatus(`Percorso "${name}" caricato. Usa "Salva JSON" o "Salva archivio" per persistere modifiche.`);
+}
+
+async function saveArchiveDesign() {
+  const defaultName = state.activeSavedDesign || els.savedDesignSelect.value || "course_design_as_25_26.json";
+  const name = prompt("Nome file archivio JSON:", defaultName);
+  if (!name) return;
+  setStatus(`Salvataggio archivio "${name}"...`);
+  const payload = await api("/api/saved-designs/save", {
+    method: "POST",
+    body: JSON.stringify({ name, design: state.design }),
+  });
+  state.savedDesigns = payload.designs || [];
+  state.activeSavedDesign = payload.saved?.name || name;
+  renderSavedDesigns();
+  setStatus(`Percorso salvato in archivio: ${state.activeSavedDesign}.`);
 }
 
 function renderAiConfig() {
@@ -776,6 +830,8 @@ function escapeHtml(value) {
 
 els.reloadBtn.addEventListener("click", loadAll);
 els.saveBtn.addEventListener("click", saveDesign);
+els.loadSavedDesignBtn.addEventListener("click", loadSavedDesign);
+els.saveArchiveBtn.addEventListener("click", saveArchiveDesign);
 els.courseAiCloseBtn.addEventListener("click", () => els.courseAiDialog.close());
 els.courseAiGenerateBtn.addEventListener("click", generateCourseAiProposal);
 els.courseAiApplyBtn.addEventListener("click", applyCourseAiProposal);

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -309,7 +309,7 @@ function renderUda(year, uda) {
   if (!items.length) {
     dropzone.innerHTML = '<p class="empty">Trascina qui paragrafi o sottoparagrafi.</p>';
   } else {
-    items.forEach((item, index) => dropzone.append(renderItem(uda, uda.items, item, index, 0)));
+    items.forEach((item, index) => dropzone.append(renderItem(year, uda, uda.items, item, index, 0)));
   }
   details.append(dropzone);
   return details;
@@ -337,7 +337,7 @@ function headingTreeIds(heading) {
   return ids;
 }
 
-function renderItem(uda, siblings, item, index, depth) {
+function renderItem(year, uda, siblings, item, index, depth) {
   const node = document.createElement("article");
   node.className = "item";
   node.style.setProperty("--item-depth", depth);
@@ -352,6 +352,7 @@ function renderItem(uda, siblings, item, index, depth) {
         <div class="itemMeta">${escapeHtml(item.source)} · H${item.level || "?"} · ${escapeHtml(item.frame?.status || "ok")}</div>
       </div>
       <div class="itemActions">
+        <button type="button" data-action="ai">AI assisted</button>
         <button type="button" data-action="up">Su</button>
         <button type="button" data-action="down">Giu</button>
         <button type="button" data-action="remove">Rimuovi</button>
@@ -378,6 +379,7 @@ function renderItem(uda, siblings, item, index, depth) {
   const titleText = document.createElement("span");
   titleText.textContent = item.title;
   title.append(titleText);
+  node.querySelector('[data-action="ai"]').addEventListener("click", () => fillFrameWithAi(year, uda, item));
   node.querySelector('[data-action="up"]').addEventListener("click", () => moveItem(siblings, index, -1));
   node.querySelector('[data-action="down"]').addEventListener("click", () => moveItem(siblings, index, 1));
   node.querySelector('[data-action="remove"]').addEventListener("click", () => removeItem(siblings, index));
@@ -385,10 +387,30 @@ function renderItem(uda, siblings, item, index, depth) {
   if (children.length && !isCollapsed) {
     const childList = document.createElement("div");
     childList.className = "itemChildren";
-    children.forEach((child, childIndex) => childList.append(renderItem(uda, children, child, childIndex, depth + 1)));
+    children.forEach((child, childIndex) => childList.append(renderItem(year, uda, children, child, childIndex, depth + 1)));
     node.append(childList);
   }
   return node;
+}
+
+async function fillFrameWithAi(year, uda, item) {
+  setStatus(`AI assisted: preparo la cornice per "${item.title}"...`);
+  try {
+    const payload = await api("/api/ai-frame", {
+      method: "POST",
+      body: JSON.stringify({
+        design: state.design,
+        year_id: year.id,
+        uda_id: uda.id,
+        item_id: item.id,
+      }),
+    });
+    item.frame = { ...defaultFrame(), ...(item.frame || {}), ...payload.frame, status: "draft" };
+    renderCourse();
+    setStatus(`Cornice didattica generata per "${item.title}".`);
+  } catch (error) {
+    setStatus(`AI assisted non riuscito: ${error.message}`);
+  }
 }
 
 function renderFrameEditor(item) {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -23,6 +23,7 @@ const els = {
   savedDesignSelect: document.querySelector("#savedDesignSelect"),
   loadSavedDesignBtn: document.querySelector("#loadSavedDesignBtn"),
   saveArchiveBtn: document.querySelector("#saveArchiveBtn"),
+  generateAllFramesBtn: document.querySelector("#generateAllFramesBtn"),
   reloadBtn: document.querySelector("#reloadBtn"),
   saveBtn: document.querySelector("#saveBtn"),
   courseAiDialog: document.querySelector("#courseAiDialog"),
@@ -107,7 +108,7 @@ function failAiProgress(message = "Operazione non riuscita.") {
   updateAiProgress(100, message);
   setTimeout(() => {
     if (!aiProgressTimer) els.aiBusy.hidden = true;
-  }, 2200);
+  }, 8000);
 }
 
 async function api(path, options = {}) {
@@ -744,13 +745,14 @@ async function fillFrameWithAi(year, uda, item) {
     stopAiProgress("Cornice didattica generata.");
   } catch (error) {
     setStatus(`AI assisted non riuscito. Dettaglio provider/server: ${error.message}`);
-    failAiProgress("Errore durante la generazione della cornice.");
+    failAiProgress(`Errore provider/server: ${error.message}`);
   }
 }
 
 function renderFrameEditor(item) {
   const details = document.createElement("details");
   details.className = "frameEditor";
+  details.classList.add(frameHasContent(item.frame) ? "frameReady" : "frameEmpty");
   details.innerHTML = `
     <summary>Cornice didattica</summary>
     <div class="frameGrid">
@@ -787,6 +789,63 @@ function renderFrameEditor(item) {
     grid.append(label);
   }
   return details;
+}
+
+function frameHasContent(frame = {}) {
+  return FRAME_FIELDS.some((field) => String(frame[field.key] || "").trim());
+}
+
+function collectCourseItems() {
+  const entries = [];
+  for (const year of state.design.years || []) {
+    for (const uda of year.udas || []) {
+      collectItemsFromTree(year, uda, uda.items || [], entries);
+    }
+  }
+  return entries;
+}
+
+function collectItemsFromTree(year, uda, items, entries) {
+  for (const item of items) {
+    entries.push({ year, uda, item });
+    collectItemsFromTree(year, uda, item.children || [], entries);
+  }
+}
+
+async function generateAllFrames() {
+  const entries = collectCourseItems();
+  if (!entries.length) {
+    setStatus("Nessun argomento nel percorso: non ci sono cornici da generare.");
+    return;
+  }
+  if (!confirm(`Generare o aggiornare le cornici didattiche per ${entries.length} argomenti? L'operazione puo richiedere tempo.`)) return;
+  els.generateAllFramesBtn.disabled = true;
+  startAiProgress(`AI assisted cornici: ${entries.length} argomenti`);
+  try {
+    for (const [index, entry] of entries.entries()) {
+      const percent = Math.min(95, Math.round((index / entries.length) * 95));
+      updateAiProgress(percent, `Genero cornice ${index + 1}/${entries.length}: ${entry.item.title}`);
+      setStatus(`Genero cornice ${index + 1}/${entries.length}: ${entry.item.title}`);
+      const payload = await api("/api/ai-frame", {
+        method: "POST",
+        body: JSON.stringify({
+          design: state.design,
+          year_id: entry.year.id,
+          uda_id: entry.uda.id,
+          item_id: entry.item.id,
+        }),
+      });
+      entry.item.frame = { ...defaultFrame(), ...(entry.item.frame || {}), ...payload.frame, status: "draft" };
+    }
+    renderCourse();
+    stopAiProgress("Cornici didattiche generate.");
+    setStatus(`Generate ${entries.length} cornici didattiche. Ricordati di salvare il JSON.`);
+  } catch (error) {
+    failAiProgress(`Errore provider/server: ${error.message}`);
+    setStatus(`Generazione cornici interrotta. Dettaglio provider/server: ${error.message}`);
+  } finally {
+    els.generateAllFramesBtn.disabled = false;
+  }
 }
 
 function moveItem(items, index, delta) {
@@ -832,6 +891,7 @@ els.reloadBtn.addEventListener("click", loadAll);
 els.saveBtn.addEventListener("click", saveDesign);
 els.loadSavedDesignBtn.addEventListener("click", loadSavedDesign);
 els.saveArchiveBtn.addEventListener("click", saveArchiveDesign);
+els.generateAllFramesBtn.addEventListener("click", generateAllFrames);
 els.courseAiCloseBtn.addEventListener("click", () => els.courseAiDialog.close());
 els.courseAiGenerateBtn.addEventListener("click", generateCourseAiProposal);
 els.courseAiApplyBtn.addEventListener("click", applyCourseAiProposal);

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -37,6 +37,11 @@ const els = {
   aiBusyMessage: document.querySelector("#aiBusyMessage"),
   aiBusyPercent: document.querySelector("#aiBusyPercent"),
   aiBusyBarFill: document.querySelector("#aiBusyBarFill"),
+  aiBusyControls: document.querySelector("#aiBusyControls"),
+  aiBusyNextBtn: document.querySelector("#aiBusyNextBtn"),
+  aiBusyAllBtn: document.querySelector("#aiBusyAllBtn"),
+  aiBusyCloseBtn: document.querySelector("#aiBusyCloseBtn"),
+  aiBusyCancelBtn: document.querySelector("#aiBusyCancelBtn"),
   briefSubject: document.querySelector("#briefSubject"),
   briefYearTitle: document.querySelector("#briefYearTitle"),
   briefDescription: document.querySelector("#briefDescription"),
@@ -68,6 +73,7 @@ const AI_PROGRESS_STAGES = [
 ];
 
 let aiProgressTimer = null;
+let frameBatch = null;
 
 function setStatus(message) {
   els.status.textContent = message;
@@ -77,6 +83,7 @@ function startAiProgress(title) {
   let percent = 4;
   let stageIndex = 0;
   els.aiBusy.hidden = false;
+  els.aiBusyControls.hidden = true;
   els.aiBusyTitle.textContent = title;
   updateAiProgress(percent, AI_PROGRESS_STAGES[stageIndex]);
   clearInterval(aiProgressTimer);
@@ -109,6 +116,24 @@ function failAiProgress(message = "Operazione non riuscita.") {
   setTimeout(() => {
     if (!aiProgressTimer) els.aiBusy.hidden = true;
   }, 8000);
+}
+
+function showFrameBatchProgress() {
+  if (!frameBatch) return;
+  clearInterval(aiProgressTimer);
+  aiProgressTimer = null;
+  els.aiBusy.hidden = false;
+  els.aiBusyControls.hidden = false;
+  const total = frameBatch.entries.length;
+  const done = frameBatch.index;
+  const current = frameBatch.entries[done]?.item;
+  const percent = total ? Math.round((done / total) * 100) : 100;
+  els.aiBusyTitle.textContent = `AI assisted cornici: ${frameBatch.rootTitle}`;
+  updateAiProgress(percent, current ? `Prossimo ${done + 1}/${total}: ${current.title}` : `Completati ${done}/${total} argomenti.`);
+  els.aiBusyNextBtn.disabled = frameBatch.running || done >= total;
+  els.aiBusyAllBtn.disabled = frameBatch.running || done >= total;
+  els.aiBusyCloseBtn.disabled = false;
+  els.aiBusyCancelBtn.disabled = false;
 }
 
 async function api(path, options = {}) {
@@ -755,19 +780,19 @@ function contextLabel(index, siblings, item) {
 }
 
 async function fillFrameWithAi(year, uda, item) {
+  const entries = collectSubtreeItems(year, uda, item);
+  if (entries.length > 1) {
+    openFrameBatch(year, uda, item, entries);
+    return;
+  }
+  await fillSingleFrameWithAi(year, uda, item);
+}
+
+async function fillSingleFrameWithAi(year, uda, item) {
   setStatus(`AI assisted: preparo la cornice per "${item.title}"...`);
   startAiProgress(`AI assisted cornice: ${item.title}`);
   try {
-    const payload = await api("/api/ai-frame", {
-      method: "POST",
-      body: JSON.stringify({
-        design: state.design,
-        year_id: year.id,
-        uda_id: uda.id,
-        item_id: item.id,
-      }),
-    });
-    item.frame = { ...defaultFrame(), ...(item.frame || {}), ...payload.frame, status: "draft" };
+    await generateFrameForEntry({ year, uda, item });
     renderCourse();
     setStatus(`Cornice didattica generata per "${item.title}".`);
     stopAiProgress("Cornice didattica generata.");
@@ -775,6 +800,164 @@ async function fillFrameWithAi(year, uda, item) {
     setStatus(`AI assisted non riuscito. Dettaglio provider/server: ${error.message}`);
     failAiProgress(`Errore provider/server: ${error.message}`);
   }
+}
+
+function collectSubtreeItems(year, uda, item) {
+  const entries = [];
+  const visit = (candidate) => {
+    entries.push({ year, uda, item: candidate });
+    for (const child of candidate.children || []) visit(child);
+  };
+  visit(item);
+  return entries;
+}
+
+function openFrameBatch(year, uda, item, entries) {
+  frameBatch = {
+    rootTitle: item.title,
+    entries,
+    index: 0,
+    running: false,
+    cancelled: false,
+    cancelAction: "",
+    snapshots: entries.map((entry) => ({
+      item: entry.item,
+      frame: JSON.parse(JSON.stringify({ ...defaultFrame(), ...(entry.item.frame || {}) })),
+    })),
+  };
+  setStatus(`Coda AI pronta: ${entries.length} cornici da generare per "${item.title}" e sottoparagrafi.`);
+  showFrameBatchProgress();
+}
+
+async function generateFrameForEntry(entry) {
+  const payload = await api("/api/ai-frame", {
+    method: "POST",
+    body: JSON.stringify({
+      design: state.design,
+      year_id: entry.year.id,
+      uda_id: entry.uda.id,
+      item_id: entry.item.id,
+    }),
+  });
+  entry.item.frame = { ...defaultFrame(), ...(entry.item.frame || {}), ...payload.frame, status: "draft" };
+}
+
+async function generateNextFrameInBatch() {
+  if (!frameBatch || frameBatch.running || frameBatch.index >= frameBatch.entries.length) return;
+  frameBatch.running = true;
+  frameBatch.cancelled = false;
+  showFrameBatchProgress();
+  const entry = frameBatch.entries[frameBatch.index];
+  setStatus(`Genero cornice ${frameBatch.index + 1}/${frameBatch.entries.length}: ${entry.item.title}`);
+  try {
+    await generateFrameForEntry(entry);
+    frameBatch.index += 1;
+    renderCourse();
+    setStatus(`Cornice generata per "${entry.item.title}".`);
+  } catch (error) {
+    setStatus(`Generazione cornice interrotta. Dettaglio provider/server: ${error.message}`);
+    failAiProgress(`Errore provider/server: ${error.message}`);
+    frameBatch = null;
+    return;
+  } finally {
+    if (frameBatch) frameBatch.running = false;
+  }
+  if (frameBatch?.cancelled) {
+    finishCancelledFrameBatch();
+    return;
+  }
+  if (frameBatch) showFrameBatchProgress();
+}
+
+async function generateAllFramesInBatch() {
+  if (!frameBatch || frameBatch.running) return;
+  frameBatch.running = true;
+  frameBatch.cancelled = false;
+  showFrameBatchProgress();
+  try {
+    while (frameBatch && frameBatch.index < frameBatch.entries.length && !frameBatch.cancelled) {
+      const entry = frameBatch.entries[frameBatch.index];
+      const percent = Math.round((frameBatch.index / frameBatch.entries.length) * 100);
+      updateAiProgress(percent, `Genero ${frameBatch.index + 1}/${frameBatch.entries.length}: ${entry.item.title}`);
+      setStatus(`Genero cornice ${frameBatch.index + 1}/${frameBatch.entries.length}: ${entry.item.title}`);
+      await generateFrameForEntry(entry);
+      frameBatch.index += 1;
+      renderCourse();
+    }
+    if (!frameBatch) return;
+    frameBatch.running = false;
+    if (frameBatch.cancelled) {
+      finishCancelledFrameBatch();
+      return;
+    }
+    setStatus(`Generate ${frameBatch.entries.length} cornici per "${frameBatch.rootTitle}". Ricordati di salvare il JSON.`);
+    stopAiProgress("Cornici didattiche generate.");
+    frameBatch = null;
+  } catch (error) {
+    if (frameBatch) frameBatch.running = false;
+    setStatus(`Generazione cornice interrotta. Dettaglio provider/server: ${error.message}`);
+    failAiProgress(`Errore provider/server: ${error.message}`);
+    frameBatch = null;
+  }
+}
+
+function closeFrameBatch() {
+  if (!frameBatch) return;
+  frameBatch.cancelled = true;
+  frameBatch.cancelAction = "close";
+  if (frameBatch.running) {
+    setStatus("La coda si chiudera dopo la richiesta AI in corso.");
+    showFrameBatchProgress();
+    return;
+  }
+  const done = frameBatch.index;
+  const total = frameBatch.entries.length;
+  frameBatch = null;
+  els.aiBusy.hidden = true;
+  els.aiBusyControls.hidden = true;
+  setStatus(`Coda chiusa: mantenute ${done}/${total} cornici generate. Ricordati di salvare il JSON.`);
+}
+
+function cancelFrameBatch() {
+  if (!frameBatch) return;
+  frameBatch.cancelled = true;
+  frameBatch.cancelAction = "restore";
+  if (frameBatch.running) {
+    setStatus("Annullamento richiesto: ripristino appena termina la richiesta AI in corso.");
+    showFrameBatchProgress();
+    return;
+  }
+  for (const snapshot of frameBatch.snapshots) {
+    snapshot.item.frame = JSON.parse(JSON.stringify(snapshot.frame));
+  }
+  const total = frameBatch.entries.length;
+  frameBatch = null;
+  renderCourse();
+  els.aiBusy.hidden = true;
+  els.aiBusyControls.hidden = true;
+  setStatus(`Generazione annullata: ripristinate le ${total} cornici della coda.`);
+}
+
+function finishCancelledFrameBatch() {
+  if (!frameBatch) return;
+  if (frameBatch.cancelAction === "restore") {
+    for (const snapshot of frameBatch.snapshots) {
+      snapshot.item.frame = JSON.parse(JSON.stringify(snapshot.frame));
+    }
+    const total = frameBatch.entries.length;
+    frameBatch = null;
+    renderCourse();
+    els.aiBusy.hidden = true;
+    els.aiBusyControls.hidden = true;
+    setStatus(`Generazione annullata: ripristinate le ${total} cornici della coda.`);
+    return;
+  }
+  const done = frameBatch.index;
+  const total = frameBatch.entries.length;
+  frameBatch = null;
+  els.aiBusy.hidden = true;
+  els.aiBusyControls.hidden = true;
+  setStatus(`Generazione fermata dopo ${done}/${total} cornici. Ricordati di salvare il JSON.`);
 }
 
 function renderFrameEditor(item) {
@@ -920,6 +1103,10 @@ els.saveBtn.addEventListener("click", saveDesign);
 els.loadSavedDesignBtn.addEventListener("click", loadSavedDesign);
 els.saveArchiveBtn.addEventListener("click", saveArchiveDesign);
 els.generateAllFramesBtn.addEventListener("click", generateAllFrames);
+els.aiBusyNextBtn.addEventListener("click", generateNextFrameInBatch);
+els.aiBusyAllBtn.addEventListener("click", generateAllFramesInBatch);
+els.aiBusyCloseBtn.addEventListener("click", closeFrameBatch);
+els.aiBusyCancelBtn.addEventListener("click", cancelFrameBatch);
 els.courseAiCloseBtn.addEventListener("click", () => els.courseAiDialog.close());
 els.courseAiGenerateBtn.addEventListener("click", generateCourseAiProposal);
 els.courseAiApplyBtn.addEventListener("click", applyCourseAiProposal);

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -4,6 +4,8 @@
   draggedHeading: null,
   collapsedHeadingIds: new Set(),
   collapsedCourseItemIds: new Set(),
+  courseAiYearId: null,
+  courseAiProposal: null,
 };
 
 const els = {
@@ -16,6 +18,21 @@ const els = {
   status: document.querySelector("#status"),
   reloadBtn: document.querySelector("#reloadBtn"),
   saveBtn: document.querySelector("#saveBtn"),
+  courseAiDialog: document.querySelector("#courseAiDialog"),
+  courseAiTitle: document.querySelector("#courseAiTitle"),
+  courseAiCloseBtn: document.querySelector("#courseAiCloseBtn"),
+  courseAiGenerateBtn: document.querySelector("#courseAiGenerateBtn"),
+  courseAiApplyBtn: document.querySelector("#courseAiApplyBtn"),
+  courseAiPreview: document.querySelector("#courseAiPreview"),
+  briefSubject: document.querySelector("#briefSubject"),
+  briefYearTitle: document.querySelector("#briefYearTitle"),
+  briefDescription: document.querySelector("#briefDescription"),
+  briefWeeklyHours: document.querySelector("#briefWeeklyHours"),
+  briefWeeks: document.querySelector("#briefWeeks"),
+  briefTotalHours: document.querySelector("#briefTotalHours"),
+  briefGoals: document.querySelector("#briefGoals"),
+  briefConstraints: document.querySelector("#briefConstraints"),
+  briefPreferences: document.querySelector("#briefPreferences"),
 };
 
 const FRAME_FIELDS = [
@@ -265,8 +282,10 @@ function renderCourse() {
           <h3>${escapeHtml(year.title)}</h3>
           <div class="yearMeta">${escapeHtml(year.description || "")} · ${year.weeks || "?"} settimane · ${year.weekly_hours || "?"} ore/settimana</div>
         </div>
+        <button type="button" data-action="ai-course">AI assisted percorso</button>
       </div>
     `;
+    yearNode.querySelector('[data-action="ai-course"]').addEventListener("click", () => openCourseAiDialog(year));
 
     for (const uda of year.udas || []) {
       yearNode.append(renderUda(year, uda));
@@ -394,6 +413,145 @@ function renderItem(year, uda, siblings, item, index, depth) {
   return node;
 }
 
+function defaultCourseBrief(year) {
+  const totalHours = Number(year.weekly_hours || 0) * Number(year.weeks || 0);
+  return {
+    subject: "TPSI",
+    year_title: year.title || "",
+    description: year.description || "",
+    weekly_hours: year.weekly_hours || 3,
+    weeks: year.weeks || 33,
+    total_hours: totalHours || "",
+    goals: [
+      "Scrivere piccoli programmi in C.",
+      "Comprendere variabili, tipi, operatori, condizioni, cicli e funzioni.",
+      "Introdurre array, stringhe, puntatori e memoria.",
+      "Integrare teoria e laboratorio in modo progressivo."
+    ].join("\n"),
+    constraints: [
+      "Usa solo argomenti presenti tra i paragrafi disponibili.",
+      "Non duplicare argomenti nello stesso anno.",
+      "Mantieni una progressione didattica dal semplice al complesso.",
+      "Lascia tra i non assegnati gli argomenti non coerenti con questo anno.",
+      "Non inserire argomenti Linux/processi/thread nel terzo anno se non richiesto esplicitamente."
+    ].join("\n"),
+    preferences: [
+      "Preferire UDA da 3-5 settimane.",
+      "Alternare spiegazione teorica e attivita di laboratorio.",
+      "Mettere i puntatori dopo funzioni, array e stringhe.",
+      "Produrre una proposta modificabile, non una soluzione definitiva."
+    ].join("\n")
+  };
+}
+
+function openCourseAiDialog(year) {
+  const brief = { ...defaultCourseBrief(year), ...(year.ai_brief || {}) };
+  state.courseAiYearId = year.id;
+  state.courseAiProposal = null;
+  els.courseAiTitle.textContent = `Genera percorso per ${year.title}`;
+  els.briefSubject.value = brief.subject;
+  els.briefYearTitle.value = brief.year_title;
+  els.briefDescription.value = brief.description;
+  els.briefWeeklyHours.value = brief.weekly_hours;
+  els.briefWeeks.value = brief.weeks;
+  els.briefTotalHours.value = brief.total_hours;
+  els.briefGoals.value = brief.goals;
+  els.briefConstraints.value = brief.constraints;
+  els.briefPreferences.value = brief.preferences;
+  els.courseAiPreview.innerHTML = '<p class="empty">Modifica il brief, poi genera una proposta.</p>';
+  els.courseAiApplyBtn.disabled = true;
+  els.courseAiDialog.showModal();
+}
+
+function readCourseBrief() {
+  return {
+    subject: els.briefSubject.value.trim(),
+    year_title: els.briefYearTitle.value.trim(),
+    description: els.briefDescription.value.trim(),
+    weekly_hours: Number(els.briefWeeklyHours.value || 0),
+    weeks: Number(els.briefWeeks.value || 0),
+    total_hours: Number(els.briefTotalHours.value || 0),
+    goals: els.briefGoals.value.trim(),
+    constraints: els.briefConstraints.value.trim(),
+    preferences: els.briefPreferences.value.trim(),
+  };
+}
+
+async function generateCourseAiProposal() {
+  const year = (state.design.years || []).find((candidate) => candidate.id === state.courseAiYearId);
+  if (!year) return;
+  const brief = readCourseBrief();
+  year.ai_brief = brief;
+  els.courseAiGenerateBtn.disabled = true;
+  els.courseAiApplyBtn.disabled = true;
+  els.courseAiPreview.innerHTML = '<p class="empty">Generazione proposta in corso...</p>';
+  setStatus(`AI assisted percorso: genero proposta per ${year.title}...`);
+  try {
+    const payload = await api("/api/ai-course-plan", {
+      method: "POST",
+      body: JSON.stringify({
+        design: state.design,
+        year_id: year.id,
+        brief,
+      }),
+    });
+    state.courseAiProposal = payload.proposal;
+    renderCourseAiPreview(payload.proposal);
+    els.courseAiApplyBtn.disabled = false;
+    setStatus(`Proposta percorso generata per ${year.title}.`);
+  } catch (error) {
+    els.courseAiPreview.innerHTML = `<p class="empty">Errore: ${escapeHtml(error.message)}</p>`;
+    setStatus(`AI assisted percorso non riuscito: ${error.message}`);
+  } finally {
+    els.courseAiGenerateBtn.disabled = false;
+  }
+}
+
+function renderCourseAiPreview(proposal) {
+  const stats = proposal.stats || {};
+  const udas = proposal.udas || [];
+  const rows = udas.map((uda) => `
+    <tr>
+      <td>${escapeHtml(uda.id)}</td>
+      <td>${escapeHtml(uda.title)}</td>
+      <td>${escapeHtml(uda.path || "")}</td>
+      <td>${escapeHtml(uda.weeks || "")}</td>
+      <td>${countItems(uda.items || [])}</td>
+    </tr>
+  `).join("");
+  els.courseAiPreview.innerHTML = `
+    <h3>Proposta generata</h3>
+    <p>
+      UDA: <strong>${udas.length}</strong> ·
+      argomenti assegnati: <strong>${stats.assigned_topics || 0}</strong> ·
+      non assegnati: <strong>${(proposal.unplaced_topics || []).length}</strong>
+    </p>
+    <table>
+      <thead><tr><th>UDA</th><th>Titolo</th><th>Percorso</th><th>Settimane</th><th>Argomenti</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    ${proposal.notes ? `<p><strong>Note:</strong> ${escapeHtml(proposal.notes)}</p>` : ""}
+  `;
+}
+
+function countItems(items) {
+  return items.reduce((total, item) => total + 1 + countItems(item.children || []), 0);
+}
+
+function applyCourseAiProposal() {
+  const year = (state.design.years || []).find((candidate) => candidate.id === state.courseAiYearId);
+  if (!year || !state.courseAiProposal) return;
+  year.title = state.courseAiProposal.title || year.title;
+  year.description = state.courseAiProposal.description || year.description;
+  year.udas = state.courseAiProposal.udas || year.udas;
+  year.ai_brief = readCourseBrief();
+  els.courseAiDialog.close();
+  state.courseAiProposal = null;
+  renderCourse();
+  renderHeadings();
+  setStatus(`Proposta AI applicata a ${year.title}. Ricordati di salvare il JSON.`);
+}
+
 function contextLabel(index, siblings, item) {
   const previous = index;
   const next = Math.max(0, siblings.length - index - 1);
@@ -504,6 +662,9 @@ function escapeHtml(value) {
 
 els.reloadBtn.addEventListener("click", loadAll);
 els.saveBtn.addEventListener("click", saveDesign);
+els.courseAiCloseBtn.addEventListener("click", () => els.courseAiDialog.close());
+els.courseAiGenerateBtn.addEventListener("click", generateCourseAiProposal);
+els.courseAiApplyBtn.addEventListener("click", applyCourseAiProposal);
 els.sourceFilter.addEventListener("change", renderHeadings);
 els.levelFilter.addEventListener("change", renderHeadings);
 els.searchInput.addEventListener("input", renderHeadings);

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -24,6 +24,11 @@ const els = {
   courseAiGenerateBtn: document.querySelector("#courseAiGenerateBtn"),
   courseAiApplyBtn: document.querySelector("#courseAiApplyBtn"),
   courseAiPreview: document.querySelector("#courseAiPreview"),
+  aiBusy: document.querySelector("#aiBusy"),
+  aiBusyTitle: document.querySelector("#aiBusyTitle"),
+  aiBusyMessage: document.querySelector("#aiBusyMessage"),
+  aiBusyPercent: document.querySelector("#aiBusyPercent"),
+  aiBusyBarFill: document.querySelector("#aiBusyBarFill"),
   briefSubject: document.querySelector("#briefSubject"),
   briefYearTitle: document.querySelector("#briefYearTitle"),
   briefDescription: document.querySelector("#briefDescription"),
@@ -45,8 +50,57 @@ const FRAME_FIELDS = [
   { key: "references", label: "Rimando" },
 ];
 
+const AI_PROGRESS_STAGES = [
+  "Preparo il contesto didattico...",
+  "Leggo paragrafi e sottoparagrafi...",
+  "Invio la richiesta al provider AI...",
+  "Il modello sta elaborando la proposta...",
+  "Ricevo e controllo la risposta strutturata...",
+  "Aggiorno la board con i dati generati..."
+];
+
+let aiProgressTimer = null;
+
 function setStatus(message) {
   els.status.textContent = message;
+}
+
+function startAiProgress(title) {
+  let percent = 4;
+  let stageIndex = 0;
+  els.aiBusy.hidden = false;
+  els.aiBusyTitle.textContent = title;
+  updateAiProgress(percent, AI_PROGRESS_STAGES[stageIndex]);
+  clearInterval(aiProgressTimer);
+  aiProgressTimer = setInterval(() => {
+    percent = Math.min(95, percent + Math.max(1, Math.round((96 - percent) / 9)));
+    stageIndex = Math.min(AI_PROGRESS_STAGES.length - 1, Math.floor(percent / 18));
+    updateAiProgress(percent, AI_PROGRESS_STAGES[stageIndex]);
+  }, 1400);
+}
+
+function updateAiProgress(percent, message) {
+  els.aiBusyMessage.textContent = message;
+  els.aiBusyPercent.textContent = `${percent}%`;
+  els.aiBusyBarFill.style.width = `${percent}%`;
+}
+
+function stopAiProgress(message = "Completato.") {
+  clearInterval(aiProgressTimer);
+  aiProgressTimer = null;
+  updateAiProgress(100, message);
+  setTimeout(() => {
+    if (!aiProgressTimer) els.aiBusy.hidden = true;
+  }, 900);
+}
+
+function failAiProgress(message = "Operazione non riuscita.") {
+  clearInterval(aiProgressTimer);
+  aiProgressTimer = null;
+  updateAiProgress(100, message);
+  setTimeout(() => {
+    if (!aiProgressTimer) els.aiBusy.hidden = true;
+  }, 2200);
 }
 
 async function api(path, options = {}) {
@@ -497,6 +551,7 @@ async function generateCourseAiProposal() {
   els.courseAiApplyBtn.disabled = true;
   els.courseAiPreview.innerHTML = '<p class="empty">Generazione proposta in corso...</p>';
   setStatus(`AI assisted percorso: genero proposta per ${year.title}...`);
+  startAiProgress(`AI assisted percorso: ${year.title}`);
   try {
     const payload = await api("/api/ai-course-plan", {
       method: "POST",
@@ -510,9 +565,11 @@ async function generateCourseAiProposal() {
     renderCourseAiPreview(payload.proposal);
     els.courseAiApplyBtn.disabled = false;
     setStatus(`Proposta percorso generata per ${year.title}.`);
+    stopAiProgress("Proposta generata. Puoi controllarla e applicarla.");
   } catch (error) {
     els.courseAiPreview.innerHTML = `<p class="empty">Errore: ${escapeHtml(error.message)}</p>`;
     setStatus(`AI assisted percorso non riuscito. Dettaglio provider/server: ${error.message}`);
+    failAiProgress("Errore durante la generazione AI.");
   } finally {
     els.courseAiGenerateBtn.disabled = false;
   }
@@ -573,6 +630,7 @@ function contextLabel(index, siblings, item) {
 
 async function fillFrameWithAi(year, uda, item) {
   setStatus(`AI assisted: preparo la cornice per "${item.title}"...`);
+  startAiProgress(`AI assisted cornice: ${item.title}`);
   try {
     const payload = await api("/api/ai-frame", {
       method: "POST",
@@ -586,8 +644,10 @@ async function fillFrameWithAi(year, uda, item) {
     item.frame = { ...defaultFrame(), ...(item.frame || {}), ...payload.frame, status: "draft" };
     renderCourse();
     setStatus(`Cornice didattica generata per "${item.title}".`);
+    stopAiProgress("Cornice didattica generata.");
   } catch (error) {
     setStatus(`AI assisted non riuscito. Dettaglio provider/server: ${error.message}`);
+    failAiProgress("Errore durante la generazione della cornice.");
   }
 }
 

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -352,6 +352,7 @@ function renderItem(year, uda, siblings, item, index, depth) {
         <div class="itemMeta">${escapeHtml(item.source)} · H${item.level || "?"} · ${escapeHtml(item.frame?.status || "ok")}</div>
       </div>
       <div class="itemActions">
+        <span class="contextBadge">${escapeHtml(contextLabel(index, siblings, item))}</span>
         <button type="button" data-action="ai">AI assisted</button>
         <button type="button" data-action="up">Su</button>
         <button type="button" data-action="down">Giu</button>
@@ -391,6 +392,14 @@ function renderItem(year, uda, siblings, item, index, depth) {
     node.append(childList);
   }
   return node;
+}
+
+function contextLabel(index, siblings, item) {
+  const previous = index;
+  const next = Math.max(0, siblings.length - index - 1);
+  if (previous && next) return "contesto buono";
+  if (previous || next || (item.children || []).length) return "contesto medio";
+  return "poco contesto";
 }
 
 async function fillFrameWithAi(year, uda, item) {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -208,21 +208,32 @@ function renderAiConfig() {
   const options = providers.map((provider) => {
     const configured = provider.api_key_configured ? "configurato" : "non configurato";
     const selected = provider.id === state.aiConfig.provider ? "selected" : "";
-    return `<option value="${escapeHtml(provider.id)}" ${selected}>${escapeHtml(provider.label)} · ${escapeHtml(provider.model)} · ${configured}</option>`;
+    return `<option value="${escapeHtml(provider.id)}" ${selected}>${escapeHtml(provider.label)} · ${configured}</option>`;
   }).join("");
+  const activeProvider = providers.find((provider) => provider.id === state.aiConfig.provider) || providers[0] || {};
+  const modelOptions = (activeProvider.models || []).map((model) => {
+    const selected = model.id === state.aiConfig.model ? "selected" : "";
+    return `<option value="${escapeHtml(model.id)}" ${selected}>${escapeHtml(model.label || model.id)} · ${escapeHtml(model.tier || "tier n/d")}</option>`;
+  }).join("");
+  const modelDisabled = activeProvider.api_key_configured ? "" : "disabled";
   const keyStatus = state.aiConfig.api_key_configured ? "API key impostata" : "API key non impostata";
   els.aiConfig.innerHTML = `
     <label>
       <span>AI provider</span>
       <select id="aiProviderSelect">${options}</select>
     </label>
+    <label>
+      <span>Modello</span>
+      <select id="aiModelSelect" ${modelDisabled}>${modelOptions}</select>
+    </label>
     <span>${escapeHtml(keyStatus)} · ${escapeHtml(state.aiConfig.billing_note)}</span>
   `;
   els.aiConfig.querySelector("#aiProviderSelect").addEventListener("change", switchAiProvider);
+  els.aiConfig.querySelector("#aiModelSelect").addEventListener("change", switchAiModel);
 }
 
 async function switchAiProvider(event) {
-  const provider = event.target.value;
+  const provider = els.aiConfig.querySelector("#aiProviderSelect").value;
   setStatus(`Cambio provider AI in ${provider}...`);
   try {
     state.aiConfig = await api("/api/ai-config", {
@@ -230,10 +241,27 @@ async function switchAiProvider(event) {
       body: JSON.stringify({ provider }),
     });
     renderAiConfig();
-    setStatus(`Provider AI attivo: ${state.aiConfig.provider}.`);
+    setStatus(`Provider AI attivo: ${state.aiConfig.provider} · modello ${state.aiConfig.model}.`);
   } catch (error) {
     renderAiConfig();
     setStatus(`Cambio provider AI non riuscito. Dettaglio: ${error.message}`);
+  }
+}
+
+async function switchAiModel() {
+  const provider = els.aiConfig.querySelector("#aiProviderSelect").value;
+  const model = els.aiConfig.querySelector("#aiModelSelect")?.value || "";
+  setStatus(`Cambio modello AI in ${model}...`);
+  try {
+    state.aiConfig = await api("/api/ai-config", {
+      method: "POST",
+      body: JSON.stringify({ provider, model }),
+    });
+    renderAiConfig();
+    setStatus(`Modello AI attivo: ${state.aiConfig.model}.`);
+  } catch (error) {
+    renderAiConfig();
+    setStatus(`Cambio modello AI non riuscito. Dettaglio: ${error.message}`);
   }
 }
 

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -18,6 +18,16 @@ const els = {
   saveBtn: document.querySelector("#saveBtn"),
 };
 
+const FRAME_FIELDS = [
+  { key: "context", label: "Contesto" },
+  { key: "prerequisites", label: "Prerequisiti" },
+  { key: "objectives", label: "Obiettivi" },
+  { key: "recall", label: "Richiamo" },
+  { key: "preview", label: "Anticipazione" },
+  { key: "next_step", label: "Prossimo passo" },
+  { key: "references", label: "Rimando" },
+];
+
 function setStatus(message) {
   els.status.textContent = message;
 }
@@ -191,9 +201,7 @@ function itemFromHeading(heading) {
     href: heading.href,
     level: heading.level,
     line: heading.line,
-    frame: {
-      status: "todo"
-    }
+    frame: defaultFrame()
   };
   const children = childItemsFromHeading(heading);
   if (children.length) item.children = children;
@@ -215,9 +223,7 @@ function childItemsFromHeading(parentHeading) {
       href: heading.href,
       level: heading.level,
       line: heading.line,
-      frame: {
-        status: "todo"
-      }
+      frame: defaultFrame()
     };
     while (stack.length && heading.level <= stack.at(-1).level) {
       stack.pop();
@@ -233,6 +239,19 @@ function childItemsFromHeading(parentHeading) {
   };
   roots.forEach(pruneEmptyChildren);
   return roots;
+}
+
+function defaultFrame() {
+  return {
+    status: "todo",
+    context: "",
+    prerequisites: "",
+    objectives: "",
+    recall: "",
+    preview: "",
+    next_step: "",
+    references: ""
+  };
 }
 
 function renderCourse() {
@@ -323,6 +342,7 @@ function renderItem(uda, siblings, item, index, depth) {
   node.className = "item";
   node.style.setProperty("--item-depth", depth);
   const children = item.children || [];
+  item.frame = { ...defaultFrame(), ...(item.frame || {}) };
   const collapseKey = `${uda.id}:${item.id}`;
   const isCollapsed = state.collapsedCourseItemIds.has(collapseKey);
   node.innerHTML = `
@@ -361,6 +381,7 @@ function renderItem(uda, siblings, item, index, depth) {
   node.querySelector('[data-action="up"]').addEventListener("click", () => moveItem(siblings, index, -1));
   node.querySelector('[data-action="down"]').addEventListener("click", () => moveItem(siblings, index, 1));
   node.querySelector('[data-action="remove"]').addEventListener("click", () => removeItem(siblings, index));
+  node.append(renderFrameEditor(item));
   if (children.length && !isCollapsed) {
     const childList = document.createElement("div");
     childList.className = "itemChildren";
@@ -368,6 +389,47 @@ function renderItem(uda, siblings, item, index, depth) {
     node.append(childList);
   }
   return node;
+}
+
+function renderFrameEditor(item) {
+  const details = document.createElement("details");
+  details.className = "frameEditor";
+  details.innerHTML = `
+    <summary>Cornice didattica</summary>
+    <div class="frameGrid">
+      <label>
+        <span>Stato</span>
+        <select data-frame-field="status">
+          <option value="todo">todo</option>
+          <option value="draft">draft</option>
+          <option value="review">review</option>
+          <option value="done">done</option>
+        </select>
+      </label>
+    </div>
+  `;
+  const grid = details.querySelector(".frameGrid");
+  const status = details.querySelector('[data-frame-field="status"]');
+  status.value = item.frame.status || "todo";
+  status.addEventListener("change", () => {
+    item.frame.status = status.value;
+    renderCourse();
+  });
+
+  for (const field of FRAME_FIELDS) {
+    const label = document.createElement("label");
+    label.innerHTML = `
+      <span>${escapeHtml(field.label)}</span>
+      <textarea data-frame-field="${field.key}" rows="2"></textarea>
+    `;
+    const textarea = label.querySelector("textarea");
+    textarea.value = item.frame[field.key] || "";
+    textarea.addEventListener("input", () => {
+      item.frame[field.key] = textarea.value;
+    });
+    grid.append(label);
+  }
+  return details;
 }
 
 function moveItem(items, index, delta) {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1,6 +1,7 @@
 ﻿const state = {
   headings: [],
   design: null,
+  aiConfig: null,
   draggedHeading: null,
   collapsedHeadingIds: new Set(),
   collapsedCourseItemIds: new Set(),
@@ -16,6 +17,7 @@ const els = {
   searchInput: document.querySelector("#searchInput"),
   courseTree: document.querySelector("#courseTree"),
   status: document.querySelector("#status"),
+  aiConfig: document.querySelector("#aiConfig"),
   reloadBtn: document.querySelector("#reloadBtn"),
   saveBtn: document.querySelector("#saveBtn"),
   courseAiDialog: document.querySelector("#courseAiDialog"),
@@ -127,16 +129,28 @@ async function responseErrorMessage(response) {
 
 async function loadAll() {
   setStatus("Caricamento...");
-  const [headingsPayload, design] = await Promise.all([
+  const [headingsPayload, design, aiConfig] = await Promise.all([
     api("/api/headings"),
     api("/api/course-design"),
+    api("/api/ai-config"),
   ]);
   state.headings = headingsPayload.headings;
   state.design = design;
+  state.aiConfig = aiConfig;
   populateFilters();
+  renderAiConfig();
   renderHeadings();
   renderCourse();
   setStatus("Pronto.");
+}
+
+function renderAiConfig() {
+  if (!state.aiConfig) {
+    els.aiConfig.textContent = "AI: configurazione non caricata.";
+    return;
+  }
+  const keyStatus = state.aiConfig.api_key_configured ? "API key impostata" : "API key non impostata";
+  els.aiConfig.textContent = `AI: ${state.aiConfig.provider} · modello ${state.aiConfig.model} · ${keyStatus} · ${state.aiConfig.billing_note}`;
 }
 
 function populateFilters() {


### PR DESCRIPTION
## Riassunto

Questa PR introduce e documenta la Course Design Board come strumento operativo per costruire, salvare e aggiornare percorsi didattici a partire dai paragrafi delle dispense.

### Board e percorso didattico

- Aggiunta interfaccia visuale per organizzare paragrafi e sottoparagrafi nei percorsi didattici.
- Supportata struttura ad albero con collapse/expand sia nei paragrafi disponibili sia negli argomenti assegnati.
- Aggiunta gestione di percorsi archiviati caricabili, aggiornabili e impostabili come percorso corrente.
- Migliorata la UI con layout piu compatto, tema chiaro essenziale e branding statico.

### Cornice didattica

- Aggiunti campi di cornice didattica per ogni argomento: contesto, prerequisiti, obiettivi, richiamo, anticipazione, prossimo passo e rimando.
- Aggiunto indicatore visuale per distinguere cornici vuote e gia compilate.
- Aggiunta generazione ricorsiva controllata per un paragrafo e i suoi sottoparagrafi tramite coda con `Genera prossimo`, `Genera tutti`, `Chiudi` e `Annulla`.

### AI assisted

- Aggiunta generazione AI assisted del percorso annuale a partire da brief modificabile.
- Aggiunta generazione AI assisted della cornice didattica.
- Supportati provider multipli: OpenAI, Gemini, Groq e OpenRouter.
- Aggiunta selezione provider/modello dalla UI, con stato di configurazione della API key.
- Aggiunta progress bar con messaggi di avanzamento e diagnostica errori provider/server piu esplicita.

### Configurazione, limiti e diagnostica

- Aggiunto `config/ai_providers.yaml` per dichiarare provider e modelli disponibili.
- Aggiunto supporto a `.secrets/ai.secret` per configurazioni locali non versionate.
- Aggiunto probe `scripts/probe_ai_payload_limit.py` per calibrare il payload massimo pratico dei provider.
- Calibrati valori compatti consigliati per i provider testati:
  - `GROQ_COMPACT_TEXT_CHARS=6360`
  - `GEMINI_COMPACT_TEXT_CHARS=3022`
  - `OPENROUTER_COMPACT_TEXT_CHARS=404`

### Documentazione

- Estesa `doc/COURSE_BOARD.md` con guida completa a board, provider AI, secret locali, flussi manuali, comportamento UI, payload inviato all'AI e criteri di scelta provider.
- Documentato l'ordine consigliato dei provider: Groq, Gemini, OpenAI, OpenRouter free.

## Note

I file JSON locali generati dalla board non fanno parte di questa PR e restano fuori dal commit.