### PR TITLE
Aggiungi storage JSON per percorsi e calendari

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -34,7 +34,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts import track_assignments
+from scripts import thebitlab_storage, track_assignments
 
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
@@ -72,6 +72,12 @@ COMPACT_TEXT_CHARS = 1200
 MAX_SUBMISSION_FILE_BYTES = 512 * 1024
 
 
+def course_storage() -> thebitlab_storage.JsonCourseStorage:
+    """Return the JSON storage adapter for course designs and calendars."""
+
+    return thebitlab_storage.JsonCourseStorage(ROOT, DEFAULT_SOURCES)
+
+
 def github_anchor(title: str, seen: dict[str, int]) -> str:
     """Return a GitHub-like Markdown anchor for a heading title."""
 
@@ -89,16 +95,13 @@ def github_anchor(title: str, seen: dict[str, int]) -> str:
 def read_design() -> dict:
     """Load the course design JSON file, creating a minimal shape if missing."""
 
-    if DESIGN_PATH.exists():
-        return json.loads(DESIGN_PATH.read_text(encoding="utf-8-sig"))
-    return {"version": 1, "source_files": DEFAULT_SOURCES, "years": []}
+    return course_storage().read_design()
 
 
 def write_design(payload: dict) -> None:
     """Persist the course design JSON with stable formatting."""
 
-    DESIGN_PATH.parent.mkdir(parents=True, exist_ok=True)
-    DESIGN_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    course_storage().write_design(payload)
 
 
 def generate_course_plan_md(payload: dict) -> dict:
@@ -138,22 +141,19 @@ def update_readme_frames(payload: dict) -> dict:
 def safe_design_name(name: str) -> str:
     """Validate a saved course-design filename."""
 
-    name = name.strip()
-    if not DESIGN_NAME_RE.match(name):
-        raise ValueError("Nome non valido. Usa solo lettere, numeri, trattino, underscore, punto e suffisso .json.")
-    return name
+    return course_storage().safe_design_name(name)
 
 
 def saved_design_path(name: str) -> Path:
     """Return the safe path for a saved course design."""
 
-    return COURSE_DESIGNS_DIR / safe_design_name(name)
+    return course_storage().saved_design_path(name)
 
 
 def school_calendar_path(name: str) -> Path:
     """Return the safe path for a saved school calendar."""
 
-    return SCHOOL_CALENDARS_DIR / safe_design_name(name)
+    return course_storage().school_calendar_path(name)
 
 
 def safe_teacher_report_path(name: str) -> Path:
@@ -170,73 +170,31 @@ def safe_teacher_report_path(name: str) -> Path:
 def list_saved_designs() -> list[dict]:
     """List saved course designs stored in doc/course_designs."""
 
-    COURSE_DESIGNS_DIR.mkdir(parents=True, exist_ok=True)
-    designs = []
-    for path in sorted(COURSE_DESIGNS_DIR.glob("*.json")):
-        designs.append({"name": path.name, "path": str(path.relative_to(ROOT))})
-    return designs
+    return course_storage().list_saved_designs()
 
 
 def read_saved_design(name: str) -> dict:
     """Read a saved course design by filename."""
 
-    path = saved_design_path(name)
-    if not path.is_file():
-        raise FileNotFoundError(f"Percorso salvato non trovato: {name}")
-    return json.loads(path.read_text(encoding="utf-8-sig"))
+    return course_storage().read_saved_design(name)
 
 
 def write_saved_design(name: str, payload: dict) -> dict:
     """Persist a named course design in the archive folder."""
 
-    COURSE_DESIGNS_DIR.mkdir(parents=True, exist_ok=True)
-    path = saved_design_path(name)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    return {"name": path.name, "path": str(path.relative_to(ROOT))}
+    return course_storage().write_saved_design(name, payload)
 
 
 def delete_saved_design(name: str, delete_calendars: bool = False, calendars: list[str] | None = None) -> dict:
     """Delete an archived course design and, optionally, its linked calendars."""
 
-    safe_name = safe_design_name(name)
-    path = saved_design_path(safe_name)
-    if not path.is_file():
-        raise FileNotFoundError(f"Percorso salvato non trovato: {safe_name}")
-    path.unlink()
-    deleted_calendars = []
-    if delete_calendars:
-        for calendar_name in calendars or []:
-            safe_calendar_name = safe_design_name(calendar_name)
-            calendar_path = school_calendar_path(safe_calendar_name)
-            if not calendar_path.is_file():
-                continue
-            payload = json.loads(calendar_path.read_text(encoding="utf-8-sig"))
-            if payload.get("course_design_name", "") != safe_name:
-                continue
-            calendar_path.unlink()
-            deleted_calendars.append(safe_calendar_name)
-    return {
-        "name": safe_name,
-        "deleted_calendars": deleted_calendars,
-        "designs": list_saved_designs(),
-        "calendars": list_school_calendars(),
-    }
+    return course_storage().delete_saved_design(name, delete_calendars, calendars)
 
 
 def list_school_calendars() -> list[dict]:
     """List saved school calendars stored in doc/calendars."""
 
