### PR TITLE
Aggiungi normalizer per contratti dati

### DIFF
--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -80,7 +80,7 @@ def normalize_grading(payload: dict[str, Any]) -> dict[str, Any]:
 
     normalized = deepcopy(payload)
     normalized.setdefault("status", "")
-    normalized.setdefault("passed", None)
+    normalized["passed"] = None if payload.get("passed") is None else bool_value(payload.get("passed"))
     normalized.setdefault("tests_passed", None)
     normalized.setdefault("tests_total", None)
     normalized.setdefault("failed_tests", [])
@@ -96,7 +96,7 @@ def normalize_ai_feedback(payload: dict[str, Any]) -> dict[str, Any]:
     normalized.setdefault("status", "not_generated")
     normalized.setdefault("suggested_grade", None)
     normalized.setdefault("summary", None)
-    normalized.setdefault("approved_by_teacher", False)
+    normalized["approved_by_teacher"] = bool_value(payload.get("approved_by_teacher", False))
     return normalized
 
 

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -34,6 +34,20 @@ def first_dict(payload: dict[str, Any], *keys: str) -> dict[str, Any]:
     return {}
 
 
+def bool_value(value: Any, default: bool = False) -> bool:
+    """Return a conservative boolean value from bools or common string forms."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "si", "s"}:
+            return True
+        if normalized in {"false", "0", "no", "n"}:
+            return False
+    return default
+
+
 def normalize_activity(payload: dict[str, Any]) -> dict[str, Any]:
     """Return an activity with canonical fields populated from legacy aliases."""
 
@@ -137,9 +151,9 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
     normalized["student"] = first_text(payload, "student")
     normalized["student_id"] = first_text(payload, "student_id") or normalized["student"]
     normalized["repo"] = first_text(payload, "repo")
-    normalized["submitted"] = bool(payload.get("submitted", False))
+    normalized["submitted"] = bool_value(payload.get("submitted", False))
     normalized["status"] = first_text(payload, "status")
-    normalized["late"] = bool(payload.get("late", False))
+    normalized["late"] = bool_value(payload.get("late", False))
     submission = payload.get("submission") if isinstance(payload.get("submission"), dict) else {}
     grading = payload.get("grading") if isinstance(payload.get("grading"), dict) else {}
     ai_feedback = payload.get("ai_feedback") if isinstance(payload.get("ai_feedback"), dict) else {}

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+def first_text(payload: dict[str, Any], *keys: str) -> str:
+    """Return the first non-empty string value found in payload."""
+
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def first_list(payload: dict[str, Any], *keys: str) -> list[Any]:
+    """Return the first list value found in payload."""
+
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, list):
+            return deepcopy(value)
+    return []
+
+
+def first_dict(payload: dict[str, Any], *keys: str) -> dict[str, Any]:
+    """Return the first dict value found in payload."""
+
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, dict):
+            return deepcopy(value)
+    return {}
+
+
+def normalize_activity(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return an activity with canonical fields populated from legacy aliases."""
+
+    context = payload.get("contesto") if isinstance(payload.get("contesto"), dict) else {}
+    normalized = deepcopy(payload)
+    normalized["schema_version"] = first_text(payload, "schema_version") or "1.0"
+    normalized["id"] = first_text(payload, "id")
+    normalized["title"] = first_text(payload, "title", "titolo")
+    normalized["kind"] = first_text(payload, "kind", "tipo")
+    normalized["language"] = first_text(payload, "language", "linguaggio")
+    normalized["difficulty"] = first_text(payload, "difficulty", "difficolta")
+    normalized["topics"] = first_list(payload, "topics", "argomenti")
+    normalized["instructions"] = first_text(payload, "instructions", "consegna")
+    normalized["student_support_mode"] = first_text(
+        payload,
+        "student_support_mode",
+        "support_mode",
+        "modalita_studente",
+    )
+    normalized["grading_policy"] = first_dict(payload, "grading_policy", "correzione")
+    normalized["test_cases"] = first_list(payload, "test_cases")
+    normalized["source_refs"] = first_list(payload, "source_refs")
+    normalized["class_id"] = first_text(payload, "class_id") or first_text(context, "classe")
+    normalized["github_team"] = first_text(payload, "github_team") or first_text(context, "team_github")
+    return normalized
+
+
+def normalize_grading(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return grading fields with stable defaults for dashboard contracts."""
+
+    normalized = deepcopy(payload)
+    normalized.setdefault("status", "")
+    normalized.setdefault("passed", None)
+    normalized.setdefault("tests_passed", None)
+    normalized.setdefault("tests_total", None)
+    normalized.setdefault("failed_tests", [])
+    normalized.setdefault("score", None)
+    normalized.setdefault("teacher_grade", None)
+    return normalized
+
+
+def normalize_ai_feedback(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return AI feedback fields with stable defaults for dashboard contracts."""
+
+    normalized = deepcopy(payload)
+    normalized.setdefault("status", "not_generated")
+    normalized.setdefault("suggested_grade", None)
+    normalized.setdefault("summary", None)
+    normalized.setdefault("approved_by_teacher", False)
+    return normalized
+
+
+def normalize_submission(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return submission fields with stable defaults for dashboard contracts."""
+
+    normalized = deepcopy(payload)
+    normalized.setdefault("id", "")
+    normalized.setdefault("assignment_id", "")
+    normalized.setdefault("activity_id", "")
+    normalized.setdefault("student_id", "")
+    normalized.setdefault("repo_ref", "")
+    normalized.setdefault("commit", None)
+    normalized.setdefault("submitted_at", None)
+    normalized.setdefault("status", "")
+    normalized.setdefault("late", False)
+    normalized.setdefault("files", [])
+    return normalized
+
+
+def normalize_assignment_register(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return an assignment register with canonical fields populated."""
+
+    normalized = deepcopy(payload)
+    normalized["schema_version"] = first_text(payload, "schema_version") or "1.0"
+    normalized["id"] = first_text(payload, "id")
+    normalized["assignment_id"] = first_text(payload, "assignment_id")
+    normalized["activity_id"] = first_text(payload, "activity_id")
+    normalized["title"] = first_text(payload, "title")
+    normalized["kind"] = first_text(payload, "kind", "tipo")
+    normalized["student_support_mode"] = first_text(
+        payload,
+        "student_support_mode",
+        "support_mode",
+        "modalita_studente",
+    )
+    normalized["class_id"] = first_text(payload, "class_id")
+    normalized["class_label"] = first_text(payload, "class_label") or normalized["class_id"]
+    normalized["github_team"] = first_text(payload, "github_team")
+    normalized["assigned_at"] = payload.get("assigned_at")
+    normalized["due_at"] = payload.get("due_at")
+
+    students = payload.get("students") if isinstance(payload.get("students"), list) else []
+    normalized["students"] = [normalize_register_student(student) for student in students if isinstance(student, dict)]
+    return normalized
+
+
+def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a register student row with normalized nested submission/grading/feedback."""
+
+    normalized = deepcopy(payload)
+    normalized["student"] = first_text(payload, "student")
+    normalized["student_id"] = first_text(payload, "student_id") or normalized["student"]
+    normalized["repo"] = first_text(payload, "repo")
+    normalized["submitted"] = bool(payload.get("submitted", False))
+    normalized["status"] = first_text(payload, "status")
+    normalized["late"] = bool(payload.get("late", False))
+    submission = payload.get("submission") if isinstance(payload.get("submission"), dict) else {}
+    grading = payload.get("grading") if isinstance(payload.get("grading"), dict) else {}
+    ai_feedback = payload.get("ai_feedback") if isinstance(payload.get("ai_feedback"), dict) else {}
+    normalized["submission"] = normalize_submission(submission)
+    normalized["grading"] = normalize_grading(grading)
+    normalized["ai_feedback"] = normalize_ai_feedback(ai_feedback)
+    return normalized

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -112,7 +112,7 @@ def normalize_submission(payload: dict[str, Any]) -> dict[str, Any]:
     normalized.setdefault("commit", None)
     normalized.setdefault("submitted_at", None)
     normalized.setdefault("status", "")
-    normalized.setdefault("late", False)
+    normalized["late"] = bool_value(payload.get("late", False))
     normalized.setdefault("files", [])
     return normalized
 

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts import thebitlab_contracts
+
+
+FIXTURES = Path("tests/fixtures/contracts")
+
+
+def load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def test_normalize_activity_preserves_contract_fixture() -> None:
+    payload = load_fixture("activity.json")
+
+    normalized = thebitlab_contracts.normalize_activity(payload)
+
+    assert normalized["id"] == "python-base-somma-001"
+    assert normalized["title"] == "Somma in Python"
+    assert normalized["kind"] == "compito-casa"
+    assert normalized["language"] == "python"
+    assert normalized["difficulty"] == "B"
+    assert normalized["topics"] == ["variabili", "input-output"]
+    assert normalized["instructions"] == "Scrivi un programma che legge due numeri e stampa la somma."
+    assert normalized["grading_policy"] == payload["correzione"]
+    assert normalized["class_id"] == "3A-TPSI"
+    assert normalized["github_team"] == "team-3a-tpsi"
+
+
+def test_normalize_activity_reads_legacy_aliases() -> None:
+    payload = {
+        "id": "c-base-contatore-001",
+        "titolo": "Contatore in C",
+        "tipo": "laboratorio",
+        "linguaggio": "c",
+        "difficolta": "C",
+        "argomenti": ["cicli"],
+        "consegna": "Scrivi un contatore.",
+        "support_mode": "feedback-tecnico",
+        "correzione": {"compila": True},
+        "contesto": {"classe": "4A-INF", "team_github": "team-4a-inf"},
+    }
+
+    normalized = thebitlab_contracts.normalize_activity(payload)
+
+    assert normalized["schema_version"] == "1.0"
+    assert normalized["title"] == "Contatore in C"
+    assert normalized["kind"] == "laboratorio"
+    assert normalized["language"] == "c"
+    assert normalized["difficulty"] == "C"
+    assert normalized["topics"] == ["cicli"]
+    assert normalized["instructions"] == "Scrivi un contatore."
+    assert normalized["student_support_mode"] == "feedback-tecnico"
+    assert normalized["grading_policy"] == {"compila": True}
+    assert normalized["class_id"] == "4A-INF"
+    assert normalized["github_team"] == "team-4a-inf"
+
+
+def test_normalize_assignment_register_preserves_contract_fixture() -> None:
+    payload = load_fixture("assignment_register.json")
+
+    normalized = thebitlab_contracts.normalize_assignment_register(payload)
+
+    assert normalized["id"] == "register-3a-tpsi-python-base-somma-001"
+    assert normalized["assignment_id"] == "assignment-3a-tpsi-python-base-somma-001"
+    assert normalized["activity_id"] == "python-base-somma-001"
+    assert normalized["class_id"] == "3a-tpsi-2026"
+    assert normalized["students"][0]["student_id"] == "rossi-mario"
+    assert normalized["students"][0]["submission"]["files"][0]["role"] == "solution"
+    assert normalized["students"][0]["grading"]["passed"] is True
+    assert normalized["students"][0]["ai_feedback"]["status"] == "not_generated"
+
+
+def test_normalize_assignment_register_adds_nested_defaults() -> None:
+    payload = {
+        "activity_id": "activity",
+        "kind": "compito-casa",
+        "class_id": "3A-TPSI",
+        "students": [
+            {
+                "student": "rossi-mario",
+                "repo": "TheBitPoets/rossi-mario",
+                "submitted": True,
+                "submission": {"commit": "abc1234"},
+                "grading": {"status": "graded_passed"},
+            }
+        ],
+    }
+
+    normalized = thebitlab_contracts.normalize_assignment_register(payload)
+    student = normalized["students"][0]
+
+    assert normalized["schema_version"] == "1.0"
+    assert normalized["class_label"] == "3A-TPSI"
+    assert student["student_id"] == "rossi-mario"
+    assert student["submission"]["commit"] == "abc1234"
+    assert student["submission"]["files"] == []
+    assert student["grading"]["failed_tests"] == []
+    assert student["grading"]["teacher_grade"] is None
+    assert student["ai_feedback"]["status"] == "not_generated"

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -102,3 +102,25 @@ def test_normalize_assignment_register_adds_nested_defaults() -> None:
     assert student["grading"]["failed_tests"] == []
     assert student["grading"]["teacher_grade"] is None
     assert student["ai_feedback"]["status"] == "not_generated"
+
+
+def test_normalize_register_student_parses_boolean_strings_conservatively() -> None:
+    student = thebitlab_contracts.normalize_register_student(
+        {
+            "student": "rossi-mario",
+            "submitted": "false",
+            "late": "0",
+        }
+    )
+    other_student = thebitlab_contracts.normalize_register_student(
+        {
+            "student": "bianchi-luca",
+            "submitted": "yes",
+            "late": "si",
+        }
+    )
+
+    assert student["submitted"] is False
+    assert student["late"] is False
+    assert other_student["submitted"] is True
+    assert other_student["late"] is True

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -132,3 +132,21 @@ def test_normalize_submission_parses_late_string_conservatively() -> None:
 
     assert submission["late"] is False
     assert other_submission["late"] is True
+
+
+def test_normalize_grading_parses_passed_string_without_losing_none() -> None:
+    failed_grading = thebitlab_contracts.normalize_grading({"passed": "false"})
+    passed_grading = thebitlab_contracts.normalize_grading({"passed": "yes"})
+    pending_grading = thebitlab_contracts.normalize_grading({})
+
+    assert failed_grading["passed"] is False
+    assert passed_grading["passed"] is True
+    assert pending_grading["passed"] is None
+
+
+def test_normalize_ai_feedback_parses_approval_string_conservatively() -> None:
+    feedback = thebitlab_contracts.normalize_ai_feedback({"approved_by_teacher": "false"})
+    other_feedback = thebitlab_contracts.normalize_ai_feedback({"approved_by_teacher": "si"})
+
+    assert feedback["approved_by_teacher"] is False
+    assert other_feedback["approved_by_teacher"] is True

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -124,3 +124,11 @@ def test_normalize_register_student_parses_boolean_strings_conservatively() -> N
     assert student["late"] is False
     assert other_student["submitted"] is True
     assert other_student["late"] is True
+
+
+def test_normalize_submission_parses_late_string_conservatively() -> None:
+    submission = thebitlab_contracts.normalize_submission({"late": "false"})
+    other_submission = thebitlab_contracts.normalize_submission({"late": "yes"})
+
+    assert submission["late"] is False
+    assert other_submission["late"] is True


### PR DESCRIPTION
## Riepilogo
- Aggiunge `scripts/thebitlab_contracts.py` con normalizer puri per contratti dati.
- Normalizza activity da campi canonici e alias legacy italiani.
- Normalizza registri consegne, righe studente, submission, grading e AI feedback con default stabili.
- Aggiunge test basati sulle fixture contrattuali introdotte in #295.

## Perche
Continua #284: dopo aver documentato i contratti dati MVP, iniziamo a codificare la transizione tra JSON legacy e forma canonica senza cambiare ancora service, storage o GUI.

## Impatto
- Nessuna modifica runtime intenzionale: i normalizer non sono ancora agganciati ai service.
- Nessuna migrazione dati.
- Funzioni pure e testabili, pronte per una PR successiva di integrazione.

## Verifica
- `pytest tests/test_thebitlab_contracts.py tests/test_data_contract_fixtures.py tests/test_validate_activity.py`
- `python -m compileall scripts/thebitlab_contracts.py`
- `git diff --check -- scripts/thebitlab_contracts.py tests/test_thebitlab_contracts.py`

Parte di #284.