### PR TITLE
Aggiunge dashboard consegne docente

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -454,6 +454,46 @@ reports/<activity_id>/latest.json
 
 In futuro la stessa struttura potra essere alimentata scaricando gli artifact GitHub Actions dei repository studenti.
 
+## Dashboard consegne docente
+
+Il registro generato puo essere visualizzato dalla GUI locale del progetto.
+
+Avvia il server:
+
+```bash
+python scripts/course_board_server.py
+```
+
+Poi apri:
+
+```text
+http://localhost:8765/tools/assignment_dashboard.html
+```
+
+La dashboard legge i file JSON presenti in:
+
+```text
+teacher-reports/**/*.json
+```
+
+Per esempio, se hai generato:
+
+```text
+teacher-reports/3A/c_sum_with_tests.json
+```
+
+lo troverai nel menu dei registri disponibili.
+
+La vista mostra:
+
+| Sezione | Cosa mostra |
+|---|---|
+| Registro selezionato | activity, scadenza, numero studenti, consegnati, mancanti, ritardi |
+| Filtro consegne | tutti, da consegnare, mancanti, consegnati, in ritardo, test falliti |
+| Studenti | stato, scadenza, data consegna, commit, sorgente, grading, voto, stato AI |
+
+La dashboard non ricalcola il grading: visualizza il formato prodotto da `scripts/track_assignments.py`. In questo modo CLI, test e GUI restano allineati allo stesso contratto JSON.
+
 ## Regole di sicurezza
 
 Regole minime:

