### PR TITLE
Documenta contratti dati MVP

### DIFF
--- a/doc/DATA_MODEL_MVP.md
+++ b/doc/DATA_MODEL_MVP.md
@@ -4,6 +4,8 @@ Questo documento inventaria i dati JSON usati oggi da TheBitLab e definisce il m
 
 Non introduce ancora uno storage layer, SQLite o nuove migrazioni. Serve a fissare il lessico e a evitare che le prossime feature continuino ad aggiungere campi scollegati tra loro.
 
+Per i contratti operativi minimi, gli alias legacy e le fixture testabili vedi anche [`architecture/data-contracts.md`](architecture/data-contracts.md).
+
 ## Obiettivi
 
 Per l'MVP di inizio anno scolastico 2026-2027 il modello dati deve permettere questo flusso:

--- a/doc/architecture/data-contracts.md
+++ b/doc/architecture/data-contracts.md
@@ -1,0 +1,217 @@
+# Contratti dati MVP
+
+Questo documento definisce i contratti dati minimi che il codice deve usare mentre TheBitLab evolve da JSON locali verso service layer, provider repository e possibile SQLite.
+
+Il documento non sostituisce [`doc/DATA_MODEL_MVP.md`](../DATA_MODEL_MVP.md): lo rende operativo. Qui fissiamo nomi canonici, alias legacy e campi minimi da usare nei test e nelle prossime PR.
+
+## Regole generali
+
+- Ogni dato sorgente nuovo dovrebbe avere `schema_version` e `id`.
+- I dati derivati possono essere salvati come snapshot o cache, ma devono essere ricalcolabili dai dati sorgente.
+- Il backend deve leggere gli alias legacy finche esistono dati e tool che li producono.
+- Le nuove API interne devono preferire i campi canonici.
+- La GUI non deve dipendere da dettagli GitHub/GitLab: deve ricevere riferimenti logici o normalizzati dal service layer.
+
+## Entita canoniche
+
+### CourseDesign
+
+Rappresenta percorso didattico, anni, UDA, item e collegamenti a fonti/activity.
+
+Campi minimi:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `schema_version` | string | Versione del contratto dati. |
+| `id` | string | Identificativo stabile del percorso. |
+| `title` | string | Titolo leggibile. |
+| `source_ids` | array | Fonti didattiche collegate. |
+| `years` | array | Anni/indirizzi del percorso. |
+
+Compatibilita attuale:
+
+- `doc/course_design.json` puo non avere ancora `schema_version` e `id`.
+- `source_files` e accettato come alias legacy/operativo di `source_ids`.
+
+### SchoolCalendar
+
+Rappresenta calendario scolastico e pianificazione.
+
+Campi minimi:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `schema_version` | string | Versione del contratto dati. |
+| `id` | string | Identificativo calendario. |
+| `title` | string | Titolo leggibile. |
+| `school_year` | string | Anno scolastico, per esempio `2026-2027`. |
+| `course_design_id` | string | Percorso collegato. |
+| `events` | array | Eventi pianificati. |
+
+Compatibilita attuale:
+
+- `course_design_name` resta alias legacy/operativo quando il collegamento e ancora per nome file.
+
+### ClassGroup
+
+Rappresenta una classe didattica.
+
+Campi minimi:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `schema_version` | string | Versione del contratto dati. |
+| `id` | string | Slug stabile della classe. |
+| `label` | string | Etichetta leggibile. |
+| `school_year` | string | Anno scolastico. |
+| `provider` | string | `github`, `gitlab`, `local` o futuro provider. |
+| `provider_ref` | string | Riferimento provider normalizzato. |
+| `students` | array | Studenti della classe. |
+
+Compatibilita attuale:
+
+- `github_team` e un dettaglio GitHub, non l'identita canonica della classe.
+
+### Student
+
+Rappresenta uno studente.
+
+Campi minimi:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `schema_version` | string | Versione del contratto dati. |
+| `id` | string | Identificativo stabile, per esempio `rossi-mario`. |
+| `display_name` | string | Nome leggibile. |
+| `class_ids` | array | Classi associate. |
+| `provider_accounts` | object | Account per GitHub/GitLab/local. |
+| `repo_refs` | array | Repository collegati. |
+
+### Activity
+
+Rappresenta il template didattico di una attivita.
+
+Campi minimi canonici:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `schema_version` | string | Versione schema activity. |
+| `id` | string | Identificativo stabile. |
+| `title` | string | Titolo leggibile. |
+| `kind` | string | Tipo activity. |
+| `language` | string | Linguaggio principale. |
+| `difficulty` | string | Livello A-F. |
+| `topics` | array | Argomenti. |
+| `instructions` | string | Testo consegna. |
+| `student_support_mode` | string | Modalita di aiuto consentita. |
+| `grading_policy` | object | Regole correzione. |
+| `test_cases` | array | Test deterministici, se presenti. |
+| `source_refs` | array | Fonti/paragrafi collegati. |
+
+Alias legacy letti oggi:
+
+| Alias legacy | Campo canonico |
+|---|---|
+| `titolo` | `title` |
+| `tipo` | `kind` |
+| `linguaggio` | `language` |
+| `difficolta` | `difficulty` |
+| `argomenti` | `topics` |
+| `consegna` | `instructions` |
+| `correzione` | `grading_policy` |
+| `student_support_mode`, `support_mode`, `modalita_studente` | `student_support_mode` |
+| `contesto.classe` | `class_id` quando l'activity e assegnata |
+| `contesto.team_github` | `github_team` / provider ref |
+
+Fase di transizione:
+
+- I writer attuali possono continuare a produrre campi legacy italiani.
+- I service futuri dovrebbero normalizzare verso i campi canonici senza rompere i lettori esistenti.
+
+### AssignmentRegister
+
+Rappresenta il registro docente generato per una activity assegnata.
+
+Campi minimi:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `schema_version` | string | Versione contratto registro. |
+| `id` | string | Identificativo registro. |
+| `assignment_id` | string | Assegnazione collegata, quando disponibile. |
+| `activity_id` | string | Activity collegata. |
+| `class_id` | string | Classe collegata. |
+| `class_label` | string | Etichetta classe. |
+| `assigned_at` | string/null | Data assegnazione ISO. |
+| `due_at` | string/null | Scadenza ISO. |
+| `students` | array | Righe studente. |
+
+Compatibilita attuale:
+
+- `teacher-reports/**/*.json` puo non avere `schema_version`, `id` e `assignment_id`.
+- I conteggi `submitted`, `late`, `not_submitted` sono derivati e non campi sorgente obbligatori.
+
+### Submission
+
+Rappresenta la consegna di uno studente per una assegnazione.
+
+Campi minimi:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `schema_version` | string | Versione contratto submission, quando materializzata. |
+| `id` | string | Identificativo submission. |
+| `assignment_id` | string | Assegnazione collegata. |
+| `activity_id` | string | Activity collegata. |
+| `student_id` | string | Studente. |
+| `repo_ref` | string | Repository normalizzato. |
+| `commit` | string/null | Commit consegnato. |
+| `submitted_at` | string/null | Data consegna ISO. |
+| `status` | string | Stato consegna. |
+| `late` | boolean | Consegna in ritardo. |
+| `files` | array | File consegnati, anche multipli. |
+
+### Grading
+
+Rappresenta esito deterministico di compilazione/test/runner.
+
+Campi minimi:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `status` | string | Stato grading. |
+| `passed` | boolean/null | Esito complessivo. |
+| `tests_passed` | number/null | Test superati. |
+| `tests_total` | number/null | Test totali. |
+| `failed_tests` | array | Nomi test falliti. |
+| `score` | number/null | Punteggio automatico. |
+| `teacher_grade` | number/null | Voto docente, se inserito. |
+
+### AiFeedback
+
+Rappresenta feedback generativo o assistito.
+
+Campi minimi:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `status` | string | `not_generated`, `draft`, `approved`, `rejected` o simili. |
+| `suggested_grade` | number/null | Voto suggerito, se presente. |
+| `summary` | string/null | Sintesi feedback. |
+| `approved_by_teacher` | boolean | Approvazione docente. |
+
+## Fixture contrattuali
+
+Le fixture minime stanno in:
+
+```text
+tests/fixtures/contracts/
+```
+
+Queste fixture non sono demo complete. Servono come esempi stabili per testare che i contratti minimi restino leggibili e coerenti mentre evolvono service, storage e provider.
+
+## Prossime PR suggerite
+
+1. Introdurre normalizer piccoli nei service, per esempio `normalize_activity` e `normalize_assignment_register`.
+2. Collegare `AssignmentRegister` ad `assignment_id` quando l'entita Assignment sara disponibile.
+3. Usare questi contratti per disegnare la valutazione SQLite/provider senza migrare subito.

