### PR TITLE
Aggiunge CLI per feedback AI manuale

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -182,4 +182,11 @@ Nel codice questo contratto e gia rappresentato da helper puri:
 - `manual_ai_feedback_result_from_response()` normalizza la risposta incollata dal provider manuale;
 - `ai_feedback_result_from_payload()` valida il JSON `ai_feedback_response.v1` e lo normalizza in `AiFeedbackResult`.
 
+Per provarlo senza GUI e senza API key e disponibile anche lo script CLI:
+
+```bash
+python -m scripts.manual_ai_feedback package request.json
+python -m scripts.manual_ai_feedback parse-response response.json
+```
+
 Se ChatGPT cambia stile di risposta, si modifica solo l'adapter del workflow manuale o il validatore dello schema, non il resto della dashboard. Lo stesso contratto JSON puo essere riusato anche dagli adapter automatici, che inviano e ricevono dati strutturati senza legarsi al testo libero del provider.

--- a/scripts/manual_ai_feedback.py
+++ b/scripts/manual_ai_feedback.py
@@ -51,7 +51,7 @@ def request_from_payload(payload: dict[str, Any]) -> tuple[AiFeedbackRequest, di
         failed_tests=_optional_string_list(grading_payload, "failed_tests"),
         score=_optional_number(grading_payload, "score"),
         teacher_grade=_optional_number(grading_payload, "teacher_grade"),
-        detail=str(grading_payload.get("detail") or ""),
+        detail=_optional_text(grading_payload, "detail") or "",
     )
     return (
         AiFeedbackRequest(
@@ -138,6 +138,15 @@ def _optional_mapping(payload: dict[str, Any], key: str) -> dict[str, Any]:
         return {}
     if not isinstance(value, dict):
         raise ValueError(f"request: {key} deve essere un oggetto")
+    return value
+
+
+def _optional_text(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"request: grading.{key} deve essere una stringa o null")
     return value
 
 

--- a/scripts/manual_ai_feedback.py
+++ b/scripts/manual_ai_feedback.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.thebitlab_technical_services import (
+    AiFeedbackRequest,
+    GradingResult,
+    InvalidServicePayloadError,
+    ai_feedback_result_from_payload,
+    manual_ai_feedback_package,
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON object from disk."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{path}: JSON non valido: {error.msg}") from error
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: il contenuto deve essere un oggetto JSON")
+    return payload
+
+
+def request_from_payload(payload: dict[str, Any]) -> tuple[AiFeedbackRequest, dict[str, Any], dict[str, Any]]:
+    """Build an AI feedback request plus optional activity/policy metadata."""
+
+    grading_payload = payload.get("grading")
+    if not isinstance(grading_payload, dict):
+        raise ValueError("request: campo obbligatorio grading mancante o non valido")
+
+    activity_id = _required_text(payload, "activity_id")
+    student_id = _required_text(payload, "student_id")
+    activity = _optional_mapping(payload, "activity")
+    policy = _optional_mapping(payload, "policy")
+    allowed_context = _optional_mapping(payload, "allowed_context")
+
+    grading = GradingResult(
+        status=_required_text(grading_payload, "status"),
+        passed=_optional_bool(grading_payload, "passed"),
+        tests_passed=_optional_int(grading_payload, "tests_passed"),
+        tests_total=_optional_int(grading_payload, "tests_total"),
+        failed_tests=_optional_string_list(grading_payload, "failed_tests"),
+        score=_optional_number(grading_payload, "score"),
+        teacher_grade=_optional_number(grading_payload, "teacher_grade"),
+        detail=str(grading_payload.get("detail") or ""),
+    )
+    return (
+        AiFeedbackRequest(
+            activity_id=activity_id,
+            student_id=student_id,
+            grading=grading,
+            allowed_context=allowed_context,
+        ),
+        activity,
+        policy,
+    )
+
+
+def package_command(args: argparse.Namespace) -> int:
+    request, activity, policy = request_from_payload(load_json(args.request_json))
+    package = manual_ai_feedback_package(request, activity=activity, policy=policy)
+    output = {
+        "prompt": package.prompt,
+        "request_json": package.request_json,
+    }
+    print(json.dumps(output, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def parse_response_command(args: argparse.Namespace) -> int:
+    feedback = ai_feedback_result_from_payload(load_json(args.response_json))
+    output = {
+        "status": feedback.status,
+        "summary": feedback.summary,
+        "suggested_grade": feedback.suggested_grade,
+        "student_feedback": feedback.student_feedback,
+        "teacher_notes": feedback.teacher_notes,
+        "confidence": feedback.confidence,
+        "approved_by_teacher": feedback.approved_by_teacher,
+        "detail": feedback.detail,
+    }
+    print(json.dumps(output, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Workflow manuale per feedback AI TheBitLab.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    package_parser = subparsers.add_parser("package", help="Genera prompt e JSON da copiare nel provider AI.")
+    package_parser.add_argument("request_json", type=Path, help="File JSON con activity_id, student_id e grading.")
+    package_parser.set_defaults(func=package_command)
+
+    parse_parser = subparsers.add_parser("parse-response", help="Valida una risposta JSON del provider AI.")
+    parse_parser.add_argument("response_json", type=Path, help="File JSON restituito/incollato dal provider AI.")
+    parse_parser.set_defaults(func=parse_response_command)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except (InvalidServicePayloadError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+
+def _required_text(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"request: {key} deve essere una stringa non vuota")
+    return value
+
+
+def _optional_mapping(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"request: {key} deve essere un oggetto")
+    return value
+
+
+def _optional_bool(payload: dict[str, Any], key: str) -> bool | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise ValueError(f"request: grading.{key} deve essere boolean o null")
+    return value
+
+
+def _optional_int(payload: dict[str, Any], key: str) -> int | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"request: grading.{key} deve essere intero o null")
+    return value
+
+
+def _optional_number(payload: dict[str, Any], key: str) -> float | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"request: grading.{key} deve essere numerico o null")
+    return float(value)
+
+
+def _optional_string_list(payload: dict[str, Any], key: str) -> list[str]:
+    value = payload.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"request: grading.{key} deve essere una lista di stringhe")
+    return value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/manual_ai_feedback.py
+++ b/scripts/manual_ai_feedback.py
@@ -8,11 +8,14 @@ from typing import Any
 
 from scripts.thebitlab_technical_services import (
     AiFeedbackRequest,
+    GradingStatus,
     GradingResult,
     InvalidServicePayloadError,
     ai_feedback_result_from_payload,
     manual_ai_feedback_package,
 )
+
+ALLOWED_GRADING_STATUSES: set[GradingStatus] = {"graded_passed", "graded_failed", "not_run", "error"}
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -41,7 +44,7 @@ def request_from_payload(payload: dict[str, Any]) -> tuple[AiFeedbackRequest, di
     allowed_context = _optional_mapping(payload, "allowed_context")
 
     grading = GradingResult(
-        status=_required_text(grading_payload, "status"),
+        status=_required_grading_status(grading_payload),
         passed=_optional_bool(grading_payload, "passed"),
         tests_passed=_optional_int(grading_payload, "tests_passed"),
         tests_total=_optional_int(grading_payload, "tests_total"),
@@ -118,6 +121,14 @@ def _required_text(payload: dict[str, Any], key: str) -> str:
     value = payload.get(key)
     if not isinstance(value, str) or not value:
         raise ValueError(f"request: {key} deve essere una stringa non vuota")
+    return value
+
+
+def _required_grading_status(payload: dict[str, Any]) -> GradingStatus:
+    value = _required_text(payload, "status")
+    if value not in ALLOWED_GRADING_STATUSES:
+        allowed = ", ".join(sorted(ALLOWED_GRADING_STATUSES))
+        raise ValueError(f"request: grading.status non valido: {value}. Ammessi: {allowed}")
     return value
 
 

--- a/tests/test_manual_ai_feedback.py
+++ b/tests/test_manual_ai_feedback.py
@@ -71,3 +71,15 @@ def test_package_command_reports_invalid_request(tmp_path, capsys) -> None:
 
     assert exit_code == 1
     assert "grading mancante" in capsys.readouterr().err
+
+
+def test_package_command_rejects_invalid_grading_status(tmp_path, capsys) -> None:
+    payload = request_payload()
+    payload["grading"]["status"] = "approved"
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(["package", str(request_path)])
+
+    assert exit_code == 1
+    assert "grading.status non valido" in capsys.readouterr().err

--- a/tests/test_manual_ai_feedback.py
+++ b/tests/test_manual_ai_feedback.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+
+from scripts import manual_ai_feedback
+
+
+def request_payload() -> dict:
+    return {
+        "activity_id": "c-base-somma-001",
+        "student_id": "rossi-mario",
+        "activity": {"title": "Somma in C"},
+        "allowed_context": {"teacher_notes": "Controllare il caso con negativi."},
+        "grading": {
+            "status": "graded_failed",
+            "passed": False,
+            "tests_passed": 1,
+            "tests_total": 2,
+            "failed_tests": ["somma_negativi"],
+            "score": 5,
+            "detail": "Output errato",
+        },
+    }
+
+
+def test_package_command_prints_prompt_and_request_json(tmp_path, capsys) -> None:
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(request_payload()), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(["package", str(request_path)])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert "Non aggiungere testo fuori dal JSON" in output["prompt"]
+    assert "ai_feedback_response.v1" in output["prompt"]
+    request_json = json.loads(output["request_json"])
+    assert request_json["schema_version"] == "ai_feedback_request.v1"
+    assert request_json["activity"]["id"] == "c-base-somma-001"
+    assert request_json["student"] == {"id": "rossi-mario"}
+
+
+def test_parse_response_command_prints_normalized_feedback(tmp_path, capsys) -> None:
+    response_path = tmp_path / "response.json"
+    response_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ai_feedback_response.v1",
+                "status": "draft",
+                "summary": "La consegna fallisce un caso limite.",
+                "student_feedback": "Rivedi i numeri negativi.",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = manual_ai_feedback.main(["parse-response", str(response_path)])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "draft"
+    assert output["summary"] == "La consegna fallisce un caso limite."
+    assert output["student_feedback"] == "Rivedi i numeri negativi."
+    assert output["approved_by_teacher"] is False
+
+
+def test_package_command_reports_invalid_request(tmp_path, capsys) -> None:
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps({"activity_id": "activity"}), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(["package", str(request_path)])
+
+    assert exit_code == 1
+    assert "grading mancante" in capsys.readouterr().err

--- a/tests/test_manual_ai_feedback.py
+++ b/tests/test_manual_ai_feedback.py
@@ -83,3 +83,15 @@ def test_package_command_rejects_invalid_grading_status(tmp_path, capsys) -> Non
 
     assert exit_code == 1
     assert "grading.status non valido" in capsys.readouterr().err
+
+
+def test_package_command_rejects_invalid_grading_detail(tmp_path, capsys) -> None:
+    payload = request_payload()
+    payload["grading"]["detail"] = {"message": "errore"}
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(["package", str(request_path)])
+
+    assert exit_code == 1
+    assert "grading.detail deve essere una stringa" in capsys.readouterr().err


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `scripts/manual_ai_feedback.py` con due subcomandi:
  - `package` genera prompt e request JSON per ChatGPT/Codex/manual provider;
  - `parse-response` valida e normalizza la risposta JSON del provider.
- Aggiunge test CLI per generazione pacchetto, parsing risposta e richiesta malformata.
- Aggiorna la documentazione architetturale con i comandi minimi.

## Perché

Dopo il contratto JSON e il workflow manuale, serve un modo pratico per provarli senza GUI e senza API key. Questo script permette di validare il flusso copia/incolla end-to-end restando sul contratto `AiFeedbackResult`.

## Verifica

- `python -m pytest tests/test_manual_ai_feedback.py tests/test_thebitlab_technical_services.py tests/test_track_assignments.py`
- `git diff --check`
