### PR TITLE
Collega report grading ai servizi tecnici

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -103,3 +103,7 @@ Le prossime implementazioni concrete devono preservare questi casi:
 2. Spostare la logica di `grade_activity.py` dietro `GradingService`.
 3. Aggiungere un `AiFeedbackService` mockabile per feedback docente/studente.
 4. Salvare i risultati nei registri e, in futuro, nell'indice SQLite senza cambiare la GUI.
+
+## Bridge con i report esistenti
+
+Durante la transizione, i report prodotti da `scripts/grade_activity.py` vengono convertiti nel contratto tecnico con `grading_dict_from_grade_activity_report()`. Questo permette al tracking delle consegne di usare `GradingService` senza cambiare subito il formato dei report gia prodotti.

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -231,6 +231,8 @@ def execution_result_from_grade_activity_report(report: dict[str, Any]) -> Execu
     ]
     if status in {"compile-error", "compile-timeout"} and not tests:
         tests.append(RunnerTestResult(name="compilazione", passed=False, detail=_grade_activity_report_detail(report)))
+    if status == "source-not-found" and not tests:
+        tests.append(RunnerTestResult(name="sorgente", passed=False, detail=_grade_activity_report_detail(report)))
 
     if report.get("passed") is True:
         execution_status: ExecutionStatus = "passed"
@@ -238,7 +240,7 @@ def execution_result_from_grade_activity_report(report: dict[str, Any]) -> Execu
         execution_status = "timeout"
     elif status in {"invalid-activity"}:
         execution_status = "invalid_payload"
-    elif status in {"compiler-not-found", "unsupported-language", "unknown-language", "source-not-found"}:
+    elif status in {"compiler-not-found", "unsupported-language", "unknown-language"}:
         execution_status = "runner_unavailable"
     else:
         execution_status = "failed"

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -229,12 +229,12 @@ def execution_result_from_grade_activity_report(report: dict[str, Any]) -> Execu
         for index, test in enumerate(report.get("tests", []) if isinstance(report.get("tests"), list) else [])
         if isinstance(test, dict) and isinstance(test.get("passed"), bool)
     ]
-    if status == "compile-error" and not tests:
+    if status in {"compile-error", "compile-timeout"} and not tests:
         tests.append(RunnerTestResult(name="compilazione", passed=False, detail=_grade_activity_report_detail(report)))
 
     if report.get("passed") is True:
         execution_status: ExecutionStatus = "passed"
-    elif status in {"timeout", "compile-timeout"}:
+    elif status == "timeout":
         execution_status = "timeout"
     elif status in {"invalid-activity"}:
         execution_status = "invalid_payload"

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -216,6 +216,79 @@ def execution_result_from_payload(payload: str | dict[str, Any]) -> ExecutionRes
     )
 
 