--- a/tests/fixtures/contracts/activity.json
+++ b/tests/fixtures/contracts/activity.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "1.0",
+  "id": "python-base-somma-001",
+  "title": "Somma in Python",
+  "titolo": "Somma in Python",
+  "kind": "compito-casa",
+  "tipo": "compito-casa",
+  "language": "python",
+  "linguaggio": "python",
+  "difficulty": "B",
+  "difficolta": "B",
+  "topics": [
+    "variabili",
+    "input-output"
+  ],
+  "argomenti": [
+    "variabili",
+    "input-output"
+  ],
+  "instructions": "Scrivi un programma che legge due numeri e stampa la somma.",
+  "consegna": "Scrivi un programma che legge due numeri e stampa la somma.",
+  "student_support_mode": "feedback-tecnico",
+  "grading_policy": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": false
+  },
+  "correzione": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": false
+  },
+  "metriche": {
+    "tempo_stimato_minuti": 25,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": true
+  },
+  "test_cases": [
+    {
+      "name": "somma positiva",
+      "stdin": "2 3\n",
+      "expected_stdout": "5\n"
+    }
+  ],
+  "source_refs": [
+    {
+      "source_id": "readme-main",
+      "href": "README.md#input-e-output"
+    }
+  ],
+  "contesto": {
+    "classe": "3A-TPSI",
+    "team_github": "team-3a-tpsi",
+    "percorso": "terzo",
+    "uda": "uda-programmazione-base"
+  }
+}

