### PR TITLE
Aggiunge schema attivita TheBitLab

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - "scripts/**"
       - "tests/**"
+      - "activities/**"
+      - "doc/ACTIVITIES_SCHEMA.md"
       - "doc/course_design.json"
       - "doc/PERCORSO_DIDATTICO.md"
       - "pyproject.toml"
@@ -20,6 +22,8 @@ on:
     paths:
       - "scripts/**"
       - "tests/**"
+      - "activities/**"
+      - "doc/ACTIVITIES_SCHEMA.md"
       - "doc/course_design.json"
       - "doc/PERCORSO_DIDATTICO.md"
       - "pyproject.toml"

--- a/activities/examples/debug_uninitialized_pointer.json
+++ b/activities/examples/debug_uninitialized_pointer.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1.0",
+  "id": "c-intermedio-debug-puntatori-001",
+  "titolo": "Debug di un puntatore non inizializzato",
+  "tipo": "debug-didattico",
+  "difficolta": "D",
+  "argomenti": [
+    "puntatori",
+    "memoria",
+    "undefined-behavior"
+  ],
+  "contesto": {
+    "classe": "3A-TPSI",
+    "team_github": "3A-TPSI",
+    "percorso": "terzo-anno",
+    "uda": "uda-7"
+  },
+  "consegna": "Analizza un programma che dereferenzia un puntatore non inizializzato, spiega il problema e correggilo.",
+  "vincoli": [
+    "spiega perche il comportamento e indefinito",
+    "proponi una correzione sicura",
+    "verifica la correzione con sanitizer quando disponibile"
+  ],
+  "correzione": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": true
+  },
+  "metriche": {
+    "tempo_stimato_minuti": 35,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": true
+  }
+}

--- a/activities/examples/homework_variables.json
+++ b/activities/examples/homework_variables.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "1.0",
+  "id": "c-base-variabili-001",
+  "titolo": "Calcolo della differenza tra due interi",
+  "tipo": "compito-casa",
+  "difficolta": "B",
+  "argomenti": [
+    "variabili",
+    "input-output",
+    "operatori"
+  ],
+  "contesto": {
+    "classe": "3A-TPSI",
+    "team_github": "3A-TPSI",
+    "percorso": "terzo-anno",
+    "uda": "uda-2"
+  },
+  "consegna": "Scrivi un programma C che legge due interi e stampa la loro differenza.",
+  "vincoli": [
+    "usa scanf",
+    "usa printf",
+    "gestisci anche risultati negativi"
+  ],
+  "soluzione_attesa": {
+    "tipo": "programma-c",
+    "file": "main.c",
+    "output_atteso": "Differenza: 3"
+  },
+  "correzione": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": true
+  },
+  "metriche": {
+    "tempo_stimato_minuti": 25,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": true
+  },
+  "rubrica": [
+    {
+      "criterio": "Compilazione",
+      "punti": 2
+    },
+    {
+      "criterio": "Correttezza del risultato",
+      "punti": 4
+    },
+    {
+      "criterio": "Chiarezza del codice",
+      "punti": 2
+    },
+    {
+      "criterio": "Gestione dei casi limite",
+      "punti": 2
+    }
+  ]
+}

--- a/activities/examples/lab_arrays.json
+++ b/activities/examples/lab_arrays.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1.0",
+  "id": "c-base-array-lab-001",
+  "titolo": "Somma degli elementi di un array",
+  "tipo": "laboratorio",
+  "difficolta": "C",
+  "argomenti": [
+    "array",
+    "cicli",
+    "input-output"
+  ],
+  "contesto": {
+    "classe": "3A-TPSI",
+    "team_github": "3A-TPSI",
+    "percorso": "terzo-anno",
+    "uda": "uda-5"
+  },
+  "consegna": "Scrivi un programma che legge cinque interi in un array e stampa la somma totale.",
+  "materiali": [
+    {
+      "tipo": "paragrafo",
+      "titolo": "Array",
+      "link": "../README.md#array"
+    }
+  ],
+  "correzione": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": true
+  },
+  "metriche": {
+    "tempo_stimato_minuti": 40,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": true
+  }
+}

--- a/activities/examples/practical_test_functions.json
+++ b/activities/examples/practical_test_functions.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "1.0",
+  "id": "c-base-funzioni-verifica-001",
+  "titolo": "Verifica pratica su funzioni e condizioni",
+  "tipo": "verifica-pratica",
+  "difficolta": "C",
+  "argomenti": [
+    "funzioni",
+    "if",
+    "operatori"
+  ],
+  "contesto": {
+    "classe": "3A-TPSI",
+    "team_github": "3A-TPSI",
+    "percorso": "terzo-anno",
+    "uda": "uda-4"
+  },
+  "consegna": "Implementa una funzione che riceve tre interi e restituisce il maggiore.",
+  "vincoli": [
+    "la logica principale deve stare in una funzione separata",
+    "il main deve occuparsi solo di input e output"
+  ],
+  "correzione": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": false
+  },
+  "metriche": {
+    "tempo_stimato_minuti": 50,
+    "traccia_tempo_dichiarato": false,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": true
+  },
+  "rubrica": [
+    {
+      "criterio": "Compilazione senza errori",
+      "punti": 2
+    },
+    {
+      "criterio": "Funzione corretta",
+      "punti": 4
+    },
+    {
+      "criterio": "Gestione dei casi con valori uguali",
+      "punti": 2
+    },
+    {
+      "criterio": "Pulizia del codice",
+      "punti": 2
+    }
+  ]
+}

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -174,11 +174,11 @@ Campi obbligatori:
 
 | Campo | Tipo | Significato |
 |---|---|---|
