### PR TITLE
Migliora controlli riordino pannelli consegne

### DIFF
--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -50,16 +50,25 @@ def run_dashboard_js(assertions: str) -> None:
       addEventListener() {{}}
       removeEventListener() {{}}
       setAttribute(name, value) {{ this[name] = value; }}
-      append(child) {{
-        this.children = this.children.filter((candidate) => candidate !== child);
-        child.parentElement = this;
-        this.children.push(child);
+      toggleAttribute(name, force) {{
+        const enabled = force === undefined ? !Boolean(this[name]) : Boolean(force);
+        this[name] = enabled;
+        return enabled;
+      }}
+      append(...children) {{
+        children.forEach((child) => {{
+          this.children = this.children.filter((candidate) => candidate !== child);
+          child.parentElement = this;
+          this.children.push(child);
+        }});
         this.syncSiblings();
       }}
-      prepend(child) {{
-        this.children = this.children.filter((candidate) => candidate !== child);
-        child.parentElement = this;
-        this.children.unshift(child);
+      prepend(...children) {{
+        children.reverse().forEach((child) => {{
+          this.children = this.children.filter((candidate) => candidate !== child);
+          child.parentElement = this;
+          this.children.unshift(child);
+        }});
         this.syncSiblings();
       }}
       insertBefore(child, reference) {{
@@ -75,10 +84,21 @@ def run_dashboard_js(assertions: str) -> None:
           child.nextSibling = this.children[index + 1] || null;
         }});
       }}
+      findDescendant(predicate) {{
+        for (const child of this.children) {{
+          if (predicate(child)) return child;
+          const descendant = child.findDescendant(predicate);
+          if (descendant) return descendant;
+        }}
+        return null;
+      }}
       querySelector(selector) {{
         if (selector === ".panelHead") return this.panelHead || null;
         if (selector === "h2") return this.titleElement || null;
-        if (selector === ".panelDragHandle") return this.children.find((child) => child.className === "panelDragHandle") || null;
+        if (selector === ".panelOrderControls") return this.findDescendant((child) => child.className === "panelOrderControls");
+        if (selector === ".panelDragHandle") return this.findDescendant((child) => child.className === "panelDragHandle");
+        if (selector === ".panelMoveUp") return this.findDescendant((child) => child.className === "panelMoveButton panelMoveUp");
+        if (selector === ".panelMoveDown") return this.findDescendant((child) => child.className === "panelMoveButton panelMoveDown");
         return null;
       }}
       querySelectorAll() {{ return []; }}
@@ -113,9 +133,14 @@ def run_dashboard_js(assertions: str) -> None:
         store: {{}},
         getItem(key) {{ return this.store[key] ?? null; }},
         setItem(key, value) {{ this.store[key] = String(value); }},
+        removeItem(key) {{ delete this.store[key]; }},
       }},
       window: {{
         addEventListener() {{}},
+        location: {{
+          reloaded: false,
+          reload() {{ this.reloaded = true; }},
+        }},
       }},
       document: {{
         createElement: (tag) => new FakeElement(tag),
@@ -155,11 +180,15 @@ def run_dashboard_js(assertions: str) -> None:
         applyPanelOrder,
         currentPanels,
         writePanelOrder,
+        movePanel,
+        resetPanelOrder,
+        setupPanelDragAndDrop,
         renderLegend,
         els,
         layout,
         FakeElement,
         localStorage,
+        window,
       }};
     `, context);
 
@@ -283,5 +312,57 @@ def test_panel_order_keeps_missing_saved_panels_after_ordered_ones() -> None:
           JSON.stringify(tested.currentPanels().map((panel) => panel.dataset.panelKey)),
           JSON.stringify(["students", "generate", "selected-report", "class-overview"]),
         );
+        """
+    )
+
+
+def test_panel_move_buttons_reorder_panels_and_update_disabled_state() -> None:
+    run_dashboard_js(
+        """
+        function panelWithHead(key) {
+          const panel = new tested.FakeElement(key);
+          panel.dataset.panelKey = key;
+          const head = new tested.FakeElement(`${key}-head`);
+          panel.panelHead = head;
+          panel.append(head);
+          return panel;
+        }
+        const generate = panelWithHead("generate");
+        const overview = panelWithHead("class-overview");
+        const students = panelWithHead("students");
+        tested.layout.append(generate);
+        tested.layout.append(overview);
+        tested.layout.append(students);
+
+        tested.setupPanelDragAndDrop();
+        assert.equal(generate.querySelector(".panelMoveUp").disabled, true);
+        assert.equal(students.querySelector(".panelMoveDown").disabled, true);
+
+        tested.movePanel(students, -1);
+        assert.equal(
+          JSON.stringify(tested.currentPanels().map((panel) => panel.dataset.panelKey)),
+          JSON.stringify(["generate", "students", "class-overview"]),
+        );
+        assert.equal(
+          tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelOrder"),
+          JSON.stringify(["generate", "students", "class-overview"]),
+        );
+        assert.equal(students.querySelector(".panelMoveUp").disabled, false);
+        assert.equal(overview.querySelector(".panelMoveDown").disabled, true);
+        """
+    )
+
+
+def test_reset_panel_order_clears_saved_order_and_reloads() -> None:
+    run_dashboard_js(
+        """
+        tested.localStorage.setItem(
+          "2cornot2c.assignmentDashboardPanelOrder",
+          JSON.stringify(["students", "generate"]),
+        );
+
+        tested.resetPanelOrder();
+        assert.equal(tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelOrder"), null);
+        assert.equal(tested.window.location.reloaded, true);
         """
     )

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -576,14 +576,25 @@ label {
   font-size: 1.25rem;
 }
 
-.panelDragHandle {
+.panelOrderControls {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  flex: 0 0 auto;
+}
+
+.panelDragHandle,
+.panelMoveButton {
   flex: 0 0 auto;
   border-radius: 999px;
   padding: .45rem .65rem;
   color: var(--muted);
   font-size: .8rem;
-  letter-spacing: .08em;
   box-shadow: none;
+}
+
+.panelDragHandle {
+  letter-spacing: .08em;
   cursor: grab;
 }
 
@@ -591,13 +602,41 @@ label {
   cursor: grabbing;
 }
 
+.panelMoveButton {
+  min-width: 3.2rem;
+}
+
+.panelMoveButton:disabled {
+  opacity: .38;
+  cursor: not-allowed;
+}
+
 .isDraggingPanel {
   opacity: .62;
 }
 
 .isDragTarget {
-  outline: 2px dashed rgba(17, 17, 17, .28);
-  outline-offset: 4px;
+  position: relative;
+}
+
+.isDragTarget::before,
+.isDragTarget::after {
+  position: absolute;
+  left: .9rem;
+  right: .9rem;
+  z-index: 2;
+  height: 4px;
+  border-radius: 999px;
+  background: #111111;
+  content: "";
+}
+
+.isDragTarget.dropBefore::before {
+  top: -2px;
+}
+
+.isDragTarget.dropAfter::after {
+  bottom: -2px;
 }
 
 .panelHead h2::before {

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -28,6 +28,7 @@
         </select>
         <button id="loadReportBtn" type="button" title="Carica il registro consegne selezionato da teacher-reports.">Carica registro</button>
         <button id="reloadBtn" type="button" title="Ricarica la lista dei registri disponibili.">Ricarica</button>
+        <button id="resetPanelOrderBtn" type="button" title="Ripristina l'ordine iniziale dei pannelli della dashboard.">Reset pannelli</button>
       </div>
     </div>
   </header>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -107,6 +107,7 @@ const els = {
   reportSelect: document.querySelector("#reportSelect"),
   loadReportBtn: document.querySelector("#loadReportBtn"),
   reloadBtn: document.querySelector("#reloadBtn"),
+  resetPanelOrderBtn: document.querySelector("#resetPanelOrderBtn"),
   status: document.querySelector("#status"),
   coverageStatus: document.querySelector("#coverageStatus"),
   coverageSummary: document.querySelector("#coverageSummary"),
@@ -450,6 +451,11 @@ function writePanelOrder() {
   localStorage.setItem(PANEL_ORDER_KEY, JSON.stringify(panels.map((panel, index) => panelKey(panel, index))));
 }
 
+function resetPanelOrder() {
+  localStorage.removeItem(PANEL_ORDER_KEY);
+  window.location.reload();
+}
+
 function readTableWidths() {
   try {
     const value = JSON.parse(localStorage.getItem(TABLE_WIDTHS_KEY) || "{}");
@@ -599,9 +605,41 @@ function applyPanelOrder() {
   });
 }
 
-function addPanelDragHandle(panel, key) {
+function movePanel(panel, direction) {
+  const panels = currentPanels();
+  const index = panels.indexOf(panel);
+  if (index === -1) return;
+  const target = panels[index + direction];
+  if (!target) return;
+  if (direction < 0) {
+    panel.parentElement.insertBefore(panel, target);
+  } else {
+    panel.parentElement.insertBefore(target, panel);
+  }
+  writePanelOrder();
+  updatePanelOrderControls();
+}
+
+function updatePanelOrderControls() {
+  const panels = currentPanels();
+  panels.forEach((panel, index) => {
+    panel.querySelector(".panelMoveUp")?.toggleAttribute("disabled", index === 0);
+    panel.querySelector(".panelMoveDown")?.toggleAttribute("disabled", index === panels.length - 1);
+  });
+}
+
+function clearPanelDropMarkers() {
+  currentPanels().forEach((panel) => {
+    panel.classList.remove("isDragTarget", "dropBefore", "dropAfter");
+  });
+}
+
+function addPanelOrderControls(panel, key) {
   const head = panel.querySelector(".panelHead");
-  if (!head || head.querySelector(".panelDragHandle")) return;
+  if (!head || head.querySelector(".panelOrderControls")) return;
+  const controls = document.createElement("div");
+  controls.className = "panelOrderControls";
+  controls.setAttribute("aria-label", "Riordina pannello");
   const handle = document.createElement("button");
   handle.type = "button";
   handle.className = "panelDragHandle";
@@ -619,17 +657,39 @@ function addPanelDragHandle(panel, key) {
   handle.addEventListener("dragend", () => {
     state.draggedPanelKey = "";
     panel.classList.remove("isDraggingPanel");
-    currentPanels().forEach((candidate) => candidate.classList.remove("isDragTarget"));
+    clearPanelDropMarkers();
     writePanelOrder();
+    updatePanelOrderControls();
   });
-  head.append(handle);
+  const up = document.createElement("button");
+  up.type = "button";
+  up.className = "panelMoveButton panelMoveUp";
+  up.textContent = "Su";
+  up.title = "Sposta questo pannello sopra.";
+  up.setAttribute("aria-label", "Sposta questo pannello sopra.");
+  up.addEventListener("click", (event) => {
+    event.stopPropagation();
+    movePanel(panel, -1);
+  });
+  const down = document.createElement("button");
+  down.type = "button";
+  down.className = "panelMoveButton panelMoveDown";
+  down.textContent = "Giu";
+  down.title = "Sposta questo pannello sotto.";
+  down.setAttribute("aria-label", "Sposta questo pannello sotto.");
+  down.addEventListener("click", (event) => {
+    event.stopPropagation();
+    movePanel(panel, 1);
+  });
+  controls.append(handle, up, down);
+  head.append(controls);
 }
 
 function setupPanelDragAndDrop() {
   currentPanels().forEach((panel, index) => {
     const key = panelKey(panel, index);
     panel.dataset.panelKey = key;
-    addPanelDragHandle(panel, key);
+    addPanelOrderControls(panel, key);
     if (panel.dataset.dragReady === "true") return;
     panel.dataset.dragReady = "true";
     panel.addEventListener("dragover", (event) => {
@@ -640,15 +700,19 @@ function setupPanelDragAndDrop() {
       panel.classList.add("isDragTarget");
       const rect = panel.getBoundingClientRect();
       const after = event.clientY > rect.top + rect.height / 2;
+      panel.classList.toggle("dropBefore", !after);
+      panel.classList.toggle("dropAfter", after);
       panel.parentElement.insertBefore(dragged, after ? panel.nextSibling : panel);
     });
-    panel.addEventListener("dragleave", () => panel.classList.remove("isDragTarget"));
+    panel.addEventListener("dragleave", clearPanelDropMarkers);
     panel.addEventListener("drop", (event) => {
       event.preventDefault();
-      panel.classList.remove("isDragTarget");
+      clearPanelDropMarkers();
       writePanelOrder();
+      updatePanelOrderControls();
     });
   });
+  updatePanelOrderControls();
 }
 
 function setupCollapsiblePanels() {
@@ -1830,6 +1894,7 @@ els.reloadBtn.addEventListener("click", async () => {
   await loadReports();
   await loadOverview();
 });
+els.resetPanelOrderBtn.addEventListener("click", resetPanelOrder);
 els.generateReportBtn.addEventListener("click", generateReport);
 els.reportSelect.addEventListener("change", loadSelectedReport);
 els.coverageOpenBtn.addEventListener("click", openCoverageDialog);


### PR DESCRIPTION
## Summary
- aggiunge un reset globale per ripristinare l'ordine iniziale dei pannelli
- aggiunge controlli Su/Giu nelle intestazioni dei pannelli come fallback al drag and drop
- mostra un marker sopra/sotto durante il drag per chiarire il punto di inserimento
- estende i test frontend per bottoni di riordino e reset

## Test
- `node --check tools\assignment_dashboard.js`
- `python -m pytest tests\test_assignment_dashboard_frontend.py tests\test_track_assignments.py tests\test_course_board_server.py`

## Note
- La PR migliora il riordino verticale gia' presente; il layout a griglia con pannelli affiancati resta volutamente fuori scope.