+def execution_result_from_grade_activity_report(report: dict[str, Any]) -> ExecutionResult:
+    """Convert the legacy grade_activity.py report into an ExecutionResult."""
+
+    status = str(report.get("status", ""))
+    tests = [
+        RunnerTestResult(
+            name=str(test.get("name") or test.get("id") or f"test {index + 1}"),
+            passed=bool(test.get("passed")),
+            detail=str(test.get("message") or test.get("error") or test.get("stderr") or ""),
+        )
+        for index, test in enumerate(report.get("tests", []) if isinstance(report.get("tests"), list) else [])
+        if isinstance(test, dict) and isinstance(test.get("passed"), bool)
+    ]
+
+    if report.get("passed") is True:
+        execution_status: ExecutionStatus = "passed"
+    elif status in {"timeout", "compile-timeout"}:
+        execution_status = "timeout"
+    elif status in {"invalid-activity"}:
+        execution_status = "invalid_payload"
+    elif status in {"compiler-not-found", "unsupported-language", "unknown-language", "source-not-found"}:
+        execution_status = "runner_unavailable"
+    else:
+        execution_status = "failed"
+
+    detail = _grade_activity_report_detail(report)
+    return ExecutionResult(status=execution_status, tests=tests, detail=detail)
+
+
+def grading_dict_from_grade_activity_report(report: dict[str, Any]) -> dict[str, Any]:
+    """Return dashboard-ready grading fields from a legacy grade_activity.py report."""
+
+    execution = execution_result_from_grade_activity_report(report)
+    grading = DeterministicGradingService().grade(
+        GradingRequest(
+            activity_id=str(report.get("activity_id") or ""),
+            student_id=str(report.get("student_id") or ""),
+            execution=execution,
+        )
+    )
+    result = grading.to_dashboard_dict()
+    result["score"] = report.get("score", result["score"])
+    result["teacher_grade"] = report.get("teacher_grade", result["teacher_grade"])
+    result["tests"] = _grade_activity_report_tests(report)
+    result["report_status"] = report.get("status")
+    return result
+
+
+def _grade_activity_report_tests(report: dict[str, Any]) -> list[dict[str, Any]]:
+    tests = []
+    for index, test in enumerate(report.get("tests", []) if isinstance(report.get("tests"), list) else []):
+        if not isinstance(test, dict):
+            continue
+        tests.append(
+            {
+                "name": str(test.get("name") or test.get("id") or f"test {index + 1}"),
+                "passed": test.get("passed"),
+                "status": test.get("status"),
+                "message": test.get("message") or test.get("error") or "",
+                "expected_stdout": test.get("expected_stdout"),
+                "actual_stdout": test.get("actual_stdout"),
+            }
+        )
+    return tests
+
+
+def _grade_activity_report_detail(report: dict[str, Any]) -> str:
+    if isinstance(report.get("errors"), list):
+        return "; ".join(str(error) for error in report["errors"])
+    compile_result = report.get("compile") if isinstance(report.get("compile"), dict) else {}
+    return str(report.get("error") or compile_result.get("stderr") or report.get("status") or "")
+
+
 def _decode_payload(payload: str | dict[str, Any]) -> dict[str, Any]:
     if isinstance(payload, dict):
         return payload

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -229,6 +229,8 @@ def execution_result_from_grade_activity_report(report: dict[str, Any]) -> Execu
         for index, test in enumerate(report.get("tests", []) if isinstance(report.get("tests"), list) else [])
         if isinstance(test, dict) and isinstance(test.get("passed"), bool)
     ]
+    if status == "compile-error" and not tests:
+        tests.append(RunnerTestResult(name="compilazione", passed=False, detail=_grade_activity_report_detail(report)))
 
     if report.get("passed") is True:
         execution_status: ExecutionStatus = "passed"

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -16,6 +16,7 @@ from scripts.thebitlab_contracts import (
     validate_normalized_activity,
 )
 from scripts.thebitlab_repository_providers import RepositoryProvider
+from scripts.thebitlab_technical_services import grading_dict_from_grade_activity_report
 
 
 NO_DUE_DATE_STATUS = "no_due_date"
@@ -318,34 +319,7 @@ def grading_summary(report: dict[str, Any] | None) -> dict[str, Any]:
             "teacher_grade": None,
             "report_status": None,
         }
-    summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
-    tests = []
-    for index, test in enumerate(report.get("tests", []) if isinstance(report.get("tests"), list) else []):
-        if not isinstance(test, dict):
-            continue
-        name = str(test.get("name") or test.get("id") or f"test {index + 1}")
-        tests.append(
-            {
-                "name": name,
-                "passed": test.get("passed"),
-                "status": test.get("status"),
-                "message": test.get("message") or test.get("error") or "",
-                "expected_stdout": test.get("expected_stdout"),
-                "actual_stdout": test.get("actual_stdout"),
-            }
-        )
-    failed_tests = [test["name"] for test in tests if test.get("passed") is False]
-    return {
-        "status": "graded_passed" if report.get("passed") is True else "graded_failed",
-        "passed": report.get("passed"),
-        "tests_passed": summary.get("passed"),
-        "tests_total": summary.get("total"),
-        "tests": tests,
-        "failed_tests": failed_tests,
-        "score": report.get("score"),
-        "teacher_grade": report.get("teacher_grade"),
-        "report_status": report.get("status"),
-    }
+    return grading_dict_from_grade_activity_report(report)
 
 
 def ai_feedback_placeholder() -> dict[str, Any]:

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -199,6 +199,27 @@ def test_grading_dict_from_grade_activity_report_marks_compile_timeout_as_failed
     assert result["report_status"] == "compile-timeout"
 
 