-| `tempo_stimato_minuti` | numero | Tempo stimato dal docente o dal sistema |
-| `traccia_tempo_dichiarato` | boolean | Lo studente puo dichiarare il tempo impiegato |
-| `traccia_sessioni_thebitlab` | boolean | TheBitLab puo registrare durata delle sessioni |
-| `traccia_eventi_didattici` | boolean | TheBitLab puo registrare eventi espliciti |
-| `traccia_errori_compilazione` | boolean | Gli errori di compilazione vengono raccolti |
+| `tempo_stimato_minuti` | numero obbligatorio | Tempo stimato dal docente o dal sistema |
+| `traccia_tempo_dichiarato` | boolean obbligatorio | Lo studente puo dichiarare il tempo impiegato |
+| `traccia_sessioni_thebitlab` | boolean obbligatorio | TheBitLab puo registrare durata delle sessioni |
+| `traccia_eventi_didattici` | boolean obbligatorio | TheBitLab puo registrare eventi espliciti |
+| `traccia_errori_compilazione` | boolean obbligatorio | Gli errori di compilazione vengono raccolti |
 
 TheBitLab non deve usare queste metriche come sorveglianza. Servono a capire difficolta, progressi e bisogni di recupero.
 

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -209,6 +209,7 @@ Il validatore controlla:
 
 - JSON valido;
 - campi obbligatori;
+- campi testuali obbligatori non vuoti;
 - tipo di attivita ammesso;
 - difficolta ammessa;
 - lista `argomenti` non vuota;

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -170,7 +170,7 @@ Regola importante:
 
 Il campo `metriche` indica cosa raccogliere.
 
-Campi consigliati:
+Campi obbligatori:
 
 | Campo | Tipo | Significato |
 |---|---|---|

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -214,7 +214,8 @@ Il validatore controlla:
 - lista `argomenti` non vuota;
 - oggetto `correzione` completo;
 - valori booleani in `correzione`;
