### PR TITLE
Aggiungi AssignmentService per la dashboard consegne

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -33,7 +33,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts import thebitlab_storage, track_assignments
+from scripts import thebitlab_services, thebitlab_storage, track_assignments
 
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
@@ -81,6 +81,12 @@ def assignment_storage() -> thebitlab_storage.JsonAssignmentStorage:
     """Return the JSON storage adapter for activities and assignment reports."""
 
     return thebitlab_storage.JsonAssignmentStorage(ROOT, TEACHER_REPORTS_DIR, ACTIVITY_DIRS)
+
+
+def assignment_service() -> thebitlab_services.AssignmentService:
+    """Return the application service for assignment dashboard data."""
+
+    return thebitlab_services.AssignmentService(assignment_storage())
 
 
 def github_anchor(title: str, seen: dict[str, int]) -> str:
@@ -164,7 +170,7 @@ def school_calendar_path(name: str) -> Path:
 def safe_teacher_report_path(name: str) -> Path:
     """Return a safe teacher-report path below teacher-reports."""
 
-    return assignment_storage().safe_teacher_report_path(name)
+    return assignment_service().safe_teacher_report_path(name)
 
 
 def list_saved_designs() -> list[dict]:
@@ -200,25 +206,25 @@ def list_school_calendars() -> list[dict]:
 def list_assignment_reports() -> list[dict]:
     """List assignment tracking reports stored in teacher-reports."""
 
-    return assignment_storage().list_assignment_reports()
+    return assignment_service().list_assignment_reports()
 
 
 def read_assignment_report(name: str) -> dict:
     """Read one assignment tracking report from teacher-reports."""
 
-    return assignment_storage().read_assignment_report(name)
+    return assignment_service().read_assignment_report(name)
 
 
 def assignment_overview() -> list[dict]:
     """Return one row per student/activity across all saved teacher reports."""
 
-    return assignment_storage().assignment_overview()
+    return assignment_service().assignment_overview()
 
 
 def list_activities() -> list[dict]:
     """List available activity JSON files for the assignment dashboard."""
 
-    return assignment_storage().list_activities()
+    return assignment_service().list_activities()
 
 
 def resolve_submission_file_path(student: dict, file_path: str) -> Path:

--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from scripts.thebitlab_storage import JsonAssignmentStorage
+
+
+class AssignmentService:
+    """Application service for assignment dashboard data."""
+
+    def __init__(self, storage: JsonAssignmentStorage) -> None:
+        self.storage = storage
+
+    def safe_teacher_report_path(self, name: str) -> Path:
+        """Return a safe teacher-report path below the configured reports folder."""
+
+        return self.storage.safe_teacher_report_path(name)
+
+    def list_assignment_reports(self) -> list[dict[str, Any]]:
+        """List saved assignment tracking reports."""
+
+        return self.storage.list_assignment_reports()
+
+    def read_assignment_report(self, name: str) -> dict[str, Any]:
+        """Read one saved assignment tracking report."""
+
+        return self.storage.read_assignment_report(name)
+
+    def list_activities(self) -> list[dict[str, Any]]:
+        """List available activities for the assignment dashboard."""
+
+        return self.storage.list_activities()
+
+    def assignment_overview(self) -> list[dict[str, Any]]:
+        """Return one row per student/activity across all saved teacher reports."""
+
+        rows = []
+        for report in self.storage.list_assignment_reports():
+            try:
+                payload = self.storage.read_assignment_report(report["name"])
+            except Exception:  # noqa: BLE001
+                continue
+            for student in payload.get("students", []):
+                if not isinstance(student, dict):
+                    continue
+                submission = student.get("submission") if isinstance(student.get("submission"), dict) else {}
+                grading = student.get("grading") if isinstance(student.get("grading"), dict) else {}
+                ai_feedback = student.get("ai_feedback") if isinstance(student.get("ai_feedback"), dict) else {}
+                rows.append(
+                    {
+                        "report_name": report["name"],
+                        "report_path": report["path"],
+                        "activity_id": payload.get("activity_id", ""),
+                        "title": payload.get("title", ""),
+                        "class_id": payload.get("class_id", ""),
+                        "class_label": payload.get("class_label", ""),
+                        "github_team": payload.get("github_team", ""),
+                        "kind": payload.get("kind", ""),
+                        "student_support_mode": payload.get("student_support_mode", ""),
+                        "assigned_at": payload.get("assigned_at", ""),
+                        "due_at": payload.get("due_at", ""),
+                        "student": student.get("student", ""),
+                        "repo": student.get("repo", ""),
+                        "status": student.get("status", ""),
+                        "submitted": bool(student.get("submitted", False)),
+                        "late": bool(student.get("late", False)),
+                        "submitted_at": submission.get("submitted_at"),
+                        "commit": submission.get("commit"),
+                        "source_path": submission.get("source_path"),
+                        "grading_status": grading.get("status", ""),
+                        "tests_passed": grading.get("tests_passed"),
+                        "tests_total": grading.get("tests_total"),
+                        "failed_tests": grading.get("failed_tests", []),
+                        "teacher_grade": grading.get("teacher_grade"),
+                        "score": grading.get("score"),
+                        "ai_status": ai_feedback.get("status", ""),
+                    }
+                )
+        return rows

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -232,53 +232,6 @@ class JsonAssignmentStorage:
             raise ValueError("Registro consegne non valido: students deve essere una lista.")
         return payload
 
