### PR TITLE
Introduce porte per servizi tecnici

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -1,0 +1,105 @@
+# Servizi tecnici per grading, AI e runner
+
+Questa nota copre il primo passo di #289. L'obiettivo non e integrare subito Docker o provider AI reali, ma fissare i confini tra servizi tecnici e dominio didattico.
+
+## Confini
+
+Il backend deve trattare esecuzione, grading e feedback come tre passaggi separati.
+
+```text
+Submission
+  |
+  v
+ExecutionService
+  |
+  v
+GradingService
+  |
+  v
+AiFeedbackService
+```
+
+### ExecutionService
+
+Esegue codice studente in un runner isolato, per esempio Docker.
+
+Responsabilita:
+
+- preparare un workspace tecnico;
+- imporre timeout e limiti del runner;
+- restituire stdout, stderr, durata ed esiti test grezzi;
+- distinguere chiaramente runner non disponibile, timeout e payload non valido.
+
+Non deve:
+
+- decidere il voto;
+- chiamare provider AI;
+- conoscere dettagli della GUI.
+
+### GradingService
+
+Applica regole deterministiche agli esiti del runner.
+
+Responsabilita:
+
+- calcolare `graded_passed`, `graded_failed`, `not_run` o `error`;
+- mantenere visibili i nomi dei test falliti;
+- produrre una struttura compatibile con i registri e la dashboard docente;
+- lasciare al docente il voto finale quando serve.
+
+Non deve:
+
+- eseguire codice non fidato;
+- generare feedback naturale con AI;
+- nascondere errori tecnici come se fossero errori dello studente.
+
+### AiFeedbackService
+
+Produce bozze di feedback a partire da dati gia calcolati.
+
+Responsabilita:
+
+- usare solo contesto consentito dalla policy didattica;
+- restituire una bozza approvabile dal docente;
+- non sostituire grading deterministico o voto docente.
+
+Non deve:
+
+- inventare risultati dei test;
+- assegnare automaticamente un voto definitivo;
+- inviare dati studente a provider esterni senza policy esplicita.
+
+## Contratti iniziali
+
+I contratti Python stanno in:
+
+```text
+scripts/thebitlab_technical_services.py
+```
+
+Sono volutamente piccoli:
+
+- `ExecutionRequest` e `ExecutionResult`;
+- `GradingRequest` e `GradingResult`;
+- `AiFeedbackRequest` e `AiFeedbackResult`;
+- porte `ExecutionService`, `GradingService`, `AiFeedbackService`;
+- errori `RunnerUnavailableError`, `ExecutionTimeoutError`, `InvalidServicePayloadError`.
+
+## Casi errore minimi
+
+Le prossime implementazioni concrete devono preservare questi casi:
+
+| Caso | Output atteso |
+|---|---|
+| Docker/runner mancante | grading `not_run`, dettaglio tecnico leggibile |
+| Timeout | grading `error`, non voto negativo mascherato |
+| JSON runner non valido | errore tecnico esplicito |
+| Test falliti | grading `graded_failed` con nomi test visibili |
+| Test superati | grading `graded_passed` con conteggio test |
+
+## Evoluzione prevista
+
+1. Collegare il runner Docker reale a `ExecutionService`.
+2. Spostare la logica di `grade_activity.py` dietro `GradingService`.
+3. Aggiungere un `AiFeedbackService` mockabile per feedback docente/studente.
+4. Salvare i risultati nei registri e, in futuro, nell'indice SQLite senza cambiare la GUI.

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -161,6 +161,15 @@ class DeterministicGradingService:
         if execution.status not in {"passed", "failed"}:
             return GradingResult(status="error", passed=False, tests_passed=None, tests_total=None, detail=execution.detail)
 
+        if not execution.tests:
+            return GradingResult(
+                status="error",
+                passed=False,
+                tests_passed=None,
+                tests_total=0,
+                detail=execution.detail or "Runner concluso senza test eseguiti.",
+            )
+
         total = len(execution.tests)
         passed = sum(1 for test in execution.tests if test.passed)
         failed_tests = [test.name for test in execution.tests if not test.passed]

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -188,6 +188,8 @@ def execution_result_from_payload(payload: str | dict[str, Any]) -> ExecutionRes
     tests_raw = raw.get("tests", [])
     if not isinstance(tests_raw, list):
         raise InvalidServicePayloadError("Payload runner con tests non validi.")
