### PR TITLE
[codex] Generate course plan Markdown from board

### DIFF
--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -224,12 +224,61 @@ Dalla board puoi rigenerare direttamente il documento:
 doc/PERCORSO_DIDATTICO.md
 ```
 
+### Metodo da UI
+
+Il metodo consigliato e usare direttamente la board.
+
+Flusso:
+
+1. apri la board;
+2. carica o modifica il percorso;
+3. controlla UDA, paragrafi, sottoparagrafi e cornici didattiche;
+4. clicca `Aggiorna percorso MD`.
+
 Il bottone `Aggiorna percorso MD` esegue due passaggi:
 
 1. salva lo stato corrente della board in `doc/course_design.json`;
 2. rigenera `doc/PERCORSO_DIDATTICO.md` usando `scripts/generate_course_plan.py`.
 
 In questo modo non devi ricordare il comando da terminale e riduci il rischio di avere un JSON aggiornato ma un Markdown vecchio.
+
+Se l'operazione riesce, la board mostra il percorso del file aggiornato. Se fallisce, mostra il dettaglio dell'errore restituito dal server.
+
+### Metodo manuale da terminale
+
+Puoi ottenere lo stesso risultato anche senza usare il bottone della UI.
+
+Prima salva il percorso corrente nella board con:
+
+```text
+Imposta corrente
+```
+
+Questo aggiorna:
+
+```text
+doc/course_design.json
+```
+
+Poi dal terminale esegui:
+
+```powershell
+python scripts/generate_course_plan.py
+```
+
+Lo script legge:
+
+```text
+doc/course_design.json
+```
+
+e genera:
+
+```text
+doc/PERCORSO_DIDATTICO.md
+```
+
+Il metodo manuale e utile quando vuoi rigenerare il Markdown in uno script, in una shell oppure prima di fare commit, senza aprire la board.
 
 ## Cornice didattica degli argomenti
 

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -216,6 +216,21 @@ Solo cliccando `Applica proposta` la struttura dell'anno viene sostituita nella 
 
 La modifica diventa persistente solo dopo `Salva JSON`.
 
+### Aggiornare il percorso didattico Markdown
+
+Dalla board puoi rigenerare direttamente il documento:
+
+```text
+doc/PERCORSO_DIDATTICO.md
+```
+
+Il bottone `Aggiorna percorso MD` esegue due passaggi:
+
+1. salva lo stato corrente della board in `doc/course_design.json`;
+2. rigenera `doc/PERCORSO_DIDATTICO.md` usando `scripts/generate_course_plan.py`.
+
+In questo modo non devi ricordare il comando da terminale e riduci il rischio di avere un JSON aggiornato ma un Markdown vecchio.
+
 ## Cornice didattica degli argomenti
 
 Ogni argomento inserito in una UDA puo avere una cornice didattica compilabile dalla board.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -21,6 +21,7 @@ import json
 import mimetypes
 import os
 import re
+import subprocess
 import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -30,6 +31,7 @@ from urllib.parse import unquote, urlparse
 ROOT = Path(__file__).resolve().parents[1]
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
+COURSE_PLAN_MD_PATH = ROOT / "doc" / "PERCORSO_DIDATTICO.md"
 AI_PROVIDERS_PATH = ROOT / "config" / "ai_providers.yaml"
 AI_SECRET_PATH = ROOT / ".secrets" / "ai.secret"
 DEFAULT_SOURCES = ["README.md", "LINUX_PROGRAMMING.md"]
@@ -85,6 +87,23 @@ def write_design(payload: dict) -> None:
 
     DESIGN_PATH.parent.mkdir(parents=True, exist_ok=True)
     DESIGN_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def generate_course_plan_md(payload: dict) -> dict:
+    """Persist the current design and regenerate doc/PERCORSO_DIDATTICO.md."""
+
+    write_design(payload)
+    command = [sys.executable, str(ROOT / "scripts" / "generate_course_plan.py")]
+    completed = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, check=False)
+    if completed.returncode:
+        detail = (completed.stderr or completed.stdout or "Errore sconosciuto durante la generazione del percorso MD.").strip()
+        raise RuntimeError(detail)
+    return {
+        "ok": True,
+        "design_path": str(DESIGN_PATH.relative_to(ROOT)),
+        "markdown_path": str(COURSE_PLAN_MD_PATH.relative_to(ROOT)),
+        "message": (completed.stdout or "").strip(),
+    }
 
 
 def safe_design_name(name: str) -> str:
@@ -1229,6 +1248,15 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/course-design":
             write_design(payload)
             self.write_json({"ok": True, "path": str(DESIGN_PATH.relative_to(ROOT))})
+            return
+        if parsed.path == "/api/course-plan-md":
+            try:
+                self.write_json(generate_course_plan_md(payload.get("design", payload)))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
             return
         if parsed.path == "/api/saved-designs/load":
             try:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -22,6 +22,7 @@ import mimetypes
 import os
 import re
 import subprocess
+import sys
 import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -24,6 +24,7 @@
         <button id="loadSavedDesignBtn" type="button">Carica archiviato</button>
         <button id="saveArchiveBtn" type="button">Aggiorna archivio</button>
         <button id="generateAllFramesBtn" type="button">Genera cornici</button>
+        <button id="generateCoursePlanMdBtn" type="button">Aggiorna percorso MD</button>
         <button id="reloadBtn" type="button">Ricarica</button>
         <button id="saveBtn" type="button" class="primary">Imposta corrente</button>
       </div>

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -24,6 +24,7 @@ const els = {
   loadSavedDesignBtn: document.querySelector("#loadSavedDesignBtn"),
   saveArchiveBtn: document.querySelector("#saveArchiveBtn"),
   generateAllFramesBtn: document.querySelector("#generateAllFramesBtn"),
+  generateCoursePlanMdBtn: document.querySelector("#generateCoursePlanMdBtn"),
   reloadBtn: document.querySelector("#reloadBtn"),
   saveBtn: document.querySelector("#saveBtn"),
   courseAiDialog: document.querySelector("#courseAiDialog"),
@@ -1086,6 +1087,22 @@ async function saveDesign() {
   setStatus("Percorso impostato come corrente in doc/course_design.json.");
 }
 
+async function generateCoursePlanMd() {
+  els.generateCoursePlanMdBtn.disabled = true;
+  setStatus("Aggiornamento percorso Markdown: salvo il JSON corrente e rigenero doc/PERCORSO_DIDATTICO.md...");
+  try {
+    const payload = await api("/api/course-plan-md", {
+      method: "POST",
+      body: JSON.stringify({ design: state.design }),
+    });
+    setStatus(`Percorso Markdown aggiornato: ${payload.markdown_path}.`);
+  } catch (error) {
+    setStatus(`Aggiornamento percorso Markdown non riuscito. Dettaglio: ${error.message}`);
+  } finally {
+    els.generateCoursePlanMdBtn.disabled = false;
+  }
+}
+
 function escapeHtml(value) {
   return String(value ?? "")
     .replaceAll("&", "&amp;")
@@ -1099,6 +1116,7 @@ els.saveBtn.addEventListener("click", saveDesign);
 els.loadSavedDesignBtn.addEventListener("click", loadSavedDesign);
 els.saveArchiveBtn.addEventListener("click", saveArchiveDesign);
 els.generateAllFramesBtn.addEventListener("click", generateAllFrames);
+els.generateCoursePlanMdBtn.addEventListener("click", generateCoursePlanMd);
 els.aiBusyNextBtn.addEventListener("click", generateNextFrameInBatch);
 els.aiBusyAllBtn.addEventListener("click", generateAllFramesInBatch);
 els.aiBusyCloseBtn.addEventListener("click", closeFrameBatch);


### PR DESCRIPTION
## Riassunto

- Aggiunge il bottone \Aggiorna percorso MD\ nella Course Design Board.
- Il bottone salva lo stato corrente della board in \doc/course_design.json\.
- Poi rigenera \doc/PERCORSO_DIDATTICO.md\ usando \scripts/generate_course_plan.py\ lato server.
- Documenta il nuovo flusso in \doc/COURSE_BOARD.md\.

## Verifica

- \python -m py_compile scripts/course_board_server.py\
- \
ode --check tools/course_board.js\

Non sono stati chiamati provider AI.