### PR TITLE
Aggiunge execution service per grade_activity

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -107,3 +107,5 @@ Le prossime implementazioni concrete devono preservare questi casi:
 ## Bridge con i report esistenti
 
 Durante la transizione, i report prodotti da `scripts/grade_activity.py` vengono convertiti nel contratto tecnico con `grading_dict_from_grade_activity_report()`. Questo permette al tracking delle consegne di usare `GradingService` senza cambiare subito il formato dei report gia prodotti.
+
+`GradeActivityExecutionService` espone inoltre `grade_activity.py` dietro la porta `ExecutionService`: i chiamanti passano `activity_path` e `source_path` nei metadati della richiesta e ricevono un `ExecutionResult`, senza dipendere dal formato legacy del report.

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -2,6 +2,7 @@
 
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Literal, Protocol
 
 
@@ -184,6 +185,32 @@ class DeterministicGradingService:
             score=score,
             detail=execution.detail,
         )
+
+
+class GradeActivityExecutionService:
+    """ExecutionService adapter backed by scripts.grade_activity."""
+
+    def run(self, request: ExecutionRequest) -> ExecutionResult:
+        """Run the existing grade_activity runner and return an ExecutionResult."""
+
+        from scripts import grade_activity
+
+        activity_path = request.metadata.get("activity_path")
+        source_path = request.metadata.get("source_path")
+        if not activity_path or not source_path:
+            return ExecutionResult(
+                status="invalid_payload",
+                detail="ExecutionRequest.metadata deve includere activity_path e source_path.",
+            )
+
+        activity = grade_activity.load_activity(Path(str(activity_path)))
+        report = grade_activity.grade_activity(
+            activity,
+            Path(str(source_path)),
+            timeout_seconds=request.timeout_seconds,
+            language=request.language,
+        )
+        return execution_result_from_grade_activity_report(report)
 
 
 def execution_result_from_payload(payload: str | dict[str, Any]) -> ExecutionResult:

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -203,7 +203,11 @@ class GradeActivityExecutionService:
                 detail="ExecutionRequest.metadata deve includere activity_path e source_path.",
             )
 
-        activity = grade_activity.load_activity(Path(str(activity_path)))
+        try:
+            activity = grade_activity.load_activity(Path(str(activity_path)))
+        except (OSError, json.JSONDecodeError) as error:
+            return ExecutionResult(status="invalid_payload", detail=f"Activity non caricata: {error}")
+
         report = grade_activity.grade_activity(
             activity,
             Path(str(source_path)),

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -274,6 +274,39 @@ def test_grade_activity_execution_service_rejects_missing_paths() -> None:
     assert "activity_path" in result.detail
 
 
+def test_grade_activity_execution_service_returns_invalid_payload_for_missing_activity(tmp_path) -> None:
+    result = GradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="c-base-somma-001",
+            student_id="rossi-mario",
+            files={},
+            language="c",
+            metadata={"activity_path": tmp_path / "missing.json", "source_path": tmp_path / "main.c"},
+        )
+    )
+
+    assert result.status == "invalid_payload"
+    assert "Activity non caricata" in result.detail
+
+
+def test_grade_activity_execution_service_returns_invalid_payload_for_bad_activity_json(tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    activity_path.write_text("{not-json", encoding="utf-8")
+
+    result = GradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="c-base-somma-001",
+            student_id="rossi-mario",
+            files={},
+            language="c",
+            metadata={"activity_path": activity_path, "source_path": tmp_path / "main.c"},
+        )
+    )
+
+    assert result.status == "invalid_payload"
+    assert "Activity non caricata" in result.detail
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -5,6 +5,8 @@ import pytest
 from scripts.thebitlab_technical_services import (
     DeterministicGradingService,
     ExecutionResult,
+    ExecutionRequest,
+    GradeActivityExecutionService,
     GradingRequest,
     InvalidServicePayloadError,
     RunnerTestResult,
@@ -218,6 +220,58 @@ def test_grading_dict_from_grade_activity_report_marks_missing_source_as_failed_
     assert result["failed_tests"] == ["sorgente"]
     assert result["detail"] == "Sorgente non trovato: assignments/c-base-somma-001/main.c"
     assert result["report_status"] == "source-not-found"
+
+
+def test_grade_activity_execution_service_runs_existing_runner(monkeypatch, tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.c"
+    activity_path.write_text('{"id": "c-base-somma-001"}', encoding="utf-8")
+    source_path.write_text("int main(void){return 0;}", encoding="utf-8")
+
+    from scripts import grade_activity
+
+    def fake_grade_activity(activity, source, *, timeout_seconds, language):
+        assert activity == {"id": "c-base-somma-001"}
+        assert source == source_path
+        assert timeout_seconds == 7
+        assert language == "c"
+        return {
+            "activity_id": activity["id"],
+            "passed": True,
+            "status": "passed",
+            "tests": [{"name": "base", "passed": True, "status": "passed"}],
+        }
+
+    monkeypatch.setattr(grade_activity, "grade_activity", fake_grade_activity)
+
+    result = GradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="c-base-somma-001",
+            student_id="rossi-mario",
+            files={"main.c": str(source_path)},
+            language="c",
+            timeout_seconds=7,
+            metadata={"activity_path": activity_path, "source_path": source_path},
+        )
+    )
+
+    assert result.status == "passed"
+    assert result.tests == [RunnerTestResult("base", True)]
+
+
+def test_grade_activity_execution_service_rejects_missing_paths() -> None:
+    result = GradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="c-base-somma-001",
+            student_id="rossi-mario",
+            files={},
+            language="c",
+            metadata={},
+        )
+    )
+
+    assert result.status == "invalid_payload"
+    assert "activity_path" in result.detail
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `GradeActivityExecutionService`, un adapter `ExecutionService` sopra `scripts.grade_activity`.
- La richiesta passa `activity_path` e `source_path` nei metadati e riceve un `ExecutionResult`, senza esporre ai chiamanti il report legacy.
- Aggiunge test con monkeypatch, quindi non dipendono da `gcc` o Docker.
- Documenta l adapter in `doc/architecture/technical-services.md`.

## Perche

E' il passo successivo di #289: dopo le porte tecniche e il bridge dei report, colleghiamo il runner esistente alla porta `ExecutionService` senza cambiare CLI, dashboard o formato dei report.

## Test

- `python -m pytest tests/test_thebitlab_technical_services.py tests/test_track_assignments.py`
- Risultato: `40 passed`

Parte di #289.
