### PR TITLE
Aggiunge feedback AI deterministico

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -109,3 +109,5 @@ Le prossime implementazioni concrete devono preservare questi casi:
 Durante la transizione, i report prodotti da `scripts/grade_activity.py` vengono convertiti nel contratto tecnico con `grading_dict_from_grade_activity_report()`. Questo permette al tracking delle consegne di usare `GradingService` senza cambiare subito il formato dei report gia prodotti.
 
 `GradeActivityExecutionService` espone inoltre `grade_activity.py` dietro la porta `ExecutionService`: i chiamanti passano `activity_path` e `source_path` nei metadati della richiesta e ricevono un `ExecutionResult`, senza dipendere dal formato legacy del report.
+
+`DeterministicAiFeedbackService` fornisce una prima implementazione mockabile di `AiFeedbackService`: genera bozze di feedback a partire dal `GradingResult` senza chiamare provider esterni. Serve per stabilizzare flussi, test e dashboard prima di collegare un adapter AI reale.

--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -111,3 +111,67 @@ Durante la transizione, i report prodotti da `scripts/grade_activity.py` vengono
 `GradeActivityExecutionService` espone inoltre `grade_activity.py` dietro la porta `ExecutionService`: i chiamanti passano `activity_path` e `source_path` nei metadati della richiesta e ricevono un `ExecutionResult`, senza dipendere dal formato legacy del report.
 
 `DeterministicAiFeedbackService` fornisce una prima implementazione mockabile di `AiFeedbackService`: genera bozze di feedback a partire dal `GradingResult` senza chiamare provider esterni. Serve per stabilizzare flussi, test e dashboard prima di collegare un adapter AI reale.
+
+## Provider AI e workflow ChatGPT
+
+`AiFeedbackService` deve restare indipendente dal modo concreto con cui viene prodotto il feedback. Non tutti gli scenari avranno una API key disponibile: una scuola potrebbe avere ChatGPT Edu/Team, Codex, un provider API diverso o nessun servizio AI automatico.
+
+Per questo il confine architetturale resta unico, ma gli adapter possono essere diversi:
+
+- `DeterministicAiFeedbackService`: mock/fallback locale, nessun provider esterno.
+- `OpenAiApiFeedbackService`: chiamata automatica via OpenAI API key.
+- `CodexCliFeedbackService`: chiamata locale via Codex CLI, se autorizzata nel contesto del docente o della scuola.
+- `ChatGptManualFeedbackWorkflow`: flusso manuale assistito per ChatGPT web/app, senza scraping o automazione fragile dell'interfaccia.
+- adapter futuri per Gemini, Groq, OpenRouter, GitLab/GitHub AI o provider interno.
+
+Il workflow manuale ChatGPT non deve essere trattato come una API stabile. Deve invece preparare un pacchetto JSON di scambio controllato dal nostro sistema:
+
+```json
+{
+  "schema_version": "ai_feedback_request.v1",
+  "activity": {
+    "id": "c-base-somma-001",
+    "title": "Somma in C",
+    "instructions": "..."
+  },
+  "student": {
+    "id": "rossi-mario"
+  },
+  "grading": {
+    "status": "graded_failed",
+    "tests_passed": 1,
+    "tests_total": 2,
+    "failed_tests": ["somma_negativi"],
+    "detail": "Output errato"
+  },
+  "policy": {
+    "mode": "bozza_docente",
+    "allow_grade_suggestion": true,
+    "allowed_context": ["instructions", "grading", "teacher_notes"]
+  }
+}
+```
+
+L'output atteso deve essere un altro JSON validabile:
+
+```json
+{
+  "schema_version": "ai_feedback_response.v1",
+  "status": "draft",
+  "summary": "La soluzione gestisce il caso base ma fallisce con numeri negativi.",
+  "suggested_grade": 5,
+  "student_feedback": "Rivedi il caso con addendi negativi e confronta l'output atteso.",
+  "teacher_notes": "Verificare se l'errore dipende da sottrazione invece che somma.",
+  "confidence": "medium"
+}
+```
+
+L'adapter del workflow manuale deve:
+
+1. generare il JSON di richiesta e un prompt breve per ChatGPT;
+2. permettere al docente di incollare la risposta JSON;
+3. validare schema e campi obbligatori;
+4. normalizzare la risposta in `AiFeedbackResult`;
+5. salvare solo bozze non approvate finche il docente non conferma.
+
+Se ChatGPT cambia stile di risposta, si modifica solo l'adapter del workflow manuale o il validatore dello schema, non il resto della dashboard. Lo stesso contratto JSON puo essere riusato anche dagli adapter automatici, che inviano e ricevono dati strutturati senza legarsi al testo libero del provider.

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -217,6 +217,61 @@ class GradeActivityExecutionService:
         return execution_result_from_grade_activity_report(report)
 
 
