### PR TITLE
Aggiunge grading deterministico multi linguaggio

### DIFF
--- a/activities/examples/c_sum_with_tests.json
+++ b/activities/examples/c_sum_with_tests.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1.0",
+  "id": "c-base-somma-001",
+  "titolo": "Somma di due interi",
+  "linguaggio": "c",
+  "tipo": "compito-casa",
+  "difficolta": "B",
+  "argomenti": [
+    "variabili",
+    "input-output",
+    "operatori"
+  ],
+  "consegna": "Scrivi un programma C che legge due interi e stampa la loro somma.",
+  "correzione": {
+    "compila": true,
+    "test": true,
+    "sandbox": false,
+    "ai_feedback": false
+  },
+  "metriche": {
+    "tempo_stimato_minuti": 20,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": true
+  },
+  "test_cases": [
+    {
+      "name": "somma positiva",
+      "stdin": "2 3\n",
+      "expected_stdout": "5\n"
+    },
+    {
+      "name": "somma con negativo",
+      "stdin": "-2 3\n",
+      "expected_stdout": "1\n"
+    }
+  ]
+}

--- a/doc/ASSIGNMENT_GRADING.md
+++ b/doc/ASSIGNMENT_GRADING.md
@@ -120,6 +120,7 @@ Questa e una fondazione minimale.
 Limiti noti:
 
 - solo il runner C e implementato in questa fase;
+- i runner pianificati ma non implementati restituiscono `unsupported-language`;
 - l'esecuzione non e ancora isolata in Docker;
 - non vengono ancora applicati limiti su memoria o filesystem;
 - non viene disabilitata la rete;

