### PR TITLE
Aggiunge vista Gantt UDA al calendario

### DIFF
--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -135,6 +135,159 @@ La pagina calcola per ogni track:
 
 Questi dati saranno poi usati per costruire la vista cronologica/Gantt del percorso didattico.
 
+### Diagramma Gantt UDA
+
+La pagina calendario include anche il `Diagramma Gantt UDA`.
+
+Il Gantt usa:
+
+- il progetto didattico associato;
+- le UDA presenti nel progetto;
+- il campo `weeks` di ogni UDA;
+- le date di inizio e fine anno scolastico;
+- gli slot settimanali dei percorsi;
+- vacanze, festivita, ponti e sospensioni.
+
+La vista e divisa in due parti:
+
+- `Pianificato`: programmazione prevista;
+- `Svolto`: programmazione reale registrata durante l'anno.
+
+#### Programmazione prevista
+
+La riga `Pianificato` mostra le UDA nella sequenza prevista dal progetto didattico.
+
+Per ogni UDA la barra mostra:
+
+- codice UDA;
+- titolo breve;
+- ore previste;
+- data iniziale e finale calcolate;
+- micro-calendario dei giorni interni alla barra.
+
+Nel micro-calendario:
+
+- verde: giorno con lezione;
+- rosso: giorno di chiusura, festivita o sospensione;
+- rosso/verde: giorno in cui ci sarebbe lezione, ma la lezione salta per chiusura;
+- nero/scuro: giorno senza lezione.
+
+Sotto i pallini sono mostrate le abbreviazioni dei giorni della settimana:
+
+```text
+L M M G V S D
+```
+
+Sabato e evidenziato in giallo, domenica in rosso.
+
+#### Tooltip e dettaglio UDA
+
+Passando con il mouse su una barra UDA, la pagina mostra un tooltip con:
+
+- titolo UDA;
+- settimane effettive;
+- date calcolate;
+- ore previste;
+- ore perse;
+- argomenti e sottoparagrafi.
+
+Cliccando su una UDA nel Gantt oppure sulla stessa UDA nella vista calendario si apre lo stesso modal di dettaglio.
+
+Il modal mostra:
+
+- dati della programmazione prevista;
+- ore perse;
+- argomenti e sottoparagrafi;
+- campi della programmazione svolta.
+
+#### Programmazione svolta
+
+La riga `Svolto` serve a registrare il consuntivo durante l'anno.
+
+Nel modal UDA puoi compilare:
+
+- stato: da fare, in corso, conclusa, sospesa, saltata;
+- data di inizio reale;
+- data di fine reale;
+- ore svolte;
+- note.
+
+Questi dati vengono salvati nel progetto didattico, dentro la UDA:
+
+```json
+{
+  "actual": {
+    "status": "done",
+    "start_date": "2026-10-01",
+    "end_date": "2026-10-20",
+    "hours_done": 8,
+    "notes": "Recuperata un'ora nella settimana successiva."
+  }
+}
+```
+
+Se il calendario e associato al progetto corrente, il salvataggio aggiorna:
+
+```text
+doc/course_design.json
+```
+
+Se il calendario e associato a un progetto archiviato, aggiorna il file corrispondente in:
+
+```text
+doc/course_designs/
+```
+
+#### Calcolo delle ore svolte
+
+Il campo `Ore svolte` puo essere compilato manualmente oppure calcolato con:
+
+```text
+Calcola ore da calendario
+```
+
+Il calcolo usa:
+
+- data di inizio reale;
+- data di fine reale;
+- slot settimanali del percorso;
+- chiusure, festivita e sospensioni.
+
+Le ore che cadono in giorni chiusi non vengono conteggiate.
+
+Il valore calcolato resta modificabile manualmente, perche nella realta didattica potrebbero esserci assemblee, verifiche, recuperi, uscite o attivita non riconducibili automaticamente alla UDA.
+
+#### Zoom del Gantt
+
+Il Gantt ha controlli di zoom:
+
+- `-`: riduce la larghezza delle settimane;
+- `+`: aumenta la larghezza delle settimane;
+- percentuale centrale: ripristina lo zoom predefinito.
+
+Lo zoom modifica una scala temporale comune, quindi restano allineati:
+
+- mesi;
+- settimane;
+- festivita;
+- barre UDA pianificate;
+- barre UDA svolte.
+
+Il valore di zoom viene salvato nel browser con `localStorage`.
+
+#### Sezioni collassabili
+
+Le sezioni della pagina calendario sono collassabili cliccando sul titolo:
+
+- `Anno scolastico`;
+- `Percorsi orari`;
+- `Vacanze, festivita e sospensioni`;
+- `Vista calendario`;
+- `Diagramma Gantt UDA`;
+- `Riepilogo ore effettive`.
+
+Lo stato aperto/chiuso viene salvato nel browser con `localStorage`.
+
 ## Archivio dei percorsi didattici
 
 La board usa `doc/course_design.json` come progetto didattico corrente.
@@ -1401,10 +1554,56 @@ python scripts/generate_course_plan.py --check
 
 ## Cosa non fa ancora
 
-Questa e una prima versione MVP. Non genera ancora automaticamente:
+Questa e una versione ancora in evoluzione. Non gestisce ancora automaticamente:
 
-- le cornici `Orientamento della sezione` dentro il README;
-- report dei TODO;
-- report dei paragrafi non assegnati.
+- un unico JSON che contenga insieme progetto didattico e calendario;
+- modifica drag/resize delle UDA direttamente dal Gantt;
+- ricalcolo automatico completo di tutte le UDA adiacenti quando una UDA viene allungata o accorciata;
+- report automatico `in anticipo`, `in linea`, `in ritardo`;
+- esportazione o stampa del Gantt;
+- confronto sintetico tra ore previste, ore perse e ore svolte per tutto il corso.
 
-Queste funzioni saranno aggiunte dopo aver stabilizzato il modello dati.
+### Direzione futura: un solo JSON per corso e calendario
+
+Al momento progetto didattico e calendario sono file separati:
+
+```text
+doc/course_design.json
+doc/course_designs/*.json
+doc/calendars/*.json
+```
+
+Questa separazione ha permesso di sviluppare velocemente board e calendario, ma a lungo termine conviene valutare un modello unico.
+
+L'idea futura e avere un solo file progetto che contenga:
+
+- metadati del corso;
+- percorsi didattici;
+- UDA;
+- cornici didattiche;
+- calendario scolastico;
+- slot settimanali;
+- chiusure e festivita;
+- programmazione svolta.
+
+Esempio concettuale:
+
+```json
+{
+  "version": 2,
+  "project": {
+    "title": "TPSI 2026/2027"
+  },
+  "years": [],
+  "calendar": {
+    "school_year": "2026/2027",
+    "start_date": "2026-09-03",
+    "end_date": "2027-06-04",
+    "closures": []
+  }
+}
+```
+
+Questo eviterebbe dubbi su quale calendario sia associato a quale progetto e renderebbe piu semplice cancellare, duplicare, archiviare o esportare un intero corso.
+
+La migrazione va fatta in una PR dedicata, perche tocca modello dati, UI, script e documentazione.

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -161,9 +161,21 @@ Per ogni UDA la barra mostra:
 
 - codice UDA;
 - titolo breve;
-- ore previste;
+- ore disponibili;
 - data iniziale e finale calcolate;
 - micro-calendario dei giorni interni alla barra.
+
+#### Ore teoriche, disponibili e perse
+
+Nel Gantt le ore sono distinte in tre valori:
+
+- `Ore teoriche`: ore che la UDA avrebbe avuto se non ci fossero state vacanze, festivita, ponti o sospensioni;
+- `Ore perse`: ore che cadono in giorni in cui il calendario prevede lezione, ma la scuola e chiusa o la lezione e sospesa;
+- `Ore disponibili`: ore realmente utilizzabili per la UDA dopo aver sottratto le ore perse.
+
+Esempio: se una UDA occupa tre settimane da 3 ore ciascuna, avrebbe `9h` teoriche. Se in quelle settimane una lezione da `1h` cade in un giorno di sospensione, il Gantt mostra `9h` teoriche, `1h` persa e `8h` disponibili.
+
+La barra della UDA mostra le ore disponibili, perche sono quelle effettivamente usabili nella programmazione didattica. Il tooltip e il modal mostrano anche ore teoriche e ore perse, cosi puoi capire quanto calendario e stato assorbito dalle chiusure.
 
 Nel micro-calendario:
 
@@ -187,7 +199,8 @@ Passando con il mouse su una barra UDA, la pagina mostra un tooltip con:
 - titolo UDA;
 - settimane effettive;
 - date calcolate;
-- ore previste;
+- ore teoriche;
+- ore disponibili;
 - ore perse;
 - argomenti e sottoparagrafi.
 
@@ -196,6 +209,8 @@ Cliccando su una UDA nel Gantt oppure sulla stessa UDA nella vista calendario si
 Il modal mostra:
 
 - dati della programmazione prevista;
+- ore teoriche;
+- ore disponibili;
 - ore perse;
 - argomenti e sottoparagrafi;
 - campi della programmazione svolta.

--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -1576,7 +1576,7 @@ Questa e una versione ancora in evoluzione. Non gestisce ancora automaticamente:
 - ricalcolo automatico completo di tutte le UDA adiacenti quando una UDA viene allungata o accorciata;
 - report automatico `in anticipo`, `in linea`, `in ritardo`;
 - esportazione o stampa del Gantt;
