### PR TITLE
Normalizza metadata activity nei registri

### DIFF
--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -358,6 +358,16 @@ def legacy_activity_validation_payload(activity: dict[str, Any], normalized_acti
     payload.setdefault("argomenti", normalized_activity.get("topics", []))
     payload.setdefault("consegna", normalized_activity.get("instructions", ""))
     payload.setdefault("correzione", normalized_activity.get("grading_policy", {}))
+    payload.setdefault(
+        "metriche",
+        {
+            "tempo_stimato_minuti": 0,
+            "traccia_tempo_dichiarato": False,
+            "traccia_sessioni_thebitlab": False,
+            "traccia_eventi_didattici": False,
+            "traccia_errori_compilazione": False,
+        },
+    )
     return payload
 
 

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from scripts import assign_activity, create_submission_scaffold
+from scripts import assign_activity, create_submission_scaffold, validate_activity
 from scripts.thebitlab_contracts import normalize_activity
 
 
@@ -340,6 +340,14 @@ def clean_metadata(value: str | None) -> str:
     return str(value or "").strip()
 
 
+def validate_normalized_activity_or_raise(activity: dict[str, Any], identifier: str) -> None:
+    """Validate canonical activity fields used by the tracking register."""
+
+    kind = clean_metadata(activity.get("kind"))
+    if kind and kind not in validate_activity.ALLOWED_TYPES:
+        raise ValueError(f"{identifier}: kind non ammesso: {kind}")
+
+
 def track_assignments(
     *,
     activity_path: Path,
@@ -356,6 +364,7 @@ def track_assignments(
     normalized_activity = normalize_activity(activity)
     activity_id = create_submission_scaffold.activity_id(activity)
     create_submission_scaffold.validate_activity_or_raise(activity, activity_id)
+    validate_normalized_activity_or_raise(normalized_activity, activity_id)
     normalized_assigned_at = parse_datetime(assigned_at, "assigned_at")
     normalized_due_at = parse_datetime(due_at, "due_at")
     normalized_now = parse_datetime(now, "now")

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts import assign_activity, create_submission_scaffold
+from scripts.thebitlab_contracts import normalize_activity
 
 
 NO_DUE_DATE_STATUS = "no_due_date"
@@ -334,12 +335,6 @@ def ai_feedback_placeholder() -> dict[str, Any]:
     }
 
 
-def activity_context(activity: dict[str, Any]) -> dict[str, Any]:
-    """Return the optional didactic context from an activity."""
-    context = activity.get("contesto")
-    return context if isinstance(context, dict) else {}
-
-
 def clean_metadata(value: str | None) -> str:
     """Normalize optional text metadata for JSON output."""
     return str(value or "").strip()
@@ -358,15 +353,15 @@ def track_assignments(
 ) -> dict[str, Any]:
     """Build a teacher-facing tracking index for one activity."""
     activity = create_submission_scaffold.load_activity(activity_path)
+    normalized_activity = normalize_activity(activity)
     activity_id = create_submission_scaffold.activity_id(activity)
     create_submission_scaffold.validate_activity_or_raise(activity, activity_id)
     normalized_assigned_at = parse_datetime(assigned_at, "assigned_at")
     normalized_due_at = parse_datetime(due_at, "due_at")
     normalized_now = parse_datetime(now, "now")
-    context = activity_context(activity)
-    normalized_class_id = clean_metadata(class_id) or clean_metadata(context.get("classe"))
+    normalized_class_id = clean_metadata(class_id) or clean_metadata(normalized_activity.get("class_id"))
     normalized_class_label = clean_metadata(class_label) or normalized_class_id
-    normalized_github_team = clean_metadata(github_team) or clean_metadata(context.get("team_github"))
+    normalized_github_team = clean_metadata(github_team) or clean_metadata(normalized_activity.get("github_team"))
 
     students: list[dict[str, Any]] = []
     for target in targets:
@@ -410,9 +405,9 @@ def track_assignments(
 
     return {
         "activity_id": activity_id,
-        "title": activity.get("titolo") or activity_id,
-        "kind": activity.get("tipo"),
-        "student_support_mode": activity.get("student_support_mode") or activity.get("support_mode") or activity.get("modalita_studente") or "",
+        "title": normalized_activity.get("title") or activity_id,
+        "kind": normalized_activity.get("kind"),
+        "student_support_mode": normalized_activity.get("student_support_mode") or "",
         "class_id": normalized_class_id,
         "class_label": normalized_class_label,
         "github_team": normalized_github_team,

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -348,6 +348,19 @@ def validate_normalized_activity_or_raise(activity: dict[str, Any], identifier: 
         raise ValueError(f"{identifier}: kind non ammesso: {kind}")
 
 
+def legacy_activity_validation_payload(activity: dict[str, Any], normalized_activity: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy with legacy aliases filled from canonical activity fields."""
+
+    payload = dict(activity)
+    payload.setdefault("titolo", normalized_activity.get("title", ""))
+    payload.setdefault("tipo", normalized_activity.get("kind", ""))
+    payload.setdefault("difficolta", normalized_activity.get("difficulty", ""))
+    payload.setdefault("argomenti", normalized_activity.get("topics", []))
+    payload.setdefault("consegna", normalized_activity.get("instructions", ""))
+    payload.setdefault("correzione", normalized_activity.get("grading_policy", {}))
+    return payload
+
+
 def track_assignments(
     *,
     activity_path: Path,
@@ -363,7 +376,8 @@ def track_assignments(
     activity = create_submission_scaffold.load_activity(activity_path)
     normalized_activity = normalize_activity(activity)
     activity_id = create_submission_scaffold.activity_id(activity)
-    create_submission_scaffold.validate_activity_or_raise(activity, activity_id)
+    validation_payload = legacy_activity_validation_payload(activity, normalized_activity)
+    create_submission_scaffold.validate_activity_or_raise(validation_payload, activity_id)
     validate_normalized_activity_or_raise(normalized_activity, activity_id)
     normalized_assigned_at = parse_datetime(assigned_at, "assigned_at")
     normalized_due_at = parse_datetime(due_at, "due_at")

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -174,6 +174,30 @@ def test_track_assignments_uses_activity_context_class_metadata(tmp_path) -> Non
     assert index["github_team"] == "team-4a-inf"
 
 
+def test_track_assignments_uses_canonical_activity_metadata(tmp_path) -> None:
+    payload = activity()
+    payload["title"] = "Somma canonica"
+    payload["kind"] = "compito-classe"
+    payload["student_support_mode"] = "senza-aiuto"
+    payload["class_id"] = "5A-INF"
+    payload["github_team"] = "team-5a-inf"
+    activity_path = tmp_path / "activity.json"
+    activity_path.write_text(json.dumps(payload), encoding="utf-8")
+    student = target(tmp_path, "rossi-mario")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+    )
+
+    assert index["title"] == "Somma canonica"
+    assert index["kind"] == "compito-classe"
+    assert index["student_support_mode"] == "senza-aiuto"
+    assert index["class_id"] == "5A-INF"
+    assert index["class_label"] == "5A-INF"
+    assert index["github_team"] == "team-5a-inf"
+
+
 def test_track_assignments_lists_multiple_submission_files(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "rossi-mario")

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -190,13 +190,6 @@ def test_track_assignments_uses_canonical_activity_metadata(tmp_path) -> None:
             "sandbox": True,
             "ai_feedback": False,
         },
-        "metriche": {
-            "tempo_stimato_minuti": 20,
-            "traccia_tempo_dichiarato": True,
-            "traccia_sessioni_thebitlab": True,
-            "traccia_eventi_didattici": True,
-            "traccia_errori_compilazione": True,
-        },
         "student_support_mode": "senza-aiuto",
         "class_id": "5A-INF",
         "github_team": "team-5a-inf",

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -177,7 +177,7 @@ def test_track_assignments_uses_activity_context_class_metadata(tmp_path) -> Non
 def test_track_assignments_uses_canonical_activity_metadata(tmp_path) -> None:
     payload = activity()
     payload["title"] = "Somma canonica"
-    payload["kind"] = "compito-classe"
+    payload["kind"] = "verifica-pratica"
     payload["student_support_mode"] = "senza-aiuto"
     payload["class_id"] = "5A-INF"
     payload["github_team"] = "team-5a-inf"
@@ -191,11 +191,29 @@ def test_track_assignments_uses_canonical_activity_metadata(tmp_path) -> None:
     )
 
     assert index["title"] == "Somma canonica"
-    assert index["kind"] == "compito-classe"
+    assert index["kind"] == "verifica-pratica"
     assert index["student_support_mode"] == "senza-aiuto"
     assert index["class_id"] == "5A-INF"
     assert index["class_label"] == "5A-INF"
     assert index["github_team"] == "team-5a-inf"
+
+
+def test_track_assignments_rejects_invalid_canonical_kind(tmp_path) -> None:
+    payload = activity()
+    payload["tipo"] = "compito-casa"
+    payload["kind"] = "compito-classe"
+    activity_path = tmp_path / "activity.json"
+    activity_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        track_assignments.track_assignments(
+            activity_path=activity_path,
+            targets=[],
+        )
+    except ValueError as error:
+        assert "kind non ammesso: compito-classe" in str(error)
+    else:
+        raise AssertionError("track_assignments should reject invalid canonical kind")
 
 
 def test_track_assignments_lists_multiple_submission_files(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -175,12 +175,32 @@ def test_track_assignments_uses_activity_context_class_metadata(tmp_path) -> Non
 
 
 def test_track_assignments_uses_canonical_activity_metadata(tmp_path) -> None:
-    payload = activity()
-    payload["title"] = "Somma canonica"
-    payload["kind"] = "verifica-pratica"
-    payload["student_support_mode"] = "senza-aiuto"
-    payload["class_id"] = "5A-INF"
-    payload["github_team"] = "team-5a-inf"
+    payload = {
+        "schema_version": "1.0",
+        "id": "python-base-somma-001",
+        "title": "Somma canonica",
+        "kind": "verifica-pratica",
+        "difficulty": "B",
+        "topics": ["variabili", "input-output"],
+        "language": "python",
+        "instructions": "Scrivi un programma Python che stampa una somma.",
+        "grading_policy": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "student_support_mode": "senza-aiuto",
+        "class_id": "5A-INF",
+        "github_team": "team-5a-inf",
+    }
     activity_path = tmp_path / "activity.json"
     activity_path.write_text(json.dumps(payload), encoding="utf-8")
     student = target(tmp_path, "rossi-mario")


### PR DESCRIPTION
﻿## Cosa cambia

- `track_assignments` usa `normalize_activity(...)` per leggere metadata activity canonici e alias legacy.
- I registri generati possono partire sia da activity legacy (`titolo`, `tipo`, `contesto`) sia da activity canoniche (`title`, `kind`, `class_id`, `github_team`).
- Rimuove la funzione locale `activity_context`, ora sostituita dal normalizer condiviso.
- Aggiunge un test per activity con metadata canonici.

## Perche

Dopo aver collegato i normalizer allo storage/dashboard, anche il generatore dei registri deve produrre output coerente con i contratti dati unificati. Questo riduce la duplicazione degli alias e prepara meglio il passaggio futuro a storage/database.

## Issue

Parte di #284.

## Verifica

`pytest tests/test_track_assignments.py tests/test_thebitlab_contracts.py tests/test_thebitlab_storage.py tests/test_thebitlab_services.py tests/test_course_board_server.py`

Risultato locale: `42 passed`.