--- a/doc/ASSIGNMENT_GRADING.md
+++ b/doc/ASSIGNMENT_GRADING.md
@@ -70,6 +70,10 @@ Un test case ha questa forma:
 }
 ```
 
+`expected_stdout` e obbligatorio e deve essere una stringa.
+
+`stdin` e opzionale; se presente, deve essere una stringa.
+
 `stdout` viene normalizzato rimuovendo differenze finali di spazi e newline.
 
 ## Linguaggio nella scheda attivita

--- a/doc/ASSIGNMENT_GRADING.md
+++ b/doc/ASSIGNMENT_GRADING.md
@@ -1,0 +1,141 @@
+# Correzione deterministica multi-linguaggio
+
+Questo documento descrive il primo motore minimale di correzione deterministica in TheBitLab.
+
+Questa PR non introduce ancora Docker, sandbox completa, GitHub automation o feedback AI. Serve a fissare il ciclo tecnico minimo:
+
+```text
+scheda attivita -> sorgente -> runner linguaggio -> test -> report JSON
+```
+
+Il primo runner implementato e quello per C. Gli altri linguaggi vengono previsti nel modello per evitare di legare TheBitLab a un solo linguaggio.
+
+## Linguaggi previsti
+
+| Linguaggio | Stato iniziale |
+|---|---|
+| `c` | Implementato |
+| `python` | Previsto |
+| `javascript` | Previsto |
+| `nodejs` | Previsto |
+| `html` | Previsto |
+| `java` | Previsto |
+| `sql` | Previsto |
+| `golang` | Previsto |
+| `assembly` | Previsto |
+| `cpp` | Previsto |
+| `php` | Previsto |
+
+## Script
+
+Lo script principale e:
+
+```text
+scripts/grade_activity.py
+```
+
+Esempio:
+
+```bash
+python scripts/grade_activity.py \
+  --activity activities/examples/c_sum_with_tests.json \
+  --source main.c \
+  --language c \
+  --report reports/c_sum_report.json
+```
+
+## Cosa fa
+
+Lo script:
+
+- legge una scheda attivita JSON;
+- legge il campo `linguaggio`, se presente;
+- cerca il campo `test_cases`;
+- seleziona il runner del linguaggio;
+- per C compila il sorgente con `gcc`;
+- esegue il binario per ogni test case;
+- passa lo `stdin` configurato;
+- confronta `stdout` ottenuto e `expected_stdout`;
+- produce un report JSON.
+
+## Test case
+
+Un test case ha questa forma:
+
+```json
+{
+  "name": "somma positiva",
+  "stdin": "2 3\n",
+  "expected_stdout": "5\n"
+}
+```
+
+`stdout` viene normalizzato rimuovendo differenze finali di spazi e newline.
+
+## Linguaggio nella scheda attivita
+
+Una scheda puo dichiarare il linguaggio:
+
+```json
+{
+  "linguaggio": "c"
+}
+```
+
+La CLI puo anche forzarlo con:
+
+```bash
+python scripts/grade_activity.py --language c ...
+```
+
+## Report
+
+Il report contiene:
+
+- esito complessivo;
+- esito compilazione;
+- esito di ogni test;
+- stdout atteso e ottenuto;
+- stderr;
+- riepilogo test passati/totali.
+
+Esempio ridotto:
+
+```json
+{
+  "passed": true,
+  "status": "passed",
+  "activity_id": "c-base-somma-001",
+  "summary": {
+    "passed": 2,
+    "total": 2
+  }
+}
+```
+
+## Limiti attuali
+
+Questa e una fondazione minimale.
+
+Limiti noti:
+
+- solo il runner C e implementato in questa fase;
+- l'esecuzione non e ancora isolata in Docker;
+- non vengono ancora applicati limiti su memoria o filesystem;
+- non viene disabilitata la rete;
+- non c'e ancora integrazione GitHub automatica;
+- non c'e feedback AI;
+- non c'e ancora gestione avanzata di piu file sorgente o Makefile.
+
+## Regola architetturale
+
+Il risultato deterministico viene prima di qualsiasi feedback AI.
+
+Il flusso corretto resta:
+
+1. compilazione;
+2. esecuzione test;
+3. report deterministico;
+4. eventuale feedback AI in una fase separata.
+
+La futura sandbox Docker dovra eseguire questo stesso flusso in ambiente isolato.

--- a/doc/README.md
+++ b/doc/README.md
@@ -39,6 +39,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | [`COURSE_BOARD.md`](COURSE_BOARD.md) | Quando devi usare la board dei progetti didattici, il calendario scolastico o le funzioni AI assisted |
 | [`ASSIGNMENTS.md`](ASSIGNMENTS.md) | Quando devi progettare esercizi, compiti, verifiche, correzioni automatiche o metriche di classe |
 | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) | Quando devi creare o validare schede JSON di attivita TheBitLab |
+| [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) | Quando devi correggere in modo deterministico una consegna TheBitLab |
 
 ## Script collegati
 
@@ -51,6 +52,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/update_course_frames.py` | Inserisce nel README le cornici didattiche presenti nel progetto | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/create_activity.py` | Crea una scheda JSON di attivita TheBitLab da prompt guidato o argomenti CLI | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 | `scripts/validate_activity.py` | Valida le schede JSON di attivita TheBitLab | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
+| `scripts/grade_activity.py` | Esegue il runner deterministico del linguaggio richiesto e produce un report | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) |
 
 ## GitHub Actions collegate
 

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -208,12 +208,12 @@ def grade_c_activity(activity: dict[str, Any], source: Path, *, timeout_seconds:
         if not compile_result["passed"]:
             return {
                 "passed": False,
-            "status": compile_result["status"],
-            "activity_id": activity.get("id"),
-            "language": "c",
-            "source": str(source),
-            "compile": compile_result,
-            "tests": [],
+                "status": compile_result["status"],
+                "activity_id": activity.get("id"),
+                "language": "c",
+                "source": str(source),
+                "compile": compile_result,
+                "tests": [],
             }
 
         tests = [run_test_case(binary, test_case, timeout_seconds=timeout_seconds) for test_case in test_cases]

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -198,6 +198,10 @@ def grade_c_activity(activity: dict[str, Any], source: Path, *, timeout_seconds:
         return {
             "passed": False,
             "status": "invalid-activity",
+            "activity_id": activity.get("id"),
+            "language": "c",
+            "source": str(source),
+            "tests": [],
             "errors": test_case_errors,
         }
 

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_TIMEOUT_SECONDS = 5
+SUPPORTED_LANGUAGES = {
+    "c": "implemented",
+    "python": "planned",
+    "javascript": "planned",
+    "nodejs": "planned",
+    "html": "planned",
+    "java": "planned",
+    "sql": "planned",
+    "golang": "planned",
+    "assembly": "planned",
+    "cpp": "planned",
+    "php": "planned",
+}
+
+
+def load_activity(path: Path) -> dict[str, Any]:
+    """Load an activity JSON file."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def compile_c_source(source: Path, output: Path, *, timeout_seconds: int) -> dict[str, Any]:
+    """Compile a C source file with gcc and return a deterministic result."""
+    command = ["gcc", str(source), "-o", str(output)]
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=timeout_seconds, check=False)
+    except subprocess.TimeoutExpired as error:
+        return {
+            "passed": False,
+            "status": "compile-timeout",
+            "command": command,
+            "stdout": error.stdout or "",
+            "stderr": error.stderr or "",
+        }
+    except FileNotFoundError:
+        return {
+            "passed": False,
+            "status": "compiler-not-found",
+            "command": command,
+            "stdout": "",
+            "stderr": "gcc non trovato",
+        }
+
+    return {
+        "passed": result.returncode == 0,
+        "status": "compiled" if result.returncode == 0 else "compile-error",
+        "command": command,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def normalize_output(value: str) -> str:
+    """Normalize output for deterministic stdout comparisons."""
+    return value.replace("\r\n", "\n").strip()
+
+
+def run_test_case(binary: Path, test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
+    """Run a compiled binary against one test case."""
+    stdin = str(test_case.get("stdin", ""))
+    expected_stdout = str(test_case.get("expected_stdout", ""))
+    name = str(test_case.get("name", "test"))
+
+    try:
+        result = subprocess.run(
+            [str(binary)],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        return {
+            "name": name,
+            "passed": False,
+            "status": "timeout",
+            "stdin": stdin,
+            "expected_stdout": expected_stdout,
+            "stdout": error.stdout or "",
+            "stderr": error.stderr or "",
+        }
+
+    actual_stdout = result.stdout
+    passed = result.returncode == 0 and normalize_output(actual_stdout) == normalize_output(expected_stdout)
+    return {
+        "name": name,
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "returncode": result.returncode,
+        "stdin": stdin,
+        "expected_stdout": expected_stdout,
+        "stdout": actual_stdout,
+        "stderr": result.stderr,
+    }
+
+
+def activity_language(activity: dict[str, Any], explicit_language: str | None = None) -> str:
+    """Return the language requested by CLI or activity metadata."""
+    return (explicit_language or activity.get("linguaggio") or activity.get("language") or "c").lower()
+
+
+def unsupported_language_report(activity: dict[str, Any], source: Path, language: str) -> dict[str, Any]:
+    """Return a deterministic report for planned but not implemented languages."""
+    return {
+        "passed": False,
+        "status": "unsupported-language",
+        "activity_id": activity.get("id"),
+        "source": str(source),
+        "language": language,
+        "supported_languages": SUPPORTED_LANGUAGES,
+        "error": f"Runner non ancora implementato per il linguaggio: {language}",
+    }
+
+
+def grade_activity(
+    activity: dict[str, Any],
+    source: Path,
+    *,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    language: str | None = None,
+) -> dict[str, Any]:
+    """Grade a source file using the language runner requested by the activity."""
+    selected_language = activity_language(activity, language)
+    if SUPPORTED_LANGUAGES.get(selected_language) != "implemented":
+        return unsupported_language_report(activity, source, selected_language)
+
+    if selected_language == "c":
+        return grade_c_activity(activity, source, timeout_seconds=timeout_seconds)
+
+    return unsupported_language_report(activity, source, selected_language)
+
+
+def grade_c_activity(activity: dict[str, Any], source: Path, *, timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    """Compile and grade a C source file using test cases from an activity."""
+    test_cases = activity.get("test_cases", [])
+    if not isinstance(test_cases, list) or not test_cases:
+        return {
+            "passed": False,
+            "status": "invalid-activity",
+            "error": "L'attivita deve contenere una lista non vuota test_cases.",
+        }
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        suffix = ".exe" if os.name == "nt" else ""
+        binary = Path(temp_dir) / f"submission{suffix}"
+        compile_result = compile_c_source(source, binary, timeout_seconds=timeout_seconds)
+        if not compile_result["passed"]:
+            return {
+                "passed": False,
+            "status": compile_result["status"],
+            "activity_id": activity.get("id"),
+            "language": "c",
+            "source": str(source),
+            "compile": compile_result,
+            "tests": [],
+            }
+
+        tests = [run_test_case(binary, test_case, timeout_seconds=timeout_seconds) for test_case in test_cases]
+        passed = all(test["passed"] for test in tests)
+        return {
+            "passed": passed,
+            "status": "passed" if passed else "failed",
+            "activity_id": activity.get("id"),
+            "language": "c",
+            "source": str(source),
+            "compile": compile_result,
+            "tests": tests,
+            "summary": {
+                "passed": sum(1 for test in tests if test["passed"]),
+                "total": len(tests),
+            },
+        }
+
+
+def write_report(report: dict[str, Any], path: Path) -> None:
+    """Write a grading report as JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Corregge in modo deterministico una consegna TheBitLab.")
+    parser.add_argument("--activity", type=Path, required=True, help="Scheda attivita JSON con test_cases.")
+    parser.add_argument("--source", type=Path, required=True, help="File sorgente da correggere.")
+    parser.add_argument("--language", choices=sorted(SUPPORTED_LANGUAGES), help="Linguaggio da usare, se diverso dalla scheda.")
+    parser.add_argument("--report", type=Path, help="Percorso report JSON da scrivere.")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout compilazione/esecuzione.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    activity = load_activity(args.activity)
+    report = grade_activity(activity, args.source, timeout_seconds=args.timeout, language=args.language)
+
+    if args.report:
+        write_report(report, args.report)
+    else:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -125,6 +125,19 @@ def unsupported_language_report(activity: dict[str, Any], source: Path, language
     }
 
 
+def unknown_language_report(activity: dict[str, Any], source: Path, language: str) -> dict[str, Any]:
+    """Return a deterministic report for languages outside the supported model."""
+    return {
+        "passed": False,
+        "status": "unknown-language",
+        "activity_id": activity.get("id"),
+        "source": str(source),
+        "language": language,
+        "supported_languages": SUPPORTED_LANGUAGES,
+        "error": f"Linguaggio non riconosciuto: {language}",
+    }
+
+
 def grade_activity(
     activity: dict[str, Any],
     source: Path,
@@ -134,6 +147,9 @@ def grade_activity(
 ) -> dict[str, Any]:
     """Grade a source file using the language runner requested by the activity."""
     selected_language = activity_language(activity, language)
+    if selected_language not in SUPPORTED_LANGUAGES:
+        return unknown_language_report(activity, source, selected_language)
+
     if SUPPORTED_LANGUAGES.get(selected_language) != "implemented":
         return unsupported_language_report(activity, source, selected_language)
 

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -87,6 +87,7 @@ def run_test_case(binary: Path, test_case: dict[str, Any], *, timeout_seconds: i
             "name": name,
             "passed": False,
             "status": "timeout",
+            "returncode": None,
             "stdin": stdin,
             "expected_stdout": expected_stdout,
             "stdout": error.stdout or "",

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -207,13 +207,24 @@ def write_report(report: dict[str, Any], path: Path) -> None:
     path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
 
 
+def positive_int(value: str) -> int:
+    """Parse a positive integer CLI argument."""
+    try:
+        number = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("deve essere un numero intero") from error
+    if number <= 0:
+        raise argparse.ArgumentTypeError("deve essere un numero positivo")
+    return number
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Corregge in modo deterministico una consegna TheBitLab.")
     parser.add_argument("--activity", type=Path, required=True, help="Scheda attivita JSON con test_cases.")
     parser.add_argument("--source", type=Path, required=True, help="File sorgente da correggere.")
     parser.add_argument("--language", choices=sorted(SUPPORTED_LANGUAGES), help="Linguaggio da usare, se diverso dalla scheda.")
     parser.add_argument("--report", type=Path, help="Percorso report JSON da scrivere.")
-    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout compilazione/esecuzione.")
+    parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout compilazione/esecuzione.")
     return parser.parse_args()
 
 

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -129,7 +129,7 @@ def validate_test_cases(test_cases: Any) -> list[str]:
 
 def activity_language(activity: dict[str, Any], explicit_language: str | None = None) -> str:
     """Return the language requested by CLI or activity metadata."""
-    return (explicit_language or activity.get("linguaggio") or activity.get("language") or "c").lower()
+    return str(explicit_language or activity.get("linguaggio") or activity.get("language") or "c").strip().lower()
 
 
 def unsupported_language_report(activity: dict[str, Any], source: Path, language: str) -> dict[str, Any]:

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -107,6 +107,26 @@ def run_test_case(binary: Path, test_case: dict[str, Any], *, timeout_seconds: i
     }
 
 
+def validate_test_cases(test_cases: Any) -> list[str]:
+    """Validate minimal deterministic test case structure."""
+    if not isinstance(test_cases, list) or not test_cases:
+        return ["L'attivita deve contenere una lista non vuota test_cases."]
+
+    errors: list[str] = []
+    for index, test_case in enumerate(test_cases):
+        prefix = f"test_cases[{index}]"
+        if not isinstance(test_case, dict):
+            errors.append(f"{prefix} deve essere un oggetto")
+            continue
+        if "expected_stdout" not in test_case:
+            errors.append(f"{prefix}.expected_stdout mancante")
+        elif not isinstance(test_case["expected_stdout"], str):
+            errors.append(f"{prefix}.expected_stdout deve essere una stringa")
+        if "stdin" in test_case and not isinstance(test_case["stdin"], str):
+            errors.append(f"{prefix}.stdin deve essere una stringa")
+    return errors
+
+
 def activity_language(activity: dict[str, Any], explicit_language: str | None = None) -> str:
     """Return the language requested by CLI or activity metadata."""
     return (explicit_language or activity.get("linguaggio") or activity.get("language") or "c").lower()
@@ -173,11 +193,12 @@ def grade_c_activity(activity: dict[str, Any], source: Path, *, timeout_seconds:
         }
 
     test_cases = activity.get("test_cases", [])
-    if not isinstance(test_cases, list) or not test_cases:
+    test_case_errors = validate_test_cases(test_cases)
+    if test_case_errors:
         return {
             "passed": False,
             "status": "invalid-activity",
-            "error": "L'attivita deve contenere una lista non vuota test_cases.",
+            "errors": test_case_errors,
         }
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -161,6 +161,17 @@ def grade_activity(
 
 def grade_c_activity(activity: dict[str, Any], source: Path, *, timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
     """Compile and grade a C source file using test cases from an activity."""
+    if not source.exists():
+        return {
+            "passed": False,
+            "status": "source-not-found",
+            "activity_id": activity.get("id"),
+            "language": "c",
+            "source": str(source),
+            "tests": [],
+            "error": f"Sorgente non trovato: {source}",
+        }
+
     test_cases = activity.get("test_cases", [])
     if not isinstance(test_cases, list) or not test_cases:
         return {

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -71,6 +71,10 @@ def test_grade_activity_requires_test_cases(tmp_path) -> None:
 
     assert report["passed"] is False
     assert report["status"] == "invalid-activity"
+    assert report["activity_id"] == "vuota"
+    assert report["language"] == "c"
+    assert report["source"] == str(source)
+    assert report["tests"] == []
 
 
 def test_grade_activity_requires_expected_stdout(tmp_path) -> None:

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+
+from scripts import grade_activity
+
+
+def activity() -> dict:
+    return {
+        "id": "c-base-somma-001",
+        "linguaggio": "c",
+        "test_cases": [
+            {
+                "name": "somma positiva",
+                "stdin": "2 3\n",
+                "expected_stdout": "5\n",
+            },
+            {
+                "name": "somma con negativo",
+                "stdin": "-2 3\n",
+                "expected_stdout": "1\n",
+            },
+        ],
+    }
+
+
+def test_grade_activity_passes_valid_c_program(tmp_path) -> None:
+    source = tmp_path / "main.c"
+    source.write_text(
+        '#include <stdio.h>\nint main(void){int a,b; scanf("%d %d",&a,&b); printf("%d\\n", a+b); return 0;}\n',
+        encoding="utf-8",
+    )
+
+    report = grade_activity.grade_activity(activity(), source)
+
+    assert report["passed"] is True
+    assert report["summary"] == {"passed": 2, "total": 2}
+
+
+def test_grade_activity_reports_wrong_output(tmp_path) -> None:
+    source = tmp_path / "main.c"
+    source.write_text(
+        '#include <stdio.h>\nint main(void){int a,b; scanf("%d %d",&a,&b); printf("%d\\n", a-b); return 0;}\n',
+        encoding="utf-8",
+    )
+
+    report = grade_activity.grade_activity(activity(), source)
+
+    assert report["passed"] is False
+    assert report["status"] == "failed"
+    assert report["summary"]["passed"] == 0
+
+
+def test_grade_activity_reports_compile_error(tmp_path) -> None:
+    source = tmp_path / "main.c"
+    source.write_text("int main(void){ return }\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity(activity(), source)
+
+    assert report["passed"] is False
+    assert report["status"] == "compile-error"
+    assert report["tests"] == []
+
+
+def test_grade_activity_requires_test_cases(tmp_path) -> None:
+    source = tmp_path / "main.c"
+    source.write_text("int main(void){ return 0; }\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity({"id": "vuota", "linguaggio": "c"}, source)
+
+    assert report["passed"] is False
+    assert report["status"] == "invalid-activity"
+
+
+def test_write_report_writes_json(tmp_path) -> None:
+    report_path = tmp_path / "report.json"
+    report = {"passed": True, "status": "passed"}
+
+    grade_activity.write_report(report, report_path)
+
+    assert json.loads(report_path.read_text(encoding="utf-8")) == report
+
+
+def test_grade_activity_reports_unsupported_planned_language(tmp_path) -> None:
+    source = tmp_path / "main.py"
+    source.write_text("print(5)\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity({"id": "python-001", "linguaggio": "python", "test_cases": []}, source)
+
+    assert report["passed"] is False
+    assert report["status"] == "unsupported-language"
+    assert report["language"] == "python"

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import argparse
+import subprocess
 
 from scripts import grade_activity
 
@@ -131,6 +132,17 @@ def test_grade_activity_reports_unknown_language(tmp_path) -> None:
 
 def test_activity_language_strips_spaces() -> None:
     assert grade_activity.activity_language({"linguaggio": " C "}) == "c"
+
+
+def test_timeout_report_has_null_returncode(monkeypatch) -> None:
+    def timeout_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="submission", timeout=1)
+
+    monkeypatch.setattr(grade_activity.subprocess, "run", timeout_run)
+
+    report = grade_activity.run_test_case("submission", {"expected_stdout": ""}, timeout_seconds=1)
+
+    assert report["returncode"] is None
 
 
 def test_positive_int_rejects_zero() -> None:

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -73,6 +73,16 @@ def test_grade_activity_requires_test_cases(tmp_path) -> None:
     assert report["status"] == "invalid-activity"
 
 
+def test_grade_activity_reports_missing_source(tmp_path) -> None:
+    source = tmp_path / "missing.c"
+
+    report = grade_activity.grade_activity(activity(), source)
+
+    assert report["passed"] is False
+    assert report["status"] == "source-not-found"
+    assert report["tests"] == []
+
+
 def test_write_report_writes_json(tmp_path) -> None:
     report_path = tmp_path / "report.json"
     report = {"passed": True, "status": "passed"}

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -129,6 +129,10 @@ def test_grade_activity_reports_unknown_language(tmp_path) -> None:
     assert report["language"] == "brainheck"
 
 
+def test_activity_language_strips_spaces() -> None:
+    assert grade_activity.activity_language({"linguaggio": " C "}) == "c"
+
+
 def test_positive_int_rejects_zero() -> None:
     try:
         grade_activity.positive_int("0")

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -73,6 +73,17 @@ def test_grade_activity_requires_test_cases(tmp_path) -> None:
     assert report["status"] == "invalid-activity"
 
 
+def test_grade_activity_requires_expected_stdout(tmp_path) -> None:
+    source = tmp_path / "main.c"
+    source.write_text("int main(void){ return 0; }\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity({"id": "senza-output", "linguaggio": "c", "test_cases": [{"stdin": ""}]}, source)
+
+    assert report["passed"] is False
+    assert report["status"] == "invalid-activity"
+    assert "test_cases[0].expected_stdout mancante" in report["errors"]
+
+
 def test_grade_activity_reports_missing_source(tmp_path) -> None:
     source = tmp_path / "missing.c"
 

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -90,3 +90,14 @@ def test_grade_activity_reports_unsupported_planned_language(tmp_path) -> None:
     assert report["passed"] is False
     assert report["status"] == "unsupported-language"
     assert report["language"] == "python"
+
+
+def test_grade_activity_reports_unknown_language(tmp_path) -> None:
+    source = tmp_path / "main.xyz"
+    source.write_text("contenuto\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity({"id": "x-001", "linguaggio": "brainheck", "test_cases": []}, source)
+
+    assert report["passed"] is False
+    assert report["status"] == "unknown-language"
+    assert report["language"] == "brainheck"

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import argparse
 
 from scripts import grade_activity
 
@@ -101,3 +102,12 @@ def test_grade_activity_reports_unknown_language(tmp_path) -> None:
     assert report["passed"] is False
     assert report["status"] == "unknown-language"
     assert report["language"] == "brainheck"
+
+
+def test_positive_int_rejects_zero() -> None:
+    try:
+        grade_activity.positive_int("0")
+    except argparse.ArgumentTypeError as error:
+        assert "positivo" in str(error)
+    else:
+        raise AssertionError("positive_int should reject zero")


### PR DESCRIPTION
﻿## Obiettivo

Questa PR introduce il primo motore di correzione deterministica per TheBitLab.

Dopo il chiarimento sul fatto che gli studenti lavorano anche con piu linguaggi, la PR non nasce come grading solo C: introduce una base multi-linguaggio, con il runner C implementato per primo e gli altri linguaggi previsti nel modello.

## Linguaggi previsti

- `c`: implementato in questa PR;
- `python`: previsto;
- `javascript`: previsto;
- `nodejs`: previsto;
- `html`: previsto;
- `java`: previsto;
- `sql`: previsto;
- `golang`: previsto;
- `assembly`: previsto;
- `cpp`: previsto;
- `php`: previsto.

## Cosa cambia

- Aggiunge `scripts/grade_activity.py`:
  - legge una scheda attivita JSON;
  - legge il campo `linguaggio` o l'override `--language`;
  - seleziona il runner del linguaggio;
  - implementa il runner C con `gcc`;
  - esegue test case con `stdin` ed `expected_stdout`;
  - confronta stdout normalizzato;
  - produce report JSON;
  - restituisce `unsupported-language` per linguaggi previsti ma non ancora implementati.
- Aggiunge `activities/examples/c_sum_with_tests.json` come esempio di attivita C con test case.
- Aggiunge `tests/test_grade_activity.py` con test su:
  - programma C corretto;
  - output errato;
  - errore di compilazione;
  - attivita senza test case;
  - scrittura report JSON;
  - linguaggio previsto ma non ancora implementato.
- Aggiunge `doc/ASSIGNMENT_GRADING.md`.
- Aggiorna `doc/README.md` con il nuovo documento e script.

## Esempio

```bash
python scripts/grade_activity.py \
  --activity activities/examples/c_sum_with_tests.json \
  --source main.c \
  --language c \
  --report reports/c_sum_report.json
