### PR TITLE
Genera feedback AI manuale dai registri

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -186,6 +186,7 @@ Per provarlo senza GUI e senza API key e disponibile anche lo script CLI:
 
 ```bash
 python -m scripts.manual_ai_feedback package request.json
+python -m scripts.manual_ai_feedback package-from-register teacher-reports/demo/register.json rossi-mario
 python -m scripts.manual_ai_feedback parse-response response.json
 ```
 

--- a/scripts/manual_ai_feedback.py
+++ b/scripts/manual_ai_feedback.py
@@ -78,7 +78,7 @@ def request_payload_from_register(register: dict[str, Any], student_id: str) -> 
         raise ValueError(f"register: grading mancante o non valido per {student_id}")
 
     activity_id = _required_text(register, "activity_id")
-    resolved_student_id = _required_text(student, "student_id")
+    resolved_student_id = _student_identifier(student)
     return {
         "activity_id": activity_id,
         "student_id": resolved_student_id,
@@ -202,6 +202,13 @@ def _find_student(students: list[Any], student_id: str) -> dict[str, Any]:
         if student.get("student_id") == student_id or student.get("student") == student_id:
             return student
     raise ValueError(f"register: studente non trovato: {student_id}")
+
+
+def _student_identifier(student: dict[str, Any]) -> str:
+    value = student.get("student_id") or student.get("student")
+    if not isinstance(value, str) or not value:
+        raise ValueError("register: student_id o student deve essere una stringa non vuota")
+    return value
 
 
 def _optional_text(payload: dict[str, Any], key: str) -> str | None:

--- a/scripts/manual_ai_feedback.py
+++ b/scripts/manual_ai_feedback.py
@@ -65,8 +65,54 @@ def request_from_payload(payload: dict[str, Any]) -> tuple[AiFeedbackRequest, di
     )
 
 
+def request_payload_from_register(register: dict[str, Any], student_id: str) -> dict[str, Any]:
+    """Build a manual AI feedback request payload from an assignment register row."""
+
+    students = register.get("students")
+    if not isinstance(students, list):
+        raise ValueError("register: campo students mancante o non valido")
+
+    student = _find_student(students, student_id)
+    grading = student.get("grading")
+    if not isinstance(grading, dict):
+        raise ValueError(f"register: grading mancante o non valido per {student_id}")
+
+    activity_id = _required_text(register, "activity_id")
+    resolved_student_id = _required_text(student, "student_id")
+    return {
+        "activity_id": activity_id,
+        "student_id": resolved_student_id,
+        "activity": {
+            "id": activity_id,
+            "title": register.get("title") or activity_id,
+            "kind": register.get("kind"),
+            "class_id": register.get("class_id"),
+            "class_label": register.get("class_label"),
+        },
+        "allowed_context": {
+            "assignment_id": register.get("assignment_id"),
+            "student_status": student.get("status"),
+            "late": student.get("late"),
+            "submission": student.get("submission") if isinstance(student.get("submission"), dict) else {},
+        },
+        "grading": grading,
+    }
+
+
 def package_command(args: argparse.Namespace) -> int:
     request, activity, policy = request_from_payload(load_json(args.request_json))
+    package = manual_ai_feedback_package(request, activity=activity, policy=policy)
+    output = {
+        "prompt": package.prompt,
+        "request_json": package.request_json,
+    }
+    print(json.dumps(output, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def package_from_register_command(args: argparse.Namespace) -> int:
+    payload = request_payload_from_register(load_json(args.register_json), args.student_id)
+    request, activity, policy = request_from_payload(payload)
     package = manual_ai_feedback_package(request, activity=activity, policy=policy)
     output = {
         "prompt": package.prompt,
@@ -99,6 +145,14 @@ def build_parser() -> argparse.ArgumentParser:
     package_parser = subparsers.add_parser("package", help="Genera prompt e JSON da copiare nel provider AI.")
     package_parser.add_argument("request_json", type=Path, help="File JSON con activity_id, student_id e grading.")
     package_parser.set_defaults(func=package_command)
+
+    register_parser = subparsers.add_parser(
+        "package-from-register",
+        help="Genera prompt e JSON partendo da un registro consegne e da uno studente.",
+    )
+    register_parser.add_argument("register_json", type=Path, help="File JSON del registro consegne.")
+    register_parser.add_argument("student_id", help="Studente da estrarre dal registro.")
+    register_parser.set_defaults(func=package_from_register_command)
 
     parse_parser = subparsers.add_parser("parse-response", help="Valida una risposta JSON del provider AI.")
     parse_parser.add_argument("response_json", type=Path, help="File JSON restituito/incollato dal provider AI.")
@@ -139,6 +193,15 @@ def _optional_mapping(payload: dict[str, Any], key: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"request: {key} deve essere un oggetto")
     return value
+
+
+def _find_student(students: list[Any], student_id: str) -> dict[str, Any]:
+    for student in students:
+        if not isinstance(student, dict):
+            continue
+        if student.get("student_id") == student_id or student.get("student") == student_id:
+            return student
+    raise ValueError(f"register: studente non trovato: {student_id}")
 
 
 def _optional_text(payload: dict[str, Any], key: str) -> str | None:

--- a/tests/test_manual_ai_feedback.py
+++ b/tests/test_manual_ai_feedback.py
@@ -68,6 +68,20 @@ def test_package_from_register_command_reports_missing_student(tmp_path, capsys)
     assert "studente non trovato" in capsys.readouterr().err
 
 
+def test_package_from_register_command_accepts_legacy_student_field(tmp_path, capsys) -> None:
+    register = json.loads(REGISTER_FIXTURE.read_text(encoding="utf-8"))
+    del register["students"][0]["student_id"]
+    register_path = tmp_path / "register.json"
+    register_path.write_text(json.dumps(register), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(["package-from-register", str(register_path), "rossi-mario"])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    request_json = json.loads(output["request_json"])
+    assert request_json["student"] == {"id": "rossi-mario"}
+
+
 def test_parse_response_command_prints_normalized_feedback(tmp_path, capsys) -> None:
     response_path = tmp_path / "response.json"
     response_path.write_text(

--- a/tests/test_manual_ai_feedback.py
+++ b/tests/test_manual_ai_feedback.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from scripts import manual_ai_feedback
+
+REGISTER_FIXTURE = Path("tests/fixtures/contracts/assignment_register.json")
 
 
 def request_payload() -> dict:
@@ -37,6 +40,32 @@ def test_package_command_prints_prompt_and_request_json(tmp_path, capsys) -> Non
     assert request_json["schema_version"] == "ai_feedback_request.v1"
     assert request_json["activity"]["id"] == "c-base-somma-001"
     assert request_json["student"] == {"id": "rossi-mario"}
+
+
+def test_package_from_register_command_prints_prompt_for_student(tmp_path, capsys) -> None:
+    register_path = tmp_path / "register.json"
+    register_path.write_text(REGISTER_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(["package-from-register", str(register_path), "rossi-mario"])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    request_json = json.loads(output["request_json"])
+    assert request_json["activity"]["id"] == "python-base-somma-001"
+    assert request_json["activity"]["class_id"] == "3a-tpsi-2026"
+    assert request_json["student"] == {"id": "rossi-mario"}
+    assert request_json["grading"]["status"] == "graded_passed"
+    assert request_json["context"]["student_status"] == "submitted_on_time"
+
+
+def test_package_from_register_command_reports_missing_student(tmp_path, capsys) -> None:
+    register_path = tmp_path / "register.json"
+    register_path.write_text(REGISTER_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(["package-from-register", str(register_path), "missing-student"])
+
+    assert exit_code == 1
+    assert "studente non trovato" in capsys.readouterr().err
 
 
 def test_parse_response_command_prints_normalized_feedback(tmp_path, capsys) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `package-from-register` al CLI manuale AI.
- Permette di generare prompt e request JSON partendo da un registro consegne e da uno `student_id`.
- Estrae activity, classe, stato studente, submission e grading dal registro.
- Aggiunge test sul registro fixture e sul caso studente mancante.
- Aggiorna la documentazione architetturale con il nuovo comando.

## Perché

Il CLI precedente richiedeva un `request.json` scritto a mano. Questo step permette di provare il workflow su registri/consegne reali, quindi e piu vicino all'uso docente senza coinvolgere ancora la GUI o provider esterni.

## Verifica

- `python -m pytest tests/test_manual_ai_feedback.py tests/test_thebitlab_technical_services.py tests/test_track_assignments.py`
- `git diff --check`
