### PR TITLE
Organizza pannelli dashboard consegne in righe

### DIFF
--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -14,8 +14,8 @@ def run_dashboard_js(assertions: str) -> None:
       constructor() {{
         this.values = new Set();
       }}
-      add(value) {{ this.values.add(value); }}
-      remove(value) {{ this.values.delete(value); }}
+      add(...values) {{ values.forEach((value) => this.values.add(value)); }}
+      remove(...values) {{ values.forEach((value) => this.values.delete(value)); }}
       contains(value) {{ return this.values.has(value); }}
       toggle(value, force) {{
         const shouldAdd = force === undefined ? !this.values.has(value) : Boolean(force);
@@ -57,6 +57,10 @@ def run_dashboard_js(assertions: str) -> None:
       }}
       append(...children) {{
         children.forEach((child) => {{
+          if (child.parentElement && child.parentElement !== this) {{
+            child.parentElement.children = child.parentElement.children.filter((candidate) => candidate !== child);
+            child.parentElement.syncSiblings();
+          }}
           this.children = this.children.filter((candidate) => candidate !== child);
           child.parentElement = this;
           this.children.push(child);
@@ -65,6 +69,10 @@ def run_dashboard_js(assertions: str) -> None:
       }}
       prepend(...children) {{
         children.reverse().forEach((child) => {{
+          if (child.parentElement && child.parentElement !== this) {{
+            child.parentElement.children = child.parentElement.children.filter((candidate) => candidate !== child);
+            child.parentElement.syncSiblings();
+          }}
           this.children = this.children.filter((candidate) => candidate !== child);
           child.parentElement = this;
           this.children.unshift(child);
@@ -72,12 +80,23 @@ def run_dashboard_js(assertions: str) -> None:
         this.syncSiblings();
       }}
       insertBefore(child, reference) {{
+        if (child.parentElement && child.parentElement !== this) {{
+          child.parentElement.children = child.parentElement.children.filter((candidate) => candidate !== child);
+          child.parentElement.syncSiblings();
+        }}
         this.children = this.children.filter((candidate) => candidate !== child);
         const index = reference ? this.children.indexOf(reference) : -1;
         child.parentElement = this;
         if (index === -1) this.children.push(child);
         else this.children.splice(index, 0, child);
         this.syncSiblings();
+      }}
+      remove() {{
+        if (!this.parentElement) return;
+        this.parentElement.children = this.parentElement.children.filter((child) => child !== this);
+        this.parentElement.syncSiblings();
+        this.parentElement = null;
+        this.nextSibling = null;
       }}
       syncSiblings() {{
         this.children.forEach((child, index) => {{
@@ -93,6 +112,7 @@ def run_dashboard_js(assertions: str) -> None:
         return null;
       }}
       querySelector(selector) {{
+        if (selector === ":scope > .panel") return this.children.find((child) => child.classList.contains("panel")) || null;
         if (selector === ".panelHead") return this.panelHead || null;
         if (selector === "h2") return this.titleElement || null;
         if (selector === ".panelOrderControls") return this.findDescendant((child) => child.className === "panelOrderControls");
@@ -101,9 +121,12 @@ def run_dashboard_js(assertions: str) -> None:
         if (selector === ".panelMoveDown") return this.findDescendant((child) => child.className === "panelMoveButton panelMoveDown");
         return null;
       }}
-      querySelectorAll() {{ return []; }}
+      querySelectorAll(selector) {{
+        if (selector === ":scope > .panel") return this.children.filter((child) => child.classList.contains("panel"));
+        return [];
+      }}
       closest() {{ return {{ clientWidth: 960 }}; }}
-      getBoundingClientRect() {{ return {{ width: 120 }}; }}
+      getBoundingClientRect() {{ return {{ top: 0, bottom: 120, left: 0, right: 240, width: 240, height: 120 }}; }}
       showModal() {{ this.open = true; }}
       close() {{ this.open = false; }}
       setPointerCapture() {{}}
@@ -112,6 +135,18 @@ def run_dashboard_js(assertions: str) -> None:
 
     const elements = new Map();
     const layout = new FakeElement("main.layout");
+    function collectPanels(root) {{
+      return root.children.flatMap((child) => [
+        ...(child.classList.contains("panel") ? [child] : []),
+        ...collectPanels(child),
+      ]);
+    }}
+    function collectRows(root) {{
+      return root.children.flatMap((child) => [
+        ...(child.className === "panelRow" ? [child] : []),
+        ...collectRows(child),
+      ]);
+    }}
     function elementFor(selector) {{
       if (selector === "main.layout") return layout;
       if (!elements.has(selector)) elements.set(selector, new FakeElement(selector));
@@ -147,7 +182,8 @@ def run_dashboard_js(assertions: str) -> None:
         querySelector: elementFor,
         querySelectorAll: (selector) => {{
           if (selector === "[data-legend-tab]") return legendTabs;
-          if (selector === "main.layout > .panel") return layout.children;
+          if (selector === "main.layout .panel") return collectPanels(layout);
+          if (selector === "main.layout > .panelRow") return collectRows(layout);
           return [];
         }},
       }},
@@ -179,6 +215,7 @@ def run_dashboard_js(assertions: str) -> None:
         activityCoverageKey,
         applyPanelOrder,
         currentPanels,
+        currentPanelRows,
         writePanelOrder,
         movePanel,
         resetPanelOrder,
@@ -258,10 +295,13 @@ def test_panel_order_is_applied_and_persisted() -> None:
         """
         const generate = new tested.FakeElement("generate");
         generate.dataset.panelKey = "generate";
+        generate.classList.add("panel");
         const overview = new tested.FakeElement("class-overview");
         overview.dataset.panelKey = "class-overview";
+        overview.classList.add("panel");
         const students = new tested.FakeElement("students");
         students.dataset.panelKey = "students";
+        students.classList.add("panel");
         tested.layout.append(generate);
         tested.layout.append(overview);
         tested.layout.append(students);
@@ -280,7 +320,7 @@ def test_panel_order_is_applied_and_persisted() -> None:
         tested.writePanelOrder();
         assert.equal(
           tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelOrder"),
-          JSON.stringify(["students", "generate", "class-overview"]),
+          JSON.stringify([["students"], ["generate"], ["class-overview"]]),
         );
         """
     )
@@ -291,12 +331,16 @@ def test_panel_order_keeps_missing_saved_panels_after_ordered_ones() -> None:
         """
         const generate = new tested.FakeElement("generate");
         generate.dataset.panelKey = "generate";
+        generate.classList.add("panel");
         const selected = new tested.FakeElement("selected-report");
         selected.dataset.panelKey = "selected-report";
+        selected.classList.add("panel");
         const overview = new tested.FakeElement("class-overview");
         overview.dataset.panelKey = "class-overview";
+        overview.classList.add("panel");
         const students = new tested.FakeElement("students");
         students.dataset.panelKey = "students";
+        students.classList.add("panel");
         tested.layout.append(generate);
         tested.layout.append(selected);
         tested.layout.append(overview);
@@ -316,12 +360,49 @@ def test_panel_order_keeps_missing_saved_panels_after_ordered_ones() -> None:
     )
 
 
+def test_panel_rows_are_applied_and_persisted() -> None:
+    run_dashboard_js(
+        """
+        const generate = new tested.FakeElement("generate");
+        generate.dataset.panelKey = "generate";
+        generate.classList.add("panel");
+        const selected = new tested.FakeElement("selected-report");
+        selected.dataset.panelKey = "selected-report";
+        selected.classList.add("panel");
+        const students = new tested.FakeElement("students");
+        students.dataset.panelKey = "students";
+        students.classList.add("panel");
+        tested.layout.append(generate);
+        tested.layout.append(selected);
+        tested.layout.append(students);
+
+        tested.localStorage.setItem(
+          "2cornot2c.assignmentDashboardPanelOrder",
+          JSON.stringify([["generate", "selected-report"], ["students"]]),
+        );
+
+        tested.applyPanelOrder();
+        assert.equal(
+          JSON.stringify(tested.currentPanelRows().map((row) => row.querySelectorAll(":scope > .panel").map((panel) => panel.dataset.panelKey))),
+          JSON.stringify([["generate", "selected-report"], ["students"]]),
+        );
+
+        tested.writePanelOrder();
+        assert.equal(
+          tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelOrder"),
+          JSON.stringify([["generate", "selected-report"], ["students"]]),
+        );
+        """
+    )
+
+
 def test_panel_move_buttons_reorder_panels_and_update_disabled_state() -> None:
     run_dashboard_js(
         """
         function panelWithHead(key) {
           const panel = new tested.FakeElement(key);
           panel.dataset.panelKey = key;
+          panel.classList.add("panel");
           const head = new tested.FakeElement(`${key}-head`);
           panel.panelHead = head;
           panel.append(head);
@@ -345,7 +426,7 @@ def test_panel_move_buttons_reorder_panels_and_update_disabled_state() -> None:
         );
         assert.equal(
           tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelOrder"),
-          JSON.stringify(["generate", "students", "class-overview"]),
+          JSON.stringify([["generate"], ["students"], ["class-overview"]]),
         );
         assert.equal(students.querySelector(".panelMoveUp").disabled, false);
         assert.equal(overview.querySelector(".panelMoveDown").disabled, true);

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -566,8 +566,8 @@ label > textarea {
 }
 
 .panel {
-  flex: 1 1 24rem;
-  min-width: min(24rem, 100%);
+  flex: 1 1 clamp(14rem, 24vw, 24rem);
+  min-width: 0;
   border: 1px solid rgba(17, 17, 17, .16);
   border-radius: 28px;
   background: rgba(255, 255, 255, .92);

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -108,6 +108,7 @@ button, select, input, textarea {
   background: #ffffff;
   color: var(--ink);
   font: 700 .88rem/1.2 var(--mono);
+  max-width: 100%;
 }
 
 button, select {
@@ -157,7 +158,7 @@ button:disabled {
 }
 
 select {
-  min-width: 18rem;
+  min-width: 0;
   padding: .72rem .9rem;
 }
 
@@ -196,9 +197,17 @@ select {
 label {
   display: grid;
   gap: .32rem;
+  min-width: 0;
   color: var(--muted);
   font-size: .72rem;
   font-weight: 700;
+}
+
+label > select,
+label > input,
+label > textarea {
+  width: 100%;
+  min-width: 0;
 }
 
 .wideField {
@@ -1037,6 +1046,7 @@ label {
   margin: 0;
   color: var(--muted);
   font-size: .9rem;
+  overflow-wrap: anywhere;
 }
 
 .summaryGrid {
@@ -1047,6 +1057,7 @@ label {
 }
 
 .summaryCard {
+  min-width: 0;
   border: 1px solid rgba(17, 17, 17, .16);
   border-radius: 18px;
   background: #ffffff;
@@ -1062,6 +1073,9 @@ label {
 }
 
 .summaryCard span {
+  display: block;
+  min-width: 0;
+  overflow-wrap: anywhere;
   font-size: 1.55rem;
   font-weight: 900;
 }

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -709,7 +709,7 @@ label > textarea {
 
 .studentsSummary {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(5.5rem, 100%), 1fr));
   gap: .75rem;
   padding: 1.1rem;
 }
@@ -728,9 +728,11 @@ label > textarea {
 
 .studentsSummaryItem strong {
   display: block;
+  min-width: 0;
   margin-bottom: .35rem;
   color: var(--muted);
   font-size: .72rem;
+  overflow-wrap: anywhere;
   text-transform: uppercase;
 }
 
@@ -770,7 +772,7 @@ label > textarea {
 
 .overviewSummary {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(5.5rem, 100%), 1fr));
   gap: .75rem;
   padding: 1.1rem;
 }
@@ -789,9 +791,11 @@ label > textarea {
 
 .overviewSummaryItem strong {
   display: block;
+  min-width: 0;
   margin-bottom: .35rem;
   color: var(--muted);
   font-size: .72rem;
+  overflow-wrap: anywhere;
   text-transform: uppercase;
 }
 
@@ -1657,14 +1661,6 @@ code {
   }
 
   .summaryGrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .studentsSummary {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .overviewSummary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -543,12 +543,22 @@ label {
 .coverageReportMissing { color: #8a5a00; font-size: .72rem; font-weight: 800; }
 
 .layout {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
   padding: 0 clamp(1rem, 3vw, 3rem) 2rem;
 }
 
+.panelRow {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+  min-width: 0;
+}
+
 .panel {
+  flex: 1 1 24rem;
+  min-width: min(24rem, 100%);
   border: 1px solid rgba(17, 17, 17, .16);
   border-radius: 28px;
   background: rgba(255, 255, 255, .92);
@@ -628,15 +638,36 @@ label {
   height: 4px;
   border-radius: 999px;
   background: #111111;
-  content: "";
 }
 
 .isDragTarget.dropBefore::before {
   top: -2px;
+  content: "";
 }
 
 .isDragTarget.dropAfter::after {
   bottom: -2px;
+  content: "";
+}
+
+.isDragTarget.dropInlineBefore::before,
+.isDragTarget.dropInlineAfter::after {
+  top: .9rem;
+  bottom: .9rem;
+  width: 4px;
+  height: auto;
+  right: auto;
+}
+
+.isDragTarget.dropInlineBefore::before {
+  left: -2px;
+  content: "";
+}
+
+.isDragTarget.dropInlineAfter::after {
+  left: auto;
+  right: -2px;
+  content: "";
 }
 
 .panelHead h2::before {
@@ -1604,6 +1635,11 @@ code {
 
   .actions {
     justify-content: flex-start;
+  }
+
+  .panelRow {
+    display: grid;
+    grid-template-columns: 1fr;
   }
 
   .summaryGrid {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -170,7 +170,7 @@ const els = {
   nowAt: document.querySelector("#nowAt"),
   targetsText: document.querySelector("#targetsText"),
   generateReportBtn: document.querySelector("#generateReportBtn"),
-  panels: document.querySelectorAll("main.layout > .panel"),
+  panels: document.querySelectorAll("main.layout .panel"),
 };
 
 async function api(path, options = {}) {
@@ -440,15 +440,17 @@ function writeCollapsedPanels(collapsedPanels) {
 function readPanelOrder() {
   try {
     const value = JSON.parse(localStorage.getItem(PANEL_ORDER_KEY) || "[]");
-    return Array.isArray(value) ? value.map(String) : [];
+    if (!Array.isArray(value)) return [];
+    if (value.every(Array.isArray)) return value.map((row) => row.map(String).filter(Boolean)).filter((row) => row.length);
+    return value.map(String).filter(Boolean);
   } catch {
     return [];
   }
 }
 
 function writePanelOrder() {
-  const panels = [...document.querySelectorAll("main.layout > .panel")];
-  localStorage.setItem(PANEL_ORDER_KEY, JSON.stringify(panels.map((panel, index) => panelKey(panel, index))));
+  const rows = currentPanelRows().map((row) => [...row.querySelectorAll(":scope > .panel")].map((panel, index) => panelKey(panel, index)));
+  localStorage.setItem(PANEL_ORDER_KEY, JSON.stringify(rows.filter((row) => row.length)));
 }
 
 function resetPanelOrder() {
@@ -583,25 +585,72 @@ function panelKey(panel, index) {
 }
 
 function currentPanels() {
-  return [...document.querySelectorAll("main.layout > .panel")];
+  return [...document.querySelectorAll("main.layout .panel")];
+}
+
+function currentPanelRows() {
+  return [...document.querySelectorAll("main.layout > .panelRow")];
+}
+
+function createPanelRow() {
+  const row = document.createElement("div");
+  row.className = "panelRow";
+  row.dataset.panelRow = "true";
+  return row;
+}
+
+function normalizePanelRows() {
+  const layout = document.querySelector("main.layout");
+  if (!layout) return;
+  [...layout.children].forEach((child) => {
+    if (!child.classList?.contains("panel")) return;
+    const row = createPanelRow();
+    layout.insertBefore(row, child);
+    row.append(child);
+  });
+  currentPanelRows().forEach((row) => {
+    if (!row.querySelector(":scope > .panel")) row.remove();
+  });
+}
+
+function removeEmptyPanelRows() {
+  currentPanelRows().forEach((row) => {
+    if (!row.querySelector(":scope > .panel")) row.remove();
+  });
+}
+
+function normalizedPanelLayoutRows(savedLayout, panels) {
+  const byKey = new Map(panels.map((panel, index) => [panelKey(panel, index), panel]));
+  const used = new Set();
+  const savedRows = Array.isArray(savedLayout[0]) ? savedLayout : savedLayout.map((key) => [key]);
+  const rows = savedRows
+    .map((savedRow) => savedRow.map((key) => byKey.get(key)).filter((panel) => {
+      if (!panel || used.has(panel)) return false;
+      used.add(panel);
+      return true;
+    }))
+    .filter((row) => row.length);
+  panels.forEach((panel) => {
+    if (!used.has(panel)) rows.push([panel]);
+  });
+  return rows;
 }
 
 function applyPanelOrder() {
   const layout = document.querySelector("main.layout");
   if (!layout) return;
+  normalizePanelRows();
   const panels = currentPanels();
   panels.forEach((panel, index) => {
     panel.dataset.panelKey = panelKey(panel, index);
   });
   const order = readPanelOrder();
-  if (!order.length) return;
-  const byKey = new Map(panels.map((panel, index) => [panelKey(panel, index), panel]));
-  const orderedPanels = order.map((key) => byKey.get(key)).filter(Boolean);
-  panels.forEach((panel) => {
-    if (!orderedPanels.includes(panel)) orderedPanels.push(panel);
-  });
-  orderedPanels.forEach((panel) => {
-    layout.append(panel);
+  const rows = normalizedPanelLayoutRows(order, panels);
+  currentPanelRows().forEach((row) => row.remove());
+  rows.forEach((panelsInRow) => {
+    const row = createPanelRow();
+    panelsInRow.forEach((panel) => row.append(panel));
+    layout.append(row);
   });
 }
 
@@ -612,10 +661,11 @@ function movePanel(panel, direction) {
   const target = panels[index + direction];
   if (!target) return;
   if (direction < 0) {
-    panel.parentElement.insertBefore(panel, target);
+    movePanelToNewRow(panel, target.parentElement, false);
   } else {
-    panel.parentElement.insertBefore(target, panel);
+    movePanelToNewRow(panel, target.parentElement, true);
   }
+  removeEmptyPanelRows();
   writePanelOrder();
   updatePanelOrderControls();
 }
@@ -630,8 +680,22 @@ function updatePanelOrderControls() {
 
 function clearPanelDropMarkers() {
   currentPanels().forEach((panel) => {
-    panel.classList.remove("isDragTarget", "dropBefore", "dropAfter");
+    panel.classList.remove("isDragTarget", "dropBefore", "dropAfter", "dropInlineBefore", "dropInlineAfter");
   });
+}
+
+function movePanelToNewRow(panel, targetRow, after) {
+  const layout = document.querySelector("main.layout");
+  if (!layout || !targetRow) return;
+  const row = createPanelRow();
+  row.append(panel);
+  layout.insertBefore(row, after ? targetRow.nextSibling : targetRow);
+  removeEmptyPanelRows();
+}
+
+function movePanelInline(panel, targetPanel, after) {
+  targetPanel.parentElement.insertBefore(panel, after ? targetPanel.nextSibling : targetPanel);
+  removeEmptyPanelRows();
 }
 
 function addPanelOrderControls(panel, key) {
@@ -686,6 +750,7 @@ function addPanelOrderControls(panel, key) {
 }
 
 function setupPanelDragAndDrop() {
+  normalizePanelRows();
   currentPanels().forEach((panel, index) => {
     const key = panelKey(panel, index);
     panel.dataset.panelKey = key;
@@ -697,12 +762,23 @@ function setupPanelDragAndDrop() {
       event.preventDefault();
       const dragged = currentPanels().find((candidate) => candidate.dataset.panelKey === state.draggedPanelKey);
       if (!dragged) return;
+      clearPanelDropMarkers();
       panel.classList.add("isDragTarget");
       const rect = panel.getBoundingClientRect();
-      const after = event.clientY > rect.top + rect.height / 2;
-      panel.classList.toggle("dropBefore", !after);
-      panel.classList.toggle("dropAfter", after);
-      panel.parentElement.insertBefore(dragged, after ? panel.nextSibling : panel);
+      const topBand = rect.top + rect.height * .24;
+      const bottomBand = rect.bottom - rect.height * .24;
+      if (event.clientY < topBand) {
+        panel.classList.add("dropBefore");
+        movePanelToNewRow(dragged, panel.parentElement, false);
+      } else if (event.clientY > bottomBand) {
+        panel.classList.add("dropAfter");
+        movePanelToNewRow(dragged, panel.parentElement, true);
+      } else {
+        const after = event.clientX > rect.left + rect.width / 2;
+        panel.classList.toggle("dropInlineBefore", !after);
+        panel.classList.toggle("dropInlineAfter", after);
+        movePanelInline(dragged, panel, after);
+      }
     });
     panel.addEventListener("dragleave", clearPanelDropMarkers);
     panel.addEventListener("drop", (event) => {


### PR DESCRIPTION
## Summary
- organizza i pannelli della dashboard consegne in righe persistenti
- consente di affiancare pannelli nella stessa riga tramite drag and drop
- mantiene i comandi Su/Giu come movimento verticale su nuove righe
- forza le righe a una sola colonna su viewport strette
- conserva compatibilita' con il vecchio ordine piatto salvato in localStorage
- aggiunge test frontend per layout a righe e persistenza

## Test
- `node --check tools\assignment_dashboard.js`
- `python -m pytest tests\test_assignment_dashboard_frontend.py tests\test_track_assignments.py tests\test_course_board_server.py`

## Note
- Il reset pannelli continua a cancellare la preferenza salvata e torna a un pannello per riga.
- La struttura salvata diventa una lista di righe, per esempio `[ [generate, selected-report], [class-overview] ]`.