+def test_grading_dict_from_grade_activity_report_marks_missing_source_as_failed_grading() -> None:
+    result = grading_dict_from_grade_activity_report(
+        {
+            "activity_id": "c-base-somma-001",
+            "passed": False,
+            "status": "source-not-found",
+            "source": "assignments/c-base-somma-001/main.c",
+            "error": "Sorgente non trovato: assignments/c-base-somma-001/main.c",
+            "tests": [],
+        }
+    )
+
+    assert result["status"] == "graded_failed"
+    assert result["passed"] is False
+    assert result["tests_passed"] == 0
+    assert result["tests_total"] == 1
+    assert result["failed_tests"] == ["sorgente"]
+    assert result["detail"] == "Sorgente non trovato: assignments/c-base-somma-001/main.c"
+    assert result["report_status"] == "source-not-found"
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -159,6 +159,26 @@ def test_grading_dict_from_grade_activity_report_marks_infrastructure_errors_not
     assert result["report_status"] == "unsupported-language"
 
 
+def test_grading_dict_from_grade_activity_report_marks_compile_error_as_failed_grading() -> None:
+    result = grading_dict_from_grade_activity_report(
+        {
+            "activity_id": "c-base-somma-001",
+            "passed": False,
+            "status": "compile-error",
+            "compile": {"stderr": "main.c: errore di sintassi"},
+            "tests": [],
+        }
+    )
+
+    assert result["status"] == "graded_failed"
+    assert result["passed"] is False
+    assert result["tests_passed"] == 0
+    assert result["tests_total"] == 1
+    assert result["failed_tests"] == ["compilazione"]
+    assert result["detail"] == "main.c: errore di sintassi"
+    assert result["report_status"] == "compile-error"
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -9,6 +9,7 @@ from scripts.thebitlab_technical_services import (
     InvalidServicePayloadError,
     RunnerTestResult,
     execution_result_from_payload,
+    grading_dict_from_grade_activity_report,
 )
 
 
@@ -113,6 +114,49 @@ def test_execution_result_from_payload_accepts_runner_json() -> None:
     assert result.status == "failed"
     assert result.tests[1] == RunnerTestResult("somma_negativi", False, "Output errato")
     assert result.duration_ms == 42
+
+
+def test_grading_dict_from_grade_activity_report_keeps_failed_tests_visible() -> None:
+    result = grading_dict_from_grade_activity_report(
+        {
+            "activity_id": "c-base-somma-001",
+            "passed": False,
+            "status": "failed",
+            "teacher_grade": 5.5,
+            "tests": [
+                {"name": "somma_positivi", "passed": True, "status": "passed"},
+                {"name": "somma_negativi", "passed": False, "status": "failed", "stderr": "Output errato"},
+            ],
+        }
+    )
+
+    assert result["status"] == "graded_failed"
+    assert result["passed"] is False
+    assert result["tests_passed"] == 1
+    assert result["tests_total"] == 2
+    assert result["failed_tests"] == ["somma_negativi"]
+    assert result["score"] == 5
+    assert result["teacher_grade"] == 5.5
+    assert result["report_status"] == "failed"
+
+
+def test_grading_dict_from_grade_activity_report_marks_infrastructure_errors_not_run() -> None:
+    result = grading_dict_from_grade_activity_report(
+        {
+            "activity_id": "python-001",
+            "passed": False,
+            "status": "unsupported-language",
+            "tests": [],
+            "error": "Runner non ancora implementato per il linguaggio: python",
+        }
+    )
+
+    assert result["status"] == "not_run"
+    assert result["passed"] is None
+    assert result["tests_passed"] is None
+    assert result["tests_total"] is None
+    assert result["detail"] == "Runner non ancora implementato per il linguaggio: python"
+    assert result["report_status"] == "unsupported-language"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -179,6 +179,26 @@ def test_grading_dict_from_grade_activity_report_marks_compile_error_as_failed_g
     assert result["report_status"] == "compile-error"
 
 
