### PR TITLE
Introduce provider repository locale

### DIFF
--- a/doc/architecture/data-contracts.md
+++ b/doc/architecture/data-contracts.md
@@ -223,5 +223,5 @@ Gia fatto:
 Prossimi passi:
 
 1. Collegare `AssignmentRegister` ad `assignment_id` quando l'entita Assignment sara disponibile.
-2. Introdurre il layer provider repository per GitHub/GitLab/local senza far dipendere la GUI dai dettagli provider.
+2. Introdurre il layer provider repository per GitHub/GitLab/local senza far dipendere la GUI dai dettagli provider. Vedi [`repository-providers.md`](repository-providers.md).
 3. Usare questi contratti per disegnare la valutazione SQLite/provider senza migrare subito.

--- a/doc/architecture/repository-providers.md
+++ b/doc/architecture/repository-providers.md
@@ -1,0 +1,34 @@
+# Repository provider
+
+## Obiettivo
+
+Il repository provider separa il dominio TheBitLab dal sistema concreto usato per ospitare i repository studenti.
+
+La GUI e i service non devono sapere se una classe arriva da directory locali, team GitHub, gruppi GitLab o da un sistema interno futuro. Devono parlare con una porta applicativa stabile.
+
+## Porta applicativa
+
+Il contratto minimo e in `scripts/thebitlab_repository_providers.py`:
+
+- `RepositoryProvider`: interfaccia per elencare e risolvere repository studenti.
+- `StudentRepository`: riferimento normalizzato a un repository studente.
+- `LocalRepositoryProvider`: adapter iniziale basato su directory locali.
+
+## Dato normalizzato
+
+`StudentRepository` espone:
+
+- `student_id`: identificativo dello studente nel dominio TheBitLab.
+- `repo_ref`: riferimento repository normalizzato e mostrabile in UI.
+- `provider`: nome provider, per esempio `local`, `github`, `gitlab`.
+- `path`: path locale quando disponibile.
+- `metadata`: metadati opzionali specifici del provider.
+
+## Strategia incrementale
+
+1. Stabilizzare provider locale e test unitari.
+2. Collegare un flusso reale al provider senza cambiare comportamento utente.
+3. Aggiungere adapter GitHub minimale dietro la stessa interfaccia.
+4. Progettare GitLab e provider interno senza far dipendere GUI e service dai dettagli esterni.
+
+Questa scelta mantiene piccoli i cambiamenti: rete, autenticazione e semantica team restano fuori dal primo passo.

--- a/doc/architecture/repository-providers.md
+++ b/doc/architecture/repository-providers.md
@@ -14,6 +14,8 @@ Il contratto minimo e in `scripts/thebitlab_repository_providers.py`:
 - `StudentRepository`: riferimento normalizzato a un repository studente.
 - `LocalRepositoryProvider`: adapter iniziale basato su directory locali.
 
+Il parametro `class_ref` e parte della porta per GitHub/GitLab/team/classi, ma il provider locale lo rifiuta finche non esiste una mappa locale classe/studenti. Questo evita di restituire tutti i repository quando il chiamante si aspetta un filtro di classe.
+
 ## Dato normalizzato
 
 `StudentRepository` espone:

--- a/scripts/thebitlab_repository_providers.py
+++ b/scripts/thebitlab_repository_providers.py
@@ -45,10 +45,13 @@ class LocalRepositoryProvider:
         """List local student repositories.
 
         `class_ref` is accepted to keep the signature aligned with future
-        team/class providers. The local implementation filters only when the
-        caller supplies explicit metadata through a future adapter.
+        team/class providers. The local implementation rejects it until a
+        local class/student mapping exists, so callers never receive an
+        unfiltered list by mistake.
         """
 
+        if class_ref:
+            raise ValueError("Filtro classe non supportato dal provider locale senza mappa studenti.")
         paths = self.student_dirs if self.student_dirs is not None else self._discover_student_dirs()
         repositories = [self._repository_from_path(path) for path in paths]
         return sorted(repositories, key=lambda repository: repository.student_id)

--- a/scripts/thebitlab_repository_providers.py
+++ b/scripts/thebitlab_repository_providers.py
@@ -79,6 +79,8 @@ class LocalRepositoryProvider:
             resolved.relative_to(self.root)
         except ValueError as exc:
             raise ValueError(f"Repository fuori dalla radice locale: {path}") from exc
