### PR TITLE
Aggiunge CLI creazione attivita TheBitLab

### DIFF
--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -65,6 +65,14 @@ Lo script chiede i campi principali, applica default coerenti per `correzione` e
 activities/drafts/
 ```
 
+Se esiste gia un file con lo stesso ID/slug, la CLI non lo sovrascrive automaticamente.
+
+Per sovrascrivere in modo esplicito:
+
+```bash
+python scripts/create_activity.py --interactive --force
+```
+
 Puoi anche usare la modalita non interattiva:
 
 ```bash

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -89,6 +89,8 @@ Per sovrascrivere in modo esplicito:
 python scripts/create_activity.py --interactive --force
 ```
 
+Usa `--force` con cautela: il file esistente viene sostituito.
+
 Puoi anche usare la modalita non interattiva:
 
 ```bash

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -65,6 +65,22 @@ Lo script chiede i campi principali, applica default coerenti per `correzione` e
 activities/drafts/
 ```
 
+Il nome del file viene generato dallo slug dell'ID dell'attivita.
+
+Per esempio, un ID come:
+
+```text
+Esercizio Variabili 01
+```
+
+viene salvato in un file simile a:
+
+```text
+esercizio-variabili-01.json
+```
+
+L'ID interno resta quello scelto nella scheda, mentre il nome del file viene normalizzato per essere sicuro sul filesystem.
+
 Se esiste gia un file con lo stesso ID/slug, la CLI non lo sovrascrive automaticamente.
 
 Per sovrascrivere in modo esplicito:

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -51,6 +51,31 @@ Per validare un singolo file:
 python scripts/validate_activity.py activities/examples/homework_variables.json
 ```
 
+## Creazione guidata
+
+Per creare una nuova attivita senza scrivere il JSON a mano puoi usare:
+
+```bash
+python scripts/create_activity.py --interactive
+```
+
+Lo script chiede i campi principali, applica default coerenti per `correzione` e `metriche`, valida la scheda e salva il file in:
+
+```text
+activities/drafts/
+```
+
+Puoi anche usare la modalita non interattiva:
+
+```bash
+python scripts/create_activity.py \
+  --titolo "Somma di due interi" \
+  --tipo compito-casa \
+  --difficolta B \
+  --argomenti "variabili,input-output,operatori" \
+  --consegna "Scrivi un programma C che legge due interi e stampa la somma."
+```
+
 ## Tipi di attivita
 
 Il campo `tipo` deve avere uno di questi valori:

