### PR TITLE
Definisce flusso consegne GitHub per TheBitLab

### DIFF
--- a/doc/ASSIGNMENTS.md
+++ b/doc/ASSIGNMENTS.md
@@ -17,6 +17,7 @@ Per orientarti rapidamente:
 
 - [Assunzioni organizzative](#assunzioni-organizzative): organizzazione GitHub, team classe e repository;
 - [Strategia iniziale per i repository studenti](#strategia-iniziale-per-i-repository-studenti): scelta operativa di partenza;
+- [Flusso consegne studenti con GitHub](ASSIGNMENT_SUBMISSIONS.md): processo operativo per repository studente, push/PR, grading e report;
 - [Correzione automatica reale](#correzione-automatica-reale): grading deterministico e sicurezza;
 - [Metriche individuali e di classe](#metriche-individuali-e-di-classe): cosa misurare e con quali limiti;
 - [Policy minima per AI assisted](#policy-minima-per-ai-assisted): dati, privacy e modalita AI;
@@ -990,6 +991,8 @@ File possibili:
 - `doc/ASSIGNMENT_SANDBOX.md`
 
 ### PR 6: Report e metriche
+
+Stato: da fare, dopo il flusso consegne GitHub.
 
 Obiettivo:
 

--- a/doc/ASSIGNMENTS.md
+++ b/doc/ASSIGNMENTS.md
@@ -219,7 +219,7 @@ La fase di grading deve rispettare queste regole:
 - non usare segreti;
 - non usare `pull_request_target` per eseguire codice proveniente da fork o repository studente;
 - avere timeout espliciti;
-- produrre report come file o artifact;
+- produrre report come artifact o raccolta centralizzata, seguendo il flusso descritto in `ASSIGNMENT_SUBMISSIONS.md`;
 - non avere accesso a credenziali o token con permessi di scrittura;
 - eseguire il codice in sandbox appena il runner Docker sara disponibile.
 
@@ -1003,7 +1003,7 @@ Obiettivo:
 File possibili:
 
 - `scripts/collect_assignment_metrics.py`
-- `reports/`
+- `teacher-reports/` o altra raccolta centralizzata non modificabile dagli studenti
 - `doc/ASSIGNMENT_METRICS.md`
 
 ### PR 7: AI assisted feedback

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -85,6 +85,8 @@ Il file `latest.json` rappresenta l'ultimo esito noto.
 
 I file `attempt-*.json` permettono di conservare la storia dei tentativi.
 
+Nell'MVP, pero, il report autorevole e quello prodotto dalla GitHub Action come artifact o raccolto dal docente tramite automazione dedicata. I file dentro `reports/` nel repository studente sono copie informative o cache locali: non devono essere usati come unica fonte per metriche ufficiali, perche lo studente potrebbe modificarli manualmente.
+
 ## Stati della consegna
 
 Una consegna dovrebbe attraversare stati espliciti.
@@ -246,6 +248,14 @@ Il report deve essere il dato principale per:
 - metriche individuali;
 - metriche di classe;
 - feedback AI assisted.
+
+Per dashboard e metriche docente, la fonte autorevole deve essere:
+
+- artifact prodotto dal workflow di grading;
+- esito del check GitHub;
+- raccolta centralizzata eseguita dal docente o da TheBitLab.
+
+Una copia versionata nel repository studente puo essere utile per consultazione, ma non deve essere l'unica sorgente affidabile.
 
 ## Metriche minime
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -287,14 +287,16 @@ Per ogni consegna conviene raccogliere almeno:
 
 Queste metriche non devono diventare sorveglianza. Servono a capire difficolta, progressi e bisogni di recupero.
 
-## File indice futuro
+## File indice centralizzato futuro
 
-Per aggregare le consegne senza database, una prima versione puo usare file JSON versionati.
+Per aggregare le consegne senza database, una prima versione puo usare file JSON versionati in un repository docente, nel repository sorgente o in una raccolta centralizzata TheBitLab.
+
+Questo indice non deve vivere come fonte autorevole nel repository studente.
 
 Esempio:
 
 ```text
-reports/index.json
+teacher-reports/class-index.json
 ```
 
 Esempio concettuale:

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -1,0 +1,323 @@
+# Flusso consegne studenti con GitHub
+
+Questo documento descrive il primo flusso operativo per assegnare, consegnare, correggere e tracciare esercizi TheBitLab usando GitHub come infrastruttura iniziale.
+
+L'obiettivo non e costruire subito una piattaforma completa, ma definire un processo chiaro, automatizzabile e abbastanza semplice da poter essere nascosto in futuro dietro una CLI, una TUI o una UI grafica.
+
+## Obiettivo
+
+Il flusso deve permettere al docente di:
+
+- assegnare attivita a una classe;
+- usare i team GitHub dell'organizzazione `TheBitPoets` come gruppi classe;
+- far lavorare ogni studente nel proprio repository;
+- avviare grading deterministico in sandbox Docker;
+- raccogliere report e metriche;
+- preparare feedback AI assisted in una fase separata e sicura.
+
+Lo studente, nella prima fase, puo usare GitHub direttamente. In seguito TheBitLab dovra nascondere le operazioni Git piu difficili dietro azioni didattiche come "Inizia", "Salva", "Consegna" e "Controlla risultato".
+
+## Attori
+
+| Attore | Responsabilita |
+|---|---|
+| Docente | Crea attivita, assegna consegne, controlla report e metriche |
+| Team GitHub classe | Rappresenta una classe dentro `TheBitPoets` |
+| Studente | Lavora nel proprio repository e consegna tramite push o PR |
+| Repository sorgente | Contiene lezioni, schede attivita, runner, test e template |
+| Repository studente | Contiene il lavoro dello studente, tentativi, report e feedback |
+| GitHub Actions | Esegue grading, sandbox e raccolta artifact |
+| TheBitLab | Automatizza progressivamente creazione, consegna, controllo e lettura risultati |
+
+## Modello repository
+
+La scelta iniziale consigliata e un repository per studente dentro l'organizzazione `TheBitPoets`.
+
+Esempio:
+
+```text
+TheBitPoets/tpsi-3a-rossi-mario
+TheBitPoets/tpsi-3a-bianchi-luca
+```
+
+Ogni repository studente dovrebbe nascere da un template comune.
+
+Il template dovrebbe contenere almeno:
+
+```text
+assignments/
+reports/
+feedback/
+.github/workflows/
+README.md
+```
+
+Significato:
+
+| Path | Scopo |
+|---|---|
+| `assignments/` | Codice e file consegnati dallo studente |
+| `reports/` | Report deterministici prodotti dal grading |
+| `feedback/` | Feedback docente o AI assisted approvato |
+| `.github/workflows/` | Workflow di correzione |
+| `README.md` | Istruzioni per lo studente |
+
+## Struttura di una consegna
+
+Ogni consegna dovrebbe avere un identificativo stabile uguale o derivato dall'activity JSON.
+
+Esempio:
+
+```text
+assignments/c-base-somma-001/
+  main.c
+  README.md
+
+reports/c-base-somma-001/
+  attempt-001.json
+  latest.json
+
+feedback/c-base-somma-001/
+  latest.md
+```
+
+Il file `latest.json` rappresenta l'ultimo esito noto.
+
+I file `attempt-*.json` permettono di conservare la storia dei tentativi.
+
+## Stati della consegna
+
+Una consegna dovrebbe attraversare stati espliciti.
+
+| Stato | Significato |
+|---|---|
+| `assigned` | Attivita assegnata allo studente |
+| `started` | Lo studente ha iniziato a lavorare |
+| `submitted` | Lo studente ha fatto push o PR |
+| `grading-running` | La GitHub Action sta correggendo |
+| `passed` | Test deterministici superati |
+| `failed` | Test deterministici falliti |
+| `needs-feedback` | Serve feedback docente o AI |
+| `feedback-ready` | Feedback disponibile |
+| `reviewed` | Il docente ha controllato |
+| `closed` | Attivita conclusa |
+
+Questi stati possono essere calcolati inizialmente da commit, workflow e report. In futuro TheBitLab potra salvarli in un file indice o in un database.
+
+## Flusso docente
+
+### 1. Preparare la classe
+
+1. Creare o verificare il team GitHub della classe in `TheBitPoets`.
+2. Aggiungere gli studenti al team.
+3. Scegliere o creare il template repository studente.
+4. Creare un repository per ogni studente.
+5. Associare ogni repository al team corretto.
+
+Questa fase potra essere automatizzata da una futura CLI TheBitLab.
+
+### 2. Preparare l'attivita
+
+1. Creare una scheda activity JSON.
+2. Validarla con `scripts/validate_activity.py`.
+3. Collegarla a percorso, UDA e argomenti.
+4. Preparare eventuali test case.
+5. Decidere se richiede grading Docker.
+
+Esempio:
+
+```bash
+python scripts/validate_activity.py activities/examples/c_sum_with_tests.json
+```
+
+### 3. Pubblicare l'attivita
+
+Nella prima fase, pubblicare significa rendere disponibile l'activity JSON e indicare allo studente dove mettere la soluzione.
+
+Esempio didattico:
+
+```text
+Attivita: c-base-somma-001
+Path consegna: assignments/c-base-somma-001/main.c
+Comando locale opzionale:
+python scripts/grade_activity.py --activity activities/c-base-somma-001.json --source assignments/c-base-somma-001/main.c --language c --docker --report reports/c-base-somma-001/latest.json
+```
+
+In futuro TheBitLab potra creare automaticamente cartelle, branch, issue o PR.
+
+## Flusso studente
+
+Lo studente dovrebbe vedere un processo semplice.
+
+| Azione didattica | Operazioni tecniche possibili |
+|---|---|
+| Inizia esercizio | crea cartella consegna o branch |
+| Salva progresso | commit locale o remoto |
+| Consegna | push o apertura PR |
+| Controlla risultato | lettura stato GitHub Actions |
+| Correggi e riprova | nuovo commit e nuovo tentativo |
+| Leggi feedback | apertura report o feedback Markdown |
+
+Nella fase iniziale lo studente puo lavorare direttamente con GitHub.
+
+Nel frontend TheBitLab, invece, Git dovrebbe diventare progressivo:
+
+| Livello | Esperienza |
+|---|---|
+| Git invisibile | Lo studente clicca "Consegna" |
+| Git assistito | La UI spiega che sta creando commit e push |
+| Git esplicito | La UI mostra anche i comandi Git equivalenti |
+
+## Evento di consegna
+
+Una consegna puo essere attivata da:
+
+- push su branch principale del repository studente;
+- push su branch dedicato all'attivita;
+- pull request verso un branch di consegna;
+- comando TheBitLab che esegue commit e push.
+
+Scelta iniziale consigliata:
+
+| Contesto | Evento consigliato |
+|---|---|
+| Esercizi a casa | push su repository studente |
+| Laboratorio guidato | push o comando TheBitLab |
+| Verifica pratica | branch o repository dedicato |
+| Revisione docente | pull request |
+
+Per studenti alle prime armi, TheBitLab dovrebbe nascondere push e PR dietro il bottone "Consegna".
+
+## Workflow di grading
+
+Il workflow di grading deve essere separato in due fasi.
+
+| Fase | Esegue codice studente | Puo usare segreti | Output |
+|---|---|---|---|
+| Grading deterministico | Si | No | report JSON |
+| Feedback/reporting | No | Solo se necessario | feedback, riepiloghi, dashboard |
+
+La fase di grading dovrebbe:
+
+- usare `permissions: contents: read`;
+- non usare segreti;
+- eseguire `scripts/grade_activity.py --docker`;
+- salvare il report come artifact o file versionato;
+- fallire se il grading fallisce;
+- non inviare codice studente a provider AI.
+
+La fase feedback puo leggere il report e generare spiegazioni, ma non deve eseguire codice studente.
+
+## Report
+
+Il report deterministico minimo e quello prodotto da:
+
+```text
+scripts/grade_activity.py
+```
+
+Esempio:
+
+```json
+{
+  "passed": false,
+  "status": "failed",
+  "activity_id": "c-base-somma-001",
+  "language": "c",
+  "summary": {
+    "passed": 1,
+    "total": 2
+  }
+}
+```
+
+Il report deve essere il dato principale per:
+
+- stato della consegna;
+- tentativi;
+- errori ricorrenti;
+- metriche individuali;
+- metriche di classe;
+- feedback AI assisted.
+
+## Metriche minime
+
+Per ogni consegna conviene raccogliere almeno:
+
+| Metrica | Fonte |
+|---|---|
+| Studente/repository | metadati GitHub |
+| Classe/team | team GitHub |
+| Activity ID | activity JSON |
+| Timestamp consegna | commit, push o workflow |
+| Numero tentativo | report precedenti |
+| Esito | report JSON |
+| Test superati/totali | report JSON |
+| Errori compilazione | report JSON |
+| Errori esecuzione | report JSON |
+| Ritardo | confronto con scadenza |
+
+Queste metriche non devono diventare sorveglianza. Servono a capire difficolta, progressi e bisogni di recupero.
+
+## File indice futuro
+
+Per aggregare le consegne senza database, una prima versione puo usare file JSON versionati.
+
+Esempio:
+
+```text
+reports/index.json
+```
+
+Esempio concettuale:
+
+```json
+{
+  "class_team": "3A-TPSI",
+  "assignments": [
+    {
+      "activity_id": "c-base-somma-001",
+      "student_repo": "TheBitPoets/tpsi-3a-rossi-mario",
+      "status": "passed",
+      "attempts": 3,
+      "latest_report": "reports/c-base-somma-001/latest.json"
+    }
+  ]
+}
+```
+
+Questo indice potra alimentare una dashboard Markdown, CLI, TUI o web.
+
+## Automazioni future
+
+TheBitLab potra automatizzare:
+
+- creazione repository studenti da template;
+- associazione repository a team GitHub;
+- assegnazione activity a una classe;
+- apertura issue o PR per consegna;
+- commit/push assistito;
+- lettura stato GitHub Actions;
+- download artifact report;
+- generazione dashboard classe;
+- feedback AI assisted da report deterministico.
+
+## Regole di sicurezza
+
+Regole minime:
+
+- il job che esegue codice studente non deve avere segreti;
+- il grading deve usare sandbox Docker;
+- i report devono essere prodotti prima di qualsiasi feedback AI;
+- i provider AI non devono ricevere token o dati personali non necessari;
+- eventuali classifiche devono essere progettate con visibilita diversa per docente e studenti.
+
+## Prossimi passi
+
+Le prossime PR possono introdurre:
+
+1. Template repository studente.
+2. Workflow grading riusabile per repository studente.
+3. Script per generare scaffold consegna.
+4. Script per raccogliere report e metriche.
+5. Dashboard Markdown minima per docente.

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -145,6 +145,8 @@ Comando locale opzionale:
 python scripts/grade_activity.py --activity activities/c-base-somma-001.json --source assignments/c-base-somma-001/main.c --language c --docker --report reports/c-base-somma-001/latest.json
 ```
 
+Questo comando serve per prova locale o autoverifica. Il report autorevole per docente, metriche e dashboard deve arrivare dalla GitHub Action di grading o da una raccolta centralizzata.
+
 In futuro TheBitLab potra creare automaticamente cartelle, branch, issue o PR.
 
 ## Flusso studente

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -202,9 +202,16 @@ La fase di grading dovrebbe:
 - usare `permissions: contents: read`;
 - non usare segreti;
 - eseguire `scripts/grade_activity.py --docker`;
-- salvare il report come artifact o file versionato;
+- salvare il report come artifact GitHub;
 - fallire se il grading fallisce;
 - non inviare codice studente a provider AI.
+
+Il job di grading non deve committare file nel repository studente, perche per farlo avrebbe bisogno di permessi di scrittura. Se serve una copia versionata del report, deve produrla una fase separata di reporting che:
+
+- non esegue codice studente;
+- legge solo artifact/report gia prodotti;
+- usa permessi espliciti e limitati;
+- mantiene separata la scrittura dei risultati dall'esecuzione del codice.
 
 La fase feedback puo leggere il report e generare spiegazioni, ma non deve eseguire codice studente.
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -312,7 +312,7 @@ Esempio concettuale:
       "student_repo": "TheBitPoets/tpsi-3a-rossi-mario",
       "status": "passed",
       "attempts": 3,
-      "latest_report": "reports/c-base-somma-001/latest.json"
+      "latest_report_artifact": "grading-reports/c-base-somma-001/attempt-003.json"
     }
   ]
 }

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -57,7 +57,7 @@ Significato:
 | Path | Scopo |
 |---|---|
 | `assignments/` | Codice e file consegnati dallo studente |
-| `reports/` | Report deterministici prodotti dal grading |
+| `reports/` | Copie informative o cache locali dei report; la fonte autorevole resta artifact/raccolta centralizzata |
 | `feedback/` | Feedback docente o AI assisted approvato |
 | `.github/workflows/` | Workflow di correzione |
 | `README.md` | Istruzioni per lo studente |

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -183,10 +183,21 @@ Scelta iniziale consigliata:
 
 | Contesto | Evento consigliato |
 |---|---|
-| Esercizi a casa | push su repository studente |
-| Laboratorio guidato | push o comando TheBitLab |
+| Esercizi a casa | push su `main` del repository studente |
+| Laboratorio guidato | push su `main` o comando TheBitLab equivalente |
 | Verifica pratica | branch o repository dedicato |
 | Revisione docente | pull request |
+
+Per l'MVP, il default operativo e:
+
+```text
+repository studente
+branch: main
+path soluzione: assignments/<activity_id>/
+evento: push
+```
+
+Branch dedicati, pull request e repository separati restano opzioni avanzate per verifiche pratiche, revisioni formali o attivita in cui serve maggiore controllo.
 
 Per studenti alle prime armi, TheBitLab dovrebbe nascondere push e PR dietro il bottone "Consegna".
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -39,6 +39,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | [`COURSE_BOARD.md`](COURSE_BOARD.md) | Quando devi usare la board dei progetti didattici, il calendario scolastico o le funzioni AI assisted |
 | [`ASSIGNMENTS.md`](ASSIGNMENTS.md) | Quando devi progettare esercizi, compiti, verifiche, correzioni automatiche o metriche di classe |
 | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) | Quando devi creare o validare schede JSON di attivita TheBitLab |
+| [`ASSIGNMENT_SUBMISSIONS.md`](ASSIGNMENT_SUBMISSIONS.md) | Quando devi progettare il flusso consegne studenti con GitHub, team classe e repository studente |
 | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) | Quando devi correggere in modo deterministico una consegna TheBitLab |
 | [`ASSIGNMENT_SANDBOX.md`](ASSIGNMENT_SANDBOX.md) | Quando devi eseguire il grading in una sandbox Docker |
 | [`TESTING.md`](TESTING.md) | Quando devi lanciare test locali o capire quali GitHub Actions sono attive |


### PR DESCRIPTION
﻿﻿﻿﻿﻿﻿﻿﻿## Obiettivo

Questa PR definisce il primo flusso operativo per le consegne studenti TheBitLab usando GitHub come infrastruttura iniziale.

Dopo schema attivita, grading deterministico e sandbox Docker, questo passo chiarisce come usare organizzazione `TheBitPoets`, team GitHub, repository studente, push/PR, report e metriche.

## Cosa cambia

- Aggiunge `doc/ASSIGNMENT_SUBMISSIONS.md`:
  - attori del flusso;
  - modello repository studente;
  - struttura cartelle per consegne, report e feedback;
  - stati della consegna;
  - flusso docente;
  - flusso studente;
  - eventi GitHub che possono attivare consegne;
  - separazione tra grading deterministico e feedback/reporting;
  - metriche minime;
  - file indice futuro;
  - automazioni future TheBitLab.
- Aggiorna `doc/README.md` collegando il nuovo documento.
- Aggiorna `doc/ASSIGNMENTS.md` collegando il flusso consegne alla roadmap.

## Scelte progettuali

- GitHub resta l'identita iniziale degli studenti.
- I team GitHub rappresentano le classi.
- La scelta iniziale consigliata e un repository per studente dentro `TheBitPoets`.
- Il grading che esegue codice studente deve restare separato da feedback AI e job con segreti.
- TheBitLab dovra nascondere progressivamente Git dietro azioni didattiche semplici.

## Cosa non implementa ancora

- Non crea repository studenti automaticamente.
- Non aggiunge ancora template repository studente.
- Non aggiunge workflow riusabile per i repository studenti.
- Non raccoglie ancora metriche reali.
- Non aggiunge dashboard docente.

## Prossimi step naturali

1. Template repository studente.
2. Workflow grading riusabile per repository studente.
3. Script scaffold consegna.
4. Raccolta report e metriche.
5. Dashboard Markdown minima per docente.

## Validazione

Non ho eseguito test locali: la PR e documentale.
## Review finding e fix

### 1. Report versionati e permessi `contents: read` sono ambigui

**Finding:** il documento citava report in `reports/` e report come artifact/file versionato, ma il job di grading consigliato usa `permissions: contents: read`, quindi non puo committare report nel repository studente.

**Come lo fixo:** chiarisco che il default sicuro dell'MVP e il report come artifact GitHub; eventuali report versionati devono essere prodotti solo da una fase separata di reporting che non esegue codice studente e ha permessi espliciti.

**Fix:** la sezione workflow ora indica il report come artifact GitHub e chiarisce che il job di grading non deve committare nel repository studente.

Commit: [`2757231`](https://github.com/TheBitPoets/2cornot2c/commit/2757231)

### 2. `latest.json` nel repository studente non e una fonte autorevole

**Finding:** se `reports/latest.json` vive nel repository studente, lo studente puo modificarlo manualmente. Per metriche e dashboard docente sarebbe una fonte fragile.

**Come lo fixo:** distinguo tra report autorevole prodotto dalla GitHub Action/artifact e copia locale informativa nel repository studente.

**Fix:** il documento ora dichiara che artifact, check GitHub e raccolta docente/TheBitLab sono fonti autorevoli; i file in `reports/` nel repo studente sono copie informative o cache locali.

Commit: [`bf0943b`](https://github.com/TheBitPoets/2cornot2c/commit/bf0943b)

### 3. Evento di consegna troppo aperto per la prima implementazione

**Finding:** push, branch, PR e comando TheBitLab erano descritti come opzioni quasi equivalenti. Per il primo template e la prima CLI serve un default unico.

**Come lo fixo:** aggiungo una scelta MVP esplicita: push su `main` con soluzione in `assignments/<activity_id>/`; branch e PR restano opzioni avanzate per verifiche o revisioni.

**Fix:** aggiunta la sezione default MVP: repository studente, branch `main`, path `assignments/<activity_id>/`, evento `push`.

Commit: [`4dd881b`](https://github.com/TheBitPoets/2cornot2c/commit/4dd881b)

## Seconda review finding e fix

### 1. File indice futuro ambiguo rispetto al repository studente

**Finding:** la sezione File indice futuro usava `reports/index.json`, ma non specificava chiaramente che l'indice autorevole non deve vivere nel repository studente.

**Come lo fixo:** rinomino e contestualizzo l'esempio come indice centralizzato docente, separato dai file modificabili dallo studente.

**Fix:** la sezione ora parla di file indice centralizzato futuro e usa `teacher-reports/class-index.json`, specificando che non deve essere una fonte autorevole nel repository studente.

Commit: [`3c9a2d0`](https://github.com/TheBitPoets/2cornot2c/commit/3c9a2d0)

### 2. Comando locale opzionale sembra produrre un report ufficiale

**Finding:** l'esempio di comando locale scriveva in `reports/.../latest.json` senza chiarire che e solo una prova locale/autoverifica e non il report autorevole docente.

**Come lo fixo:** aggiungo una nota subito dopo l'esempio per distinguere autoverifica locale e report autorevole prodotto dalla GitHub Action.

**Fix:** il documento ora dichiara che il comando locale serve per prova/autoverifica; report docente, metriche e dashboard devono arrivare dalla GitHub Action o da raccolta centralizzata.

Commit: [`51a0cc3`](https://github.com/TheBitPoets/2cornot2c/commit/51a0cc3)

## Terza review finding e fix

### 1. Esempio indice centralizzato punta ancora a `reports/.../latest.json`

**Finding:** l'esempio dell'indice centralizzato usava `latest_report: reports/.../latest.json`, che poteva sembrare di nuovo un path dentro il repository studente.

**Come lo fixo:** rendo il campo esplicito come riferimento ad artifact o raccolta centralizzata.

**Fix:** l'esempio ora usa `latest_report_artifact: grading-reports/.../attempt-003.json`, chiarendo che l'indice punta a un report raccolto centralmente e non a una copia modificabile dallo studente.

Commit: [`ff73c49`](https://github.com/TheBitPoets/2cornot2c/commit/ff73c49)

### 2. `reports/` nel template studente sembra ancora prodotto diretto del grading

**Finding:** nella tabella iniziale il path `reports/` era descritto come report deterministici prodotti dal grading, ma il grading autorevole deve produrre artifact o raccolta centralizzata.

**Come lo fixo:** cambio la descrizione di `reports/` in copia informativa/cache locale opzionale.

**Fix:** la tabella del template repository ora descrive `reports/` come copie informative o cache locali; la fonte autorevole resta artifact/raccolta centralizzata.

Commit: [`181ef72`](https://github.com/TheBitPoets/2cornot2c/commit/181ef72)

## Quarta review finding e fix

### 1. `ASSIGNMENTS.md` resta ambiguo rispetto al default artifact

**Finding:** `ASSIGNMENTS.md` diceva ancora "produrre report come file o artifact" e citava genericamente `reports/` nella roadmap, mentre `ASSIGNMENT_SUBMISSIONS.md` ha chiarito che la fonte autorevole deve essere artifact/raccolta centralizzata.

**Come lo fixo:** aggiorno `ASSIGNMENTS.md` per rimandare al default sicuro definito in `ASSIGNMENT_SUBMISSIONS.md`.

**Fix:** la regola di sicurezza ora parla di artifact/raccolta centralizzata; la roadmap propone `teacher-reports/` o raccolta centralizzata non modificabile dagli studenti.

Commit: [`dae588f`](https://github.com/TheBitPoets/2cornot2c/commit/dae588f)
