### PR TITLE
Aggiunge registro consegne

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -408,12 +408,14 @@ Per ogni studente contiene:
 | Campo | Significato |
 |---|---|
 | `assigned` | Lo studente era tra i destinatari della consegna |
-| `submitted` | Esiste una consegna o un report locale associato |
+| `submitted` | Esiste un report locale valido e coerente con l'activity corrente |
 | `status` | Stato sintetico: `missing`, `submitted_on_time`, `submitted_late`, `not_graded`, ecc. |
 | `due_at` | Scadenza della consegna |
 | `submission` | Dati della consegna: sorgente, data invio, commit se disponibile |
 | `grading` | Esito deterministico, test superati, voto docente se presente |
 | `ai_feedback` | Placeholder per feedback AI assisted approvabile dal docente |
+
+La cartella `assignments/<activity_id>/` non basta per considerare consegnata l'attivita: puo essere stata creata dal docente durante l'assegnazione.
 
 Esempio ridotto:
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -386,6 +386,72 @@ Come per lo scaffold singolo, `--force` aggiorna i metadati della consegna, ma n
 
 Nella GUI futura il docente non dovra ricordare questi comandi: selezionera activity, classe/team GitHub e repository studenti; il server locale chiamera lo stesso core usato dalla CLI.
 
+## Registro consegne con scadenza, voti e AI placeholder
+
+Prima di calcolare metriche avanzate bisogna sapere chi ha consegnato e chi no.
+
+Il primo registro consegne si genera con:
+
+```bash
+python scripts/track_assignments.py \
+  --activity activities/examples/c_sum_with_tests.json \
+  --targets-file targets-3a.txt \
+  --assigned-at 2026-10-12T09:00:00+02:00 \
+  --due-at 2026-10-19T23:59:00+02:00 \
+  --output teacher-reports/3A/c_sum_with_tests.json
+```
+
+Il registro prodotto e pensato per la futura GUI docente.
+
+Per ogni studente contiene:
+
+| Campo | Significato |
+|---|---|
+| `assigned` | Lo studente era tra i destinatari della consegna |
+| `submitted` | Esiste una consegna o un report locale associato |
+| `status` | Stato sintetico: `missing`, `submitted_on_time`, `submitted_late`, `not_graded`, ecc. |
+| `due_at` | Scadenza della consegna |
+| `submission` | Dati della consegna: sorgente, data invio, commit se disponibile |
+| `grading` | Esito deterministico, test superati, voto docente se presente |
+| `ai_feedback` | Placeholder per feedback AI assisted approvabile dal docente |
+
+Esempio ridotto:
+
+```json
+{
+  "activity_id": "python-base-somma-001",
+  "due_at": "2026-10-19T23:59:00+02:00",
+  "students": [
+    {
+      "student": "rossi-mario",
+      "repo": "TheBitPoets/tpsi-3a-rossi-mario",
+      "status": "submitted_on_time",
+      "submitted": true,
+      "late": false,
+      "grading": {
+        "status": "graded_passed",
+        "tests_passed": 2,
+        "tests_total": 2,
+        "teacher_grade": null
+      },
+      "ai_feedback": {
+        "status": "not_generated",
+        "suggested_grade": null,
+        "approved_by_teacher": false
+      }
+    }
+  ]
+}
+```
+
+Per ora il registro legge report locali nel path:
+
+```text
+reports/<activity_id>/latest.json
+```
+
+In futuro la stessa struttura potra essere alimentata scaricando gli artifact GitHub Actions dei repository studenti.
+
 ## Regole di sicurezza
 
 Regole minime:
@@ -403,8 +469,8 @@ Le prossime PR possono introdurre:
 1. Template repository studente.
 2. Workflow grading riusabile per repository studente.
 3. Script per generare scaffold consegna.
-4. Script per raccogliere report e metriche.
-5. Integrazione GUI per assegnare activity a classi/team.
+4. Integrazione GUI per assegnare activity a classi/team.
+5. Download artifact GitHub Actions e collegamento al registro consegne.
 6. Dashboard Markdown minima per docente.
 
 Il primo template repository studente e documentato in `STUDENT_REPOSITORY_TEMPLATE.md`.

