### PR TITLE
Aggiunge scaffold consegna studente

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -55,6 +55,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/generate_course_plan.py` | Rigenera `doc/PERCORSO_DIDATTICO.md` dal progetto didattico corrente | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/update_course_frames.py` | Inserisce nel README le cornici didattiche presenti nel progetto | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/create_activity.py` | Crea una scheda JSON di attivita TheBitLab da prompt guidato o argomenti CLI | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
+| `scripts/create_submission_scaffold.py` | Crea una cartella consegna in un repository studente a partire da una activity JSON | [`STUDENT_REPOSITORY_TEMPLATE.md`](STUDENT_REPOSITORY_TEMPLATE.md) |
 | `scripts/validate_activity.py` | Valida le schede JSON di attivita TheBitLab | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 | `scripts/grade_activity.py` | Esegue il runner deterministico del linguaggio richiesto e produce un report, anche via Docker | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) |
 

--- a/doc/STUDENT_REPOSITORY_TEMPLATE.md
+++ b/doc/STUDENT_REPOSITORY_TEMPLATE.md
@@ -169,3 +169,5 @@ assignments/<activity_id>/
 ```
 
 Lo scaffold non sovrascrive una consegna gia esistente, a meno di usare `--force`.
+
+`--force` aggiorna `activity.json` e `README.md`, ma non sovrascrive il sorgente se esiste gia. Per rigenerare anche il sorgente starter serve `--overwrite-source`.

--- a/doc/STUDENT_REPOSITORY_TEMPLATE.md
+++ b/doc/STUDENT_REPOSITORY_TEMPLATE.md
@@ -156,7 +156,6 @@ Per creare una cartella consegna compatibile con il template puoi usare:
 python scripts/create_submission_scaffold.py \
   --activity activities/examples/c_sum_with_tests.json \
   --target templates/student-repository \
-  --source-name main.c \
   --thebitlab-ref main
 ```
 
@@ -165,9 +164,26 @@ Lo script crea:
 ```text
 assignments/<activity_id>/
   activity.json
-  main.c
+  <source-file>
   README.md
 ```
+
+Se non passi `--source-name`, il nome del sorgente viene scelto in base al linguaggio della activity:
+
+| Linguaggio | File generato |
+|---|---|
+| `c` | `main.c` |
+| `python` | `main.py` |
+| `javascript` / `nodejs` | `main.js` |
+| `java` | `Main.java` |
+| `cpp` | `main.cpp` |
+| `go` | `main.go` |
+| `html` | `index.html` |
+| `php` | `main.php` |
+| `sql` | `main.sql` |
+| `assembly` | `main.asm` |
+
+Usa `--source-name` solo quando vuoi forzare un nome diverso da quello predefinito.
 
 Lo scaffold non sovrascrive una consegna gia esistente, a meno di usare `--force`.
 

--- a/doc/STUDENT_REPOSITORY_TEMPLATE.md
+++ b/doc/STUDENT_REPOSITORY_TEMPLATE.md
@@ -143,8 +143,29 @@ Qualunque fase di feedback AI deve essere separata dal grading.
 
 Le prossime PR possono aggiungere:
 
-1. script per creare lo scaffold di una consegna in `assignments/<activity_id>/`;
-2. trigger automatico su push;
-3. raccolta centralizzata degli artifact;
-4. dashboard docente minima;
-5. automazione GitHub per creare repository studenti da template.
+1. trigger automatico su push;
+2. raccolta centralizzata degli artifact;
+3. dashboard docente minima;
+4. automazione GitHub per creare repository studenti da template.
+
+## Scaffold consegna
+
+Per creare una cartella consegna compatibile con il template puoi usare:
+
+```bash
+python scripts/create_submission_scaffold.py \
+  --activity activities/examples/c_sum_with_tests.json \
+  --target templates/student-repository \
+  --source-name main.c
+```
+
+Lo script crea:
+
+```text
+assignments/<activity_id>/
+  activity.json
+  main.c
+  README.md
+```
+
+Lo scaffold non sovrascrive una consegna gia esistente, a meno di usare `--force`.

--- a/doc/STUDENT_REPOSITORY_TEMPLATE.md
+++ b/doc/STUDENT_REPOSITORY_TEMPLATE.md
@@ -156,7 +156,8 @@ Per creare una cartella consegna compatibile con il template puoi usare:
 python scripts/create_submission_scaffold.py \
   --activity activities/examples/c_sum_with_tests.json \
   --target templates/student-repository \
-  --source-name main.c
+  --source-name main.c \
+  --thebitlab-ref main
 ```
 
 Lo script crea:

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -100,6 +100,7 @@ def create_scaffold(
     source_name: str = DEFAULT_SOURCE_NAME,
     language: str | None = None,
     overwrite: bool = False,
+    overwrite_source: bool = False,
 ) -> Path:
     """Create an assignment scaffold in a student repository."""
     activity = load_activity(activity_path)
@@ -120,7 +121,7 @@ def create_scaffold(
     )
 
     source_path = destination / source_name
-    if overwrite or not source_path.exists():
+    if overwrite_source or not source_path.exists():
         source_path.write_text(starter_source(selected_language), encoding="utf-8", newline="\n")
 
     (destination / "README.md").write_text(
@@ -138,6 +139,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--source-name", default=DEFAULT_SOURCE_NAME, help="Nome del file sorgente da creare.")
     parser.add_argument("--language", help="Linguaggio da usare, se diverso dalla activity.")
     parser.add_argument("--force", action="store_true", help="Sovrascrive una consegna gia esistente.")
+    parser.add_argument("--overwrite-source", action="store_true", help="Sovrascrive anche il sorgente se esiste.")
     return parser.parse_args()
 
 
@@ -150,6 +152,7 @@ def main() -> int:
             source_name=args.source_name,
             language=args.language,
             overwrite=args.force,
+            overwrite_source=args.overwrite_source,
         )
     except ValueError as error:
         print(f"Scaffold consegna non creato:\n{error}")

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -81,7 +81,11 @@ def language_for(activity: dict[str, Any], explicit_language: str | None = None)
     """Return the language requested by CLI or activity metadata."""
     if explicit_language is not None:
         return validate_language(explicit_language)
-    return validate_language(activity.get("linguaggio") or activity.get("language") or "c")
+    if "linguaggio" in activity:
+        return validate_language(activity["linguaggio"])
+    if "language" in activity:
+        return validate_language(activity["language"])
+    return validate_language("c")
 
 
 def validate_language(value: Any) -> str:

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -50,6 +50,15 @@ def scaffold_dir(target_dir: Path, identifier: str) -> Path:
     return target_dir / "assignments" / identifier
 
 