+        if not resolved.is_dir():
+            raise FileNotFoundError(f"Repository studente locale non trovato: {path}")
         return StudentRepository(
             student_id=resolved.name,
             repo_ref=self._repo_ref(resolved),

--- a/scripts/thebitlab_repository_providers.py
+++ b/scripts/thebitlab_repository_providers.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class StudentRepository:
+    """Repository assegnato a uno studente, indipendente dal provider concreto."""
+
+    student_id: str
+    repo_ref: str
+    provider: str
+    path: Path | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+class RepositoryProvider(Protocol):
+    """Porta applicativa per scoprire e risolvere repository studenti."""
+
+    provider_name: str
+
+    def list_student_repositories(self, class_ref: str | None = None) -> list[StudentRepository]:
+        """Return the student repositories visible to the provider."""
+
+    def resolve_student_repository(self, student_id: str) -> StudentRepository:
+        """Return one student repository by student identifier."""
+
+
+class LocalRepositoryProvider:
+    """Repository provider backed by local directories.
+
+    This provider is intentionally small: it stabilizes the interface before
+    GitHub/GitLab adapters add network, authentication and team semantics.
+    """
+
+    provider_name = "local"
+
+    def __init__(self, root: Path, student_dirs: list[Path] | None = None) -> None:
+        self.root = root.resolve()
+        self.student_dirs = student_dirs
+
+    def list_student_repositories(self, class_ref: str | None = None) -> list[StudentRepository]:
+        """List local student repositories.
+
+        `class_ref` is accepted to keep the signature aligned with future
+        team/class providers. The local implementation filters only when the
+        caller supplies explicit metadata through a future adapter.
+        """
+
+        paths = self.student_dirs if self.student_dirs is not None else self._discover_student_dirs()
+        repositories = [self._repository_from_path(path) for path in paths]
+        return sorted(repositories, key=lambda repository: repository.student_id)
+
+    def resolve_student_repository(self, student_id: str) -> StudentRepository:
+        """Return one local student repository by directory name."""
+
+        clean_student_id = student_id.strip()
+        if not clean_student_id:
+            raise ValueError("Identificativo studente vuoto.")
+        for repository in self.list_student_repositories():
+            if repository.student_id == clean_student_id:
+                return repository
+        raise FileNotFoundError(f"Repository studente non trovato: {clean_student_id}")
+
+    def _discover_student_dirs(self) -> list[Path]:
+        if not self.root.is_dir():
+            return []
+        return [path for path in self.root.iterdir() if path.is_dir()]
+
+    def _repository_from_path(self, path: Path) -> StudentRepository:
+        candidate = path if path.is_absolute() else self.root / path
+        resolved = candidate.resolve()
+        try:
+            resolved.relative_to(self.root)
+        except ValueError as exc:
+            raise ValueError(f"Repository fuori dalla radice locale: {path}") from exc
+        return StudentRepository(
+            student_id=resolved.name,
+            repo_ref=self._repo_ref(resolved),
+            provider=self.provider_name,
+            path=resolved,
+        )
+
+    def _repo_ref(self, path: Path) -> str:
+        return str(path.relative_to(self.root)).replace("\\", "/")

--- a/tests/test_thebitlab_repository_providers.py
+++ b/tests/test_thebitlab_repository_providers.py
@@ -89,6 +89,10 @@ def test_local_repository_provider_rejects_missing_or_unsafe_paths(tmp_path) -> 
     with pytest.raises(ValueError, match="vuoto"):
         provider.resolve_student_repository(" ")
 
+    missing_provider = LocalRepositoryProvider(tmp_path, student_dirs=[Path("rossi-mario")])
+    with pytest.raises(FileNotFoundError, match="locale non trovato"):
+        missing_provider.list_student_repositories()
+
     safe_provider = LocalRepositoryProvider(tmp_path)
     with pytest.raises(FileNotFoundError, match="non trovato"):
         safe_provider.resolve_student_repository("rossi-mario")

--- a/tests/test_thebitlab_repository_providers.py
+++ b/tests/test_thebitlab_repository_providers.py
@@ -70,6 +70,14 @@ def test_local_repository_provider_resolves_one_student(tmp_path) -> None:
     assert repository.provider == "local"
 
 
+def test_local_repository_provider_rejects_class_filter_without_mapping(tmp_path) -> None:
+    (tmp_path / "rossi-mario").mkdir()
+    provider = LocalRepositoryProvider(tmp_path)
+
+    with pytest.raises(ValueError, match="Filtro classe"):
+        provider.list_student_repositories(class_ref="3A-INF")
+
+
 def test_local_repository_provider_rejects_missing_or_unsafe_paths(tmp_path) -> None:
     outside = tmp_path.parent / "outside-student-repo"
     outside.mkdir(exist_ok=True)

--- a/tests/test_thebitlab_repository_providers.py
+++ b/tests/test_thebitlab_repository_providers.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.thebitlab_repository_providers import LocalRepositoryProvider, RepositoryProvider, StudentRepository
+
+
+def accepts_repository_provider(provider: RepositoryProvider) -> list[StudentRepository]:
+    return provider.list_student_repositories()
+
+
+def test_local_repository_provider_lists_student_directories(tmp_path) -> None:
+    (tmp_path / "rossi-mario").mkdir()
+    (tmp_path / "bianchi-luca").mkdir()
+    (tmp_path / "README.md").write_text("non e un repository studente", encoding="utf-8")
+
+    provider = LocalRepositoryProvider(tmp_path)
+
+    assert accepts_repository_provider(provider) == [
+        StudentRepository(
+            student_id="bianchi-luca",
+            repo_ref="bianchi-luca",
+            provider="local",
+            path=(tmp_path / "bianchi-luca").resolve(),
+        ),
+        StudentRepository(
+            student_id="rossi-mario",
+            repo_ref="rossi-mario",
+            provider="local",
+            path=(tmp_path / "rossi-mario").resolve(),
+        ),
+    ]
+
+
+def test_local_repository_provider_uses_explicit_student_dirs(tmp_path) -> None:
+    included = tmp_path / "rossi-mario"
+    excluded = tmp_path / "bianchi-luca"
+    included.mkdir()
+    excluded.mkdir()
+
+    provider = LocalRepositoryProvider(tmp_path, student_dirs=[included])
+
+    assert provider.list_student_repositories() == [
+        StudentRepository(
+            student_id="rossi-mario",
+            repo_ref="rossi-mario",
+            provider="local",
+            path=included.resolve(),
+        )
+    ]
+
+
+def test_local_repository_provider_accepts_relative_explicit_student_dirs(tmp_path) -> None:
+    (tmp_path / "rossi-mario").mkdir()
+    provider = LocalRepositoryProvider(tmp_path, student_dirs=[Path("rossi-mario")])
+
+    assert provider.list_student_repositories()[0].repo_ref == "rossi-mario"
+
+
+def test_local_repository_provider_resolves_one_student(tmp_path) -> None:
+    (tmp_path / "rossi-mario").mkdir()
+    provider = LocalRepositoryProvider(tmp_path)
+
+    repository = provider.resolve_student_repository("rossi-mario")
+
+    assert repository.student_id == "rossi-mario"
+    assert repository.repo_ref == "rossi-mario"
+    assert repository.provider == "local"
+
+
+def test_local_repository_provider_rejects_missing_or_unsafe_paths(tmp_path) -> None:
+    outside = tmp_path.parent / "outside-student-repo"
+    outside.mkdir(exist_ok=True)
+    provider = LocalRepositoryProvider(tmp_path, student_dirs=[outside])
+
+    with pytest.raises(ValueError, match="fuori dalla radice"):
+        provider.list_student_repositories()
+
+    with pytest.raises(ValueError, match="vuoto"):
+        provider.resolve_student_repository(" ")
+
+    safe_provider = LocalRepositoryProvider(tmp_path)
+    with pytest.raises(FileNotFoundError, match="non trovato"):
+        safe_provider.resolve_student_repository("rossi-mario")


### PR DESCRIPTION
﻿## Cosa cambia

- Introduce `RepositoryProvider` come porta applicativa per elencare e risolvere repository studenti.
- Aggiunge `StudentRepository` come riferimento normalizzato indipendente dal provider concreto.
- Aggiunge `LocalRepositoryProvider`, adapter iniziale basato su directory locali.
- Documenta la strategia incrementale in `doc/architecture/repository-providers.md`.

## Perche

Questa e' la prima PR di #285: stabilizza il contratto minimo prima di introdurre GitHub/GitLab, rete, autenticazione e semantica team. In questo modo GUI e service potranno dipendere da una porta stabile invece che dai dettagli del provider.

## Issue

Parte di #285.

## Verifica

`pytest tests/test_thebitlab_repository_providers.py tests/test_thebitlab_services.py tests/test_thebitlab_storage.py`

Risultato locale: `21 passed`.
