### PR TITLE
Aggiungi riepilogo completo studenti

### DIFF
--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -215,6 +215,9 @@ def run_dashboard_js(assertions: str) -> None:
         hasExplicitClass,
         reportsForActivity,
         activityCoverageKey,
+        summaryCounts,
+        compactStudentsSummaryItems,
+        detailedStudentsSummaryItems,
         applyPanelOrder,
         currentPanels,
         currentPanelRows,
@@ -490,6 +493,48 @@ def test_panel_widths_can_be_persisted_and_reset_with_panel_order() -> None:
         tested.resetPanelOrder();
         assert.equal(tested.localStorage.getItem("2cornot2c.assignmentDashboardPanelWidths"), null);
         assert.equal(tested.window.location.reloaded, true);
+        """
+    )
+
+
+def test_students_summary_counts_include_grading_and_grades() -> None:
+    run_dashboard_js(
+        """
+        const counts = tested.summaryCounts([
+          { status: "pending", submitted: false, late: false, grading: {} },
+          { status: "missing", submitted: false, late: false, grading: { status: "not_run" } },
+          { status: "submitted", submitted: true, late: false, grading: { status: "graded_passed", score: 8 } },
+          { status: "submitted_late", submitted: true, late: true, grading: { status: "graded_failed", teacher_grade: 5 } },
+        ]);
+        assert.equal(JSON.stringify(counts), JSON.stringify({
+          total: 4,
+          pending: 1,
+          missing: 1,
+          submitted: 2,
+          late: 1,
+          passed: 1,
+          failed: 1,
+          averageGrade: 6.5,
+          missingGrades: 2,
+        }));
+        assert.equal(JSON.stringify(tested.compactStudentsSummaryItems(counts)), JSON.stringify([
+          ["Studenti", 4],
+          ["Consegnati", 2],
+          ["Mancanti", 1],
+          ["Ritardo", 1],
+          ["KO", 1],
+        ]));
+        assert.equal(JSON.stringify(tested.detailedStudentsSummaryItems(counts)), JSON.stringify([
+          ["Studenti", 4],
+          ["Consegnati", 2],
+          ["Mancanti", 1],
+          ["Ritardo", 1],
+          ["Pending", 1],
+          ["Grading OK", 1],
+          ["Grading KO", 1],
+          ["Media voto", "6.5"],
+          ["Voti mancanti", 2],
+        ]));
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -507,35 +507,36 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           { status: "missing", submitted: false, late: false, grading: { status: "not_run" } },
           { status: "submitted", submitted: true, late: false, grading: { status: "graded_passed", score: 8 } },
           { status: "submitted_late", submitted: true, late: true, grading: { status: "graded_failed", teacher_grade: 5 } },
