### PR TITLE
Rendi esplicita la classe nei registri consegne

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -398,6 +398,9 @@ python scripts/track_assignments.py \
   --targets-file targets-3a.txt \
   --assigned-at 2026-10-12T09:00:00+02:00 \
   --due-at 2026-10-19T23:59:00+02:00 \
+  --class-id 3A-TPSI \
+  --class-label "3A TPSI" \
+  --github-team 3A-TPSI \
   --output teacher-reports/3A/c_sum_with_tests.json
 ```
 
@@ -498,6 +501,23 @@ La dashboard non ricalcola il grading: visualizza il formato prodotto da `script
 
 Il `Quadro classe` aggrega tutti i file JSON presenti in `teacher-reports`. Serve per avere una vista trasversale: tutte le consegne di tutti gli studenti, filtrabili per studente, tipo di activity, stato e modalita di supporto. Da ogni riga si puo aprire il registro collegato e, quando disponibile, la consegna dello studente.
 
+### Classe esplicita nel registro
+
+Un registro consegne deve indicare esplicitamente la classe a cui si riferisce. Non basta dedurla dal nome file o dai repository degli studenti, perche la stessa activity puo essere assegnata a classi diverse o alla stessa classe in momenti diversi.
+
+Campi del registro:
+
+```json
+{
+  "class_id": "3A-TPSI",
+  "class_label": "3A TPSI",
+  "github_team": "3A-TPSI",
+  "activity_id": "c-stringhe-contatore-001"
+}
+```
+
+La GUI usa questi campi in generazione registro, selettore registri, riepilogo del registro selezionato, copertura registri, filtri del quadro classe e matrice. Se la classe non viene indicata durante la generazione, il sistema prova a usare `contesto.classe` e `contesto.team_github` presenti nella activity.
+
 ### Generare il registro dalla GUI
 
 La pagina `Consegne` puo anche generare un registro senza usare direttamente la CLI.
@@ -508,6 +528,9 @@ Nel riquadro `Genera registro` compila:
 |---|---|
 | Activity JSON | Scheda activity da tracciare |
 | Output registro | Path relativo dentro `teacher-reports`, per esempio `3A/somma.json` |
+| Classe | Identificativo classe dell'assegnazione, per esempio `3A-TPSI` |
+| Etichetta classe | Nome leggibile mostrato in dashboard, per esempio `3A TPSI` |
+| Team GitHub | Team GitHub della classe, se disponibile |
 | Assegnato il | Data ISO di assegnazione |
 | Scadenza | Data ISO di scadenza |
 | Ora simulata opzionale | Data ISO usata per simulare il momento attuale |

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -259,6 +259,9 @@ def list_assignment_reports() -> list[dict]:
                 "path": str(path.relative_to(ROOT)).replace("\\", "/"),
                 "activity_id": payload.get("activity_id", ""),
                 "title": payload.get("title", ""),
+                "class_id": payload.get("class_id", ""),
+                "class_label": payload.get("class_label", ""),
+                "github_team": payload.get("github_team", ""),
                 "due_at": payload.get("due_at", ""),
                 "students": len(students),
                 "submitted": submitted,
@@ -305,6 +308,9 @@ def assignment_overview() -> list[dict]:
                     "report_path": report["path"],
                     "activity_id": payload.get("activity_id", ""),
                     "title": payload.get("title", ""),
+                    "class_id": payload.get("class_id", ""),
+                    "class_label": payload.get("class_label", ""),
+                    "github_team": payload.get("github_team", ""),
                     "kind": payload.get("kind", ""),
                     "student_support_mode": payload.get("student_support_mode", ""),
                     "assigned_at": payload.get("assigned_at", ""),
@@ -348,12 +354,16 @@ def list_activities() -> list[dict]:
                 continue
             if not isinstance(payload, dict) or not payload.get("id"):
                 continue
+            context = payload.get("contesto") if isinstance(payload.get("contesto"), dict) else {}
             activities.append(
                 {
                     "id": payload.get("id", ""),
                     "title": payload.get("titolo", ""),
                     "kind": payload.get("tipo", ""),
                     "student_support_mode": payload.get("student_support_mode") or payload.get("support_mode") or payload.get("modalita_studente") or "",
+                    "class_id": context.get("classe", ""),
+                    "class_label": context.get("classe", ""),
+                    "github_team": context.get("team_github", ""),
                     "language": payload.get("linguaggio") or payload.get("language", ""),
                     "path": str(path.relative_to(ROOT)).replace("\\", "/"),
                 }
@@ -446,6 +456,9 @@ def generate_assignment_report(payload: dict) -> dict:
         assigned_at=payload.get("assigned_at") or None,
         due_at=payload.get("due_at") or None,
         now=payload.get("now") or None,
+        class_id=payload.get("class_id") or None,
+        class_label=payload.get("class_label") or None,
+        github_team=payload.get("github_team") or None,
     )
     track_assignments.write_tracking_index(index, output_path)
     return {

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -334,6 +334,17 @@ def ai_feedback_placeholder() -> dict[str, Any]:
     }
 
 