+def validate_source_name(source_name: str) -> str:
+    """Validate that a source name is a simple filename."""
+    value = source_name.strip()
+    path = Path(value)
+    if not value or path.name != value or path.is_absolute() or "/" in value or "\\" in value:
+        raise ValueError("source_name deve essere un nome file semplice, per esempio main.c.")
+    return value
+
+
 def starter_source(language: str) -> str:
     """Return a minimal starter source for the requested language."""
     if language == "c":
@@ -97,6 +106,7 @@ def create_scaffold(
     identifier = activity_id(activity)
     validate_activity_or_raise(activity, identifier)
     selected_language = language_for(activity, language)
+    source_name = validate_source_name(source_name)
     destination = scaffold_dir(target_dir, identifier)
 
     if destination.exists() and any(destination.iterdir()) and not overwrite:

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -12,6 +12,26 @@ from scripts import validate_activity
 DEFAULT_TARGET_DIR = Path(".")
 DEFAULT_SOURCE_NAME = "main.c"
 DEFAULT_THEBITLAB_REF = "main"
+SUPPORTED_LANGUAGES = {
+    "assembly",
+    "c",
+    "cpp",
+    "go",
+    "html",
+    "java",
+    "javascript",
+    "nodejs",
+    "php",
+    "python",
+    "sql",
+}
+LANGUAGE_ALIASES = {
+    "c++": "cpp",
+    "golang": "go",
+    "js": "javascript",
+    "node": "nodejs",
+    "py": "python",
+}
 
 
 def is_safe_slug(value: str) -> bool:
@@ -46,7 +66,17 @@ def validate_activity_or_raise(activity: dict[str, Any], identifier: str) -> Non
 
 def language_for(activity: dict[str, Any], explicit_language: str | None = None) -> str:
     """Return the language requested by CLI or activity metadata."""
-    return str(explicit_language or activity.get("linguaggio") or activity.get("language") or "c").strip().lower()
+    return validate_language(explicit_language or activity.get("linguaggio") or activity.get("language") or "c")
+
+
+def validate_language(value: Any) -> str:
+    """Return a supported normalized language name."""
+    language = str(value).strip().lower()
+    language = LANGUAGE_ALIASES.get(language, language)
+    if language not in SUPPORTED_LANGUAGES:
+        supported = ", ".join(sorted(SUPPORTED_LANGUAGES))
+        raise ValueError(f"Linguaggio non supportato: {value}. Valori supportati: {supported}.")
+    return language
 
 
 def scaffold_dir(target_dir: Path, identifier: str) -> Path:

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from scripts import validate_activity
+
 
 DEFAULT_TARGET_DIR = Path(".")
 DEFAULT_SOURCE_NAME = "main.c"
@@ -29,6 +31,13 @@ def activity_id(activity: dict[str, Any]) -> str:
     if not is_safe_slug(value):
         raise ValueError("activity_id deve essere uno slug sicuro: usa lettere minuscole, numeri e trattini.")
     return value
+
+
+def validate_activity_or_raise(activity: dict[str, Any], identifier: str) -> None:
+    """Validate an activity using the shared TheBitLab validator."""
+    errors = validate_activity.validate_activity(activity, identifier)
+    if errors:
+        raise ValueError("\n".join(errors))
 
 
 def language_for(activity: dict[str, Any], explicit_language: str | None = None) -> str:
@@ -86,6 +95,7 @@ def create_scaffold(
     """Create an assignment scaffold in a student repository."""
     activity = load_activity(activity_path)
     identifier = activity_id(activity)
+    validate_activity_or_raise(activity, identifier)
     selected_language = language_for(activity, language)
     destination = scaffold_dir(target_dir, identifier)
 

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -11,6 +11,7 @@ from scripts import validate_activity
 
 DEFAULT_TARGET_DIR = Path(".")
 DEFAULT_SOURCE_NAME = "main.c"
+DEFAULT_THEBITLAB_REF = "main"
 
 
 def is_safe_slug(value: str) -> bool:
@@ -72,7 +73,7 @@ def starter_source(language: str) -> str:
     return ""
 
 
-def assignment_readme(activity: dict[str, Any], identifier: str, source_name: str, language: str) -> str:
+def assignment_readme(activity: dict[str, Any], identifier: str, source_name: str, language: str, thebitlab_ref: str) -> str:
     """Build the README for one student assignment scaffold."""
     title = str(activity.get("titolo") or identifier)
     prompt = str(activity.get("consegna") or "Segui le indicazioni del docente.")
@@ -90,6 +91,7 @@ def assignment_readme(activity: dict[str, Any], identifier: str, source_name: st
         f"- `activity_path`: `assignments/{identifier}/activity.json`\n"
         f"- `source_path`: `assignments/{identifier}/{source_name}`\n"
         f"- `language`: `{language}`\n"
+        f"- `thebitlab_ref`: `{thebitlab_ref}`\n"
     )
 
 
@@ -99,6 +101,7 @@ def create_scaffold(
     target_dir: Path = DEFAULT_TARGET_DIR,
     source_name: str = DEFAULT_SOURCE_NAME,
     language: str | None = None,
+    thebitlab_ref: str = DEFAULT_THEBITLAB_REF,
     overwrite: bool = False,
     overwrite_source: bool = False,
 ) -> Path:
@@ -125,7 +128,7 @@ def create_scaffold(
         source_path.write_text(starter_source(selected_language), encoding="utf-8", newline="\n")
 
     (destination / "README.md").write_text(
-        assignment_readme(activity, identifier, source_name, selected_language),
+        assignment_readme(activity, identifier, source_name, selected_language, thebitlab_ref),
         encoding="utf-8",
         newline="\n",
     )
@@ -138,6 +141,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--target", type=Path, default=DEFAULT_TARGET_DIR, help="Root del repository studente.")
     parser.add_argument("--source-name", default=DEFAULT_SOURCE_NAME, help="Nome del file sorgente da creare.")
     parser.add_argument("--language", help="Linguaggio da usare, se diverso dalla activity.")
+    parser.add_argument("--thebitlab-ref", default=DEFAULT_THEBITLAB_REF, help="Branch, tag o commit TheBitLab da indicare nel README.")
     parser.add_argument("--force", action="store_true", help="Sovrascrive una consegna gia esistente.")
     parser.add_argument("--overwrite-source", action="store_true", help="Sovrascrive anche il sorgente se esiste.")
     return parser.parse_args()
@@ -151,6 +155,7 @@ def main() -> int:
             target_dir=args.target,
             source_name=args.source_name,
             language=args.language,
+            thebitlab_ref=args.thebitlab_ref,
             overwrite=args.force,
             overwrite_source=args.overwrite_source,
         )

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -81,6 +81,14 @@ def language_for(activity: dict[str, Any], explicit_language: str | None = None)
     """Return the language requested by CLI or activity metadata."""
     if explicit_language is not None:
         return validate_language(explicit_language)
+    if "linguaggio" in activity and "language" in activity:
+        italian_language = validate_language(activity["linguaggio"])
+        english_language = validate_language(activity["language"])
+        if italian_language != english_language:
+            raise ValueError(
+                "I campi linguaggio e language devono indicare lo stesso linguaggio normalizzato."
+            )
+        return italian_language
     if "linguaggio" in activity:
         return validate_language(activity["linguaggio"])
     if "language" in activity:

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -79,7 +79,9 @@ def validate_activity_or_raise(activity: dict[str, Any], identifier: str) -> Non
 
 def language_for(activity: dict[str, Any], explicit_language: str | None = None) -> str:
     """Return the language requested by CLI or activity metadata."""
-    return validate_language(explicit_language or activity.get("linguaggio") or activity.get("language") or "c")
+    if explicit_language is not None:
+        return validate_language(explicit_language)
+    return validate_language(activity.get("linguaggio") or activity.get("language") or "c")
 
 
 def validate_language(value: Any) -> str:

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -21,7 +21,10 @@ def is_safe_slug(value: str) -> bool:
 
 def load_activity(path: Path) -> dict[str, Any]:
     """Load an activity JSON file."""
-    return json.loads(path.read_text(encoding="utf-8"))
+    activity = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(activity, dict):
+        raise ValueError("La activity deve essere un oggetto JSON.")
+    return activity
 
 
 def activity_id(activity: dict[str, Any]) -> str:

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -211,7 +211,9 @@ def create_scaffold(
     identifier = activity_id(activity)
     validate_activity_or_raise(activity, identifier)
     selected_language = language_for(activity, language)
-    source_name = validate_source_name(source_name or default_source_name_for(selected_language))
+    source_name = validate_source_name(
+        source_name if source_name is not None else default_source_name_for(selected_language)
+    )
     thebitlab_ref = validate_thebitlab_ref(thebitlab_ref)
     destination = scaffold_dir(target_dir, identifier)
 

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_TARGET_DIR = Path(".")
+DEFAULT_SOURCE_NAME = "main.c"
+
+
+def is_safe_slug(value: str) -> bool:
+    """Return whether a value is safe for activity ids and artifact names."""
+    return bool(re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", value))
+
+
+def load_activity(path: Path) -> dict[str, Any]:
+    """Load an activity JSON file."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def activity_id(activity: dict[str, Any]) -> str:
+    """Return and validate the stable activity id."""
+    value = str(activity.get("id", "")).strip()
+    if not value:
+        raise ValueError("La activity deve contenere un campo id non vuoto.")
+    if not is_safe_slug(value):
+        raise ValueError("activity_id deve essere uno slug sicuro: usa lettere minuscole, numeri e trattini.")
+    return value
+
+
+def language_for(activity: dict[str, Any], explicit_language: str | None = None) -> str:
+    """Return the language requested by CLI or activity metadata."""
+    return str(explicit_language or activity.get("linguaggio") or activity.get("language") or "c").strip().lower()
+
+
+def scaffold_dir(target_dir: Path, identifier: str) -> Path:
+    """Return the assignment scaffold directory for an activity id."""
+    return target_dir / "assignments" / identifier
+
+
+def starter_source(language: str) -> str:
+    """Return a minimal starter source for the requested language."""
+    if language == "c":
+        return (
+            "#include <stdio.h>\n\n"
+            "int main(void) {\n"
+            "    /* Scrivi qui la tua soluzione. */\n"
+            "    return 0;\n"
+            "}\n"
+        )
+    return ""
+
+
+def assignment_readme(activity: dict[str, Any], identifier: str, source_name: str, language: str) -> str:
+    """Build the README for one student assignment scaffold."""
+    title = str(activity.get("titolo") or identifier)
+    prompt = str(activity.get("consegna") or "Segui le indicazioni del docente.")
+    return (
+        f"# {title}\n\n"
+        f"Activity ID: `{identifier}`\n\n"
+        f"Linguaggio: `{language}`\n\n"
+        "## Consegna\n\n"
+        f"{prompt}\n\n"
+        "## File da modificare\n\n"
+        f"- `{source_name}`\n\n"
+        "## Grading manuale\n\n"
+        "Apri la scheda **Actions**, scegli **TheBitLab grading** e usa questi valori:\n\n"
+        f"- `activity_id`: `{identifier}`\n"
+        f"- `activity_path`: `assignments/{identifier}/activity.json`\n"
+        f"- `source_path`: `assignments/{identifier}/{source_name}`\n"
+        f"- `language`: `{language}`\n"
+    )
+
+
+def create_scaffold(
+    *,
+    activity_path: Path,
+    target_dir: Path = DEFAULT_TARGET_DIR,
+    source_name: str = DEFAULT_SOURCE_NAME,
+    language: str | None = None,
+    overwrite: bool = False,
+) -> Path:
+    """Create an assignment scaffold in a student repository."""
+    activity = load_activity(activity_path)
+    identifier = activity_id(activity)
+    selected_language = language_for(activity, language)
+    destination = scaffold_dir(target_dir, identifier)
+
+    if destination.exists() and any(destination.iterdir()) and not overwrite:
+        raise ValueError(f"Consegna gia esistente: {destination}. Usa --force per sovrascrivere.")
+
+    destination.mkdir(parents=True, exist_ok=True)
+    (destination / "activity.json").write_text(
+        json.dumps(activity, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    source_path = destination / source_name
+    if overwrite or not source_path.exists():
+        source_path.write_text(starter_source(selected_language), encoding="utf-8", newline="\n")
+
+    (destination / "README.md").write_text(
+        assignment_readme(activity, identifier, source_name, selected_language),
+        encoding="utf-8",
+        newline="\n",
+    )
+    return destination
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Crea lo scaffold di una consegna in un repository studente.")
+    parser.add_argument("--activity", type=Path, required=True, help="Path della activity JSON.")
+    parser.add_argument("--target", type=Path, default=DEFAULT_TARGET_DIR, help="Root del repository studente.")
+    parser.add_argument("--source-name", default=DEFAULT_SOURCE_NAME, help="Nome del file sorgente da creare.")
+    parser.add_argument("--language", help="Linguaggio da usare, se diverso dalla activity.")
+    parser.add_argument("--force", action="store_true", help="Sovrascrive una consegna gia esistente.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        destination = create_scaffold(
+            activity_path=args.activity,
+            target_dir=args.target,
+            source_name=args.source_name,
+            language=args.language,
+            overwrite=args.force,
+        )
+    except ValueError as error:
+        print(f"Scaffold consegna non creato:\n{error}")
+        return 1
+
+    print(f"Scaffold consegna creato: {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -55,7 +55,14 @@ def validate_source_name(source_name: str) -> str:
     """Validate that a source name is a simple filename."""
     value = source_name.strip()
     path = Path(value)
-    if not value or path.name != value or path.is_absolute() or "/" in value or "\\" in value:
+    if (
+        not value
+        or path.name != value
+        or path.is_absolute()
+        or "/" in value
+        or "\\" in value
+        or not re.fullmatch(r"[A-Za-z0-9_.-]+", value)
+    ):
         raise ValueError("source_name deve essere un nome file semplice, per esempio main.c.")
     return value
 

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -12,6 +12,19 @@ from scripts import validate_activity
 DEFAULT_TARGET_DIR = Path(".")
 DEFAULT_SOURCE_NAME = "main.c"
 DEFAULT_THEBITLAB_REF = "main"
+DEFAULT_SOURCE_NAMES = {
+    "assembly": "main.asm",
+    "c": "main.c",
+    "cpp": "main.cpp",
+    "go": "main.go",
+    "html": "index.html",
+    "java": "Main.java",
+    "javascript": "main.js",
+    "nodejs": "main.js",
+    "php": "main.php",
+    "python": "main.py",
+    "sql": "main.sql",
+}
 SUPPORTED_LANGUAGES = {
     "assembly",
     "c",
@@ -82,6 +95,11 @@ def validate_language(value: Any) -> str:
 def scaffold_dir(target_dir: Path, identifier: str) -> Path:
     """Return the assignment scaffold directory for an activity id."""
     return target_dir / "assignments" / identifier
+
+
+def default_source_name_for(language: str) -> str:
+    """Return the default source filename for a supported language."""
+    return DEFAULT_SOURCE_NAMES[language]
 
 
 def validate_source_name(source_name: str) -> str:
@@ -182,7 +200,7 @@ def create_scaffold(
     *,
     activity_path: Path,
     target_dir: Path = DEFAULT_TARGET_DIR,
-    source_name: str = DEFAULT_SOURCE_NAME,
+    source_name: str | None = None,
     language: str | None = None,
     thebitlab_ref: str = DEFAULT_THEBITLAB_REF,
     overwrite: bool = False,
@@ -193,7 +211,7 @@ def create_scaffold(
     identifier = activity_id(activity)
     validate_activity_or_raise(activity, identifier)
     selected_language = language_for(activity, language)
-    source_name = validate_source_name(source_name)
+    source_name = validate_source_name(source_name or default_source_name_for(selected_language))
     thebitlab_ref = validate_thebitlab_ref(thebitlab_ref)
     destination = scaffold_dir(target_dir, identifier)
 
@@ -223,7 +241,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Crea lo scaffold di una consegna in un repository studente.")
     parser.add_argument("--activity", type=Path, required=True, help="Path della activity JSON.")
     parser.add_argument("--target", type=Path, default=DEFAULT_TARGET_DIR, help="Root del repository studente.")
-    parser.add_argument("--source-name", default=DEFAULT_SOURCE_NAME, help="Nome del file sorgente da creare.")
+    parser.add_argument("--source-name", help="Nome del file sorgente da creare. Se omesso, viene scelto in base al linguaggio.")
     parser.add_argument("--language", help="Linguaggio da usare, se diverso dalla activity.")
     parser.add_argument("--thebitlab-ref", default=DEFAULT_THEBITLAB_REF, help="Branch, tag o commit TheBitLab da indicare nel README.")
     parser.add_argument("--force", action="store_true", help="Sovrascrive una consegna gia esistente.")

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -60,6 +60,14 @@ def validate_source_name(source_name: str) -> str:
     return value
 
 
+def validate_thebitlab_ref(value: str) -> str:
+    """Validate a TheBitLab git ref for README usage."""
+    clean_value = value.strip()
+    if not clean_value or "\n" in clean_value or "\r" in clean_value:
+        raise ValueError("thebitlab_ref deve essere un branch, tag o commit non vuoto e su una sola riga.")
+    return clean_value
+
+
 def starter_source(language: str) -> str:
     """Return a minimal starter source for the requested language."""
     if language == "c":
@@ -111,6 +119,7 @@ def create_scaffold(
     validate_activity_or_raise(activity, identifier)
     selected_language = language_for(activity, language)
     source_name = validate_source_name(source_name)
+    thebitlab_ref = validate_thebitlab_ref(thebitlab_ref)
     destination = scaffold_dir(target_dir, identifier)
 
     if destination.exists() and any(destination.iterdir()) and not overwrite:

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -118,6 +118,41 @@ def starter_source(language: str) -> str:
             "    return 0;\n"
             "}\n"
         )
+    if language == "cpp":
+        return (
+            "#include <iostream>\n\n"
+            "int main() {\n"
+            "    // Scrivi qui la tua soluzione.\n"
+            "    return 0;\n"
+            "}\n"
+        )
+    if language == "go":
+        return (
+            "package main\n\n"
+            "func main() {\n"
+            "    // Scrivi qui la tua soluzione.\n"
+            "}\n"
+        )
+    if language == "java":
+        return (
+            "public class Main {\n"
+            "    public static void main(String[] args) {\n"
+            "        // Scrivi qui la tua soluzione.\n"
+            "    }\n"
+            "}\n"
+        )
+    if language == "javascript" or language == "nodejs":
+        return "// Scrivi qui la tua soluzione.\n"
+    if language == "php":
+        return "<?php\n// Scrivi qui la tua soluzione.\n"
+    if language == "python":
+        return "# Scrivi qui la tua soluzione.\n"
+    if language == "html":
+        return "<!doctype html>\n<html lang=\"it\">\n<body>\n  <!-- Scrivi qui la tua soluzione. -->\n</body>\n</html>\n"
+    if language == "sql":
+        return "-- Scrivi qui la tua soluzione.\n"
+    if language == "assembly":
+        return "; Scrivi qui la tua soluzione.\n"
     return ""
 
 

--- a/templates/student-repository/README.md
+++ b/templates/student-repository/README.md
@@ -43,6 +43,8 @@ Esempio:
 assignments/c-base-somma-001/main.c
 ```
 
+Il docente puo generare questa cartella con lo script TheBitLab di scaffold consegna. Se la cartella e gia pronta, lavora solo sui file indicati nella consegna.
+
 ## Grading manuale da GitHub Actions
 
 Il workflow `TheBitLab grading` puo essere avviato manualmente dalla scheda Actions.

--- a/templates/student-repository/README.md
+++ b/templates/student-repository/README.md
@@ -32,7 +32,7 @@ Il report autorevole e quello prodotto dalla GitHub Action come artifact. I file
 Per l'MVP, il flusso consigliato e:
 
 1. Crea o apri la cartella dell'attivita in `assignments/<activity_id>/`.
-2. Scrivi il file richiesto, per esempio `main.c`.
+2. Scrivi il file indicato nel README della consegna, per esempio `main.c` per C o `main.py` per Python.
 3. Fai commit e push su `main`.
 4. Avvia o controlla la GitHub Action di grading.
 5. Leggi il report prodotto come artifact.
@@ -43,7 +43,7 @@ Esempio:
 assignments/c-base-somma-001/main.c
 ```
 
-Il docente puo generare questa cartella con lo script TheBitLab di scaffold consegna. Se la cartella e gia pronta, lavora solo sui file indicati nella consegna.
+Il docente puo generare questa cartella con lo script TheBitLab di scaffold consegna. Se la cartella e gia pronta, lavora solo sui file indicati nel README della consegna.
 
 ## Grading manuale da GitHub Actions
 

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -237,3 +237,18 @@ def test_create_scaffold_rejects_source_name_with_unsafe_characters(tmp_path) ->
         assert "nome file semplice" in str(error)
     else:
         raise AssertionError("create_scaffold should reject unsafe characters in source_name")
+
+
+def test_create_scaffold_rejects_empty_source_name(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    try:
+        create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=tmp_path,
+            source_name="",
+        )
+    except ValueError as error:
+        assert "nome file semplice" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject empty source_name")

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -210,6 +210,20 @@ def test_create_scaffold_rejects_empty_activity_language(tmp_path) -> None:
         raise AssertionError("create_scaffold should reject empty activity languages")
 
 
+def test_create_scaffold_rejects_conflicting_activity_languages(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, {**activity(), "linguaggio": "python", "language": "c"})
+
+    try:
+        create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=tmp_path,
+        )
+    except ValueError as error:
+        assert "linguaggio e language" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject conflicting activity languages")
+
+
 def test_create_scaffold_supports_custom_thebitlab_ref(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
 

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+
+from scripts import create_submission_scaffold
+
+
+def activity() -> dict:
+    return {
+        "id": "c-base-somma-001",
+        "titolo": "Somma di due interi",
+        "linguaggio": "c",
+        "consegna": "Scrivi un programma C che legge due interi e stampa la somma.",
+    }
+
+
+def write_activity(tmp_path, payload: dict | None = None):
+    path = tmp_path / "activity.json"
+    path.write_text(json.dumps(payload or activity()), encoding="utf-8")
+    return path
+
+
+def test_create_scaffold_writes_assignment_files(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    destination = create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+
+    assert destination == tmp_path / "assignments" / "c-base-somma-001"
+    assert json.loads((destination / "activity.json").read_text(encoding="utf-8"))["id"] == "c-base-somma-001"
+    assert (destination / "main.c").read_text(encoding="utf-8").startswith("#include <stdio.h>")
+    readme = (destination / "README.md").read_text(encoding="utf-8")
+    assert "activity_id`: `c-base-somma-001`" in readme
+    assert "source_path`: `assignments/c-base-somma-001/main.c`" in readme
+
+
+def test_create_scaffold_rejects_unsafe_activity_id(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, {**activity(), "id": "Somma 001"})
+
+    try:
+        create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+    except ValueError as error:
+        assert "slug sicuro" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject unsafe activity ids")
+
+
+def test_create_scaffold_refuses_existing_assignment_without_force(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+
+    try:
+        create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+    except ValueError as error:
+        assert "Consegna gia esistente" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject existing assignments")
+
+
+def test_create_scaffold_can_overwrite_with_force(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    destination = create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+    (destination / "main.c").write_text("custom\n", encoding="utf-8")
+
+    create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path, overwrite=True)
+
+    assert "Scrivi qui" in (destination / "main.c").read_text(encoding="utf-8")
+
+
+def test_create_scaffold_supports_custom_source_name_and_language(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    destination = create_submission_scaffold.create_scaffold(
+        activity_path=activity_path,
+        target_dir=tmp_path,
+        source_name="solution.py",
+        language="python",
+    )
+
+    assert (destination / "solution.py").exists()
+    readme = (destination / "README.md").read_text(encoding="utf-8")
+    assert "language`: `python`" in readme
+    assert "source_path`: `assignments/c-base-somma-001/solution.py`" in readme

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -86,12 +86,27 @@ def test_create_scaffold_refuses_existing_assignment_without_force(tmp_path) -> 
         raise AssertionError("create_scaffold should reject existing assignments")
 
 
-def test_create_scaffold_can_overwrite_with_force(tmp_path) -> None:
+def test_create_scaffold_force_preserves_existing_source(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     destination = create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
     (destination / "main.c").write_text("custom\n", encoding="utf-8")
 
     create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path, overwrite=True)
+
+    assert (destination / "main.c").read_text(encoding="utf-8") == "custom\n"
+
+
+def test_create_scaffold_can_overwrite_source_explicitly(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    destination = create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+    (destination / "main.c").write_text("custom\n", encoding="utf-8")
+
+    create_submission_scaffold.create_scaffold(
+        activity_path=activity_path,
+        target_dir=tmp_path,
+        overwrite=True,
+        overwrite_source=True,
+    )
 
     assert "Scrivi qui" in (destination / "main.c").read_text(encoding="utf-8")
 

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -75,6 +75,17 @@ def test_create_scaffold_rejects_invalid_activity_before_writing(tmp_path) -> No
     assert not (tmp_path / "assignments").exists()
 
 
+def test_create_scaffold_rejects_non_object_activity_json(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, [])
+
+    try:
+        create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+    except ValueError as error:
+        assert "oggetto JSON" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject non-object activity JSON")
+
+
 def test_create_scaffold_refuses_existing_assignment_without_force(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -48,6 +48,7 @@ def test_create_scaffold_writes_assignment_files(tmp_path) -> None:
     readme = (destination / "README.md").read_text(encoding="utf-8")
     assert "activity_id`: `c-base-somma-001`" in readme
     assert "source_path`: `assignments/c-base-somma-001/main.c`" in readme
+    assert "thebitlab_ref`: `main`" in readme
 
 
 def test_create_scaffold_rejects_unsafe_activity_id(tmp_path) -> None:
@@ -125,6 +126,19 @@ def test_create_scaffold_supports_custom_source_name_and_language(tmp_path) -> N
     readme = (destination / "README.md").read_text(encoding="utf-8")
     assert "language`: `python`" in readme
     assert "source_path`: `assignments/c-base-somma-001/solution.py`" in readme
+
+
+def test_create_scaffold_supports_custom_thebitlab_ref(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    destination = create_submission_scaffold.create_scaffold(
+        activity_path=activity_path,
+        target_dir=tmp_path,
+        thebitlab_ref="v1.0.0",
+    )
+
+    readme = (destination / "README.md").read_text(encoding="utf-8")
+    assert "thebitlab_ref`: `v1.0.0`" in readme
 
 
 def test_create_scaffold_rejects_source_name_with_path_segments(tmp_path) -> None:

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -110,3 +110,18 @@ def test_create_scaffold_supports_custom_source_name_and_language(tmp_path) -> N
     readme = (destination / "README.md").read_text(encoding="utf-8")
     assert "language`: `python`" in readme
     assert "source_path`: `assignments/c-base-somma-001/solution.py`" in readme
+
+
+def test_create_scaffold_rejects_source_name_with_path_segments(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    try:
+        create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=tmp_path,
+            source_name="../main.c",
+        )
+    except ValueError as error:
+        assert "nome file semplice" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject path traversal in source_name")

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -169,3 +169,18 @@ def test_create_scaffold_rejects_source_name_with_path_segments(tmp_path) -> Non
         assert "nome file semplice" in str(error)
     else:
         raise AssertionError("create_scaffold should reject path traversal in source_name")
+
+
+def test_create_scaffold_rejects_source_name_with_unsafe_characters(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    try:
+        create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=tmp_path,
+            source_name="`main`.c",
+        )
+    except ValueError as error:
+        assert "nome file semplice" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject unsafe characters in source_name")

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -156,13 +156,14 @@ def test_create_scaffold_writes_non_empty_starter_for_supported_languages(tmp_pa
     for language in create_submission_scaffold.SUPPORTED_LANGUAGES:
         activity_id = f"{language}-exercise"
         activity_path = write_activity(tmp_path, {**activity(), "id": activity_id, "linguaggio": language})
+        source_name = create_submission_scaffold.default_source_name_for(language)
 
         destination = create_submission_scaffold.create_scaffold(
             activity_path=activity_path,
             target_dir=tmp_path / language,
         )
 
-        assert (destination / "main.c").read_text(encoding="utf-8").strip()
+        assert (destination / source_name).read_text(encoding="utf-8").strip()
 
 
 def test_create_scaffold_rejects_unsupported_language(tmp_path) -> None:

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -152,6 +152,19 @@ def test_create_scaffold_normalizes_language_aliases(tmp_path) -> None:
     assert "language`: `cpp`" in readme
 
 
+def test_create_scaffold_writes_non_empty_starter_for_supported_languages(tmp_path) -> None:
+    for language in create_submission_scaffold.SUPPORTED_LANGUAGES:
+        activity_id = f"{language}-exercise"
+        activity_path = write_activity(tmp_path, {**activity(), "id": activity_id, "linguaggio": language})
+
+        destination = create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=tmp_path / language,
+        )
+
+        assert (destination / "main.c").read_text(encoding="utf-8").strip()
+
+
 def test_create_scaffold_rejects_unsupported_language(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
 

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -196,6 +196,20 @@ def test_create_scaffold_rejects_empty_language(tmp_path) -> None:
         raise AssertionError("create_scaffold should reject empty languages")
 
 
+def test_create_scaffold_rejects_empty_activity_language(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, {**activity(), "linguaggio": ""})
+
+    try:
+        create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=tmp_path,
+        )
+    except ValueError as error:
+        assert "Linguaggio non supportato" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject empty activity languages")
+
+
 def test_create_scaffold_supports_custom_thebitlab_ref(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
 

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -139,6 +139,34 @@ def test_create_scaffold_supports_custom_source_name_and_language(tmp_path) -> N
     assert "source_path`: `assignments/c-base-somma-001/solution.py`" in readme
 
 
+def test_create_scaffold_normalizes_language_aliases(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    destination = create_submission_scaffold.create_scaffold(
+        activity_path=activity_path,
+        target_dir=tmp_path,
+        language="c++",
+    )
+
+    readme = (destination / "README.md").read_text(encoding="utf-8")
+    assert "language`: `cpp`" in readme
+
+
+def test_create_scaffold_rejects_unsupported_language(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    try:
+        create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=tmp_path,
+            language="brainfuck",
+        )
+    except ValueError as error:
+        assert "Linguaggio non supportato" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject unsupported languages")
+
+
 def test_create_scaffold_supports_custom_thebitlab_ref(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
 

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -7,10 +7,27 @@ from scripts import create_submission_scaffold
 
 def activity() -> dict:
     return {
+        "schema_version": "1.0",
         "id": "c-base-somma-001",
         "titolo": "Somma di due interi",
+        "tipo": "compito-casa",
+        "difficolta": "B",
+        "argomenti": ["variabili", "operatori"],
         "linguaggio": "c",
         "consegna": "Scrivi un programma C che legge due interi e stampa la somma.",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
     }
 
 
@@ -42,6 +59,19 @@ def test_create_scaffold_rejects_unsafe_activity_id(tmp_path) -> None:
         assert "slug sicuro" in str(error)
     else:
         raise AssertionError("create_scaffold should reject unsafe activity ids")
+
+
+def test_create_scaffold_rejects_invalid_activity_before_writing(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, {"id": "c-base-somma-001"})
+
+    try:
+        create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+    except ValueError as error:
+        assert "schema_version" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject invalid activities")
+
+    assert not (tmp_path / "assignments").exists()
 
 
 def test_create_scaffold_refuses_existing_assignment_without_force(tmp_path) -> None:

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -33,7 +33,7 @@ def activity() -> dict:
 
 def write_activity(tmp_path, payload: dict | None = None):
     path = tmp_path / "activity.json"
-    path.write_text(json.dumps(payload or activity()), encoding="utf-8")
+    path.write_text(json.dumps(activity() if payload is None else payload), encoding="utf-8")
     return path
 
 

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -141,6 +141,21 @@ def test_create_scaffold_supports_custom_thebitlab_ref(tmp_path) -> None:
     assert "thebitlab_ref`: `v1.0.0`" in readme
 
 
+def test_create_scaffold_rejects_multiline_thebitlab_ref(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    try:
+        create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=tmp_path,
+            thebitlab_ref="main\naltro",
+        )
+    except ValueError as error:
+        assert "thebitlab_ref" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject multiline refs")
+
+
 def test_create_scaffold_rejects_source_name_with_path_segments(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
 

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -181,6 +181,21 @@ def test_create_scaffold_rejects_unsupported_language(tmp_path) -> None:
         raise AssertionError("create_scaffold should reject unsupported languages")
 
 
+def test_create_scaffold_rejects_empty_language(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+
+    try:
+        create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=tmp_path,
+            language="",
+        )
+    except ValueError as error:
+        assert "Linguaggio non supportato" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject empty languages")
+
+
 def test_create_scaffold_supports_custom_thebitlab_ref(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
 


### PR DESCRIPTION
﻿## Obiettivo

Aggiunge il primo scaffold operativo per il flusso consegne studenti: da una activity JSON validata si genera una cartella consegna pronta per repo studente, con README, sorgente iniziale e manifest di consegna.

## Cosa cambia

- Aggiunto `scripts/create_submission_scaffold.py` per generare lo scaffold di una consegna studente.
- Aggiunti test unitari sullo scaffold e sui casi di errore principali.
- Documentato il flusso consegne in `doc/STUDENT_REPOSITORY_TEMPLATE.md`.
- Collegata la nuova documentazione dall'indice in `doc/README.md`.
- Aggiornato il template repository studente per indicare lo scaffold generato dal docente.

## Review finding e fix

### 1. Il validatore non bloccava activity malformate prima della generazione

**Finding:** lo scaffold poteva essere generato da un JSON formalmente leggibile ma non conforme allo schema minimo delle activity.

**Fix:** prima della generazione ora viene chiamato `validate_activity`; in caso di errore lo scaffold non viene scritto.

Commit: [`5c880aa`](https://github.com/TheBitPoets/2cornot2c/commit/5c880aa)

### 2. `source_name` accettava path invece di soli nomi file

**Finding:** un valore come `../main.c` poteva scrivere fuori dalla cartella della consegna.

**Fix:** `source_name` viene validato come nome file semplice: niente path assoluti, niente segmenti e niente slash/backslash.

Commit: [`f0fb1fc`](https://github.com/TheBitPoets/2cornot2c/commit/f0fb1fc)

### 3. `--force` sovrascriveva anche il sorgente studente

**Finding:** rigenerando lo scaffold con `--force`, il file sorgente poteva essere riportato al placeholder iniziale.

**Fix:** `--force` aggiorna solo i metadati; per sovrascrivere il sorgente serve il flag esplicito `--overwrite-source`.

Commit: [`e04ed91`](https://github.com/TheBitPoets/2cornot2c/commit/e04ed91)

### 4. Mancava il riferimento alla versione TheBitLab usata dallo studente

**Finding:** lo scaffold non registrava quale versione di TheBitLab fosse prevista per eseguire/correggere la consegna.

**Fix:** il README generato ora include `thebitlab_ref`, configurabile da CLI con `--thebitlab-ref`.

Commit: [`a58e31e`](https://github.com/TheBitPoets/2cornot2c/commit/a58e31e)

## Seconda review finding e fix

### 1. `thebitlab_ref` non era validato come valore semplice

**Finding:** il riferimento TheBitLab entrava nel README senza controllo, quindi valori vuoti o multilinea potevano rendere ambiguo il manifest testuale della consegna.

**Fix:** aggiunta `validate_thebitlab_ref()`: il ref deve essere non vuoto e su una sola riga prima di generare lo scaffold.

Commit: [`bb7e672`](https://github.com/TheBitPoets/2cornot2c/commit/bb7e672)

### 2. `source_name` accettava caratteri non adatti a un filename didattico

**Finding:** pur bloccando i path, il nome sorgente poteva contenere caratteri strani come backtick o spazi, con rischio di rendering ambiguo nel README e nei manifest.

**Fix:** `validate_source_name()` ora accetta solo lettere, numeri, underscore, trattino e punto; aggiunto test dedicato sul caso con caratteri non sicuri.

Commit: [`dbe5e19`](https://github.com/TheBitPoets/2cornot2c/commit/dbe5e19)

## Terza review finding e fix

### 1. Activity JSON non oggetto non gestita in modo controllato

**Finding:** se `activity_path` contiene JSON valido ma non un oggetto, per esempio una lista, lo scaffold poteva andare in errore con eccezione interna invece di restituire un messaggio chiaro.

**Fix:** `load_activity()` ora verifica che il JSON caricato sia un oggetto; in caso contrario solleva un `ValueError` didattico. Aggiunto test dedicato sul caso lista JSON.

Commit: [`4f48b76`](https://github.com/TheBitPoets/2cornot2c/commit/4f48b76)

### 2. Linguaggio non validato

**Finding:** `language_for()` accettava qualsiasi stringa da CLI o activity. Il valore finiva nel README e nei parametri di grading anche per linguaggi non gestiti.

**Fix:** aggiunta una whitelist dei linguaggi supportati nello scaffold MVP multi-linguaggio e una normalizzazione degli alias comuni, per esempio `c++` verso `cpp`, `golang` verso `go`, `js` verso `javascript`. Aggiunti test per alias valido e linguaggio non supportato.

Commit: [`d7c7e85`](https://github.com/TheBitPoets/2cornot2c/commit/d7c7e85)

## Quarta review finding e fix

### 1. Test JSON non oggetto non esercitava davvero il caso lista

**Finding:** `write_activity(tmp_path, [])` usava `payload or activity()`, quindi una lista vuota veniva sostituita dalla activity valida di default. Il test sul JSON non oggetto passava senza verificare davvero il caso.

**Fix:** l'helper `write_activity()` ora usa la activity di default solo quando `payload is None`, quindi valori falsy intenzionali come `[]` vengono scritti davvero nel file.

Commit: [`cca201a`](https://github.com/TheBitPoets/2cornot2c/commit/cca201a)

### 2. Starter source multi-linguaggio incoerenti

**Finding:** lo scaffold validava piu linguaggi, ma `starter_source()` generava codice solo per C e lasciava vuoti tutti gli altri file.

**Fix:** aggiunti starter minimi e commentati per i linguaggi supportati nello scaffold; aggiunto test per garantire che ogni linguaggio supportato generi un file sorgente non vuoto.

Commit: [`85e06be`](https://github.com/TheBitPoets/2cornot2c/commit/85e06be)

## Quinta review finding e fix

### 1. Nome sorgente di default non coerente con il linguaggio

**Finding:** lo scaffold e multi-linguaggio, ma il nome sorgente di default restava sempre `main.c`. Una consegna Python senza `--source-name` generava quindi `main.c` con contenuto Python, una Java generava `main.c` con classe Java, ecc.

**Fix:** aggiunta una mappa `DEFAULT_SOURCE_NAMES` e una funzione `default_source_name_for()`: se il docente non passa `--source-name`, lo scaffold sceglie il filename coerente con il linguaggio, per esempio `main.py`, `Main.java`, `index.html`, `main.cpp`.

Commit: [`9b58252`](https://github.com/TheBitPoets/2cornot2c/commit/9b58252)

### 2. Test multi-linguaggio vincolato accidentalmente a `main.c`

**Finding:** il test degli starter multi-linguaggio leggeva sempre `main.c`, rafforzando il comportamento sbagliato.

**Fix:** il test ora ricava il filename atteso da `default_source_name_for(language)` e verifica che ogni linguaggio generi un file sorgente non vuoto con il nome corretto.

Commit: [`9a773d9`](https://github.com/TheBitPoets/2cornot2c/commit/9a773d9)

## Sesta review finding e fix

### 1. Documentazione scaffold ancora centrata su `main.c`

**Finding:** `doc/STUDENT_REPOSITORY_TEMPLATE.md` mostrava ancora `--source-name main.c` e un albero generato con `main.c`, anche se ora il filename di default dipende dal linguaggio.

**Fix:** la documentazione chiarisce che `--source-name` e opzionale; se omesso, lo script sceglie il file in base al linguaggio. L'albero usa `<source-file>` e una tabella elenca i default per linguaggio.

Commit: [`3001701`](https://github.com/TheBitPoets/2cornot2c/commit/3001701)

### 2. Template studente usa `main.c` come esempio unico

**Finding:** `templates/student-repository/README.md` diceva agli studenti di scrivere `main.c`, ma nel flusso multi-linguaggio il file reale dipende dalla consegna.

**Fix:** il testo ora invita a modificare il file indicato nel README della consegna, con esempi C/Python, senza far sembrare `main.c` l'unico nome possibile.

Commit: [`6c56011`](https://github.com/TheBitPoets/2cornot2c/commit/6c56011)

## Settima review finding e fix

### 1. `source_name` esplicito vuoto trattato come valore omesso

**Finding:** `source_name` vuoto veniva trattato come fallback al nome sorgente di default, invece di essere rifiutato come input invalido.

**Fix:** `create_scaffold()` ora usa il default solo quando `source_name is None`; una stringa vuota passa a `validate_source_name()` e viene rifiutata. Aggiunto test dedicato.

Commit: [`c5e1647`](https://github.com/TheBitPoets/2cornot2c/commit/c5e1647)

### 2. `language` esplicito vuoto trattato come valore omesso

**Finding:** `language_for()` ignorava `language=""` e ricadeva sulla activity o sul default.

**Fix:** `language_for()` ora usa il fallback solo quando `explicit_language is None`; una stringa vuota passa a `validate_language()` e viene rifiutata. Aggiunto test dedicato.

Commit: [`2e98472`](https://github.com/TheBitPoets/2cornot2c/commit/2e98472)

## Ottava review finding e fix

### 1. Descrizione PR con sezioni di piano duplicate

**Finding:** nella descrizione della PR erano rimaste sezioni `piano fix` oltre alle sezioni finali `fix`.

**Fix:** la descrizione viene ricostruita in forma pulita, mantenendo solo le sezioni finali di fix.

Commit: [`7f739fb`](https://github.com/TheBitPoets/2cornot2c/commit/7f739fb)

### 2. Linguaggio vuoto nella activity trattato come fallback a C

**Finding:** `language_for()` rifiutava `language=""` quando passato esplicitamente, ma se la activity conteneva `"linguaggio": ""` o `"language": ""`, il fallback con `or` trasformava ancora il valore vuoto in `c`.

**Fix:** `language_for()` ora distingue campo assente da campo presente ma vuoto anche nei metadati della activity. Se `linguaggio` o `language` sono presenti, vengono validati; il fallback a `c` vale solo se entrambi i campi sono assenti. Aggiunto test dedicato.

Commit: [`b6ac738`](https://github.com/TheBitPoets/2cornot2c/commit/b6ac738)

## Nona review finding e fix

### 1. Descrizione PR ancora con sezioni duplicate

**Finding:** la descrizione PR conteneva ancora sezioni `... piano fix` duplicate per settima e ottava review.

**Fix:** ricostruita la descrizione PR completa e pulita, mantenendo solo le sezioni finali `finding e fix`. Commit marker separato per tracciare questo fix metadata nella storia della PR.

Commit: [`7f739fb`](https://github.com/TheBitPoets/2cornot2c/commit/7f739fb)

### 2. `linguaggio` e `language` discordanti non vengono rilevati

**Finding:** se una activity contiene entrambi i campi `linguaggio` e `language`, `linguaggio` vinceva sempre anche se `language` aveva un valore diverso.

**Fix:** se entrambi i campi sono presenti, lo scaffold normalizza e valida entrambi; se i valori normalizzati non coincidono, rifiuta la activity con errore esplicito. Aggiunto test dedicato.

Commit: [`904d00d`](https://github.com/TheBitPoets/2cornot2c/commit/904d00d)
