### PR TITLE
Supporta activity canoniche nello scaffold

### DIFF
--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -51,8 +51,8 @@ def assign_activity_to_targets(
     """Create the activity scaffold in each target student repository."""
     activity = create_submission_scaffold.load_activity(activity_path)
     identifier = create_submission_scaffold.activity_id(activity)
-    create_submission_scaffold.validate_activity_or_raise(activity, identifier)
-    selected_language = create_submission_scaffold.language_for(activity, language)
+    normalized_activity = create_submission_scaffold.validate_activity_contract_or_raise(activity, identifier)
+    selected_language = create_submission_scaffold.language_for(normalized_activity, language)
     create_submission_scaffold.validate_source_name(
         source_name
         if source_name is not None

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -101,12 +101,21 @@ def legacy_activity_validation_payload(activity: dict[str, Any], normalized_acti
     return payload
 
 
+def validate_normalized_activity_or_raise(activity: dict[str, Any], identifier: str) -> None:
+    """Validate canonical activity fields used by the assignment scaffold."""
+
+    kind = str(activity.get("kind") or "").strip()
+    if kind and kind not in validate_activity.ALLOWED_TYPES:
+        raise ValueError(f"{identifier}: kind non ammesso: {kind}")
+
+
 def validate_activity_contract_or_raise(activity: dict[str, Any], identifier: str) -> dict[str, Any]:
     """Validate legacy/canonical activity metadata and return canonical fields."""
 
     normalized_activity = normalize_activity(activity)
     validation_payload = legacy_activity_validation_payload(activity, normalized_activity)
     validate_activity_or_raise(validation_payload, identifier)
+    validate_normalized_activity_or_raise(normalized_activity, identifier)
     return normalized_activity
 
 

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts import validate_activity
+from scripts.thebitlab_contracts import normalize_activity
 
 
 DEFAULT_TARGET_DIR = Path(".")
@@ -75,6 +76,38 @@ def validate_activity_or_raise(activity: dict[str, Any], identifier: str) -> Non
     errors = validate_activity.validate_activity(activity, identifier)
     if errors:
         raise ValueError("\n".join(errors))
+
+
+def legacy_activity_validation_payload(activity: dict[str, Any], normalized_activity: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy with legacy aliases filled from canonical activity fields."""
+
+    payload = dict(activity)
+    payload.setdefault("titolo", normalized_activity.get("title", ""))
+    payload.setdefault("tipo", normalized_activity.get("kind", ""))
+    payload.setdefault("difficolta", normalized_activity.get("difficulty", ""))
+    payload.setdefault("argomenti", normalized_activity.get("topics", []))
+    payload.setdefault("consegna", normalized_activity.get("instructions", ""))
+    payload.setdefault("correzione", normalized_activity.get("grading_policy", {}))
+    payload.setdefault(
+        "metriche",
+        {
+            "tempo_stimato_minuti": 0,
+            "traccia_tempo_dichiarato": False,
+            "traccia_sessioni_thebitlab": False,
+            "traccia_eventi_didattici": False,
+            "traccia_errori_compilazione": False,
+        },
+    )
+    return payload
+
+
+def validate_activity_contract_or_raise(activity: dict[str, Any], identifier: str) -> dict[str, Any]:
+    """Validate legacy/canonical activity metadata and return canonical fields."""
+
+    normalized_activity = normalize_activity(activity)
+    validation_payload = legacy_activity_validation_payload(activity, normalized_activity)
+    validate_activity_or_raise(validation_payload, identifier)
+    return normalized_activity
 
 
 def language_for(activity: dict[str, Any], explicit_language: str | None = None) -> str:
@@ -190,8 +223,9 @@ def starter_source(language: str) -> str:
 
 def assignment_readme(activity: dict[str, Any], identifier: str, source_name: str, language: str, thebitlab_ref: str) -> str:
     """Build the README for one student assignment scaffold."""
-    title = str(activity.get("titolo") or identifier)
-    prompt = str(activity.get("consegna") or "Segui le indicazioni del docente.")
+    normalized_activity = normalize_activity(activity)
+    title = str(normalized_activity.get("title") or identifier)
+    prompt = str(normalized_activity.get("instructions") or "Segui le indicazioni del docente.")
     return (
         f"# {title}\n\n"
         f"Activity ID: `{identifier}`\n\n"
@@ -223,8 +257,8 @@ def create_scaffold(
     """Create an assignment scaffold in a student repository."""
     activity = load_activity(activity_path)
     identifier = activity_id(activity)
-    validate_activity_or_raise(activity, identifier)
-    selected_language = language_for(activity, language)
+    normalized_activity = validate_activity_contract_or_raise(activity, identifier)
+    selected_language = language_for(normalized_activity, language)
     source_name = validate_source_name(
         source_name if source_name is not None else default_source_name_for(selected_language)
     )

--- a/tests/test_assign_activity.py
+++ b/tests/test_assign_activity.py
@@ -39,6 +39,34 @@ def write_activity(tmp_path):
     return path
 
 
+def write_canonical_activity(tmp_path):
+    """Write a canonical activity JSON and return its path."""
+    path = tmp_path / "activity.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": "python-base-somma-001",
+                "title": "Somma canonica",
+                "kind": "compito-casa",
+                "difficulty": "B",
+                "topics": ["variabili", "input-output"],
+                "language": "python",
+                "instructions": "Scrivi un programma Python che stampa una somma.",
+                "student_support_mode": "senza-aiuto",
+                "grading_policy": {
+                    "compila": True,
+                    "test": True,
+                    "sandbox": True,
+                    "ai_feedback": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
 def test_collect_targets_uses_direct_and_file_targets(tmp_path) -> None:
     targets_dir = tmp_path / "classes"
     targets_dir.mkdir()
@@ -82,6 +110,19 @@ def test_assign_activity_to_multiple_targets(tmp_path) -> None:
         assert (assignment_dir / "main.py").exists()
         readme = (assignment_dir / "README.md").read_text(encoding="utf-8")
         assert "source_path`: `assignments/python-base-somma-001/main.py`" in readme
+
+
+def test_assign_activity_supports_canonical_activity_metadata(tmp_path) -> None:
+    activity_path = write_canonical_activity(tmp_path)
+    target = tmp_path / "student-a"
+
+    assign_activity.assign_activity_to_targets(activity_path=activity_path, targets=[target])
+
+    assignment_dir = target / "assignments" / "python-base-somma-001"
+    assert (assignment_dir / "main.py").exists()
+    readme = (assignment_dir / "README.md").read_text(encoding="utf-8")
+    assert "# Somma canonica" in readme
+    assert "language`: `python`" in readme
 
 
 def test_assign_activity_preserves_existing_source_with_force(tmp_path) -> None:

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -84,6 +84,26 @@ def test_create_scaffold_supports_canonical_activity_metadata(tmp_path) -> None:
     assert "language`: `python`" in readme
 
 
+def test_create_scaffold_rejects_invalid_canonical_kind(tmp_path) -> None:
+    activity_path = write_activity(
+        tmp_path,
+        {
+            **activity(),
+            "tipo": "compito-casa",
+            "kind": "compito-classe",
+        },
+    )
+
+    try:
+        create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+    except ValueError as error:
+        assert "kind non ammesso: compito-classe" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject invalid canonical kind")
+
+    assert not (tmp_path / "assignments").exists()
+
+
 def test_create_scaffold_rejects_unsafe_activity_id(tmp_path) -> None:
     activity_path = write_activity(tmp_path, {**activity(), "id": "Somma 001"})
 

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -37,6 +37,26 @@ def write_activity(tmp_path, payload: dict | None = None):
     return path
 
 
+def canonical_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-base-somma-001",
+        "title": "Somma canonica",
+        "kind": "compito-casa",
+        "difficulty": "B",
+        "topics": ["variabili", "operatori"],
+        "language": "python",
+        "instructions": "Scrivi un programma Python che stampa una somma.",
+        "student_support_mode": "senza-aiuto",
+        "grading_policy": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+    }
+
+
 def test_create_scaffold_writes_assignment_files(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
 
@@ -49,6 +69,19 @@ def test_create_scaffold_writes_assignment_files(tmp_path) -> None:
     assert "activity_id`: `c-base-somma-001`" in readme
     assert "source_path`: `assignments/c-base-somma-001/main.c`" in readme
     assert "thebitlab_ref`: `main`" in readme
+
+
+def test_create_scaffold_supports_canonical_activity_metadata(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, canonical_activity())
+
+    destination = create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+
+    assert destination == tmp_path / "assignments" / "python-base-somma-001"
+    assert (destination / "main.py").exists()
+    readme = (destination / "README.md").read_text(encoding="utf-8")
+    assert "# Somma canonica" in readme
+    assert "Scrivi un programma Python che stampa una somma." in readme
+    assert "language`: `python`" in readme
 
 
 def test_create_scaffold_rejects_unsafe_activity_id(tmp_path) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- `create_submission_scaffold` usa `normalize_activity(...)` per leggere titolo, consegna, lingua e metadata canonici.
- Aggiunge una copia di validazione compatibile con il validatore legacy, derivando gli alias italiani dai campi canonici senza modificare il payload originale.
- `assign_activity` usa lo stesso helper di validazione/preflight, quindi anche l'assegnazione multipla accetta activity canoniche.
- Aggiunge test su activity canoniche pure per scaffold e assegnazione.

## Perche

Dopo #298, i registri generati supportano metadata activity canonici. Questa PR estende lo stesso ponte al flusso precedente: activity -> scaffold studente -> assegnazione a piu repository.

## Issue

Parte di #284.

## Verifica

`pytest tests/test_create_submission_scaffold.py tests/test_assign_activity.py tests/test_track_assignments.py tests/test_thebitlab_contracts.py tests/test_validate_activity.py`

Risultato locale: `65 passed`.
