### PR TITLE
Introduce provider repository GitHub esplicito

### DIFF
--- a/doc/architecture/repository-providers.md
+++ b/doc/architecture/repository-providers.md
@@ -13,6 +13,7 @@ Il contratto minimo e in `scripts/thebitlab_repository_providers.py`:
 - `RepositoryProvider`: interfaccia per elencare e risolvere repository studenti.
 - `StudentRepository`: riferimento normalizzato a un repository studente.
 - `LocalRepositoryProvider`: adapter iniziale basato su directory locali.
+- `GitHubRepositoryProvider`: adapter iniziale basato su riferimenti GitHub espliciti, senza chiamate API.
 
 Il parametro `class_ref` e parte della porta per GitHub/GitLab/team/classi, ma il provider locale lo rifiuta finche non esiste una mappa locale classe/studenti. Questo evita di restituire tutti i repository quando il chiamante si aspetta un filtro di classe.
 
@@ -26,12 +27,15 @@ Il parametro `class_ref` e parte della porta per GitHub/GitLab/team/classi, ma i
 - `path`: path locale quando disponibile.
 - `metadata`: metadati opzionali specifici del provider.
 
+Per GitHub, `path` resta `null` finche il repository non e clonato localmente. Questo e sufficiente per discovery, link e metadati; i flussi che leggono o scrivono file locali continuano a richiedere un provider con path locale.
+
 ## Strategia incrementale
 
 1. Stabilizzare provider locale e test unitari.
 2. Collegare un flusso reale al provider senza cambiare comportamento utente.
 3. Aggiungere adapter GitHub minimale dietro la stessa interfaccia.
-4. Progettare GitLab e provider interno senza far dipendere GUI e service dai dettagli esterni.
+4. Aggiungere discovery GitHub via team/API solo quando serve davvero.
+5. Progettare GitLab e provider interno senza far dipendere GUI e service dai dettagli esterni.
 
 I primi collegamenti operativi sono:
 

--- a/scripts/thebitlab_repository_providers.py
+++ b/scripts/thebitlab_repository_providers.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+import re
 from typing import Protocol
+
+
+GITHUB_RE = re.compile(r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^/\s]+?)(?:\.git)?/?$")
+OWNER_REPO_RE = re.compile(r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)$")
 
 
 @dataclass(frozen=True)
@@ -90,3 +95,63 @@ class LocalRepositoryProvider:
 
     def _repo_ref(self, path: Path) -> str:
         return str(path.relative_to(self.root)).replace("\\", "/")
+
+
+class GitHubRepositoryProvider:
+    """Repository provider backed by explicit GitHub repository references."""
+
+    provider_name = "github"
+
+    def __init__(self, repositories: list[str]) -> None:
+        self.repositories = repositories
+
+    def list_student_repositories(self, class_ref: str | None = None) -> list[StudentRepository]:
+        """List explicit GitHub repositories.
+
+        Team/class discovery through GitHub APIs is intentionally outside this
+        adapter: until it exists, `class_ref` must not silently return every
+        configured repository.
+        """
+
+        if class_ref:
+            raise ValueError("Filtro classe non supportato dal provider GitHub esplicito.")
+        repositories = [self._repository_from_ref(ref) for ref in self.repositories]
+        return sorted(repositories, key=lambda repository: repository.student_id)
+
+    def resolve_student_repository(self, student_id: str) -> StudentRepository:
+        """Return one GitHub repository by student identifier or repo ref."""
+
+        clean_student_id = student_id.strip()
+        if not clean_student_id:
+            raise ValueError("Identificativo studente vuoto.")
+        for repository in self.list_student_repositories():
+            if repository.student_id == clean_student_id or repository.repo_ref == clean_student_id:
+                return repository
+        raise FileNotFoundError(f"Repository GitHub studente non trovato: {clean_student_id}")
+
+    def _repository_from_ref(self, ref: str) -> StudentRepository:
+        owner, repo = normalize_github_repo_ref(ref)
+        repo_ref = f"{owner}/{repo}"
+        return StudentRepository(
+            student_id=repo,
+            repo_ref=repo_ref,
+            provider=self.provider_name,
+            path=None,
+            metadata={
+                "owner": owner,
+                "repo": repo,
+                "url": f"https://github.com/{repo_ref}",
+            },
+        )
+
+
+def normalize_github_repo_ref(ref: str) -> tuple[str, str]:
+    """Return owner/repo from a GitHub owner/repo, HTTPS URL or SSH URL."""
+
+    clean_ref = ref.strip()
+    if not clean_ref:
+        raise ValueError("Repository GitHub vuoto.")
+    match = OWNER_REPO_RE.match(clean_ref) or GITHUB_RE.search(clean_ref)
+    if not match:
+        raise ValueError(f"Repository GitHub non valido: {ref}")
+    return match.group("owner"), match.group("repo")