+          { status: "submitted", submitted: true, late: false, grading: { status: "graded_passed", teacher_grade: "" } },
         ]);
         assert.equal(JSON.stringify(counts), JSON.stringify({
-          total: 4,
+          total: 5,
           pending: 1,
           missing: 1,
-          submitted: 2,
+          submitted: 3,
           late: 1,
-          passed: 1,
+          passed: 2,
           failed: 1,
           averageGrade: 6.5,
-          missingGrades: 2,
+          missingGrades: 3,
         }));
         assert.equal(JSON.stringify(tested.compactStudentsSummaryItems(counts)), JSON.stringify([
-          ["Studenti", 4],
-          ["Consegnati", 2],
+          ["Studenti", 5],
+          ["Consegnati", 3],
           ["Mancanti", 1],
           ["Ritardo", 1],
           ["KO", 1],
         ]));
         assert.equal(JSON.stringify(tested.detailedStudentsSummaryItems(counts)), JSON.stringify([
-          ["Studenti", 4],
-          ["Consegnati", 2],
+          ["Studenti", 5],
+          ["Consegnati", 3],
           ["Mancanti", 1],
           ["Ritardo", 1],
           ["Pending", 1],
-          ["Grading OK", 1],
+          ["Grading OK", 2],
           ["Grading KO", 1],
           ["Media voto", "6.5"],
-          ["Voti mancanti", 2],
+          ["Voti mancanti", 3],
         ]));
         """
     )

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -215,7 +215,9 @@ def run_dashboard_js(assertions: str) -> None:
         hasExplicitClass,
         reportsForActivity,
         activityCoverageKey,
+        summaryTooltip,
         summaryCounts,
+        renderStudentsSummaryCards,
         compactStudentsSummaryItems,
         detailedStudentsSummaryItems,
         applyPanelOrder,
@@ -535,6 +537,17 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           ["Media voto", "6.5"],
           ["Voti mancanti", 2],
         ]));
+        """
+    )
+
+
+def test_students_summary_cards_include_tooltips() -> None:
+    run_dashboard_js(
+        """
+        const html = tested.renderStudentsSummaryCards([["Consegnati", 3], ["KO", 1]]);
+        assert.match(html, /title="Numero di studenti che hanno effettuato una consegna\\."/);
+        assert.match(html, /title="Numero di studenti con grading o test falliti\\."/);
+        assert.equal(tested.summaryTooltip("Etichetta nuova"), "Valore riepilogativo: Etichetta nuova.");
         """
     )
 

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -772,7 +772,7 @@ label > textarea {
 }
 
 .studentsDialog {
-  grid-template-rows: auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto auto minmax(0, 1fr);
   width: min(96vw, 88rem);
   height: min(88vh, 50rem);
   min-width: min(92vw, 38rem);
@@ -1121,6 +1121,10 @@ label > textarea {
 
 .studentsDialogFilters .filterBar {
   padding: 0;
+}
+
+.studentsDialogSummary {
+  padding: .85rem 1rem;
 }
 
 .filterBar button.isActive {

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -298,6 +298,9 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         <button type="button" data-filter="failed" title="Mostra gli studenti con grading o test falliti.">Test falliti</button>
       </div>
     </div>
+    <div id="studentsDialogSummary" class="studentsSummary studentsDialogSummary" aria-live="polite">
+      <p class="status">Carica un registro per vedere il riepilogo studenti.</p>
+    </div>
     <div class="tableWrap studentsDialogTable">
       <table id="studentsTable" class="resizableTable">
         <thead>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1172,9 +1172,9 @@ function renderCoverage() {
     ? `${withReport} activity con registro, ${withoutReport} senza registro.`
     : "Nessuna activity trovata.";
   els.coverageSummary.innerHTML = `
-    <article><strong>Activity</strong><span>${escapeHtml(rows.length)}</span></article>
-    <article><strong>Con registro</strong><span>${escapeHtml(withReport)}</span></article>
-    <article><strong>Senza registro</strong><span>${escapeHtml(withoutReport)}</span></article>
+    <article title="${escapeHtml(summaryTooltip("Activity"))}"><strong>Activity</strong><span>${escapeHtml(rows.length)}</span></article>
+    <article title="${escapeHtml(summaryTooltip("Con registro"))}"><strong>Con registro</strong><span>${escapeHtml(withReport)}</span></article>
+    <article title="${escapeHtml(summaryTooltip("Senza registro"))}"><strong>Senza registro</strong><span>${escapeHtml(withoutReport)}</span></article>
   `;
   els.coverageBody.innerHTML = "";
   if (!rows.length) {
@@ -1371,7 +1371,7 @@ function renderOverviewSummary(rows) {
     ["Filtri", activeFilters ? `${activeFilters} attivi` : "nessuno"],
   ];
   els.overviewSummary.innerHTML = cards.map(([label, value]) => `
-    <article class="overviewSummaryItem">
+    <article class="overviewSummaryItem" title="${escapeHtml(summaryTooltip(label))}">
       <strong>${escapeHtml(label)}</strong>
       <span>${escapeHtml(value)}</span>
     </article>
@@ -1680,6 +1680,33 @@ function externalLink(url, label = "GitHub") {
   return `<a class="externalLink" href="${escapeHtml(url)}" target="_blank" rel="noreferrer">${escapeHtml(label)}</a>`;
 }
 
+const SUMMARY_TOOLTIPS = {
+  Activity: "Activity o numero di activity a cui si riferisce questo riepilogo.",
+  "Con registro": "Numero di activity per cui esiste almeno un registro consegne generato.",
+  "Senza registro": "Numero di activity per cui non e' stato ancora trovato alcun registro consegne.",
+  Classi: "Numero di classi diverse presenti nelle righe del quadro classe filtrato.",
+  Studenti: "Numero di studenti considerati nel riepilogo.",
+  Consegne: "Numero di activity/consegne diverse presenti nel quadro classe filtrato.",
+  Righe: "Righe activity-studente mostrate rispetto al totale disponibile.",
+  Filtri: "Numero di filtri attivi nel quadro classe.",
+  Classe: "Classe associata al registro consegne selezionato.",
+  Scadenza: "Data e ora di scadenza del registro consegne selezionato.",
+  Consegnati: "Numero di studenti che hanno effettuato una consegna.",
+  Mancanti: "Numero di studenti senza consegna registrata.",
+  "In ritardo": "Numero di studenti che hanno consegnato oltre la scadenza.",
+  Ritardo: "Numero di studenti che hanno consegnato oltre la scadenza.",
+  KO: "Numero di studenti con grading o test falliti.",
+  Pending: "Numero di studenti ancora in attesa di consegna o valutazione definitiva.",
+  "Grading OK": "Numero di studenti con grading completato e superato.",
+  "Grading KO": "Numero di studenti con grading completato ma fallito.",
+  "Media voto": "Media dei voti numerici disponibili nel registro selezionato.",
+  "Voti mancanti": "Numero di studenti senza voto numerico disponibile.",
+};
+
+function summaryTooltip(label) {
+  return SUMMARY_TOOLTIPS[label] || `Valore riepilogativo: ${label}.`;
+}
+
 function gradingValue(student) {
   const grading = student.grading || {};
   const value = grading.teacher_grade ?? grading.score;
@@ -1704,7 +1731,7 @@ function summaryCounts(students) {
 
 function renderStudentsSummaryCards(items) {
   return items.map(([label, value]) => `
-    <article class="studentsSummaryItem">
+    <article class="studentsSummaryItem" title="${escapeHtml(summaryTooltip(label))}">
       <strong>${escapeHtml(label)}</strong>
       <span>${escapeHtml(value)}</span>
     </article>
@@ -1758,7 +1785,7 @@ function renderSummary(students) {
     ["In ritardo", counts.late],
   ];
   els.reportSummary.innerHTML = cards.map(([label, value]) => `
-    <article class="summaryCard">
+    <article class="summaryCard" title="${escapeHtml(summaryTooltip(label))}">
       <strong>${escapeHtml(label)}</strong>
       <span>${escapeHtml(value)}</span>
     </article>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1710,6 +1710,7 @@ function summaryTooltip(label) {
 function gradingValue(student) {
   const grading = student.grading || {};
   const value = grading.teacher_grade ?? grading.score;
+  if (value == null || String(value).trim() === "") return null;
   const number = Number(value);
   return Number.isFinite(number) ? number : null;
 }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -141,6 +141,7 @@ const els = {
   overviewMatrixBody: document.querySelector("#overviewMatrixBody"),
   tableStatus: document.querySelector("#tableStatus"),
   studentsSummary: document.querySelector("#studentsSummary"),
+  studentsDialogSummary: document.querySelector("#studentsDialogSummary"),
   studentsDialog: document.querySelector("#studentsDialog"),
   studentsBreadcrumb: document.querySelector("#studentsBreadcrumb"),
   studentsOpenBtn: document.querySelector("#studentsOpenBtn"),
@@ -1679,15 +1680,59 @@ function externalLink(url, label = "GitHub") {
   return `<a class="externalLink" href="${escapeHtml(url)}" target="_blank" rel="noreferrer">${escapeHtml(label)}</a>`;
 }
 
+function gradingValue(student) {
+  const grading = student.grading || {};
+  const value = grading.teacher_grade ?? grading.score;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
 function summaryCounts(students) {
+  const grades = students.map(gradingValue).filter((grade) => grade != null);
   return {
     total: students.length,
     pending: students.filter((student) => student.status === "pending").length,
     missing: students.filter((student) => student.status === "missing").length,
     submitted: students.filter((student) => student.submitted).length,
     late: students.filter((student) => student.submitted && student.late).length,
+    passed: students.filter((student) => student.grading?.status === "graded_passed").length,
     failed: students.filter((student) => student.grading?.status === "graded_failed").length,
+    averageGrade: grades.length ? grades.reduce((sum, grade) => sum + grade, 0) / grades.length : null,
+    missingGrades: students.length - grades.length,
   };
+}
+
+function renderStudentsSummaryCards(items) {
+  return items.map(([label, value]) => `
+    <article class="studentsSummaryItem">
+      <strong>${escapeHtml(label)}</strong>
+      <span>${escapeHtml(value)}</span>
+    </article>
+  `).join("");
+}
+
+function compactStudentsSummaryItems(counts) {
+  return [
+    ["Studenti", counts.total],
+    ["Consegnati", counts.submitted],
+    ["Mancanti", counts.missing],
+    ["Ritardo", counts.late],
+    ["KO", counts.failed],
+  ];
+}
+
+function detailedStudentsSummaryItems(counts) {
+  return [
+    ["Studenti", counts.total],
+    ["Consegnati", counts.submitted],
+    ["Mancanti", counts.missing],
+    ["Ritardo", counts.late],
+    ["Pending", counts.pending],
+    ["Grading OK", counts.passed],
+    ["Grading KO", counts.failed],
+    ["Media voto", counts.averageGrade == null ? "-" : counts.averageGrade.toFixed(1)],
+    ["Voti mancanti", counts.missingGrades],
+  ];
 }
 
 function renderDashboard() {
@@ -1737,20 +1782,11 @@ function renderStudents(students) {
   els.studentsOpenBtn.disabled = !state.report;
   if (!state.report) {
     els.studentsSummary.innerHTML = '<p class="status">Carica un registro per vedere il riepilogo studenti.</p>';
+    els.studentsDialogSummary.innerHTML = '<p class="status">Carica un registro per vedere il riepilogo studenti.</p>';
   } else {
     const counts = summaryCounts(students);
-    const summaryItems = [
-      ["Studenti", counts.total],
-      ["Consegnati", counts.submitted],
-      ["Mancanti", counts.missing],
-      ["In ritardo", counts.late],
-    ];
-    els.studentsSummary.innerHTML = summaryItems.map(([label, value]) => `
-      <article class="studentsSummaryItem">
-        <strong>${escapeHtml(label)}</strong>
-        <span>${escapeHtml(value)}</span>
-      </article>
-    `).join("");
+    els.studentsSummary.innerHTML = renderStudentsSummaryCards(compactStudentsSummaryItems(counts));
+    els.studentsDialogSummary.innerHTML = renderStudentsSummaryCards(detailedStudentsSummaryItems(counts));
   }
   els.studentsBody.innerHTML = "";
   if (!state.report) {


### PR DESCRIPTION
## Summary
- rende il pannello Studenti coerente con gli altri riepiloghi compatti
- aggiunge nel modal Studenti un riepilogo completo sopra la tabella
- include metriche su consegne, ritardi, pending, grading OK/KO, media voto e voti mancanti
- riusa lo stesso stile responsive delle card Studenti
- aggiunge test frontend sui conteggi e sulla formattazione delle card

## Test
- `node --check tools\assignment_dashboard.js`
- `python -m pytest tests\test_assignment_dashboard_frontend.py tests\test_track_assignments.py tests\test_course_board_server.py`

## Prove manuali consigliate
1. Carica un registro consegne.
2. Nel pannello `Studenti`, verifica le card compatte: Studenti, Consegnati, Mancanti, Ritardo, KO.
3. Apri il modal `Studenti` e verifica il riepilogo completo sopra la tabella.
4. Cambia filtro studenti: il contatore `Mostrati x/y` deve cambiare, mentre il riepilogo deve restare sul registro completo.
5. Ridimensiona/affianca il pannello Studenti: le card devono andare a capo senza uscire dai bordi.