```

## Scelte progettuali

- Il risultato deterministico viene prima di qualsiasi feedback AI.
- Il runner C e solo il primo runner implementato.
- I linguaggi futuri sono dichiarati subito per evitare un'architettura C-only.
- La sandbox Docker non e ancora inclusa: arrivera nella PR successiva.
- I linguaggi non implementati producono un report deterministico `unsupported-language` invece di fallire in modo ambiguo.

## Validazione

Non ho eseguito test localmente in questa sessione. La PR include test pytest e si affida alla workflow Quality.


## Review finding e fix

### 1. Linguaggio sconosciuto confuso con runner pianificato

**Finding:** un valore `linguaggio` non presente in `SUPPORTED_LANGUAGES` veniva trattato come `unsupported-language`, uguale a un linguaggio previsto ma non ancora implementato.

**Come lo fixo:** distinguo i due casi: linguaggio fuori modello e linguaggio previsto ma non implementato.

**Fix:** aggiunto report `unknown-language` per linguaggi non riconosciuti, lasciando `unsupported-language` per runner pianificati ma non ancora disponibili.

Commit: [`e0880b2`](https://github.com/TheBitPoets/2cornot2c/commit/e0880b2e19ab0fd7309ba3240aaf5d863e1f148b)

### 2. Timeout CLI non vincolato

**Finding:** `--timeout` accettava `0` o valori negativi, con rischio di timeout immediati o comportamento poco chiaro.

**Come lo fixo:** aggiungo parser dedicato per interi positivi.

**Fix:** `--timeout` ora accetta solo numeri interi positivi.

Commit: [`a7cb4eb`](https://github.com/TheBitPoets/2cornot2c/commit/a7cb4eb87ac04ecfd7f2ec2d017412194d950dff)

### 3. Sorgente mancante riportato come compile-error

**Finding:** se il path `--source` non esisteva, il report finiva in errore di compilazione generico.

**Come lo fixo:** controllo l'esistenza del sorgente prima di invocare il compilatore.

**Fix:** il runner C ora restituisce `source-not-found` con messaggio esplicito.

Commit: [`5446804`](https://github.com/TheBitPoets/2cornot2c/commit/54468040b735fad062275c6526553f525192b4b7)

### 4. Test case non validati

**Finding:** i test case accettavano implicitamente `expected_stdout` mancante come stringa vuota, rendendo ambigua la correzione deterministica.

**Come lo fixo:** aggiungo validazione minima dei test case prima della compilazione/esecuzione.

**Fix:** `expected_stdout` e obbligatorio per ogni test case; `stdin`, se presente, deve essere stringa. Gli errori producono `invalid-activity`.

Commit: [`7ff5dc0`](https://github.com/TheBitPoets/2cornot2c/commit/7ff5dc017bb2948c98e11860f507a03c827c034b)

### 5. Limiti dei runner pianificati non ribaditi nei limiti attuali

**Finding:** la documentazione dichiarava i linguaggi pianificati sopra, ma nella sezione limiti non ribadiva che solo C e implementato.

**Come lo fixo:** aggiungo una nota esplicita nei limiti attuali.

**Fix:** `ASSIGNMENT_GRADING.md` ora indica che i runner pianificati ma non implementati restituiscono `unsupported-language`.

Commit: [`befa40f`](https://github.com/TheBitPoets/2cornot2c/commit/befa40f8b0c360326913b0a27ad95c492b607fce)

### 6. Indentazione poco leggibile nel report compile failure

**Finding:** nel dizionario restituito in caso di errore compilazione alcune chiavi erano indentate male.

**Come lo fixo:** riallineo la formattazione del blocco di report.

**Fix:** nessun cambio comportamentale, solo leggibilita del codice.

Commit: [`a502008`](https://github.com/TheBitPoets/2cornot2c/commit/a5020080546cdecb69e5196b30fac08811871581)


## Ulteriore review finding e fix

### 1. Report `invalid-activity` non uniforme

**Finding:** quando i `test_cases` erano invalidi, il report non includeva campi presenti negli altri errori del runner C, come `activity_id`, `language`, `source` e `tests`.

**Come lo fixo:** uniformo la forma del report anche per `invalid-activity`.

**Fix:** il report include ora `activity_id`, `language`, `source`, `tests` ed `errors`.

Commit: [`78c1ddc`](https://github.com/TheBitPoets/2cornot2c/commit/78c1ddc6df6bc7f693df8e6d313123d363a25654)

### 2. Linguaggio non normalizzato con spazi

**Finding:** `activity_language()` usava `.lower()` ma non `.strip()`, quindi valori come `" C "` diventavano sconosciuti.

**Come lo fixo:** normalizzo il linguaggio con `strip().lower()`.

**Fix:** valori con spazi accidentali vengono interpretati correttamente.

Commit: [`f3e787b`](https://github.com/TheBitPoets/2cornot2c/commit/f3e787b8c88e2911bfabf441c7130cfa987dab63)

### 3. Vincoli dei test case non documentati

**Finding:** il codice richiede `expected_stdout` e valida il tipo di `stdin`, ma la documentazione non lo dichiarava.

**Come lo fixo:** aggiorno `ASSIGNMENT_GRADING.md` nella sezione test case.

**Fix:** la documentazione ora indica che `expected_stdout` e obbligatorio e che `stdin`, se presente, deve essere stringa.

Commit: [`73c6ee9`](https://github.com/TheBitPoets/2cornot2c/commit/73c6ee9b3e0932c03fb933ffa3c3f0306080c340)

### 4. Report timeout senza `returncode`

**Finding:** i report dei test completati includevano `returncode`, mentre i timeout no. Questo poteva complicare dashboard e consumer dei report.

**Come lo fixo:** aggiungo `returncode: null` ai report di timeout.

**Fix:** i timeout ora mantengono una forma piu uniforme del report.

Commit: [`aa12ab9`](https://github.com/TheBitPoets/2cornot2c/commit/aa12ab97e8c2678f3aaeda0443881fac698fb6f9)
