### PR TITLE
Riordina pannelli dashboard consegne

### DIFF
--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -29,6 +29,8 @@ def run_dashboard_js(assertions: str) -> None:
       constructor(selector = "") {{
         this.selector = selector;
         this.children = [];
+        this.parentElement = null;
+        this.nextSibling = null;
         this.dataset = {{}};
         this.classList = new FakeClassList();
         this.style = {{
@@ -48,9 +50,37 @@ def run_dashboard_js(assertions: str) -> None:
       addEventListener() {{}}
       removeEventListener() {{}}
       setAttribute(name, value) {{ this[name] = value; }}
-      append(child) {{ this.children.push(child); }}
-      prepend(child) {{ this.children.unshift(child); }}
-      querySelector() {{ return null; }}
+      append(child) {{
+        this.children = this.children.filter((candidate) => candidate !== child);
+        child.parentElement = this;
+        this.children.push(child);
+        this.syncSiblings();
+      }}
+      prepend(child) {{
+        this.children = this.children.filter((candidate) => candidate !== child);
+        child.parentElement = this;
+        this.children.unshift(child);
+        this.syncSiblings();
+      }}
+      insertBefore(child, reference) {{
+        this.children = this.children.filter((candidate) => candidate !== child);
+        const index = reference ? this.children.indexOf(reference) : -1;
+        child.parentElement = this;
+        if (index === -1) this.children.push(child);
+        else this.children.splice(index, 0, child);
+        this.syncSiblings();
+      }}
+      syncSiblings() {{
+        this.children.forEach((child, index) => {{
+          child.nextSibling = this.children[index + 1] || null;
+        }});
+      }}
+      querySelector(selector) {{
+        if (selector === ".panelHead") return this.panelHead || null;
+        if (selector === "h2") return this.titleElement || null;
+        if (selector === ".panelDragHandle") return this.children.find((child) => child.className === "panelDragHandle") || null;
+        return null;
+      }}
       querySelectorAll() {{ return []; }}
       closest() {{ return {{ clientWidth: 960 }}; }}
       getBoundingClientRect() {{ return {{ width: 120 }}; }}
@@ -61,7 +91,9 @@ def run_dashboard_js(assertions: str) -> None:
     }}
 
     const elements = new Map();
+    const layout = new FakeElement("main.layout");
     function elementFor(selector) {{
+      if (selector === "main.layout") return layout;
       if (!elements.has(selector)) elements.set(selector, new FakeElement(selector));
       return elements.get(selector);
     }}
@@ -90,6 +122,7 @@ def run_dashboard_js(assertions: str) -> None:
         querySelector: elementFor,
         querySelectorAll: (selector) => {{
           if (selector === "[data-legend-tab]") return legendTabs;
+          if (selector === "main.layout > .panel") return layout.children;
           return [];
         }},
       }},
@@ -107,6 +140,8 @@ def run_dashboard_js(assertions: str) -> None:
       }}),
     }};
     context.globalThis = context;
+    context.layout = layout;
+    context.FakeElement = FakeElement;
 
     const source = fs.readFileSync("tools/assignment_dashboard.js", "utf8");
     vm.runInNewContext(`${{source}}
@@ -117,8 +152,14 @@ def run_dashboard_js(assertions: str) -> None:
         hasExplicitClass,
         reportsForActivity,
         activityCoverageKey,
+        applyPanelOrder,
+        currentPanels,
+        writePanelOrder,
         renderLegend,
         els,
+        layout,
+        FakeElement,
+        localStorage,
       }};
     `, context);
 
@@ -179,5 +220,38 @@ def test_legend_renders_static_marks_but_escapes_descriptions() -> None:
         assert.match(html, /<button type="button" class="smallButton">Apri<\\/button>/);
         assert.match(html, /&lt;script&gt;alert\\(1\\)&lt;\\/script&gt;/);
         assert.doesNotMatch(html, /<td><script>alert\\(1\\)<\\/script><\\/td>/);
+        """
+    )
+
+
+def test_panel_order_is_applied_and_persisted() -> None:
+    run_dashboard_js(
+        """
+        const generate = new tested.FakeElement("generate");
+        generate.dataset.panelKey = "generate";
+        const overview = new tested.FakeElement("class-overview");
+        overview.dataset.panelKey = "class-overview";
+        const students = new tested.FakeElement("students");
+        students.dataset.panelKey = "students";
+        tested.layout.append(generate);
+        tested.layout.append(overview);
+        tested.layout.append(students);
+
+        tested.localStorage.setItem(
+          "2cornot2c.assignmentDashboardPanelOrder",
+          JSON.stringify(["students", "generate", "class-overview"]),
+        );
+
+        tested.applyPanelOrder();
+        assert.equal(
+          JSON.stringify(tested.currentPanels().map((panel) => panel.dataset.panelKey)),
+          JSON.stringify(["students", "generate", "class-overview"]),
+        );
+
+        tested.writePanelOrder();
+        assert.equal(
+          tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelOrder"),
+          JSON.stringify(["students", "generate", "class-overview"]),
+        );
         """
     )

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -255,3 +255,33 @@ def test_panel_order_is_applied_and_persisted() -> None:
         );
         """
     )