-- confronto sintetico tra ore previste, ore perse e ore svolte per tutto il corso.
+- confronto sintetico tra ore teoriche, ore disponibili, ore perse e ore svolte per tutto il corso.
 
 ### Direzione futura: un solo JSON per corso e calendario
 

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -588,6 +588,7 @@ button:disabled {
 }
 
 .ganttTrack {
+  --gantt-week-width: 3.4rem;
   border: 1px solid rgba(17, 17, 17, .16);
   border-radius: 18px;
   background: #ffffff;
@@ -617,7 +618,7 @@ button:disabled {
 .ganttClosures,
 .ganttBars {
   display: grid;
-  min-width: max-content;
+  width: max-content;
 }
 
 .ganttMonths {
@@ -732,7 +733,8 @@ button:disabled {
 }
 
 .ganttBarWeekStart {
-  box-shadow: -3px 0 0 rgba(255, 255, 255, .78);
+  border-left: 2px solid rgba(255, 255, 255, .9);
+  border-radius: 0 999px 999px 0;
 }
 
 .ganttBarDayLesson {

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -176,7 +176,34 @@ input, select {
   background: rgba(255, 255, 255, .72);
 }
 
-.panelHead h2 { margin-bottom: 0; font-size: 1.25rem; }
+.panelHead h2 {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  margin-bottom: 0;
+  font-size: 1.25rem;
+}
+
+.panelHead h2::before {
+  content: "−";
+  display: inline-grid;
+  place-items: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 1px solid rgba(17, 17, 17, .18);
+  border-radius: 999px;
+  font-size: .82rem;
+  line-height: 1;
+}
+
+.panelCollapsed .panelHead h2::before {
+  content: "+";
+}
+
+.panelCollapsed > :not(.panelHead) {
+  display: none !important;
+}
 
 .panelActions {
   display: flex;

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -618,12 +618,12 @@ button:disabled {
 }
 
 .ganttTrackHead strong {
-  font-size: .92rem;
+  font-size: 1.35rem;
 }
 
 .ganttTrackHead span {
   color: var(--muted);
-  font-size: .74rem;
+  font-size: 1.05rem;
 }
 
 .ganttMonths,
@@ -641,7 +641,7 @@ button:disabled {
 .ganttMonths span {
   border-left: 1px solid rgba(17, 17, 17, .12);
   color: #111111;
-  font: 800 .68rem/1 var(--mono);
+  font: 800 1.15rem/1 var(--mono);
   padding: .25rem .3rem;
   text-transform: uppercase;
 }
@@ -659,19 +659,19 @@ button:disabled {
   color: var(--muted);
   display: grid;
   gap: .16rem;
-  font: 700 .62rem/1 var(--mono);
+  font: 700 1rem/1.05 var(--mono);
   padding: .25rem .2rem;
   text-align: center;
 }
 
 .ganttWeeks strong {
   color: #111111;
-  font-size: .66rem;
+  font-size: 1.08rem;
 }
 
 .ganttWeeks small {
   color: var(--muted);
-  font-size: .52rem;
+  font-size: .88rem;
   font-weight: 700;
 }
 
@@ -691,7 +691,7 @@ button:disabled {
   background: #fdecea;
   color: #8f1d14;
   display: grid;
-  font: 800 .58rem/1.1 var(--mono);
+  font: 800 .95rem/1.1 var(--mono);
   min-height: 1.2rem;
   overflow: hidden;
   padding: .18rem .45rem;
@@ -701,19 +701,19 @@ button:disabled {
 
 .ganttBars {
   gap: .35rem 0;
-  min-height: 4.4rem;
+  min-height: 5.4rem;
 }
 
 .ganttBar {
   display: grid;
   align-content: center;
   gap: .34rem;
-  min-height: 4.4rem;
+  min-height: 5.4rem;
   border: 1px solid rgba(17, 17, 17, .24);
   border-radius: 12px;
   background: linear-gradient(135deg, #111111, #3a3a3a);
   color: #ffffff;
-  padding: .7rem .8rem;
+  padding: .85rem 1rem;
   overflow: hidden;
   cursor: pointer;
 }
@@ -739,16 +739,16 @@ button:disabled {
 }
 
 .ganttBarText strong {
-  font: 800 .66rem/1.15 var(--mono);
+  font: 800 1.16rem/1.15 var(--mono);
 }
 
 .ganttBarText span {
-  font-size: .7rem;
+  font-size: 1.08rem;
   opacity: .9;
 }
 
 .ganttBarMeta {
-  font: 800 .62rem/1.15 var(--mono);
+  font: 800 1rem/1.15 var(--mono);
   opacity: .86;
   text-align: right;
 }
@@ -803,7 +803,7 @@ button:disabled {
 
 .ganttDialogHead h2 {
   margin: .15rem 0 0;
-  font-size: 1.1rem;
+  font-size: 1.45rem;
 }
 
 .ganttDialogBody {
@@ -829,13 +829,13 @@ button:disabled {
 
 .ganttDialogMeta strong {
   color: var(--muted);
-  font-size: .66rem;
+  font-size: .95rem;
   text-transform: uppercase;
 }
 
 .ganttDialogBody h3 {
   margin: 0 0 .55rem;
-  font-size: .9rem;
+  font-size: 1.2rem;
 }
 
 .ganttDialogTopics ul {

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -693,6 +693,7 @@ button:disabled {
 .ganttBar {
   display: grid;
   align-content: center;
+  gap: .34rem;
   min-height: 2.7rem;
   border: 1px solid rgba(17, 17, 17, .24);
   border-radius: 12px;
@@ -716,6 +717,26 @@ button:disabled {
 .ganttBar span {
   font-size: .7rem;
   opacity: .9;
+}
+
+.ganttBarDays {
+  display: grid;
+  gap: .12rem;
+  margin-top: .08rem;
+}
+
+.ganttBarDay {
+  min-height: .38rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, .18);
+}
+
+.ganttBarDayLesson {
+  background: #39d98a;
+}
+
+.ganttBarDayClosed {
+  background: #ff5c4d;
 }
 
 @media (max-width: 950px) {

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -701,19 +701,19 @@ button:disabled {
 
 .ganttBars {
   gap: .35rem 0;
-  min-height: 2.7rem;
+  min-height: 3.7rem;
 }
 
 .ganttBar {
   display: grid;
   align-content: center;
   gap: .34rem;
-  min-height: 2.7rem;
+  min-height: 3.7rem;
   border: 1px solid rgba(17, 17, 17, .24);
   border-radius: 12px;
   background: linear-gradient(135deg, #111111, #3a3a3a);
   color: #ffffff;
-  padding: .45rem .6rem;
+  padding: .55rem .7rem;
   overflow: hidden;
   cursor: pointer;
 }
@@ -760,7 +760,7 @@ button:disabled {
 }
 
 .ganttBarDay {
-  min-height: .38rem;
+  min-height: .52rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, .18);
 }

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -701,19 +701,19 @@ button:disabled {
 
 .ganttBars {
   gap: .35rem 0;
-  min-height: 3.7rem;
+  min-height: 4.4rem;
 }
 
 .ganttBar {
   display: grid;
   align-content: center;
   gap: .34rem;
-  min-height: 3.7rem;
+  min-height: 4.4rem;
   border: 1px solid rgba(17, 17, 17, .24);
   border-radius: 12px;
   background: linear-gradient(135deg, #111111, #3a3a3a);
   color: #ffffff;
-  padding: .55rem .7rem;
+  padding: .7rem .8rem;
   overflow: hidden;
   cursor: pointer;
 }
@@ -760,7 +760,7 @@ button:disabled {
 }
 
 .ganttBarDay {
-  min-height: .52rem;
+  min-height: .68rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, .18);
 }

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -581,6 +581,92 @@ button:disabled {
   line-height: 1.2;
 }
 
+.ganttChart {
+  display: grid;
+  gap: 1rem;
+  padding: 1.1rem;
+}
+
+.ganttTrack {
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 18px;
+  background: #ffffff;
+  overflow-x: auto;
+  padding: .9rem;
+}
+
+.ganttTrackHead {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+  margin-bottom: .75rem;
+}
+
+.ganttTrackHead strong {
+  font-size: .92rem;
+}
+
+.ganttTrackHead span {
+  color: var(--muted);
+  font-size: .74rem;
+}
+
+.ganttWeeks,
+.ganttBars {
+  display: grid;
+  min-width: max-content;
+}
+
+.ganttWeeks {
+  margin-bottom: .35rem;
+}
+
+.ganttWeeks span {
+  border-left: 1px solid rgba(17, 17, 17, .08);
+  color: var(--muted);
+  font: 700 .62rem/1 var(--mono);
+  padding: .25rem .2rem;
+  text-align: center;
+}
+
+.ganttWeeks span:first-child {
+  border-left: 0;
+}
+
+.ganttBars {
+  gap: .35rem 0;
+  min-height: 2.7rem;
+}
+
+.ganttBar {
+  display: grid;
+  align-content: center;
+  min-height: 2.7rem;
+  border: 1px solid rgba(17, 17, 17, .24);
+  border-radius: 12px;
+  background: linear-gradient(135deg, #111111, #3a3a3a);
+  color: #ffffff;
+  padding: .45rem .6rem;
+  overflow: hidden;
+}
+
+.ganttBar strong,
+.ganttBar span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ganttBar strong {
+  font: 800 .66rem/1.15 var(--mono);
+}
+
+.ganttBar span {
+  font-size: .7rem;
+  opacity: .9;
+}
+
 @media (max-width: 950px) {
   .hero, .panelHead {
     display: grid;

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -704,20 +704,39 @@ button:disabled {
   overflow: hidden;
 }
 
-.ganttBar strong,
-.ganttBar span {
+.ganttBarContent {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: .55rem;
+  align-items: start;
+}
+
+.ganttBarText {
+  display: grid;
+  min-width: 0;
+}
+
+.ganttBarText strong,
+.ganttBarText span,
+.ganttBarMeta {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.ganttBar strong {
+.ganttBarText strong {
   font: 800 .66rem/1.15 var(--mono);
 }
 
-.ganttBar span {
+.ganttBarText span {
   font-size: .7rem;
   opacity: .9;
+}
+
+.ganttBarMeta {
+  font: 800 .62rem/1.15 var(--mono);
+  opacity: .86;
+  text-align: right;
 }
 
 .ganttBarDays {

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -798,6 +798,10 @@ button:disabled {
   background: #ff5c4d;
 }
 
+.ganttBarDayInterrupted {
+  background: linear-gradient(135deg, #ff5c4d 0 50%, #39d98a 50% 100%);
+}
+
 .ganttDialog {
   width: min(760px, calc(100vw - 2rem));
   border: 1px solid rgba(17, 17, 17, .18);
@@ -834,7 +838,7 @@ button:disabled {
 
 .ganttDialogMeta {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: .6rem;
 }
 

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -773,10 +773,16 @@ button:disabled {
   text-align: right;
 }
 
-.ganttBarDays {
+.ganttBarDayBlock {
+  display: grid;
+  gap: .18rem;
+  margin-top: .08rem;
+}
+
+.ganttBarDays,
+.ganttBarDayLabels {
   display: grid;
   gap: .12rem;
-  margin-top: .08rem;
 }
 
 .ganttBarDay {
@@ -800,6 +806,20 @@ button:disabled {
 
 .ganttBarDayInterrupted {
   background: linear-gradient(135deg, #ff5c4d 0 50%, #39d98a 50% 100%);
+}
+
+.ganttBarDayLabels span {
+  color: rgba(255, 255, 255, .72);
+  font: 800 .62rem/1 var(--mono);
+  text-align: center;
+}
+
+.ganttBarDayLabels .ganttBarDayLabelSaturday {
+  color: #ffd166;
+}
+
+.ganttBarDayLabels .ganttBarDayLabelSunday {
+  color: #ff7a70;
 }
 
 .ganttDialog {

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -968,6 +968,11 @@ button:disabled {
   margin: .75rem 0;
 }
 
+[data-action="calculate-actual-hours"] {
+  justify-self: start;
+  margin-top: .65rem;
+}
+
 .actualNotes textarea {
   min-height: 5rem;
   resize: vertical;

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -702,6 +702,7 @@ button:disabled {
   color: #ffffff;
   padding: .45rem .6rem;
   overflow: hidden;
+  cursor: pointer;
 }
 
 .ganttBarContent {
@@ -764,6 +765,79 @@ button:disabled {
   background: #ff5c4d;
 }
 
+.ganttDialog {
+  width: min(760px, calc(100vw - 2rem));
+  border: 1px solid rgba(17, 17, 17, .18);
+  border-radius: 22px;
+  background: #ffffff;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, .24);
+  color: var(--ink);
+  padding: 0;
+}
+
+.ganttDialog::backdrop {
+  background: rgba(17, 17, 17, .36);
+}
+
+.ganttDialogHead {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  border-bottom: 1px solid var(--line);
+  padding: 1rem;
+}
+
+.ganttDialogHead h2 {
+  margin: .15rem 0 0;
+  font-size: 1.1rem;
+}
+
+.ganttDialogBody {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.ganttDialogMeta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: .6rem;
+}
+
+.ganttDialogMeta span {
+  border: 1px solid rgba(17, 17, 17, .12);
+  border-radius: 14px;
+  background: #f7f7f7;
+  display: grid;
+  gap: .2rem;
+  padding: .65rem;
+}
+
+.ganttDialogMeta strong {
+  color: var(--muted);
+  font-size: .66rem;
+  text-transform: uppercase;
+}
+
+.ganttDialogBody h3 {
+  margin: 0 0 .55rem;
+  font-size: .9rem;
+}
+
+.ganttDialogTopics ul {
+  margin: .3rem 0 .3rem 1.1rem;
+  padding: 0;
+}
+
+.ganttDialogTopics li {
+  margin: .28rem 0;
+}
+
+.ganttDialogTopics span {
+  line-height: 1.35;
+}
+
 @media (max-width: 950px) {
   .hero, .panelHead {
     display: grid;
@@ -782,6 +856,10 @@ button:disabled {
   }
 
   .slotRow, .closureRow {
+    grid-template-columns: 1fr;
+  }
+
+  .ganttDialogMeta {
     grid-template-columns: 1fr;
   }
 }

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -9,6 +9,7 @@
   --warm: #3f3f46;
   --shadow: 0 18px 42px rgba(0, 0, 0, 0.08);
   --mono: "Cascadia Code", "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, monospace;
+  --gantt-week-width: 3.4rem;
 }
 
 * { box-sizing: border-box; }
@@ -587,8 +588,20 @@ button:disabled {
   padding: 1.1rem;
 }
 
+.ganttHelp {
+  margin: 0 1.1rem;
+}
+
+.ganttZoomControls {
+  align-items: center;
+}
+
+.ganttZoomControls button {
+  min-width: 2.5rem;
+  padding: .45rem .65rem;
+}
+
 .ganttTrack {
-  --gantt-week-width: 3.4rem;
   border: 1px solid rgba(17, 17, 17, .16);
   border-radius: 18px;
   background: #ffffff;

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -582,6 +582,26 @@ button:disabled {
   line-height: 1.2;
 }
 
+.dayLessonButton {
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: rgba(17, 17, 17, .07);
+  box-shadow: none;
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  font: inherit;
+  justify-content: flex-start;
+  padding: .18rem .24rem;
+  text-align: left;
+}
+
+.dayLessonButton:hover {
+  background: rgba(17, 17, 17, .12);
+  transform: none;
+}
+
 .ganttChart {
   display: grid;
   gap: 1rem;

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -731,6 +731,10 @@ button:disabled {
   background: rgba(255, 255, 255, .18);
 }
 
+.ganttBarWeekStart {
+  box-shadow: -3px 0 0 rgba(255, 255, 255, .78);
+}
+
 .ganttBarDayLesson {
   background: #39d98a;
 }

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -612,10 +612,28 @@ button:disabled {
   font-size: .74rem;
 }
 
+.ganttMonths,
 .ganttWeeks,
+.ganttClosures,
 .ganttBars {
   display: grid;
   min-width: max-content;
+}
+
+.ganttMonths {
+  margin-bottom: .2rem;
+}
+
+.ganttMonths span {
+  border-left: 1px solid rgba(17, 17, 17, .12);
+  color: #111111;
+  font: 800 .68rem/1 var(--mono);
+  padding: .25rem .3rem;
+  text-transform: uppercase;
+}
+
+.ganttMonths span:first-child {
+  border-left: 0;
 }
 
 .ganttWeeks {
@@ -625,13 +643,46 @@ button:disabled {
 .ganttWeeks span {
   border-left: 1px solid rgba(17, 17, 17, .08);
   color: var(--muted);
+  display: grid;
+  gap: .16rem;
   font: 700 .62rem/1 var(--mono);
   padding: .25rem .2rem;
   text-align: center;
 }
 
+.ganttWeeks strong {
+  color: #111111;
+  font-size: .66rem;
+}
+
+.ganttWeeks small {
+  color: var(--muted);
+  font-size: .52rem;
+  font-weight: 700;
+}
+
 .ganttWeeks span:first-child {
   border-left: 0;
+}
+
+.ganttClosures {
+  min-height: 1.45rem;
+  margin-bottom: .35rem;
+}
+
+.ganttClosure {
+  align-content: center;
+  border: 1px solid rgba(143, 29, 20, .32);
+  border-radius: 999px;
+  background: #fdecea;
+  color: #8f1d14;
+  display: grid;
+  font: 800 .58rem/1.1 var(--mono);
+  min-height: 1.2rem;
+  overflow: hidden;
+  padding: .18rem .45rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ganttBars {

--- a/tools/school_calendar.css
+++ b/tools/school_calendar.css
@@ -724,6 +724,67 @@ button:disabled {
   min-height: 5.4rem;
 }
 
+.ganttLaneLabel {
+  color: var(--muted);
+  font: 900 .78rem/1 var(--mono);
+  margin: .7rem 0 .35rem;
+  text-transform: uppercase;
+}
+
+.ganttActualBars {
+  display: grid;
+  gap: .35rem 0;
+  min-height: 2.8rem;
+  width: max-content;
+}
+
+.ganttActualBar {
+  display: grid;
+  align-content: center;
+  border: 1px solid rgba(17, 17, 17, .18);
+  border-radius: 12px;
+  background: #dbeafe;
+  color: #0f172a;
+  min-height: 2.8rem;
+  overflow: hidden;
+  padding: .5rem .65rem;
+}
+
+.ganttActualBar strong,
+.ganttActualBar span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ganttActualBar strong {
+  font: 900 .86rem/1.1 var(--mono);
+}
+
+.ganttActualBar span {
+  font-size: .78rem;
+}
+
+.ganttActualBar-done {
+  background: #dcfce7;
+}
+
+.ganttActualBar-in_progress {
+  background: #fef3c7;
+}
+
+.ganttActualBar-paused,
+.ganttActualBar-skipped {
+  background: #fee2e2;
+}
+
+.ganttActualEmpty {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: .82rem;
+  padding: .45rem 0;
+}
+
 .ganttBar {
   display: grid;
   align-content: center;
@@ -895,6 +956,23 @@ button:disabled {
   line-height: 1.35;
 }
 
+.actualForm {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: .65rem;
+}
+
+.actualNotes {
+  display: grid;
+  gap: .35rem;
+  margin: .75rem 0;
+}
+
+.actualNotes textarea {
+  min-height: 5rem;
+  resize: vertical;
+}
+
 @media (max-width: 950px) {
   .hero, .panelHead {
     display: grid;
@@ -917,6 +995,10 @@ button:disabled {
   }
 
   .ganttDialogMeta {
+    grid-template-columns: 1fr;
+  }
+
+  .actualForm {
     grid-template-columns: 1fr;
   }
 }

--- a/tools/school_calendar.html
+++ b/tools/school_calendar.html
@@ -116,8 +116,13 @@
     <section class="panel">
       <div class="panelHead">
         <h2>Diagramma Gantt UDA</h2>
-        <p class="status">Distribuzione cronologica delle UDA sulle settimane effettive di lezione.</p>
+        <div class="panelActions ganttZoomControls">
+          <button id="ganttZoomOutBtn" type="button" title="Riduce lo zoom del diagramma Gantt.">-</button>
+          <button id="ganttZoomResetBtn" type="button" title="Ripristina lo zoom predefinito del diagramma Gantt.">100%</button>
+          <button id="ganttZoomInBtn" type="button" title="Aumenta lo zoom del diagramma Gantt.">+</button>
+        </div>
       </div>
+      <p class="status ganttHelp">Distribuzione cronologica delle UDA sulle settimane effettive di lezione.</p>
       <div id="ganttChart" class="ganttChart"></div>
     </section>
 

--- a/tools/school_calendar.html
+++ b/tools/school_calendar.html
@@ -32,7 +32,7 @@
   </header>
 
   <main class="layout">
-    <section class="panel">
+    <section class="panel" data-panel-key="school-year">
       <div class="panelHead">
         <h2>Anno scolastico</h2>
         <p id="status" class="status">Pronto.</p>
@@ -71,7 +71,7 @@
       </div>
     </section>
 
-    <section class="panel">
+    <section class="panel" data-panel-key="schedule-tracks">
       <div class="panelHead">
         <h2>Percorsi orari</h2>
         <button id="addTrackBtn" type="button" title="Aggiunge un nuovo anno o percorso orario.">Aggiungi percorso</button>
@@ -79,7 +79,7 @@
       <div id="tracks" class="tracks"></div>
     </section>
 
-    <section class="panel">
+    <section class="panel" data-panel-key="school-closures">
       <div class="panelHead">
         <h2>Vacanze, festività e sospensioni</h2>
         <div class="panelActions">
@@ -104,7 +104,7 @@
       </div>
     </section>
 
-    <section class="panel">
+    <section class="panel" data-panel-key="calendar-view">
       <div class="panelHead">
         <h2>Vista calendario</h2>
         <p class="status">Legenda: lezione del percorso, chiusura, fuori anno scolastico.</p>
@@ -113,7 +113,7 @@
       <div id="monthGrid" class="monthGrid"></div>
     </section>
 
-    <section class="panel">
+    <section class="panel" data-panel-key="uda-gantt">
       <div class="panelHead">
         <h2>Diagramma Gantt UDA</h2>
         <div class="panelActions ganttZoomControls">
@@ -137,7 +137,7 @@
       <div id="ganttDialogBody" class="ganttDialogBody"></div>
     </dialog>
 
-    <section class="panel">
+    <section class="panel" data-panel-key="effective-hours-summary">
       <div class="panelHead">
         <h2>Riepilogo ore effettive</h2>
         <button id="recalculateBtn" type="button" title="Ricalcola ore teoriche, ore perse e ore effettive per ogni percorso.">Ricalcola</button>

--- a/tools/school_calendar.html
+++ b/tools/school_calendar.html
@@ -115,6 +115,14 @@
 
     <section class="panel">
       <div class="panelHead">
+        <h2>Diagramma Gantt UDA</h2>
+        <p class="status">Distribuzione cronologica delle UDA sulle settimane effettive di lezione.</p>
+      </div>
+      <div id="ganttChart" class="ganttChart"></div>
+    </section>
+
+    <section class="panel">
+      <div class="panelHead">
         <h2>Riepilogo ore effettive</h2>
         <button id="recalculateBtn" type="button" title="Ricalcola ore teoriche, ore perse e ore effettive per ogni percorso.">Ricalcola</button>
       </div>

--- a/tools/school_calendar.html
+++ b/tools/school_calendar.html
@@ -121,6 +121,17 @@
       <div id="ganttChart" class="ganttChart"></div>
     </section>
 
+    <dialog id="ganttDialog" class="ganttDialog">
+      <div class="ganttDialogHead">
+        <div>
+          <p class="eyebrow">Dettaglio UDA</p>
+          <h2 id="ganttDialogTitle">UDA</h2>
+        </div>
+        <button id="ganttDialogCloseBtn" type="button" title="Chiude il dettaglio della UDA.">Chiudi</button>
+      </div>
+      <div id="ganttDialogBody" class="ganttDialogBody"></div>
+    </dialog>
+
     <section class="panel">
       <div class="panelHead">
         <h2>Riepilogo ore effettive</h2>

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1069,6 +1069,7 @@ function udaGanttSegments(track, weeks) {
     const hours = segmentWeeks.reduce((total, week) => total + Number(week.hours || 0), 0);
     segments.push({
       uda,
+      track,
       startIndex,
       endIndex,
       weeks: segmentWeeks,
@@ -1098,12 +1099,14 @@ function renderTopicList(items) {
 }
 
 function openGanttDialog(segment, firstWeek, lastWeek) {
+  const lostHours = ganttSegmentLostHours(segment);
   els.ganttDialogTitle.textContent = `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`;
   els.ganttDialogBody.innerHTML = `
     <div class="ganttDialogMeta">
       <span><strong>Settimane effettive</strong>${segment.startIndex + 1}-${segment.endIndex + 1}</span>
       <span><strong>Date</strong>${shortDate(firstWeek.start)}-${shortDate(lastWeek.end)}</span>
       <span><strong>Ore previste</strong>${segment.hours}h</span>
+      <span><strong>Ore perse</strong>${lostHours}h</span>
     </div>
     <section>
       <h3>Argomenti e sottoparagrafi</h3>
@@ -1116,11 +1119,13 @@ function openGanttDialog(segment, firstWeek, lastWeek) {
 function ganttSegmentTooltip(segment) {
   const firstWeek = segment.weeks[0];
   const lastWeek = segment.weeks[segment.weeks.length - 1];
+  const lostHours = ganttSegmentLostHours(segment);
   return [
     `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`,
     `Settimane effettive: ${segment.startIndex + 1}-${segment.endIndex + 1}`,
     `Date: ${firstWeek.start.toLocaleDateString("it-IT")} - ${lastWeek.end.toLocaleDateString("it-IT")}`,
     `Ore previste: ${segment.hours}`,
+    `Ore perse: ${lostHours}`,
     "",
     "Argomenti:",
     ...collectUdaTopicTitles(segment.uda.items || []),
@@ -1197,6 +1202,22 @@ function resetGanttZoom() {
   applyGanttZoom();
 }
 
+function ganttSegmentLostHours(segment) {
+  const closures = closedLabelsByDate();
+  let lost = 0;
+  for (const week of segment.weeks || []) {
+    for (let offset = 0; offset < 7; offset += 1) {
+      const date = addDays(week.start, offset);
+      const iso = isoDate(date);
+      if (!closures.has(iso)) continue;
+      lost += (segment.track?.weekly_slots || [])
+        .filter((slot) => DAY_INDEX[slot.day] === date.getDay())
+        .reduce((total, slot) => total + Number(slot.hours || 0), 0);
+    }
+  }
+  return lost;
+}
+
 function renderGanttBarDays(track, segment, closures) {
   const strip = document.createElement("div");
   strip.className = "ganttBarDays";
@@ -1211,7 +1232,10 @@ function renderGanttBarDays(track, segment, closures) {
       if (offset === 0) {
         day.classList.add("ganttBarWeekStart");
       }
-      if (closures.has(iso)) {
+      if (closures.has(iso) && hasLesson) {
+        day.classList.add("ganttBarDayInterrupted");
+        day.title = `${date.toLocaleDateString("it-IT")} - lezione sospesa: ${closures.get(iso)}`;
+      } else if (closures.has(iso)) {
         day.classList.add("ganttBarDayClosed");
         day.title = `${date.toLocaleDateString("it-IT")} - ${closures.get(iso)}`;
       } else if (hasLesson) {

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1400,7 +1400,7 @@ function actualUdaSegments(track, weeks) {
   return segments;
 }
 
-function renderActualGanttBar(segment, dialogSegment = segment) {
+function renderActualGanttBar(segment, dialogSegment = null) {
   const bar = document.createElement("div");
   const status = segment.actual.status || "todo";
   bar.className = `ganttActualBar ganttActualBar-${status}`;
@@ -1417,12 +1417,21 @@ function renderActualGanttBar(segment, dialogSegment = segment) {
     <strong>${escapeHtml(String(segment.uda.id || "").toUpperCase())}</strong>
     <span>${escapeHtml(segment.hours ? `${segment.hours}h` : status)}</span>
   `;
-  bar.addEventListener("click", () => {
-    const firstWeek = dialogSegment.weeks[0];
-    const lastWeek = dialogSegment.weeks[dialogSegment.weeks.length - 1];
-    openGanttDialog(dialogSegment, firstWeek, lastWeek);
-  });
+  if (dialogSegment?.weeks?.length) {
+    bar.addEventListener("click", () => {
+      const firstWeek = dialogSegment.weeks[0];
+      const lastWeek = dialogSegment.weeks[dialogSegment.weeks.length - 1];
+      openGanttDialog(dialogSegment, firstWeek, lastWeek);
+    });
+  }
   return bar;
+}
+
+function matchesUdaSegment(candidate, segment) {
+  if (candidate.uda === segment.uda) return true;
+  const candidateId = candidate.uda?.id;
+  const segmentId = segment.uda?.id;
+  return Boolean(candidateId && segmentId && candidateId === segmentId);
 }
 
 function renderGanttBarDays(track, segment, closures) {
@@ -1567,8 +1576,8 @@ function renderGanttChart() {
     const actualSegments = actualUdaSegments(track, weeks);
     if (actualSegments.length) {
       for (const segment of actualSegments) {
-        const plannedSegment = plannedSegments.find((candidate) => candidate.uda === segment.uda || candidate.uda.id === segment.uda.id);
-        actualBars.append(renderActualGanttBar(segment, plannedSegment || segment));
+        const plannedSegment = plannedSegments.find((candidate) => matchesUdaSegment(candidate, segment));
+        actualBars.append(renderActualGanttBar(segment, plannedSegment));
       }
     } else {
       const empty = document.createElement("div");

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -42,6 +42,7 @@ const els = {
   closures: document.querySelector("#closures"),
   calendarValidation: document.querySelector("#calendarValidation"),
   monthGrid: document.querySelector("#monthGrid"),
+  ganttChart: document.querySelector("#ganttChart"),
   summary: document.querySelector("#summary"),
 };
 
@@ -1002,6 +1003,125 @@ function trackSchedules(start, end, closures) {
   return schedules;
 }
 
+function teachingWeeksForTrack(track, start, end, closures) {
+  const weeks = [];
+  const byKey = new Map();
+  for (const date = new Date(start); date <= end; date.setDate(date.getDate() + 1)) {
+    const iso = isoDate(date);
+    if (closures.has(iso)) continue;
+    const daySlots = (track.weekly_slots || []).filter((slot) => DAY_INDEX[slot.day] === date.getDay() && Number(slot.hours || 0) > 0);
+    if (!daySlots.length) continue;
+    const key = weekKey(date);
+    if (!byKey.has(key)) {
+      const monday = dateFromInput(key);
+      const week = {
+        key,
+        start: monday,
+        end: addDays(monday, 6),
+        hours: 0,
+      };
+      byKey.set(key, week);
+      weeks.push(week);
+    }
+    byKey.get(key).hours += daySlots.reduce((total, slot) => total + Number(slot.hours || 0), 0);
+  }
+  return weeks;
+}
+
+function udaGanttSegments(track, weeks) {
+  const year = courseYearForTrack(track);
+  const segments = [];
+  let cursor = 0;
+  for (const uda of year?.udas || []) {
+    const duration = parseUdaWeeks(uda.weeks);
+    if (cursor >= weeks.length) break;
+    const startIndex = cursor;
+    const endIndex = Math.min(cursor + duration, weeks.length) - 1;
+    const segmentWeeks = weeks.slice(startIndex, endIndex + 1);
+    const hours = segmentWeeks.reduce((total, week) => total + Number(week.hours || 0), 0);
+    segments.push({
+      uda,
+      startIndex,
+      endIndex,
+      weeks: segmentWeeks,
+      hours,
+    });
+    cursor = endIndex + 1;
+  }
+  return segments;
+}
+
+function renderGanttChart() {
+  syncFormToCalendar();
+  els.ganttChart.innerHTML = "";
+  const start = dateFromInput(state.calendar.start_date);
+  const end = dateFromInput(state.calendar.end_date);
+  if (!start || !end || start > end) {
+    els.ganttChart.innerHTML = '<p class="empty">Inserisci date di inizio e fine lezioni valide per generare il Gantt.</p>';
+    return;
+  }
+  const tracks = visibleTracks();
+  if (!tracks.length) {
+    els.ganttChart.innerHTML = '<p class="empty">Seleziona almeno un percorso da visualizzare.</p>';
+    return;
+  }
+  const closures = closedLabelsByDate();
+  for (const track of tracks) {
+    const weeks = teachingWeeksForTrack(track, start, end, closures);
+    const year = courseYearForTrack(track);
+    const row = document.createElement("article");
+    row.className = "ganttTrack";
+    const title = track.label || year?.title || track.id || "Percorso";
+    if (!weeks.length || !year?.udas?.length) {
+      row.innerHTML = `
+        <div class="ganttTrackHead">
+          <strong>${escapeHtml(title)}</strong>
+          <span>${weeks.length ? "Nessuna UDA associata" : "Nessuna settimana di lezione disponibile"}</span>
+        </div>
+      `;
+      els.ganttChart.append(row);
+      continue;
+    }
+    row.innerHTML = `
+      <div class="ganttTrackHead">
+        <strong>${escapeHtml(title)}</strong>
+        <span>${weeks.length} settimane effettive - ${weeks.reduce((total, week) => total + Number(week.hours || 0), 0)}h previste</span>
+      </div>
+      <div class="ganttWeeks"></div>
+      <div class="ganttBars"></div>
+    `;
+    const weekGrid = row.querySelector(".ganttWeeks");
+    weekGrid.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
+    weeks.forEach((week, index) => {
+      const label = document.createElement("span");
+      label.title = `${week.start.toLocaleDateString("it-IT")} - ${week.end.toLocaleDateString("it-IT")} - ${week.hours}h`;
+      label.textContent = String(index + 1);
+      weekGrid.append(label);
+    });
+    const bars = row.querySelector(".ganttBars");
+    bars.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
+    for (const segment of udaGanttSegments(track, weeks)) {
+      const bar = document.createElement("div");
+      bar.className = "ganttBar";
+      bar.style.gridColumn = `${segment.startIndex + 1} / ${segment.endIndex + 2}`;
+      const firstWeek = segment.weeks[0];
+      const lastWeek = segment.weeks[segment.weeks.length - 1];
+      bar.title = [
+        `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`,
+        `Settimane effettive: ${segment.startIndex + 1}-${segment.endIndex + 1}`,
+        `Date: ${firstWeek.start.toLocaleDateString("it-IT")} - ${lastWeek.end.toLocaleDateString("it-IT")}`,
+        `Ore previste: ${segment.hours}`,
+      ].join("\n");
+      bar.innerHTML = `
+        <strong>${escapeHtml(String(segment.uda.id || "").toUpperCase())}</strong>
+        <span>${escapeHtml(segment.uda.title || "UDA senza titolo")}</span>
+      `;
+      bars.append(bar);
+    }
+    els.ganttChart.append(row);
+  }
+}
+
 function calendarMonths(start, end) {
   const months = [];
   if (!start || !end || start > end) return months;
@@ -1088,12 +1208,16 @@ function renderCalendarView() {
   els.monthGrid.classList.toggle("monthFocusGrid", state.calendarView.mode === "month");
   const start = dateFromInput(state.calendar.start_date);
   const end = dateFromInput(state.calendar.end_date);
-  if (!start || !end || start > end) return;
+  if (!start || !end || start > end) {
+    renderGanttChart();
+    return;
+  }
   const closures = closedLabelsByDate();
   const lessons = lessonLabelsByDate();
   if (state.calendarView.mode === "week") {
     const week = selectedCalendarWeek(start, end);
     if (week) els.monthGrid.append(renderWeek(week, start, end, lessons, closures));
+    renderGanttChart();
     return;
   }
   const months = state.calendarView.mode === "month"
@@ -1110,6 +1234,7 @@ function renderCalendarView() {
     const role = item.role || "main";
     els.monthGrid.append(renderMonth(month, start, end, lessons, closures, role));
   }
+  renderGanttChart();
 }
 
 function selectedCalendarMonthContext(start, end) {

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -21,6 +21,9 @@ const DAY_INDEX = {
 const ACTIVE_COURSE_DESIGN_KEY = "2cornot2c.activeCourseDesign";
 const ACTIVE_SCHOOL_CALENDAR_KEY = "2cornot2c.activeSchoolCalendar";
 const ACTIVE_COURSE_SESSION_KEY = "2cornot2c.keepActiveCourseInSession";
+const GANTT_ZOOM_KEY = "2cornot2c.ganttZoom";
+const GANTT_WEEK_WIDTHS = [2.4, 3.0, 3.4, 4.2, 5.2, 6.4];
+const GANTT_DEFAULT_ZOOM_INDEX = 2;
 
 const els = {
   calendarSelect: document.querySelector("#calendarSelect"),
@@ -47,6 +50,9 @@ const els = {
   ganttDialogTitle: document.querySelector("#ganttDialogTitle"),
   ganttDialogBody: document.querySelector("#ganttDialogBody"),
   ganttDialogCloseBtn: document.querySelector("#ganttDialogCloseBtn"),
+  ganttZoomOutBtn: document.querySelector("#ganttZoomOutBtn"),
+  ganttZoomResetBtn: document.querySelector("#ganttZoomResetBtn"),
+  ganttZoomInBtn: document.querySelector("#ganttZoomInBtn"),
   summary: document.querySelector("#summary"),
 };
 
@@ -61,6 +67,7 @@ const state = {
     month: "",
     week: "",
   },
+  ganttZoomIndex: GANTT_DEFAULT_ZOOM_INDEX,
   statusTimer: null,
 };
 
@@ -1139,6 +1146,26 @@ function ganttWeekColumns(weeks) {
   return `repeat(${weeks.length}, var(--gantt-week-width))`;
 }
 
+function applyGanttZoom() {
+  const width = GANTT_WEEK_WIDTHS[state.ganttZoomIndex] || GANTT_WEEK_WIDTHS[GANTT_DEFAULT_ZOOM_INDEX];
+  document.documentElement.style.setProperty("--gantt-week-width", `${width}rem`);
+  const percent = Math.round((width / GANTT_WEEK_WIDTHS[GANTT_DEFAULT_ZOOM_INDEX]) * 100);
+  els.ganttZoomResetBtn.textContent = `${percent}%`;
+  els.ganttZoomOutBtn.disabled = state.ganttZoomIndex <= 0;
+  els.ganttZoomInBtn.disabled = state.ganttZoomIndex >= GANTT_WEEK_WIDTHS.length - 1;
+  localStorage.setItem(GANTT_ZOOM_KEY, String(state.ganttZoomIndex));
+}
+
+function changeGanttZoom(delta) {
+  state.ganttZoomIndex = Math.min(GANTT_WEEK_WIDTHS.length - 1, Math.max(0, state.ganttZoomIndex + delta));
+  applyGanttZoom();
+}
+
+function resetGanttZoom() {
+  state.ganttZoomIndex = GANTT_DEFAULT_ZOOM_INDEX;
+  applyGanttZoom();
+}
+
 function renderGanttBarDays(track, segment, closures) {
   const strip = document.createElement("div");
   strip.className = "ganttBarDays";
@@ -1559,6 +1586,15 @@ els.addClosureBtn.addEventListener("click", addClosure);
 els.importItalianHolidaysBtn.addEventListener("click", importItalianHolidays);
 els.recalculateBtn.addEventListener("click", renderSummary);
 els.ganttDialogCloseBtn.addEventListener("click", () => els.ganttDialog.close());
+els.ganttZoomOutBtn.addEventListener("click", () => changeGanttZoom(-1));
+els.ganttZoomResetBtn.addEventListener("click", resetGanttZoom);
+els.ganttZoomInBtn.addEventListener("click", () => changeGanttZoom(1));
+
+state.ganttZoomIndex = Number(localStorage.getItem(GANTT_ZOOM_KEY) || GANTT_DEFAULT_ZOOM_INDEX);
+if (!Number.isInteger(state.ganttZoomIndex) || state.ganttZoomIndex < 0 || state.ganttZoomIndex >= GANTT_WEEK_WIDTHS.length) {
+  state.ganttZoomIndex = GANTT_DEFAULT_ZOOM_INDEX;
+}
+applyGanttZoom();
 
 Promise.all([loadCalendarList(), loadSavedDesignList()])
   .then(() => loadCalendarForActiveCourseDesign())

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -926,6 +926,17 @@ function lessonLabelsByDate() {
   const tracks = visibleTracks();
   const closures = closedLabelsByDate();
   const schedules = trackSchedules(start, end, closures);
+  const segmentByTrackWeek = new Map();
+  for (const track of tracks) {
+    const weeks = teachingWeeksForTrack(track, start, end, closures);
+    const byWeek = new Map();
+    for (const segment of udaGanttSegments(track, weeks)) {
+      for (const week of segment.weeks) {
+        byWeek.set(week.key, segment);
+      }
+    }
+    segmentByTrackWeek.set(track.id, byWeek);
+  }
   const lessonCounters = new Map();
   for (const date = new Date(start); date <= end; date.setDate(date.getDate() + 1)) {
     const iso = isoDate(date);
@@ -936,21 +947,27 @@ function lessonLabelsByDate() {
       if (hours <= 0) continue;
       const prefix = trackShortLabel(track);
       if (closures.has(iso)) {
-        dayLabels.push(`${prefix}: lezione sospesa (${hours}h)`);
+        dayLabels.push({ label: `${prefix}: lezione sospesa (${hours}h)` });
         continue;
       }
       const count = (lessonCounters.get(track.id) || 0) + 1;
       lessonCounters.set(track.id, count);
-      const uda = schedules.get(track.id)?.get(weekKey(date));
+      const week = weekKey(date);
+      const uda = schedules.get(track.id)?.get(week);
+      const segment = segmentByTrackWeek.get(track.id)?.get(week);
       const udaLabel = uda ? `${String(uda.id || "").toUpperCase()} ${uda.title || ""}`.trim() : "UDA non assegnata";
       const types = [...new Set(matching.map((slot) => slot.type).filter(Boolean))].join("/");
-      dayLabels.push(`${prefix}: ${udaLabel} · L${count} · ${hours}h${types ? ` ${types}` : ""}`);
+      const label = `${prefix}: ${udaLabel} - L${count} - ${hours}h${types ? ` ${types}` : ""}`;
+      dayLabels.push({
+        label,
+        segment,
+        title: segment ? ganttSegmentTooltip(segment) : label,
+      });
     }
     if (dayLabels.length) labels.set(isoDate(date), dayLabels);
   }
   return labels;
 }
-
 function trackShortLabel(track) {
   const subject = String(track.subject || "").trim();
   if (subject) return subject;
@@ -1094,6 +1111,20 @@ function openGanttDialog(segment, firstWeek, lastWeek) {
     </section>
   `;
   els.ganttDialog.showModal();
+}
+
+function ganttSegmentTooltip(segment) {
+  const firstWeek = segment.weeks[0];
+  const lastWeek = segment.weeks[segment.weeks.length - 1];
+  return [
+    `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`,
+    `Settimane effettive: ${segment.startIndex + 1}-${segment.endIndex + 1}`,
+    `Date: ${firstWeek.start.toLocaleDateString("it-IT")} - ${lastWeek.end.toLocaleDateString("it-IT")}`,
+    `Ore previste: ${segment.hours}`,
+    "",
+    "Argomenti:",
+    ...collectUdaTopicTitles(segment.uda.items || []),
+  ].join("\n");
 }
 
 function ganttMonthSegments(weeks) {
@@ -1270,15 +1301,7 @@ function renderGanttChart() {
       bar.style.gridColumn = `${segment.startIndex + 1} / ${segment.endIndex + 2}`;
       const firstWeek = segment.weeks[0];
       const lastWeek = segment.weeks[segment.weeks.length - 1];
-      bar.title = [
-        `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`,
-        `Settimane effettive: ${segment.startIndex + 1}-${segment.endIndex + 1}`,
-        `Date: ${firstWeek.start.toLocaleDateString("it-IT")} - ${lastWeek.end.toLocaleDateString("it-IT")}`,
-        `Ore previste: ${segment.hours}`,
-        "",
-        "Argomenti:",
-        ...collectUdaTopicTitles(segment.uda.items || []),
-      ].join("\n");
+      bar.title = ganttSegmentTooltip(segment);
       bar.innerHTML = `
         <div class="ganttBarContent">
           <div class="ganttBarText">
@@ -1495,8 +1518,28 @@ function renderDayCell(date, month, start, end, lessons, closures) {
   cell.innerHTML = `
     <span class="dayNumber">${date.getDate()}</span>
     ${closure ? `<span class="dayMeta">${escapeHtml(closure)}</span>` : ""}
-    ${lesson.length ? `<span class="dayMeta">${escapeHtml(lesson.join(" · "))}</span>` : ""}
   `;
+  for (const entry of lesson) {
+    if (entry.segment) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "dayMeta dayLessonButton";
+      button.title = entry.title;
+      button.textContent = entry.label;
+      button.addEventListener("click", (event) => {
+        event.stopPropagation();
+        const firstWeek = entry.segment.weeks[0];
+        const lastWeek = entry.segment.weeks[entry.segment.weeks.length - 1];
+        openGanttDialog(entry.segment, firstWeek, lastWeek);
+      });
+      cell.append(button);
+    } else {
+      const meta = document.createElement("span");
+      meta.className = "dayMeta";
+      meta.textContent = entry.label;
+      cell.append(meta);
+    }
+  }
   return cell;
 }
 

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -24,6 +24,7 @@ const ACTIVE_COURSE_SESSION_KEY = "2cornot2c.keepActiveCourseInSession";
 const GANTT_ZOOM_KEY = "2cornot2c.ganttZoom";
 const GANTT_WEEK_WIDTHS = [2.4, 3.0, 3.4, 4.2, 5.2, 6.4, 8.0, 10.0, 12.0];
 const GANTT_DEFAULT_ZOOM_INDEX = 2;
+const GANTT_DAY_ABBR = ["L", "M", "M", "G", "V", "S", "D"];
 
 const els = {
   calendarSelect: document.querySelector("#calendarSelect"),
@@ -1219,9 +1220,15 @@ function ganttSegmentLostHours(segment) {
 }
 
 function renderGanttBarDays(track, segment, closures) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "ganttBarDayBlock";
   const strip = document.createElement("div");
+  const labels = document.createElement("div");
   strip.className = "ganttBarDays";
-  strip.style.gridTemplateColumns = `repeat(${segment.weeks.length * 7}, minmax(.34rem, 1fr))`;
+  labels.className = "ganttBarDayLabels";
+  const columns = `repeat(${segment.weeks.length * 7}, minmax(.34rem, 1fr))`;
+  strip.style.gridTemplateColumns = columns;
+  labels.style.gridTemplateColumns = columns;
   for (const week of segment.weeks) {
     for (let offset = 0; offset < 7; offset += 1) {
       const date = addDays(week.start, offset);
@@ -1245,9 +1252,15 @@ function renderGanttBarDays(track, segment, closures) {
         day.title = date.toLocaleDateString("it-IT");
       }
       strip.append(day);
+      const label = document.createElement("span");
+      label.textContent = GANTT_DAY_ABBR[offset];
+      if (offset === 5) label.className = "ganttBarDayLabelSaturday";
+      if (offset === 6) label.className = "ganttBarDayLabelSunday";
+      labels.append(label);
     }
   }
-  return strip;
+  wrapper.append(strip, labels);
+  return wrapper;
 }
 
 function renderGanttChart() {

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1142,13 +1142,15 @@ function renderTopicList(items) {
 
 function openGanttDialog(segment, firstWeek, lastWeek) {
   const lostHours = ganttSegmentLostHours(segment);
+  const theoreticalHours = segment.hours + lostHours;
   const actual = segment.uda.actual || {};
   els.ganttDialogTitle.textContent = `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`;
   els.ganttDialogBody.innerHTML = `
     <div class="ganttDialogMeta">
       <span><strong>Settimane effettive</strong>${segment.startIndex + 1}-${segment.endIndex + 1}</span>
       <span><strong>Date</strong>${shortDate(firstWeek.start)}-${shortDate(lastWeek.end)}</span>
-      <span><strong>Ore previste</strong>${segment.hours}h</span>
+      <span><strong>Ore teoriche</strong>${theoreticalHours}h</span>
+      <span><strong>Ore disponibili</strong>${segment.hours}h</span>
       <span><strong>Ore perse</strong>${lostHours}h</span>
     </div>
     <section>
@@ -1203,11 +1205,13 @@ function ganttSegmentTooltip(segment) {
   const firstWeek = segment.weeks[0];
   const lastWeek = segment.weeks[segment.weeks.length - 1];
   const lostHours = ganttSegmentLostHours(segment);
+  const theoreticalHours = segment.hours + lostHours;
   return [
     `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`,
     `Settimane effettive: ${segment.startIndex + 1}-${segment.endIndex + 1}`,
     `Date: ${firstWeek.start.toLocaleDateString("it-IT")} - ${lastWeek.end.toLocaleDateString("it-IT")}`,
-    `Ore previste: ${segment.hours}`,
+    `Ore teoriche: ${theoreticalHours}`,
+    `Ore disponibili: ${segment.hours}`,
     `Ore perse: ${lostHours}`,
     "",
     "Argomenti:",
@@ -1486,10 +1490,10 @@ function renderGanttChart() {
       continue;
     }
     row.innerHTML = `
-      <div class="ganttTrackHead">
-        <strong>${escapeHtml(title)}</strong>
-        <span>${weeks.length} settimane effettive - ${weeks.reduce((total, week) => total + Number(week.hours || 0), 0)}h previste</span>
-      </div>
+        <div class="ganttTrackHead">
+          <strong>${escapeHtml(title)}</strong>
+          <span>${weeks.length} settimane effettive - ${weeks.reduce((total, week) => total + Number(week.hours || 0), 0)}h disponibili</span>
+        </div>
       <div class="ganttMonths"></div>
       <div class="ganttWeeks"></div>
       <div class="ganttClosures"></div>
@@ -1539,7 +1543,7 @@ function renderGanttChart() {
             <strong>${escapeHtml(String(segment.uda.id || "").toUpperCase())}</strong>
             <span>${escapeHtml(segment.uda.title || "UDA senza titolo")}</span>
           </div>
-          <span class="ganttBarMeta">${segment.hours}h - ${shortDate(firstWeek.start)}-${shortDate(lastWeek.end)}</span>
+          <span class="ganttBarMeta">${segment.hours}h disponibili - ${shortDate(firstWeek.start)}-${shortDate(lastWeek.end)}</span>
         </div>
       `;
       bar.addEventListener("click", () => openGanttDialog(segment, firstWeek, lastWeek));

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1107,14 +1107,17 @@ function renderGanttBarDays(track, segment, closures) {
       const iso = isoDate(date);
       const day = document.createElement("span");
       const hasLesson = (track.weekly_slots || []).some((slot) => DAY_INDEX[slot.day] === date.getDay() && Number(slot.hours || 0) > 0);
+      day.className = "ganttBarDay";
+      if (offset === 0) {
+        day.classList.add("ganttBarWeekStart");
+      }
       if (closures.has(iso)) {
-        day.className = "ganttBarDay ganttBarDayClosed";
+        day.classList.add("ganttBarDayClosed");
         day.title = `${date.toLocaleDateString("it-IT")} - ${closures.get(iso)}`;
       } else if (hasLesson) {
-        day.className = "ganttBarDay ganttBarDayLesson";
+        day.classList.add("ganttBarDayLesson");
         day.title = `${date.toLocaleDateString("it-IT")} - lezione`;
       } else {
-        day.className = "ganttBarDay";
         day.title = date.toLocaleDateString("it-IT");
       }
       strip.append(day);

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1097,6 +1097,10 @@ function shortDate(date) {
   return date.toLocaleDateString("it-IT", { day: "2-digit", month: "2-digit" });
 }
 
+function ganttWeekColumns(weeks) {
+  return `repeat(${weeks.length}, var(--gantt-week-width))`;
+}
+
 function renderGanttBarDays(track, segment, closures) {
   const strip = document.createElement("div");
   strip.className = "ganttBarDays";
@@ -1168,7 +1172,7 @@ function renderGanttChart() {
       <div class="ganttBars"></div>
     `;
     const monthGrid = row.querySelector(".ganttMonths");
-    monthGrid.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
+    monthGrid.style.gridTemplateColumns = ganttWeekColumns(weeks);
     for (const segment of ganttMonthSegments(weeks)) {
       const month = document.createElement("span");
       month.style.gridColumn = `${segment.startIndex + 1} / ${segment.endIndex + 2}`;
@@ -1176,7 +1180,7 @@ function renderGanttChart() {
       monthGrid.append(month);
     }
     const weekGrid = row.querySelector(".ganttWeeks");
-    weekGrid.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
+    weekGrid.style.gridTemplateColumns = ganttWeekColumns(weeks);
     weeks.forEach((week, index) => {
       const label = document.createElement("span");
       label.title = `${week.start.toLocaleDateString("it-IT")} - ${week.end.toLocaleDateString("it-IT")} - ${week.hours}h`;
@@ -1184,7 +1188,7 @@ function renderGanttChart() {
       weekGrid.append(label);
     });
     const closureGrid = row.querySelector(".ganttClosures");
-    closureGrid.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
+    closureGrid.style.gridTemplateColumns = ganttWeekColumns(weeks);
     for (const closure of ganttClosureSegments(weeks)) {
       const closureBar = document.createElement("div");
       closureBar.className = "ganttClosure";
@@ -1194,7 +1198,7 @@ function renderGanttChart() {
       closureGrid.append(closureBar);
     }
     const bars = row.querySelector(".ganttBars");
-    bars.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
+    bars.style.gridTemplateColumns = ganttWeekColumns(weeks);
     for (const segment of udaGanttSegments(track, weeks)) {
       const bar = document.createElement("div");
       bar.className = "ganttBar";

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1097,6 +1097,32 @@ function shortDate(date) {
   return date.toLocaleDateString("it-IT", { day: "2-digit", month: "2-digit" });
 }
 
+function renderGanttBarDays(track, segment, closures) {
+  const strip = document.createElement("div");
+  strip.className = "ganttBarDays";
+  strip.style.gridTemplateColumns = `repeat(${segment.weeks.length * 7}, minmax(.34rem, 1fr))`;
+  for (const week of segment.weeks) {
+    for (let offset = 0; offset < 7; offset += 1) {
+      const date = addDays(week.start, offset);
+      const iso = isoDate(date);
+      const day = document.createElement("span");
+      const hasLesson = (track.weekly_slots || []).some((slot) => DAY_INDEX[slot.day] === date.getDay() && Number(slot.hours || 0) > 0);
+      if (closures.has(iso)) {
+        day.className = "ganttBarDay ganttBarDayClosed";
+        day.title = `${date.toLocaleDateString("it-IT")} - ${closures.get(iso)}`;
+      } else if (hasLesson) {
+        day.className = "ganttBarDay ganttBarDayLesson";
+        day.title = `${date.toLocaleDateString("it-IT")} - lezione`;
+      } else {
+        day.className = "ganttBarDay";
+        day.title = date.toLocaleDateString("it-IT");
+      }
+      strip.append(day);
+    }
+  }
+  return strip;
+}
+
 function renderGanttChart() {
   syncFormToCalendar();
   els.ganttChart.innerHTML = "";
@@ -1182,6 +1208,7 @@ function renderGanttChart() {
         <strong>${escapeHtml(String(segment.uda.id || "").toUpperCase())}</strong>
         <span>${escapeHtml(segment.uda.title || "UDA senza titolo")}</span>
       `;
+      bar.append(renderGanttBarDays(track, segment, closures));
       bars.append(bar);
     }
     els.ganttChart.append(row);

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1240,18 +1240,25 @@ async function saveAssociatedCourseDesign() {
 
 async function saveActualProgress(segment) {
   const field = (name) => els.ganttDialogBody.querySelector(`[data-actual-field="${name}"]`);
-  segment.uda.actual = {
+  const previousActual = segment.uda.actual ? { ...segment.uda.actual } : null;
+  const nextActual = {
     status: field("status").value || "todo",
     start_date: field("start_date").value || "",
     end_date: field("end_date").value || "",
     hours_done: field("hours_done").value === "" ? "" : Number(field("hours_done").value),
     notes: field("notes").value.trim(),
   };
+  segment.uda.actual = nextActual;
   try {
     const path = await saveAssociatedCourseDesign();
     renderAll();
     setStatus(`Programmazione svolta salvata in ${path}.`);
   } catch (error) {
+    if (previousActual) {
+      segment.uda.actual = previousActual;
+    } else {
+      delete segment.uda.actual;
+    }
     setStatus(`Salvataggio programmazione svolta non riuscito: ${error.message}`, "error");
   }
 }

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1101,6 +1101,7 @@ function renderTopicList(items) {
 
 function openGanttDialog(segment, firstWeek, lastWeek) {
   const lostHours = ganttSegmentLostHours(segment);
+  const actual = segment.uda.actual || {};
   els.ganttDialogTitle.textContent = `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`;
   els.ganttDialogBody.innerHTML = `
     <div class="ganttDialogMeta">
@@ -1110,10 +1111,48 @@ function openGanttDialog(segment, firstWeek, lastWeek) {
       <span><strong>Ore perse</strong>${lostHours}h</span>
     </div>
     <section>
+      <h3>Programmazione svolta</h3>
+      <div class="actualForm">
+        <label>
+          <span>Stato</span>
+          <select data-actual-field="status">
+            <option value="todo">Da fare</option>
+            <option value="in_progress">In corso</option>
+            <option value="done">Conclusa</option>
+            <option value="paused">Sospesa</option>
+            <option value="skipped">Saltata</option>
+          </select>
+        </label>
+        <label>
+          <span>Inizio reale</span>
+          <input data-actual-field="start_date" type="date">
+        </label>
+        <label>
+          <span>Fine reale</span>
+          <input data-actual-field="end_date" type="date">
+        </label>
+        <label>
+          <span>Ore svolte</span>
+          <input data-actual-field="hours_done" type="number" min="0" step="0.5">
+        </label>
+      </div>
+      <label class="actualNotes">
+        <span>Note</span>
+        <textarea data-actual-field="notes" rows="3" placeholder="Annota recuperi, ritardi, tagli o approfondimenti."></textarea>
+      </label>
+      <button type="button" data-action="save-actual" class="primary" title="Salva il consuntivo nel progetto didattico associato.">Salva programmazione svolta</button>
+    </section>
+    <section>
       <h3>Argomenti e sottoparagrafi</h3>
       <div class="ganttDialogTopics">${renderTopicList(segment.uda.items || [])}</div>
     </section>
   `;
+  els.ganttDialogBody.querySelector('[data-actual-field="status"]').value = actual.status || "todo";
+  els.ganttDialogBody.querySelector('[data-actual-field="start_date"]').value = actual.start_date || "";
+  els.ganttDialogBody.querySelector('[data-actual-field="end_date"]').value = actual.end_date || "";
+  els.ganttDialogBody.querySelector('[data-actual-field="hours_done"]').value = actual.hours_done ?? "";
+  els.ganttDialogBody.querySelector('[data-actual-field="notes"]').value = actual.notes || "";
+  els.ganttDialogBody.querySelector('[data-action="save-actual"]').addEventListener("click", () => saveActualProgress(segment));
   els.ganttDialog.showModal();
 }
 
@@ -1131,6 +1170,43 @@ function ganttSegmentTooltip(segment) {
     "Argomenti:",
     ...collectUdaTopicTitles(segment.uda.items || []),
   ].join("\n");
+}
+
+async function saveAssociatedCourseDesign() {
+  if (!state.courseDesign) {
+    throw new Error("Nessun progetto didattico associato caricato.");
+  }
+  const name = state.calendar.course_design_name || "";
+  if (name) {
+    await api("/api/saved-designs/save", {
+      method: "POST",
+      body: JSON.stringify({ name, design: state.courseDesign }),
+    });
+    return `doc/course_designs/${name}`;
+  }
+  await api("/api/course-design", {
+    method: "POST",
+    body: JSON.stringify(state.courseDesign),
+  });
+  return "doc/course_design.json";
+}
+
+async function saveActualProgress(segment) {
+  const field = (name) => els.ganttDialogBody.querySelector(`[data-actual-field="${name}"]`);
+  segment.uda.actual = {
+    status: field("status").value || "todo",
+    start_date: field("start_date").value || "",
+    end_date: field("end_date").value || "",
+    hours_done: field("hours_done").value === "" ? "" : Number(field("hours_done").value),
+    notes: field("notes").value.trim(),
+  };
+  try {
+    const path = await saveAssociatedCourseDesign();
+    renderAll();
+    setStatus(`Programmazione svolta salvata in ${path}.`);
+  } catch (error) {
+    setStatus(`Salvataggio programmazione svolta non riuscito: ${error.message}`, "error");
+  }
 }
 
 function ganttMonthSegments(weeks) {
@@ -1219,6 +1295,58 @@ function ganttSegmentLostHours(segment) {
   return lost;
 }
 
+function actualUdaSegments(track, weeks) {
+  const year = courseYearForTrack(track);
+  const segments = [];
+  for (const uda of year?.udas || []) {
+    const actual = uda.actual || {};
+    const start = dateFromInput(actual.start_date || "");
+    const end = dateFromInput(actual.end_date || actual.start_date || "");
+    if (!start || !end) continue;
+    let startIndex = -1;
+    let endIndex = -1;
+    for (const [index, week] of weeks.entries()) {
+      if (week.start <= end && week.end >= start) {
+        if (startIndex < 0) startIndex = index;
+        endIndex = index;
+      }
+    }
+    if (startIndex < 0) continue;
+    segments.push({
+      uda,
+      track,
+      actual,
+      start,
+      end,
+      startIndex,
+      endIndex,
+      weeks: weeks.slice(startIndex, endIndex + 1),
+      hours: Number(actual.hours_done || 0),
+    });
+  }
+  return segments;
+}
+
+function renderActualGanttBar(segment) {
+  const bar = document.createElement("div");
+  const status = segment.actual.status || "todo";
+  bar.className = `ganttActualBar ganttActualBar-${status}`;
+  bar.style.gridColumn = `${segment.startIndex + 1} / ${segment.endIndex + 2}`;
+  const label = `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`;
+  bar.title = [
+    label,
+    `Stato: ${status}`,
+    `Date reali: ${segment.start.toLocaleDateString("it-IT")} - ${segment.end.toLocaleDateString("it-IT")}`,
+    `Ore svolte: ${segment.hours}`,
+    segment.actual.notes ? `Note: ${segment.actual.notes}` : "",
+  ].filter(Boolean).join("\n");
+  bar.innerHTML = `
+    <strong>${escapeHtml(String(segment.uda.id || "").toUpperCase())}</strong>
+    <span>${escapeHtml(segment.hours ? `${segment.hours}h` : status)}</span>
+  `;
+  return bar;
+}
+
 function renderGanttBarDays(track, segment, closures) {
   const wrapper = document.createElement("div");
   wrapper.className = "ganttBarDayBlock";
@@ -1302,7 +1430,10 @@ function renderGanttChart() {
       <div class="ganttMonths"></div>
       <div class="ganttWeeks"></div>
       <div class="ganttClosures"></div>
+      <div class="ganttLaneLabel">Pianificato</div>
       <div class="ganttBars"></div>
+      <div class="ganttLaneLabel">Svolto</div>
+      <div class="ganttActualBars"></div>
     `;
     const monthGrid = row.querySelector(".ganttMonths");
     monthGrid.style.gridTemplateColumns = ganttWeekColumns(weeks);
@@ -1351,6 +1482,19 @@ function renderGanttChart() {
       bar.addEventListener("click", () => openGanttDialog(segment, firstWeek, lastWeek));
       bar.append(renderGanttBarDays(track, segment, closures));
       bars.append(bar);
+    }
+    const actualBars = row.querySelector(".ganttActualBars");
+    actualBars.style.gridTemplateColumns = ganttWeekColumns(weeks);
+    const actualSegments = actualUdaSegments(track, weeks);
+    if (actualSegments.length) {
+      for (const segment of actualSegments) {
+        actualBars.append(renderActualGanttBar(segment));
+      }
+    } else {
+      const empty = document.createElement("div");
+      empty.className = "ganttActualEmpty";
+      empty.textContent = "Nessuna UDA svolta registrata.";
+      actualBars.append(empty);
     }
     els.ganttChart.append(row);
   }

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -43,6 +43,10 @@ const els = {
   calendarValidation: document.querySelector("#calendarValidation"),
   monthGrid: document.querySelector("#monthGrid"),
   ganttChart: document.querySelector("#ganttChart"),
+  ganttDialog: document.querySelector("#ganttDialog"),
+  ganttDialogTitle: document.querySelector("#ganttDialogTitle"),
+  ganttDialogBody: document.querySelector("#ganttDialogBody"),
+  ganttDialogCloseBtn: document.querySelector("#ganttDialogCloseBtn"),
   summary: document.querySelector("#summary"),
 };
 
@@ -1060,6 +1064,31 @@ function collectUdaTopicTitles(items, depth = 0, output = []) {
   return output;
 }
 
+function renderTopicList(items) {
+  if (!items?.length) return '<p class="empty">Nessun argomento assegnato.</p>';
+  const list = items.map((item) => {
+    const children = item.children?.length ? renderTopicList(item.children) : "";
+    return `<li><span>${escapeHtml(item.title || item.id || "Argomento senza titolo")}</span>${children}</li>`;
+  }).join("");
+  return `<ul>${list}</ul>`;
+}
+
+function openGanttDialog(segment, firstWeek, lastWeek) {
+  els.ganttDialogTitle.textContent = `${String(segment.uda.id || "").toUpperCase()} - ${segment.uda.title || "UDA senza titolo"}`;
+  els.ganttDialogBody.innerHTML = `
+    <div class="ganttDialogMeta">
+      <span><strong>Settimane effettive</strong>${segment.startIndex + 1}-${segment.endIndex + 1}</span>
+      <span><strong>Date</strong>${shortDate(firstWeek.start)}-${shortDate(lastWeek.end)}</span>
+      <span><strong>Ore previste</strong>${segment.hours}h</span>
+    </div>
+    <section>
+      <h3>Argomenti e sottoparagrafi</h3>
+      <div class="ganttDialogTopics">${renderTopicList(segment.uda.items || [])}</div>
+    </section>
+  `;
+  els.ganttDialog.showModal();
+}
+
 function ganttMonthSegments(weeks) {
   const segments = [];
   for (const [index, week] of weeks.entries()) {
@@ -1232,6 +1261,7 @@ function renderGanttChart() {
           <span class="ganttBarMeta">${segment.hours}h - ${shortDate(firstWeek.start)}-${shortDate(lastWeek.end)}</span>
         </div>
       `;
+      bar.addEventListener("click", () => openGanttDialog(segment, firstWeek, lastWeek));
       bar.append(renderGanttBarDays(track, segment, closures));
       bars.append(bar);
     }
@@ -1528,6 +1558,7 @@ els.addTrackBtn.addEventListener("click", addTrack);
 els.addClosureBtn.addEventListener("click", addClosure);
 els.importItalianHolidaysBtn.addEventListener("click", importItalianHolidays);
 els.recalculateBtn.addEventListener("click", renderSummary);
+els.ganttDialogCloseBtn.addEventListener("click", () => els.ganttDialog.close());
 
 Promise.all([loadCalendarList(), loadSavedDesignList()])
   .then(() => loadCalendarForActiveCourseDesign())

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1418,6 +1418,11 @@ function renderActualGanttBar(segment) {
     <strong>${escapeHtml(String(segment.uda.id || "").toUpperCase())}</strong>
     <span>${escapeHtml(segment.hours ? `${segment.hours}h` : status)}</span>
   `;
+  bar.addEventListener("click", () => {
+    const firstWeek = segment.weeks[0];
+    const lastWeek = segment.weeks[segment.weeks.length - 1];
+    openGanttDialog(segment, firstWeek, lastWeek);
+  });
   return bar;
 }
 

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1224,8 +1224,13 @@ function renderGanttChart() {
         ...collectUdaTopicTitles(segment.uda.items || []),
       ].join("\n");
       bar.innerHTML = `
-        <strong>${escapeHtml(String(segment.uda.id || "").toUpperCase())}</strong>
-        <span>${escapeHtml(segment.uda.title || "UDA senza titolo")}</span>
+        <div class="ganttBarContent">
+          <div class="ganttBarText">
+            <strong>${escapeHtml(String(segment.uda.id || "").toUpperCase())}</strong>
+            <span>${escapeHtml(segment.uda.title || "UDA senza titolo")}</span>
+          </div>
+          <span class="ganttBarMeta">${segment.hours}h - ${shortDate(firstWeek.start)}-${shortDate(lastWeek.end)}</span>
+        </div>
       `;
       bar.append(renderGanttBarDays(track, segment, closures));
       bars.append(bar);

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1400,7 +1400,7 @@ function actualUdaSegments(track, weeks) {
   return segments;
 }
 
-function renderActualGanttBar(segment) {
+function renderActualGanttBar(segment, dialogSegment = segment) {
   const bar = document.createElement("div");
   const status = segment.actual.status || "todo";
   bar.className = `ganttActualBar ganttActualBar-${status}`;
@@ -1418,9 +1418,9 @@ function renderActualGanttBar(segment) {
     <span>${escapeHtml(segment.hours ? `${segment.hours}h` : status)}</span>
   `;
   bar.addEventListener("click", () => {
-    const firstWeek = segment.weeks[0];
-    const lastWeek = segment.weeks[segment.weeks.length - 1];
-    openGanttDialog(segment, firstWeek, lastWeek);
+    const firstWeek = dialogSegment.weeks[0];
+    const lastWeek = dialogSegment.weeks[dialogSegment.weeks.length - 1];
+    openGanttDialog(dialogSegment, firstWeek, lastWeek);
   });
   return bar;
 }
@@ -1541,7 +1541,8 @@ function renderGanttChart() {
     }
     const bars = row.querySelector(".ganttBars");
     bars.style.gridTemplateColumns = ganttWeekColumns(weeks);
-    for (const segment of udaGanttSegments(track, weeks)) {
+    const plannedSegments = udaGanttSegments(track, weeks);
+    for (const segment of plannedSegments) {
       const bar = document.createElement("div");
       bar.className = "ganttBar";
       bar.style.gridColumn = `${segment.startIndex + 1} / ${segment.endIndex + 2}`;
@@ -1566,7 +1567,8 @@ function renderGanttChart() {
     const actualSegments = actualUdaSegments(track, weeks);
     if (actualSegments.length) {
       for (const segment of actualSegments) {
-        actualBars.append(renderActualGanttBar(segment));
+        const plannedSegment = plannedSegments.find((candidate) => candidate.uda === segment.uda || candidate.uda.id === segment.uda.id);
+        actualBars.append(renderActualGanttBar(segment, plannedSegment || segment));
       }
     } else {
       const empty = document.createElement("div");

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -22,7 +22,7 @@ const ACTIVE_COURSE_DESIGN_KEY = "2cornot2c.activeCourseDesign";
 const ACTIVE_SCHOOL_CALENDAR_KEY = "2cornot2c.activeSchoolCalendar";
 const ACTIVE_COURSE_SESSION_KEY = "2cornot2c.keepActiveCourseInSession";
 const GANTT_ZOOM_KEY = "2cornot2c.ganttZoom";
-const GANTT_WEEK_WIDTHS = [2.4, 3.0, 3.4, 4.2, 5.2, 6.4];
+const GANTT_WEEK_WIDTHS = [2.4, 3.0, 3.4, 4.2, 5.2, 6.4, 8.0, 10.0, 12.0];
 const GANTT_DEFAULT_ZOOM_INDEX = 2;
 
 const els = {

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1136,6 +1136,7 @@ function openGanttDialog(segment, firstWeek, lastWeek) {
           <input data-actual-field="hours_done" type="number" min="0" step="0.5">
         </label>
       </div>
+      <button type="button" data-action="calculate-actual-hours" title="Calcola le ore svolte usando date reali, slot settimanali e chiusure del calendario.">Calcola ore da calendario</button>
       <label class="actualNotes">
         <span>Note</span>
         <textarea data-actual-field="notes" rows="3" placeholder="Annota recuperi, ritardi, tagli o approfondimenti."></textarea>
@@ -1152,6 +1153,7 @@ function openGanttDialog(segment, firstWeek, lastWeek) {
   els.ganttDialogBody.querySelector('[data-actual-field="end_date"]').value = actual.end_date || "";
   els.ganttDialogBody.querySelector('[data-actual-field="hours_done"]').value = actual.hours_done ?? "";
   els.ganttDialogBody.querySelector('[data-actual-field="notes"]').value = actual.notes || "";
+  els.ganttDialogBody.querySelector('[data-action="calculate-actual-hours"]').addEventListener("click", () => calculateActualHours(segment));
   els.ganttDialogBody.querySelector('[data-action="save-actual"]').addEventListener("click", () => saveActualProgress(segment));
   els.ganttDialog.showModal();
 }
@@ -1207,6 +1209,26 @@ async function saveActualProgress(segment) {
   } catch (error) {
     setStatus(`Salvataggio programmazione svolta non riuscito: ${error.message}`, "error");
   }
+}
+
+function calculateActualHours(segment) {
+  const start = dateFromInput(els.ganttDialogBody.querySelector('[data-actual-field="start_date"]').value || "");
+  const end = dateFromInput(els.ganttDialogBody.querySelector('[data-actual-field="end_date"]').value || "");
+  if (!start || !end || start > end) {
+    setStatus("Inserisci date reali valide prima di calcolare le ore svolte.", "error");
+    return;
+  }
+  const closures = closedLabelsByDate();
+  let hours = 0;
+  for (const date = new Date(start); date <= end; date.setDate(date.getDate() + 1)) {
+    const iso = isoDate(date);
+    if (closures.has(iso)) continue;
+    hours += (segment.track?.weekly_slots || [])
+      .filter((slot) => DAY_INDEX[slot.day] === date.getDay())
+      .reduce((total, slot) => total + Number(slot.hours || 0), 0);
+  }
+  els.ganttDialogBody.querySelector('[data-actual-field="hours_done"]').value = hours;
+  setStatus(`Ore svolte calcolate dal calendario: ${hours}h.`);
 }
 
 function ganttMonthSegments(weeks) {

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -25,6 +25,7 @@ const GANTT_ZOOM_KEY = "2cornot2c.ganttZoom";
 const GANTT_WEEK_WIDTHS = [2.4, 3.0, 3.4, 4.2, 5.2, 6.4, 8.0, 10.0, 12.0];
 const GANTT_DEFAULT_ZOOM_INDEX = 2;
 const GANTT_DAY_ABBR = ["L", "M", "M", "G", "V", "S", "D"];
+const COLLAPSED_PANELS_KEY = "2cornot2c.calendarCollapsedPanels";
 
 const els = {
   calendarSelect: document.querySelector("#calendarSelect"),
@@ -167,6 +168,46 @@ function setStatus(message, kind = "neutral") {
       state.statusTimer = null;
     }, 4500);
   }
+}
+
+function collapsedPanels() {
+  try {
+    return new Set(JSON.parse(localStorage.getItem(COLLAPSED_PANELS_KEY) || "[]"));
+  } catch {
+    return new Set();
+  }
+}
+
+function saveCollapsedPanels(values) {
+  localStorage.setItem(COLLAPSED_PANELS_KEY, JSON.stringify([...values]));
+}
+
+function panelKey(panel, index) {
+  const title = panel.querySelector(".panelHead h2")?.textContent?.trim() || `panel-${index}`;
+  return title.toLowerCase().replaceAll(/\s+/g, "-");
+}
+
+function setupCollapsiblePanels() {
+  const collapsed = collapsedPanels();
+  document.querySelectorAll("main.layout > .panel").forEach((panel, index) => {
+    const head = panel.querySelector(".panelHead");
+    const title = head?.querySelector("h2");
+    if (!head || !title) return;
+    const key = panelKey(panel, index);
+    panel.dataset.panelKey = key;
+    if (collapsed.has(key)) panel.classList.add("panelCollapsed");
+    title.title = "Apri o chiudi questa sezione.";
+    title.addEventListener("click", () => {
+      panel.classList.toggle("panelCollapsed");
+      const current = collapsedPanels();
+      if (panel.classList.contains("panelCollapsed")) {
+        current.add(key);
+      } else {
+        current.delete(key);
+      }
+      saveCollapsedPanels(current);
+    });
+  });
 }
 
 function flashFieldError(input) {
@@ -1841,6 +1882,7 @@ if (!Number.isInteger(state.ganttZoomIndex) || state.ganttZoomIndex < 0 || state
   state.ganttZoomIndex = GANTT_DEFAULT_ZOOM_INDEX;
 }
 applyGanttZoom();
+setupCollapsiblePanels();
 
 Promise.all([loadCalendarList(), loadSavedDesignList()])
   .then(() => loadCalendarForActiveCourseDesign())

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1051,6 +1051,15 @@ function udaGanttSegments(track, weeks) {
   return segments;
 }
 
+function collectUdaTopicTitles(items, depth = 0, output = []) {
+  for (const item of items || []) {
+    const prefix = depth > 0 ? `${"  ".repeat(depth)}- ` : "- ";
+    output.push(`${prefix}${item.title || item.id || "Argomento senza titolo"}`);
+    collectUdaTopicTitles(item.children || [], depth + 1, output);
+  }
+  return output;
+}
+
 function ganttMonthSegments(weeks) {
   const segments = [];
   for (const [index, week] of weeks.entries()) {
@@ -1210,6 +1219,9 @@ function renderGanttChart() {
         `Settimane effettive: ${segment.startIndex + 1}-${segment.endIndex + 1}`,
         `Date: ${firstWeek.start.toLocaleDateString("it-IT")} - ${lastWeek.end.toLocaleDateString("it-IT")}`,
         `Ore previste: ${segment.hours}`,
+        "",
+        "Argomenti:",
+        ...collectUdaTopicTitles(segment.uda.items || []),
       ].join("\n");
       bar.innerHTML = `
         <strong>${escapeHtml(String(segment.uda.id || "").toUpperCase())}</strong>

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -1051,6 +1051,52 @@ function udaGanttSegments(track, weeks) {
   return segments;
 }
 
+function ganttMonthSegments(weeks) {
+  const segments = [];
+  for (const [index, week] of weeks.entries()) {
+    const key = `${week.start.getFullYear()}-${week.start.getMonth()}`;
+    const label = week.start.toLocaleDateString("it-IT", { month: "short", year: "numeric" });
+    const last = segments[segments.length - 1];
+    if (last?.key === key) {
+      last.endIndex = index;
+    } else {
+      segments.push({ key, label, startIndex: index, endIndex: index });
+    }
+  }
+  return segments;
+}
+
+function ganttClosureSegments(weeks) {
+  const segments = [];
+  for (const closure of state.calendar.closures || []) {
+    const from = dateFromInput(closure.from);
+    const to = dateFromInput(closure.to || closure.from);
+    if (!from || !to) continue;
+    let startIndex = -1;
+    let endIndex = -1;
+    for (const [index, week] of weeks.entries()) {
+      if (week.start <= to && week.end >= from) {
+        if (startIndex < 0) startIndex = index;
+        endIndex = index;
+      }
+    }
+    if (startIndex >= 0) {
+      segments.push({
+        label: closure.label || closure.type || "Chiusura",
+        from,
+        to,
+        startIndex,
+        endIndex,
+      });
+    }
+  }
+  return segments;
+}
+
+function shortDate(date) {
+  return date.toLocaleDateString("it-IT", { day: "2-digit", month: "2-digit" });
+}
+
 function renderGanttChart() {
   syncFormToCalendar();
   els.ganttChart.innerHTML = "";
@@ -1087,17 +1133,37 @@ function renderGanttChart() {
         <strong>${escapeHtml(title)}</strong>
         <span>${weeks.length} settimane effettive - ${weeks.reduce((total, week) => total + Number(week.hours || 0), 0)}h previste</span>
       </div>
+      <div class="ganttMonths"></div>
       <div class="ganttWeeks"></div>
+      <div class="ganttClosures"></div>
       <div class="ganttBars"></div>
     `;
+    const monthGrid = row.querySelector(".ganttMonths");
+    monthGrid.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
+    for (const segment of ganttMonthSegments(weeks)) {
+      const month = document.createElement("span");
+      month.style.gridColumn = `${segment.startIndex + 1} / ${segment.endIndex + 2}`;
+      month.textContent = segment.label;
+      monthGrid.append(month);
+    }
     const weekGrid = row.querySelector(".ganttWeeks");
     weekGrid.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
     weeks.forEach((week, index) => {
       const label = document.createElement("span");
       label.title = `${week.start.toLocaleDateString("it-IT")} - ${week.end.toLocaleDateString("it-IT")} - ${week.hours}h`;
-      label.textContent = String(index + 1);
+      label.innerHTML = `<strong>${index + 1}</strong><small>${shortDate(week.start)}-${shortDate(week.end)}</small>`;
       weekGrid.append(label);
     });
+    const closureGrid = row.querySelector(".ganttClosures");
+    closureGrid.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
+    for (const closure of ganttClosureSegments(weeks)) {
+      const closureBar = document.createElement("div");
+      closureBar.className = "ganttClosure";
+      closureBar.style.gridColumn = `${closure.startIndex + 1} / ${closure.endIndex + 2}`;
+      closureBar.title = `${closure.label}: ${closure.from.toLocaleDateString("it-IT")} - ${closure.to.toLocaleDateString("it-IT")}`;
+      closureBar.textContent = closure.label;
+      closureGrid.append(closureBar);
+    }
     const bars = row.querySelector(".ganttBars");
     bars.style.gridTemplateColumns = `repeat(${weeks.length}, minmax(2.1rem, 1fr))`;
     for (const segment of udaGanttSegments(track, weeks)) {

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -183,8 +183,7 @@ function saveCollapsedPanels(values) {
 }
 
 function panelKey(panel, index) {
-  const title = panel.querySelector(".panelHead h2")?.textContent?.trim() || `panel-${index}`;
-  return title.toLowerCase().replaceAll(/\s+/g, "-");
+  return panel.dataset.panelKey || panel.id || `panel-${index}`;
 }
 
 function setupCollapsiblePanels() {


### PR DESCRIPTION
## Sintesi
- aggiunge una sezione Diagramma Gantt UDA nella pagina calendario
- calcola le settimane effettive per ogni percorso in base a slot settimanali e chiusure
- disegna una barra per ogni UDA usando la durata indicata nel campo weeks
- mostra tooltip con intervallo settimane, date e ore previste

## Verifica
- node --check tools/school_calendar.js

Nota: doc/course_design.json risulta modificato localmente ma non e incluso in questa PR.