### PR TITLE
Applica feedback AI manuale ai registri

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -188,6 +188,7 @@ Per provarlo senza GUI e senza API key e disponibile anche lo script CLI:
 python -m scripts.manual_ai_feedback package request.json
 python -m scripts.manual_ai_feedback package-from-register teacher-reports/demo/register.json rossi-mario
 python -m scripts.manual_ai_feedback parse-response response.json
+python -m scripts.manual_ai_feedback apply-response teacher-reports/demo/register.json rossi-mario response.json --output updated-register.json
 ```
 
 Se ChatGPT cambia stile di risposta, si modifica solo l'adapter del workflow manuale o il validatore dello schema, non il resto della dashboard. Lo stesso contratto JSON puo essere riusato anche dagli adapter automatici, che inviano e ricevono dati strutturati senza legarsi al testo libero del provider.

--- a/scripts/manual_ai_feedback.py
+++ b/scripts/manual_ai_feedback.py
@@ -22,7 +22,7 @@ def load_json(path: Path) -> dict[str, Any]:
     """Load a JSON object from disk."""
 
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
     except json.JSONDecodeError as error:
         raise ValueError(f"{path}: JSON non valido: {error.msg}") from error
     if not isinstance(payload, dict):

--- a/scripts/manual_ai_feedback.py
+++ b/scripts/manual_ai_feedback.py
@@ -99,6 +99,33 @@ def request_payload_from_register(register: dict[str, Any], student_id: str) -> 
     }
 
 
+def apply_feedback_to_register(
+    register: dict[str, Any],
+    student_id: str,
+    feedback_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a register copy with validated AI feedback assigned to one student."""
+
+    students = register.get("students")
+    if not isinstance(students, list):
+        raise ValueError("register: campo students mancante o non valido")
+
+    feedback = ai_feedback_result_from_payload(feedback_payload)
+    updated = json.loads(json.dumps(register))
+    updated_student = _find_student(updated["students"], student_id)
+    updated_student["ai_feedback"] = {
+        "status": feedback.status,
+        "suggested_grade": feedback.suggested_grade,
+        "summary": feedback.summary,
+        "student_feedback": feedback.student_feedback,
+        "teacher_notes": feedback.teacher_notes,
+        "confidence": feedback.confidence,
+        "approved_by_teacher": False,
+        "detail": feedback.detail,
+    }
+    return updated
+
+
 def package_command(args: argparse.Namespace) -> int:
     request, activity, policy = request_from_payload(load_json(args.request_json))
     package = manual_ai_feedback_package(request, activity=activity, policy=policy)
@@ -119,6 +146,24 @@ def package_from_register_command(args: argparse.Namespace) -> int:
         "request_json": package.request_json,
     }
     print(json.dumps(output, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def apply_response_command(args: argparse.Namespace) -> int:
+    output_path = args.output
+    if output_path.exists() and not args.force:
+        raise ValueError(f"{output_path}: file gia esistente, usa --force per sovrascrivere")
+
+    updated = apply_feedback_to_register(
+        load_json(args.register_json),
+        args.student_id,
+        load_json(args.response_json),
+    )
+    output_path.write_text(
+        json.dumps(updated, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(str(output_path))
     return 0
 
 
@@ -153,6 +198,17 @@ def build_parser() -> argparse.ArgumentParser:
     register_parser.add_argument("register_json", type=Path, help="File JSON del registro consegne.")
     register_parser.add_argument("student_id", help="Studente da estrarre dal registro.")
     register_parser.set_defaults(func=package_from_register_command)
+
+    apply_parser = subparsers.add_parser(
+        "apply-response",
+        help="Applica una risposta AI validata a uno studente del registro, scrivendo un nuovo file.",
+    )
+    apply_parser.add_argument("register_json", type=Path, help="File JSON del registro consegne.")
+    apply_parser.add_argument("student_id", help="Studente da aggiornare nel registro.")
+    apply_parser.add_argument("response_json", type=Path, help="Risposta JSON del provider AI.")
+    apply_parser.add_argument("--output", required=True, type=Path, help="File registro aggiornato da scrivere.")
+    apply_parser.add_argument("--force", action="store_true", help="Sovrascrive --output se esiste gia.")
+    apply_parser.set_defaults(func=apply_response_command)
 
     parse_parser = subparsers.add_parser("parse-response", help="Valida una risposta JSON del provider AI.")
     parse_parser.add_argument("response_json", type=Path, help="File JSON restituito/incollato dal provider AI.")

--- a/tests/test_manual_ai_feedback.py
+++ b/tests/test_manual_ai_feedback.py
@@ -82,6 +82,64 @@ def test_package_from_register_command_accepts_legacy_student_field(tmp_path, ca
     assert request_json["student"] == {"id": "rossi-mario"}
 
 
+def test_apply_response_command_writes_updated_register(tmp_path, capsys) -> None:
+    register_path = tmp_path / "register.json"
+    response_path = tmp_path / "response.json"
+    output_path = tmp_path / "updated-register.json"
+    register_path.write_text(REGISTER_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    response_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ai_feedback_response.v1",
+                "status": "draft",
+                "summary": "La consegna e corretta.",
+                "suggested_grade": 9,
+                "student_feedback": "Buon lavoro.",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = manual_ai_feedback.main(
+        ["apply-response", str(register_path), "rossi-mario", str(response_path), "--output", str(output_path)]
+    )
+
+    assert exit_code == 0
+    assert str(output_path) in capsys.readouterr().out
+    updated = json.loads(output_path.read_text(encoding="utf-8"))
+    feedback = updated["students"][0]["ai_feedback"]
+    assert feedback["status"] == "draft"
+    assert feedback["summary"] == "La consegna e corretta."
+    assert feedback["suggested_grade"] == 9.0
+    assert feedback["student_feedback"] == "Buon lavoro."
+    assert feedback["approved_by_teacher"] is False
+
+
+def test_apply_response_command_refuses_existing_output_without_force(tmp_path, capsys) -> None:
+    register_path = tmp_path / "register.json"
+    response_path = tmp_path / "response.json"
+    output_path = tmp_path / "updated-register.json"
+    register_path.write_text(REGISTER_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    response_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ai_feedback_response.v1",
+                "status": "draft",
+                "summary": "Feedback valido.",
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path.write_text("{}", encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(
+        ["apply-response", str(register_path), "rossi-mario", str(response_path), "--output", str(output_path)]
+    )
+
+    assert exit_code == 1
+    assert "file gia esistente" in capsys.readouterr().err
+
+
 def test_parse_response_command_prints_normalized_feedback(tmp_path, capsys) -> None:
     response_path = tmp_path / "response.json"
     response_path.write_text(

--- a/tests/test_manual_ai_feedback.py
+++ b/tests/test_manual_ai_feedback.py
@@ -140,6 +140,31 @@ def test_apply_response_command_refuses_existing_output_without_force(tmp_path, 
     assert "file gia esistente" in capsys.readouterr().err
 
 
+def test_apply_response_command_accepts_utf8_bom_response(tmp_path) -> None:
+    register_path = tmp_path / "register.json"
+    response_path = tmp_path / "response.json"
+    output_path = tmp_path / "updated-register.json"
+    register_path.write_text(REGISTER_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    response_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ai_feedback_response.v1",
+                "status": "draft",
+                "summary": "Feedback salvato da editor Windows.",
+            }
+        ),
+        encoding="utf-8-sig",
+    )
+
+    exit_code = manual_ai_feedback.main(
+        ["apply-response", str(register_path), "rossi-mario", str(response_path), "--output", str(output_path)]
+    )
+
+    assert exit_code == 0
+    updated = json.loads(output_path.read_text(encoding="utf-8"))
+    assert updated["students"][0]["ai_feedback"]["summary"] == "Feedback salvato da editor Windows."
+
+
 def test_parse_response_command_prints_normalized_feedback(tmp_path, capsys) -> None:
     response_path = tmp_path / "response.json"
     response_path.write_text(


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `apply-response` al CLI manuale AI.
- Valida la risposta `ai_feedback_response.v1` e aggiorna `ai_feedback` dello studente nel registro.
- Scrive su `--output` senza modificare il registro sorgente; `--force` serve per sovrascrivere.
- Mantiene `approved_by_teacher: false`, così il feedback resta una bozza da approvare.
- Aggiunge test per scrittura del registro aggiornato e protezione da overwrite.

## Perché

Completa il workflow manuale end-to-end senza GUI: genera prompt da registro, valida la risposta AI e produce un registro aggiornato con bozza non approvata.

## Verifica

- `python -m pytest tests/test_manual_ai_feedback.py tests/test_thebitlab_technical_services.py tests/test_track_assignments.py`
- `git diff --check`