--- a/doc/README.md
+++ b/doc/README.md
@@ -49,6 +49,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/course_board_server.py` | Avvia il server locale della board e del calendario | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/generate_course_plan.py` | Rigenera `doc/PERCORSO_DIDATTICO.md` dal progetto didattico corrente | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/update_course_frames.py` | Inserisce nel README le cornici didattiche presenti nel progetto | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
+| `scripts/create_activity.py` | Crea una scheda JSON di attivita TheBitLab da prompt guidato o argomenti CLI | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 | `scripts/validate_activity.py` | Valida le schede JSON di attivita TheBitLab | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 
 ## GitHub Actions collegate

--- a/scripts/create_activity.py
+++ b/scripts/create_activity.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Callable
+
+from scripts import validate_activity
+
+
+DEFAULT_OUTPUT_DIR = Path("activities/drafts")
+
+DEFAULT_CORRECTION = {
+    "compila": True,
+    "test": True,
+    "sandbox": True,
+    "ai_feedback": True,
+}
+
+DEFAULT_METRICS = {
+    "tempo_stimato_minuti": 30,
+    "traccia_tempo_dichiarato": True,
+    "traccia_sessioni_thebitlab": True,
+    "traccia_eventi_didattici": True,
+    "traccia_errori_compilazione": True,
+}
+
+
+def slugify(value: str) -> str:
+    """Convert an activity id or title into a stable filesystem-friendly slug."""
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", value.strip().lower())
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug or "attivita"
+
+
+def split_csv(value: str) -> list[str]:
+    """Split a comma-separated input into a clean list of non-empty values."""
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def build_activity(
+    *,
+    activity_id: str,
+    title: str,
+    activity_type: str,
+    difficulty: str,
+    topics: list[str],
+    prompt: str,
+    estimated_minutes: int,
+    context: dict[str, str] | None = None,
+) -> dict:
+    """Build a minimal activity dictionary compatible with validate_activity."""
+    activity = {
+        "schema_version": validate_activity.SUPPORTED_SCHEMA_VERSION,
+        "id": activity_id,
+        "titolo": title,
+        "tipo": activity_type,
+        "difficolta": difficulty,
+        "argomenti": topics,
+        "consegna": prompt,
+        "correzione": dict(DEFAULT_CORRECTION),
+        "metriche": {
+            **DEFAULT_METRICS,
+            "tempo_stimato_minuti": estimated_minutes,
+        },
+    }
+
+    clean_context = {key: value for key, value in (context or {}).items() if value}
+    if clean_context:
+        activity["contesto"] = clean_context
+
+    return activity
+
+
+def output_path_for(activity: dict, output_dir: Path) -> Path:
+    """Return the default output path for a generated activity."""
+    return output_dir / f"{slugify(activity['id'])}.json"
+
+
+def write_activity(activity: dict, output_dir: Path) -> Path:
+    """Validate and write an activity JSON file."""
+    errors = validate_activity.validate_activity(activity, activity["id"])
+    if errors:
+        raise ValueError("\n".join(errors))
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_path_for(activity, output_dir)
+    output_path.write_text(
+        json.dumps(activity, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return output_path
+
+
+def ask(prompt: str, *, default: str | None = None, input_fn: Callable[[str], str] = input) -> str:
+    """Ask for a value, optionally showing and returning a default."""
+    suffix = f" [{default}]" if default is not None else ""
+    value = input_fn(f"{prompt}{suffix}: ").strip()
+    if not value and default is not None:
+        return default
+    return value
+
+
+def ask_required(prompt: str, *, input_fn: Callable[[str], str] = input) -> str:
+    """Ask until a non-empty value is provided."""
+    while True:
+        value = ask(prompt, input_fn=input_fn)
+        if value:
+            return value
+        print("Valore obbligatorio.")
+
+
+def ask_choice(
+    prompt: str,
+    allowed: set[str],
+    *,
+    default: str,
+    input_fn: Callable[[str], str] = input,
+) -> str:
+    """Ask until the value belongs to the allowed set."""
+    while True:
+        value = ask(prompt, default=default, input_fn=input_fn)
+        if value in allowed:
+            return value
+        print(f"Valore non ammesso. Valori validi: {', '.join(sorted(allowed))}")
+
+
+def ask_int(prompt: str, *, default: int, input_fn: Callable[[str], str] = input) -> int:
+    """Ask until a non-negative integer is provided."""
+    while True:
+        value = ask(prompt, default=str(default), input_fn=input_fn)
+        try:
+            number = int(value)
+        except ValueError:
+            print("Inserisci un numero intero.")
+            continue
+        if number >= 0:
+            return number
+        print("Inserisci un numero non negativo.")
+
+
+def create_interactive(input_fn: Callable[[str], str] = input) -> dict:
+    """Collect fields interactively and return an activity dictionary."""
+    title = ask_required("Titolo", input_fn=input_fn)
+    suggested_id = slugify(title)
+    activity_id = ask("ID attivita", default=suggested_id, input_fn=input_fn)
+    activity_type = ask_choice(
+        "Tipo attivita",
+        validate_activity.ALLOWED_TYPES,
+        default="compito-casa",
+        input_fn=input_fn,
+    )
+    difficulty = ask_choice(
+        "Difficolta",
+        validate_activity.ALLOWED_DIFFICULTIES,
+        default="B",
+        input_fn=input_fn,
+    )
+    topics = split_csv(ask_required("Argomenti separati da virgola", input_fn=input_fn))
+    prompt = ask_required("Consegna", input_fn=input_fn)
+    estimated_minutes = ask_int("Tempo stimato minuti", default=30, input_fn=input_fn)
+
+    context = {
+        "classe": ask("Classe", input_fn=input_fn),
+        "team_github": ask("Team GitHub", input_fn=input_fn),
+        "percorso": ask("Percorso", input_fn=input_fn),
+        "uda": ask("UDA", input_fn=input_fn),
+    }
+
+    return build_activity(
+        activity_id=activity_id,
+        title=title,
+        activity_type=activity_type,
+        difficulty=difficulty,
+        topics=topics,
+        prompt=prompt,
+        estimated_minutes=estimated_minutes,
+        context=context,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Crea una scheda attivita TheBitLab.")
+    parser.add_argument("--id", dest="activity_id", help="Identificativo stabile dell'attivita.")
+    parser.add_argument("--titolo", help="Titolo leggibile dell'attivita.")
+    parser.add_argument("--tipo", choices=sorted(validate_activity.ALLOWED_TYPES), help="Tipo attivita.")
+    parser.add_argument("--difficolta", choices=sorted(validate_activity.ALLOWED_DIFFICULTIES), help="Difficolta A-F.")
+    parser.add_argument("--argomenti", help="Argomenti separati da virgola.")
+    parser.add_argument("--consegna", help="Testo della consegna.")
+    parser.add_argument("--tempo-stimato", type=int, default=30, help="Tempo stimato in minuti.")
+    parser.add_argument("--classe", default="", help="Classe collegata all'attivita.")
+    parser.add_argument("--team-github", default="", help="Team GitHub collegato all'attivita.")
+    parser.add_argument("--percorso", default="", help="Percorso didattico collegato.")
+    parser.add_argument("--uda", default="", help="UDA collegata.")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR, help="Cartella di output.")
+    parser.add_argument("--interactive", action="store_true", help="Avvia la modalita guidata.")
+    return parser.parse_args()
+
+
+def activity_from_args(args: argparse.Namespace) -> dict:
+    """Build an activity from CLI arguments."""
+    required = {
+        "--titolo": args.titolo,
+        "--tipo": args.tipo,
+        "--difficolta": args.difficolta,
+        "--argomenti": args.argomenti,
+        "--consegna": args.consegna,
+    }
+    missing = [flag for flag, value in required.items() if not value]
+    if missing:
+        raise ValueError(f"Argomenti mancanti: {', '.join(missing)}. Usa --interactive per la modalita guidata.")
+
+    title = args.titolo
+    activity_id = args.activity_id or slugify(title)
+
+    return build_activity(
+        activity_id=activity_id,
+        title=title,
+        activity_type=args.tipo,
+        difficulty=args.difficolta,
+        topics=split_csv(args.argomenti),
+        prompt=args.consegna,
+        estimated_minutes=args.tempo_stimato,
+        context={
+            "classe": args.classe,
+            "team_github": args.team_github,
+            "percorso": args.percorso,
+            "uda": args.uda,
+        },
+    )
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        activity = create_interactive() if args.interactive else activity_from_args(args)
+        output_path = write_activity(activity, args.output_dir)
+    except ValueError as error:
+        print(f"Creazione attivita non riuscita:\n{error}")
+        return 1
+
+    print(f"Attivita creata: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/create_activity.py
+++ b/scripts/create_activity.py
@@ -59,6 +59,10 @@ def build_activity(
     context: dict[str, str] | None = None,
 ) -> dict:
     """Build a minimal activity dictionary compatible with validate_activity."""
+    activity_id = activity_id.strip()
+    title = title.strip()
+    prompt = prompt.strip()
+
     activity = {
         "schema_version": validate_activity.SUPPORTED_SCHEMA_VERSION,
         "id": activity_id,
@@ -240,12 +244,12 @@ def activity_from_args(args: argparse.Namespace) -> dict:
         "--argomenti": args.argomenti,
         "--consegna": args.consegna,
     }
-    missing = [flag for flag, value in required.items() if not value]
+    missing = [flag for flag, value in required.items() if not value or not str(value).strip()]
     if missing:
         raise ValueError(f"Argomenti mancanti: {', '.join(missing)}. Usa --interactive per la modalita guidata.")
 
-    title = args.titolo
-    activity_id = args.activity_id or slugify(title)
+    title = args.titolo.strip()
+    activity_id = args.activity_id.strip() if args.activity_id else slugify(title)
 
     return build_activity(
         activity_id=activity_id,

--- a/scripts/create_activity.py
+++ b/scripts/create_activity.py
@@ -151,6 +151,16 @@ def ask_int(prompt: str, *, default: int, input_fn: Callable[[str], str] = input
         print("Inserisci un numero positivo.")
 
 
+def ask_topics(input_fn: Callable[[str], str] = input) -> list[str]:
+    """Ask until at least one topic is provided."""
+    while True:
+        value = ask_required("Argomenti separati da virgola", input_fn=input_fn)
+        try:
+            return parse_topics(value)
+        except ValueError as error:
+            print(error)
+
+
 def positive_int(value: str) -> int:
     """Parse a positive integer CLI argument."""
     try:
@@ -179,7 +189,7 @@ def create_interactive(input_fn: Callable[[str], str] = input) -> dict:
         default="B",
         input_fn=input_fn,
     )
-    topics = split_csv(ask_required("Argomenti separati da virgola", input_fn=input_fn))
+    topics = ask_topics(input_fn=input_fn)
     prompt = ask_required("Consegna", input_fn=input_fn)
     estimated_minutes = ask_int("Tempo stimato minuti", default=30, input_fn=input_fn)
 

--- a/scripts/create_activity.py
+++ b/scripts/create_activity.py
@@ -138,7 +138,7 @@ def ask_choice(
 
 
 def ask_int(prompt: str, *, default: int, input_fn: Callable[[str], str] = input) -> int:
-    """Ask until a non-negative integer is provided."""
+    """Ask until a positive integer is provided."""
     while True:
         value = ask(prompt, default=str(default), input_fn=input_fn)
         try:
@@ -146,9 +146,20 @@ def ask_int(prompt: str, *, default: int, input_fn: Callable[[str], str] = input
         except ValueError:
             print("Inserisci un numero intero.")
             continue
-        if number >= 0:
+        if number > 0:
             return number
-        print("Inserisci un numero non negativo.")
+        print("Inserisci un numero positivo.")
+
+
+def positive_int(value: str) -> int:
+    """Parse a positive integer CLI argument."""
+    try:
+        number = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("deve essere un numero intero") from error
+    if number <= 0:
+        raise argparse.ArgumentTypeError("deve essere un numero positivo")
+    return number
 
 
 def create_interactive(input_fn: Callable[[str], str] = input) -> dict:
@@ -199,7 +210,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--difficolta", choices=sorted(validate_activity.ALLOWED_DIFFICULTIES), help="Difficolta A-F.")
     parser.add_argument("--argomenti", help="Argomenti separati da virgola.")
     parser.add_argument("--consegna", help="Testo della consegna.")
-    parser.add_argument("--tempo-stimato", type=int, default=30, help="Tempo stimato in minuti.")
+    parser.add_argument("--tempo-stimato", type=positive_int, default=30, help="Tempo stimato in minuti.")
     parser.add_argument("--classe", default="", help="Classe collegata all'attivita.")
     parser.add_argument("--team-github", default="", help="Team GitHub collegato all'attivita.")
     parser.add_argument("--percorso", default="", help="Percorso didattico collegato.")

--- a/scripts/create_activity.py
+++ b/scripts/create_activity.py
@@ -39,6 +39,14 @@ def split_csv(value: str) -> list[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
+def parse_topics(value: str) -> list[str]:
+    """Parse topics and fail early when no valid topic is provided."""
+    topics = split_csv(value)
+    if not topics:
+        raise ValueError("Inserisci almeno un argomento valido.")
+    return topics
+
+
 def build_activity(
     *,
     activity_id: str,
@@ -223,7 +231,7 @@ def activity_from_args(args: argparse.Namespace) -> dict:
         title=title,
         activity_type=args.tipo,
         difficulty=args.difficolta,
-        topics=split_csv(args.argomenti),
+        topics=parse_topics(args.argomenti),
         prompt=args.consegna,
         estimated_minutes=args.tempo_stimato,
         context={

--- a/scripts/create_activity.py
+++ b/scripts/create_activity.py
@@ -78,7 +78,7 @@ def output_path_for(activity: dict, output_dir: Path) -> Path:
     return output_dir / f"{slugify(activity['id'])}.json"
 
 
-def write_activity(activity: dict, output_dir: Path) -> Path:
+def write_activity(activity: dict, output_dir: Path, *, overwrite: bool = False) -> Path:
     """Validate and write an activity JSON file."""
     errors = validate_activity.validate_activity(activity, activity["id"])
     if errors:
@@ -86,6 +86,8 @@ def write_activity(activity: dict, output_dir: Path) -> Path:
 
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_path_for(activity, output_dir)
+    if output_path.exists() and not overwrite:
+        raise ValueError(f"File gia esistente: {output_path}. Usa --force per sovrascriverlo.")
     output_path.write_text(
         json.dumps(activity, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
@@ -196,6 +198,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--uda", default="", help="UDA collegata.")
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR, help="Cartella di output.")
     parser.add_argument("--interactive", action="store_true", help="Avvia la modalita guidata.")
+    parser.add_argument("--force", action="store_true", help="Sovrascrive un file attivita gia esistente.")
     return parser.parse_args()
 
 
@@ -237,7 +240,7 @@ def main() -> int:
 
     try:
         activity = create_interactive() if args.interactive else activity_from_args(args)
-        output_path = write_activity(activity, args.output_dir)
+        output_path = write_activity(activity, args.output_dir, overwrite=args.force)
     except ValueError as error:
         print(f"Creazione attivita non riuscita:\n{error}")
         return 1

--- a/tests/test_create_activity.py
+++ b/tests/test_create_activity.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+
+from scripts import create_activity, validate_activity
+
+
+def test_slugify_creates_filesystem_friendly_names() -> None:
+    assert create_activity.slugify("Somma di due numeri!") == "somma-di-due-numeri"
+
+
+def test_build_activity_generates_valid_activity() -> None:
+    activity = create_activity.build_activity(
+        activity_id="c-base-test-001",
+        title="Esercizio test",
+        activity_type="compito-casa",
+        difficulty="B",
+        topics=["variabili", "input-output"],
+        prompt="Scrivi un programma minimale.",
+        estimated_minutes=25,
+        context={"classe": "3A-TPSI", "team_github": "3A-TPSI", "percorso": "", "uda": "uda-1"},
+    )
+
+    assert activity["schema_version"] == "1.0"
+    assert activity["contesto"] == {"classe": "3A-TPSI", "team_github": "3A-TPSI", "uda": "uda-1"}
+    assert validate_activity.validate_activity(activity) == []
+
+
+def test_write_activity_uses_slugged_id_and_valid_json(tmp_path) -> None:
+    activity = create_activity.build_activity(
+        activity_id="Esercizio Variabili 01",
+        title="Esercizio variabili",
+        activity_type="compito-casa",
+        difficulty="B",
+        topics=["variabili"],
+        prompt="Scrivi un programma minimale.",
+        estimated_minutes=20,
+    )
+
+    output_path = create_activity.write_activity(activity, tmp_path)
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert output_path.name == "esercizio-variabili-01.json"
+    assert written["id"] == "Esercizio Variabili 01"
+    assert validate_activity.validate_activity(written) == []
+
+
+def test_activity_from_args_requires_required_fields() -> None:
+    class Args:
+        titolo = "Titolo"
+        tipo = None
+        difficolta = "B"
+        argomenti = "variabili"
+        consegna = "Consegna"
+        activity_id = None
+        tempo_stimato = 30
+        classe = ""
+        team_github = ""
+        percorso = ""
+        uda = ""
+
+    try:
+        create_activity.activity_from_args(Args())
+    except ValueError as error:
+        assert "--tipo" in str(error)
+    else:
+        raise AssertionError("activity_from_args should reject missing required fields")
+
+
+def test_create_interactive_uses_defaults() -> None:
+    answers = iter(
+        [
+            "Somma due interi",
+            "",
+            "",
+            "",
+            "variabili, operatori",
+            "Scrivi un programma C.",
+            "",
+            "3A-TPSI",
+            "3A-TPSI",
+            "terzo-anno",
+            "uda-2",
+        ]
+    )
+
+    activity = create_activity.create_interactive(input_fn=lambda _: next(answers))
+
+    assert activity["id"] == "somma-due-interi"
+    assert activity["tipo"] == "compito-casa"
+    assert activity["difficolta"] == "B"
+    assert activity["argomenti"] == ["variabili", "operatori"]
+    assert activity["metriche"]["tempo_stimato_minuti"] == 30
+    assert validate_activity.validate_activity(activity) == []

--- a/tests/test_create_activity.py
+++ b/tests/test_create_activity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import argparse
 
 from scripts import create_activity, validate_activity
 
@@ -151,7 +152,7 @@ def test_activity_from_args_rejects_empty_topics() -> None:
 def test_positive_int_rejects_zero() -> None:
     try:
         create_activity.positive_int("0")
-    except Exception as error:
+    except argparse.ArgumentTypeError as error:
         assert "positivo" in str(error)
     else:
         raise AssertionError("positive_int should reject zero")

--- a/tests/test_create_activity.py
+++ b/tests/test_create_activity.py
@@ -126,6 +126,15 @@ def test_activity_from_args_rejects_empty_topics() -> None:
         raise AssertionError("activity_from_args should reject empty topics")
 
 
+def test_positive_int_rejects_zero() -> None:
+    try:
+        create_activity.positive_int("0")
+    except Exception as error:
+        assert "positivo" in str(error)
+    else:
+        raise AssertionError("positive_int should reject zero")
+
+
 def test_create_interactive_uses_defaults() -> None:
     answers = iter(
         [

--- a/tests/test_create_activity.py
+++ b/tests/test_create_activity.py
@@ -104,6 +104,28 @@ def test_activity_from_args_requires_required_fields() -> None:
         raise AssertionError("activity_from_args should reject missing required fields")
 
 
+def test_activity_from_args_rejects_empty_topics() -> None:
+    class Args:
+        titolo = "Titolo"
+        tipo = "compito-casa"
+        difficolta = "B"
+        argomenti = " , , "
+        consegna = "Consegna"
+        activity_id = None
+        tempo_stimato = 30
+        classe = ""
+        team_github = ""
+        percorso = ""
+        uda = ""
+
+    try:
+        create_activity.activity_from_args(Args())
+    except ValueError as error:
+        assert "almeno un argomento" in str(error)
+    else:
+        raise AssertionError("activity_from_args should reject empty topics")
+
+
 def test_create_interactive_uses_defaults() -> None:
     answers = iter(
         [

--- a/tests/test_create_activity.py
+++ b/tests/test_create_activity.py
@@ -104,6 +104,28 @@ def test_activity_from_args_requires_required_fields() -> None:
         raise AssertionError("activity_from_args should reject missing required fields")
 
 
+def test_activity_from_args_rejects_blank_text_fields() -> None:
+    class Args:
+        titolo = "   "
+        tipo = "compito-casa"
+        difficolta = "B"
+        argomenti = "variabili"
+        consegna = "Consegna"
+        activity_id = None
+        tempo_stimato = 30
+        classe = ""
+        team_github = ""
+        percorso = ""
+        uda = ""
+
+    try:
+        create_activity.activity_from_args(Args())
+    except ValueError as error:
+        assert "--titolo" in str(error)
+    else:
+        raise AssertionError("activity_from_args should reject blank titles")
+
+
 def test_activity_from_args_rejects_empty_topics() -> None:
     class Args:
         titolo = "Titolo"

--- a/tests/test_create_activity.py
+++ b/tests/test_create_activity.py
@@ -45,6 +45,43 @@ def test_write_activity_uses_slugged_id_and_valid_json(tmp_path) -> None:
     assert validate_activity.validate_activity(written) == []
 
 
+def test_write_activity_refuses_to_overwrite_existing_file(tmp_path) -> None:
+    activity = create_activity.build_activity(
+        activity_id="attivita-duplicata",
+        title="Attivita duplicata",
+        activity_type="compito-casa",
+        difficulty="B",
+        topics=["variabili"],
+        prompt="Scrivi un programma minimale.",
+        estimated_minutes=20,
+    )
+    create_activity.write_activity(activity, tmp_path)
+
+    try:
+        create_activity.write_activity(activity, tmp_path)
+    except ValueError as error:
+        assert "File gia esistente" in str(error)
+    else:
+        raise AssertionError("write_activity should reject overwrite without force")
+
+
+def test_write_activity_can_overwrite_with_force(tmp_path) -> None:
+    activity = create_activity.build_activity(
+        activity_id="attivita-force",
+        title="Attivita force",
+        activity_type="compito-casa",
+        difficulty="B",
+        topics=["variabili"],
+        prompt="Scrivi un programma minimale.",
+        estimated_minutes=20,
+    )
+    create_activity.write_activity(activity, tmp_path)
+
+    output_path = create_activity.write_activity(activity, tmp_path, overwrite=True)
+
+    assert output_path.exists()
+
+
 def test_activity_from_args_requires_required_fields() -> None:
     class Args:
         titolo = "Titolo"

--- a/tests/test_create_activity.py
+++ b/tests/test_create_activity.py
@@ -160,3 +160,26 @@ def test_create_interactive_uses_defaults() -> None:
     assert activity["argomenti"] == ["variabili", "operatori"]
     assert activity["metriche"]["tempo_stimato_minuti"] == 30
     assert validate_activity.validate_activity(activity) == []
+
+
+def test_create_interactive_repeats_empty_topics() -> None:
+    answers = iter(
+        [
+            "Somma due interi",
+            "",
+            "",
+            "",
+            ", ,",
+            "variabili",
+            "Scrivi un programma C.",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]
+    )
+
+    activity = create_activity.create_interactive(input_fn=lambda _: next(answers))
+
+    assert activity["argomenti"] == ["variabili"]


### PR DESCRIPTION
﻿## Obiettivo

Questa PR aggiunge la prima CLI operativa per creare schede attivita TheBitLab a partire dallo schema introdotto nella PR precedente.

L'obiettivo e permettere al docente di creare nuovi JSON validi senza scriverli a mano.

## Cosa cambia

- Aggiunge `scripts/create_activity.py`:
  - modalita interattiva con `--interactive`;
  - modalita non interattiva con argomenti CLI;
  - default coerenti per `correzione` e `metriche`;
  - generazione automatica dello slug/nome file;
  - validazione tramite `scripts/validate_activity.py` prima della scrittura;
  - salvataggio predefinito in `activities/drafts/`.
- Aggiunge `tests/test_create_activity.py`:
  - test su slug;
  - test su costruzione attivita valida;
  - test su scrittura JSON;
  - test su argomenti mancanti;
  - test su modalita interattiva con default.
- Aggiorna `doc/ACTIVITIES_SCHEMA.md` con esempi di uso della CLI.
- Aggiorna `doc/README.md` nella tabella degli script.

## Esempio uso interattivo

```bash
python scripts/create_activity.py --interactive
```

## Esempio uso non interattivo

```bash
python scripts/create_activity.py \
  --titolo "Somma di due interi" \
  --tipo compito-casa \
  --difficolta B \
  --argomenti "variabili,input-output,operatori" \
  --consegna "Scrivi un programma C che legge due interi e stampa la somma."