--- a/doc/README.md
+++ b/doc/README.md
@@ -57,6 +57,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/create_activity.py` | Crea una scheda JSON di attivita TheBitLab da prompt guidato o argomenti CLI | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 | `scripts/create_submission_scaffold.py` | Crea una cartella consegna in un repository studente a partire da una activity JSON | [`STUDENT_REPOSITORY_TEMPLATE.md`](STUDENT_REPOSITORY_TEMPLATE.md) |
 | `scripts/assign_activity.py` | Assegna una activity a uno o piu repository studente usando lo scaffold consegna | [`ASSIGNMENT_SUBMISSIONS.md`](ASSIGNMENT_SUBMISSIONS.md) |
+| `scripts/track_assignments.py` | Genera un registro consegne con scadenza, stato consegna, grading e placeholder AI | [`ASSIGNMENT_SUBMISSIONS.md`](ASSIGNMENT_SUBMISSIONS.md) |
 | `scripts/validate_activity.py` | Valida le schede JSON di attivita TheBitLab | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 | `scripts/grade_activity.py` | Esegue il runner deterministico del linguaggio richiesto e produce un report, anche via Docker | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) |
 

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -59,12 +59,21 @@ def load_report(path: Path) -> dict[str, Any] | None:
     return report
 
 
-def submission_status(*, submitted: bool, submitted_at: str | None, due_at: str | None) -> tuple[str, bool]:
+def submission_status(
+    *,
+    submitted: bool,
+    submitted_at: str | None,
+    due_at: str | None,
+    now: str | None = None,
+) -> tuple[str, bool]:
     """Return the submission status and late flag."""
     if due_at is None:
         return (NO_DUE_DATE_STATUS if not submitted else "submitted_no_due_date", False)
     due = datetime.fromisoformat(due_at)
     if not submitted:
+        current_time = datetime.fromisoformat(now) if now is not None else datetime.now(due.tzinfo)
+        if current_time <= due:
+            return ("pending", False)
         return ("missing", True)
     if submitted_at is None:
         return ("submitted_unknown_time", False)
@@ -114,6 +123,7 @@ def track_assignments(
     targets: list[TrackingTarget],
     assigned_at: str | None = None,
     due_at: str | None = None,
+    now: str | None = None,
 ) -> dict[str, Any]:
     """Build a teacher-facing tracking index for one activity."""
     activity = create_submission_scaffold.load_activity(activity_path)
@@ -121,6 +131,7 @@ def track_assignments(
     create_submission_scaffold.validate_activity_or_raise(activity, activity_id)
     normalized_assigned_at = parse_datetime(assigned_at, "assigned_at")
     normalized_due_at = parse_datetime(due_at, "due_at")
+    normalized_now = parse_datetime(now, "now")
 
     students: list[dict[str, Any]] = []
     for target in targets:
@@ -131,7 +142,12 @@ def track_assignments(
         source_exists = Path(source_path).exists() if source_path else current_assignment_dir.exists()
         submitted = source_exists or report is not None
         submitted_at = report.get("submitted_at") if report else None
-        status, late = submission_status(submitted=submitted, submitted_at=submitted_at, due_at=normalized_due_at)
+        status, late = submission_status(
+            submitted=submitted,
+            submitted_at=submitted_at,
+            due_at=normalized_due_at,
+            now=normalized_now,
+        )
         students.append(
             {
                 "student": target.student,
@@ -177,6 +193,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--targets-file", type=Path, help="File con repository studenti, uno per riga.")
     parser.add_argument("--assigned-at", help="Data ISO di assegnazione.")
     parser.add_argument("--due-at", help="Data ISO di scadenza.")
+    parser.add_argument("--now", help="Data ISO da usare come riferimento temporale nei test o nelle simulazioni.")
     parser.add_argument("--output", type=Path, required=True, help="Path JSON del registro generato.")
     return parser.parse_args()
 
@@ -191,6 +208,7 @@ def main() -> int:
             targets=targets,
             assigned_at=args.assigned_at,
             due_at=args.due_at,
+            now=args.now,
         )
         write_tracking_index(index, args.output)
     except ValueError as error:

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -70,7 +70,9 @@ def load_report(path: Path) -> dict[str, Any] | None:
 def validate_report_activity(report: dict[str, Any], expected_activity_id: str, report_path: Path) -> None:
     """Ensure a grading report belongs to the tracked activity."""
     report_activity_id = report.get("activity_id")
-    if report_activity_id is not None and report_activity_id != expected_activity_id:
+    if report_activity_id is None:
+        raise ValueError(f"Report non coerente per {report_path}: manca activity_id.")
+    if report_activity_id != expected_activity_id:
         raise ValueError(
             f"Report non coerente per {report_path}: atteso {expected_activity_id}, trovato {report_activity_id}."
         )

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -67,6 +67,15 @@ def load_report(path: Path) -> dict[str, Any] | None:
     return report
 
 
+def validate_report_activity(report: dict[str, Any], expected_activity_id: str, report_path: Path) -> None:
+    """Ensure a grading report belongs to the tracked activity."""
+    report_activity_id = report.get("activity_id")
+    if report_activity_id is not None and report_activity_id != expected_activity_id:
+        raise ValueError(
+            f"Report non coerente per {report_path}: atteso {expected_activity_id}, trovato {report_activity_id}."
+        )
+
+
 def submission_status(
     *,
     submitted: bool,
@@ -145,6 +154,8 @@ def track_assignments(
     for target in targets:
         report_path = default_report_path(target, activity_id)
         report = load_report(report_path)
+        if report is not None:
+            validate_report_activity(report, activity_id, report_path)
         source_path = report.get("source") if report else None
         submitted = report is not None
         submitted_at = report.get("submitted_at") if report else None

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -135,12 +135,10 @@ def track_assignments(
 
     students: list[dict[str, Any]] = []
     for target in targets:
-        current_assignment_dir = assignment_dir(target, activity_id)
         report_path = default_report_path(target, activity_id)
         report = load_report(report_path)
         source_path = report.get("source") if report else None
-        source_exists = Path(source_path).exists() if source_path else current_assignment_dir.exists()
-        submitted = source_exists or report is not None
+        submitted = report is not None
         submitted_at = report.get("submitted_at") if report else None
         status, late = submission_status(
             submitted=submitted,

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -33,6 +33,14 @@ def parse_datetime(value: str | None, field_name: str) -> str | None:
     return value
 
 
+def parse_timezone_datetime(value: str, field_name: str) -> datetime:
+    """Parse an ISO datetime and require timezone information for safe comparisons."""
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None or parsed.tzinfo.utcoffset(parsed) is None:
+        raise ValueError(f"{field_name} deve includere il timezone, per esempio +02:00.")
+    return parsed
+
+
 def load_targets(targets: list[Path] | None = None, targets_file: Path | None = None) -> list[TrackingTarget]:
     """Load tracking targets from direct paths and an optional targets file."""
     paths = assign_activity.collect_targets(targets, targets_file)
@@ -69,15 +77,15 @@ def submission_status(
     """Return the submission status and late flag."""
     if due_at is None:
         return (NO_DUE_DATE_STATUS if not submitted else "submitted_no_due_date", False)
-    due = datetime.fromisoformat(due_at)
+    due = parse_timezone_datetime(due_at, "due_at")
     if not submitted:
-        current_time = datetime.fromisoformat(now) if now is not None else datetime.now(due.tzinfo)
+        current_time = parse_timezone_datetime(now, "now") if now is not None else datetime.now(due.tzinfo)
         if current_time <= due:
             return ("pending", False)
         return ("missing", True)
     if submitted_at is None:
         return ("submitted_unknown_time", False)
-    submitted_time = datetime.fromisoformat(submitted_at)
+    submitted_time = parse_timezone_datetime(submitted_at, "submitted_at")
     if submitted_time > due:
         return ("submitted_late", True)
     return ("submitted_on_time", False)

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from scripts import assign_activity, create_submission_scaffold
+
+
+NO_DUE_DATE_STATUS = "no_due_date"
+
+
+@dataclass(frozen=True)
+class TrackingTarget:
+    """Student/repository target tracked for one assignment."""
+
+    student: str
+    repo: str
+    path: Path
+
+
+def parse_datetime(value: str | None, field_name: str) -> str | None:
+    """Validate an ISO datetime string and return it unchanged for JSON output."""
+    if value is None:
+        return None
+    try:
+        datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ValueError(f"{field_name} deve essere una data ISO valida.") from error
+    return value
+
+
+def load_targets(targets: list[Path] | None = None, targets_file: Path | None = None) -> list[TrackingTarget]:
+    """Load tracking targets from direct paths and an optional targets file."""
+    paths = assign_activity.collect_targets(targets, targets_file)
+    return [TrackingTarget(student=path.name, repo=str(path), path=path) for path in paths]
+
+
+def assignment_dir(target: TrackingTarget, activity_id: str) -> Path:
+    """Return the assignment directory in a student repository."""
+    return target.path / "assignments" / activity_id
+
+
+def default_report_path(target: TrackingTarget, activity_id: str) -> Path:
+    """Return the default local report path for an activity in a student repository."""
+    return target.path / "reports" / activity_id / "latest.json"
+
+
+def load_report(path: Path) -> dict[str, Any] | None:
+    """Load a report if present, otherwise return None."""
+    if not path.exists():
+        return None
+    report = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(report, dict):
+        raise ValueError(f"Report non valido: {path}")
+    return report
+
+
+def submission_status(*, submitted: bool, submitted_at: str | None, due_at: str | None) -> tuple[str, bool]:
+    """Return the submission status and late flag."""
+    if due_at is None:
+        return (NO_DUE_DATE_STATUS if not submitted else "submitted_no_due_date", False)
+    due = datetime.fromisoformat(due_at)
+    if not submitted:
+        return ("missing", True)
+    if submitted_at is None:
+        return ("submitted_unknown_time", False)
+    submitted_time = datetime.fromisoformat(submitted_at)
+    if submitted_time > due:
+        return ("submitted_late", True)
+    return ("submitted_on_time", False)
+
+
+def grading_summary(report: dict[str, Any] | None) -> dict[str, Any]:
+    """Return grading fields for the tracking index."""
+    if report is None:
+        return {
+            "status": "not_graded",
+            "passed": None,
+            "tests_passed": None,
+            "tests_total": None,
+            "score": None,
+            "teacher_grade": None,
+            "report_status": None,
+        }
+    summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
+    return {
+        "status": "graded_passed" if report.get("passed") is True else "graded_failed",
+        "passed": report.get("passed"),
+        "tests_passed": summary.get("passed"),
+        "tests_total": summary.get("total"),
+        "score": report.get("score"),
+        "teacher_grade": report.get("teacher_grade"),
+        "report_status": report.get("status"),
+    }
+
+
+def ai_feedback_placeholder() -> dict[str, Any]:
+    """Return the default AI feedback state for a tracked assignment."""
+    return {
+        "status": "not_generated",
+        "suggested_grade": None,
+        "summary": None,
+        "approved_by_teacher": False,
+    }
+
+
+def track_assignments(
+    *,
+    activity_path: Path,
+    targets: list[TrackingTarget],
+    assigned_at: str | None = None,
+    due_at: str | None = None,
+) -> dict[str, Any]:
+    """Build a teacher-facing tracking index for one activity."""
+    activity = create_submission_scaffold.load_activity(activity_path)
+    activity_id = create_submission_scaffold.activity_id(activity)
+    create_submission_scaffold.validate_activity_or_raise(activity, activity_id)
+    normalized_assigned_at = parse_datetime(assigned_at, "assigned_at")
+    normalized_due_at = parse_datetime(due_at, "due_at")
+
+    students: list[dict[str, Any]] = []
+    for target in targets:
+        current_assignment_dir = assignment_dir(target, activity_id)
+        report_path = default_report_path(target, activity_id)
+        report = load_report(report_path)
+        source_path = report.get("source") if report else None
+        source_exists = Path(source_path).exists() if source_path else current_assignment_dir.exists()
+        submitted = source_exists or report is not None
+        submitted_at = report.get("submitted_at") if report else None
+        status, late = submission_status(submitted=submitted, submitted_at=submitted_at, due_at=normalized_due_at)
+        students.append(
+            {
+                "student": target.student,
+                "repo": target.repo,
+                "assigned": True,
+                "submitted": submitted,
+                "status": status,
+                "assigned_at": normalized_assigned_at,
+                "due_at": normalized_due_at,
+                "late": late,
+                "submission": {
+                    "source_path": source_path,
+                    "submitted_at": submitted_at,
+                    "commit": report.get("commit") if report else None,
+                },
+                "grading": grading_summary(report),
+                "ai_feedback": ai_feedback_placeholder(),
+                "report_path": str(report_path) if report_path.exists() else None,
+            }
+        )
+
+    return {
+        "activity_id": activity_id,
+        "title": activity.get("titolo") or activity_id,
+        "kind": activity.get("tipo"),
+        "assigned_at": normalized_assigned_at,
+        "due_at": normalized_due_at,
+        "students": students,
+    }
+
+
+def write_tracking_index(index: dict[str, Any], output: Path) -> None:
+    """Write the tracking index as pretty JSON."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(index, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for assignment tracking."""
+    parser = argparse.ArgumentParser(description="Genera un registro consegne per una activity TheBitLab.")
+    parser.add_argument("--activity", type=Path, required=True, help="Path della activity JSON.")
+    parser.add_argument("--target", type=Path, action="append", help="Repository studente da includere.")
+    parser.add_argument("--targets-file", type=Path, help="File con repository studenti, uno per riga.")
+    parser.add_argument("--assigned-at", help="Data ISO di assegnazione.")
+    parser.add_argument("--due-at", help="Data ISO di scadenza.")
+    parser.add_argument("--output", type=Path, required=True, help="Path JSON del registro generato.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the tracking CLI."""
+    args = parse_args()
+    try:
+        targets = load_targets(args.target, args.targets_file)
+        index = track_assignments(
+            activity_path=args.activity,
+            targets=targets,
+            assigned_at=args.assigned_at,
+            due_at=args.due_at,
+        )
+        write_tracking_index(index, args.output)
+    except ValueError as error:
+        print(f"Registro consegne non generato:\n{error}")
+        return 1
+
+    print(f"Registro consegne generato: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -92,6 +92,23 @@ def test_track_assignments_marks_submitted_on_time(tmp_path) -> None:
     assert row["ai_feedback"]["status"] == "not_generated"
 
 
+def test_track_assignments_marks_pending_before_due_date(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "bianchi-luca")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-19T23:59:00+02:00",
+        now="2026-10-18T12:00:00+02:00",
+    )
+
+    row = index["students"][0]
+    assert row["status"] == "pending"
+    assert row["submitted"] is False
+    assert row["late"] is False
+
+
 def test_track_assignments_marks_missing_after_due_date(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "bianchi-luca")
@@ -100,6 +117,7 @@ def test_track_assignments_marks_missing_after_due_date(tmp_path) -> None:
         activity_path=activity_path,
         targets=[student],
         due_at="2026-10-19T23:59:00+02:00",
+        now="2026-10-20T12:00:00+02:00",
     )
 
     row = index["students"][0]

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+
+from scripts import track_assignments
+
+
+def activity() -> dict:
+    """Return a minimal valid activity for tracking tests."""
+    return {
+        "schema_version": "1.0",
+        "id": "python-base-somma-001",
+        "titolo": "Somma in Python",
+        "tipo": "compito-casa",
+        "difficolta": "B",
+        "argomenti": ["variabili", "input-output"],
+        "linguaggio": "python",
+        "consegna": "Scrivi un programma Python che stampa una somma.",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+    }
+
+
+def write_activity(tmp_path):
+    """Write a valid activity JSON and return its path."""
+    path = tmp_path / "activity.json"
+    path.write_text(json.dumps(activity()), encoding="utf-8")
+    return path
+
+
+def target(tmp_path, name: str) -> track_assignments.TrackingTarget:
+    """Return a tracking target rooted in tmp_path."""
+    root = tmp_path / name
+    return track_assignments.TrackingTarget(student=name, repo=f"TheBitPoets/{name}", path=root)
+
+
+def write_report(root, submitted_at: str, passed: bool = True) -> None:
+    """Write a local grading report in the default report location."""
+    report_path = root / "reports" / "python-base-somma-001" / "latest.json"
+    source_path = root / "assignments" / "python-base-somma-001" / "main.py"
+    report_path.parent.mkdir(parents=True)
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("print(3)\n", encoding="utf-8")
+    report_path.write_text(
+        json.dumps(
+            {
+                "passed": passed,
+                "status": "passed" if passed else "failed",
+                "activity_id": "python-base-somma-001",
+                "source": str(source_path),
+                "submitted_at": submitted_at,
+                "commit": "abc1234",
+                "summary": {
+                    "passed": 2 if passed else 1,
+                    "total": 2,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_track_assignments_marks_submitted_on_time(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    write_report(student.path, "2026-10-18T18:22:10+02:00")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assigned_at="2026-10-12T09:00:00+02:00",
+        due_at="2026-10-19T23:59:00+02:00",
+    )
+
+    row = index["students"][0]
+    assert row["status"] == "submitted_on_time"
+    assert row["submitted"] is True
+    assert row["late"] is False
+    assert row["grading"]["status"] == "graded_passed"
+    assert row["grading"]["tests_passed"] == 2
+    assert row["ai_feedback"]["status"] == "not_generated"
+
+
+def test_track_assignments_marks_missing_after_due_date(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "bianchi-luca")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-19T23:59:00+02:00",
+    )
+
+    row = index["students"][0]
+    assert row["status"] == "missing"
+    assert row["submitted"] is False
+    assert row["grading"]["status"] == "not_graded"
+
+
+def test_track_assignments_marks_submitted_late(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "verdi-anna")
+    write_report(student.path, "2026-10-20T08:00:00+02:00", passed=False)
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-19T23:59:00+02:00",
+    )
+
+    row = index["students"][0]
+    assert row["status"] == "submitted_late"
+    assert row["late"] is True
+    assert row["grading"]["status"] == "graded_failed"
+
+
+def test_write_tracking_index_creates_parent_directories(tmp_path) -> None:
+    output = tmp_path / "teacher-reports" / "3A" / "index.json"
+    index = {"activity_id": "python-base-somma-001", "students": []}
+
+    track_assignments.write_tracking_index(index, output)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == index

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -109,6 +109,26 @@ def test_track_assignments_marks_pending_before_due_date(tmp_path) -> None:
     assert row["late"] is False
 
 
+def test_track_assignments_does_not_count_scaffold_as_submission(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "bianchi-luca")
+    assignment_dir = student.path / "assignments" / "python-base-somma-001"
+    assignment_dir.mkdir(parents=True)
+    (assignment_dir / "main.py").write_text("# starter\n", encoding="utf-8")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-19T23:59:00+02:00",
+        now="2026-10-18T12:00:00+02:00",
+    )
+
+    row = index["students"][0]
+    assert row["status"] == "pending"
+    assert row["submitted"] is False
+    assert row["submission"]["source_path"] is None
+
+
 def test_track_assignments_marks_missing_after_due_date(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "bianchi-luca")

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -146,6 +146,40 @@ def test_track_assignments_marks_missing_after_due_date(tmp_path) -> None:
     assert row["grading"]["status"] == "not_graded"
 
 
+def test_track_assignments_rejects_naive_now_when_due_has_timezone(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "bianchi-luca")
+
+    try:
+        track_assignments.track_assignments(
+            activity_path=activity_path,
+            targets=[student],
+            due_at="2026-10-19T23:59:00+02:00",
+            now="2026-10-18T12:00:00",
+        )
+    except ValueError as error:
+        assert "now deve includere il timezone" in str(error)
+    else:
+        raise AssertionError("track_assignments should reject now without timezone")
+
+
+def test_track_assignments_rejects_naive_submitted_at_when_due_has_timezone(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "verdi-anna")
+    write_report(student.path, "2026-10-20T08:00:00", passed=False)
+
+    try:
+        track_assignments.track_assignments(
+            activity_path=activity_path,
+            targets=[student],
+            due_at="2026-10-19T23:59:00+02:00",
+        )
+    except ValueError as error:
+        assert "submitted_at deve includere il timezone" in str(error)
+    else:
+        raise AssertionError("track_assignments should reject submitted_at without timezone")
+
+
 def test_track_assignments_marks_submitted_late(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "verdi-anna")

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -71,6 +71,28 @@ def write_report(root, submitted_at: str, passed: bool = True) -> None:
     )
 
 
+def write_report_with_activity_id(root, activity_id: str) -> None:
+    """Write a local grading report with a configurable activity id."""
+    report_path = root / "reports" / "python-base-somma-001" / "latest.json"
+    source_path = root / "assignments" / "python-base-somma-001" / "main.py"
+    report_path.parent.mkdir(parents=True)
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("print(3)\n", encoding="utf-8")
+    report_path.write_text(
+        json.dumps(
+            {
+                "passed": True,
+                "status": "passed",
+                "activity_id": activity_id,
+                "source": str(source_path),
+                "submitted_at": "2026-10-18T18:22:10+02:00",
+                "commit": "abc1234",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_track_assignments_marks_submitted_on_time(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "rossi-mario")
@@ -195,6 +217,25 @@ def test_track_assignments_marks_submitted_late(tmp_path) -> None:
     assert row["status"] == "submitted_late"
     assert row["late"] is True
     assert row["grading"]["status"] == "graded_failed"
+
+
+def test_track_assignments_rejects_report_for_different_activity(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "verdi-anna")
+    write_report_with_activity_id(student.path, "altra-activity")
+
+    try:
+        track_assignments.track_assignments(
+            activity_path=activity_path,
+            targets=[student],
+            due_at="2026-10-19T23:59:00+02:00",
+        )
+    except ValueError as error:
+        assert "Report non coerente" in str(error)
+        assert "python-base-somma-001" in str(error)
+        assert "altra-activity" in str(error)
+    else:
+        raise AssertionError("track_assignments should reject reports for a different activity")
 
 
 def test_write_tracking_index_creates_parent_directories(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -93,6 +93,27 @@ def write_report_with_activity_id(root, activity_id: str) -> None:
     )
 
 
+def write_report_without_activity_id(root) -> None:
+    """Write a local grading report without activity id."""
+    report_path = root / "reports" / "python-base-somma-001" / "latest.json"
+    source_path = root / "assignments" / "python-base-somma-001" / "main.py"
+    report_path.parent.mkdir(parents=True)
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("print(3)\n", encoding="utf-8")
+    report_path.write_text(
+        json.dumps(
+            {
+                "passed": True,
+                "status": "passed",
+                "source": str(source_path),
+                "submitted_at": "2026-10-18T18:22:10+02:00",
+                "commit": "abc1234",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_track_assignments_marks_submitted_on_time(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "rossi-mario")
@@ -236,6 +257,24 @@ def test_track_assignments_rejects_report_for_different_activity(tmp_path) -> No
         assert "altra-activity" in str(error)
     else:
         raise AssertionError("track_assignments should reject reports for a different activity")
+
+
+def test_track_assignments_rejects_report_without_activity_id(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "verdi-anna")
+    write_report_without_activity_id(student.path)
+
+    try:
+        track_assignments.track_assignments(
+            activity_path=activity_path,
+            targets=[student],
+            due_at="2026-10-19T23:59:00+02:00",
+        )
+    except ValueError as error:
+        assert "Report non coerente" in str(error)
+        assert "manca activity_id" in str(error)
+    else:
+        raise AssertionError("track_assignments should reject reports without activity_id")
 
 
 def test_write_tracking_index_creates_parent_directories(tmp_path) -> None:


### PR DESCRIPTION
﻿## Obiettivo

Aggiunge il primo registro consegne docente per sapere chi ha consegnato, chi manca, chi ha consegnato in ritardo e quali risultati di grading/AI placeholder sono disponibili.

Questo e' il formato dati che la futura GUI potra' mostrare in tabella.

## Cosa cambia

- Aggiunto `scripts/track_assignments.py`.
- Aggiunto core `track_assignments(...)` riusabile da CLI, test e futura GUI.
- Supportata scadenza con `--due-at` e data assegnazione con `--assigned-at`.
- Calcolati stati minimi: `pending`, `missing`, `submitted_on_time`, `submitted_late`, `submitted_no_due_date`.
- Collegati report locali da `reports/<activity_id>/latest.json`.
- Aggiunto blocco `grading` con esito test, stato report e voto docente se presente.
- Aggiunto blocco `ai_feedback` placeholder per feedback AI assisted approvabile dal docente.
- Aggiunti test su consegna in tempo, consegna pendente, consegna mancante, consegna in ritardo e scrittura JSON.
- Documentato il flusso in `doc/ASSIGNMENT_SUBMISSIONS.md`.
- Collegato il nuovo script da `doc/README.md`.

## Nota GUI futura

La GUI docente potra' leggere il JSON prodotto e mostrare:

- studente;
- stato consegna;
- scadenza;
- link/apertura consegna;
- esito test;
- voto docente;
- feedback AI assisted.

## Review finding e fix

### 1. Studente marcato `missing` prima della scadenza

**Finding:** `submission_status()` restituiva `missing` appena esisteva una scadenza e non c'era una consegna, anche quando la scadenza era ancora futura.

**Fix:** ho introdotto il parametro controllabile `now` nel core e nella CLI. Prima della scadenza lo stato ora resta `pending`; solo dopo la scadenza diventa `missing`. Ho aggiunto test dedicati per entrambi i casi.

Commit: [`4dc7391`](https://github.com/TheBitPoets/2cornot2c/commit/4dc7391d257074dcd53738926460ba033d5da539)

### 2. Cartella scaffold trattata come consegna effettuata

**Finding:** la presenza della cartella `assignments/<activity_id>/` poteva far risultare una consegna come effettuata, anche se quella cartella e' creata dal docente quando prepara lo scaffold.

**Fix:** il registro ora considera consegnato solo uno studente che ha un report locale autorevole in `reports/<activity_id>/latest.json`. Il sorgente resta un'informazione del report, ma non determina piu' da solo lo stato `submitted`. Ho aggiunto un test che crea solo lo scaffold e verifica che lo stato resti `pending`.

Commit: [`6163333`](https://github.com/TheBitPoets/2cornot2c/commit/6163333ce5efe7695351ac599027a0b069be58a8)

### 3. Crash con date ISO miste timezone-aware/timezone-naive

**Finding:** `submission_status()` confrontava direttamente `datetime` con timezone e senza timezone. Se `due_at` aveva `+02:00` ma `now` o `submitted_at` non lo avevano, Python poteva generare `TypeError` durante il confronto.

**Fix:** ho aggiunto una funzione dedicata per i confronti temporali che richiede timezone esplicito. `due_at`, `now` e `submitted_at` vengono quindi validati prima del confronto e, in caso di data ambigua, viene restituito un `ValueError` leggibile. Ho aggiunto test sui casi `now` senza timezone e `submitted_at` senza timezone.

Commit: [`051edb1`](https://github.com/TheBitPoets/2cornot2c/commit/051edb100c2ce8153ec7a9b4a571c7a05f184393)

### 4. Report `latest.json` non verificato rispetto all'activity corrente

**Finding:** il registro accettava qualunque `reports/<activity_id>/latest.json` presente nel path atteso senza verificare che il contenuto del report appartenesse davvero all'activity tracciata.

**Fix:** ho aggiunto una validazione di coerenza tra `activity_id` del report e activity corrente. Se il report dichiara un'activity diversa, il registro fallisce con un `ValueError` esplicito invece di segnare una falsa consegna. Ho aggiunto un test con report finito nel path giusto ma riferito a `altra-activity`.

Commit: [`5e068f1`](https://github.com/TheBitPoets/2cornot2c/commit/5e068f15943e319164994bd18f48c175ede144aa)

### 5. Report senza `activity_id` accettato come consegna valida

**Finding:** dopo il controllo sull'activity diversa, un report privo di `activity_id` veniva ancora accettato. Poiche' il report e' il segnale autorevole della consegna, questo poteva far risultare valida una consegna senza prova che appartenesse davvero all'activity corrente.

**Fix:** ho reso `activity_id` obbligatorio nei report letti dal registro. Se manca, il registro fallisce con `ValueError` chiaro. Ho aggiunto un test con `latest.json` incompleto e senza `activity_id`.

Commit: [`b83caf7`](https://github.com/TheBitPoets/2cornot2c/commit/b83caf71c83c978ec36fe96f4fdba5f4bd47e51d)

### 6. Documentazione non allineata al nuovo significato di `submitted`

**Finding:** la documentazione diceva che `submitted` indicava la presenza di una consegna o di un report locale, ma il codice ora usa volutamente solo un report valido e coerente come segnale autorevole.

**Fix:** ho aggiornato `doc/ASSIGNMENT_SUBMISSIONS.md` chiarendo che `submitted=True` richiede un report locale valido e coerente con l'activity corrente. Ho aggiunto anche una nota: la cartella `assignments/<activity_id>/` non basta, perche' puo essere stata creata dal docente durante l'assegnazione.

Commit: [`65093e1`](https://github.com/TheBitPoets/2cornot2c/commit/65093e1614deb8143409e8ccf328830919e35a1a)

## Test

Non lanciati localmente.
