### PR TITLE
Ridimensiona pannelli affiancati nella dashboard consegne

### DIFF
--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -45,6 +45,7 @@ def run_dashboard_js(assertions: str) -> None:
         this.disabled = false;
         this.open = false;
         this.clientWidth = 960;
+        this.testWidth = 240;
         this.tHead = {{ rows: [{{ cells: [] }}] }};
       }}
       addEventListener() {{}}
@@ -117,6 +118,7 @@ def run_dashboard_js(assertions: str) -> None:
         if (selector === "h2") return this.titleElement || null;
         if (selector === ".panelOrderControls") return this.findDescendant((child) => child.className === "panelOrderControls");
         if (selector === ".panelDragHandle") return this.findDescendant((child) => child.className === "panelDragHandle");
+        if (selector === ".panelWidthHandle") return this.findDescendant((child) => child.className === "panelWidthHandle");
         if (selector === ".panelMoveUp") return this.findDescendant((child) => child.className === "panelMoveButton panelMoveUp");
         if (selector === ".panelMoveDown") return this.findDescendant((child) => child.className === "panelMoveButton panelMoveDown");
         return null;
@@ -126,7 +128,7 @@ def run_dashboard_js(assertions: str) -> None:
         return [];
       }}
       closest() {{ return {{ clientWidth: 960 }}; }}
-      getBoundingClientRect() {{ return {{ top: 0, bottom: 120, left: 0, right: 240, width: 240, height: 120 }}; }}
+      getBoundingClientRect() {{ return {{ top: 0, bottom: 120, left: 0, right: this.testWidth, width: this.testWidth, height: 120 }}; }}
       showModal() {{ this.open = true; }}
       close() {{ this.open = false; }}
       setPointerCapture() {{}}
@@ -217,6 +219,11 @@ def run_dashboard_js(assertions: str) -> None:
         currentPanels,
         currentPanelRows,
         writePanelOrder,
+        readPanelWidths,
+        writePanelWidths,
+        applyPanelWidths,
+        currentPanelPercents,
+        setupPanelWidthResizers,
         movePanel,
         resetPanelOrder,
         setupPanelDragAndDrop,
@@ -392,6 +399,97 @@ def test_panel_rows_are_applied_and_persisted() -> None:
           tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelOrder"),
           JSON.stringify([["generate", "selected-report"], ["students"]]),
         );