-    SCHOOL_CALENDARS_DIR.mkdir(parents=True, exist_ok=True)
-    calendars = []
-    for path in sorted(SCHOOL_CALENDARS_DIR.glob("*.json")):
-        metadata = {"name": path.name, "path": str(path.relative_to(ROOT)), "course_design_name": ""}
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8-sig"))
-            metadata["course_design_name"] = payload.get("course_design_name", "")
-        except Exception:  # noqa: BLE001
-            metadata["course_design_name"] = ""
-        calendars.append(metadata)
-    return calendars
+    return course_storage().list_school_calendars()
 
 
 def list_assignment_reports() -> list[dict]:
@@ -475,19 +433,13 @@ def generate_assignment_report(payload: dict) -> dict:
 def read_school_calendar(name: str) -> dict:
     """Read a saved school calendar by filename."""
 
-    path = school_calendar_path(name)
-    if not path.is_file():
-        raise FileNotFoundError(f"Calendario scolastico non trovato: {name}")
-    return json.loads(path.read_text(encoding="utf-8-sig"))
+    return course_storage().read_school_calendar(name)
 
 
 def write_school_calendar(name: str, payload: dict) -> dict:
     """Persist a named school calendar in the calendars folder."""
 
-    SCHOOL_CALENDARS_DIR.mkdir(parents=True, exist_ok=True)
-    path = school_calendar_path(name)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    return {"name": path.name, "path": str(path.relative_to(ROOT))}
+    return course_storage().write_school_calendar(name, payload)
 
 
 def read_secret_env() -> dict[str, str]:

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -101,7 +101,8 @@ class JsonCourseStorage:
             metadata = {"name": path.name, "path": self.relative_path(path), "course_design_name": ""}
             try:
                 payload = self.read_json(path)