-    def assignment_overview(self) -> list[dict[str, Any]]:
-        """Return one row per student/activity across all saved teacher reports."""
-
-        rows = []
-        for report in self.list_assignment_reports():
-            try:
-                payload = self.read_assignment_report(report["name"])
-            except Exception:  # noqa: BLE001
-                continue
-            for student in payload.get("students", []):
-                if not isinstance(student, dict):
-                    continue
-                submission = student.get("submission") if isinstance(student.get("submission"), dict) else {}
-                grading = student.get("grading") if isinstance(student.get("grading"), dict) else {}
-                ai_feedback = student.get("ai_feedback") if isinstance(student.get("ai_feedback"), dict) else {}
-                rows.append(
-                    {
-                        "report_name": report["name"],
-                        "report_path": report["path"],
-                        "activity_id": payload.get("activity_id", ""),
-                        "title": payload.get("title", ""),
-                        "class_id": payload.get("class_id", ""),
-                        "class_label": payload.get("class_label", ""),
-                        "github_team": payload.get("github_team", ""),
-                        "kind": payload.get("kind", ""),
-                        "student_support_mode": payload.get("student_support_mode", ""),
-                        "assigned_at": payload.get("assigned_at", ""),
-                        "due_at": payload.get("due_at", ""),
-                        "student": student.get("student", ""),
-                        "repo": student.get("repo", ""),
-                        "status": student.get("status", ""),
-                        "submitted": bool(student.get("submitted", False)),
-                        "late": bool(student.get("late", False)),
-                        "submitted_at": submission.get("submitted_at"),
-                        "commit": submission.get("commit"),
-                        "source_path": submission.get("source_path"),
-                        "grading_status": grading.get("status", ""),
-                        "tests_passed": grading.get("tests_passed"),
-                        "tests_total": grading.get("tests_total"),
-                        "failed_tests": grading.get("failed_tests", []),
-                        "teacher_grade": grading.get("teacher_grade"),
-                        "score": grading.get("score"),
-                        "ai_status": ai_feedback.get("status", ""),
-                    }
-                )
-        return rows
-
     def list_activities(self) -> list[dict[str, Any]]:
         """List available activity JSON files for the assignment dashboard."""
 