+def test_grading_dict_from_grade_activity_report_marks_compile_timeout_as_failed_grading() -> None:
+    result = grading_dict_from_grade_activity_report(
+        {
+            "activity_id": "c-base-somma-001",
+            "passed": False,
+            "status": "compile-timeout",
+            "compile": {"stderr": "Compilazione interrotta per timeout"},
+            "tests": [],
+        }
+    )
+
+    assert result["status"] == "graded_failed"
+    assert result["passed"] is False
+    assert result["tests_passed"] == 0
+    assert result["tests_total"] == 1
+    assert result["failed_tests"] == ["compilazione"]
+    assert result["detail"] == "Compilazione interrotta per timeout"
+    assert result["report_status"] == "compile-timeout"
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -76,6 +76,10 @@ def write_report(root, submitted_at: str, passed: bool = True) -> None:
                     "passed": 2 if passed else 1,
                     "total": 2,
                 },
+                "tests": [
+                    {"name": "somma positiva", "passed": True, "status": "passed"},
+                    {"name": "somma con negativo", "passed": passed, "status": "passed" if passed else "failed"},
+                ],
             }
         ),
         encoding="utf-8",
@@ -446,6 +450,44 @@ def test_track_assignments_marks_submitted_late(tmp_path) -> None:
     assert row["status"] == "submitted_late"
     assert row["late"] is True
     assert row["grading"]["status"] == "graded_failed"
+
+
+def test_track_assignments_uses_technical_grading_adapter_for_infrastructure_errors(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    report_path = student.path / "reports" / "python-base-somma-001" / "latest.json"
+    source_path = student.path / "assignments" / "python-base-somma-001" / "main.py"
+    report_path.parent.mkdir(parents=True)
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("print(3)\n", encoding="utf-8")
+    report_path.write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "passed": False,
+                "status": "unsupported-language",
+                "language": "python",
+                "source": str(source_path),
+                "submitted_at": "2026-10-20T08:00:00+02:00",
+                "error": "Runner non ancora implementato per il linguaggio: python",
+                "tests": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T08:00:00+02:00",
+    )
+
+    grading = index["students"][0]["grading"]
+
+    assert grading["status"] == "not_run"
+    assert grading["passed"] is None
+    assert grading["report_status"] == "unsupported-language"
 
 
 def test_track_assignments_rejects_report_for_different_activity(tmp_path) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge un bridge dai report legacy di `scripts/grade_activity.py` ai contratti tecnici introdotti in #312.
- Fa passare `track_assignments.grading_summary()` da `grading_dict_from_grade_activity_report()`, quindi il registro docente usa il `DeterministicGradingService` invece di duplicare la logica.
- Mantiene `score`, `teacher_grade`, `tests`, `failed_tests` e `report_status` leggibili per dashboard e registri.
- Documenta il bridge transitorio in `doc/architecture/technical-services.md`.

## Perche

E' il passo successivo di #289: avvicina il grading reale al service layer senza riscrivere ancora il runner Docker o il formato dei report esistenti.

## Test

- `python -m pytest tests/test_thebitlab_technical_services.py tests/test_track_assignments.py`
- Risultato: `35 passed`

Nota: non ho incluso `tests/test_grade_activity.py` nella verifica finale perche in questa macchina due test non marcati skip richiedono `gcc`; quando `gcc` manca falliscono con `compiler-not-found` prima di esercitare la logica attesa.

Parte di #289.
