### PR TITLE
Condividi validazione contratti activity

### DIFF
--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -7,7 +7,11 @@ from pathlib import Path
 from typing import Any
 
 from scripts import validate_activity
-from scripts.thebitlab_contracts import normalize_activity
+from scripts.thebitlab_contracts import (
+    legacy_activity_validation_payload,
+    normalize_activity,
+    validate_normalized_activity,
+)
 
 
 DEFAULT_TARGET_DIR = Path(".")
@@ -78,44 +82,15 @@ def validate_activity_or_raise(activity: dict[str, Any], identifier: str) -> Non
         raise ValueError("\n".join(errors))
 
 
-def legacy_activity_validation_payload(activity: dict[str, Any], normalized_activity: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy with legacy aliases filled from canonical activity fields."""
-
-    payload = dict(activity)
-    payload.setdefault("titolo", normalized_activity.get("title", ""))
-    payload.setdefault("tipo", normalized_activity.get("kind", ""))
-    payload.setdefault("difficolta", normalized_activity.get("difficulty", ""))
-    payload.setdefault("argomenti", normalized_activity.get("topics", []))
-    payload.setdefault("consegna", normalized_activity.get("instructions", ""))
-    payload.setdefault("correzione", normalized_activity.get("grading_policy", {}))
-    payload.setdefault(
-        "metriche",
-        {
-            "tempo_stimato_minuti": 0,
-            "traccia_tempo_dichiarato": False,
-            "traccia_sessioni_thebitlab": False,
-            "traccia_eventi_didattici": False,
-            "traccia_errori_compilazione": False,
-        },
-    )
-    return payload
-
-
-def validate_normalized_activity_or_raise(activity: dict[str, Any], identifier: str) -> None:
-    """Validate canonical activity fields used by the assignment scaffold."""
-
-    kind = str(activity.get("kind") or "").strip()
-    if kind and kind not in validate_activity.ALLOWED_TYPES:
-        raise ValueError(f"{identifier}: kind non ammesso: {kind}")
-
-
 def validate_activity_contract_or_raise(activity: dict[str, Any], identifier: str) -> dict[str, Any]:
     """Validate legacy/canonical activity metadata and return canonical fields."""
 
     normalized_activity = normalize_activity(activity)
     validation_payload = legacy_activity_validation_payload(activity, normalized_activity)
     validate_activity_or_raise(validation_payload, identifier)
-    validate_normalized_activity_or_raise(normalized_activity, identifier)
+    errors = validate_normalized_activity(normalized_activity, identifier)
+    if errors:
+        raise ValueError("\n".join(errors))
     return normalized_activity
 
 

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -4,6 +4,17 @@ from copy import deepcopy
 from typing import Any
 
 
+ALLOWED_ACTIVITY_KINDS = {
+    "studio-guidato",
+    "esercizio-classe",
+    "compito-casa",
+    "laboratorio",
+    "verifica-pratica",
+    "verifica-scritta",
+    "debug-didattico",
+}
+
+
 def first_text(payload: dict[str, Any], *keys: str) -> str:
     """Return the first non-empty string value found in payload."""
 
@@ -73,6 +84,39 @@ def normalize_activity(payload: dict[str, Any]) -> dict[str, Any]:
     normalized["class_id"] = first_text(payload, "class_id") or first_text(context, "classe")
     normalized["github_team"] = first_text(payload, "github_team") or first_text(context, "team_github")
     return normalized
+
+
+def legacy_activity_validation_payload(activity: dict[str, Any], normalized_activity: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy with legacy aliases filled from canonical activity fields."""
+
+    payload = dict(activity)
+    payload.setdefault("titolo", normalized_activity.get("title", ""))
+    payload.setdefault("tipo", normalized_activity.get("kind", ""))
+    payload.setdefault("difficolta", normalized_activity.get("difficulty", ""))
+    payload.setdefault("argomenti", normalized_activity.get("topics", []))
+    payload.setdefault("consegna", normalized_activity.get("instructions", ""))
+    payload.setdefault("correzione", normalized_activity.get("grading_policy", {}))
+    payload.setdefault(
+        "metriche",
+        {
+            "tempo_stimato_minuti": 0,
+            "traccia_tempo_dichiarato": False,
+            "traccia_sessioni_thebitlab": False,
+            "traccia_eventi_didattici": False,
+            "traccia_errori_compilazione": False,
+        },
+    )
+    return payload
+
+
+def validate_normalized_activity(activity: dict[str, Any], identifier: str) -> list[str]:
+    """Return validation errors for canonical activity fields used by readers."""
+
+    errors = []
+    kind = first_text(activity, "kind")
+    if kind and kind not in ALLOWED_ACTIVITY_KINDS:
+        errors.append(f"{identifier}: kind non ammesso: {kind}")
+    return errors
 
 
 def normalize_grading(payload: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -9,8 +9,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from scripts import assign_activity, create_submission_scaffold, validate_activity
-from scripts.thebitlab_contracts import normalize_activity
+from scripts import assign_activity, create_submission_scaffold
+from scripts.thebitlab_contracts import (
+    legacy_activity_validation_payload,
+    normalize_activity,
+    validate_normalized_activity,
+)
 
 
 NO_DUE_DATE_STATUS = "no_due_date"
@@ -340,37 +344,6 @@ def clean_metadata(value: str | None) -> str:
     return str(value or "").strip()
 
 
-def validate_normalized_activity_or_raise(activity: dict[str, Any], identifier: str) -> None:
-    """Validate canonical activity fields used by the tracking register."""
-
-    kind = clean_metadata(activity.get("kind"))
-    if kind and kind not in validate_activity.ALLOWED_TYPES:
-        raise ValueError(f"{identifier}: kind non ammesso: {kind}")
-
-
-def legacy_activity_validation_payload(activity: dict[str, Any], normalized_activity: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy with legacy aliases filled from canonical activity fields."""
-
-    payload = dict(activity)
-    payload.setdefault("titolo", normalized_activity.get("title", ""))
-    payload.setdefault("tipo", normalized_activity.get("kind", ""))
-    payload.setdefault("difficolta", normalized_activity.get("difficulty", ""))
-    payload.setdefault("argomenti", normalized_activity.get("topics", []))
-    payload.setdefault("consegna", normalized_activity.get("instructions", ""))
-    payload.setdefault("correzione", normalized_activity.get("grading_policy", {}))
-    payload.setdefault(
-        "metriche",
-        {
-            "tempo_stimato_minuti": 0,
-            "traccia_tempo_dichiarato": False,
-            "traccia_sessioni_thebitlab": False,
-            "traccia_eventi_didattici": False,
-            "traccia_errori_compilazione": False,
-        },
-    )
-    return payload
-
-
 def track_assignments(
     *,
     activity_path: Path,
@@ -388,7 +361,9 @@ def track_assignments(
     activity_id = create_submission_scaffold.activity_id(activity)
     validation_payload = legacy_activity_validation_payload(activity, normalized_activity)
     create_submission_scaffold.validate_activity_or_raise(validation_payload, activity_id)
-    validate_normalized_activity_or_raise(normalized_activity, activity_id)
+    normalized_errors = validate_normalized_activity(normalized_activity, activity_id)
+    if normalized_errors:
+        raise ValueError("\n".join(normalized_errors))
     normalized_assigned_at = parse_datetime(assigned_at, "assigned_at")
     normalized_due_at = parse_datetime(due_at, "due_at")
     normalized_now = parse_datetime(now, "now")

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -5,16 +5,9 @@ import json
 from pathlib import Path
 from typing import Any
 
+from scripts.thebitlab_contracts import ALLOWED_ACTIVITY_KINDS
 
-ALLOWED_TYPES = {
-    "studio-guidato",
-    "esercizio-classe",
-    "compito-casa",
-    "laboratorio",
-    "verifica-pratica",
-    "verifica-scritta",
-    "debug-didattico",
-}
+ALLOWED_TYPES = ALLOWED_ACTIVITY_KINDS
 
 ALLOWED_DIFFICULTIES = {"A", "B", "C", "D", "E", "F"}
 SUPPORTED_SCHEMA_VERSION = "1.0"

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -60,6 +60,44 @@ def test_normalize_activity_reads_legacy_aliases() -> None:
     assert normalized["github_team"] == "team-4a-inf"
 
 
+def test_legacy_activity_validation_payload_fills_legacy_aliases() -> None:
+    payload = {
+        "schema_version": "1.0",
+        "id": "python-base-somma-001",
+        "title": "Somma canonica",
+        "kind": "compito-casa",
+        "difficulty": "B",
+        "topics": ["variabili"],
+        "instructions": "Scrivi una somma.",
+        "grading_policy": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+    }
+    normalized = thebitlab_contracts.normalize_activity(payload)
+
+    legacy_payload = thebitlab_contracts.legacy_activity_validation_payload(payload, normalized)
+
+    assert legacy_payload["titolo"] == "Somma canonica"
+    assert legacy_payload["tipo"] == "compito-casa"
+    assert legacy_payload["difficolta"] == "B"
+    assert legacy_payload["argomenti"] == ["variabili"]
+    assert legacy_payload["consegna"] == "Scrivi una somma."
+    assert legacy_payload["correzione"] == payload["grading_policy"]
+    assert legacy_payload["metriche"]["tempo_stimato_minuti"] == 0
+
+
+def test_validate_normalized_activity_rejects_invalid_kind() -> None:
+    errors = thebitlab_contracts.validate_normalized_activity(
+        {"kind": "compito-classe"},
+        "activity",
+    )
+
+    assert errors == ["activity: kind non ammesso: compito-classe"]
+
+
 def test_normalize_assignment_register_preserves_contract_fixture() -> None:
     payload = load_fixture("assignment_register.json")
 

--- a/tests/test_validate_activity.py
+++ b/tests/test_validate_activity.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from scripts import validate_activity
+from scripts.thebitlab_contracts import ALLOWED_ACTIVITY_KINDS
 
 
 EXAMPLES = Path("activities/examples")
@@ -32,6 +33,10 @@ def valid_activity() -> dict:
             "traccia_errori_compilazione": True,
         },
     }
+
+
+def test_allowed_types_come_from_activity_contracts() -> None:
+    assert validate_activity.ALLOWED_TYPES is ALLOWED_ACTIVITY_KINDS
 
 
 def test_examples_are_valid() -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Sposta in `scripts/thebitlab_contracts.py` la costruzione della vista legacy per validare activity canoniche.
- Sposta in `scripts/thebitlab_contracts.py` la validazione del `kind` canonico.
- `create_submission_scaffold` e `track_assignments` usano gli stessi helper condivisi.
- Aggiunge test diretti sui helper di compatibilita canonico/legacy.

## Perche

Dopo #298 e #299, scaffold e registri avevano due copie quasi identiche della stessa logica di fallback legacy. Questa PR riduce la duplicazione e rende il contratto activity il punto unico da cui passano normalizzazione e validazione canonica.

## Issue

Parte di #284.

## Verifica

`pytest tests/test_thebitlab_contracts.py tests/test_create_submission_scaffold.py tests/test_assign_activity.py tests/test_track_assignments.py tests/test_validate_activity.py`

Risultato locale: `68 passed`.