--- a/tests/test_thebitlab_services.py
+++ b/tests/test_thebitlab_services.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+
+from scripts.thebitlab_services import AssignmentService
+from scripts.thebitlab_storage import JsonAssignmentStorage
+
+
+def assignment_service(tmp_path) -> AssignmentService:
+    storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [])
+    return AssignmentService(storage)
+
+
+def test_assignment_overview_lists_student_rows(tmp_path) -> None:
+    service = assignment_service(tmp_path)
+    reports_dir = tmp_path / "teacher-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "activity.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "title": "Somma in Python",
+                "kind": "compito-casa",
+                "student_support_mode": "guidato",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "repo": "TheBitPoets/rossi-mario",
+                        "status": "submitted_on_time",
+                        "submitted": True,
+                        "submission": {"submitted_at": "2026-10-18T18:22:10+02:00", "commit": "abc1234"},
+                        "grading": {"status": "graded_passed", "tests_passed": 2, "tests_total": 2, "teacher_grade": 9},
+                        "ai_feedback": {"status": "not_generated"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rows = service.assignment_overview()
+
+    assert rows == [
+        {
+            "report_name": "activity.json",
+            "report_path": "teacher-reports/activity.json",
+            "activity_id": "python-base-somma-001",
+            "title": "Somma in Python",
+            "class_id": "",
+            "class_label": "",
+            "github_team": "",
+            "kind": "compito-casa",
+            "student_support_mode": "guidato",
+            "assigned_at": "",
+            "due_at": "",
+            "student": "rossi-mario",
+            "repo": "TheBitPoets/rossi-mario",
+            "status": "submitted_on_time",
+            "submitted": True,
+            "late": False,
+            "submitted_at": "2026-10-18T18:22:10+02:00",
+            "commit": "abc1234",
+            "source_path": None,
+            "grading_status": "graded_passed",
+            "tests_passed": 2,
+            "tests_total": 2,
+            "failed_tests": [],
+            "teacher_grade": 9,
+            "score": None,
+            "ai_status": "not_generated",
+        }
+    ]
+
+
+def test_assignment_overview_skips_invalid_reports(tmp_path) -> None:
+    service = assignment_service(tmp_path)
+    reports_dir = tmp_path / "teacher-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "invalid.json").write_text(json.dumps({"students": {}}), encoding="utf-8")
+    (reports_dir / "valid.json").write_text(
+        json.dumps({"activity_id": "activity", "students": [{"student": "rossi-mario"}]}),
+        encoding="utf-8",
+    )
+
+    rows = service.assignment_overview()
+
+    assert len(rows) == 1
+    assert rows[0]["report_name"] == "valid.json"
+    assert rows[0]["student"] == "rossi-mario"
+
+
+def test_assignment_service_delegates_storage_lists(tmp_path) -> None:
+    service = assignment_service(tmp_path)
+    activities_dir = tmp_path / "activities"
+    activities_dir.mkdir()
+    (activities_dir / "activity.json").write_text(json.dumps({"id": "activity"}), encoding="utf-8")
+    service.storage.activity_dirs = [activities_dir]
+
+    assert service.list_activities()[0]["id"] == "activity"
+    assert service.list_assignment_reports() == []

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -152,67 +152,6 @@ def test_assignment_report_rejects_unsafe_or_invalid_reports(tmp_path) -> None:
         storage.read_assignment_report("invalid.json")
 
 
-def test_assignment_overview_lists_student_rows(tmp_path) -> None:
-    storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [])
-    reports_dir = tmp_path / "teacher-reports"
-    reports_dir.mkdir(parents=True)
-    (reports_dir / "activity.json").write_text(
-        json.dumps(
-            {
-                "activity_id": "python-base-somma-001",
-                "title": "Somma in Python",
-                "kind": "compito-casa",
-                "student_support_mode": "guidato",
-                "students": [
-                    {
-                        "student": "rossi-mario",
-                        "repo": "TheBitPoets/rossi-mario",
-                        "status": "submitted_on_time",
-                        "submitted": True,
-                        "submission": {"submitted_at": "2026-10-18T18:22:10+02:00", "commit": "abc1234"},
-                        "grading": {"status": "graded_passed", "tests_passed": 2, "tests_total": 2, "teacher_grade": 9},
-                        "ai_feedback": {"status": "not_generated"},
-                    }
-                ],
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    rows = storage.assignment_overview()
-
-    assert rows == [
-        {
-            "report_name": "activity.json",
-            "report_path": "teacher-reports/activity.json",
-            "activity_id": "python-base-somma-001",
-            "title": "Somma in Python",
-            "class_id": "",
-            "class_label": "",
-            "github_team": "",
-            "kind": "compito-casa",
-            "student_support_mode": "guidato",
-            "assigned_at": "",
-            "due_at": "",
-            "student": "rossi-mario",
-            "repo": "TheBitPoets/rossi-mario",
-            "status": "submitted_on_time",
-            "submitted": True,
-            "late": False,
-            "submitted_at": "2026-10-18T18:22:10+02:00",
-            "commit": "abc1234",
-            "source_path": None,
-            "grading_status": "graded_passed",
-            "tests_passed": 2,
-            "tests_total": 2,
-            "failed_tests": [],
-            "teacher_grade": 9,
-            "score": None,
-            "ai_status": "not_generated",
-        }
-    ]
-
-
 def test_list_activities_skips_invalid_json_and_deduplicates_paths(tmp_path) -> None:
     activities_dir = tmp_path / "activities"
     activities_dir.mkdir()


### PR DESCRIPTION
## Riepilogo
- Aggiunge `AssignmentService` in `scripts/thebitlab_services.py`.
- Sposta la costruzione del quadro classe/overview fuori da `JsonAssignmentStorage`.
- Fa passare `course_board_server.py` da `AssignmentService` per le API della dashboard consegne.
- Aggiunge test dedicati per il service.

## Perche
Questo e' il primo passo della issue #283: lo storage deve restare focalizzato su persistenza e path sicuri, mentre il service contiene il significato applicativo della dashboard.

## Impatto
- Nessuna modifica intenzionale alla GUI.
- Nessuna migrazione dati.
- Endpoint esistenti invariati.
- Il server resta compatibile, ma inizia a dipendere da un service invece che direttamente dallo storage.

## Verifica
- `pytest tests/test_thebitlab_services.py tests/test_thebitlab_storage.py tests/test_course_board_server.py tests/test_track_assignments.py`
- `python -m compileall scripts/thebitlab_services.py scripts/thebitlab_storage.py scripts/course_board_server.py`
- `git diff --check -- scripts/course_board_server.py scripts/thebitlab_storage.py scripts/thebitlab_services.py tests/test_thebitlab_storage.py tests/test_thebitlab_services.py`

Parte di #283.