--- a/scripts/thebitlab_repository_providers.py
+++ b/scripts/thebitlab_repository_providers.py
@@ -6,8 +6,9 @@ import re
 from typing import Protocol
 
 
-GITHUB_RE = re.compile(r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^/\s]+?)(?:\.git)?/?$")
 OWNER_REPO_RE = re.compile(r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)$")
+GITHUB_HTTPS_RE = re.compile(r"^https://github\.com/(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+?)(?:\.git)?/?$")
+GITHUB_SSH_RE = re.compile(r"^git@github\.com:(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+?)(?:\.git)?$")
 
 
 @dataclass(frozen=True)
@@ -151,7 +152,7 @@ def normalize_github_repo_ref(ref: str) -> tuple[str, str]:
     clean_ref = ref.strip()
     if not clean_ref:
         raise ValueError("Repository GitHub vuoto.")
-    match = OWNER_REPO_RE.match(clean_ref) or GITHUB_RE.search(clean_ref)
+    match = OWNER_REPO_RE.match(clean_ref) or GITHUB_HTTPS_RE.match(clean_ref) or GITHUB_SSH_RE.match(clean_ref)
     if not match:
         raise ValueError(f"Repository GitHub non valido: {ref}")
     return match.group("owner"), match.group("repo")

--- a/tests/test_thebitlab_repository_providers.py
+++ b/tests/test_thebitlab_repository_providers.py
@@ -158,6 +158,12 @@ def test_github_repository_provider_rejects_class_filter_and_invalid_refs() -> N
     with pytest.raises(ValueError, match="non valido"):
         GitHubRepositoryProvider(["not-a-repo"]).list_student_repositories()
 
+    with pytest.raises(ValueError, match="non valido"):
+        GitHubRepositoryProvider(["https://notgithub.com/TheBitPoets/rossi-mario"]).list_student_repositories()
+
+    with pytest.raises(ValueError, match="non valido"):
+        GitHubRepositoryProvider(["https://github.com/TheBitPoets/rossi-mario/issues"]).list_student_repositories()
+
 
 def test_normalize_github_repo_ref_accepts_supported_forms() -> None:
     assert normalize_github_repo_ref("TheBitPoets/rossi-mario") == ("TheBitPoets", "rossi-mario")

--- a/tests/test_thebitlab_repository_providers.py
+++ b/tests/test_thebitlab_repository_providers.py
@@ -4,7 +4,13 @@ from pathlib import Path
 
 import pytest
 
-from scripts.thebitlab_repository_providers import LocalRepositoryProvider, RepositoryProvider, StudentRepository
+from scripts.thebitlab_repository_providers import (
+    GitHubRepositoryProvider,
+    LocalRepositoryProvider,
+    RepositoryProvider,
+    StudentRepository,
+    normalize_github_repo_ref,
+)
 
 
 def accepts_repository_provider(provider: RepositoryProvider) -> list[StudentRepository]:
@@ -96,3 +102,64 @@ def test_local_repository_provider_rejects_missing_or_unsafe_paths(tmp_path) -> 
     safe_provider = LocalRepositoryProvider(tmp_path)
     with pytest.raises(FileNotFoundError, match="non trovato"):
         safe_provider.resolve_student_repository("rossi-mario")
+
+
+def test_github_repository_provider_lists_explicit_repositories() -> None:
+    provider = GitHubRepositoryProvider(
+        [
+            "https://github.com/TheBitPoets/rossi-mario.git",
+            "git@github.com:TheBitPoets/bianchi-luca.git",
+        ]
+    )
+
+    assert accepts_repository_provider(provider) == [
+        StudentRepository(
+            student_id="bianchi-luca",
+            repo_ref="TheBitPoets/bianchi-luca",
+            provider="github",
+            metadata={
+                "owner": "TheBitPoets",
+                "repo": "bianchi-luca",
+                "url": "https://github.com/TheBitPoets/bianchi-luca",
+            },
+        ),
+        StudentRepository(
+            student_id="rossi-mario",
+            repo_ref="TheBitPoets/rossi-mario",
+            provider="github",
+            metadata={
+                "owner": "TheBitPoets",
+                "repo": "rossi-mario",
+                "url": "https://github.com/TheBitPoets/rossi-mario",
+            },
+        ),
+    ]
+
+
+def test_github_repository_provider_resolves_student_or_repo_ref() -> None:
+    provider = GitHubRepositoryProvider(["TheBitPoets/rossi-mario"])
+
+    assert provider.resolve_student_repository("rossi-mario").repo_ref == "TheBitPoets/rossi-mario"
+    assert provider.resolve_student_repository("TheBitPoets/rossi-mario").student_id == "rossi-mario"
+
+
+def test_github_repository_provider_rejects_class_filter_and_invalid_refs() -> None:
+    provider = GitHubRepositoryProvider(["TheBitPoets/rossi-mario"])
+
+    with pytest.raises(ValueError, match="Filtro classe"):
+        provider.list_student_repositories(class_ref="3A-INF")
+
+    with pytest.raises(ValueError, match="vuoto"):
+        provider.resolve_student_repository(" ")
+
+    with pytest.raises(FileNotFoundError, match="non trovato"):
+        provider.resolve_student_repository("bianchi-luca")
+
+    with pytest.raises(ValueError, match="non valido"):
+        GitHubRepositoryProvider(["not-a-repo"]).list_student_repositories()
+
+
+def test_normalize_github_repo_ref_accepts_supported_forms() -> None:
+    assert normalize_github_repo_ref("TheBitPoets/rossi-mario") == ("TheBitPoets", "rossi-mario")
+    assert normalize_github_repo_ref("https://github.com/TheBitPoets/rossi-mario") == ("TheBitPoets", "rossi-mario")
+    assert normalize_github_repo_ref("git@github.com:TheBitPoets/rossi-mario.git") == ("TheBitPoets", "rossi-mario")


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `GitHubRepositoryProvider` dietro la stessa interfaccia `RepositoryProvider`.
- Normalizza riferimenti GitHub espliciti in formato `owner/repo`, URL HTTPS e URL SSH.
- Restituisce `StudentRepository(provider="github", repo_ref="owner/repo", path=None, metadata={...})`.
- Aggiunge test su listing, risoluzione, formati supportati e rifiuto del filtro classe non implementato.
- Aggiorna la documentazione architetturale del repository provider.

## Perche

Questa PR completa il primo adapter GitHub senza introdurre ancora chiamate API, autenticazione, discovery team o clone locale. Serve a stabilizzare il contratto GitHub minimo prima di collegarlo a flussi piu' ricchi.

## Issue

Parte di #285.

## Verifica

`pytest tests/test_thebitlab_repository_providers.py tests/test_assign_activity.py tests/test_track_assignments.py -q`

Risultato locale: test mirati verdi.