--- a/doc/README.md
+++ b/doc/README.md
@@ -61,6 +61,22 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/validate_activity.py` | Valida le schede JSON di attivita TheBitLab | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 | `scripts/grade_activity.py` | Esegue il runner deterministico del linguaggio richiesto e produce un report, anche via Docker | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) |
 
+## Pagine GUI locali
+
+Avvia il server locale con:
+
+```bash
+python scripts/course_board_server.py
+```
+
+Poi usa:
+
+| Pagina | Scopo |
+|---|---|
+| `tools/course_board.html` | Progettare percorsi, UDA e cornici didattiche |
+| `tools/school_calendar.html` | Gestire calendario scolastico, orari e Gantt |
+| `tools/assignment_dashboard.html` | Visualizzare registri consegne docente da `teacher-reports/**/*.json` |
+
 ## Test e controlli automatici
 
 Per sapere quali test e GitHub Actions sono attivi, cosa controllano e come lanciarli in locale, leggi:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -33,6 +33,7 @@ ROOT = Path(__file__).resolve().parents[1]
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
 SCHOOL_CALENDARS_DIR = ROOT / "doc" / "calendars"
+TEACHER_REPORTS_DIR = ROOT / "teacher-reports"
 COURSE_PLAN_MD_PATH = ROOT / "doc" / "PERCORSO_DIDATTICO.md"
 README_PATH = ROOT / "README.md"
 AI_PROVIDERS_PATH = ROOT / "config" / "ai_providers.yaml"
@@ -147,6 +148,17 @@ def school_calendar_path(name: str) -> Path:
     return SCHOOL_CALENDARS_DIR / safe_design_name(name)
 
 
+def safe_teacher_report_path(name: str) -> Path:
+    """Return a safe teacher-report path below teacher-reports."""
+
+    name = name.strip().replace("\\", "/")
+    if not name or name.startswith("/") or ".." in Path(name).parts or not name.endswith(".json"):
+        raise ValueError("Nome registro non valido. Usa un path relativo .json dentro teacher-reports.")
+    path = (TEACHER_REPORTS_DIR / name).resolve()
+    path.relative_to(TEACHER_REPORTS_DIR.resolve())
+    return path
+
+
 def list_saved_designs() -> list[dict]:
     """List saved course designs stored in doc/course_designs."""
 
@@ -217,6 +229,41 @@ def list_school_calendars() -> list[dict]:
             metadata["course_design_name"] = ""
         calendars.append(metadata)
     return calendars
+
+
+def list_assignment_reports() -> list[dict]:
+    """List assignment tracking reports stored in teacher-reports."""
+
+    TEACHER_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    reports = []
+    for path in sorted(TEACHER_REPORTS_DIR.rglob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8-sig"))
+        except Exception:  # noqa: BLE001
+            payload = {}
+        reports.append(
+            {
+                "name": str(path.relative_to(TEACHER_REPORTS_DIR)).replace("\\", "/"),
+                "path": str(path.relative_to(ROOT)).replace("\\", "/"),
+                "activity_id": payload.get("activity_id", ""),
+                "title": payload.get("title", ""),
+                "due_at": payload.get("due_at", ""),
+                "students": len(payload.get("students", [])) if isinstance(payload.get("students"), list) else 0,
+            }
+        )
+    return reports
+
+
+def read_assignment_report(name: str) -> dict:
+    """Read one assignment tracking report from teacher-reports."""
+
+    path = safe_teacher_report_path(name)
+    if not path.is_file():
+        raise FileNotFoundError(f"Registro consegne non trovato: {name}")
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Registro consegne non valido: {name}")
+    return payload
 
 
 def read_school_calendar(name: str) -> dict:
@@ -1497,6 +1544,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/school-calendars":
             self.write_json({"calendars": list_school_calendars()})
             return
+        if parsed.path == "/api/assignment-reports":
+            self.write_json({"reports": list_assignment_reports()})
+            return
         if parsed.path == "/api/ai-config":
             self.write_json(ai_config())
             return
@@ -1563,6 +1613,15 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/school-calendars/load":
             try:
                 self.write_json({"calendar": read_school_calendar(payload.get("name", ""))})
+            except Exception as error:  # noqa: BLE001
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/assignment-reports/load":
+            try:
+                self.write_json({"report": read_assignment_report(payload.get("name", ""))})
             except Exception as error:  # noqa: BLE001
                 self.send_response(404)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -263,6 +263,8 @@ def read_assignment_report(name: str) -> dict:
     payload = json.loads(path.read_text(encoding="utf-8-sig"))
     if not isinstance(payload, dict):
         raise ValueError(f"Registro consegne non valido: {name}")
+    if not isinstance(payload.get("students"), list):
+        raise ValueError("Registro consegne non valido: students deve essere una lista.")
     return payload
 
 

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1,0 +1,262 @@
+:root {
+  --ink: #111111;
+  --muted: #666666;
+  --paper: #f6f6f6;
+  --panel: #ffffff;
+  --line: #d7d7d7;
+  --accent: #111111;
+  --shadow: 0 18px 42px rgba(0, 0, 0, 0.08);
+  --mono: "Cascadia Code", "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--ink);
+  background:
+    linear-gradient(rgba(0, 0, 0, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.025) 1px, transparent 1px),
+    #f7f7f7;
+  background-size: 24px 24px;
+  font-family: var(--mono);
+}
+
+.topNav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+  padding: .65rem clamp(1rem, 3vw, 3rem);
+  border-bottom: 1px solid rgba(17, 17, 17, .12);
+  background: rgba(255, 255, 255, .94);
+  backdrop-filter: blur(10px);
+}
+
+.topNavBrand {
+  display: grid;
+  place-items: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  margin-right: .25rem;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: .7rem;
+  background: #ffffff;
+  padding: 0;
+  overflow: hidden;
+}
+
+.topNavBrand img {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.topNav a:not(.topNavBrand) {
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--ink);
+  font: 800 .78rem/1.2 var(--mono);
+  padding: .55rem .85rem;
+  text-decoration: none;
+}
+
+.topNav a:not(.topNavBrand)[aria-current="page"] {
+  background: #111111;
+  color: #ffffff;
+}
+
+.hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2rem clamp(1rem, 3vw, 3rem) 1.25rem;
+}
+
+h1, h2, h3, p { margin-top: 0; }
+
+h1 {
+  margin-bottom: .35rem;
+  font-size: clamp(2rem, 5vw, 4.6rem);
+  line-height: .92;
+  letter-spacing: -.06em;
+}
+
+.subtitle {
+  max-width: 52rem;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.heroTools,
+.actions {
+  display: flex;
+  align-items: center;
+  gap: .55rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+button, select {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--ink);
+  font: 700 .88rem/1.2 var(--mono);
+}
+
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: .72rem 1rem;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
+}
+
+button:hover { transform: translateY(-1px); }
+
+select {
+  min-width: 18rem;
+  padding: .72rem .9rem;
+}
+
+.layout {
+  display: grid;
+  gap: 1rem;
+  padding: 0 clamp(1rem, 3vw, 3rem) 2rem;
+}
+
+.panel {
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, .92);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+  overflow: hidden;
+}
+
+.panelHead {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  padding: 1.1rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, .72);
+}
+
+.panelHead h2 {
+  margin-bottom: .2rem;
+  font-size: 1.25rem;
+}
+
+.status {
+  margin: 0;
+  color: var(--muted);
+  font-size: .9rem;
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: .8rem;
+  padding: 1.1rem;
+}
+
+.summaryCard {
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 18px;
+  background: #ffffff;
+  padding: .85rem;
+}
+
+.summaryCard strong {
+  display: block;
+  margin-bottom: .35rem;
+  color: var(--muted);
+  font-size: .72rem;
+  text-transform: uppercase;
+}
+
+.summaryCard span {
+  font-size: 1.55rem;
+  font-weight: 900;
+}
+
+.filterBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .55rem;
+  padding: 1.1rem;
+}
+
+.filterBar button.isActive {
+  background: #111111;
+  color: #ffffff;
+}
+
+.tableWrap {
+  overflow-x: auto;
+  padding: 1.1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border-bottom: 1px solid var(--line);
+  padding: .65rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  color: var(--muted);
+  font-size: .75rem;
+  text-transform: uppercase;
+}
+
+.badge {
+  display: inline-flex;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 999px;
+  background: #f4f4f4;
+  color: var(--ink);
+  font-size: .72rem;
+  font-weight: 900;
+  padding: .28rem .55rem;
+}
+
+.badgeOk { background: #eaf7ef; color: #0f6b3d; }
+.badgeWarn { background: #fff5df; color: #6b4700; }
+.badgeBad { background: #fdecea; color: #8f1d14; }
+.badgeMuted { background: #eeeeee; color: #666666; }
+
+code {
+  border-radius: .35rem;
+  background: #eeeeee;
+  padding: .1rem .25rem;
+}
+
+@media (max-width: 950px) {
+  .hero, .panelHead {
+    display: grid;
+  }
+
+  .actions {
+    justify-content: flex-start;
+  }
+
+  .summaryGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Assignment Dashboard</title>
+  <link rel="stylesheet" href="assignment_dashboard.css">
+</head>
+<body>
+  <nav class="topNav" aria-label="Navigazione strumenti">
+    <a class="topNavBrand" href="https://github.com/TheBitPoets" target="_blank" rel="noreferrer" aria-label="Apri TheBitPoets su GitHub">
+      <img src="https://github.com/TheBitPoets.png" alt="TheBitPoets">
+    </a>
+    <a href="course_board.html">Percorso</a>
+    <a href="school_calendar.html">Calendario</a>
+    <a href="assignment_dashboard.html" aria-current="page">Consegne</a>
+  </nav>
+
+  <header class="hero">
+    <div>
+      <h1>Assignment Dashboard</h1>
+      <p class="subtitle">Controlla chi ha consegnato, chi manca, ritardi, grading e placeholder AI partendo dai registri JSON docente.</p>
+    </div>
+    <div class="heroTools">
+      <div class="actions">
+        <select id="reportSelect" aria-label="Registri consegne salvati">
+          <option value="">Registri consegne</option>
+        </select>
+        <button id="loadReportBtn" type="button" title="Carica il registro consegne selezionato da teacher-reports.">Carica registro</button>
+        <button id="reloadBtn" type="button" title="Ricarica la lista dei registri disponibili.">Ricarica</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="panel">
+      <div class="panelHead">
+        <div>
+          <h2>Registro selezionato</h2>
+          <p id="status" class="status">Pronto.</p>
+        </div>
+      </div>
+      <div id="reportSummary" class="summaryGrid"></div>
+    </section>
+
+    <section class="panel">
+      <div class="panelHead">
+        <div>
+          <h2>Filtro consegne</h2>
+          <p class="status">Usa i filtri per isolare mancanti, ritardi ed esiti di grading.</p>
+        </div>
+      </div>
+      <div class="filterBar">
+        <button type="button" data-filter="all">Tutti</button>
+        <button type="button" data-filter="pending">Da consegnare</button>
+        <button type="button" data-filter="missing">Mancanti</button>
+        <button type="button" data-filter="submitted">Consegnati</button>
+        <button type="button" data-filter="late">In ritardo</button>
+        <button type="button" data-filter="failed">Test falliti</button>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="panelHead">
+        <div>
+          <h2>Studenti</h2>
+          <p id="tableStatus" class="status">Nessun registro caricato.</p>
+        </div>
+      </div>
+      <div class="tableWrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Studente</th>
+              <th>Stato</th>
+              <th>Scadenza</th>
+              <th>Consegna</th>
+              <th>Grading</th>
+              <th>Voto</th>
+              <th>AI</th>
+            </tr>
+          </thead>
+          <tbody id="studentsBody"></tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <script src="assignment_dashboard.js"></script>
+</body>
+</html>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1,0 +1,222 @@
+const state = {
+  reports: [],
+  report: null,
+  filter: "all",
+};
+
+const els = {
+  reportSelect: document.querySelector("#reportSelect"),
+  loadReportBtn: document.querySelector("#loadReportBtn"),
+  reloadBtn: document.querySelector("#reloadBtn"),
+  status: document.querySelector("#status"),
+  reportSummary: document.querySelector("#reportSummary"),
+  tableStatus: document.querySelector("#tableStatus"),
+  studentsBody: document.querySelector("#studentsBody"),
+  filterButtons: document.querySelectorAll("[data-filter]"),
+};
+
+async function api(path, options = {}) {
+  const response = await fetch(path, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  if (!response.ok) {
+    let detail = "";
+    try {
+      detail = (await response.json()).error || "";
+    } catch {
+      detail = await response.text();
+    }
+    throw new Error(`${response.status} ${response.statusText}${detail ? `: ${detail}` : ""}`);
+  }
+  return response.json();
+}
+
+function setStatus(message) {
+  els.status.textContent = message;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function formatDate(value) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString("it-IT", {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+async function loadReports() {
+  setStatus("Caricamento registri...");
+  const payload = await api("/api/assignment-reports");
+  state.reports = payload.reports || [];
+  renderReportSelect();
+  setStatus(state.reports.length ? `Registri disponibili: ${state.reports.length}.` : "Nessun registro trovato in teacher-reports.");
+}
+
+function renderReportSelect() {
+  const selected = els.reportSelect.value;
+  els.reportSelect.innerHTML = '<option value="">Registri consegne</option>';
+  for (const report of state.reports) {
+    const option = document.createElement("option");
+    option.value = report.name;
+    const title = report.title || report.activity_id || report.name;
+    option.textContent = `${report.name} · ${title} · ${report.students} studenti`;
+    els.reportSelect.append(option);
+  }
+  els.reportSelect.value = selected;
+}
+
+async function loadSelectedReport() {
+  const name = els.reportSelect.value;
+  if (!name) {
+    setStatus("Seleziona un registro consegne.");
+    return;
+  }
+  setStatus(`Caricamento registro ${name}...`);
+  const payload = await api("/api/assignment-reports/load", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+  state.report = payload.report;
+  renderDashboard();
+  setStatus(`Registro caricato: ${name}.`);
+}
+
+function statusKind(status, late, grading) {
+  if (status === "missing") return "bad";
+  if (status === "pending") return "warn";
+  if (late) return "warn";
+  if (grading?.status === "graded_failed") return "bad";
+  if (status?.startsWith("submitted")) return "ok";
+  return "muted";
+}
+
+function badge(text, kind = "muted") {
+  const className = {
+    ok: "badgeOk",
+    warn: "badgeWarn",
+    bad: "badgeBad",
+    muted: "badgeMuted",
+  }[kind] || "badgeMuted";
+  return `<span class="badge ${className}">${escapeHtml(text || "-")}</span>`;
+}
+
+function summaryCounts(students) {
+  return {
+    total: students.length,
+    pending: students.filter((student) => student.status === "pending").length,
+    missing: students.filter((student) => student.status === "missing").length,
+    submitted: students.filter((student) => student.submitted).length,
+    late: students.filter((student) => student.late).length,
+    failed: students.filter((student) => student.grading?.status === "graded_failed").length,
+  };
+}
+
+function renderDashboard() {
+  const students = state.report?.students || [];
+  renderSummary(students);
+  renderStudents(students);
+}
+
+function renderSummary(students) {
+  if (!state.report) {
+    els.reportSummary.innerHTML = '<p class="status">Carica un registro per vedere il riepilogo.</p>';
+    return;
+  }
+  const counts = summaryCounts(students);
+  const cards = [
+    ["Activity", state.report.activity_id || "-"],
+    ["Scadenza", formatDate(state.report.due_at)],
+    ["Studenti", counts.total],
+    ["Consegnati", counts.submitted],
+    ["Mancanti", counts.missing],
+    ["In ritardo", counts.late],
+  ];
+  els.reportSummary.innerHTML = cards.map(([label, value]) => `
+    <article class="summaryCard">
+      <strong>${escapeHtml(label)}</strong>
+      <span>${escapeHtml(value)}</span>
+    </article>
+  `).join("");
+}
+
+function filteredStudents(students) {
+  if (state.filter === "pending") return students.filter((student) => student.status === "pending");
+  if (state.filter === "missing") return students.filter((student) => student.status === "missing");
+  if (state.filter === "submitted") return students.filter((student) => student.submitted);
+  if (state.filter === "late") return students.filter((student) => student.late);
+  if (state.filter === "failed") return students.filter((student) => student.grading?.status === "graded_failed");
+  return students;
+}
+
+function renderStudents(students) {
+  const visible = filteredStudents(students);
+  els.tableStatus.textContent = state.report
+    ? `Mostrati ${visible.length}/${students.length} studenti.`
+    : "Nessun registro caricato.";
+  els.studentsBody.innerHTML = "";
+  if (!state.report) {
+    els.studentsBody.innerHTML = '<tr><td colspan="7">Carica un registro consegne.</td></tr>';
+    return;
+  }
+  if (!visible.length) {
+    els.studentsBody.innerHTML = '<tr><td colspan="7">Nessuno studente per questo filtro.</td></tr>';
+    return;
+  }
+  for (const student of visible) {
+    const grading = student.grading || {};
+    const ai = student.ai_feedback || {};
+    const submission = student.submission || {};
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>
+        <strong>${escapeHtml(student.student)}</strong><br>
+        <small>${escapeHtml(student.repo)}</small>
+      </td>
+      <td>${badge(student.status, statusKind(student.status, student.late, grading))}</td>
+      <td>${escapeHtml(formatDate(student.due_at))}</td>
+      <td>
+        ${escapeHtml(formatDate(submission.submitted_at))}<br>
+        <small>${submission.commit ? `commit ${escapeHtml(submission.commit)}` : "commit non disponibile"}</small><br>
+        <small>${submission.source_path ? escapeHtml(submission.source_path) : "sorgente non indicato"}</small>
+      </td>
+      <td>
+        ${badge(grading.status, grading.status === "graded_passed" ? "ok" : grading.status === "graded_failed" ? "bad" : "muted")}<br>
+        <small>Test: ${escapeHtml(grading.tests_passed ?? "-")}/${escapeHtml(grading.tests_total ?? "-")}</small>
+      </td>
+      <td><code>${escapeHtml(grading.teacher_grade ?? grading.score ?? "-")}</code></td>
+      <td>
+        ${badge(ai.status || "not_generated", ai.approved_by_teacher ? "ok" : "muted")}<br>
+        <small>${ai.suggested_grade ? `Suggerito: ${escapeHtml(ai.suggested_grade)}` : "Nessun voto AI"}</small>
+      </td>
+    `;
+    els.studentsBody.append(row);
+  }
+}
+
+function setFilter(filter) {
+  state.filter = filter;
+  for (const button of els.filterButtons) {
+    button.classList.toggle("isActive", button.dataset.filter === filter);
+  }
+  renderDashboard();
+}
+
+els.loadReportBtn.addEventListener("click", loadSelectedReport);
+els.reloadBtn.addEventListener("click", loadReports);
+els.reportSelect.addEventListener("change", loadSelectedReport);
+els.filterButtons.forEach((button) => {
+  button.addEventListener("click", () => setFilter(button.dataset.filter));
+});
+
+setFilter("all");
+loadReports().catch((error) => setStatus(`Errore: ${error.message}`));

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -122,7 +122,7 @@ function summaryCounts(students) {
 }
 
 function renderDashboard() {
-  const students = state.report?.students || [];
+  const students = Array.isArray(state.report?.students) ? state.report.students : [];
   renderSummary(students);
   renderStudents(students);
 }

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -13,6 +13,7 @@
     </a>
     <a href="course_board.html" aria-current="page">Percorso</a>
     <a href="school_calendar.html">Calendario</a>