+    if status in {"passed", "failed"} and not tests_raw:
+        raise InvalidServicePayloadError("Payload runner conclusivo senza test eseguiti.")
 
     tests = []
     for item in tests_raw:

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -1,0 +1,217 @@
+﻿from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+
+ExecutionStatus = Literal["passed", "failed", "timeout", "runner_unavailable", "invalid_payload"]
+GradingStatus = Literal["graded_passed", "graded_failed", "not_run", "error"]
+AiFeedbackStatus = Literal["not_generated", "draft", "error"]
+
+
+class TechnicalServiceError(RuntimeError):
+    """Base error for isolated technical services."""
+
+
+class RunnerUnavailableError(TechnicalServiceError):
+    """Raised when Docker or another configured execution runner is not available."""
+
+
+class ExecutionTimeoutError(TechnicalServiceError):
+    """Raised when student code execution exceeds the configured timeout."""
+
+
+class InvalidServicePayloadError(TechnicalServiceError):
+    """Raised when a technical service returns malformed or incomplete data."""
+
+
+@dataclass(frozen=True)
+class ExecutionRequest:
+    """Input for a sandboxed execution service."""
+
+    activity_id: str
+    student_id: str
+    files: dict[str, str]
+    language: str
+    timeout_seconds: int = 10
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RunnerTestResult:
+    """Result of one deterministic test case."""
+
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Output produced by a runner before didactic grading policy is applied."""
+
+    status: ExecutionStatus
+    tests: list[RunnerTestResult] = field(default_factory=list)
+    stdout: str = ""
+    stderr: str = ""
+    duration_ms: int | None = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class GradingRequest:
+    """Input for deterministic grading."""
+
+    activity_id: str
+    student_id: str
+    execution: ExecutionResult
+    grading_policy: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GradingResult:
+    """Dashboard-ready deterministic grading result."""
+
+    status: GradingStatus
+    passed: bool | None
+    tests_passed: int | None
+    tests_total: int | None
+    failed_tests: list[str] = field(default_factory=list)
+    score: float | None = None
+    teacher_grade: float | None = None
+    detail: str = ""
+
+    def to_dashboard_dict(self) -> dict[str, Any]:
+        """Return the shape already used by assignment registers."""
+
+        return {
+            "status": self.status,
+            "passed": self.passed,
+            "tests_passed": self.tests_passed,
+            "tests_total": self.tests_total,
+            "failed_tests": self.failed_tests,
+            "score": self.score,
+            "teacher_grade": self.teacher_grade,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class AiFeedbackRequest:
+    """Input for AI feedback generation, after deterministic grading exists."""
+
+    activity_id: str
+    student_id: str
+    grading: GradingResult
+    allowed_context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AiFeedbackResult:
+    """Teacher-approvable AI feedback draft."""
+
+    status: AiFeedbackStatus
+    summary: str | None = None
+    suggested_grade: float | None = None
+    approved_by_teacher: bool = False
+    detail: str = ""
+
+
+class ExecutionService(Protocol):
+    """Port for Docker/local execution of untrusted student code."""
+
+    def run(self, request: ExecutionRequest) -> ExecutionResult: ...
+
+
+class GradingService(Protocol):
+    """Port for deterministic grading based on runner output and policy."""
+
+    def grade(self, request: GradingRequest) -> GradingResult: ...
+
+
+class AiFeedbackService(Protocol):
+    """Port for provider-backed feedback drafts separated from grading."""
+
+    def generate_feedback(self, request: AiFeedbackRequest) -> AiFeedbackResult: ...
+
+
+class DeterministicGradingService:
+    """Small grading service that summarizes runner tests without calling AI."""
+
+    def grade(self, request: GradingRequest) -> GradingResult:
+        execution = request.execution
+        if execution.status == "timeout":
+            return GradingResult(
+                status="error",
+                passed=False,
+                tests_passed=0,
+                tests_total=len(execution.tests) if execution.tests else None,
+                failed_tests=[test.name for test in execution.tests if not test.passed],
+                detail=execution.detail or "Esecuzione interrotta per timeout.",
+            )
+        if execution.status in {"runner_unavailable", "invalid_payload"}:
+            return GradingResult(
+                status="not_run",
+                passed=None,
+                tests_passed=None,
+                tests_total=None,
+                detail=execution.detail or "Runner non disponibile o payload non valido.",
+            )
+        if execution.status not in {"passed", "failed"}:
+            return GradingResult(status="error", passed=False, tests_passed=None, tests_total=None, detail=execution.detail)
+
+        total = len(execution.tests)
+        passed = sum(1 for test in execution.tests if test.passed)
+        failed_tests = [test.name for test in execution.tests if not test.passed]
+        all_passed = execution.status == "passed" and not failed_tests
+        score = round((passed / total) * 10, 2) if total else None
+        return GradingResult(
+            status="graded_passed" if all_passed else "graded_failed",
+            passed=all_passed,
+            tests_passed=passed,
+            tests_total=total,
+            failed_tests=failed_tests,
+            score=score,
+            detail=execution.detail,
+        )
+
+
+def execution_result_from_payload(payload: str | dict[str, Any]) -> ExecutionResult:
+    """Parse a runner payload into an ExecutionResult."""
+
+    raw = _decode_payload(payload)
+    status = raw.get("status")
+    if status not in {"passed", "failed", "timeout", "runner_unavailable", "invalid_payload"}:
+        raise InvalidServicePayloadError("Payload runner senza status valido.")
+
+    tests_raw = raw.get("tests", [])
+    if not isinstance(tests_raw, list):
+        raise InvalidServicePayloadError("Payload runner con tests non validi.")
+
+    tests = []
+    for item in tests_raw:
+        if not isinstance(item, dict) or not item.get("name") or not isinstance(item.get("passed"), bool):
+            raise InvalidServicePayloadError("Payload runner con test case incompleto.")
+        tests.append(RunnerTestResult(name=str(item["name"]), passed=item["passed"], detail=str(item.get("detail", ""))))
+
+    return ExecutionResult(
+        status=status,
+        tests=tests,
+        stdout=str(raw.get("stdout", "")),
+        stderr=str(raw.get("stderr", "")),
+        duration_ms=raw.get("duration_ms") if isinstance(raw.get("duration_ms"), int) else None,
+        detail=str(raw.get("detail", "")),
+    )
+
+
+def _decode_payload(payload: str | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        return payload
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise InvalidServicePayloadError("Payload runner non e JSON valido.") from exc
+    if not isinstance(decoded, dict):
+        raise InvalidServicePayloadError("Payload runner JSON non e un oggetto.")
+    return decoded

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -84,6 +84,16 @@ def test_deterministic_grading_does_not_run_when_runner_is_missing() -> None:
     assert result.detail == "Docker non disponibile."
 
 
+def test_deterministic_grading_rejects_conclusive_execution_without_tests() -> None:
+    result = grade(ExecutionResult(status="passed"))
+
+    assert result.status == "error"
+    assert result.passed is False
+    assert result.tests_passed is None
+    assert result.tests_total == 0
+    assert result.detail == "Runner concluso senza test eseguiti."
+
+
 def test_execution_result_from_payload_accepts_runner_json() -> None:
     result = execution_result_from_payload(
         """

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -111,6 +111,8 @@ def test_execution_result_from_payload_accepts_runner_json() -> None:
         "{not-json",
         "[]",
         {"status": "unknown"},
