### PR TITLE
Mostra riepiloghi nei modal consegne

### DIFF
--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -216,6 +216,8 @@ def run_dashboard_js(assertions: str) -> None:
         reportsForActivity,
         activityCoverageKey,
         summaryTooltip,
+        renderCoverageSummaryCards,
+        renderOverviewSummaryCards,
         summaryCounts,
         renderStudentsSummaryCards,
         compactStudentsSummaryItems,
@@ -549,6 +551,20 @@ def test_students_summary_cards_include_tooltips() -> None:
         assert.match(html, /title="Numero di studenti che hanno effettuato una consegna\\."/);
         assert.match(html, /title="Numero di studenti con grading o test falliti\\."/);
         assert.equal(tested.summaryTooltip("Etichetta nuova"), "Valore riepilogativo: Etichetta nuova.");
+        """
+    )
+
+
+def test_modal_summary_helpers_include_tooltips() -> None:
+    run_dashboard_js(
+        """
+        const coverageHtml = tested.renderCoverageSummaryCards(5, 3, 2);
+        assert.match(coverageHtml, /title="Activity o numero di activity a cui si riferisce questo riepilogo\\."/);
+        assert.match(coverageHtml, /<strong>Con registro<\\/strong><span>3<\\/span>/);
+
+        const overviewHtml = tested.renderOverviewSummaryCards([["Classi", 2], ["Filtri", "nessuno"]]);
+        assert.match(overviewHtml, /title="Numero di classi diverse presenti nelle righe del quadro classe filtrato\\."/);
+        assert.match(overviewHtml, /title="Numero di filtri attivi nel quadro classe\\."/);
         """
     )
 

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -296,7 +296,7 @@ label > textarea {
 }
 
 .coverageDialog {
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
   width: min(96vw, 88rem);
   height: min(88vh, 50rem);
   min-width: min(92vw, 38rem);
@@ -835,7 +835,7 @@ label > textarea {
 }
 
 .overviewDialog {
-  grid-template-rows: auto auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto auto auto minmax(0, 1fr);
   width: min(96vw, 92rem);
   height: min(90vh, 54rem);
   min-width: min(92vw, 38rem);
@@ -1124,6 +1124,11 @@ label > textarea {
 }
 
 .studentsDialogSummary {
+  padding: .85rem 1rem;
+}
+
+.coverageDialogSummary,
+.overviewDialogSummary {
   padding: .85rem 1rem;
 }
 

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -190,6 +190,9 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         </select>
       </label>
     </div>
+    <div id="overviewDialogSummary" class="overviewSummary overviewDialogSummary" aria-live="polite">
+      <p class="status">Genera o carica almeno un registro per vedere il quadro classe.</p>
+    </div>
     <div class="viewTabs" role="tablist" aria-label="Vista quadro classe">
       <button type="button" class="isActive" data-overview-view="list" role="tab" aria-selected="true" title="Mostra il quadro classe come elenco ordinabile, una riga per studente e activity.">Elenco</button>
       <button type="button" data-overview-view="matrix" role="tab" aria-selected="false" title="Mostra il quadro classe come matrice con studenti a sinistra e consegne in colonna.">Matrice</button>
@@ -253,6 +256,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         <button type="button" class="smallButton" data-legend-topic="coverage" title="Mostra la legenda dei simboli e degli stati della copertura registri.">Legenda</button>
       </div>
     </div>
+    <div id="coverageDialogSummary" class="coverageSummary coverageDialogSummary" aria-live="polite"></div>
     <div class="tableWrap coverageDialogTable">
       <table id="coverageTable" class="resizableTable">
         <thead>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -113,6 +113,7 @@ const els = {
   status: document.querySelector("#status"),
   coverageStatus: document.querySelector("#coverageStatus"),
   coverageSummary: document.querySelector("#coverageSummary"),
+  coverageDialogSummary: document.querySelector("#coverageDialogSummary"),
   coverageDialog: document.querySelector("#coverageDialog"),
   coverageBreadcrumb: document.querySelector("#coverageBreadcrumb"),
   coverageOpenBtn: document.querySelector("#coverageOpenBtn"),
@@ -123,6 +124,7 @@ const els = {
   overviewStatus: document.querySelector("#overviewStatus"),
   overviewBody: document.querySelector("#overviewBody"),
   overviewSummary: document.querySelector("#overviewSummary"),
+  overviewDialogSummary: document.querySelector("#overviewDialogSummary"),
   overviewClassFilter: document.querySelector("#overviewClassFilter"),
   overviewStudentFilter: document.querySelector("#overviewStudentFilter"),
   overviewKindFilter: document.querySelector("#overviewKindFilter"),
@@ -1163,6 +1165,14 @@ function coverageStatusCell(outcome, report, isLatest = false) {
   `;
 }
 
+function renderCoverageSummaryCards(total, withReport, withoutReport) {
+  return `
+    <article title="${escapeHtml(summaryTooltip("Activity"))}"><strong>Activity</strong><span>${escapeHtml(total)}</span></article>
+    <article title="${escapeHtml(summaryTooltip("Con registro"))}"><strong>Con registro</strong><span>${escapeHtml(withReport)}</span></article>
+    <article title="${escapeHtml(summaryTooltip("Senza registro"))}"><strong>Senza registro</strong><span>${escapeHtml(withoutReport)}</span></article>
+  `;
+}
+
 function renderCoverage() {
   if (!els.coverageBody) return;
   const rows = reportCoverageRows();
@@ -1171,11 +1181,9 @@ function renderCoverage() {
   els.coverageStatus.textContent = rows.length
     ? `${withReport} activity con registro, ${withoutReport} senza registro.`
     : "Nessuna activity trovata.";
-  els.coverageSummary.innerHTML = `
-    <article title="${escapeHtml(summaryTooltip("Activity"))}"><strong>Activity</strong><span>${escapeHtml(rows.length)}</span></article>
-    <article title="${escapeHtml(summaryTooltip("Con registro"))}"><strong>Con registro</strong><span>${escapeHtml(withReport)}</span></article>
-    <article title="${escapeHtml(summaryTooltip("Senza registro"))}"><strong>Senza registro</strong><span>${escapeHtml(withoutReport)}</span></article>
-  `;
+  const summaryHtml = renderCoverageSummaryCards(rows.length, withReport, withoutReport);
+  els.coverageSummary.innerHTML = summaryHtml;
+  els.coverageDialogSummary.innerHTML = summaryHtml;
   els.coverageBody.innerHTML = "";
   if (!rows.length) {
     els.coverageBody.innerHTML = '<tr><td colspan="8">Nessuna activity disponibile.</td></tr>';
@@ -1357,9 +1365,20 @@ function renderOverviewViewTabs() {
   els.overviewMatrixView.hidden = state.overviewView !== "matrix";
 }
 
+function renderOverviewSummaryCards(cards) {
+  return cards.map(([label, value]) => `
+    <article class="overviewSummaryItem" title="${escapeHtml(summaryTooltip(label))}">
+      <strong>${escapeHtml(label)}</strong>
+      <span>${escapeHtml(value)}</span>
+    </article>
+  `).join("");
+}
+
 function renderOverviewSummary(rows) {
   if (!state.overviewRows.length) {
-    els.overviewSummary.innerHTML = '<p class="status">Genera o carica almeno un registro per vedere il quadro classe.</p>';
+    const emptySummary = '<p class="status">Genera o carica almeno un registro per vedere il quadro classe.</p>';
+    els.overviewSummary.innerHTML = emptySummary;
+    els.overviewDialogSummary.innerHTML = emptySummary;
     return;
   }
   const activeFilters = Object.values(state.overviewFilters).filter(Boolean).length;
@@ -1370,12 +1389,9 @@ function renderOverviewSummary(rows) {
     ["Righe", `${rows.length}/${state.overviewRows.length}`],
     ["Filtri", activeFilters ? `${activeFilters} attivi` : "nessuno"],
   ];
-  els.overviewSummary.innerHTML = cards.map(([label, value]) => `
-    <article class="overviewSummaryItem" title="${escapeHtml(summaryTooltip(label))}">
-      <strong>${escapeHtml(label)}</strong>
-      <span>${escapeHtml(value)}</span>
-    </article>
-  `).join("");
+  const summaryHtml = renderOverviewSummaryCards(cards);
+  els.overviewSummary.innerHTML = summaryHtml;
+  els.overviewDialogSummary.innerHTML = summaryHtml;
 }
 
 function activityKey(row) {


### PR DESCRIPTION
## Summary
- aggiunge il riepilogo anche nel modal Copertura registri
- aggiunge il riepilogo anche nel modal Quadro classe, sotto i filtri
- riusa gli stessi helper del pannello per mantenere tooltip e valori coerenti
- aggiunge test frontend sui nuovi helper dei riepiloghi modal

## Test
- `node --check tools\assignment_dashboard.js`
- `python -m pytest tests\test_assignment_dashboard_frontend.py tests\test_track_assignments.py tests\test_course_board_server.py`

## Prove manuali consigliate
1. Apri `Copertura registri`: sopra la tabella devono comparire Activity, Con registro, Senza registro.
2. Apri `Quadro classe`: sotto i filtri deve comparire lo stesso riepilogo del pannello.
3. Cambia filtri nel quadro classe: il riepilogo nel modal deve aggiornarsi come quello del pannello.
4. Verifica tooltip sulle card riepilogo nei modal.
5. Ridimensiona i modal: il riepilogo deve andare a capo senza sovrapporsi alla tabella.