### PR TITLE
Aggiungi storage JSON per consegne e registri

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -25,7 +25,6 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
-from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import unquote, urlparse
@@ -76,6 +75,12 @@ def course_storage() -> thebitlab_storage.JsonCourseStorage:
     """Return the JSON storage adapter for course designs and calendars."""
 
     return thebitlab_storage.JsonCourseStorage(ROOT, DEFAULT_SOURCES)
+
+
+def assignment_storage() -> thebitlab_storage.JsonAssignmentStorage:
+    """Return the JSON storage adapter for activities and assignment reports."""
+
+    return thebitlab_storage.JsonAssignmentStorage(ROOT, TEACHER_REPORTS_DIR, ACTIVITY_DIRS)
 
 
 def github_anchor(title: str, seen: dict[str, int]) -> str:
@@ -159,12 +164,7 @@ def school_calendar_path(name: str) -> Path:
 def safe_teacher_report_path(name: str) -> Path:
     """Return a safe teacher-report path below teacher-reports."""
 
-    name = name.strip().replace("\\", "/")
-    if not name or name.startswith("/") or ".." in Path(name).parts or not name.endswith(".json"):
-        raise ValueError("Nome registro non valido. Usa un path relativo .json dentro teacher-reports.")
-    path = (TEACHER_REPORTS_DIR / name).resolve()
-    path.relative_to(TEACHER_REPORTS_DIR.resolve())
-    return path
+    return assignment_storage().safe_teacher_report_path(name)
 
 
 def list_saved_designs() -> list[dict]:
@@ -200,133 +200,25 @@ def list_school_calendars() -> list[dict]:
 def list_assignment_reports() -> list[dict]:
     """List assignment tracking reports stored in teacher-reports."""
 
-    TEACHER_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
-    reports = []
-    for path in sorted(TEACHER_REPORTS_DIR.rglob("*.json")):
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8-sig"))
-        except Exception:  # noqa: BLE001
-            payload = {}
-        students = payload.get("students", []) if isinstance(payload.get("students"), list) else []
-        submitted = sum(1 for student in students if isinstance(student, dict) and student.get("submitted"))
-        late = sum(1 for student in students if isinstance(student, dict) and student.get("submitted") and student.get("late"))
-        not_submitted = sum(1 for student in students if isinstance(student, dict) and not student.get("submitted"))
-        reports.append(
-            {
-                "name": str(path.relative_to(TEACHER_REPORTS_DIR)).replace("\\", "/"),
-                "path": str(path.relative_to(ROOT)).replace("\\", "/"),
-                "activity_id": payload.get("activity_id", ""),
-                "title": payload.get("title", ""),
-                "class_id": payload.get("class_id", ""),
-                "class_label": payload.get("class_label", ""),
-                "github_team": payload.get("github_team", ""),
-                "due_at": payload.get("due_at", ""),
-                "students": len(students),
-                "submitted": submitted,
-                "late": late,
-                "not_submitted": not_submitted,
-                "updated_at": datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds"),
-            }
-        )
-    return reports
+    return assignment_storage().list_assignment_reports()
 
 
 def read_assignment_report(name: str) -> dict:
     """Read one assignment tracking report from teacher-reports."""
 
