### PR TITLE
Collega provider repository all'assegnazione

### DIFF
--- a/doc/architecture/repository-providers.md
+++ b/doc/architecture/repository-providers.md
@@ -33,6 +33,11 @@ Il parametro `class_ref` e parte della porta per GitHub/GitLab/team/classi, ma i
 3. Aggiungere adapter GitHub minimale dietro la stessa interfaccia.
 4. Progettare GitLab e provider interno senza far dipendere GUI e service dai dettagli esterni.
 
-Il primo collegamento operativo e `track_assignments.load_targets_from_provider()`: converte repository forniti da `RepositoryProvider` in `TrackingTarget` locali. La CLI esistente resta invariata e continua a usare `--target` / `--targets-file`.
+I primi collegamenti operativi sono:
+
+- `track_assignments.load_targets_from_provider()`: converte repository forniti da `RepositoryProvider` in `TrackingTarget` locali.
+- `assign_activity.collect_targets_from_provider()`: converte repository forniti da `RepositoryProvider` in path locali assegnabili.
+
+Le CLI esistenti restano invariate e continuano a usare `--target` / `--targets-file`.
 
 Questa scelta mantiene piccoli i cambiamenti: rete, autenticazione e semantica team restano fuori dal primo passo.

--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from scripts import create_submission_scaffold
+from scripts.thebitlab_repository_providers import RepositoryProvider
 
 
 @dataclass(frozen=True)
@@ -36,6 +37,20 @@ def collect_targets(targets: list[Path] | None = None, targets_file: Path | None
     if not collected:
         raise ValueError("Indica almeno un repository studente con --target o --targets-file.")
     return collected
+
+
+def collect_targets_from_provider(provider: RepositoryProvider, class_ref: str | None = None) -> list[Path]:
+    """Return local target paths exposed by a repository provider."""
+
+    repositories = provider.list_student_repositories(class_ref=class_ref)
+    paths = []
+    for repository in repositories:
+        if repository.path is None:
+            raise ValueError(f"Repository senza path locale: {repository.repo_ref}")
+        paths.append(repository.path)
+    if not paths:
+        raise ValueError("Il provider non ha restituito repository studenti.")
+    return paths
 
 
 def assign_activity_to_targets(

--- a/tests/test_assign_activity.py
+++ b/tests/test_assign_activity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from scripts import assign_activity
+from scripts.thebitlab_repository_providers import LocalRepositoryProvider, StudentRepository
 
 
 def activity() -> dict:
@@ -67,6 +68,26 @@ def write_canonical_activity(tmp_path):
     return path
 
 
+class MissingPathProvider:
+    provider_name = "missing-path"
+
+    def list_student_repositories(self, class_ref: str | None = None) -> list[StudentRepository]:
+        return [StudentRepository(student_id="rossi-mario", repo_ref="TheBitPoets/rossi-mario", provider=self.provider_name)]
+
+    def resolve_student_repository(self, student_id: str) -> StudentRepository:
+        return self.list_student_repositories()[0]
+
+
+class EmptyProvider:
+    provider_name = "empty"
+
+    def list_student_repositories(self, class_ref: str | None = None) -> list[StudentRepository]:
+        return []
+
+    def resolve_student_repository(self, student_id: str) -> StudentRepository:
+        raise FileNotFoundError(student_id)
+
+
 def test_collect_targets_uses_direct_and_file_targets(tmp_path) -> None:
     targets_dir = tmp_path / "classes"
     targets_dir.mkdir()
@@ -86,6 +107,37 @@ def test_collect_targets_uses_direct_and_file_targets(tmp_path) -> None:
     targets = assign_activity.collect_targets([tmp_path / "student-a"], targets_file)
 
     assert targets == [tmp_path / "student-a", tmp_path / "student-b", tmp_path / "student-c"]
+
+
+def test_collect_targets_from_local_repository_provider(tmp_path) -> None:
+    (tmp_path / "rossi-mario").mkdir()
+    (tmp_path / "bianchi-luca").mkdir()
+    provider = LocalRepositoryProvider(tmp_path)
+
+    targets = assign_activity.collect_targets_from_provider(provider)
+
+    assert targets == [
+        (tmp_path / "bianchi-luca").resolve(),
+        (tmp_path / "rossi-mario").resolve(),
+    ]
+
+
+def test_collect_targets_from_provider_requires_local_paths() -> None:
+    try:
+        assign_activity.collect_targets_from_provider(MissingPathProvider())
+    except ValueError as error:
+        assert "Repository senza path locale" in str(error)
+    else:
+        raise AssertionError("collect_targets_from_provider should reject repositories without a local path")
+
+
+def test_collect_targets_from_provider_rejects_empty_provider() -> None:
+    try:
+        assign_activity.collect_targets_from_provider(EmptyProvider())
+    except ValueError as error:
+        assert "non ha restituito repository studenti" in str(error)
+    else:
+        raise AssertionError("collect_targets_from_provider should reject an empty provider")
 
 
 def test_collect_targets_requires_at_least_one_target() -> None:

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import json
 import argparse
+import shutil
 import subprocess
+
+import pytest
 
 from scripts import grade_activity
 
@@ -26,6 +29,7 @@ def activity() -> dict:
     }
 
 
+@pytest.mark.skipif(shutil.which("gcc") is None, reason="gcc non disponibile nell'ambiente di test")
 def test_grade_activity_passes_valid_c_program(tmp_path) -> None:
     source = tmp_path / "main.c"
     source.write_text(


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `assign_activity.collect_targets_from_provider()`.
- Converte i `StudentRepository` esposti da un `RepositoryProvider` in path locali assegnabili.
- Aggiunge test per `LocalRepositoryProvider`, provider senza path locale e provider vuoto.
- Aggiorna la documentazione del repository provider indicando anche il collegamento operativo all'assegnazione.

## Perche

Questa e' un'altra PR incrementale di #285: dopo il tracking, colleghiamo il provider locale anche al flusso di assegnazione senza cambiare CLI, dashboard o comportamento utente. La CLI continua a usare `--target` / `--targets-file`; il nuovo helper resta disponibile per i service futuri.

## Issue

Parte di #285.

## Verifica

`pytest tests/test_assign_activity.py tests/test_thebitlab_repository_providers.py tests/test_track_assignments.py`

Risultato locale: `35 passed`.