+class DeterministicAiFeedbackService:
+    """Mockable AI feedback service that never calls external providers."""
+
+    def generate_feedback(self, request: AiFeedbackRequest) -> AiFeedbackResult:
+        """Generate a deterministic teacher-reviewable feedback draft."""
+
+        grading = request.grading
+        if grading.status == "not_run":
+            return AiFeedbackResult(
+                status="draft",
+                summary="Correzione automatica non eseguita: serve verificare il runner o i dati della consegna.",
+                suggested_grade=None,
+                detail=grading.detail,
+            )
+        if grading.status == "error":
+            return AiFeedbackResult(
+                status="draft",
+                summary="La correzione ha incontrato un errore tecnico: controlla il dettaglio prima di dare feedback allo studente.",
+                suggested_grade=None,
+                detail=grading.detail,
+            )
+        if grading.status == "graded_passed":
+            return AiFeedbackResult(
+                status="draft",
+                summary=f"Tutti i test deterministici risultano superati ({grading.tests_passed}/{grading.tests_total}).",
+                suggested_grade=grading.score,
+            )
+
+        failed = ", ".join(grading.failed_tests) if grading.failed_tests else "nessun nome test disponibile"
+        return AiFeedbackResult(
+            status="draft",
+            summary=(
+                f"La consegna non supera tutti i test deterministici "
+                f"({grading.tests_passed}/{grading.tests_total}). Test da rivedere: {failed}."
+            ),
+            suggested_grade=grading.score,
+            detail=grading.detail,
+        )
+
+
+def ai_feedback_dict_from_grading(grading: GradingResult) -> dict[str, Any]:
+    """Return register-compatible AI feedback fields from deterministic feedback."""
+
+    feedback = DeterministicAiFeedbackService().generate_feedback(
+        AiFeedbackRequest(activity_id="", student_id="", grading=grading)
+    )
+    return {
+        "status": feedback.status,
+        "suggested_grade": feedback.suggested_grade,
+        "summary": feedback.summary,
+        "approved_by_teacher": feedback.approved_by_teacher,
+        "detail": feedback.detail,
+    }
+
+
 def execution_result_from_payload(payload: str | dict[str, Any]) -> ExecutionResult:
     """Parse a runner payload into an ExecutionResult."""
 

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -3,13 +3,17 @@
 import pytest
 
 from scripts.thebitlab_technical_services import (
+    AiFeedbackRequest,
     DeterministicGradingService,
+    DeterministicAiFeedbackService,
     ExecutionResult,
     ExecutionRequest,
     GradeActivityExecutionService,
+    GradingResult,
     GradingRequest,
     InvalidServicePayloadError,
     RunnerTestResult,
+    ai_feedback_dict_from_grading,
     execution_result_from_payload,
     grading_dict_from_grade_activity_report,
 )
@@ -305,6 +309,68 @@ def test_grade_activity_execution_service_returns_invalid_payload_for_bad_activi
 
     assert result.status == "invalid_payload"
     assert "Activity non caricata" in result.detail
+
+
+def test_deterministic_ai_feedback_summarizes_passed_grading() -> None:
+    grading = GradingResult(
+        status="graded_passed",
+        passed=True,
+        tests_passed=2,
+        tests_total=2,
+        failed_tests=[],
+        score=10,
+    )
+
+    feedback = DeterministicAiFeedbackService().generate_feedback(
+        AiFeedbackRequest(activity_id="activity", student_id="rossi-mario", grading=grading)
+    )
+
+    assert feedback.status == "draft"
+    assert feedback.summary == "Tutti i test deterministici risultano superati (2/2)."
+    assert feedback.suggested_grade == 10
+    assert feedback.approved_by_teacher is False
+
+
+def test_deterministic_ai_feedback_names_failed_tests() -> None:
+    grading = GradingResult(
+        status="graded_failed",
+        passed=False,
+        tests_passed=1,
+        tests_total=2,
+        failed_tests=["somma_negativi"],
+        score=5,
+        detail="Output errato",
+    )
+
+    feedback = DeterministicAiFeedbackService().generate_feedback(
+        AiFeedbackRequest(activity_id="activity", student_id="rossi-mario", grading=grading)
+    )
+
+    assert feedback.status == "draft"
+    assert "somma_negativi" in feedback.summary
+    assert feedback.suggested_grade == 5
+    assert feedback.detail == "Output errato"
+
+
+def test_ai_feedback_dict_from_grading_is_register_compatible() -> None:
+    grading = GradingResult(
+        status="not_run",
+        passed=None,
+        tests_passed=None,
+        tests_total=None,
+        failed_tests=[],
+        detail="Runner non disponibile",
+    )
+
+    feedback = ai_feedback_dict_from_grading(grading)
+
+    assert feedback == {
+        "status": "draft",
+        "suggested_grade": None,
+        "summary": "Correzione automatica non eseguita: serve verificare il runner o i dati della consegna.",
+        "approved_by_teacher": False,
+        "detail": "Runner non disponibile",
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `DeterministicAiFeedbackService`, implementazione mockabile di `AiFeedbackService` senza chiamate a provider esterni.
- Genera bozze di feedback da `GradingResult` per casi superati, falliti, non eseguiti o con errore tecnico.
- Aggiunge `ai_feedback_dict_from_grading()` per produrre campi compatibili con registri/dashboard.
- Documenta il servizio nella nota architetturale dei servizi tecnici.

## Perche

E' il passo successivo di #289: dopo ExecutionService e GradingService, fissiamo anche un confine testabile per il feedback AI prima di collegare provider reali. Questo permette di sviluppare dashboard e flussi docente/studente senza consumare crediti o introdurre non determinismo nei test.

## Test

- `python -m pytest tests/test_thebitlab_technical_services.py tests/test_track_assignments.py`
- Risultato: `45 passed`

Parte di #289.