-    path = safe_teacher_report_path(name)
-    if not path.is_file():
-        raise FileNotFoundError(f"Registro consegne non trovato: {name}")
-    payload = json.loads(path.read_text(encoding="utf-8-sig"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"Registro consegne non valido: {name}")
-    if not isinstance(payload.get("students"), list):
-        raise ValueError("Registro consegne non valido: students deve essere una lista.")
-    return payload
+    return assignment_storage().read_assignment_report(name)
 
 
 def assignment_overview() -> list[dict]:
     """Return one row per student/activity across all saved teacher reports."""
 
-    rows = []
-    for report in list_assignment_reports():
-        try:
-            payload = read_assignment_report(report["name"])
-        except Exception:  # noqa: BLE001
-            continue
-        for student in payload.get("students", []):
-            if not isinstance(student, dict):
-                continue
-            submission = student.get("submission") if isinstance(student.get("submission"), dict) else {}
-            grading = student.get("grading") if isinstance(student.get("grading"), dict) else {}
-            ai_feedback = student.get("ai_feedback") if isinstance(student.get("ai_feedback"), dict) else {}
-            rows.append(
-                {
-                    "report_name": report["name"],
-                    "report_path": report["path"],
-                    "activity_id": payload.get("activity_id", ""),
-                    "title": payload.get("title", ""),
-                    "class_id": payload.get("class_id", ""),
-                    "class_label": payload.get("class_label", ""),
-                    "github_team": payload.get("github_team", ""),
-                    "kind": payload.get("kind", ""),
-                    "student_support_mode": payload.get("student_support_mode", ""),
-                    "assigned_at": payload.get("assigned_at", ""),
-                    "due_at": payload.get("due_at", ""),
-                    "student": student.get("student", ""),
-                    "repo": student.get("repo", ""),
-                    "status": student.get("status", ""),
-                    "submitted": bool(student.get("submitted", False)),
-                    "late": bool(student.get("late", False)),
-                    "submitted_at": submission.get("submitted_at"),
-                    "commit": submission.get("commit"),
-                    "source_path": submission.get("source_path"),
-                    "grading_status": grading.get("status", ""),
-                    "tests_passed": grading.get("tests_passed"),
-                    "tests_total": grading.get("tests_total"),
-                    "failed_tests": grading.get("failed_tests", []),
-                    "teacher_grade": grading.get("teacher_grade"),
-                    "score": grading.get("score"),
-                    "ai_status": ai_feedback.get("status", ""),
-                }
-            )
-    return rows
+    return assignment_storage().assignment_overview()
 
 
 def list_activities() -> list[dict]:
     """List available activity JSON files for the assignment dashboard."""
 
-    activities = []
-    seen_paths = set()
-    for directory in ACTIVITY_DIRS:
-        if not directory.is_dir():
-            continue
-        for path in sorted(directory.rglob("*.json")):
-            resolved = path.resolve()
-            if resolved in seen_paths:
-                continue
-            seen_paths.add(resolved)
-            try:
-                payload = json.loads(path.read_text(encoding="utf-8-sig"))
-            except Exception:  # noqa: BLE001
-                continue
-            if not isinstance(payload, dict) or not payload.get("id"):
-                continue
-            context = payload.get("contesto") if isinstance(payload.get("contesto"), dict) else {}
-            activities.append(
-                {
-                    "id": payload.get("id", ""),
-                    "title": payload.get("titolo", ""),
-                    "kind": payload.get("tipo", ""),
-                    "student_support_mode": payload.get("student_support_mode") or payload.get("support_mode") or payload.get("modalita_studente") or "",
-                    "class_id": context.get("classe", ""),
-                    "class_label": context.get("classe", ""),
-                    "github_team": context.get("team_github", ""),
-                    "language": payload.get("linguaggio") or payload.get("language", ""),
-                    "path": str(path.relative_to(ROOT)).replace("\\", "/"),
-                }
-            )
-    return activities
+    return assignment_storage().list_activities()
 
 
 def resolve_submission_file_path(student: dict, file_path: str) -> Path:

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -154,3 +155,161 @@ class JsonCourseStorage:
             "designs": self.list_saved_designs(),
             "calendars": self.list_school_calendars(),
         }