-                metadata["course_design_name"] = str(payload.get("course_design_name", ""))
+                course_design_name = payload.get("course_design_name", "")
+                metadata["course_design_name"] = course_design_name if isinstance(course_design_name, str) else ""
             except Exception:  # noqa: BLE001
                 metadata["course_design_name"] = ""
             calendars.append(metadata)

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+DESIGN_NAME_RE = re.compile(r"^[a-zA-Z0-9_.-]+\.json$")
+
+
+class JsonCourseStorage:
+    """JSON storage adapter for course designs and school calendars."""
+
+    def __init__(self, root: Path, default_sources: list[str] | None = None) -> None:
+        self.root = root
+        self.default_sources = default_sources or []
+        self.design_path = root / "doc" / "course_design.json"
+        self.course_designs_dir = root / "doc" / "course_designs"
+        self.school_calendars_dir = root / "doc" / "calendars"
+
+    def safe_design_name(self, name: str) -> str:
+        """Validate a JSON filename used by saved designs and calendars."""
+
+        clean_name = name.strip()
+        if not DESIGN_NAME_RE.match(clean_name):
+            raise ValueError("Nome non valido. Usa solo lettere, numeri, trattino, underscore, punto e suffisso .json.")
+        return clean_name
+
+    def saved_design_path(self, name: str) -> Path:
+        """Return the safe path for a saved course design."""
+
+        return self.course_designs_dir / self.safe_design_name(name)
+
+    def school_calendar_path(self, name: str) -> Path:
+        """Return the safe path for a saved school calendar."""
+
+        return self.school_calendars_dir / self.safe_design_name(name)
+
+    def read_json(self, path: Path) -> dict[str, Any]:
+        """Read a JSON object from path."""
+
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"JSON non valido: {path}")
+        return payload
+
+    def write_json(self, path: Path, payload: dict[str, Any]) -> None:
+        """Write a JSON object with stable formatting."""
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def relative_path(self, path: Path) -> str:
+        """Return a repository-relative path with URL-style separators."""
+
+        return str(path.relative_to(self.root)).replace("\\", "/")
+
+    def read_design(self) -> dict[str, Any]:
+        """Load the current course design, returning a minimal shape if missing."""
+
+        if self.design_path.exists():
+            return self.read_json(self.design_path)
+        return {"version": 1, "source_files": self.default_sources, "years": []}
+
+    def write_design(self, payload: dict[str, Any]) -> None:
+        """Persist the current course design."""
+
+        self.write_json(self.design_path, payload)
+
+    def list_saved_designs(self) -> list[dict[str, str]]:
+        """List saved course designs stored in doc/course_designs."""
+
+        self.course_designs_dir.mkdir(parents=True, exist_ok=True)
+        return [
+            {"name": path.name, "path": self.relative_path(path)}
+            for path in sorted(self.course_designs_dir.glob("*.json"))
+        ]
+
+    def read_saved_design(self, name: str) -> dict[str, Any]:
+        """Read a saved course design by filename."""
+
+        path = self.saved_design_path(name)
+        if not path.is_file():
+            raise FileNotFoundError(f"Percorso salvato non trovato: {name}")
+        return self.read_json(path)
+
+    def write_saved_design(self, name: str, payload: dict[str, Any]) -> dict[str, str]:
+        """Persist a named course design in the archive folder."""
+
+        path = self.saved_design_path(name)
+        self.write_json(path, payload)
+        return {"name": path.name, "path": self.relative_path(path)}
+
+    def list_school_calendars(self) -> list[dict[str, str]]:
+        """List saved school calendars stored in doc/calendars."""
+
+        self.school_calendars_dir.mkdir(parents=True, exist_ok=True)
+        calendars = []
+        for path in sorted(self.school_calendars_dir.glob("*.json")):
+            metadata = {"name": path.name, "path": self.relative_path(path), "course_design_name": ""}
+            try:
+                payload = self.read_json(path)
+                metadata["course_design_name"] = str(payload.get("course_design_name", ""))
+            except Exception:  # noqa: BLE001
+                metadata["course_design_name"] = ""
+            calendars.append(metadata)
+        return calendars
+
+    def read_school_calendar(self, name: str) -> dict[str, Any]:
+        """Read a saved school calendar by filename."""
+
+        path = self.school_calendar_path(name)
+        if not path.is_file():
+            raise FileNotFoundError(f"Calendario scolastico non trovato: {name}")
+        return self.read_json(path)
+
+    def write_school_calendar(self, name: str, payload: dict[str, Any]) -> dict[str, str]:
+        """Persist a named school calendar in the calendars folder."""
+
+        path = self.school_calendar_path(name)
+        self.write_json(path, payload)
+        return {"name": path.name, "path": self.relative_path(path)}
+
+    def delete_saved_design(
+        self,
+        name: str,
+        delete_calendars: bool = False,
+        calendars: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Delete an archived course design and, optionally, its linked calendars."""
+
+        safe_name = self.safe_design_name(name)
+        path = self.saved_design_path(safe_name)
+        if not path.is_file():
+            raise FileNotFoundError(f"Percorso salvato non trovato: {safe_name}")
+        path.unlink()
+        deleted_calendars = []
+        if delete_calendars:
+            for calendar_name in calendars or []:
+                safe_calendar_name = self.safe_design_name(calendar_name)
+                calendar_path = self.school_calendar_path(safe_calendar_name)
+                if not calendar_path.is_file():
+                    continue
+                payload = self.read_json(calendar_path)
+                if payload.get("course_design_name", "") != safe_name:
+                    continue
+                calendar_path.unlink()
+                deleted_calendars.append(safe_calendar_name)
+        return {
+            "name": safe_name,
+            "deleted_calendars": deleted_calendars,
+            "designs": self.list_saved_designs(),
+            "calendars": self.list_school_calendars(),
+        }

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.thebitlab_storage import JsonCourseStorage
+
+
+def test_read_design_returns_minimal_default_when_missing(tmp_path) -> None:
+    storage = JsonCourseStorage(tmp_path, ["README.md"])
+
+    assert storage.read_design() == {"version": 1, "source_files": ["README.md"], "years": []}
+
+
+def test_write_and_read_current_design(tmp_path) -> None:
+    storage = JsonCourseStorage(tmp_path)
+    payload = {"schema_version": "1.0", "years": [{"id": "terzo"}]}
+
+    storage.write_design(payload)
+
+    assert storage.read_design() == payload
+    assert (tmp_path / "doc" / "course_design.json").read_text(encoding="utf-8").endswith("\n")
+
+
+def test_saved_designs_are_validated_and_listed(tmp_path) -> None:
+    storage = JsonCourseStorage(tmp_path)
+
+    saved = storage.write_saved_design("as_2026_2027.json", {"title": "AS 2026/2027"})
+
+    assert saved == {
+        "name": "as_2026_2027.json",
+        "path": "doc/course_designs/as_2026_2027.json",
+    }
+    assert storage.list_saved_designs() == [saved]
+    assert storage.read_saved_design("as_2026_2027.json") == {"title": "AS 2026/2027"}
+
+
+def test_saved_design_rejects_unsafe_name(tmp_path) -> None:
+    storage = JsonCourseStorage(tmp_path)
+
+    with pytest.raises(ValueError):
+        storage.write_saved_design("../unsafe.json", {})
+
+
+def test_school_calendar_metadata_tolerates_invalid_json(tmp_path) -> None:
+    storage = JsonCourseStorage(tmp_path)
+    calendars_dir = tmp_path / "doc" / "calendars"
+    calendars_dir.mkdir(parents=True)
+    (calendars_dir / "broken.json").write_text("{", encoding="utf-8")
+    storage.write_school_calendar("valid.json", {"course_design_name": "as_2026_2027.json"})
+
+    assert storage.list_school_calendars() == [
+        {
+            "name": "broken.json",
+            "path": "doc/calendars/broken.json",
+            "course_design_name": "",
+        },
+        {
+            "name": "valid.json",
+            "path": "doc/calendars/valid.json",
+            "course_design_name": "as_2026_2027.json",
+        },
+    ]
+
+
+def test_delete_saved_design_deletes_only_linked_calendars(tmp_path) -> None:
+    storage = JsonCourseStorage(tmp_path)
+    storage.write_saved_design("as_2026_2027.json", {"title": "AS 2026/2027"})
+    storage.write_school_calendar("linked.json", {"course_design_name": "as_2026_2027.json"})
+    storage.write_school_calendar("other.json", {"course_design_name": "other.json"})
+
+    result = storage.delete_saved_design(
+        "as_2026_2027.json",
+        delete_calendars=True,
+        calendars=["linked.json", "other.json", "missing.json"],
+    )
+
+    assert result["name"] == "as_2026_2027.json"
+    assert result["deleted_calendars"] == ["linked.json"]
+    assert result["designs"] == []
+    assert result["calendars"] == [
+        {
+            "name": "other.json",
+            "path": "doc/calendars/other.json",
+            "course_design_name": "other.json",
+        }
+    ]
+    assert not (tmp_path / "doc" / "calendars" / "linked.json").exists()
+    assert (tmp_path / "doc" / "calendars" / "other.json").exists()
+
+
+def test_read_json_rejects_non_object_payload(tmp_path) -> None:
+    storage = JsonCourseStorage(tmp_path)
+    path = tmp_path / "list.json"
+    path.write_text(json.dumps([]), encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        storage.read_json(path)

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -48,12 +48,18 @@ def test_school_calendar_metadata_tolerates_invalid_json(tmp_path) -> None:
     calendars_dir = tmp_path / "doc" / "calendars"
     calendars_dir.mkdir(parents=True)
     (calendars_dir / "broken.json").write_text("{", encoding="utf-8")
+    (calendars_dir / "empty-link.json").write_text(json.dumps({"course_design_name": None}), encoding="utf-8")
     storage.write_school_calendar("valid.json", {"course_design_name": "as_2026_2027.json"})
 
     assert storage.list_school_calendars() == [
         {
             "name": "broken.json",
             "path": "doc/calendars/broken.json",
+            "course_design_name": "",
+        },
+        {
+            "name": "empty-link.json",
+            "path": "doc/calendars/empty-link.json",
             "course_design_name": "",
         },
         {


### PR DESCRIPTION
﻿## Riepilogo
- Aggiunge `JsonCourseStorage`, un adapter iniziale per leggere/scrivere percorsi didattici e calendari scolastici su JSON.
- Fa delegare `course_board_server.py` al nuovo storage mantenendo le funzioni pubbliche esistenti.
- Aggiunge test dedicati per nomi sicuri, path relativi, calendario invalido tollerato e cancellazione dei calendari collegati.

## Perche
Questo e' il primo passo tecnico verso il layer dati discusso in roadmap: oggi resta tutto su JSON, ma il server non deve piu' conoscere direttamente i dettagli di persistenza dei percorsi e dei calendari. In questo modo sara' piu' semplice introdurre in seguito un backend diverso, ad esempio SQLite, senza riscrivere la logica HTTP.

## Impatto
- Nessuna modifica intenzionale alla GUI.
- Nessuna migrazione dati.
- Il comportamento atteso dei file JSON resta invariato: stessi percorsi, stessa formattazione, stessi nomi file validi.

## Verifica
- `pytest tests/test_thebitlab_storage.py tests/test_course_board_server.py`
- `pytest tests/test_thebitlab_storage.py tests/test_course_board_server.py tests/test_generate_course_plan.py`
