### PR TITLE
Aggiunge flusso assegnazione activity

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -334,6 +334,58 @@ TheBitLab potra automatizzare:
 - generazione dashboard classe;
 - feedback AI assisted da report deterministico.
 
+## Assegnare una activity a repository studenti
+
+Dopo aver creato e validato una activity JSON, il docente puo assegnarla a uno o piu repository studente usando:
+
+```bash
+python scripts/assign_activity.py \
+  --activity activities/examples/c_sum_with_tests.json \
+  --target ../studenti/tpsi-3a-rossi-mario \
+  --target ../studenti/tpsi-3a-bianchi-luca \
+  --thebitlab-ref main
+```
+
+Lo script usa lo stesso motore di `create_submission_scaffold.py`, quindi per ogni repository crea:
+
+```text
+assignments/<activity_id>/
+  activity.json
+  <source-file>
+  README.md
+```
+
+Il flusso e pensato in tre livelli:
+
+| Livello | Responsabilita |
+|---|---|
+| Core Python | Funzioni riusabili da test, CLI e futura GUI |
+| CLI | Wrapper operativo per docente, CI e debug |
+| GUI futura | Form e bottoni che chiamano lo stesso core, senza duplicare logica |
+
+Se la classe ha molti repository, puoi usare un file di target:
+
+```text
+# targets-3a.txt
+../studenti/tpsi-3a-rossi-mario
+../studenti/tpsi-3a-bianchi-luca
+../studenti/tpsi-3a-verdi-anna
+```
+
+Poi:
+
+```bash
+python scripts/assign_activity.py \
+  --activity activities/examples/c_sum_with_tests.json \
+  --targets-file targets-3a.txt
+```
+
+Le righe vuote e le righe che iniziano con `#` vengono ignorate.
+
+Come per lo scaffold singolo, `--force` aggiorna i metadati della consegna, ma non sovrascrive il sorgente dello studente. Per rigenerare anche il sorgente serve `--overwrite-source`.
+
+Nella GUI futura il docente non dovra ricordare questi comandi: selezionera activity, classe/team GitHub e repository studenti; il server locale chiamera lo stesso core usato dalla CLI.
+
 ## Regole di sicurezza
 
 Regole minime:
@@ -352,6 +404,7 @@ Le prossime PR possono introdurre:
 2. Workflow grading riusabile per repository studente.
 3. Script per generare scaffold consegna.
 4. Script per raccogliere report e metriche.
-5. Dashboard Markdown minima per docente.
+5. Integrazione GUI per assegnare activity a classi/team.
+6. Dashboard Markdown minima per docente.
 
 Il primo template repository studente e documentato in `STUDENT_REPOSITORY_TEMPLATE.md`.

--- a/doc/README.md
+++ b/doc/README.md
@@ -56,6 +56,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/update_course_frames.py` | Inserisce nel README le cornici didattiche presenti nel progetto | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/create_activity.py` | Crea una scheda JSON di attivita TheBitLab da prompt guidato o argomenti CLI | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 | `scripts/create_submission_scaffold.py` | Crea una cartella consegna in un repository studente a partire da una activity JSON | [`STUDENT_REPOSITORY_TEMPLATE.md`](STUDENT_REPOSITORY_TEMPLATE.md) |
+| `scripts/assign_activity.py` | Assegna una activity a uno o piu repository studente usando lo scaffold consegna | [`ASSIGNMENT_SUBMISSIONS.md`](ASSIGNMENT_SUBMISSIONS.md) |
 | `scripts/validate_activity.py` | Valida le schede JSON di attivita TheBitLab | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 | `scripts/grade_activity.py` | Esegue il runner deterministico del linguaggio richiesto e produce un report, anche via Docker | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) |
 

--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -46,6 +46,19 @@ def assign_activity_to_targets(
     overwrite_source: bool = False,
 ) -> list[AssignmentResult]:
     """Create the activity scaffold in each target student repository."""