+        {"status": "passed"},
+        {"status": "failed", "tests": []},
         {"status": "passed", "tests": {}},
         {"status": "passed", "tests": [{"name": "senza_esito"}]},
     ],

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -1,0 +1,120 @@
+﻿from __future__ import annotations
+
+import pytest
+
+from scripts.thebitlab_technical_services import (
+    DeterministicGradingService,
+    ExecutionResult,
+    GradingRequest,
+    InvalidServicePayloadError,
+    RunnerTestResult,
+    execution_result_from_payload,
+)
+
+
+def grade(execution: ExecutionResult):
+    service = DeterministicGradingService()
+    return service.grade(
+        GradingRequest(
+            activity_id="python-base-somma-001",
+            student_id="rossi-mario",
+            execution=execution,
+        )
+    )
+
+
+def test_deterministic_grading_summarizes_passed_tests_for_dashboard() -> None:
+    result = grade(
+        ExecutionResult(
+            status="passed",
+            tests=[
+                RunnerTestResult("somma_positivi", True),
+                RunnerTestResult("somma_negativi", True),
+            ],
+        )
+    )
+
+    assert result.status == "graded_passed"
+    assert result.passed is True
+    assert result.tests_passed == 2
+    assert result.tests_total == 2
+    assert result.failed_tests == []
+    assert result.score == 10
+    assert result.to_dashboard_dict()["status"] == "graded_passed"
+
+
+def test_deterministic_grading_keeps_failed_test_names_visible() -> None:
+    result = grade(
+        ExecutionResult(
+            status="failed",
+            tests=[
+                RunnerTestResult("somma_positivi", True),
+                RunnerTestResult("somma_negativi", False, "Output errato"),
+            ],
+            detail="Test deterministici falliti.",
+        )
+    )
+
+    assert result.status == "graded_failed"
+    assert result.passed is False
+    assert result.tests_passed == 1
+    assert result.tests_total == 2
+    assert result.failed_tests == ["somma_negativi"]
+    assert result.score == 5
+    assert result.detail == "Test deterministici falliti."
+
+
+def test_deterministic_grading_reports_timeout_as_error() -> None:
+    result = grade(ExecutionResult(status="timeout", detail="Limite di 10 secondi superato."))
+
+    assert result.status == "error"
+    assert result.passed is False
+    assert result.tests_passed == 0
+    assert result.tests_total is None
+    assert result.detail == "Limite di 10 secondi superato."
+
+
+def test_deterministic_grading_does_not_run_when_runner_is_missing() -> None:
+    result = grade(ExecutionResult(status="runner_unavailable", detail="Docker non disponibile."))
+
+    assert result.status == "not_run"
+    assert result.passed is None
+    assert result.tests_passed is None
+    assert result.tests_total is None
+    assert result.detail == "Docker non disponibile."
+
+
+def test_execution_result_from_payload_accepts_runner_json() -> None:
+    result = execution_result_from_payload(
+        """
+        {
+          "status": "failed",
+          "tests": [
+            {"name": "somma_positivi", "passed": true},
+            {"name": "somma_negativi", "passed": false, "detail": "Output errato"}
+          ],
+          "stdout": "1",
+          "stderr": "",
+          "duration_ms": 42
+        }
+        """
+    )
+
+    assert result.status == "failed"
+    assert result.tests[1] == RunnerTestResult("somma_negativi", False, "Output errato")
+    assert result.duration_ms == 42
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{not-json",
+        "[]",
+        {"status": "unknown"},
+        {"status": "passed", "tests": {}},
+        {"status": "passed", "tests": [{"name": "senza_esito"}]},
+    ],
+)
+def test_execution_result_from_payload_rejects_invalid_payloads(payload) -> None:
+    with pytest.raises(InvalidServicePayloadError):
+        execution_result_from_payload(payload)


### PR DESCRIPTION
﻿## Cosa cambia

- Introduce le porte applicative per `ExecutionService`, `GradingService` e `AiFeedbackService`.
- Aggiunge DTO espliciti per richiesta/risultato di esecuzione, grading deterministico e feedback AI.
- Aggiunge una prima implementazione piccola di `DeterministicGradingService` per produrre output leggibile dalla dashboard.
- Documenta i confini tra runner Docker, grading deterministico e feedback AI in `doc/architecture/technical-services.md`.

## Perche

Questo e il primo passo di #289: prima di integrare Docker reale o provider AI reali, serve un confine stabile e testabile. Il grading resta deterministico; l'AI puo solo produrre bozze di feedback approvabili dal docente.

## Test

- `python -m pytest tests/test_thebitlab_technical_services.py tests/test_thebitlab_services.py tests/test_thebitlab_sqlite_index.py`

Closes parte di #289.