-- oggetto `metriche` presente;
+- oggetto `metriche` completo;
+- campi obbligatori e tipi in `metriche`;
 - rubrica ben formata quando presente.
 
 Il validatore non esegue codice e non valuta la qualita didattica dell'attivita.

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -1,0 +1,231 @@
+# Schema delle attivita didattiche
+
+Questo documento descrive il primo schema dati per rappresentare attivita didattiche in TheBitLab.
+
+Lo schema serve a descrivere in modo uniforme:
+
+- esercizi in classe;
+- compiti a casa;
+- laboratori;
+- verifiche pratiche;
+- verifiche scritte;
+- attivita di debug;
+- studio guidato.
+
+L'obiettivo non e coprire subito tutti i casi futuri, ma fissare un formato minimo, leggibile e validabile.
+
+## Perche uno schema
+
+Uno schema comune permette di:
+
+- generare attivita manualmente o con AI assisted;
+- collegare ogni attivita a percorso, UDA e argomenti;
+- validare consegne prima di pubblicarle;
+- preparare correzione automatica e sandbox;
+- raccogliere metriche coerenti;
+- alimentare in futuro CLI, TUI, dashboard e plugin.
+
+## File e cartelle
+
+Gli esempi iniziali stanno in:
+
+```text
+activities/examples/
+```
+
+Il validatore e:
+
+```text
+scripts/validate_activity.py
+```
+
+Per validare gli esempi:
+
+```bash
+python scripts/validate_activity.py activities/examples
+```
+
+Per validare un singolo file:
+
+```bash
+python scripts/validate_activity.py activities/examples/homework_variables.json
+```
+
+## Tipi di attivita
+
+Il campo `tipo` deve avere uno di questi valori:
+
+| Tipo | Uso |
+|---|---|
+| `studio-guidato` | Attivita di ripasso o studio interattivo |
+| `esercizio-classe` | Esercizio svolto durante la lezione |
+| `compito-casa` | Attivita assegnata per casa |
+| `laboratorio` | Esercizio pratico guidato o semi-guidato |
+| `verifica-pratica` | Prova valutativa basata su codice |
+| `verifica-scritta` | Prova teorica o mista |
+| `debug-didattico` | Attivita centrata su errore, bug o undefined behavior |
+
+## Livelli di difficolta
+
+Il campo `difficolta` usa la tassonomia definita in `ASSIGNMENTS.md`.
+
+| Livello | Significato |
+|---|---|
+| `A` | Copia, compila, osserva |
+| `B` | Modifica piccola |
+| `C` | Scrivi da zero |
+| `D` | Trova il bug |
+| `E` | Mini-progetto |
+| `F` | Produzione |
+
+## Struttura minima
+
+Esempio ridotto:
+
+```json
+{
+  "schema_version": "1.0",
+  "id": "c-base-variabili-001",
+  "titolo": "Calcolo della differenza tra due interi",
+  "tipo": "compito-casa",
+  "difficolta": "B",
+  "argomenti": [
+    "variabili",
+    "input-output",
+    "operatori"
+  ],
+  "consegna": "Scrivi un programma C che legge due interi e stampa la loro differenza.",
+  "correzione": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": true
+  },
+  "metriche": {
+    "tempo_stimato_minuti": 25,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": true
+  }
+}
+```
+
+## Campi principali
+
+| Campo | Obbligatorio | Descrizione |
+|---|---|---|
+| `schema_version` | Si | Versione dello schema |
+| `id` | Si | Identificativo stabile dell'attivita |
+| `titolo` | Si | Titolo leggibile |
+| `tipo` | Si | Tipo di attivita |
+| `difficolta` | Si | Livello `A`-`F` |
+| `argomenti` | Si | Lista di argomenti collegati |
+| `consegna` | Si | Testo della consegna |
+| `contesto` | No | Collegamento a classe, percorso, UDA e team |
+| `vincoli` | No | Regole tecniche o didattiche |
+| `materiali` | No | File, link o paragrafi collegati |
+| `soluzione_attesa` | No | Descrizione della soluzione o output atteso |
+| `correzione` | Si | Regole minime di grading |
+| `metriche` | Si | Metriche da raccogliere |
+| `rubrica` | No | Criteri di valutazione |
+
+## Contesto didattico
+
+Il campo `contesto` collega l'attivita al progetto didattico.
+
+Esempio:
+
+```json
+{
+  "contesto": {
+    "classe": "3A-TPSI",
+    "team_github": "3A-TPSI",
+    "percorso": "terzo-anno",
+    "uda": "uda-2"
+  }
+}
+```
+
+Questi campi non sono obbligatori perche TheBitLab deve poter descrivere anche attivita non scolastiche o non ancora associate a un corso.
+
+## Correzione
+
+Il campo `correzione` indica quali controlli sono previsti.
+
+Campi obbligatori:
+
+| Campo | Tipo | Significato |
+|---|---|---|
+| `compila` | boolean | L'attivita richiede compilazione |
+| `test` | boolean | L'attivita prevede test automatici |
+| `sandbox` | boolean | L'esecuzione deve avvenire in sandbox |
+| `ai_feedback` | boolean | Il feedback AI assisted e previsto |
+
+Regola importante:
+
+> Il feedback AI non sostituisce la correzione deterministica.
+
+## Metriche
+
+Il campo `metriche` indica cosa raccogliere.
+
+Campi consigliati:
+
+| Campo | Tipo | Significato |
+|---|---|---|
+| `tempo_stimato_minuti` | numero | Tempo stimato dal docente o dal sistema |
+| `traccia_tempo_dichiarato` | boolean | Lo studente puo dichiarare il tempo impiegato |
+| `traccia_sessioni_thebitlab` | boolean | TheBitLab puo registrare durata delle sessioni |
+| `traccia_eventi_didattici` | boolean | TheBitLab puo registrare eventi espliciti |
+| `traccia_errori_compilazione` | boolean | Gli errori di compilazione vengono raccolti |
+
+TheBitLab non deve usare queste metriche come sorveglianza. Servono a capire difficolta, progressi e bisogni di recupero.
+
+## Rubrica
+
+La rubrica e opzionale, ma consigliata per verifiche e compiti valutativi.
+
+Esempio:
+
+```json
+{
+  "rubrica": [
+    {
+      "criterio": "Compilazione",
+      "punti": 2
+    },
+    {
+      "criterio": "Correttezza del risultato",
+      "punti": 4
+    }
+  ]
+}
+```
+
+## Validazione
+
+Il validatore controlla:
+
+- JSON valido;
+- campi obbligatori;
+- tipo di attivita ammesso;
+- difficolta ammessa;
+- lista `argomenti` non vuota;
+- oggetto `correzione` completo;
+- valori booleani in `correzione`;
+- oggetto `metriche` presente;
+- rubrica ben formata quando presente.
+
+Il validatore non esegue codice e non valuta la qualita didattica dell'attivita.
+
+## Prossimi passi
+
+Le PR successive potranno aggiungere:
+
+- CLI guidata per creare attivita;
+- generazione AI assisted di consegne;
+- collegamento automatico a paragrafi del README;
+- correzione deterministica C;
+- sandbox Docker;
+- report e metriche.

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -157,10 +157,10 @@ Campi obbligatori:
 
 | Campo | Tipo | Significato |
 |---|---|---|
-| `compila` | boolean | L'attivita richiede compilazione |
-| `test` | boolean | L'attivita prevede test automatici |
-| `sandbox` | boolean | L'esecuzione deve avvenire in sandbox |
-| `ai_feedback` | boolean | Il feedback AI assisted e previsto |
+| `compila` | boolean obbligatorio | L'attivita richiede compilazione |
+| `test` | boolean obbligatorio | L'attivita prevede test automatici |
+| `sandbox` | boolean obbligatorio | L'esecuzione deve avvenire in sandbox |
+| `ai_feedback` | boolean obbligatorio | Il feedback AI assisted e previsto |
 
 Regola importante:
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -24,8 +24,11 @@ Se devi lavorare sulla progettazione del corso, sui percorsi didattici o sul cal
 Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o metriche studenti, leggi:
 
 1. [`ASSIGNMENTS.md`](ASSIGNMENTS.md)
+2. [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md)
 
 `ASSIGNMENTS.md` descrive il modello leggero per attivita didattiche, uso dei team GitHub come classi, correzione automatica, sandbox, metriche e roadmap delle prossime PR.