--- a/tests/fixtures/contracts/assignment_register.json
+++ b/tests/fixtures/contracts/assignment_register.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "1.0",
+  "id": "register-3a-tpsi-python-base-somma-001",
+  "assignment_id": "assignment-3a-tpsi-python-base-somma-001",
+  "activity_id": "python-base-somma-001",
+  "title": "Somma in Python",
+  "kind": "compito-casa",
+  "student_support_mode": "feedback-tecnico",
+  "class_id": "3a-tpsi-2026",
+  "class_label": "3A TPSI",
+  "github_team": "team-3a-tpsi",
+  "assigned_at": "2026-10-12T09:00:00+02:00",
+  "due_at": "2026-10-19T23:59:00+02:00",
+  "students": [
+    {
+      "student": "rossi-mario",
+      "student_id": "rossi-mario",
+      "repo": "TheBitPoets/rossi-mario",
+      "repo_github_url": "https://github.com/TheBitPoets/rossi-mario",
+      "assigned": true,
+      "submitted": true,
+      "status": "submitted_on_time",
+      "late": false,
+      "submission": {
+        "id": "submission-rossi-mario-python-base-somma-001",
+        "assignment_id": "assignment-3a-tpsi-python-base-somma-001",
+        "activity_id": "python-base-somma-001",
+        "student_id": "rossi-mario",
+        "repo_ref": "TheBitPoets/rossi-mario",
+        "commit": "abc1234",
+        "submitted_at": "2026-10-18T18:22:10+02:00",
+        "status": "submitted_on_time",
+        "late": false,
+        "files": [
+          {
+            "path": "assignments/python-base-somma-001/main.py",
+            "role": "solution"
+          }
+        ]
+      },
+      "grading": {
+        "status": "graded_passed",
+        "passed": true,
+        "tests_passed": 1,
+        "tests_total": 1,
+        "failed_tests": [],
+        "score": 10,
+        "teacher_grade": null
+      },
+      "ai_feedback": {
+        "status": "not_generated",
+        "suggested_grade": null,
+        "summary": null,
+        "approved_by_teacher": false
+      }
+    }
+  ]
+}

