### PR TITLE
Collega provider repository al tracking

### DIFF
--- a/doc/architecture/repository-providers.md
+++ b/doc/architecture/repository-providers.md
@@ -33,4 +33,6 @@ Il parametro `class_ref` e parte della porta per GitHub/GitLab/team/classi, ma i
 3. Aggiungere adapter GitHub minimale dietro la stessa interfaccia.
 4. Progettare GitLab e provider interno senza far dipendere GUI e service dai dettagli esterni.
 
+Il primo collegamento operativo e `track_assignments.load_targets_from_provider()`: converte repository forniti da `RepositoryProvider` in `TrackingTarget` locali. La CLI esistente resta invariata e continua a usare `--target` / `--targets-file`.
+
 Questa scelta mantiene piccoli i cambiamenti: rete, autenticazione e semantica team restano fuori dal primo passo.

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -15,6 +15,7 @@ from scripts.thebitlab_contracts import (
     normalize_activity,
     validate_normalized_activity,
 )
+from scripts.thebitlab_repository_providers import RepositoryProvider
 
 
 NO_DUE_DATE_STATUS = "no_due_date"
@@ -57,6 +58,24 @@ def load_targets(targets: list[Path] | None = None, targets_file: Path | None = 
     """Load tracking targets from direct paths and an optional targets file."""
     paths = assign_activity.collect_targets(targets, targets_file)
     return [TrackingTarget(student=path.name, repo=str(path), path=path) for path in paths]
+
+
+def load_targets_from_provider(provider: RepositoryProvider, class_ref: str | None = None) -> list[TrackingTarget]:
+    """Load tracking targets from a repository provider."""
+
+    repositories = provider.list_student_repositories(class_ref=class_ref)
+    targets = []
+    for repository in repositories:
+        if repository.path is None:
+            raise ValueError(f"Repository senza path locale: {repository.repo_ref}")
+        targets.append(
+            TrackingTarget(
+                student=repository.student_id,
+                repo=repository.repo_ref,
+                path=repository.path,
+            )
+        )
+    return targets
 
 
 def assignment_dir(target: TrackingTarget, activity_id: str) -> Path:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from scripts import track_assignments
+from scripts.thebitlab_repository_providers import LocalRepositoryProvider, StudentRepository
 
 
 def activity() -> dict:
@@ -43,6 +44,16 @@ def target(tmp_path, name: str) -> track_assignments.TrackingTarget:
     """Return a tracking target rooted in tmp_path."""
     root = tmp_path / name
     return track_assignments.TrackingTarget(student=name, repo=f"TheBitPoets/{name}", path=root)
+
+
+class MissingPathProvider:
+    provider_name = "missing-path"
+
+    def list_student_repositories(self, class_ref: str | None = None) -> list[StudentRepository]:
+        return [StudentRepository(student_id="rossi-mario", repo_ref="TheBitPoets/rossi-mario", provider=self.provider_name)]
+
+    def resolve_student_repository(self, student_id: str) -> StudentRepository:
+        return self.list_student_repositories()[0]
 
 
 def write_report(root, submitted_at: str, passed: bool = True) -> None:
@@ -112,6 +123,36 @@ def write_report_without_activity_id(root) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def test_load_targets_from_local_repository_provider(tmp_path) -> None:
+    (tmp_path / "rossi-mario").mkdir()
+    (tmp_path / "bianchi-luca").mkdir()
+    provider = LocalRepositoryProvider(tmp_path)
+
+    targets = track_assignments.load_targets_from_provider(provider)
+
+    assert targets == [
+        track_assignments.TrackingTarget(
+            student="bianchi-luca",
+            repo="bianchi-luca",
+            path=(tmp_path / "bianchi-luca").resolve(),
+        ),
+        track_assignments.TrackingTarget(
+            student="rossi-mario",
+            repo="rossi-mario",
+            path=(tmp_path / "rossi-mario").resolve(),
+        ),
+    ]
+
+
+def test_load_targets_from_provider_requires_local_path() -> None:
+    try:
+        track_assignments.load_targets_from_provider(MissingPathProvider())
+    except ValueError as error:
+        assert "Repository senza path locale" in str(error)
+    else:
+        raise AssertionError("load_targets_from_provider should reject repositories without a local path")
 
 
 def test_track_assignments_marks_submitted_on_time(tmp_path) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `track_assignments.load_targets_from_provider()`.
- Converte i `StudentRepository` esposti da un `RepositoryProvider` in `TrackingTarget` locali.
- Aggiunge test per `LocalRepositoryProvider` e per provider senza path locale.
- Aggiorna la documentazione del repository provider indicando il primo collegamento operativo al tracking.

## Perche

Questa e' la seconda PR di #285: dopo aver introdotto il provider locale, colleghiamo il contratto a un flusso reale senza cambiare CLI, dashboard o formato dei registri. La CLI continua a usare `--target` / `--targets-file`; il nuovo percorso resta disponibile per i service futuri.

## Issue

Parte di #285.

## Verifica

`pytest tests/test_track_assignments.py tests/test_thebitlab_repository_providers.py`

Risultato locale: `25 passed`.