+
+
+def test_panel_order_keeps_missing_saved_panels_after_ordered_ones() -> None:
+    run_dashboard_js(
+        """
+        const generate = new tested.FakeElement("generate");
+        generate.dataset.panelKey = "generate";
+        const selected = new tested.FakeElement("selected-report");
+        selected.dataset.panelKey = "selected-report";
+        const overview = new tested.FakeElement("class-overview");
+        overview.dataset.panelKey = "class-overview";
+        const students = new tested.FakeElement("students");
+        students.dataset.panelKey = "students";
+        tested.layout.append(generate);
+        tested.layout.append(selected);
+        tested.layout.append(overview);
+        tested.layout.append(students);
+
+        tested.localStorage.setItem(
+          "2cornot2c.assignmentDashboardPanelOrder",
+          JSON.stringify(["students", "generate"]),
+        );
+
+        tested.applyPanelOrder();
+        assert.equal(
+          JSON.stringify(tested.currentPanels().map((panel) => panel.dataset.panelKey)),
+          JSON.stringify(["students", "generate", "selected-report", "class-overview"]),
+        );
+        """
+    )

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -576,6 +576,30 @@ label {
   font-size: 1.25rem;
 }
 
+.panelDragHandle {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: .45rem .65rem;
+  color: var(--muted);
+  font-size: .8rem;
+  letter-spacing: .08em;
+  box-shadow: none;
+  cursor: grab;
+}
+
+.panelDragHandle:active {
+  cursor: grabbing;
+}
+
+.isDraggingPanel {
+  opacity: .62;
+}
+
+.isDragTarget {
+  outline: 2px dashed rgba(17, 17, 17, .28);
+  outline-offset: 4px;
+}
+
 .panelHead h2::before {
   content: "-";
   display: inline-grid;

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -583,15 +583,19 @@ function currentPanels() {
 function applyPanelOrder() {
   const layout = document.querySelector("main.layout");
   if (!layout) return;
-  currentPanels().forEach((panel, index) => {
+  const panels = currentPanels();
+  panels.forEach((panel, index) => {
     panel.dataset.panelKey = panelKey(panel, index);
   });
   const order = readPanelOrder();
   if (!order.length) return;
-  const byKey = new Map(currentPanels().map((panel, index) => [panelKey(panel, index), panel]));
-  order.forEach((key) => {
-    const panel = byKey.get(key);
-    if (panel) layout.append(panel);
+  const byKey = new Map(panels.map((panel, index) => [panelKey(panel, index), panel]));
+  const orderedPanels = order.map((key) => byKey.get(key)).filter(Boolean);
+  panels.forEach((panel) => {
+    if (!orderedPanels.includes(panel)) orderedPanels.push(panel);
+  });
+  orderedPanels.forEach((panel) => {
+    layout.append(panel);
   });
 }
 

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1,5 +1,6 @@
 const REVIEW_SPLIT_KEY = "2cornot2c.assignmentReviewSplit";
 const COLLAPSED_PANELS_KEY = "2cornot2c.assignmentDashboardCollapsedPanels";
+const PANEL_ORDER_KEY = "2cornot2c.assignmentDashboardPanelOrder";
 const TABLE_WIDTHS_KEY = "2cornot2c.assignmentDashboardTableWidths";
 const DEFAULT_REVIEW_SPLIT = 320;
 const MIN_REVIEW_SPLIT = 180;
@@ -99,6 +100,7 @@ const state = {
   reviewFilePath: "",
   reviewFile: null,
   reviewSplit: readReviewSplit(),
+  draggedPanelKey: "",
 };
 
 const els = {
@@ -434,6 +436,20 @@ function writeCollapsedPanels(collapsedPanels) {
   localStorage.setItem(COLLAPSED_PANELS_KEY, JSON.stringify([...collapsedPanels]));
 }
 
+function readPanelOrder() {
+  try {
+    const value = JSON.parse(localStorage.getItem(PANEL_ORDER_KEY) || "[]");
+    return Array.isArray(value) ? value.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writePanelOrder() {
+  const panels = [...document.querySelectorAll("main.layout > .panel")];
+  localStorage.setItem(PANEL_ORDER_KEY, JSON.stringify(panels.map((panel, index) => panelKey(panel, index))));
+}
+
 function readTableWidths() {
   try {
     const value = JSON.parse(localStorage.getItem(TABLE_WIDTHS_KEY) || "{}");
@@ -560,9 +576,80 @@ function panelKey(panel, index) {
   return panel.dataset.panelKey || panel.id || `panel-${index}`;
 }
 
+function currentPanels() {
+  return [...document.querySelectorAll("main.layout > .panel")];
+}
+
+function applyPanelOrder() {
+  const layout = document.querySelector("main.layout");
+  if (!layout) return;
+  currentPanels().forEach((panel, index) => {
+    panel.dataset.panelKey = panelKey(panel, index);
+  });
+  const order = readPanelOrder();
+  if (!order.length) return;
+  const byKey = new Map(currentPanels().map((panel, index) => [panelKey(panel, index), panel]));
+  order.forEach((key) => {
+    const panel = byKey.get(key);
+    if (panel) layout.append(panel);
+  });
+}
+
+function addPanelDragHandle(panel, key) {
+  const head = panel.querySelector(".panelHead");
+  if (!head || head.querySelector(".panelDragHandle")) return;
+  const handle = document.createElement("button");
+  handle.type = "button";
+  handle.className = "panelDragHandle";
+  handle.draggable = true;
+  handle.textContent = "::";
+  handle.title = "Trascina per riordinare il pannello.";
+  handle.setAttribute("aria-label", "Trascina per riordinare il pannello.");
+  handle.addEventListener("click", (event) => event.stopPropagation());
+  handle.addEventListener("dragstart", (event) => {
+    state.draggedPanelKey = key;
+    panel.classList.add("isDraggingPanel");
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", key);
+  });
+  handle.addEventListener("dragend", () => {
+    state.draggedPanelKey = "";
+    panel.classList.remove("isDraggingPanel");
+    currentPanels().forEach((candidate) => candidate.classList.remove("isDragTarget"));
+    writePanelOrder();
+  });
+  head.append(handle);
+}
+
+function setupPanelDragAndDrop() {
+  currentPanels().forEach((panel, index) => {
+    const key = panelKey(panel, index);
+    panel.dataset.panelKey = key;
+    addPanelDragHandle(panel, key);
+    if (panel.dataset.dragReady === "true") return;
+    panel.dataset.dragReady = "true";
+    panel.addEventListener("dragover", (event) => {
+      if (!state.draggedPanelKey || state.draggedPanelKey === panel.dataset.panelKey) return;
+      event.preventDefault();
+      const dragged = currentPanels().find((candidate) => candidate.dataset.panelKey === state.draggedPanelKey);
+      if (!dragged) return;
+      panel.classList.add("isDragTarget");
+      const rect = panel.getBoundingClientRect();
+      const after = event.clientY > rect.top + rect.height / 2;
+      panel.parentElement.insertBefore(dragged, after ? panel.nextSibling : panel);
+    });
+    panel.addEventListener("dragleave", () => panel.classList.remove("isDragTarget"));
+    panel.addEventListener("drop", (event) => {
+      event.preventDefault();
+      panel.classList.remove("isDragTarget");
+      writePanelOrder();
+    });
+  });
+}
+
 function setupCollapsiblePanels() {
   const collapsed = readCollapsedPanels();
-  els.panels.forEach((panel, index) => {
+  currentPanels().forEach((panel, index) => {
     const head = panel.querySelector(".panelHead");
     const title = head?.querySelector("h2");
     if (!head || !title || title.dataset.collapseReady === "true") return;
@@ -1890,7 +1977,9 @@ els.filterButtons.forEach((button) => {
   button.addEventListener("click", () => setFilter(button.dataset.filter));
 });
 
+applyPanelOrder();
 setupCollapsiblePanels();
+setupPanelDragAndDrop();
 setFilter("all");
 setupResizableTables();
 Promise.all([loadReports(), loadActivities(), loadOverview()]).catch((error) => setStatus(`Errore: ${error.message}`));


### PR DESCRIPTION
## Summary
- aggiunge maniglie drag and drop ai pannelli principali della dashboard consegne
- salva e ripristina l'ordine dei pannelli in localStorage
- mantiene il collassamento dei pannelli compatibile con il riordino
- aggiunge test frontend per applicazione e persistenza dell'ordine

## Test
- node --check tools\\assignment_dashboard.js
- python -m pytest tests\\test_assignment_dashboard_frontend.py tests\\test_track_assignments.py tests\\test_course_board_server.py

## Note
- Il riordino riguarda solo i pannelli principali; il blocco Copertura registri resta dentro Genera registro in questa PR.
- Questa PR prepara il terreno per valutare in seguito layout su più colonne o pannelli affiancati.