```

## Scelte progettuali

- La CLI riusa il validatore esistente invece di duplicare regole.
- La struttura generata resta minimale e compatibile con lo schema `1.0`.
- La CLI non introduce ancora generazione AI assisted, grading, sandbox o integrazione GitHub.
- La modalita interattiva resta volutamente semplice: e il primo gradino verso TheBitLab CLI/TUI.

## Validazione

Non ho eseguito test localmente in questa sessione. La PR include test pytest e si affida alla workflow Quality.


## Review finding e fix

### 1. Overwrite silenzioso di file esistenti

**Finding:** `write_activity()` sovrascriveva silenziosamente un file esistente con lo stesso slug/ID, con rischio di perdere una scheda gia creata.

**Come lo fixo:** blocco l'overwrite di default e aggiungo un flag esplicito per consentirlo solo quando richiesto.

**Fix:** la CLI ora rifiuta file esistenti e accetta la sovrascrittura solo con `--force`.

Commit: [`689a9c9`](https://github.com/TheBitPoets/2cornot2c/commit/689a9c91fc509c1772337b8836d29db533842d84)

### 2. Argomenti vuoti in modalita non interattiva

**Finding:** `--argomenti ""` o valori fatti solo di virgole/spazi arrivavano al validatore solo dopo la costruzione dell'attivita, con errore meno chiaro.

**Come lo fixo:** aggiungo parsing dedicato degli argomenti e fallimento immediato se non c'e almeno un argomento valido.

**Fix:** la CLI segnala subito `Inserisci almeno un argomento valido`.

Commit: [`441ffeb`](https://github.com/TheBitPoets/2cornot2c/commit/441ffeb65f8f66ec92f9295dbdd31b3a208d1930)

### 3. Tempo stimato pari a zero

**Finding:** la CLI accettava `0` minuti come tempo stimato. Lo schema lo permetteva come numero non negativo, ma didatticamente una durata zero non e utile per una scheda docente.

**Come lo fixo:** richiedo un intero positivo sia nella modalita interattiva sia negli argomenti CLI.

**Fix:** `--tempo-stimato 0` viene rifiutato e la modalita guidata ripete la domanda finche il valore non e positivo.

Commit: [`0fd67b9`](https://github.com/TheBitPoets/2cornot2c/commit/0fd67b9dc06e1df2a043108fd9ff0e0f4eb9ae2b)

### 4. Argomenti vuoti in modalita interattiva

**Finding:** in modalita guidata, inserire solo virgole nel campo argomenti faceva fallire la creazione solo alla fine.

**Come lo fixo:** aggiungo una domanda dedicata agli argomenti che ripete il prompt finche ottiene almeno un valore valido.

**Fix:** la modalita interattiva ora guida l'utente invece di fallire tardivamente.

Commit: [`deb3e74`](https://github.com/TheBitPoets/2cornot2c/commit/deb3e747631538a0f213807b5c3d9bf3cb2fdcfb)

### 5. Comportamento anti-overwrite non documentato

**Finding:** dopo il fix anti-overwrite, la documentazione doveva spiegare cosa succede quando esiste gia un file con stesso ID/slug.

**Come lo fixo:** aggiorno `doc/ACTIVITIES_SCHEMA.md` documentando il blocco di default e l'uso esplicito di `--force`.

**Fix:** la sezione Creazione guidata spiega il comportamento e mostra il comando con `--force`.

Commit: [`31a4f22`](https://github.com/TheBitPoets/2cornot2c/commit/31a4f22399bc898b58dfa144be9714b644ba24d7)


## Ulteriore review finding e fix

### 1. Campi testuali composti solo da spazi

**Finding:** in modalita non interattiva, valori come `--titolo "   "` o `--consegna "   "` potevano attraversare il controllo iniziale perche non veniva usato `strip()`.

**Come lo fixo:** normalizzo i campi testuali e considero mancanti anche i valori composti solo da spazi.

**Fix:** `activity_from_args()` ora rifiuta titoli/consegne vuoti dopo trim e `build_activity()` salva testi normalizzati.

Commit: [`4f32db7`](https://github.com/TheBitPoets/2cornot2c/commit/4f32db7a63ffd98799f2f4eac3ccdc630f16f4fc)

### 2. Relazione tra ID interno e nome file non documentata

**Finding:** la CLI slugifica l'ID per generare il nome file, ma l'ID interno resta quello scelto dall'utente; la documentazione non lo chiariva.

**Come lo fixo:** aggiungo una spiegazione con esempio di ID e file generato.

**Fix:** `doc/ACTIVITIES_SCHEMA.md` ora spiega che il nome file deriva dallo slug dell'ID, mentre l'ID interno resta quello della scheda.

Commit: [`9554d71`](https://github.com/TheBitPoets/2cornot2c/commit/9554d712b0ac8f3e119d061e139ae1732292e288)

### 3. Test con eccezione troppo generica

**Finding:** il test su `positive_int()` catturava `Exception`, rischiando di passare anche per errori imprevisti.

**Come lo fixo:** restringo il test all'eccezione specifica generata da argparse.

**Fix:** il test ora cattura `argparse.ArgumentTypeError`.

Commit: [`5fccf5f`](https://github.com/TheBitPoets/2cornot2c/commit/5fccf5f975767ef718a734f493d2553f419c8baa)

### 4. Uso di `--force` non sufficientemente esplicito

**Finding:** la documentazione mostrava `--force`, ma non avvisava chiaramente che sovrascrive il file esistente.

**Come lo fixo:** aggiungo una nota di cautela nella sezione di creazione guidata.

**Fix:** la documentazione ora dice esplicitamente che `--force` sostituisce il file esistente.

Commit: [`f8eb371`](https://github.com/TheBitPoets/2cornot2c/commit/f8eb371592e6617c967e6113959380ba43685f21)