+    <a href="assignment_dashboard.html">Consegne</a>
   </nav>
 
   <header class="hero">

--- a/tools/school_calendar.html
+++ b/tools/school_calendar.html
@@ -13,6 +13,7 @@
     </a>
     <a href="course_board.html">Percorso</a>
     <a href="school_calendar.html" aria-current="page">Calendario</a>
+    <a href="assignment_dashboard.html">Consegne</a>
   </nav>
 
   <header class="hero">


### PR DESCRIPTION
﻿## Obiettivo

Aggiunge una prima dashboard docente per visualizzare i registri consegne prodotti da `scripts/track_assignments.py`.

Questa PR chiude il primo ciclo minimo:

- activity assegnata;
- report/registro consegna generato da CLI;
- vista GUI docente per capire chi ha consegnato e chi no.

## Cosa cambia

- Aggiunta pagina `tools/assignment_dashboard.html`.
- Aggiunti `tools/assignment_dashboard.js` e `tools/assignment_dashboard.css`.
- Aggiunto link `Consegne` nella navbar di percorso e calendario.
- Aggiunto endpoint `GET /api/assignment-reports` per listare i registri in `teacher-reports/**/*.json`.
- Aggiunto endpoint `POST /api/assignment-reports/load` per caricare un registro selezionato.
- La dashboard mostra riepilogo activity, scadenza, studenti, consegnati, mancanti e ritardi.
- La tabella mostra stato, consegna, commit, sorgente, grading, voto e placeholder AI.
- Aggiunti filtri: tutti, da consegnare, mancanti, consegnati, in ritardo, test falliti.
- Aggiornata la documentazione in `doc/ASSIGNMENT_SUBMISSIONS.md` e `doc/README.md`.

## Nota importante

La dashboard non ricalcola grading o metriche: visualizza il contratto JSON prodotto da `scripts/track_assignments.py`.

In questo modo CLI, test e GUI restano agganciati allo stesso formato dati.

## Review finding e fix

### 1. Registro con `students` non-lista rompe la dashboard

**Finding:** il server validava solo che il registro fosse un oggetto JSON, ma non che `students` fosse una lista. La dashboard usava poi `students.length` e `students.filter(...)`, quindi un registro incompleto o corrotto poteva generare errore JavaScript invece di un errore leggibile.

**Fix:** ho aggiunto validazione lato server: `students` deve essere una lista. Ho anche reso il frontend difensivo usando una lista vuota se il campo non ha il formato atteso.

Commit: [`8ecd58b`](https://github.com/TheBitPoets/2cornot2c/commit/8ecd58b16a3b3014085c01c7ac5c72b5c7eb4a50)

## Test

Non lanciati localmente.