+def activity_context(activity: dict[str, Any]) -> dict[str, Any]:
+    """Return the optional didactic context from an activity."""
+    context = activity.get("contesto")
+    return context if isinstance(context, dict) else {}
+
+
+def clean_metadata(value: str | None) -> str:
+    """Normalize optional text metadata for JSON output."""
+    return str(value or "").strip()
+
+
 def track_assignments(
     *,
     activity_path: Path,
@@ -341,6 +352,9 @@ def track_assignments(
     assigned_at: str | None = None,
     due_at: str | None = None,
     now: str | None = None,
+    class_id: str | None = None,
+    class_label: str | None = None,
+    github_team: str | None = None,
 ) -> dict[str, Any]:
     """Build a teacher-facing tracking index for one activity."""
     activity = create_submission_scaffold.load_activity(activity_path)
@@ -349,6 +363,10 @@ def track_assignments(
     normalized_assigned_at = parse_datetime(assigned_at, "assigned_at")
     normalized_due_at = parse_datetime(due_at, "due_at")
     normalized_now = parse_datetime(now, "now")
+    context = activity_context(activity)
+    normalized_class_id = clean_metadata(class_id) or clean_metadata(context.get("classe"))
+    normalized_class_label = clean_metadata(class_label) or normalized_class_id
+    normalized_github_team = clean_metadata(github_team) or clean_metadata(context.get("team_github"))
 
     students: list[dict[str, Any]] = []
     for target in targets:
@@ -395,6 +413,9 @@ def track_assignments(
         "title": activity.get("titolo") or activity_id,
         "kind": activity.get("tipo"),
         "student_support_mode": activity.get("student_support_mode") or activity.get("support_mode") or activity.get("modalita_studente") or "",
+        "class_id": normalized_class_id,
+        "class_label": normalized_class_label,
+        "github_team": normalized_github_team,
         "assigned_at": normalized_assigned_at,
         "due_at": normalized_due_at,
         "students": students,
@@ -416,6 +437,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assigned-at", help="Data ISO di assegnazione.")
     parser.add_argument("--due-at", help="Data ISO di scadenza.")
     parser.add_argument("--now", help="Data ISO da usare come riferimento temporale nei test o nelle simulazioni.")
+    parser.add_argument("--class-id", help="Identificativo classe dell'assegnazione, per esempio 3A-TPSI.")
+    parser.add_argument("--class-label", help="Etichetta leggibile della classe, per esempio 3A TPSI.")
+    parser.add_argument("--github-team", help="Team GitHub classe associato all'assegnazione.")
     parser.add_argument("--output", type=Path, required=True, help="Path JSON del registro generato.")
     return parser.parse_args()
 
@@ -431,6 +455,9 @@ def main() -> int:
             assigned_at=args.assigned_at,
             due_at=args.due_at,
             now=args.now,
+            class_id=args.class_id,
+            class_label=args.class_label,
+            github_team=args.github_team,
         )
         write_tracking_index(index, args.output)
     except ValueError as error:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -16,6 +16,9 @@ def test_assignment_overview_lists_students_across_saved_reports(tmp_path, monke
             {
                 "activity_id": "python-base-somma-001",
                 "title": "Somma in Python",
+                "class_id": "3A-TPSI",
+                "class_label": "3A TPSI",
+                "github_team": "team-3a-tpsi",
                 "kind": "compito-casa",
                 "student_support_mode": "guidato",
                 "assigned_at": "2026-10-12T09:00:00+02:00",
@@ -62,6 +65,9 @@ def test_assignment_overview_lists_students_across_saved_reports(tmp_path, monke
     assert len(rows) == 2
     assert rows[0]["report_name"] == "demo/python-base-somma-001.json"
     assert rows[0]["activity_id"] == "python-base-somma-001"
+    assert rows[0]["class_id"] == "3A-TPSI"
+    assert rows[0]["class_label"] == "3A TPSI"
+    assert rows[0]["github_team"] == "team-3a-tpsi"
     assert rows[0]["kind"] == "compito-casa"
     assert rows[0]["student_support_mode"] == "guidato"
     assert rows[0]["student"] == "rossi-mario"
@@ -83,6 +89,9 @@ def test_list_assignment_reports_counts_late_only_for_submitted_students(tmp_pat
         json.dumps(
             {
                 "activity_id": "activity",
+                "class_id": "4A-INF",
+                "class_label": "4A INF",
+                "github_team": "team-4a-inf",
                 "students": [
                     {"student": "rossi-mario", "status": "submitted_late", "submitted": True, "late": True},
                     {"student": "bianchi-luca", "status": "missing", "submitted": False, "late": True},
@@ -95,6 +104,9 @@ def test_list_assignment_reports_counts_late_only_for_submitted_students(tmp_pat
 
     reports = course_board_server.list_assignment_reports()
 
+    assert reports[0]["class_id"] == "4A-INF"
+    assert reports[0]["class_label"] == "4A INF"
+    assert reports[0]["github_team"] == "team-4a-inf"
     assert reports[0]["students"] == 3
     assert reports[0]["submitted"] == 2
     assert reports[0]["not_submitted"] == 1

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -137,6 +137,43 @@ def test_track_assignments_marks_submitted_on_time(tmp_path) -> None:
     assert row["submission"]["files"][0]["role"] == "solution"
 
 
+def test_track_assignments_records_explicit_class_metadata(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        class_id="3A-TPSI",
+        class_label="3A TPSI",
+        github_team="team-3a-tpsi",
+    )
+
+    assert index["class_id"] == "3A-TPSI"
+    assert index["class_label"] == "3A TPSI"
+    assert index["github_team"] == "team-3a-tpsi"
+
+
+def test_track_assignments_uses_activity_context_class_metadata(tmp_path) -> None:
+    payload = activity()
+    payload["contesto"] = {
+        "classe": "4A-INF",
+        "team_github": "team-4a-inf",
+    }
+    activity_path = tmp_path / "activity.json"
+    activity_path.write_text(json.dumps(payload), encoding="utf-8")
+    student = target(tmp_path, "rossi-mario")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+    )
+
+    assert index["class_id"] == "4A-INF"
+    assert index["class_label"] == "4A-INF"
+    assert index["github_team"] == "team-4a-inf"
+
+
 def test_track_assignments_lists_multiple_submission_files(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "rossi-mario")

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -681,10 +681,6 @@ label {
   min-width: 78rem;
 }
 
-#overviewListTable {
-  min-width: 96rem;
-}
-
 .status {
   margin: 0;
   color: var(--muted);
@@ -897,14 +893,6 @@ th.isResizableColumn:hover {
 }
 
 .classBadge { background: #eef4f8; color: #28506a; }
-
-.classBadge {
-  max-width: 11rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .typeHomework { background: #eaf1ff; color: #1e4fa8; }
 .typeLab { background: #e5f6ef; color: #0f684a; }
 .typeClasswork { background: #fff1df; color: #81501a; }

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -677,7 +677,7 @@ label {
 }
 
 .overviewDialog {
-  grid-template-rows: auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto auto minmax(0, 1fr);
   width: min(96vw, 92rem);
   height: min(90vh, 54rem);
   min-width: min(92vw, 38rem);
@@ -716,6 +716,12 @@ label {
 .overviewDialogHead h2 {
   margin-bottom: .25rem;
   font-size: 1.2rem;
+}
+
+.overviewDialogFilters {
+  padding-bottom: .9rem;
+  border-bottom: 1px solid var(--line);
+  background: #ffffff;
 }
 
 .overviewDialog .viewTabs {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -872,7 +872,6 @@ label {
 }
 
 .tableWrap {
-  box-sizing: border-box;
   overflow-x: auto;
   padding: 1.1rem;
 }

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1153,10 +1153,19 @@ button.matrixCell {
   cursor: pointer;
 }
 
+button.matrixCell:disabled {
+  cursor: not-allowed;
+}
+
 button.matrixCell:hover,
 button.matrixCell:focus-visible {
   outline: 2px solid rgba(17, 17, 17, .28);
   outline-offset: 2px;
+}
+
+button.matrixCell:disabled:hover,
+button.matrixCell:disabled:focus-visible {
+  outline: 0;
 }
 
 .matrixCell small {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -860,6 +860,16 @@ th.isResizableColumn:hover {
   border-left: 4px solid transparent;
 }
 
+.overviewReportName {
+  display: block;
+  max-width: 12rem;
+  margin-top: .25rem;
+  overflow: hidden;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .typeHomeworkRow { border-left-color: #2f6fed; }
 .typeLabRow { border-left-color: #16825d; }
 .typeClassworkRow { border-left-color: #b45f06; }

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -642,6 +642,40 @@ label {
   padding: 0 1.1rem 1.1rem;
 }
 
+.overviewSummary {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: .75rem;
+  padding: 1.1rem;
+}
+
+.overviewSummary > .status {
+  grid-column: 1 / -1;
+}
+
+.overviewSummaryItem {
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: .75rem;
+}
+
+.overviewSummaryItem strong {
+  display: block;
+  margin-bottom: .35rem;
+  color: var(--muted);
+  font-size: .72rem;
+  text-transform: uppercase;
+}
+
+.overviewSummaryItem span {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 1.1rem;
+  font-weight: 900;
+}
+
 .overviewDialog {
   grid-template-rows: auto auto minmax(0, 1fr);
   width: min(96vw, 92rem);
@@ -1348,6 +1382,10 @@ code {
   }
 
   .studentsSummary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .overviewSummary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -352,6 +352,8 @@ label {
 .coverageDialogTable {
   min-height: 0;
   overflow: auto;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
 }
 
 #coverageTable {
@@ -796,10 +798,21 @@ label {
 .studentsDialogTable {
   min-height: 0;
   overflow: auto;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
 }
 
 #studentsTable {
   min-width: 78rem;
+}
+
+.coverageDialogTable thead th,
+.studentsDialogTable thead th {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  background: #ffffff;
+  box-shadow: inset 0 -1px 0 var(--line);
 }
 
 .status {
@@ -852,6 +865,7 @@ label {
 }
 
 .tableWrap {
+  box-sizing: border-box;
   overflow-x: auto;
   padding: 1.1rem;
 }

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -636,6 +636,73 @@ label {
   overflow: hidden;
 }
 
+.overviewActions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 1.1rem 1.1rem;
+}
+
+.overviewDialog {
+  grid-template-rows: auto auto minmax(0, 1fr);
+  width: min(96vw, 92rem);
+  height: min(90vh, 54rem);
+  min-width: min(92vw, 38rem);
+  min-height: 24rem;
+  max-width: 98vw;
+  max-height: 94vh;
+  margin: auto;
+  border: 1px solid rgba(17, 17, 17, .18);
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 22px 70px rgba(17, 17, 17, .28);
+  color: var(--ink);
+  padding: 0;
+  resize: both;
+  overflow: hidden;
+}
+
+.overviewDialog[open] {
+  display: grid;
+}
+
+.overviewDialog::backdrop {
+  background: rgba(17, 17, 17, .42);
+}
+
+.overviewDialogHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid var(--line);
+  background: #ffffff;
+}
+
+.overviewDialogHead h2 {
+  margin-bottom: .25rem;
+  font-size: 1.2rem;
+}
+
+.overviewDialog .viewTabs {
+  border-bottom: 1px solid var(--line);
+}
+
+.overviewDialogBody {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.overviewDialogBody > .tableWrap {
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+}
+
+.overviewDialogBody > [hidden] {
+  display: none !important;
+}
+
 .studentsDialog[open] {
   display: grid;
 }

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -681,6 +681,10 @@ label {
   min-width: 78rem;
 }
 
+#overviewListTable {
+  min-width: 96rem;
+}
+
 .status {
   margin: 0;
   color: var(--muted);
@@ -893,6 +897,14 @@ th.isResizableColumn:hover {
 }
 
 .classBadge { background: #eef4f8; color: #28506a; }
+
+.classBadge {
+  max-width: 11rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .typeHomework { background: #eaf1ff; color: #1e4fa8; }
 .typeLab { background: #e5f6ef; color: #0f684a; }
 .typeClasswork { background: #fff1df; color: #81501a; }

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -498,6 +498,13 @@ label {
   align-items: center;
 }
 
+.coverageStatusCell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+  align-items: center;
+}
+
 .coverageReportCell button {
   border: 0;
   border-bottom: 1px solid currentColor;

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -737,10 +737,24 @@ label {
   height: 100%;
   min-height: 0;
   overflow: auto;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
 }
 
 .overviewDialogBody > [hidden] {
   display: none !important;
+}
+
+.overviewDialogBody thead th {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  background: #ffffff;
+  box-shadow: inset 0 -1px 0 var(--line);
+}
+
+#overviewListTable {
+  min-width: 82rem;
 }
 
 .studentsDialog[open] {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -178,7 +178,7 @@ select {
 .viewTabs {
   display: flex;
   gap: .45rem;
-  padding: .85rem 1.1rem 0;
+  padding: .85rem 1.1rem;
 }
 
 .viewTabs button {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -355,7 +355,7 @@ label {
 }
 
 #coverageTable {
-  min-width: 72rem;
+  min-width: 82rem;
 }
 
 .coverageOk { background: #f5fbf7; }
@@ -689,7 +689,7 @@ label {
 
 .summaryGrid {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
   gap: .8rem;
   padding: 1.1rem;
 }
@@ -878,6 +878,7 @@ th.isResizableColumn:hover {
 .typeUnknownRow td:first-child { border-left-color: #8a8a8a; }
 
 .typeBadge,
+.classBadge,
 .studentName {
   display: inline-flex;
   width: fit-content;
@@ -891,6 +892,7 @@ th.isResizableColumn:hover {
   overflow-wrap: anywhere;
 }
 
+.classBadge { background: #eef4f8; color: #28506a; }
 .typeHomework { background: #eaf1ff; color: #1e4fa8; }
 .typeLab { background: #e5f6ef; color: #0f684a; }
 .typeClasswork { background: #fff1df; color: #81501a; }

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -118,38 +118,6 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           <p id="overviewStatus" class="status">Caricamento quadro classe...</p>
         </div>
       </div>
-      <div class="overviewFilters">
-        <label>
-          <span>Classe</span>
-          <select id="overviewClassFilter" aria-label="Filtra quadro classe per classe">
-            <option value="">Tutte</option>
-          </select>
-        </label>
-        <label>
-          <span>Studente</span>
-          <select id="overviewStudentFilter" aria-label="Filtra quadro classe per studente">
-            <option value="">Tutti</option>
-          </select>
-        </label>
-        <label>
-          <span>Tipo</span>
-          <select id="overviewKindFilter" aria-label="Filtra quadro classe per tipo activity">
-            <option value="">Tutti</option>
-          </select>
-        </label>
-        <label>
-          <span>Stato</span>
-          <select id="overviewStatusFilter" aria-label="Filtra quadro classe per stato">
-            <option value="">Tutti</option>
-          </select>
-        </label>
-        <label>
-          <span>Modalita</span>
-          <select id="overviewSupportFilter" aria-label="Filtra quadro classe per modalita supporto">
-            <option value="">Tutte</option>
-          </select>
-        </label>
-      </div>
       <div id="overviewSummary" class="overviewSummary" aria-live="polite">
         <p class="status">Caricamento riepilogo quadro classe...</p>
       </div>
@@ -182,6 +150,38 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         <p class="status">Elenco e matrice delle consegne filtrate.</p>
       </div>
       <button id="overviewCloseBtn" type="button" class="smallButton" title="Chiudi il quadro classe e torna alla dashboard.">Chiudi</button>
+    </div>
+    <div class="overviewFilters overviewDialogFilters">
+      <label>
+        <span>Classe</span>
+        <select id="overviewClassFilter" aria-label="Filtra quadro classe per classe">
+          <option value="">Tutte</option>
+        </select>
+      </label>
+      <label>
+        <span>Studente</span>
+        <select id="overviewStudentFilter" aria-label="Filtra quadro classe per studente">
+          <option value="">Tutti</option>
+        </select>
+      </label>
+      <label>
+        <span>Tipo</span>
+        <select id="overviewKindFilter" aria-label="Filtra quadro classe per tipo activity">
+          <option value="">Tutti</option>
+        </select>
+      </label>
+      <label>
+        <span>Stato</span>
+        <select id="overviewStatusFilter" aria-label="Filtra quadro classe per stato">
+          <option value="">Tutti</option>
+        </select>
+      </label>
+      <label>
+        <span>Modalita</span>
+        <select id="overviewSupportFilter" aria-label="Filtra quadro classe per modalita supporto">
+          <option value="">Tutte</option>
+        </select>
+      </label>
     </div>
     <div class="viewTabs" role="tablist" aria-label="Vista quadro classe">
       <button type="button" class="isActive" data-overview-view="list" role="tab" aria-selected="true" title="Mostra il quadro classe come elenco ordinabile, una riga per studente e activity.">Elenco</button>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -150,10 +150,41 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           </select>
         </label>
       </div>
-      <div class="viewTabs" role="tablist" aria-label="Vista quadro classe">
-        <button type="button" class="isActive" data-overview-view="list" role="tab" aria-selected="true" title="Mostra il quadro classe come elenco ordinabile, una riga per studente e activity.">Elenco</button>
-        <button type="button" data-overview-view="matrix" role="tab" aria-selected="false" title="Mostra il quadro classe come matrice con studenti a sinistra e consegne in colonna.">Matrice</button>
+      <div class="overviewActions">
+        <button id="overviewOpenBtn" type="button" title="Apri elenco e matrice del quadro classe in un modal.">Apri quadro classe</button>
       </div>
+    </section>
+
+    <section class="panel" data-panel-key="students">
+      <div class="panelHead">
+        <div>
+          <h2>Studenti</h2>
+          <p id="tableStatus" class="status">Nessun registro caricato.</p>
+        </div>
+      </div>
+      <div id="studentsSummary" class="studentsSummary" aria-live="polite">
+        <p class="status">Carica un registro per vedere il riepilogo studenti.</p>
+      </div>
+      <div class="studentsActions">
+        <button id="studentsOpenBtn" type="button" title="Apri la tabella studenti del registro selezionato in un modal.">Apri studenti</button>
+      </div>
+    </section>
+
+  </main>
+
+  <dialog id="overviewDialog" class="overviewDialog" aria-labelledby="overviewDialogTitle">
+    <div class="overviewDialogHead">
+      <div>
+        <h2 id="overviewDialogTitle">Quadro classe</h2>
+        <p class="status">Elenco e matrice delle consegne filtrate.</p>
+      </div>
+      <button id="overviewCloseBtn" type="button" class="smallButton" title="Chiudi il quadro classe e torna alla dashboard.">Chiudi</button>
+    </div>
+    <div class="viewTabs" role="tablist" aria-label="Vista quadro classe">
+      <button type="button" class="isActive" data-overview-view="list" role="tab" aria-selected="true" title="Mostra il quadro classe come elenco ordinabile, una riga per studente e activity.">Elenco</button>
+      <button type="button" data-overview-view="matrix" role="tab" aria-selected="false" title="Mostra il quadro classe come matrice con studenti a sinistra e consegne in colonna.">Matrice</button>
+    </div>
+    <div class="overviewDialogBody">
       <div id="overviewListView" class="tableWrap">
         <table id="overviewListTable" class="resizableTable">
           <thead>
@@ -179,24 +210,8 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           <tbody id="overviewMatrixBody"></tbody>
         </table>
       </div>
-    </section>
-
-    <section class="panel" data-panel-key="students">
-      <div class="panelHead">
-        <div>
-          <h2>Studenti</h2>
-          <p id="tableStatus" class="status">Nessun registro caricato.</p>
-        </div>
-      </div>
-      <div id="studentsSummary" class="studentsSummary" aria-live="polite">
-        <p class="status">Carica un registro per vedere il riepilogo studenti.</p>
-      </div>
-      <div class="studentsActions">
-        <button id="studentsOpenBtn" type="button" title="Apri la tabella studenti del registro selezionato in un modal.">Apri studenti</button>
-      </div>
-    </section>
-
-  </main>
+    </div>
+  </dialog>
 
   <dialog id="reviewDialog" class="reviewDialog" aria-labelledby="reviewDialogTitle">
     <div class="reviewDialogHead">

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -150,6 +150,9 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           </select>
         </label>
       </div>
+      <div id="overviewSummary" class="overviewSummary" aria-live="polite">
+        <p class="status">Caricamento riepilogo quadro classe...</p>
+      </div>
       <div class="overviewActions">
         <button id="overviewOpenBtn" type="button" title="Apri elenco e matrice del quadro classe in un modal.">Apri quadro classe</button>
       </div>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -56,6 +56,18 @@
           <input id="outputName" type="text" value="demo/demo_assignment.json">
         </label>
         <label>
+          <span>Classe</span>
+          <input id="classId" type="text" value="demo" placeholder="3A-TPSI">
+        </label>
+        <label>
+          <span>Etichetta classe</span>
+          <input id="classLabel" type="text" value="Classe demo" placeholder="3A TPSI">
+        </label>
+        <label>
+          <span>Team GitHub</span>
+          <input id="githubTeam" type="text" placeholder="3A-TPSI">
+        </label>
+        <label>
           <span>Assegnato il</span>
           <input id="assignedAt" type="text" value="2026-10-12T09:00:00+02:00">
         </label>
@@ -108,6 +120,12 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       </div>
       <div class="overviewFilters">
         <label>
+          <span>Classe</span>
+          <select id="overviewClassFilter" aria-label="Filtra quadro classe per classe">
+            <option value="">Tutte</option>
+          </select>
+        </label>
+        <label>
           <span>Studente</span>
           <select id="overviewStudentFilter" aria-label="Filtra quadro classe per studente">
             <option value="">Tutti</option>
@@ -140,6 +158,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         <table id="overviewListTable" class="resizableTable">
           <thead>
             <tr>
+              <th><button type="button" class="sortButton" data-overview-sort="class" title="Ordina le righe per classe.">Classe</button></th>
               <th><button type="button" class="sortButton" data-overview-sort="student" title="Ordina le righe per studente: crescente, decrescente, poi reset.">Studente</button></th>
               <th><button type="button" class="sortButton" data-overview-sort="activity" title="Ordina le righe per titolo o id activity: crescente, decrescente, poi reset.">Activity</button></th>
               <th><button type="button" class="sortButton" data-overview-sort="kind" title="Ordina le righe per tipo di consegna secondo l'ordine didattico.">Tipo</button></th>
@@ -211,6 +230,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         <thead>
           <tr>
             <th>Activity</th>
+            <th>Classe</th>
             <th>Tipo</th>
             <th>Modalita</th>
             <th>Stato</th>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1560,9 +1560,9 @@ function selectActivity(path) {
   els.activityPath.value = path;
   const activity = state.activities.find((candidate) => candidate.path === path);
   if (activity?.id) {
-    if (activity.class_id) els.classId.value = activity.class_id;
-    if (activity.class_label) els.classLabel.value = activity.class_label;
-    if (activity.github_team) els.githubTeam.value = activity.github_team;
+    els.classId.value = activity.class_id || activity.github_team || "";
+    els.classLabel.value = activity.class_label || activity.class_id || "";
+    els.githubTeam.value = activity.github_team || "";
     els.outputName.value = defaultOutputName(activity);
   }
 }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -298,6 +298,10 @@ function classKey(entity) {
   return slugPathSegment(entity?.class_id || entity?.github_team || entity?.class_label || classValue(entity));
 }
 
+function hasExplicitClass(entity) {
+  return Boolean(entity?.class_id || entity?.github_team || entity?.class_label);
+}
+
 function slugPathSegment(value, fallback = "classe-non-indicata") {
   return String(value || fallback)
     .trim()
@@ -584,8 +588,9 @@ function activityCoverageKey(activity) {
 function reportsForActivity(activity) {
   const activityId = activity?.id || "";
   const activityClassKey = classKey(activity);
+  const activityHasClass = hasExplicitClass(activity);
   return state.reports
-    .filter((report) => report.activity_id === activityId && classKey(report) === activityClassKey)
+    .filter((report) => report.activity_id === activityId && (!activityHasClass || classKey(report) === activityClassKey))
     .sort((a, b) => {
       const first = Date.parse(a.updated_at || a.due_at || "");
       const second = Date.parse(b.updated_at || b.due_at || "");

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1099,8 +1099,8 @@ function renderOverview() {
       </td>
       <td><code>${escapeHtml(grade)}</code></td>
       <td>
-        <button type="button" class="smallButton" data-overview-report="${escapeHtml(row.report_name)}" data-overview-student="${escapeHtml(row.student || "")}" title="Apri il registro ${escapeHtml(row.report_name || "collegato")} e la consegna di ${escapeHtml(row.student || "questo studente")}.">
-          Apri
+        <button type="button" class="smallButton" data-overview-report="${escapeHtml(row.report_name)}" data-overview-student="${escapeHtml(row.student || "")}" title="Apri la consegna di ${escapeHtml(row.student || "questo studente")} per questa activity.">
+          Consegna
         </button><br>
         <small class="overviewReportName" title="${escapeHtml(row.report_name || "-")}">${escapeHtml(row.report_name || "-")}</small>
       </td>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -32,6 +32,7 @@ const state = {
   reportName: "",
   filter: "all",
   overviewFilters: {
+    class: "",
     student: "",
     kind: "",
     status: "",
@@ -66,6 +67,7 @@ const els = {
   reportSummary: document.querySelector("#reportSummary"),
   overviewStatus: document.querySelector("#overviewStatus"),
   overviewBody: document.querySelector("#overviewBody"),
+  overviewClassFilter: document.querySelector("#overviewClassFilter"),
   overviewStudentFilter: document.querySelector("#overviewStudentFilter"),
   overviewKindFilter: document.querySelector("#overviewKindFilter"),
   overviewStatusFilter: document.querySelector("#overviewStatusFilter"),
@@ -97,6 +99,9 @@ const els = {
   activitySelect: document.querySelector("#activitySelect"),
   activityPath: document.querySelector("#activityPath"),
   outputName: document.querySelector("#outputName"),
+  classId: document.querySelector("#classId"),
+  classLabel: document.querySelector("#classLabel"),
+  githubTeam: document.querySelector("#githubTeam"),
   assignedAt: document.querySelector("#assignedAt"),
   dueAt: document.querySelector("#dueAt"),
   nowAt: document.querySelector("#nowAt"),
@@ -277,6 +282,23 @@ function formatDate(value) {
   });
 }
 
+function classValue(entity) {
+  return entity?.class_label || entity?.class_id || entity?.github_team || "classe non indicata";
+}
+
+function classBadge(entity) {
+  return `<span class="classBadge">${escapeHtml(classValue(entity))}</span>`;
+}
+
+function slugPathSegment(value, fallback = "classe-non-indicata") {
+  return String(value || fallback)
+    .trim()
+    .toLowerCase()
+    .replaceAll("\\", "/")
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || fallback;
+}
+
 async function loadReports() {
   setStatus("Caricamento registri...");
   const payload = await api("/api/assignment-reports");
@@ -302,7 +324,7 @@ function renderReportSelect() {
     const option = document.createElement("option");
     option.value = report.name;
     const title = report.title || report.activity_id || report.name;
-    option.textContent = `${report.name} - ${title} - ${report.students} studenti`;
+    option.textContent = `${classValue(report)} - ${report.name} - ${title} - ${report.students} studenti`;
     els.reportSelect.append(option);
   }
   els.reportSelect.value = selected;
@@ -540,7 +562,7 @@ function renderActivitySelect() {
     const option = document.createElement("option");
     option.value = activity.path;
     option.dataset.activityId = activity.id;
-    option.textContent = `${activity.id} - ${activity.title || activity.path}`;
+    option.textContent = `${classValue(activity)} - ${activity.id} - ${activity.title || activity.path}`;
     els.activitySelect.append(option);
   }
   const current = els.activityPath.value.trim().replaceAll("\\", "/");
@@ -567,9 +589,13 @@ function reportCoverageRows() {
   });
 }
 
+function currentClassId(activity = null) {
+  return els.classId.value.trim() || activity?.class_id || activity?.github_team || "classe-non-indicata";
+}
+
 function defaultOutputName(activity) {
   const id = activity?.id || "registro";
-  return `demo/${id}.json`;
+  return `${slugPathSegment(currentClassId(activity))}/${id}.json`;
 }
 
 function selectCoverageActivity(activityPath, outputName = "") {
@@ -696,7 +722,7 @@ function renderCoverage() {
   `;
   els.coverageBody.innerHTML = "";
   if (!rows.length) {
-    els.coverageBody.innerHTML = '<tr><td colspan="7">Nessuna activity disponibile.</td></tr>';
+    els.coverageBody.innerHTML = '<tr><td colspan="8">Nessuna activity disponibile.</td></tr>';
     setupResizableTable(els.coverageTable, "coverage");
     return;
   }
@@ -729,6 +755,7 @@ function renderCoverage() {
           <small>${escapeHtml(activity.id || "-")}</small><br>
           <small>${escapeHtml(activity.path || "-")}</small>
         </td>
+        <td>${report ? classBadge(report) : classBadge(activity)}</td>
         <td>${kindLabel(activity.kind)}</td>
         <td>${escapeHtml(activity.student_support_mode || "-")}</td>
         <td>${badge(outcome.label, outcome.kind === "muted" && !report ? "warn" : outcome.kind)}</td>
@@ -769,10 +796,12 @@ function renderSelectOptions(select, values, currentValue, emptyLabel = "Tutti")
 
 function renderOverviewFilters() {
   const rows = state.overviewRows;
+  renderSelectOptions(els.overviewClassFilter, uniqueSorted(rows.map((row) => classValue(row))), state.overviewFilters.class, "Tutte");
   renderSelectOptions(els.overviewStudentFilter, uniqueSorted(rows.map((row) => row.student)), state.overviewFilters.student);
   renderSelectOptions(els.overviewKindFilter, uniqueSorted(rows.map((row) => row.kind || "tipo non indicato")), state.overviewFilters.kind);
   renderSelectOptions(els.overviewStatusFilter, uniqueSorted(rows.map((row) => row.status || "stato non indicato")), state.overviewFilters.status);
   renderSelectOptions(els.overviewSupportFilter, uniqueSorted(rows.map((row) => row.student_support_mode || "non indicata")), state.overviewFilters.support, "Tutte");
+  state.overviewFilters.class = els.overviewClassFilter.value;
   state.overviewFilters.student = els.overviewStudentFilter.value;
   state.overviewFilters.kind = els.overviewKindFilter.value;
   state.overviewFilters.status = els.overviewStatusFilter.value;
@@ -781,10 +810,12 @@ function renderOverviewFilters() {
 
 function filteredOverviewRows() {
   return state.overviewRows.filter((row) => {
+    const classLabel = classValue(row);
     const kind = row.kind || "tipo non indicato";
     const status = row.status || "stato non indicato";
     const support = row.student_support_mode || "non indicata";
-    return (!state.overviewFilters.student || row.student === state.overviewFilters.student)
+    return (!state.overviewFilters.class || classLabel === state.overviewFilters.class)
+      && (!state.overviewFilters.student || row.student === state.overviewFilters.student)
       && (!state.overviewFilters.kind || kind === state.overviewFilters.kind)
       && (!state.overviewFilters.status || status === state.overviewFilters.status)
       && (!state.overviewFilters.support || support === state.overviewFilters.support);
@@ -797,6 +828,7 @@ function orderIndex(order, value) {
 }
 
 function overviewSortValue(row, column) {
+  if (column === "class") return classValue(row);
   if (column === "student") return row.student || "";
   if (column === "activity") return `${row.title || ""} ${row.activity_id || ""}`.trim();
   if (column === "kind") return orderIndex(OVERVIEW_TYPE_ORDER, row.kind || "");
@@ -869,7 +901,7 @@ function renderOverviewViewTabs() {
 }
 
 function activityKey(row) {
-  return row.activity_id || row.title || row.report_name || "";
+  return `${classValue(row)}::${row.report_name || row.activity_id || row.title || ""}`;
 }
 
 function activityLabel(row) {
@@ -954,6 +986,7 @@ function renderOverviewMatrix(rows) {
     ${activities.map((activity) => `
       <th class="matrixActivityHeader ${kindRowClass(activity.kind)}">
         <span>${escapeHtml(activityLabel(activity))}</span>
+        <small>${escapeHtml(classValue(activity))}</small>
         <small>${escapeHtml(activity.kind || "-")}</small>
       </th>
     `).join("")}
@@ -998,13 +1031,13 @@ function renderOverview() {
   }
   els.overviewBody.innerHTML = "";
   if (!state.overviewRows.length) {
-    els.overviewBody.innerHTML = '<tr><td colspan="9">Genera o carica almeno un registro consegne.</td></tr>';
+    els.overviewBody.innerHTML = '<tr><td colspan="10">Genera o carica almeno un registro consegne.</td></tr>';
     renderOverviewMatrix(rows);
     setupResizableTables();
     return;
   }
   if (!rows.length) {
-    els.overviewBody.innerHTML = '<tr><td colspan="9">Nessuna activity per questi filtri.</td></tr>';
+    els.overviewBody.innerHTML = '<tr><td colspan="10">Nessuna activity per questi filtri.</td></tr>';
     renderOverviewMatrix(rows);
     setupResizableTables();
     return;
@@ -1015,6 +1048,7 @@ function renderOverview() {
     const tr = document.createElement("tr");
     tr.className = `overviewRow ${kindRowClass(row.kind)}`;
     tr.innerHTML = `
+      <td>${classBadge(row)}</td>
       <td>${studentLabel(row.student)}</td>
       <td>
         <strong>${escapeHtml(row.title || row.activity_id || "-")}</strong><br>
@@ -1051,6 +1085,9 @@ async function generateReport() {
       body: JSON.stringify({
         activity_path: els.activityPath.value,
         output_name: els.outputName.value,
+        class_id: els.classId.value,
+        class_label: els.classLabel.value,
+        github_team: els.githubTeam.value,
         assigned_at: els.assignedAt.value,
         due_at: els.dueAt.value,
         now: els.nowAt.value,
@@ -1181,6 +1218,7 @@ function renderSummary(students) {
   }
   const counts = summaryCounts(students);
   const cards = [
+    ["Classe", classValue(state.report)],
     ["Activity", state.report.activity_id || "-"],
     ["Scadenza", formatDate(state.report.due_at)],
     ["Studenti", counts.total],
@@ -1479,8 +1517,16 @@ function selectActivity(path) {
   els.activityPath.value = path;
   const activity = state.activities.find((candidate) => candidate.path === path);
   if (activity?.id) {
-    els.outputName.value = `demo/${activity.id}_assignment.json`;
+    if (activity.class_id) els.classId.value = activity.class_id;
+    if (activity.class_label) els.classLabel.value = activity.class_label;
+    if (activity.github_team) els.githubTeam.value = activity.github_team;
+    els.outputName.value = defaultOutputName(activity);
   }
+}
+
+function updateOutputNameForCurrentActivity() {
+  const activity = state.activities.find((candidate) => candidate.path === els.activityPath.value.trim().replaceAll("\\", "/"));
+  if (activity?.id) els.outputName.value = defaultOutputName(activity);
 }
 
 function openCoverageDialog() {
@@ -1529,6 +1575,7 @@ els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) selectActivity(els.activitySelect.value);
 });
 els.activityPath.addEventListener("input", renderActivitySelect);
+els.classId.addEventListener("change", updateOutputNameForCurrentActivity);
 els.coverageBody.addEventListener("click", async (event) => {
   const toggleButton = event.target.closest("[data-coverage-toggle]");
   const selectButton = event.target.closest("[data-coverage-select]");
@@ -1562,6 +1609,7 @@ els.coverageBody.addEventListener("click", async (event) => {
   }
 });
 [
+  [els.overviewClassFilter, "class"],
   [els.overviewStudentFilter, "student"],
   [els.overviewKindFilter, "kind"],
   [els.overviewStatusFilter, "status"],

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1080,6 +1080,10 @@ function renderOverview() {
   for (const row of rows) {
     const testText = row.tests_total == null ? "-" : `${row.tests_passed ?? "-"}/${row.tests_total}`;
     const grade = row.teacher_grade ?? row.score ?? "-";
+    const hasSubmission = row.submitted || row.status?.startsWith("submitted");
+    const submissionTitle = hasSubmission
+      ? `Apri la consegna di ${escapeHtml(row.student || "questo studente")} per questa activity.`
+      : "Consegna non disponibile: lo studente non ha ancora consegnato.";
     const tr = document.createElement("tr");
     tr.className = `overviewRow ${kindRowClass(row.kind)}`;
     tr.innerHTML = `
@@ -1099,7 +1103,7 @@ function renderOverview() {
       </td>
       <td><code>${escapeHtml(grade)}</code></td>
       <td>
-        <button type="button" class="smallButton" data-overview-report="${escapeHtml(row.report_name)}" data-overview-student="${escapeHtml(row.student || "")}" title="Apri la consegna di ${escapeHtml(row.student || "questo studente")} per questa activity.">
+        <button type="button" class="smallButton" data-overview-report="${escapeHtml(row.report_name)}" data-overview-student="${escapeHtml(row.student || "")}" title="${submissionTitle}" ${hasSubmission ? "" : "disabled"}>
           Consegna
         </button><br>
         <small class="overviewReportName" title="${escapeHtml(row.report_name || "-")}">${escapeHtml(row.report_name || "-")}</small>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -74,6 +74,9 @@ const els = {
   overviewSupportFilter: document.querySelector("#overviewSupportFilter"),
   overviewSortButtons: document.querySelectorAll("[data-overview-sort]"),
   overviewViewButtons: document.querySelectorAll("[data-overview-view]"),
+  overviewDialog: document.querySelector("#overviewDialog"),
+  overviewOpenBtn: document.querySelector("#overviewOpenBtn"),
+  overviewCloseBtn: document.querySelector("#overviewCloseBtn"),
   overviewListView: document.querySelector("#overviewListView"),
   overviewMatrixView: document.querySelector("#overviewMatrixView"),
   overviewListTable: document.querySelector("#overviewListTable"),
@@ -1543,6 +1546,20 @@ function closeCoverageDialog() {
   }
 }
 
+function openOverviewDialog() {
+  if (els.overviewDialog && !els.overviewDialog.open) {
+    els.overviewDialog.showModal();
+  }
+  setupResizableTable(els.overviewListTable, "overview-list");
+  setupResizableTable(els.overviewMatrixTable, "overview-matrix");
+}
+
+function closeOverviewDialog() {
+  if (els.overviewDialog?.open) {
+    els.overviewDialog.close();
+  }
+}
+
 function openStudentsDialog() {
   if (els.studentsDialog && !els.studentsDialog.open) {
     els.studentsDialog.showModal();
@@ -1566,6 +1583,8 @@ els.generateReportBtn.addEventListener("click", generateReport);
 els.reportSelect.addEventListener("change", loadSelectedReport);
 els.coverageOpenBtn.addEventListener("click", openCoverageDialog);
 els.coverageCloseBtn.addEventListener("click", closeCoverageDialog);
+els.overviewOpenBtn.addEventListener("click", openOverviewDialog);
+els.overviewCloseBtn.addEventListener("click", closeOverviewDialog);
 els.studentsOpenBtn.addEventListener("click", openStudentsDialog);
 els.studentsCloseBtn.addEventListener("click", closeStudentsDialog);
 els.reviewPrevBtn.addEventListener("click", () => openAdjacentSubmission(-1));
@@ -1627,6 +1646,7 @@ els.overviewViewButtons.forEach((button) => {
   button.addEventListener("click", () => {
     state.overviewView = button.dataset.overviewView;
     renderOverview();
+    setupResizableTables();
   });
 });
 els.overviewBody.addEventListener("click", async (event) => {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -294,6 +294,10 @@ function classBadge(entity) {
   return `<span class="classBadge">${escapeHtml(classValue(entity))}</span>`;
 }
 
+function classKey(entity) {
+  return slugPathSegment(entity?.class_id || entity?.github_team || entity?.class_label || classValue(entity));
+}
+
 function slugPathSegment(value, fallback = "classe-non-indicata") {
   return String(value || fallback)
     .trim()
@@ -573,9 +577,15 @@ function renderActivitySelect() {
   els.activitySelect.value = state.activities.some((activity) => activity.path === current) ? current : "";
 }
 
-function reportsForActivity(activityId) {
+function activityCoverageKey(activity) {
+  return `${classKey(activity)}::${activity?.id || ""}`;
+}
+
+function reportsForActivity(activity) {
+  const activityId = activity?.id || "";
+  const activityClassKey = classKey(activity);
   return state.reports
-    .filter((report) => report.activity_id === activityId)
+    .filter((report) => report.activity_id === activityId && classKey(report) === activityClassKey)
     .sort((a, b) => {
       const first = Date.parse(a.updated_at || a.due_at || "");
       const second = Date.parse(b.updated_at || b.due_at || "");
@@ -585,10 +595,12 @@ function reportsForActivity(activityId) {
 
 function reportCoverageRows() {
   return [...state.activities].sort((a, b) => {
-    const aMissing = reportsForActivity(a.id).length === 0 ? 1 : 0;
-    const bMissing = reportsForActivity(b.id).length === 0 ? 1 : 0;
+    const aMissing = reportsForActivity(a).length === 0 ? 1 : 0;
+    const bMissing = reportsForActivity(b).length === 0 ? 1 : 0;
     const reportDelta = bMissing - aMissing;
     if (reportDelta !== 0) return reportDelta;
+    const classDelta = classValue(a).localeCompare(classValue(b), "it", { numeric: true, sensitivity: "base" });
+    if (classDelta !== 0) return classDelta;
     return String(a.id || "").localeCompare(String(b.id || ""), "it", { numeric: true, sensitivity: "base" });
   });
 }
@@ -723,7 +735,7 @@ function coverageStatusCell(outcome, report, isLatest = false) {
 function renderCoverage() {
   if (!els.coverageBody) return;
   const rows = reportCoverageRows();
-  const withReport = rows.filter((activity) => reportsForActivity(activity.id).length > 0).length;
+  const withReport = rows.filter((activity) => reportsForActivity(activity).length > 0).length;
   const withoutReport = rows.length - withReport;
   els.coverageStatus.textContent = rows.length
     ? `${withReport} activity con registro, ${withoutReport} senza registro.`
@@ -740,11 +752,12 @@ function renderCoverage() {
     return;
   }
   for (const activity of rows) {
-    const reports = reportsForActivity(activity.id);
+    const reports = reportsForActivity(activity);
     const hasReport = reports.length > 0;
     const reportRows = hasReport ? reports : [null];
     const canCollapse = reportRows.length > 1;
-    const isCollapsed = canCollapse && state.coverageCollapsedActivities.has(activity.id);
+    const coverageKey = activityCoverageKey(activity);
+    const isCollapsed = canCollapse && state.coverageCollapsedActivities.has(coverageKey);
     const visibleReportRows = isCollapsed ? [reportRows[0]] : reportRows;
     const groupClass = coverageGroupClass(reports);
     visibleReportRows.forEach((report, index) => {
@@ -761,7 +774,7 @@ function renderCoverage() {
         <td>
           <div class="coverageActivityCell">
             ${canCollapse && index === 0 ? `
-              <button type="button" class="coverageGroupToggle" data-coverage-toggle="${escapeHtml(activity.id)}" aria-expanded="${isCollapsed ? "false" : "true"}" title="${isCollapsed ? "Espandi i registri di questa activity." : "Collassa i registri di questa activity."}">${isCollapsed ? "+" : "-"}</button>
+              <button type="button" class="coverageGroupToggle" data-coverage-toggle="${escapeHtml(coverageKey)}" aria-expanded="${isCollapsed ? "false" : "true"}" title="${isCollapsed ? "Espandi i registri di questa activity." : "Collassa i registri di questa activity."}">${isCollapsed ? "+" : "-"}</button>
             ` : '<span class="coverageGroupToggleSpacer"></span>'}
             <strong class="coverageActivityName">${escapeHtml(activity.title || activity.id)}</strong>
           </div>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -67,6 +67,7 @@ const els = {
   reportSummary: document.querySelector("#reportSummary"),
   overviewStatus: document.querySelector("#overviewStatus"),
   overviewBody: document.querySelector("#overviewBody"),
+  overviewSummary: document.querySelector("#overviewSummary"),
   overviewClassFilter: document.querySelector("#overviewClassFilter"),
   overviewStudentFilter: document.querySelector("#overviewStudentFilter"),
   overviewKindFilter: document.querySelector("#overviewKindFilter"),
@@ -903,6 +904,27 @@ function renderOverviewViewTabs() {
   els.overviewMatrixView.hidden = state.overviewView !== "matrix";
 }
 
+function renderOverviewSummary(rows) {
+  if (!state.overviewRows.length) {
+    els.overviewSummary.innerHTML = '<p class="status">Genera o carica almeno un registro per vedere il quadro classe.</p>';
+    return;
+  }
+  const activeFilters = Object.values(state.overviewFilters).filter(Boolean).length;
+  const cards = [
+    ["Classi", uniqueSorted(rows.map((row) => classValue(row))).length],
+    ["Studenti", overviewStudents(rows).length],
+    ["Consegne", overviewActivities(rows).length],
+    ["Righe", `${rows.length}/${state.overviewRows.length}`],
+    ["Filtri", activeFilters ? `${activeFilters} attivi` : "nessuno"],
+  ];
+  els.overviewSummary.innerHTML = cards.map(([label, value]) => `
+    <article class="overviewSummaryItem">
+      <strong>${escapeHtml(label)}</strong>
+      <span>${escapeHtml(value)}</span>
+    </article>
+  `).join("");
+}
+
 function activityKey(row) {
   return `${classValue(row)}::${row.report_name || row.activity_id || row.title || ""}`;
 }
@@ -1025,6 +1047,7 @@ function renderOverview() {
   const rows = sortedOverviewRows(filteredOverviewRows());
   renderOverviewSortButtons();
   renderOverviewViewTabs();
+  renderOverviewSummary(rows);
   if (!state.overviewRows.length) {
     els.overviewStatus.textContent = "Nessun registro salvato in teacher-reports.";
   } else if (state.overviewView === "matrix") {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -700,13 +700,22 @@ function coverageGroupClass(reports) {
   }[coverageWorstKind(reports)] || "coverageGroupInProgress";
 }
 
-function coverageReportCell(report, isLatest = false) {
+function coverageReportCell(report) {
   if (!report) return '<span class="coverageReportMissing">nessun registro</span>';
   return `
     <div class="coverageReportCell">
       <button type="button" data-coverage-report="${escapeHtml(report.name)}" title="Apri il registro ${escapeHtml(report.name)} e caricalo nella dashboard.">${escapeHtml(report.name)} ${reportLock(report)}</button>
-      ${isLatest ? badge("ultimo", "muted") : ""}
       ${coverageReportCounts(report)}
+    </div>
+  `;
+}
+
+function coverageStatusCell(outcome, report, isLatest = false) {
+  const statusKind = outcome.kind === "muted" && !report ? "warn" : outcome.kind;
+  return `
+    <div class="coverageStatusCell">
+      ${badge(outcome.label, statusKind)}
+      ${isLatest ? badge("ultimo", "muted") : ""}
     </div>
   `;
 }
@@ -762,8 +771,8 @@ function renderCoverage() {
         <td>${report ? classBadge(report) : classBadge(activity)}</td>
         <td>${kindLabel(activity.kind)}</td>
         <td>${escapeHtml(activity.student_support_mode || "-")}</td>
-        <td>${badge(outcome.label, outcome.kind === "muted" && !report ? "warn" : outcome.kind)}</td>
-        <td>${coverageReportCell(report, index === 0)}</td>
+        <td>${coverageStatusCell(outcome, report, index === 0)}</td>
+        <td>${coverageReportCell(report)}</td>
         <td>${escapeHtml(formatDate(report?.updated_at || report?.due_at))}</td>
         <td>
           ${report ? `

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1067,7 +1067,7 @@ function renderOverview() {
         <button type="button" class="smallButton" data-overview-report="${escapeHtml(row.report_name)}" data-overview-student="${escapeHtml(row.student || "")}" title="Apri il registro ${escapeHtml(row.report_name || "collegato")} e la consegna di ${escapeHtml(row.student || "questo studente")}.">
           Apri
         </button><br>
-        <small>${escapeHtml(row.report_name || "-")}</small>
+        <small class="overviewReportName" title="${escapeHtml(row.report_name || "-")}">${escapeHtml(row.report_name || "-")}</small>
       </td>
     `;
     els.overviewBody.append(tr);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1036,10 +1036,14 @@ function renderOverviewMatrix(rows) {
         const row = byStudentActivity.get(`${student}::${activityKey(activity)}`);
         const kind = matrixCellKind(row);
         const score = matrixScore(row);
+        const hasSubmission = row?.submitted || row?.status?.startsWith("submitted");
+        const submissionTitle = hasSubmission
+          ? `Apri la consegna di ${escapeHtml(row.student || "questo studente")} per questa activity.`
+          : "Consegna non disponibile: lo studente non ha ancora consegnato.";
         return `
           <td>
             ${row ? `
-              <button type="button" class="matrixCell matrixCell${kind}" data-overview-report="${escapeHtml(row.report_name)}" data-overview-student="${escapeHtml(row.student || "")}" title="Apri il registro ${escapeHtml(row.report_name)} e la consegna di ${escapeHtml(row.student || "questo studente")}.">
+              <button type="button" class="matrixCell matrixCell${kind}" data-overview-report="${escapeHtml(row.report_name)}" data-overview-student="${escapeHtml(row.student || "")}" title="${submissionTitle}" ${hasSubmission ? "" : "disabled"}>
                 <strong>${escapeHtml(matrixCellText(row))}</strong>
                 ${score !== "" ? `<small>${escapeHtml(score)}</small>` : ""}
               </button>
@@ -1696,7 +1700,7 @@ els.overviewBody.addEventListener("click", async (event) => {
 });
 els.overviewMatrixBody.addEventListener("click", async (event) => {
   const button = event.target.closest("[data-overview-report]");
-  if (!button) return;
+  if (!button || button.disabled) return;
   els.reportSelect.value = button.dataset.overviewReport;
   await loadSelectedReport();
   if (button.dataset.overviewStudent) {


### PR DESCRIPTION
## Summary
- aggiunge class_id, class_label e github_team ai registri generati da CLI/GUI
- mostra e filtra la classe nella dashboard consegne, copertura registri e quadro classe
- distingue in matrice registri della stessa activity assegnati a classi diverse
- documenta i nuovi metadati classe del registro

## Test
- node --check tools/assignment_dashboard.js
- python -m pytest tests/test_track_assignments.py tests/test_course_board_server.py
- python -m pytest (locale: 93 passed, 3 failed per compilatore C mancante, status compiler-not-found)