+
+
+class JsonAssignmentStorage:
+    """JSON storage adapter for activities and assignment tracking reports."""
+
+    def __init__(self, root: Path, teacher_reports_dir: Path, activity_dirs: list[Path]) -> None:
+        self.root = root
+        self.teacher_reports_dir = teacher_reports_dir
+        self.activity_dirs = activity_dirs
+
+    def relative_path(self, path: Path) -> str:
+        """Return a repository-relative path with URL-style separators."""
+
+        return str(path.relative_to(self.root)).replace("\\", "/")
+
+    def safe_teacher_report_path(self, name: str) -> Path:
+        """Return a safe teacher-report path below teacher-reports."""
+
+        clean_name = name.strip().replace("\\", "/")
+        if not clean_name or clean_name.startswith("/") or ".." in Path(clean_name).parts or not clean_name.endswith(".json"):
+            raise ValueError("Nome registro non valido. Usa un path relativo .json dentro teacher-reports.")
+        path = (self.teacher_reports_dir / clean_name).resolve()
+        path.relative_to(self.teacher_reports_dir.resolve())
+        return path
+
+    def read_json(self, path: Path) -> dict[str, Any]:
+        """Read a JSON object from path."""
+
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"JSON non valido: {path}")
+        return payload
+
+    def list_assignment_reports(self) -> list[dict[str, Any]]:
+        """List assignment tracking reports stored in teacher-reports."""
+
+        self.teacher_reports_dir.mkdir(parents=True, exist_ok=True)
+        reports = []
+        for path in sorted(self.teacher_reports_dir.rglob("*.json")):
+            try:
+                payload = self.read_json(path)
+            except Exception:  # noqa: BLE001
+                payload = {}
+            students = payload.get("students", []) if isinstance(payload.get("students"), list) else []
+            submitted = sum(1 for student in students if isinstance(student, dict) and student.get("submitted"))
+            late = sum(1 for student in students if isinstance(student, dict) and student.get("submitted") and student.get("late"))
+            not_submitted = sum(1 for student in students if isinstance(student, dict) and not student.get("submitted"))
+            reports.append(
+                {
+                    "name": str(path.relative_to(self.teacher_reports_dir)).replace("\\", "/"),
+                    "path": self.relative_path(path),
+                    "activity_id": payload.get("activity_id", ""),
+                    "title": payload.get("title", ""),
+                    "class_id": payload.get("class_id", ""),
+                    "class_label": payload.get("class_label", ""),
+                    "github_team": payload.get("github_team", ""),
+                    "due_at": payload.get("due_at", ""),
+                    "students": len(students),
+                    "submitted": submitted,
+                    "late": late,
+                    "not_submitted": not_submitted,
+                    "updated_at": datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds"),
+                }
+            )
+        return reports
+
+    def read_assignment_report(self, name: str) -> dict[str, Any]:
+        """Read one assignment tracking report from teacher-reports."""
+
+        path = self.safe_teacher_report_path(name)
+        if not path.is_file():
+            raise FileNotFoundError(f"Registro consegne non trovato: {name}")
+        payload = self.read_json(path)
+        if not isinstance(payload.get("students"), list):
+            raise ValueError("Registro consegne non valido: students deve essere una lista.")
+        return payload
+
+    def assignment_overview(self) -> list[dict[str, Any]]:
+        """Return one row per student/activity across all saved teacher reports."""
+
+        rows = []
+        for report in self.list_assignment_reports():
+            try:
+                payload = self.read_assignment_report(report["name"])
+            except Exception:  # noqa: BLE001
+                continue
+            for student in payload.get("students", []):
+                if not isinstance(student, dict):
+                    continue
+                submission = student.get("submission") if isinstance(student.get("submission"), dict) else {}
+                grading = student.get("grading") if isinstance(student.get("grading"), dict) else {}
+                ai_feedback = student.get("ai_feedback") if isinstance(student.get("ai_feedback"), dict) else {}
+                rows.append(
+                    {
+                        "report_name": report["name"],
+                        "report_path": report["path"],
+                        "activity_id": payload.get("activity_id", ""),
+                        "title": payload.get("title", ""),
+                        "class_id": payload.get("class_id", ""),
+                        "class_label": payload.get("class_label", ""),
+                        "github_team": payload.get("github_team", ""),
+                        "kind": payload.get("kind", ""),
+                        "student_support_mode": payload.get("student_support_mode", ""),
+                        "assigned_at": payload.get("assigned_at", ""),
+                        "due_at": payload.get("due_at", ""),
+                        "student": student.get("student", ""),
+                        "repo": student.get("repo", ""),
+                        "status": student.get("status", ""),
+                        "submitted": bool(student.get("submitted", False)),
+                        "late": bool(student.get("late", False)),
+                        "submitted_at": submission.get("submitted_at"),
+                        "commit": submission.get("commit"),
+                        "source_path": submission.get("source_path"),
+                        "grading_status": grading.get("status", ""),
+                        "tests_passed": grading.get("tests_passed"),
+                        "tests_total": grading.get("tests_total"),
+                        "failed_tests": grading.get("failed_tests", []),
+                        "teacher_grade": grading.get("teacher_grade"),
+                        "score": grading.get("score"),
+                        "ai_status": ai_feedback.get("status", ""),
+                    }
+                )
+        return rows
+
+    def list_activities(self) -> list[dict[str, Any]]:
+        """List available activity JSON files for the assignment dashboard."""
+
+        activities = []
+        seen_paths = set()
+        for directory in self.activity_dirs:
+            if not directory.is_dir():
+                continue
+            for path in sorted(directory.rglob("*.json")):
+                resolved = path.resolve()
+                if resolved in seen_paths:
+                    continue
+                seen_paths.add(resolved)
+                try:
+                    payload = self.read_json(path)
+                except Exception:  # noqa: BLE001
+                    continue
+                if not payload.get("id"):
+                    continue
+                context = payload.get("contesto") if isinstance(payload.get("contesto"), dict) else {}
+                activities.append(
+                    {
+                        "id": payload.get("id", ""),
+                        "title": payload.get("titolo", ""),
+                        "kind": payload.get("tipo", ""),
+                        "student_support_mode": payload.get("student_support_mode") or payload.get("support_mode") or payload.get("modalita_studente") or "",
+                        "class_id": context.get("classe", ""),
+                        "class_label": context.get("classe", ""),
+                        "github_team": context.get("team_github", ""),
+                        "language": payload.get("linguaggio") or payload.get("language", ""),
+                        "path": self.relative_path(path),
+                    }
+                )
+        return activities

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from scripts.thebitlab_storage import JsonCourseStorage
+from scripts.thebitlab_storage import JsonAssignmentStorage, JsonCourseStorage
 
 
 def test_read_design_returns_minimal_default_when_missing(tmp_path) -> None:
