### PR TITLE
Aggiorna stato contratti activity

### DIFF
--- a/doc/DATA_MODEL_MVP.md
+++ b/doc/DATA_MODEL_MVP.md
@@ -369,9 +369,10 @@ Mappatura dai campi attuali:
 
 Fase di transizione:
 
-- finche `scripts/validate_activity.py` e gli script collegati richiedono i campi legacy italiani, le nuove activity devono continuare a scrivere `titolo`, `tipo`, `difficolta`, `argomenti`, `consegna` e `correzione`;
-- i campi canonici restano il target del modello dati e possono essere affiancati solo quando lettori, validatore e writer sono compatibili;
-- la scrittura dei soli campi canonici va rimandata a una PR di migrazione schema dedicata, con fallback per le activity esistenti.
+- `scripts/thebitlab_contracts.py` contiene i normalizer e gli helper di compatibilita usati da scaffold, assegnazione, tracking e storage consegne;
+- `scripts/create_submission_scaffold.py`, `scripts/assign_activity.py` e `scripts/track_assignments.py` accettano activity con campi canonici, costruendo una vista legacy solo per il validatore esistente;
+- i writer attuali possono continuare a produrre campi legacy italiani, ma i nuovi lettori devono passare dai normalizer condivisi;
+- la migrazione completa dei writer verso soli campi canonici resta una PR separata, da fare quando GUI activity e validatore saranno allineati.
 
 ### Assignment
 

--- a/doc/architecture/data-contracts.md
+++ b/doc/architecture/data-contracts.md
@@ -126,7 +126,8 @@ Alias legacy letti oggi:
 Fase di transizione:
 
 - I writer attuali possono continuare a produrre campi legacy italiani.
-- I service futuri dovrebbero normalizzare verso i campi canonici senza rompere i lettori esistenti.
+- I lettori operativi devono usare `scripts/thebitlab_contracts.py` per normalizzare verso i campi canonici senza rompere i dati esistenti.
+- Scaffold, assegnazione, tracking e storage consegne usano gia helper condivisi per activity canoniche/legacy.
 
 ### AssignmentRegister
 
@@ -210,8 +211,17 @@ tests/fixtures/contracts/
 
 Queste fixture non sono demo complete. Servono come esempi stabili per testare che i contratti minimi restino leggibili e coerenti mentre evolvono service, storage e provider.
 
-## Prossime PR suggerite
+## Stato implementativo e prossime PR
 
-1. Introdurre normalizer piccoli nei service, per esempio `normalize_activity` e `normalize_assignment_register`.
-2. Collegare `AssignmentRegister` ad `assignment_id` quando l'entita Assignment sara disponibile.
+Gia fatto:
+
+1. Fixture contrattuali per course, class group, student, activity e assignment register.
+2. Normalizer per activity e registri consegne.
+3. Integrazione dei normalizer in storage, scaffold, assegnazione e tracking.
+4. Helper condivisi per validazione canonico/legacy delle activity.
+
+Prossimi passi:
+
+1. Collegare `AssignmentRegister` ad `assignment_id` quando l'entita Assignment sara disponibile.
+2. Introdurre il layer provider repository per GitHub/GitLab/local senza far dipendere la GUI dai dettagli provider.
 3. Usare questi contratti per disegnare la valutazione SQLite/provider senza migrare subito.


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiorna `doc/DATA_MODEL_MVP.md` con lo stato reale dei lettori activity: scaffold, assegnazione, tracking e storage usano i normalizer/helper condivisi.
- Aggiorna `doc/architecture/data-contracts.md` distinguendo il lavoro gia fatto dai prossimi passi.
- Lascia esplicita la migrazione futura dei writer verso soli campi canonici.

## Perche

Dopo #300 la documentazione diceva ancora che gli script richiedono sempre campi legacy. Questa PR riallinea i documenti allo stato attuale e prepara la chiusura di #284.

## Issue

Chiude #284.

## Verifica

`pytest tests/test_thebitlab_contracts.py tests/test_data_contract_fixtures.py tests/test_create_submission_scaffold.py tests/test_track_assignments.py tests/test_validate_activity.py`

Risultato locale: `66 passed`.