+    activity = create_submission_scaffold.load_activity(activity_path)
+    identifier = create_submission_scaffold.activity_id(activity)
+    blocked_targets = [
+        target
+        for target in targets
+        if create_submission_scaffold.scaffold_dir(target, identifier).exists()
+        and any(create_submission_scaffold.scaffold_dir(target, identifier).iterdir())
+        and not overwrite
+    ]
+    if blocked_targets:
+        blocked = "\n".join(str(target) for target in blocked_targets)
+        raise ValueError(f"Consegna gia esistente in questi repository:\n{blocked}\nUsa --force per aggiornare.")
+
     results: list[AssignmentResult] = []
     for target in targets:
         assignment_dir = create_submission_scaffold.create_scaffold(

--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -23,7 +23,7 @@ def load_targets_file(path: Path) -> list[Path]:
         if clean_line and not clean_line.startswith("#"):
             target = Path(clean_line)
             if not target.is_absolute():
-                target = path.parent / target
+                target = (path.parent / target).resolve(strict=False)
             targets.append(target)
     return targets
 

--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -51,6 +51,14 @@ def assign_activity_to_targets(
     """Create the activity scaffold in each target student repository."""
     activity = create_submission_scaffold.load_activity(activity_path)
     identifier = create_submission_scaffold.activity_id(activity)
+    create_submission_scaffold.validate_activity_or_raise(activity, identifier)
+    selected_language = create_submission_scaffold.language_for(activity, language)
+    create_submission_scaffold.validate_source_name(
+        source_name
+        if source_name is not None
+        else create_submission_scaffold.default_source_name_for(selected_language)
+    )
+    create_submission_scaffold.validate_thebitlab_ref(thebitlab_ref)
     blocked_targets = [
         target
         for target in targets

--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -21,7 +21,10 @@ def load_targets_file(path: Path) -> list[Path]:
     for line in path.read_text(encoding="utf-8").splitlines():
         clean_line = line.strip()
         if clean_line and not clean_line.startswith("#"):
-            targets.append(Path(clean_line))
+            target = Path(clean_line)
+            if not target.is_absolute():
+                target = path.parent / target
+            targets.append(target)
     return targets
 
 

--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts import create_submission_scaffold
+
+
+@dataclass(frozen=True)
+class AssignmentResult:
+    """Result of assigning one activity to one target repository."""
+
+    target: Path
+    assignment_dir: Path
+
+
+def load_targets_file(path: Path) -> list[Path]:
+    """Load target repository roots from a plain text file."""
+    targets: list[Path] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        clean_line = line.strip()
+        if clean_line and not clean_line.startswith("#"):
+            targets.append(Path(clean_line))
+    return targets
+
+
+def collect_targets(targets: list[Path] | None = None, targets_file: Path | None = None) -> list[Path]:
+    """Return the ordered target list provided directly or through a file."""
+    collected = list(targets or [])
+    if targets_file is not None:
+        collected.extend(load_targets_file(targets_file))
+    if not collected:
+        raise ValueError("Indica almeno un repository studente con --target o --targets-file.")
+    return collected
+
+
+def assign_activity_to_targets(
+    *,
+    activity_path: Path,
+    targets: list[Path],
+    source_name: str | None = None,
+    language: str | None = None,
+    thebitlab_ref: str = create_submission_scaffold.DEFAULT_THEBITLAB_REF,
+    overwrite: bool = False,
+    overwrite_source: bool = False,
+) -> list[AssignmentResult]:
+    """Create the activity scaffold in each target student repository."""
+    results: list[AssignmentResult] = []
+    for target in targets:
+        assignment_dir = create_submission_scaffold.create_scaffold(
+            activity_path=activity_path,
+            target_dir=target,
+            source_name=source_name,
+            language=language,
+            thebitlab_ref=thebitlab_ref,
+            overwrite=overwrite,
+            overwrite_source=overwrite_source,
+        )
+        results.append(AssignmentResult(target=target, assignment_dir=assignment_dir))
+    return results
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for assigning an activity to repositories."""
+    parser = argparse.ArgumentParser(description="Assegna una activity TheBitLab a uno o piu repository studente.")
+    parser.add_argument("--activity", type=Path, required=True, help="Path della activity JSON da assegnare.")
+    parser.add_argument(
+        "--target",
+        type=Path,
+        action="append",
+        help="Root di un repository studente. Ripeti il flag per piu studenti.",
+    )
+    parser.add_argument(
+        "--targets-file",
+        type=Path,
+        help="File di testo con un repository studente per riga. Le righe vuote o che iniziano con # sono ignorate.",
+    )
+    parser.add_argument("--source-name", help="Nome del file sorgente da creare. Se omesso, dipende dal linguaggio.")
+    parser.add_argument("--language", help="Linguaggio da usare, se diverso dalla activity.")
+    parser.add_argument(
+        "--thebitlab-ref",
+        default=create_submission_scaffold.DEFAULT_THEBITLAB_REF,
+        help="Branch, tag o commit TheBitLab da indicare nel README della consegna.",
+    )
+    parser.add_argument("--force", action="store_true", help="Aggiorna una consegna gia esistente.")
+    parser.add_argument("--overwrite-source", action="store_true", help="Sovrascrive anche il sorgente se esiste.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the assignment CLI."""
+    args = parse_args()
+    try:
+        targets = collect_targets(args.target, args.targets_file)
+        results = assign_activity_to_targets(
+            activity_path=args.activity,
+            targets=targets,
+            source_name=args.source_name,
+            language=args.language,
+            thebitlab_ref=args.thebitlab_ref,
+            overwrite=args.force,
+            overwrite_source=args.overwrite_source,
+        )
+    except ValueError as error:
+        print(f"Activity non assegnata:\n{error}")
+        return 1
+
+    for result in results:
+        print(f"Consegna creata per {result.target}: {result.assignment_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_assign_activity.py
+++ b/tests/test_assign_activity.py
@@ -40,14 +40,16 @@ def write_activity(tmp_path):
 
 
 def test_collect_targets_uses_direct_and_file_targets(tmp_path) -> None:
-    targets_file = tmp_path / "targets.txt"
+    targets_dir = tmp_path / "classes"
+    targets_dir.mkdir()
+    targets_file = targets_dir / "targets.txt"
     targets_file.write_text(
         "\n".join(
             [
                 "# classe 3A",
-                str(tmp_path / "student-b"),
+                "../student-b",
                 "",
-                str(tmp_path / "student-c"),
+                "../student-c",
             ]
         ),
         encoding="utf-8",

--- a/tests/test_assign_activity.py
+++ b/tests/test_assign_activity.py
@@ -92,3 +92,22 @@ def test_assign_activity_preserves_existing_source_with_force(tmp_path) -> None:
     assign_activity.assign_activity_to_targets(activity_path=activity_path, targets=[target], overwrite=True)
 
     assert source.read_text(encoding="utf-8") == "print('custom')\n"
+
+
+def test_assign_activity_preflight_blocks_partial_assignment(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    blocked_target = tmp_path / "student-a"
+    untouched_target = tmp_path / "student-b"
+    assign_activity.assign_activity_to_targets(activity_path=activity_path, targets=[blocked_target])
+
+    try:
+        assign_activity.assign_activity_to_targets(
+            activity_path=activity_path,
+            targets=[untouched_target, blocked_target],
+        )
+    except ValueError as error:
+        assert "Consegna gia esistente" in str(error)
+    else:
+        raise AssertionError("assign_activity_to_targets should reject partial assignments")
+
+    assert not (untouched_target / "assignments").exists()

--- a/tests/test_assign_activity.py
+++ b/tests/test_assign_activity.py
@@ -113,3 +113,22 @@ def test_assign_activity_preflight_blocks_partial_assignment(tmp_path) -> None:
         raise AssertionError("assign_activity_to_targets should reject partial assignments")
 
     assert not (untouched_target / "assignments").exists()
+
+
+def test_assign_activity_preflight_validates_parameters_before_writing(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    targets = [tmp_path / "student-a", tmp_path / "student-b"]
+
+    try:
+        assign_activity.assign_activity_to_targets(
+            activity_path=activity_path,
+            targets=targets,
+            thebitlab_ref="main\nbad",
+        )
+    except ValueError as error:
+        assert "thebitlab_ref" in str(error)
+    else:
+        raise AssertionError("assign_activity_to_targets should validate parameters before writing")
+
+    for target in targets:
+        assert not (target / "assignments").exists()

--- a/tests/test_assign_activity.py
+++ b/tests/test_assign_activity.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+
+from scripts import assign_activity
+
+
+def activity() -> dict:
+    """Return a minimal valid activity for assignment tests."""
+    return {
+        "schema_version": "1.0",
+        "id": "python-base-somma-001",
+        "titolo": "Somma in Python",
+        "tipo": "compito-casa",
+        "difficolta": "B",
+        "argomenti": ["variabili", "input-output"],
+        "linguaggio": "python",
+        "consegna": "Scrivi un programma Python che stampa una somma.",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+    }
+
+
+def write_activity(tmp_path):
+    """Write a valid activity JSON and return its path."""
+    path = tmp_path / "activity.json"
+    path.write_text(json.dumps(activity()), encoding="utf-8")
+    return path
+
+
+def test_collect_targets_uses_direct_and_file_targets(tmp_path) -> None:
+    targets_file = tmp_path / "targets.txt"
+    targets_file.write_text(
+        "\n".join(
+            [
+                "# classe 3A",
+                str(tmp_path / "student-b"),
+                "",
+                str(tmp_path / "student-c"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    targets = assign_activity.collect_targets([tmp_path / "student-a"], targets_file)
+
+    assert targets == [tmp_path / "student-a", tmp_path / "student-b", tmp_path / "student-c"]
+
+
+def test_collect_targets_requires_at_least_one_target() -> None:
+    try:
+        assign_activity.collect_targets()
+    except ValueError as error:
+        assert "almeno un repository studente" in str(error)
+    else:
+        raise AssertionError("collect_targets should reject an empty target list")
+
+
+def test_assign_activity_to_multiple_targets(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    targets = [tmp_path / "student-a", tmp_path / "student-b"]
+
+    results = assign_activity.assign_activity_to_targets(activity_path=activity_path, targets=targets)
+
+    assert [result.target for result in results] == targets
+    for target in targets:
+        assignment_dir = target / "assignments" / "python-base-somma-001"
+        assert (assignment_dir / "activity.json").exists()
+        assert (assignment_dir / "main.py").exists()
+        readme = (assignment_dir / "README.md").read_text(encoding="utf-8")
+        assert "source_path`: `assignments/python-base-somma-001/main.py`" in readme
+
+
+def test_assign_activity_preserves_existing_source_with_force(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    target = tmp_path / "student-a"
+    assign_activity.assign_activity_to_targets(activity_path=activity_path, targets=[target])
+    source = target / "assignments" / "python-base-somma-001" / "main.py"
+    source.write_text("print('custom')\n", encoding="utf-8")
+
+    assign_activity.assign_activity_to_targets(activity_path=activity_path, targets=[target], overwrite=True)
+
+    assert source.read_text(encoding="utf-8") == "print('custom')\n"


### PR DESCRIPTION
﻿## Obiettivo

Aggiunge il primo flusso operativo per assegnare una activity TheBitLab a uno o piu repository studente.

La CLI e progettata come wrapper sottile sopra un core Python riusabile: la futura GUI dovra chiamare la stessa logica, senza duplicarla.

## Cosa cambia

- Aggiunto `scripts/assign_activity.py`.
- Aggiunto core `assign_activity_to_targets(...)` riusabile da CLI, test e futura GUI.
- Supportati target multipli con `--target` ripetuto.
- Supportato file target con `--targets-file`.
- Riutilizzato `create_submission_scaffold.py` per mantenere identico il comportamento dello scaffold.
- Aggiunti test sul core di assegnazione e sul caricamento target.
- Documentato il flusso docente in `doc/ASSIGNMENT_SUBMISSIONS.md`.
- Collegato il nuovo script da `doc/README.md`.

## Nota architetturale

Questo step non aggiunge ancora la GUI, ma prepara il contratto stabile che la GUI usera:

1. selezione activity;
2. selezione repository studenti/classe;
3. chiamata al core Python;
4. visualizzazione risultati/errori.

## Test

Non lanciati localmente.

## Review finding e fix

### 1. Assegnazione multi-target poteva restare parziale

**Finding:** `assign_activity_to_targets()` scriveva sui target in sequenza. Se un target iniziale veniva aggiornato e un target successivo falliva, la classe poteva restare assegnata solo in parte.

**Fix:** aggiunta una fase di preflight: prima di scrivere, lo script calcola l'id activity e verifica tutti i target. Se una consegna esiste gia e `overwrite=False`, l'intera assegnazione viene fermata prima di modificare altri repository. Aggiunto test dedicato.

Commit: [`17400d7`](https://github.com/TheBitPoets/2cornot2c/commit/17400d7)

### 2. Path relativi in `--targets-file` dipendevano dalla working directory

**Finding:** i path relativi dentro il file target venivano interpretati rispetto alla directory da cui si lanciava il comando.

**Fix:** `load_targets_file()` ora risolve i path relativi rispetto a `targets_file.parent`, lasciando invariati i path assoluti. Aggiornato il test per coprire il caso.

Commit: [`825f724`](https://github.com/TheBitPoets/2cornot2c/commit/825f724)

## Seconda review finding e fix

### 1. Preflight incompleto sui parametri dello scaffold

**Finding:** il preflight controllava solo id activity e conflitti di destinazione. Parametri invalidi come `source_name=""`, `language=""` o `thebitlab_ref=""` potevano ancora fallire durante la scrittura del primo target, lasciando assegnazioni parziali.

**Fix:** il preflight valida ora activity schema, linguaggio, source name e ref TheBitLab usando le stesse funzioni dello scaffold, prima di qualsiasi scrittura. Aggiunto test dedicato.

Commit: [`2df4adc`](https://github.com/TheBitPoets/2cornot2c/commit/2df4adc)

### 2. Descrizione PR con sezione piano duplicata

**Finding:** la descrizione PR conteneva sia `Review finding e piano fix` sia `Review finding e fix`.

**Fix:** ricostruito il body della PR lasciando solo le sezioni finali di fix. Commit marker separato per tracciare questo fix metadata.

Commit: [`1bb9460`](https://github.com/TheBitPoets/2cornot2c/commit/1bb9460)


## Fix GitHub Action

### Quality / python rosso su path relativi

**Errore:** il test confrontava path normalizzati, mentre `load_targets_file()` restituiva path semanticamente corretti ma ancora contenenti `..`.

**Fix:** i path relativi letti da `--targets-file` vengono ora risolti con `resolve(strict=False)` rispetto alla directory del file target.

Commit: [`427016f`](https://github.com/TheBitPoets/2cornot2c/commit/427016f)