--- a/tests/fixtures/contracts/class_group.json
+++ b/tests/fixtures/contracts/class_group.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "id": "3a-tpsi-2026",
+  "label": "3A TPSI",
+  "school_year": "2026-2027",
+  "provider": "github",
+  "provider_ref": "team-3a-tpsi",
+  "github_team": "team-3a-tpsi",
+  "students": [
+    {
+      "id": "rossi-mario",
+      "display_name": "Mario Rossi",
+      "provider_accounts": {
+        "github": "rossi-mario"
+      },
+      "repo_refs": [
+        "TheBitPoets/rossi-mario"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/contracts/class_group.json
+++ b/tests/fixtures/contracts/class_group.json
@@ -8,8 +8,12 @@
   "github_team": "team-3a-tpsi",
   "students": [
     {
+      "schema_version": "1.0",
       "id": "rossi-mario",
       "display_name": "Mario Rossi",
+      "class_ids": [
+        "3a-tpsi-2026"
+      ],
       "provider_accounts": {
         "github": "rossi-mario"
       },

--- a/tests/fixtures/contracts/course_design.json
+++ b/tests/fixtures/contracts/course_design.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1.0",
+  "id": "course-2026-2027-tpsi",
+  "title": "Percorso TPSI 2026/2027",
+  "source_ids": [
+    "readme-main"
+  ],
+  "years": [
+    {
+      "id": "terzo",
+      "title": "Terzo anno",
+      "udas": [
+        {
+          "id": "uda-programmazione-base",
+          "title": "Programmazione di base",
+          "items": [
+            {
+              "id": "item-input-output",
+              "title": "Input e output",
+              "source_id": "readme-main",
+              "href": "README.md#input-e-output",
+              "activity_ids": [
+                "python-base-somma-001"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_data_contract_fixtures.py
+++ b/tests/test_data_contract_fixtures.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts import validate_activity
+
+
+CONTRACT_FIXTURES = Path("tests/fixtures/contracts")
+
+
+def load_fixture(name: str) -> dict[str, Any]:
+    payload = json.loads((CONTRACT_FIXTURES / name).read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def assert_required(payload: dict[str, Any], fields: set[str]) -> None:
+    missing = fields - set(payload)
+    assert not missing, f"Campi mancanti in fixture: {sorted(missing)}"
+
+
+def test_course_design_contract_fixture() -> None:
+    payload = load_fixture("course_design.json")
+
+    assert_required(payload, {"schema_version", "id", "title", "source_ids", "years"})
+    assert payload["years"][0]["udas"][0]["items"][0]["activity_ids"] == ["python-base-somma-001"]
+
+
+def test_class_group_contract_fixture() -> None:
+    payload = load_fixture("class_group.json")
+
+    assert_required(payload, {"schema_version", "id", "label", "school_year", "provider", "provider_ref", "students"})
+    assert payload["students"][0]["id"] == "rossi-mario"
+    assert payload["students"][0]["provider_accounts"]["github"] == "rossi-mario"
+
+
+def test_activity_contract_fixture_keeps_canonical_and_legacy_fields() -> None:
+    payload = load_fixture("activity.json")
+
+    assert_required(
+        payload,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "kind",
+            "language",
+            "difficulty",
+            "topics",
+            "instructions",
+            "student_support_mode",
+            "grading_policy",
+            "test_cases",
+            "source_refs",
+        },
+    )
+    assert payload["title"] == payload["titolo"]
+    assert payload["kind"] == payload["tipo"]
+    assert payload["language"] == payload["linguaggio"]
+    assert payload["difficulty"] == payload["difficolta"]
+    assert payload["topics"] == payload["argomenti"]
+    assert payload["instructions"] == payload["consegna"]
+    assert payload["grading_policy"] == payload["correzione"]
+    assert validate_activity.validate_activity(payload, "activity.json") == []
+
+
+def test_assignment_register_contract_fixture() -> None:
+    payload = load_fixture("assignment_register.json")
+
+    assert_required(
+        payload,
+        {
+            "schema_version",
+            "id",
+            "assignment_id",
+            "activity_id",
+            "class_id",
+            "class_label",
+            "assigned_at",
+            "due_at",
+            "students",
+        },
+    )
+    student = payload["students"][0]
+    assert_required(student, {"student", "student_id", "repo", "submitted", "status", "late", "submission", "grading", "ai_feedback"})
+    assert student["submission"]["files"][0]["path"] == "assignments/python-base-somma-001/main.py"
+    assert student["grading"]["failed_tests"] == []
+    assert student["ai_feedback"]["status"] == "not_generated"

--- a/tests/test_data_contract_fixtures.py
+++ b/tests/test_data_contract_fixtures.py
@@ -32,8 +32,11 @@ def test_class_group_contract_fixture() -> None:
     payload = load_fixture("class_group.json")
 
     assert_required(payload, {"schema_version", "id", "label", "school_year", "provider", "provider_ref", "students"})
-    assert payload["students"][0]["id"] == "rossi-mario"
-    assert payload["students"][0]["provider_accounts"]["github"] == "rossi-mario"
+    student = payload["students"][0]
+    assert_required(student, {"schema_version", "id", "display_name", "class_ids", "provider_accounts", "repo_refs"})
+    assert student["id"] == "rossi-mario"
+    assert student["class_ids"] == ["3a-tpsi-2026"]
+    assert student["provider_accounts"]["github"] == "rossi-mario"
 
 
 def test_activity_contract_fixture_keeps_canonical_and_legacy_fields() -> None:


### PR DESCRIPTION
## Riepilogo
- Aggiunge `doc/architecture/data-contracts.md` con i contratti dati MVP operativi.
- Collega `doc/DATA_MODEL_MVP.md` al nuovo documento.
- Aggiunge fixture minime per `CourseDesign`, `ClassGroup`, `Activity` e `AssignmentRegister`.
- Aggiunge test che validano campi minimi, alias legacy e compatibilita' della fixture activity con `validate_activity`.

## Perche
Questa PR avvia #284: prima di introdurre SQLite, provider GitHub/GitLab o nuove GUI, serve fissare il significato dei dati e la transizione tra campi legacy e campi canonici.

## Impatto
- Nessuna modifica runtime intenzionale.
- Nessuna migrazione dati.
- Le fixture sono esempi contrattuali minimi, non demo complete.

## Verifica
- `pytest tests/test_data_contract_fixtures.py tests/test_validate_activity.py tests/test_thebitlab_storage.py tests/test_thebitlab_services.py`
- `git diff --check -- doc/DATA_MODEL_MVP.md doc/architecture/data-contracts.md tests/fixtures/contracts tests/test_data_contract_fixtures.py`

Parte di #284.