+        """
+    )
+
+
+def test_panel_widths_are_applied_for_saved_rows() -> None:
+    run_dashboard_js(
+        """
+        const generate = new tested.FakeElement("generate");
+        generate.dataset.panelKey = "generate";
+        generate.classList.add("panel");
+        const selected = new tested.FakeElement("selected-report");
+        selected.dataset.panelKey = "selected-report";
+        selected.classList.add("panel");
+        tested.layout.append(generate);
+        tested.layout.append(selected);
+
+        tested.localStorage.setItem(
+          "2cornot2c.assignmentDashboardPanelOrder",
+          JSON.stringify([["generate", "selected-report"]]),
+        );
+        tested.localStorage.setItem(
+          "2cornot2c.assignmentDashboardPanelWidths",
+          JSON.stringify({ "generate|selected-report": [35, 65] }),
+        );
+
+        tested.applyPanelOrder();
+        assert.equal(generate.style.flex, "0 1 35%");
+        assert.equal(selected.style.flex, "0 1 65%");
+        """
+    )
+
+
+def test_panel_width_resizers_are_added_between_adjacent_panels() -> None:
+    run_dashboard_js(
+        """
+        const generate = new tested.FakeElement("generate");
+        generate.dataset.panelKey = "generate";
+        generate.classList.add("panel");
+        const selected = new tested.FakeElement("selected-report");
+        selected.dataset.panelKey = "selected-report";
+        selected.classList.add("panel");
+        const students = new tested.FakeElement("students");
+        students.dataset.panelKey = "students";
+        students.classList.add("panel");
+        tested.layout.append(generate);
+        tested.layout.append(selected);
+        tested.layout.append(students);
+
+        tested.localStorage.setItem(
+          "2cornot2c.assignmentDashboardPanelOrder",
+          JSON.stringify([["generate", "selected-report"], ["students"]]),
+        );
+
+        tested.applyPanelOrder();
+        tested.setupPanelWidthResizers();
+        assert.ok(generate.querySelector(".panelWidthHandle"));
+        assert.equal(selected.querySelector(".panelWidthHandle"), null);
+        assert.equal(students.querySelector(".panelWidthHandle"), null);
+        """
+    )
+
+
+def test_panel_widths_can_be_persisted_and_reset_with_panel_order() -> None:
+    run_dashboard_js(
+        """
+        const generate = new tested.FakeElement("generate");
+        generate.dataset.panelKey = "generate";
+        generate.classList.add("panel");
+        generate.testWidth = 300;
+        const selected = new tested.FakeElement("selected-report");
+        selected.dataset.panelKey = "selected-report";
+        selected.classList.add("panel");
+        selected.testWidth = 100;
+        tested.layout.append(generate);
+        tested.layout.append(selected);
+        tested.localStorage.setItem(
+          "2cornot2c.assignmentDashboardPanelOrder",
+          JSON.stringify([["generate", "selected-report"]]),
+        );
+
+        tested.applyPanelOrder();
+        const row = tested.currentPanelRows()[0];
+        tested.writePanelWidths({ "generate|selected-report": tested.currentPanelPercents(row) });
+        assert.equal(
+          tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelWidths"),
+          JSON.stringify({ "generate|selected-report": [75, 25] }),
+        );
+
+        tested.resetPanelOrder();
+        assert.equal(tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelWidths"), null);
+        assert.equal(tested.window.location.reloaded, true);
         """
     )
 

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -566,6 +566,7 @@ label > textarea {
 }
 
 .panel {
+  position: relative;
   flex: 1 1 clamp(14rem, 24vw, 24rem);
   min-width: 0;
   border: 1px solid rgba(17, 17, 17, .16);
@@ -628,6 +629,32 @@ label > textarea {
 .panelMoveButton:disabled {
   opacity: .38;
   cursor: not-allowed;
+}
+
+.panelWidthHandle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 3;
+  width: 10px;
+  cursor: col-resize;
+}
+
+.panelWidthHandle::before {
+  position: absolute;
+  top: 1rem;
+  bottom: 1rem;
+  left: 4px;
+  width: 2px;
+  border-radius: 999px;
+  background: rgba(17, 17, 17, .18);
+  content: "";
+}
+
+.panelWidthHandle:hover::before,
+.isResizingPanels .panelWidthHandle::before {
+  background: rgba(17, 17, 17, .48);
 }
 
 .isDraggingPanel {
@@ -1658,6 +1685,10 @@ code {
   .panelRow {
     display: grid;
     grid-template-columns: 1fr;
+  }
+
+  .panelWidthHandle {
+    display: none;
   }
 
   .summaryGrid {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -633,23 +633,24 @@ label > textarea {
 
 .panelWidthHandle {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
+  top: .85rem;
+  right: .25rem;
+  bottom: .85rem;
   z-index: 3;
-  width: 10px;
+  width: 12px;
   cursor: col-resize;
 }
 
 .panelWidthHandle::before {
   position: absolute;
-  top: 1rem;
-  bottom: 1rem;
-  left: 4px;
+  top: .35rem;
+  bottom: .35rem;
+  left: 50%;
   width: 2px;
   border-radius: 999px;
   background: rgba(17, 17, 17, .18);
   content: "";
+  transform: translateX(-50%);
 }
 
 .panelWidthHandle:hover::before,

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1,11 +1,13 @@
 const REVIEW_SPLIT_KEY = "2cornot2c.assignmentReviewSplit";
 const COLLAPSED_PANELS_KEY = "2cornot2c.assignmentDashboardCollapsedPanels";
 const PANEL_ORDER_KEY = "2cornot2c.assignmentDashboardPanelOrder";
+const PANEL_WIDTHS_KEY = "2cornot2c.assignmentDashboardPanelWidths";
 const TABLE_WIDTHS_KEY = "2cornot2c.assignmentDashboardTableWidths";
 const DEFAULT_REVIEW_SPLIT = 320;
 const MIN_REVIEW_SPLIT = 180;
 const MAX_REVIEW_SPLIT_RATIO = 0.65;
 const MIN_TABLE_COLUMN_WIDTH = 64;
+const MIN_PANEL_WIDTH_PERCENT = 8;
 const OVERVIEW_TYPE_ORDER = [
   "studio-guidato",
   "esercizio-classe",
@@ -453,8 +455,22 @@ function writePanelOrder() {
   localStorage.setItem(PANEL_ORDER_KEY, JSON.stringify(rows.filter((row) => row.length)));
 }
 
+function readPanelWidths() {
+  try {
+    const value = JSON.parse(localStorage.getItem(PANEL_WIDTHS_KEY) || "{}");
+    return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+function writePanelWidths(widths) {
+  localStorage.setItem(PANEL_WIDTHS_KEY, JSON.stringify(widths));
+}
+
 function resetPanelOrder() {
   localStorage.removeItem(PANEL_ORDER_KEY);
+  localStorage.removeItem(PANEL_WIDTHS_KEY);
   window.location.reload();
 }
 
@@ -619,6 +635,41 @@ function removeEmptyPanelRows() {
   });
 }
 
+function rowPanels(row) {
+  return [...row.querySelectorAll(":scope > .panel")];
+}
+
+function rowWidthKey(row) {
+  return rowPanels(row).map((panel, index) => panelKey(panel, index)).join("|");
+}
+
+function normalizePanelPercents(values, count) {
+  const fallback = Array.from({ length: count }, () => 100 / Math.max(1, count));
+  if (!Array.isArray(values) || values.length !== count) return fallback;
+  const numeric = values.map(Number);
+  if (numeric.some((value) => !Number.isFinite(value) || value <= 0)) return fallback;
+  const total = numeric.reduce((sum, value) => sum + value, 0);
+  if (!total) return fallback;
+  return numeric.map((value) => (value / total) * 100);
+}
+
+function applyPanelWidths() {
+  const saved = readPanelWidths();
+  currentPanelRows().forEach((row) => {
+    const panels = rowPanels(row);
+    const percents = normalizePanelPercents(saved[rowWidthKey(row)], panels.length);
+    panels.forEach((panel, index) => {
+      panel.style.flex = panels.length > 1 ? `0 1 ${percents[index]}%` : "";
+    });
+  });
+}
+
+function writePanelRowWidths(row, percents) {
+  const saved = readPanelWidths();
+  saved[rowWidthKey(row)] = percents.map((value) => Math.round(value * 100) / 100);
+  writePanelWidths(saved);
+}
+
 function normalizedPanelLayoutRows(savedLayout, panels) {
   const byKey = new Map(panels.map((panel, index) => [panelKey(panel, index), panel]));
   const used = new Set();
@@ -652,6 +703,7 @@ function applyPanelOrder() {
     panelsInRow.forEach((panel) => row.append(panel));
     layout.append(row);
   });
+  applyPanelWidths();
 }
 
 function movePanel(panel, direction) {
@@ -667,7 +719,9 @@ function movePanel(panel, direction) {
   }
   removeEmptyPanelRows();
   writePanelOrder();
+  applyPanelWidths();
   updatePanelOrderControls();
+  setupPanelWidthResizers();
 }
 
 function updatePanelOrderControls() {
@@ -698,6 +752,85 @@ function movePanelInline(panel, targetPanel, after) {
   removeEmptyPanelRows();
 }
 
+function currentPanelPercents(row) {
+  const panels = rowPanels(row);
+  const widths = panels.map((panel) => panel.getBoundingClientRect().width || 0);
+  const total = widths.reduce((sum, width) => sum + width, 0) || 1;
+  return widths.map((width) => (width / total) * 100);
+}
+
+function setPanelPercents(row, percents) {
+  rowPanels(row).forEach((panel, index) => {
+    panel.style.flex = `0 1 ${percents[index]}%`;
+  });
+}
+
+function setupPanelWidthResizers() {
+  currentPanelRows().forEach((row) => {
+    const panels = rowPanels(row);
+    panels.forEach((panel, index) => {
+      let handle = panel.querySelector(".panelWidthHandle");
+      if (index >= panels.length - 1) {
+        handle?.remove();
+        return;
+      }
+      if (!handle) {
+        handle = document.createElement("span");
+        handle.className = "panelWidthHandle";
+        handle.title = "Trascina per ridimensionare i pannelli nella riga. Doppio click per ripristinare.";
+        handle.setAttribute("aria-label", "Ridimensiona pannelli nella riga.");
+        handle.addEventListener("dblclick", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const activeRow = panel.parentElement;
+          const saved = readPanelWidths();
+          delete saved[rowWidthKey(activeRow)];
+          writePanelWidths(saved);
+          applyPanelWidths();
+        });
+        handle.addEventListener("pointerdown", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const activeRow = panel.parentElement;
+          const activePanels = rowPanels(activeRow);
+          const activeIndex = activePanels.indexOf(panel);
+          if (activeIndex === -1 || activeIndex >= activePanels.length - 1) return;
+          const startPercents = currentPanelPercents(activeRow);
+          const rowWidth = activeRow.getBoundingClientRect().width || 1;
+          const startX = event.clientX;
+          handle.setPointerCapture(event.pointerId);
+          activeRow.classList.add("isResizingPanels");
+
+          function onPointerMove(moveEvent) {
+            const delta = ((moveEvent.clientX - startX) / rowWidth) * 100;
+            const pairTotal = startPercents[activeIndex] + startPercents[activeIndex + 1];
+            const left = Math.min(pairTotal - MIN_PANEL_WIDTH_PERCENT, Math.max(MIN_PANEL_WIDTH_PERCENT, startPercents[activeIndex] + delta));
+            const right = pairTotal - left;
+            const nextPercents = [...startPercents];
+            nextPercents[activeIndex] = left;
+            nextPercents[activeIndex + 1] = right;
+            setPanelPercents(activeRow, nextPercents);
+          }
+
+          function onPointerUp(upEvent) {
+            handle.releasePointerCapture(upEvent.pointerId);
+            activeRow.classList.remove("isResizingPanels");
+            writePanelRowWidths(activeRow, currentPanelPercents(activeRow));
+            handle.removeEventListener("pointermove", onPointerMove);
+            handle.removeEventListener("pointerup", onPointerUp);
+            handle.removeEventListener("pointercancel", onPointerUp);
+          }
+
+          handle.addEventListener("pointermove", onPointerMove);
+          handle.addEventListener("pointerup", onPointerUp);
+          handle.addEventListener("pointercancel", onPointerUp);
+        });
+        panel.append(handle);
+      }
+    });
+  });
+}
+
 function addPanelOrderControls(panel, key) {
   const head = panel.querySelector(".panelHead");
   if (!head || head.querySelector(".panelOrderControls")) return;
@@ -723,7 +856,9 @@ function addPanelOrderControls(panel, key) {
     panel.classList.remove("isDraggingPanel");
     clearPanelDropMarkers();
     writePanelOrder();
+    applyPanelWidths();
     updatePanelOrderControls();
+    setupPanelWidthResizers();
   });
   const up = document.createElement("button");
   up.type = "button";
@@ -785,10 +920,13 @@ function setupPanelDragAndDrop() {
       event.preventDefault();
       clearPanelDropMarkers();
       writePanelOrder();
+      applyPanelWidths();
       updatePanelOrderControls();
+      setupPanelWidthResizers();
     });
   });
   updatePanelOrderControls();
+  setupPanelWidthResizers();
 }
 
 function setupCollapsiblePanels() {


### PR DESCRIPTION
## Summary
- aggiunge una maniglia verticale sul bordo destro dei pannelli affiancati nella stessa riga
- consente di ridimensionare le proporzioni tra due pannelli vicini
- salva e ripristina le proporzioni in `localStorage`
- il reset pannelli cancella anche le larghezze salvate
- nasconde la maniglia su mobile, dove le righe restano a colonna singola
- aggiunge test frontend per applicazione, persistenza, reset e presenza delle maniglie

## Test
- `node --check tools\assignment_dashboard.js`
- `python -m pytest tests\test_assignment_dashboard_frontend.py tests\test_track_assignments.py tests\test_course_board_server.py`

## Prove manuali consigliate
1. Metti `Genera registro` e `Registro selezionato` sulla stessa riga.
2. Trascina la maniglia verticale tra i due pannelli.
3. Ricarica la pagina e controlla che le proporzioni restino salvate.
4. Doppio click sulla maniglia: la riga deve tornare a proporzioni automatiche.
5. Metti tre o quattro pannelli nella stessa riga e ridimensiona una coppia vicina.
6. Premi `Reset pannelli`: deve tornare un pannello per riga e cancellare anche le larghezze.
7. Riduci a viewport mobile: i pannelli devono restare in una sola colonna e la maniglia non deve essere visibile.