@@ -103,3 +103,145 @@ def test_read_json_rejects_non_object_payload(tmp_path) -> None:
 
     with pytest.raises(ValueError):
         storage.read_json(path)
+
+
+def test_assignment_reports_are_listed_with_counts(tmp_path) -> None:
+    storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [])
+    report_dir = tmp_path / "teacher-reports" / "demo"
+    report_dir.mkdir(parents=True)
+    (report_dir / "activity.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "activity",
+                "title": "Activity demo",
+                "class_id": "4A-INF",
+                "class_label": "4A INF",
+                "github_team": "team-4a-inf",
+                "students": [
+                    {"student": "rossi-mario", "submitted": True, "late": True},
+                    {"student": "bianchi-luca", "submitted": False, "late": True},
+                    {"student": "verdi-anna", "submitted": True, "late": False},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    reports = storage.list_assignment_reports()
+
+    assert reports[0]["name"] == "demo/activity.json"
+    assert reports[0]["path"] == "teacher-reports/demo/activity.json"
+    assert reports[0]["class_id"] == "4A-INF"
+    assert reports[0]["students"] == 3
+    assert reports[0]["submitted"] == 2
+    assert reports[0]["not_submitted"] == 1
+    assert reports[0]["late"] == 1
+    assert reports[0]["updated_at"]
+
+
+def test_assignment_report_rejects_unsafe_or_invalid_reports(tmp_path) -> None:
+    storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [])
+    reports_dir = tmp_path / "teacher-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "invalid.json").write_text(json.dumps({"students": {}}), encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        storage.safe_teacher_report_path("../unsafe.json")
+
+    with pytest.raises(ValueError, match="students"):
+        storage.read_assignment_report("invalid.json")
+
+
+def test_assignment_overview_lists_student_rows(tmp_path) -> None:
+    storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [])
+    reports_dir = tmp_path / "teacher-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "activity.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "title": "Somma in Python",
+                "kind": "compito-casa",
+                "student_support_mode": "guidato",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "repo": "TheBitPoets/rossi-mario",
+                        "status": "submitted_on_time",
+                        "submitted": True,
+                        "submission": {"submitted_at": "2026-10-18T18:22:10+02:00", "commit": "abc1234"},
+                        "grading": {"status": "graded_passed", "tests_passed": 2, "tests_total": 2, "teacher_grade": 9},
+                        "ai_feedback": {"status": "not_generated"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rows = storage.assignment_overview()
+
+    assert rows == [
+        {
+            "report_name": "activity.json",
+            "report_path": "teacher-reports/activity.json",
+            "activity_id": "python-base-somma-001",
+            "title": "Somma in Python",
+            "class_id": "",
+            "class_label": "",
+            "github_team": "",
+            "kind": "compito-casa",
+            "student_support_mode": "guidato",
+            "assigned_at": "",
+            "due_at": "",
+            "student": "rossi-mario",
+            "repo": "TheBitPoets/rossi-mario",
+            "status": "submitted_on_time",
+            "submitted": True,
+            "late": False,
+            "submitted_at": "2026-10-18T18:22:10+02:00",
+            "commit": "abc1234",
+            "source_path": None,
+            "grading_status": "graded_passed",
+            "tests_passed": 2,
+            "tests_total": 2,
+            "failed_tests": [],
+            "teacher_grade": 9,
+            "score": None,
+            "ai_status": "not_generated",
+        }
+    ]
+
+
+def test_list_activities_skips_invalid_json_and_deduplicates_paths(tmp_path) -> None:
+    activities_dir = tmp_path / "activities"
+    activities_dir.mkdir()
+    valid = activities_dir / "activity.json"
+    valid.write_text(
+        json.dumps(
+            {
+                "id": "python-base-somma-001",
+                "titolo": "Somma in Python",
+                "tipo": "compito-casa",
+                "linguaggio": "python",
+                "contesto": {"classe": "3A-TPSI", "team_github": "team-3a-tpsi"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (activities_dir / "broken.json").write_text("{", encoding="utf-8")
+    storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [activities_dir, activities_dir])
+
+    assert storage.list_activities() == [
+        {
+            "id": "python-base-somma-001",
+            "title": "Somma in Python",
+            "kind": "compito-casa",
+            "student_support_mode": "",
+            "class_id": "3A-TPSI",
+            "class_label": "3A-TPSI",
+            "github_team": "team-3a-tpsi",
+            "language": "python",
+            "path": "activities/activity.json",
+        }
+    ]


### PR DESCRIPTION
﻿## Riepilogo
- Aggiunge `JsonAssignmentStorage` per activity salvate e registri consegne JSON.
- Fa delegare `course_board_server.py` allo storage per listing/lettura registri, quadro classe e activity disponibili.
- Aggiunge test dedicati su conteggi registro, path sicuri, overview studenti e deduplica activity.

## Perche
Continuiamo la separazione iniziata con percorsi e calendari: la dashboard consegne deve restare invariata, ma il server non deve piu' contenere direttamente tutta la logica di persistenza JSON. Questo prepara il passaggio futuro a un backend diverso, ad esempio SQLite, con una superficie interna piu' stabile.

## Impatto
- Nessuna modifica intenzionale alla GUI.
- Nessuna migrazione dati.
- Stessi file e stessi percorsi: `teacher-reports/**/*.json`, `activities/**/*.json`, `examples/assignment_tracking/**/*.json`.
- La generazione del registro resta affidata a `track_assignments`.

## Verifica
- `pytest tests/test_thebitlab_storage.py tests/test_course_board_server.py`
- `pytest tests/test_thebitlab_storage.py tests/test_course_board_server.py tests/test_track_assignments.py`
- `python -m compileall scripts/thebitlab_storage.py scripts/course_board_server.py`
