### PR TITLE
Aggiungi CourseService per percorsi e calendari

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -77,6 +77,12 @@ def course_storage() -> thebitlab_storage.JsonCourseStorage:
     return thebitlab_storage.JsonCourseStorage(ROOT, DEFAULT_SOURCES)
 
 
+def course_service() -> thebitlab_services.CourseService:
+    """Return the application service for course designs and calendars."""
+
+    return thebitlab_services.CourseService(course_storage())
+
+
 def assignment_storage() -> thebitlab_storage.JsonAssignmentStorage:
     """Return the JSON storage adapter for activities and assignment reports."""
 
@@ -106,13 +112,13 @@ def github_anchor(title: str, seen: dict[str, int]) -> str:
 def read_design() -> dict:
     """Load the course design JSON file, creating a minimal shape if missing."""
 
-    return course_storage().read_design()
+    return course_service().read_design()
 
 
 def write_design(payload: dict) -> None:
     """Persist the course design JSON with stable formatting."""
 
-    course_storage().write_design(payload)
+    course_service().write_design(payload)
 
 
 def generate_course_plan_md(payload: dict) -> dict:
@@ -152,19 +158,19 @@ def update_readme_frames(payload: dict) -> dict:
 def safe_design_name(name: str) -> str:
     """Validate a saved course-design filename."""
 
-    return course_storage().safe_design_name(name)
+    return course_service().safe_design_name(name)
 
 
 def saved_design_path(name: str) -> Path:
     """Return the safe path for a saved course design."""
 
-    return course_storage().saved_design_path(name)
+    return course_service().saved_design_path(name)
 
 
 def school_calendar_path(name: str) -> Path:
     """Return the safe path for a saved school calendar."""
 
-    return course_storage().school_calendar_path(name)
+    return course_service().school_calendar_path(name)
 
 
 def safe_teacher_report_path(name: str) -> Path:
@@ -176,31 +182,31 @@ def safe_teacher_report_path(name: str) -> Path:
 def list_saved_designs() -> list[dict]:
     """List saved course designs stored in doc/course_designs."""
 
-    return course_storage().list_saved_designs()
+    return course_service().list_saved_designs()
 
 
 def read_saved_design(name: str) -> dict:
     """Read a saved course design by filename."""
 
-    return course_storage().read_saved_design(name)
+    return course_service().read_saved_design(name)
 
 
 def write_saved_design(name: str, payload: dict) -> dict:
     """Persist a named course design in the archive folder."""
 
-    return course_storage().write_saved_design(name, payload)
+    return course_service().write_saved_design(name, payload)
 
 
 def delete_saved_design(name: str, delete_calendars: bool = False, calendars: list[str] | None = None) -> dict:
     """Delete an archived course design and, optionally, its linked calendars."""
 
-    return course_storage().delete_saved_design(name, delete_calendars, calendars)
+    return course_service().delete_saved_design(name, delete_calendars, calendars)
 
 
 def list_school_calendars() -> list[dict]:
     """List saved school calendars stored in doc/calendars."""
 
-    return course_storage().list_school_calendars()
+    return course_service().list_school_calendars()
 
 
 def list_assignment_reports() -> list[dict]:
@@ -331,13 +337,13 @@ def generate_assignment_report(payload: dict) -> dict:
 def read_school_calendar(name: str) -> dict:
     """Read a saved school calendar by filename."""
 
-    return course_storage().read_school_calendar(name)
+    return course_service().read_school_calendar(name)
 
 
 def write_school_calendar(name: str, payload: dict) -> dict:
     """Persist a named school calendar in the calendars folder."""
 
-    return course_storage().write_school_calendar(name, payload)
+    return course_service().write_school_calendar(name, payload)
 
 
 def read_secret_env() -> dict[str, str]:

--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -3,7 +3,79 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from scripts.thebitlab_storage import JsonAssignmentStorage
+from scripts.thebitlab_storage import JsonAssignmentStorage, JsonCourseStorage
+
+
+class CourseService:
+    """Application service for course designs and school calendars."""
+
+    def __init__(self, storage: JsonCourseStorage) -> None:
+        self.storage = storage
+
+    def safe_design_name(self, name: str) -> str:
+        """Validate a JSON filename used by saved designs and calendars."""
+
+        return self.storage.safe_design_name(name)
+
+    def saved_design_path(self, name: str) -> Path:
+        """Return the safe path for a saved course design."""
+
+        return self.storage.saved_design_path(name)
+
+    def school_calendar_path(self, name: str) -> Path:
+        """Return the safe path for a saved school calendar."""
+
+        return self.storage.school_calendar_path(name)
+
+    def read_design(self) -> dict[str, Any]:
+        """Load the current course design."""
+
+        return self.storage.read_design()
+
+    def write_design(self, payload: dict[str, Any]) -> None:
+        """Persist the current course design."""
+
+        self.storage.write_design(payload)
+
+    def list_saved_designs(self) -> list[dict[str, str]]:
+        """List saved course designs."""
+
+        return self.storage.list_saved_designs()
+
+    def read_saved_design(self, name: str) -> dict[str, Any]:
+        """Read a saved course design by filename."""
+
+        return self.storage.read_saved_design(name)
+
+    def write_saved_design(self, name: str, payload: dict[str, Any]) -> dict[str, str]:
+        """Persist a named course design."""
+
+        return self.storage.write_saved_design(name, payload)
+
+    def delete_saved_design(
+        self,
+        name: str,
+        delete_calendars: bool = False,
+        calendars: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Delete an archived course design and, optionally, its linked calendars."""
+
+        return self.storage.delete_saved_design(name, delete_calendars, calendars)
+
+    def list_school_calendars(self) -> list[dict[str, str]]:
+        """List saved school calendars."""
+
+        return self.storage.list_school_calendars()
+
+    def read_school_calendar(self, name: str) -> dict[str, Any]:
+        """Read a saved school calendar by filename."""
+
+        return self.storage.read_school_calendar(name)
+
+    def write_school_calendar(self, name: str, payload: dict[str, Any]) -> dict[str, str]:
+        """Persist a named school calendar."""
+
+        return self.storage.write_school_calendar(name, payload)
 
 
 class AssignmentService:

--- a/tests/test_thebitlab_services.py
+++ b/tests/test_thebitlab_services.py
@@ -2,13 +2,68 @@ from __future__ import annotations
 
 import json
 
-from scripts.thebitlab_services import AssignmentService
-from scripts.thebitlab_storage import JsonAssignmentStorage
+from scripts.thebitlab_services import AssignmentService, CourseService
+from scripts.thebitlab_storage import JsonAssignmentStorage, JsonCourseStorage
+
+
+def course_service(tmp_path) -> CourseService:
+    storage = JsonCourseStorage(tmp_path, ["README.md"])
+    return CourseService(storage)
 
 
 def assignment_service(tmp_path) -> AssignmentService:
     storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [])
     return AssignmentService(storage)
+
+
+def test_course_service_delegates_design_and_calendar_storage(tmp_path) -> None:
+    service = course_service(tmp_path)
+    design = {"version": 1, "years": [{"id": "terzo"}]}
+
+    assert service.read_design() == {"version": 1, "source_files": ["README.md"], "years": []}
+
+    service.write_design(design)
+    saved_design = service.write_saved_design("as_2026_2027.json", design)
+    saved_calendar = service.write_school_calendar(
+        "as_2026_2027.json",
+        {"course_design_name": "as_2026_2027.json"},
+    )
+
+    assert service.read_design() == design
+    assert service.list_saved_designs() == [saved_design]
+    assert service.read_saved_design("as_2026_2027.json") == design
+    assert saved_calendar == {"name": "as_2026_2027.json", "path": "doc/calendars/as_2026_2027.json"}
+    assert service.read_school_calendar("as_2026_2027.json") == {"course_design_name": "as_2026_2027.json"}
+    assert service.list_school_calendars() == [
+        {
+            "name": "as_2026_2027.json",
+            "path": "doc/calendars/as_2026_2027.json",
+            "course_design_name": "as_2026_2027.json",
+        }
+    ]
+
+
+def test_course_service_deletes_linked_calendars(tmp_path) -> None:
+    service = course_service(tmp_path)
+    service.write_saved_design("as_2026_2027.json", {"title": "AS 2026/2027"})
+    service.write_school_calendar("linked.json", {"course_design_name": "as_2026_2027.json"})
+    service.write_school_calendar("other.json", {"course_design_name": "other.json"})
+
+    result = service.delete_saved_design(
+        "as_2026_2027.json",
+        delete_calendars=True,
+        calendars=["linked.json", "other.json"],
+    )
+
+    assert result["deleted_calendars"] == ["linked.json"]
+    assert service.list_saved_designs() == []
+    assert service.list_school_calendars() == [
+        {
+            "name": "other.json",
+            "path": "doc/calendars/other.json",
+            "course_design_name": "other.json",
+        }
+    ]
 
 
 def test_assignment_overview_lists_student_rows(tmp_path) -> None:


### PR DESCRIPTION
## Riepilogo
- Aggiunge `CourseService` in `scripts/thebitlab_services.py`.
- Fa passare `course_board_server.py` dal service per percorso didattico, design salvati e calendari scolastici.
- Aggiunge test dedicati per il service su design, calendari e cancellazione calendari collegati.

## Perche
Completa il primo livello di service layer avviato con `AssignmentService`: il server HTTP resta il punto API, ma delega la logica applicativa a un service invece che parlare direttamente con lo storage.

## Impatto
- Nessuna modifica intenzionale alla GUI.
- Nessuna migrazione dati.
- Endpoint esistenti invariati.
- `JsonCourseStorage` resta il layer di persistenza JSON.

## Verifica
- `pytest tests/test_thebitlab_services.py tests/test_thebitlab_storage.py tests/test_course_board_server.py tests/test_generate_course_plan.py`
- `python -m compileall scripts/thebitlab_services.py scripts/thebitlab_storage.py scripts/course_board_server.py`
- `git diff --check -- scripts/course_board_server.py scripts/thebitlab_services.py tests/test_thebitlab_services.py`

Parte di #283.