### PR TITLE
Aggiunge diagnostica sicura secret AI

### DIFF
--- a/doc/COURSE_BOARD.md
+++ b/doc/COURSE_BOARD.md
@@ -968,6 +968,8 @@ La API key deve stare solo nella shell, in una variabile d'ambiente locale, oppu
 
 Il server legge prima le variabili d'ambiente e poi `.secrets/ai.secret`.
 
+Le versioni attuali della board non leggono piu il vecchio percorso `scripts/.secrets/ai.secret`. Se avevi configurato le chiavi li, spostale in `.secrets/ai.secret`: il server espone solo uno stato diagnostico sicuro, ma non legge ne mostra mai i valori del file legacy.
+
 Esempio:
 
 ```text

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -44,6 +44,7 @@ COURSE_PLAN_MD_PATH = ROOT / "doc" / "PERCORSO_DIDATTICO.md"
 README_PATH = ROOT / "README.md"
 AI_PROVIDERS_PATH = ROOT / "config" / "ai_providers.yaml"
 AI_SECRET_PATH = ROOT / ".secrets" / "ai.secret"
+LEGACY_AI_SECRET_PATH = ROOT / "scripts" / ".secrets" / "ai.secret"
 DEFAULT_SOURCES = ["README.md", "LINUX_PROGRAMMING.md"]
 ACTIVE_AI_PROVIDER = os.environ.get("AI_PROVIDER", "openai").strip().lower()
 ACTIVE_AI_MODEL = os.environ.get("AI_MODEL", "").strip()
@@ -1536,6 +1537,41 @@ def ai_config() -> dict:
         "api_key_configured": active["api_key_configured"],
         "billing_note": active["billing_note"],
         "providers": list(providers.values()),
+        "secret_status": ai_secret_status(providers),
+    }
+
+
+def diagnostic_path(path: Path) -> str:
+    """Return a stable diagnostic path without exposing host-specific separators."""
+
+    display_path = path.relative_to(ROOT) if path.is_relative_to(ROOT) else path
+    return str(display_path).replace("\\", "/")
+
+
+def ai_secret_status(providers: dict | None = None) -> dict:
+    """Return safe diagnostics about AI secrets without exposing values."""
+
+    safe_providers = providers or ai_providers()
+    secret_keys = sorted(
+        {
+            provider.get("secret_key", "")
+            for provider in parse_ai_providers_yaml()["providers"].values()
+            if provider.get("secret_key", "")
+        }
+    )
+    return {
+        "path": diagnostic_path(AI_SECRET_PATH),
+        "exists": AI_SECRET_PATH.is_file(),
+        "legacy_path": diagnostic_path(LEGACY_AI_SECRET_PATH),
+        "legacy_exists": LEGACY_AI_SECRET_PATH.is_file(),
+        "configured_keys": {
+            key: bool(secret_value(key))
+            for key in secret_keys
+        },
+        "configured_providers": {
+            provider_id: bool(provider.get("api_key_configured"))
+            for provider_id, provider in safe_providers.items()
+        },
     }
 
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -111,3 +111,27 @@ def test_list_assignment_reports_counts_late_only_for_submitted_students(tmp_pat
     assert reports[0]["submitted"] == 2
     assert reports[0]["not_submitted"] == 1
     assert reports[0]["late"] == 1
+
+
+def test_ai_secret_status_reports_paths_and_configured_keys_without_values(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "AI_SECRET_PATH", tmp_path / ".secrets" / "ai.secret")
+    monkeypatch.setattr(course_board_server, "LEGACY_AI_SECRET_PATH", tmp_path / "scripts" / ".secrets" / "ai.secret")
+    monkeypatch.setattr(course_board_server, "AI_PROVIDERS_PATH", tmp_path / "config" / "ai_providers.yaml")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    (tmp_path / ".secrets").mkdir()
+    (tmp_path / ".secrets" / "ai.secret").write_text("OPENAI_API_KEY=secret-value\n", encoding="utf-8")
+    (tmp_path / "scripts" / ".secrets").mkdir(parents=True)
+    (tmp_path / "scripts" / ".secrets" / "ai.secret").write_text("GEMINI_API_KEY=legacy-secret\n", encoding="utf-8")
+
+    status = course_board_server.ai_secret_status()
+
+    assert status["path"] == ".secrets/ai.secret"
+    assert status["exists"] is True
+    assert status["legacy_path"] == "scripts/.secrets/ai.secret"
+    assert status["legacy_exists"] is True
+    assert status["configured_keys"]["OPENAI_API_KEY"] is True
+    assert status["configured_keys"]["GEMINI_API_KEY"] is False
+    assert "secret-value" not in json.dumps(status)
+    assert "legacy-secret" not in json.dumps(status)


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `ai_secret_status()` al server per esporre solo diagnostica sicura sui secret AI.
- Include nel payload `ai_config()` lo stato dei secret senza mai esporre valori.
- Segnala se esiste il vecchio percorso `scripts/.secrets/ai.secret`.
- Documenta che il server legge `.secrets/ai.secret`, non il vecchio percorso legacy.
- Aggiunge test per verificare path, chiavi configurate e assenza dei valori nel payload diagnostico.

## Perche

Alcune chiavi AI erano rimaste nel vecchio percorso `scripts/.secrets/ai.secret`, mentre il server legge il file root `.secrets/ai.secret`. Questa PR rende il problema diagnosticabile senza rischiare leak di API key.

## Nota locale

Ho consolidato localmente le chiavi mancanti dal vecchio file al file root `.secrets/ai.secret`, senza stampare i valori e senza includere secret nella PR.

## Verifica

- `pytest tests/test_course_board_server.py -q`
- `pytest tests/test_thebitlab_services.py tests/test_thebitlab_storage.py -q`

Risultato locale: test verdi.