+
+`ACTIVITIES_SCHEMA.md` descrive il primo schema JSON per rappresentare esercizi, compiti, laboratori e verifiche in TheBitLab.
 
 ## Mappa rapida
 
@@ -35,6 +38,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | [`LAB_OUTPUTS.md`](LAB_OUTPUTS.md) | Quando devi aggiungere o aggiornare l'output di un laboratorio |
 | [`COURSE_BOARD.md`](COURSE_BOARD.md) | Quando devi usare la board dei progetti didattici, il calendario scolastico o le funzioni AI assisted |
 | [`ASSIGNMENTS.md`](ASSIGNMENTS.md) | Quando devi progettare esercizi, compiti, verifiche, correzioni automatiche o metriche di classe |
+| [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) | Quando devi creare o validare schede JSON di attivita TheBitLab |
 
 ## Script collegati
 
@@ -45,6 +49,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/course_board_server.py` | Avvia il server locale della board e del calendario | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/generate_course_plan.py` | Rigenera `doc/PERCORSO_DIDATTICO.md` dal progetto didattico corrente | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/update_course_frames.py` | Inserisce nel README le cornici didattiche presenti nel progetto | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
+| `scripts/validate_activity.py` | Valida le schede JSON di attivita TheBitLab | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 
 ## GitHub Actions collegate
 

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -136,7 +136,20 @@ def iter_activity_files(paths: list[Path]) -> list[Path]:
 def validate_files(paths: list[Path]) -> list[str]:
     """Validate all activity files found in the given paths."""
     errors: list[str] = []
-    for path in iter_activity_files(paths):
+    files: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            errors.append(f"{path}: path non trovato")
+            continue
+        if path.is_dir():
+            json_files = sorted(path.rglob("*.json"))
+            if not json_files:
+                errors.append(f"{path}: nessun file JSON trovato")
+            files.extend(json_files)
+        else:
+            files.append(path)
+
+    for path in files:
         data, load_errors = load_json(path)
         errors.extend(load_errors)
         if data is None:

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -38,6 +38,16 @@ REQUIRED_CORRECTION_FIELDS = {
     "ai_feedback",
 }
 
+REQUIRED_METRIC_FIELDS = {
+    "tempo_stimato_minuti",
+    "traccia_tempo_dichiarato",
+    "traccia_sessioni_thebitlab",
+    "traccia_eventi_didattici",
+    "traccia_errori_compilazione",
+}
+
+BOOLEAN_METRIC_FIELDS = REQUIRED_METRIC_FIELDS - {"tempo_stimato_minuti"}
+
 
 def load_json(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
     """Load an activity JSON file and return validation errors instead of raising."""
@@ -82,8 +92,8 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
         errors.extend(validate_correction(correction, source))
 
     metrics = data.get("metriche")
-    if metrics is not None and not isinstance(metrics, dict):
-        errors.append(f"{source}: metriche deve essere un oggetto")
+    if metrics is not None:
+        errors.extend(validate_metrics(metrics, source))
 
     rubric = data.get("rubrica")
     if rubric is not None:
@@ -124,6 +134,28 @@ def validate_rubric(rubric: Any, source: str) -> list[str]:
             errors.append(f"{prefix}.criterio deve essere una stringa non vuota")
         if not isinstance(item.get("punti"), (int, float)) or item.get("punti") < 0:
             errors.append(f"{prefix}.punti deve essere un numero non negativo")
+    return errors
+
+
+def validate_metrics(metrics: Any, source: str) -> list[str]:
+    """Validate required metric configuration fields."""
+    if not isinstance(metrics, dict):
+        return [f"{source}: metriche deve essere un oggetto"]
+
+    errors: list[str] = []
+    missing = sorted(REQUIRED_METRIC_FIELDS - metrics.keys())
+    for field in missing:
+        errors.append(f"{source}: metriche.{field} mancante")
+
+    estimated_time = metrics.get("tempo_stimato_minuti")
+    if estimated_time is not None:
+        if isinstance(estimated_time, bool) or not isinstance(estimated_time, (int, float)) or estimated_time < 0:
+            errors.append(f"{source}: metriche.tempo_stimato_minuti deve essere un numero non negativo")
+
+    for field in BOOLEAN_METRIC_FIELDS & metrics.keys():
+        if not isinstance(metrics[field], bool):
+            errors.append(f"{source}: metriche.{field} deve essere boolean")
+
     return errors
 
 

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -132,7 +132,8 @@ def validate_rubric(rubric: Any, source: str) -> list[str]:
             continue
         if not isinstance(item.get("criterio"), str) or not item.get("criterio"):
             errors.append(f"{prefix}.criterio deve essere una stringa non vuota")
-        if not isinstance(item.get("punti"), (int, float)) or item.get("punti") < 0:
+        points = item.get("punti")
+        if isinstance(points, bool) or not isinstance(points, (int, float)) or points < 0:
             errors.append(f"{prefix}.punti deve essere un numero non negativo")
     return errors
 

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -160,17 +160,6 @@ def validate_metrics(metrics: Any, source: str) -> list[str]:
     return errors
 
 
-def iter_activity_files(paths: list[Path]) -> list[Path]:
-    """Return JSON files from explicit files or directories."""
-    files: list[Path] = []
-    for path in paths:
-        if path.is_dir():
-            files.extend(sorted(path.rglob("*.json")))
-        else:
-            files.append(path)
-    return files
-
-
 def validate_files(paths: list[Path]) -> list[str]:
     """Validate all activity files found in the given paths."""
     errors: list[str] = []

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -31,6 +31,12 @@ REQUIRED_FIELDS = {
     "metriche",
 }
 
+REQUIRED_TEXT_FIELDS = {
+    "id",
+    "titolo",
+    "consegna",
+}
+
 REQUIRED_CORRECTION_FIELDS = {
     "compila",
     "test",
@@ -73,6 +79,10 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
     schema_version = data.get("schema_version")
     if schema_version is not None and schema_version != SUPPORTED_SCHEMA_VERSION:
         errors.append(f"{source}: schema_version non supportata: {schema_version}")
+
+    for field in sorted(REQUIRED_TEXT_FIELDS & data.keys()):
+        if not isinstance(data[field], str) or not data[field]:
+            errors.append(f"{source}: {field} deve essere una stringa non vuota")
 
     activity_type = data.get("tipo")
     if activity_type is not None and activity_type not in ALLOWED_TYPES:

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -17,6 +17,7 @@ ALLOWED_TYPES = {
 }
 
 ALLOWED_DIFFICULTIES = {"A", "B", "C", "D", "E", "F"}
+SUPPORTED_SCHEMA_VERSION = "1.0"
 
 REQUIRED_FIELDS = {
     "schema_version",
@@ -58,6 +59,10 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
     missing = sorted(REQUIRED_FIELDS - data.keys())
     for field in missing:
         errors.append(f"{source}: campo obbligatorio mancante: {field}")
+
+    schema_version = data.get("schema_version")
+    if schema_version is not None and schema_version != SUPPORTED_SCHEMA_VERSION:
+        errors.append(f"{source}: schema_version non supportata: {schema_version}")
 
     activity_type = data.get("tipo")
     if activity_type is not None and activity_type not in ALLOWED_TYPES:

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_TYPES = {
+    "studio-guidato",
+    "esercizio-classe",
+    "compito-casa",
+    "laboratorio",
+    "verifica-pratica",
+    "verifica-scritta",
+    "debug-didattico",
+}
+
+ALLOWED_DIFFICULTIES = {"A", "B", "C", "D", "E", "F"}
+
+REQUIRED_FIELDS = {
+    "schema_version",
+    "id",
+    "titolo",
+    "tipo",
+    "difficolta",
+    "argomenti",
+    "consegna",
+    "correzione",
+    "metriche",
+}
+
+REQUIRED_CORRECTION_FIELDS = {
+    "compila",
+    "test",
+    "sandbox",
+    "ai_feedback",
+}
+
+
+def load_json(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    """Load an activity JSON file and return validation errors instead of raising."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        return None, [f"{path}: JSON non valido: {error.msg}"]
+
+    if not isinstance(data, dict):
+        return None, [f"{path}: il contenuto deve essere un oggetto JSON"]
+
+    return data, []
+
+
+def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[str]:
+    """Validate the minimal TheBitLab activity schema."""
+    errors: list[str] = []
+
+    missing = sorted(REQUIRED_FIELDS - data.keys())
+    for field in missing:
+        errors.append(f"{source}: campo obbligatorio mancante: {field}")
+
+    activity_type = data.get("tipo")
+    if activity_type is not None and activity_type not in ALLOWED_TYPES:
+        errors.append(f"{source}: tipo non ammesso: {activity_type}")
+
+    difficulty = data.get("difficolta")
+    if difficulty is not None and difficulty not in ALLOWED_DIFFICULTIES:
+        errors.append(f"{source}: difficolta non ammessa: {difficulty}")
+
+    topics = data.get("argomenti")
+    if topics is not None:
+        if not isinstance(topics, list) or not topics or not all(isinstance(topic, str) and topic for topic in topics):
+            errors.append(f"{source}: argomenti deve essere una lista non vuota di stringhe")
+
+    correction = data.get("correzione")
+    if correction is not None:
+        errors.extend(validate_correction(correction, source))
+
+    metrics = data.get("metriche")
+    if metrics is not None and not isinstance(metrics, dict):
+        errors.append(f"{source}: metriche deve essere un oggetto")
+
+    rubric = data.get("rubrica")
+    if rubric is not None:
+        errors.extend(validate_rubric(rubric, source))
+
+    return errors
+
+
+def validate_correction(correction: Any, source: str) -> list[str]:
+    """Validate deterministic and AI feedback flags for an activity."""
+    if not isinstance(correction, dict):
+        return [f"{source}: correzione deve essere un oggetto"]
+
+    errors: list[str] = []
+    missing = sorted(REQUIRED_CORRECTION_FIELDS - correction.keys())
+    for field in missing:
+        errors.append(f"{source}: correzione.{field} mancante")
+
+    for field in REQUIRED_CORRECTION_FIELDS & correction.keys():
+        if not isinstance(correction[field], bool):
+            errors.append(f"{source}: correzione.{field} deve essere boolean")
+
+    return errors
+
+
+def validate_rubric(rubric: Any, source: str) -> list[str]:
+    """Validate the optional evaluation rubric."""
+    if not isinstance(rubric, list):
+        return [f"{source}: rubrica deve essere una lista"]
+
+    errors: list[str] = []
+    for index, item in enumerate(rubric):
+        prefix = f"{source}: rubrica[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} deve essere un oggetto")
+            continue
+        if not isinstance(item.get("criterio"), str) or not item.get("criterio"):
+            errors.append(f"{prefix}.criterio deve essere una stringa non vuota")
+        if not isinstance(item.get("punti"), (int, float)) or item.get("punti") < 0:
+            errors.append(f"{prefix}.punti deve essere un numero non negativo")
+    return errors
+
+
+def iter_activity_files(paths: list[Path]) -> list[Path]:
+    """Return JSON files from explicit files or directories."""
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.json")))
+        else:
+            files.append(path)
+    return files
+
+
+def validate_files(paths: list[Path]) -> list[str]:
+    """Validate all activity files found in the given paths."""
+    errors: list[str] = []
+    for path in iter_activity_files(paths):
+        data, load_errors = load_json(path)
+        errors.extend(load_errors)
+        if data is None:
+            continue
+        errors.extend(validate_activity(data, str(path)))
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Valida file attivita TheBitLab.")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[Path("activities/examples")],
+        help="File o cartelle JSON da validare.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    errors = validate_files(args.paths)
+
+    if errors:
+        print("Activity validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Activity validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_activity.py
+++ b/tests/test_validate_activity.py
@@ -95,6 +95,15 @@ def test_metric_flags_must_be_boolean() -> None:
     assert "activity.json: metriche.traccia_sessioni_thebitlab deve essere boolean" in errors
 
 
+def test_rubric_points_must_not_be_boolean() -> None:
+    activity = valid_activity()
+    activity["rubrica"] = [{"criterio": "Compilazione", "punti": True}]
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert "activity.json: rubrica[0].punti deve essere un numero non negativo" in errors
+
+
 def test_cli_validation_fails_on_invalid_file(tmp_path, monkeypatch) -> None:
     invalid_file = tmp_path / "invalid.json"
     invalid_file.write_text(json.dumps({"id": "troppo-poco"}), encoding="utf-8")

--- a/tests/test_validate_activity.py
+++ b/tests/test_validate_activity.py
@@ -58,6 +58,15 @@ def test_invalid_type_is_reported() -> None:
     assert "activity.json: tipo non ammesso: gara-di-cucina" in errors
 
 
+def test_unsupported_schema_version_is_reported() -> None:
+    activity = valid_activity()
+    activity["schema_version"] = "2.0"
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert "activity.json: schema_version non supportata: 2.0" in errors
+
+
 def test_correction_flags_must_be_boolean() -> None:
     activity = valid_activity()
     activity["correzione"]["sandbox"] = "si"

--- a/tests/test_validate_activity.py
+++ b/tests/test_validate_activity.py
@@ -83,3 +83,20 @@ def test_cli_validation_passes_on_valid_file(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr("sys.argv", ["validate_activity.py", str(valid_file)])
 
     assert validate_activity.main() == 0
+
+
+def test_missing_path_is_reported(tmp_path) -> None:
+    missing_path = tmp_path / "missing"
+
+    errors = validate_activity.validate_files([missing_path])
+
+    assert f"{missing_path}: path non trovato" in errors
+
+
+def test_empty_directory_is_reported(tmp_path) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    errors = validate_activity.validate_files([empty_dir])
+
+    assert f"{empty_dir}: nessun file JSON trovato" in errors

--- a/tests/test_validate_activity.py
+++ b/tests/test_validate_activity.py
@@ -76,6 +76,25 @@ def test_correction_flags_must_be_boolean() -> None:
     assert "activity.json: correzione.sandbox deve essere boolean" in errors
 
 
+def test_metrics_base_fields_are_required() -> None:
+    activity = valid_activity()
+    activity["metriche"] = {}
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert "activity.json: metriche.tempo_stimato_minuti mancante" in errors
+    assert "activity.json: metriche.traccia_eventi_didattici mancante" in errors
+
+
+def test_metric_flags_must_be_boolean() -> None:
+    activity = valid_activity()
+    activity["metriche"]["traccia_sessioni_thebitlab"] = "si"
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert "activity.json: metriche.traccia_sessioni_thebitlab deve essere boolean" in errors
+
+
 def test_cli_validation_fails_on_invalid_file(tmp_path, monkeypatch) -> None:
     invalid_file = tmp_path / "invalid.json"
     invalid_file.write_text(json.dumps({"id": "troppo-poco"}), encoding="utf-8")

--- a/tests/test_validate_activity.py
+++ b/tests/test_validate_activity.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import validate_activity
+
+
+EXAMPLES = Path("activities/examples")
+
+
+def valid_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "c-base-test-001",
+        "titolo": "Esercizio di test",
+        "tipo": "compito-casa",
+        "difficolta": "B",
+        "argomenti": ["variabili"],
+        "consegna": "Scrivi un programma C minimale.",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+    }
+
+
+def test_examples_are_valid() -> None:
+    errors = validate_activity.validate_files([EXAMPLES])
+
+    assert errors == []
+
+
+def test_missing_required_field_is_reported() -> None:
+    activity = valid_activity()
+    del activity["consegna"]
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert "activity.json: campo obbligatorio mancante: consegna" in errors
+
+
+def test_invalid_type_is_reported() -> None:
+    activity = valid_activity()
+    activity["tipo"] = "gara-di-cucina"
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert "activity.json: tipo non ammesso: gara-di-cucina" in errors
+
+
+def test_correction_flags_must_be_boolean() -> None:
+    activity = valid_activity()
+    activity["correzione"]["sandbox"] = "si"
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert "activity.json: correzione.sandbox deve essere boolean" in errors
+
+
+def test_cli_validation_fails_on_invalid_file(tmp_path, monkeypatch) -> None:
+    invalid_file = tmp_path / "invalid.json"
+    invalid_file.write_text(json.dumps({"id": "troppo-poco"}), encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["validate_activity.py", str(invalid_file)])
+
+    assert validate_activity.main() == 1
+
+
+def test_cli_validation_passes_on_valid_file(tmp_path, monkeypatch) -> None:
+    valid_file = tmp_path / "valid.json"
+    valid_file.write_text(json.dumps(valid_activity()), encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["validate_activity.py", str(valid_file)])
+
+    assert validate_activity.main() == 0

--- a/tests/test_validate_activity.py
+++ b/tests/test_validate_activity.py
@@ -58,6 +58,17 @@ def test_invalid_type_is_reported() -> None:
     assert "activity.json: tipo non ammesso: gara-di-cucina" in errors
 
 
+def test_required_text_fields_must_be_non_empty_strings() -> None:
+    activity = valid_activity()
+    activity["id"] = ""
+    activity["titolo"] = 123
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert "activity.json: id deve essere una stringa non vuota" in errors
+    assert "activity.json: titolo deve essere una stringa non vuota" in errors
+
+
 def test_unsupported_schema_version_is_reported() -> None:
     activity = valid_activity()
     activity["schema_version"] = "2.0"


### PR DESCRIPTION
﻿## Obiettivo

Questa PR implementa il primo mattone concreto di TheBitLab dopo la fondazione documentale: uno schema JSON leggero e validabile per descrivere attivita didattiche.

Lo schema serve a rappresentare esercizi, compiti a casa, laboratori, verifiche pratiche/scritte e attivita di debug in modo coerente.

## Cosa cambia

- Aggiunge `doc/ACTIVITIES_SCHEMA.md` con:
  - tipi di attivita ammessi;
  - livelli di difficolta `A`-`F`;
  - struttura minima di una scheda attivita;
  - campi principali;
  - contesto didattico;
  - correzione;
  - metriche;
  - rubrica;
  - uso del validatore.
- Aggiunge esempi in `activities/examples/`:
  - compito a casa sulle variabili;
  - laboratorio sugli array;
  - verifica pratica sulle funzioni;
  - debug didattico su puntatore non inizializzato.
- Aggiunge `scripts/validate_activity.py`:
  - validatore JSON senza dipendenze pesanti;
  - controllo campi obbligatori;
  - controllo tipi ammessi;
  - controllo difficolta;
  - controllo correzione e rubrica.
- Aggiunge `tests/test_validate_activity.py` con test sui casi validi e invalidi.
- Aggiorna `doc/README.md` per collegare la nuova documentazione.
- Aggiorna `.github/workflows/quality.yml` per far partire la Quality anche su modifiche a `activities/**` e `doc/ACTIVITIES_SCHEMA.md`.

## Scelte progettuali

- Lo schema resta volutamente minimale e leggibile.
- Non introduce ancora grading reale, sandbox o AI feedback.
- Il validatore controlla la struttura, non la qualita didattica.
- I campi `contesto` restano opzionali per supportare anche attivita non scolastiche o non ancora associate a un percorso.
- Le metriche usano nomi espliciti coerenti con `ASSIGNMENTS.md`.

## Validazione

Non ho eseguito test localmente in questa sessione. La PR include comunque test pytest e la workflow Quality aggiornata.

## Review finding e fix

### 1. Path inesistenti o directory senza JSON non segnalati chiaramente

**Finding:** `validate_files()` non distingueva in modo esplicito path inesistenti e directory senza file `.json`, rischiando validazioni poco chiare o configurazioni vuote.

**Come lo fixo:** aggiungo controlli espliciti per path non trovato e directory senza JSON, piu test dedicati per entrambi i casi.

**Fix:** il validatore ora produce errori chiari per `path non trovato` e `nessun file JSON trovato`.

Commit: [`d888213`](https://github.com/TheBitPoets/2cornot2c/commit/d888213c2dcba880c1eb32e958a1953f8fb2183c)

### 2. `schema_version` presente ma non validata

**Finding:** lo schema richiedeva `schema_version`, ma qualsiasi valore sarebbe stato accettato.

**Come lo fixo:** vincolo la versione supportata a `1.0` e aggiungo un test per versioni non supportate.

**Fix:** il validatore ora segnala `schema_version non supportata` se il valore non e `1.0`.

Commit: [`3e1ef6f`](https://github.com/TheBitPoets/2cornot2c/commit/3e1ef6f8fe362ccc34cddcd6ff3d3b897bb4fec2)

### 3. `metriche` troppo permissivo

**Finding:** `metriche` veniva validato solo come oggetto, quindi anche `{}` passava pur non contenendo i campi minimi descritti dalla documentazione.

**Come lo fixo:** introduco campi metriche obbligatori e validazione dei tipi, distinguendo tempo stimato numerico e flag booleani.

**Fix:** il validatore ora richiede `tempo_stimato_minuti`, `traccia_tempo_dichiarato`, `traccia_sessioni_thebitlab`, `traccia_eventi_didattici` e `traccia_errori_compilazione`, con tipi coerenti.

Commit: [`7e703c1`](https://github.com/TheBitPoets/2cornot2c/commit/7e703c1b6c01b2321369d8e3e213effbf325e1ca)

### 4. `punti: true` accettato nella rubrica

**Finding:** in Python `bool` e sottoclasse di `int`, quindi `punti: true` poteva essere accettato come numero.

**Come lo fixo:** escludo esplicitamente i booleani dalla validazione numerica dei punti e aggiungo un test dedicato.

**Fix:** la rubrica ora accetta solo numeri non negativi reali, non booleani.

Commit: [`949e113`](https://github.com/TheBitPoets/2cornot2c/commit/949e1134538beb2e0e6241ea1ffd47a5dda3018d)

### 5. Tabella `correzione` poco esplicita sui booleani obbligatori

**Finding:** la documentazione diceva che i campi di `correzione` erano boolean, ma nella tabella principale non esplicitava che sono obbligatori.

**Come lo fixo:** aggiorno la tabella di `doc/ACTIVITIES_SCHEMA.md` indicando `boolean obbligatorio` per ogni campo.

**Fix:** la documentazione ora e allineata al validatore.

Commit: [`9281f15`](https://github.com/TheBitPoets/2cornot2c/commit/9281f156f7e0b6f60610a16bed6658979401975c)


## Ulteriore review finding e fix

### 1. Funzione morta `iter_activity_files()`

**Finding:** dopo il fix su `validate_files()`, `iter_activity_files()` era rimasta inutilizzata e poteva creare ambiguita su quale fosse il percorso corretto per scoprire e validare i file.

**Come lo fixo:** rimuovo la funzione morta, lasciando un solo punto di controllo in `validate_files()`.

**Fix:** `validate_files()` resta l'unica funzione responsabile di path inesistenti, directory vuote e raccolta dei JSON.

Commit: [`749eaf8`](https://github.com/TheBitPoets/2cornot2c/commit/749eaf8b7c7c5513445def6e9b451a95f58f2dee)

### 2. Documentazione metriche non allineata al validatore

**Finding:** `doc/ACTIVITIES_SCHEMA.md` parlava ancora di "Campi consigliati" per `metriche`, ma il validatore li richiede come obbligatori.

**Come lo fixo:** aggiorno la sezione metriche per indicare chiaramente che quei campi sono obbligatori.

**Fix:** la documentazione ora dice "Campi obbligatori".

Commit: [`e88f186`](https://github.com/TheBitPoets/2cornot2c/commit/e88f18615301a5ae1fbc6998d67806443f567416)

### 3. Sezione validazione incompleta sulle metriche

**Finding:** la sezione "Validazione" diceva solo che `metriche` deve essere presente, ma il validatore ora controlla anche campi obbligatori e tipi.

**Come lo fixo:** aggiorno l'elenco dei controlli per descrivere la validazione effettiva di `metriche`.

**Fix:** la documentazione ora cita `metriche` completo e controllo di campi obbligatori/tipi.

Commit: [`f02014e`](https://github.com/TheBitPoets/2cornot2c/commit/f02014e798ea250be965dbc7a57c5777aa149908)

### 4. Campi testuali obbligatori non validati come stringhe non vuote

**Finding:** `id`, `titolo` e `consegna` erano richiesti come presenza, ma potevano essere vuoti o di tipo sbagliato.

**Come lo fixo:** aggiungo validazione esplicita per i campi testuali obbligatori e un test dedicato.

**Fix:** il validatore ora segnala `id`, `titolo` e `consegna` se non sono stringhe non vuote.

Commit: [`1bdb7c0`](https://github.com/TheBitPoets/2cornot2c/commit/1bdb7c0555da6626d34ec5cd38eefbf6d528a337)


## Ultima review finding e fix

### 1. Validazione campi testuali non documentata

**Finding:** il validatore controlla `id`, `titolo` e `consegna` come stringhe non vuote, ma la sezione "Validazione" non lo dichiarava ancora.

**Come lo fixo:** aggiorno l'elenco dei controlli documentati aggiungendo i campi testuali obbligatori non vuoti.

**Fix:** `doc/ACTIVITIES_SCHEMA.md` ora indica esplicitamente questo controllo.

Commit: [`8326009`](https://github.com/TheBitPoets/2cornot2c/commit/83260092fe53c27e8a96cfd3a1722f3d15f9cdcd)

### 2. Tabella metriche non coerente con correzione

**Finding:** la tabella `metriche` diceva "Campi obbligatori", ma nella colonna tipo usava ancora solo `numero` e `boolean`, mentre la tabella `correzione` esplicitava `boolean obbligatorio`.

**Come lo fixo:** rendo esplicita l'obbligatorieta anche nella colonna tipo della tabella metriche.

**Fix:** la tabella ora usa `numero obbligatorio` e `boolean obbligatorio`.

Commit: [`ff9412a`](https://github.com/TheBitPoets/2cornot2c/commit/ff9412a1376aaebe73be3fd1992aa534aef91506)
