### PR TITLE
Aggiunge workflow manuale per feedback AI

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -178,6 +178,8 @@ Nel codice questo contratto e gia rappresentato da helper puri:
 
 - `ai_feedback_request_payload()` costruisce il payload `ai_feedback_request.v1` partendo da `AiFeedbackRequest`, `GradingResult` e contesto consentito;
 - `ai_feedback_request_json()` serializza lo stesso payload con formato stabile, utile per copia/incolla o adapter CLI;
+- `manual_ai_feedback_package()` prepara prompt e JSON per workflow manuali con ChatGPT, Codex o provider equivalenti;
+- `manual_ai_feedback_result_from_response()` normalizza la risposta incollata dal provider manuale;
 - `ai_feedback_result_from_payload()` valida il JSON `ai_feedback_response.v1` e lo normalizza in `AiFeedbackResult`.
 
 Se ChatGPT cambia stile di risposta, si modifica solo l'adapter del workflow manuale o il validatore dello schema, non il resto della dashboard. Lo stesso contratto JSON puo essere riusato anche dagli adapter automatici, che inviano e ricevono dati strutturati senza legarsi al testo libero del provider.

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -124,6 +124,14 @@ class AiFeedbackResult:
     detail: str = ""
 
 
+@dataclass(frozen=True)
+class ManualAiFeedbackPackage:
+    """Prompt and JSON payload prepared for manual AI provider workflows."""
+
+    prompt: str
+    request_json: str
+
+
 class ExecutionService(Protocol):
     """Port for Docker/local execution of untrusted student code."""
 
@@ -314,6 +322,32 @@ def ai_feedback_request_json(
         indent=2,
         sort_keys=True,
     )
