### PR TITLE
Aggiunge contratto JSON per feedback AI

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -174,4 +174,10 @@ L'adapter del workflow manuale deve:
 4. normalizzare la risposta in `AiFeedbackResult`;
 5. salvare solo bozze non approvate finche il docente non conferma.
 
+Nel codice questo contratto e gia rappresentato da helper puri:
+
+- `ai_feedback_request_payload()` costruisce il payload `ai_feedback_request.v1` partendo da `AiFeedbackRequest`, `GradingResult` e contesto consentito;
+- `ai_feedback_request_json()` serializza lo stesso payload con formato stabile, utile per copia/incolla o adapter CLI;
+- `ai_feedback_result_from_payload()` valida il JSON `ai_feedback_response.v1` e lo normalizza in `AiFeedbackResult`.
+
 Se ChatGPT cambia stile di risposta, si modifica solo l'adapter del workflow manuale o il validatore dello schema, non il resto della dashboard. Lo stesso contratto JSON puo essere riusato anche dagli adapter automatici, che inviano e ricevono dati strutturati senza legarsi al testo libero del provider.

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -287,7 +287,7 @@ def ai_feedback_request_payload(
 
     return {
         "schema_version": AI_FEEDBACK_REQUEST_SCHEMA_VERSION,
-        "activity": {"id": request.activity_id, **(activity or {})},
+        "activity": {**(activity or {}), "id": request.activity_id},
         "student": {"id": request.student_id},
         "grading": request.grading.to_dashboard_dict(),
         "context": request.allowed_context,
@@ -329,7 +329,9 @@ def ai_feedback_result_from_payload(payload: str | dict[str, Any]) -> AiFeedback
         raise InvalidServicePayloadError("Payload feedback AI senza status valido.")
 
     suggested_grade = raw.get("suggested_grade")
-    if suggested_grade is not None and not isinstance(suggested_grade, (int, float)):
+    if suggested_grade is not None and (
+        isinstance(suggested_grade, bool) or not isinstance(suggested_grade, (int, float))
+    ):
         raise InvalidServicePayloadError("Payload feedback AI con suggested_grade non valido.")
 
     return AiFeedbackResult(

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -328,6 +328,13 @@ def ai_feedback_result_from_payload(payload: str | dict[str, Any]) -> AiFeedback
     if status not in {"draft", "error"}:
         raise InvalidServicePayloadError("Payload feedback AI senza status valido.")
 
+    summary = _optional_text(raw, "summary")
+    detail = str(raw.get("detail") or "")
+    if status == "draft" and not summary:
+        raise InvalidServicePayloadError("Payload feedback AI draft senza summary.")
+    if status == "error" and not (summary or detail):
+        raise InvalidServicePayloadError("Payload feedback AI error senza dettaglio.")
+
     suggested_grade = raw.get("suggested_grade")
     if suggested_grade is not None and (
         isinstance(suggested_grade, bool) or not isinstance(suggested_grade, (int, float))
@@ -336,13 +343,13 @@ def ai_feedback_result_from_payload(payload: str | dict[str, Any]) -> AiFeedback
 
     return AiFeedbackResult(
         status=status,
-        summary=_optional_text(raw, "summary"),
+        summary=summary,
         suggested_grade=None if suggested_grade is None else float(suggested_grade),
         student_feedback=_optional_text(raw, "student_feedback"),
         teacher_notes=_optional_text(raw, "teacher_notes"),
         confidence=_optional_text(raw, "confidence"),
         approved_by_teacher=False,
-        detail=str(raw.get("detail") or ""),
+        detail=detail,
     )
 
 

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -9,6 +9,8 @@ from typing import Any, Literal, Protocol
 ExecutionStatus = Literal["passed", "failed", "timeout", "runner_unavailable", "invalid_payload"]
 GradingStatus = Literal["graded_passed", "graded_failed", "not_run", "error"]
 AiFeedbackStatus = Literal["not_generated", "draft", "error"]
+AI_FEEDBACK_REQUEST_SCHEMA_VERSION = "ai_feedback_request.v1"
+AI_FEEDBACK_RESPONSE_SCHEMA_VERSION = "ai_feedback_response.v1"
 
 
 class TechnicalServiceError(RuntimeError):
@@ -115,6 +117,9 @@ class AiFeedbackResult:
     status: AiFeedbackStatus
     summary: str | None = None
     suggested_grade: float | None = None
+    student_feedback: str | None = None
+    teacher_notes: str | None = None
+    confidence: str | None = None
     approved_by_teacher: bool = False
     detail: str = ""
 
@@ -272,6 +277,73 @@ def ai_feedback_dict_from_grading(grading: GradingResult) -> dict[str, Any]:
     }
 
 
+def ai_feedback_request_payload(
+    request: AiFeedbackRequest,
+    *,
+    activity: dict[str, Any] | None = None,
+    policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the JSON exchange payload for manual or provider-backed feedback."""
+
+    return {
+        "schema_version": AI_FEEDBACK_REQUEST_SCHEMA_VERSION,
+        "activity": {"id": request.activity_id, **(activity or {})},
+        "student": {"id": request.student_id},
+        "grading": request.grading.to_dashboard_dict(),
+        "context": request.allowed_context,
+        "policy": {
+            "mode": "bozza_docente",
+            "allow_grade_suggestion": True,
+            "allowed_context": sorted(request.allowed_context.keys()),
+            **(policy or {}),
+        },
+    }
+
+
+def ai_feedback_request_json(
+    request: AiFeedbackRequest,
+    *,
+    activity: dict[str, Any] | None = None,
+    policy: dict[str, Any] | None = None,
+) -> str:
+    """Serialize the AI feedback request payload with stable formatting."""
+
+    return json.dumps(
+        ai_feedback_request_payload(request, activity=activity, policy=policy),
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    )
+
+
+def ai_feedback_result_from_payload(payload: str | dict[str, Any]) -> AiFeedbackResult:
+    """Validate a provider/manual JSON response and normalize it to AiFeedbackResult."""
+
+    raw = _decode_ai_feedback_payload(payload)
+    schema_version = raw.get("schema_version")
+    if schema_version != AI_FEEDBACK_RESPONSE_SCHEMA_VERSION:
+        raise InvalidServicePayloadError("Payload feedback AI con schema_version non valido.")
+
+    status = raw.get("status")
+    if status not in {"draft", "error"}:
+        raise InvalidServicePayloadError("Payload feedback AI senza status valido.")
+
+    suggested_grade = raw.get("suggested_grade")
+    if suggested_grade is not None and not isinstance(suggested_grade, (int, float)):
+        raise InvalidServicePayloadError("Payload feedback AI con suggested_grade non valido.")
+
+    return AiFeedbackResult(
+        status=status,
+        summary=_optional_text(raw, "summary"),
+        suggested_grade=None if suggested_grade is None else float(suggested_grade),
+        student_feedback=_optional_text(raw, "student_feedback"),
+        teacher_notes=_optional_text(raw, "teacher_notes"),
+        confidence=_optional_text(raw, "confidence"),
+        approved_by_teacher=False,
+        detail=str(raw.get("detail") or ""),
+    )
+
+
 def execution_result_from_payload(payload: str | dict[str, Any]) -> ExecutionResult:
     """Parse a runner payload into an ExecutionResult."""
 
@@ -389,3 +461,26 @@ def _decode_payload(payload: str | dict[str, Any]) -> dict[str, Any]:
     if not isinstance(decoded, dict):
         raise InvalidServicePayloadError("Payload runner JSON non e un oggetto.")
     return decoded
+
+
+def _decode_ai_feedback_payload(payload: str | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        return payload
+    if not isinstance(payload, str):
+        raise InvalidServicePayloadError("Payload feedback AI JSON non e un oggetto.")
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise InvalidServicePayloadError("Payload feedback AI non e JSON valido.") from exc
+    if not isinstance(decoded, dict):
+        raise InvalidServicePayloadError("Payload feedback AI JSON non e un oggetto.")
+    return decoded
+
+
+def _optional_text(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise InvalidServicePayloadError(f"Payload feedback AI con {key} non valido.")
+    return value

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -329,7 +329,7 @@ def ai_feedback_result_from_payload(payload: str | dict[str, Any]) -> AiFeedback
         raise InvalidServicePayloadError("Payload feedback AI senza status valido.")
 
     summary = _optional_text(raw, "summary")
-    detail = str(raw.get("detail") or "")
+    detail = _optional_text(raw, "detail") or ""
     if status == "draft" and not summary:
         raise InvalidServicePayloadError("Payload feedback AI draft senza summary.")
     if status == "error" and not (summary or detail):

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -432,6 +432,8 @@ def test_ai_feedback_result_from_payload_normalizes_manual_response() -> None:
         "{not-json",
         [],
         {"schema_version": "wrong", "status": "draft"},
+        {"schema_version": "ai_feedback_response.v1", "status": "draft"},
+        {"schema_version": "ai_feedback_response.v1", "status": "error"},
         {"schema_version": "ai_feedback_response.v1", "status": "approved"},
         {
             "schema_version": "ai_feedback_response.v1",

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -393,7 +393,7 @@ def test_ai_feedback_request_payload_uses_stable_manual_contract() -> None:
             grading=grading,
             allowed_context={"teacher_notes": "Controllare il caso con negativi."},
         ),
-        activity={"title": "Somma in C"},
+        activity={"id": "activity-sbagliata", "title": "Somma in C"},
     )
 
     assert payload["schema_version"] == "ai_feedback_request.v1"
@@ -437,6 +437,11 @@ def test_ai_feedback_result_from_payload_normalizes_manual_response() -> None:
             "schema_version": "ai_feedback_response.v1",
             "status": "draft",
             "suggested_grade": "cinque",
+        },
+        {
+            "schema_version": "ai_feedback_response.v1",
+            "status": "draft",
+            "suggested_grade": True,
         },
         {
             "schema_version": "ai_feedback_response.v1",

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -450,6 +450,11 @@ def test_ai_feedback_result_from_payload_normalizes_manual_response() -> None:
             "status": "draft",
             "student_feedback": ["non", "testo"],
         },
+        {
+            "schema_version": "ai_feedback_response.v1",
+            "status": "error",
+            "detail": {"message": "errore"},
+        },
     ],
 )
 def test_ai_feedback_result_from_payload_rejects_invalid_manual_responses(payload) -> None:

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -14,6 +14,8 @@ from scripts.thebitlab_technical_services import (
     InvalidServicePayloadError,
     RunnerTestResult,
     ai_feedback_dict_from_grading,
+    ai_feedback_request_payload,
+    ai_feedback_result_from_payload,
     execution_result_from_payload,
     grading_dict_from_grade_activity_report,
 )
@@ -371,6 +373,81 @@ def test_ai_feedback_dict_from_grading_is_register_compatible() -> None:
         "approved_by_teacher": False,
         "detail": "Runner non disponibile",
     }
+
+
+def test_ai_feedback_request_payload_uses_stable_manual_contract() -> None:
+    grading = GradingResult(
+        status="graded_failed",
+        passed=False,
+        tests_passed=1,
+        tests_total=2,
+        failed_tests=["somma_negativi"],
+        score=5,
+        detail="Output errato",
+    )
+
+    payload = ai_feedback_request_payload(
+        AiFeedbackRequest(
+            activity_id="c-base-somma-001",
+            student_id="rossi-mario",
+            grading=grading,
+            allowed_context={"teacher_notes": "Controllare il caso con negativi."},
+        ),
+        activity={"title": "Somma in C"},
+    )
+
+    assert payload["schema_version"] == "ai_feedback_request.v1"
+    assert payload["activity"] == {"id": "c-base-somma-001", "title": "Somma in C"}
+    assert payload["student"] == {"id": "rossi-mario"}
+    assert payload["grading"]["failed_tests"] == ["somma_negativi"]
+    assert payload["policy"]["mode"] == "bozza_docente"
+    assert payload["policy"]["allowed_context"] == ["teacher_notes"]
+
+
+def test_ai_feedback_result_from_payload_normalizes_manual_response() -> None:
+    feedback = ai_feedback_result_from_payload(
+        {
+            "schema_version": "ai_feedback_response.v1",
+            "status": "draft",
+            "summary": "La soluzione fallisce con numeri negativi.",
+            "suggested_grade": 5,
+            "student_feedback": "Rivedi il caso con addendi negativi.",
+            "teacher_notes": "Errore probabilmente nel parsing del segno.",
+            "confidence": "medium",
+        }
+    )
+
+    assert feedback.status == "draft"
+    assert feedback.summary == "La soluzione fallisce con numeri negativi."
+    assert feedback.suggested_grade == 5.0
+    assert feedback.student_feedback == "Rivedi il caso con addendi negativi."
+    assert feedback.teacher_notes == "Errore probabilmente nel parsing del segno."
+    assert feedback.confidence == "medium"
+    assert feedback.approved_by_teacher is False
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{not-json",
+        [],
+        {"schema_version": "wrong", "status": "draft"},
+        {"schema_version": "ai_feedback_response.v1", "status": "approved"},
+        {
+            "schema_version": "ai_feedback_response.v1",
+            "status": "draft",
+            "suggested_grade": "cinque",
+        },
+        {
+            "schema_version": "ai_feedback_response.v1",
+            "status": "draft",
+            "student_feedback": ["non", "testo"],
+        },
+    ],
+)
+def test_ai_feedback_result_from_payload_rejects_invalid_manual_responses(payload) -> None:
+    with pytest.raises(InvalidServicePayloadError):
+        ai_feedback_result_from_payload(payload)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge il contratto JSON `ai_feedback_request.v1` per preparare richieste di feedback AI manuali o provider-backed.
- Aggiunge la validazione del JSON `ai_feedback_response.v1` e la normalizzazione in `AiFeedbackResult`.
- Estende `AiFeedbackResult` con campi opzionali per feedback studente, note docente e confidenza.
- Aggiorna la documentazione architetturale collegando il workflow ChatGPT/Codex agli helper concreti.

## Perché

Serve un confine stabile prima di collegare OpenAI API, Codex CLI, ChatGPT manuale o altri provider. In questo modo la dashboard e i registri lavorano con lo stesso DTO, mentre gli adapter possono cambiare senza propagare dettagli del provider.

## Verifica

- `python -m pytest tests/test_thebitlab_technical_services.py tests/test_track_assignments.py`
- `git diff --check`