+
+
+def manual_ai_feedback_package(
+    request: AiFeedbackRequest,
+    *,
+    activity: dict[str, Any] | None = None,
+    policy: dict[str, Any] | None = None,
+) -> ManualAiFeedbackPackage:
+    """Prepare copy/paste material for ChatGPT, Codex, or another manual provider."""
+
+    request_json = ai_feedback_request_json(request, activity=activity, policy=policy)
+    prompt = (
+        "Sei un assistente didattico per la correzione di esercizi di programmazione. "
+        "Leggi il JSON seguente e rispondi solo con JSON valido nello schema "
+        f"{AI_FEEDBACK_RESPONSE_SCHEMA_VERSION}. "
+        "Non approvare il feedback al posto del docente. "
+        "Per status draft includi almeno summary; per status error includi summary o detail.\n\n"
+        f"{request_json}"
+    )
+    return ManualAiFeedbackPackage(prompt=prompt, request_json=request_json)
+
+
+def manual_ai_feedback_result_from_response(payload: str | dict[str, Any]) -> AiFeedbackResult:
+    """Normalize a pasted manual-provider JSON response to AiFeedbackResult."""
+
+    return ai_feedback_result_from_payload(payload)
 
 
 def ai_feedback_result_from_payload(payload: str | dict[str, Any]) -> AiFeedbackResult:

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -333,12 +333,31 @@ def manual_ai_feedback_package(
     """Prepare copy/paste material for ChatGPT, Codex, or another manual provider."""
 
     request_json = ai_feedback_request_json(request, activity=activity, policy=policy)
+    response_template = json.dumps(
+        {
+            "schema_version": AI_FEEDBACK_RESPONSE_SCHEMA_VERSION,
+            "status": "draft",
+            "summary": "Sintesi breve per il docente.",
+            "suggested_grade": None,
+            "student_feedback": "Feedback comprensibile per lo studente.",
+            "teacher_notes": "Note operative per il docente.",
+            "confidence": "medium",
+            "detail": "",
+        },
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    )
     prompt = (
         "Sei un assistente didattico per la correzione di esercizi di programmazione. "
         "Leggi il JSON seguente e rispondi solo con JSON valido nello schema "
         f"{AI_FEEDBACK_RESPONSE_SCHEMA_VERSION}. "
         "Non approvare il feedback al posto del docente. "
-        "Per status draft includi almeno summary; per status error includi summary o detail.\n\n"
+        "Per status draft includi almeno summary; per status error includi summary o detail. "
+        "Non aggiungere testo fuori dal JSON. "
+        "Usa questa forma di risposta:\n\n"
+        f"{response_template}\n\n"
+        "Richiesta da valutare:\n\n"
         f"{request_json}"
     )
     return ManualAiFeedbackPackage(prompt=prompt, request_json=request_json)

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -12,12 +12,15 @@ from scripts.thebitlab_technical_services import (
     GradingResult,
     GradingRequest,
     InvalidServicePayloadError,
+    ManualAiFeedbackPackage,
     RunnerTestResult,
     ai_feedback_dict_from_grading,
     ai_feedback_request_payload,
     ai_feedback_result_from_payload,
     execution_result_from_payload,
     grading_dict_from_grade_activity_report,
+    manual_ai_feedback_package,
+    manual_ai_feedback_result_from_response,
 )
 
 
@@ -460,6 +463,48 @@ def test_ai_feedback_result_from_payload_normalizes_manual_response() -> None:
 def test_ai_feedback_result_from_payload_rejects_invalid_manual_responses(payload) -> None:
     with pytest.raises(InvalidServicePayloadError):
         ai_feedback_result_from_payload(payload)
+
+
+def test_manual_ai_feedback_package_prepares_prompt_and_json() -> None:
+    grading = GradingResult(
+        status="graded_failed",
+        passed=False,
+        tests_passed=1,
+        tests_total=2,
+        failed_tests=["somma_negativi"],
+        score=5,
+    )
+
+    package = manual_ai_feedback_package(
+        AiFeedbackRequest(
+            activity_id="c-base-somma-001",
+            student_id="rossi-mario",
+            grading=grading,
+            allowed_context={"teacher_notes": "Controllare il caso con negativi."},
+        ),
+        activity={"title": "Somma in C"},
+    )
+
+    assert isinstance(package, ManualAiFeedbackPackage)
+    assert "ai_feedback_response.v1" in package.prompt
+    assert "Non approvare il feedback al posto del docente" in package.prompt
+    assert package.request_json in package.prompt
+    assert '"schema_version": "ai_feedback_request.v1"' in package.request_json
+    assert '"id": "c-base-somma-001"' in package.request_json
+
+
+def test_manual_ai_feedback_result_from_response_uses_validated_contract() -> None:
+    feedback = manual_ai_feedback_result_from_response(
+        {
+            "schema_version": "ai_feedback_response.v1",
+            "status": "draft",
+            "summary": "La consegna fallisce un caso limite.",
+        }
+    )
+
+    assert feedback.status == "draft"
+    assert feedback.summary == "La consegna fallisce un caso limite."
+    assert feedback.approved_by_teacher is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -488,6 +488,9 @@ def test_manual_ai_feedback_package_prepares_prompt_and_json() -> None:
     assert isinstance(package, ManualAiFeedbackPackage)
     assert "ai_feedback_response.v1" in package.prompt
     assert "Non approvare il feedback al posto del docente" in package.prompt
+    assert "Non aggiungere testo fuori dal JSON" in package.prompt
+    assert '"student_feedback": "Feedback comprensibile per lo studente."' in package.prompt
+    assert '"schema_version": "ai_feedback_response.v1"' in package.prompt
     assert package.request_json in package.prompt
     assert '"schema_version": "ai_feedback_request.v1"' in package.request_json
     assert '"id": "c-base-somma-001"' in package.request_json


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `ManualAiFeedbackPackage`, un contenitore per prompt e JSON di richiesta.
- Aggiunge `manual_ai_feedback_package()` per preparare materiale copia/incolla verso ChatGPT, Codex o provider manuali equivalenti.
- Aggiunge `manual_ai_feedback_result_from_response()` per normalizzare la risposta incollata usando il contratto `ai_feedback_response.v1` gia validato.
- Aggiorna la documentazione architetturale e i test del servizio tecnico.

## Perché

Serve un primo workflow utilizzabile anche senza API key: il docente puo generare un pacchetto JSON, passarlo manualmente a ChatGPT/Codex, incollare la risposta e ottenere comunque un `AiFeedbackResult` validato e non approvato automaticamente.

## Verifica

- `python -m pytest tests/test_thebitlab_technical_services.py tests/test_track_assignments.py`
- `git diff --check`
