### PR TITLE
Documenta workflow manuale feedback AI

### DIFF
--- a/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
+++ b/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
@@ -1,0 +1,146 @@
+# Workflow manuale feedback AI
+
+Questo flusso serve a provare il feedback AI assisted senza integrare ancora una API key o una GUI dedicata.
+
+L'idea e mantenere il docente nel controllo:
+
+- il sistema prepara un prompt e un JSON stabile;
+- il docente copia il contenuto nel provider AI scelto;
+- il docente salva la risposta in un file JSON;
+- il CLI valida la risposta;
+- il CLI produce un nuovo registro con feedback in bozza;
+- il feedback resta non approvato finche il docente non lo conferma.
+
+## Prerequisiti
+
+Serve un registro consegne gia generato, per esempio:
+
+```text
+teacher-reports/demo/register.json
+```
+
+Il registro deve contenere:
+
+- `activity_id`;
+- `students`;
+- per lo studente scelto, una sezione `grading` valida.
+
+## 1. Generare il pacchetto per il provider AI
+
+Partendo da un registro e da uno studente:
+
+```bash
+python -m scripts.manual_ai_feedback package-from-register teacher-reports/demo/register.json rossi-mario > ai-request.json
+```
+
+Il file prodotto contiene:
+
+- `prompt`: testo da copiare nel provider AI manuale;
+- `request_json`: payload strutturato `ai_feedback_request.v1`.
+
+Se invece si parte da un payload gia preparato:
+
+```bash
+python -m scripts.manual_ai_feedback package request.json > ai-request.json
+```
+
+## 2. Copiare il prompt nel provider AI
+
+Apri `ai-request.json`, copia il campo `prompt` e incollalo nel provider scelto, per esempio ChatGPT o Codex usato in modalita manuale.
+
+Il provider deve rispondere con un JSON simile:
+
+```json
+{
+  "schema_version": "ai_feedback_response.v1",
+  "status": "draft",
+  "summary": "La soluzione gestisce il caso base ma fallisce con input negativi.",
+  "suggested_grade": 5,
+  "student_feedback": "Rivedi i test sui numeri negativi e confronta l'output atteso.",
+  "teacher_notes": "Controllare se lo studente confonde somma e sottrazione.",
+  "confidence": "medium"
+}
+```
+
+Salva la risposta in un file, per esempio:
+
+```text
+response.json
+```
+
+Il file puo essere UTF-8 normale o UTF-8 con BOM.
+
+## 3. Validare la risposta
+
+Prima di applicare il feedback al registro, valida il JSON:
+
+```bash
+python -m scripts.manual_ai_feedback parse-response response.json
+```
+
+Se il comando fallisce, la risposta non rispetta il contratto atteso. In quel caso correggi `response.json` o chiedi al provider AI di restituire solo JSON valido nello schema `ai_feedback_response.v1`.
+
+## 4. Applicare la risposta al registro
+
+Quando la risposta e valida:
+
+```bash
+python -m scripts.manual_ai_feedback apply-response teacher-reports/demo/register.json rossi-mario response.json --output teacher-reports/demo/register-with-ai.json
+```
+
+Il comando:
+
+- legge il registro sorgente;
+- valida `response.json`;
+- aggiorna solo lo studente richiesto;
+- scrive un nuovo file indicato da `--output`;
+- non sovrascrive file esistenti senza `--force`.
+
+Il feedback applicato viene salvato come bozza:
+
+```json
+{
+  "status": "draft",
+  "suggested_grade": 5,
+  "summary": "La soluzione gestisce il caso base ma fallisce con input negativi.",
+  "student_feedback": "Rivedi i test sui numeri negativi e confronta l'output atteso.",
+  "teacher_notes": "Controllare se lo studente confonde somma e sottrazione.",
+  "confidence": "medium",
+  "approved_by_teacher": false,
+  "detail": ""
+}
+```
+
+`approved_by_teacher` resta sempre `false` nel workflow manuale: il provider AI non puo approvare feedback o voti al posto del docente.
+
+## 5. Sovrascrivere un output gia esistente
+
+Per evitare modifiche accidentali, il comando rifiuta un file `--output` gia presente.
+
+Usa `--force` solo se vuoi rigenerare esplicitamente lo stesso file:
+
+```bash
+python -m scripts.manual_ai_feedback apply-response teacher-reports/demo/register.json rossi-mario response.json --output teacher-reports/demo/register-with-ai.json --force
+```
+
+## Errori comuni
+
+| Errore | Significato | Come risolvere |
+|---|---|---|
+| `schema_version non valido` | La risposta non usa `ai_feedback_response.v1` | Correggere il campo o rigenerare la risposta |
+| `draft senza summary` | Un feedback in bozza deve avere un riassunto | Aggiungere `summary` |
+| `suggested_grade non valido` | Il voto suggerito non e numerico o `null` | Usare un numero, per esempio `7.5`, oppure `null` |
+| `studente non trovato` | Lo studente non esiste nel registro | Controllare `student_id` o `student` nel registro |
+| `file gia esistente` | `--output` punta a un file presente | Cambiare output o usare `--force` |
+
+## Dove si collega alla GUI
+
+Questo workflow e intenzionalmente CLI-first. La GUI docente potra riusare lo stesso contratto:
+
+1. scegliere registro e studente;
+2. generare il pacchetto manuale;
+3. incollare o importare la risposta AI;
+4. mostrare il feedback come bozza;
+5. far approvare o modificare il feedback al docente.
+
+La stessa forma JSON puo essere usata anche dagli adapter automatici futuri.

--- a/doc/README.md
+++ b/doc/README.md
@@ -29,12 +29,15 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 1. [`ASSIGNMENTS.md`](ASSIGNMENTS.md)
 2. [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md)
 3. [`DATA_MODEL_MVP.md`](DATA_MODEL_MVP.md)
+4. [`MANUAL_AI_FEEDBACK_WORKFLOW.md`](MANUAL_AI_FEEDBACK_WORKFLOW.md)
 
 `ASSIGNMENTS.md` descrive il modello leggero per attivita didattiche, uso dei team GitHub come classi, correzione automatica, sandbox, metriche e roadmap delle prossime PR.
 
 `ACTIVITIES_SCHEMA.md` descrive il primo schema JSON per rappresentare esercizi, compiti, laboratori e verifiche in TheBitLab.
 
 `DATA_MODEL_MVP.md` inventaria i JSON attuali e definisce il modello dati minimo per classi, activity, assegnazioni, consegne, registri, grading e vista studente.
+
+`MANUAL_AI_FEEDBACK_WORKFLOW.md` spiega il flusso manuale completo per generare un pacchetto AI da registro, validare la risposta e applicarla come bozza non approvata.
 
 ## Mappa rapida
 
@@ -49,6 +52,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) | Quando devi creare o validare schede JSON di attivita TheBitLab |
 | [`DATA_MODEL_MVP.md`](DATA_MODEL_MVP.md) | Quando devi lavorare su dati JSON, storage, classi, assegnazioni, registri o compatibilita schema |
 | [`ASSIGNMENT_SUBMISSIONS.md`](ASSIGNMENT_SUBMISSIONS.md) | Quando devi progettare il flusso consegne studenti con GitHub, team classe e repository studente |
+| [`MANUAL_AI_FEEDBACK_WORKFLOW.md`](MANUAL_AI_FEEDBACK_WORKFLOW.md) | Quando devi provare il feedback AI manuale da registro senza API key o GUI dedicata |
 | [`STUDENT_REPOSITORY_TEMPLATE.md`](STUDENT_REPOSITORY_TEMPLATE.md) | Quando devi creare o mantenere il template repository studente |
 | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) | Quando devi correggere in modo deterministico una consegna TheBitLab |
 | [`ASSIGNMENT_SANDBOX.md`](ASSIGNMENT_SANDBOX.md) | Quando devi eseguire il grading in una sandbox Docker |
@@ -67,6 +71,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/create_submission_scaffold.py` | Crea una cartella consegna in un repository studente a partire da una activity JSON | [`STUDENT_REPOSITORY_TEMPLATE.md`](STUDENT_REPOSITORY_TEMPLATE.md) |
 | `scripts/assign_activity.py` | Assegna una activity a uno o piu repository studente usando lo scaffold consegna | [`ASSIGNMENT_SUBMISSIONS.md`](ASSIGNMENT_SUBMISSIONS.md) |
 | `scripts/track_assignments.py` | Genera un registro consegne con scadenza, stato consegna, grading e placeholder AI | [`ASSIGNMENT_SUBMISSIONS.md`](ASSIGNMENT_SUBMISSIONS.md) |
+| `scripts/manual_ai_feedback.py` | Genera pacchetti AI manuali, valida risposte e applica feedback in bozza ai registri | [`MANUAL_AI_FEEDBACK_WORKFLOW.md`](MANUAL_AI_FEEDBACK_WORKFLOW.md) |
 | `scripts/validate_activity.py` | Valida le schede JSON di attivita TheBitLab | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |
 | `scripts/grade_activity.py` | Esegue il runner deterministico del linguaggio richiesto e produce un report, anche via Docker | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) |
 

--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -191,4 +191,6 @@ python -m scripts.manual_ai_feedback parse-response response.json
 python -m scripts.manual_ai_feedback apply-response teacher-reports/demo/register.json rossi-mario response.json --output updated-register.json
 ```
 
+Il flusso operativo completo e descritto in [`../MANUAL_AI_FEEDBACK_WORKFLOW.md`](../MANUAL_AI_FEEDBACK_WORKFLOW.md).
+
 Se ChatGPT cambia stile di risposta, si modifica solo l'adapter del workflow manuale o il validatore dello schema, non il resto della dashboard. Lo stesso contratto JSON puo essere riusato anche dagli adapter automatici, che inviano e ricevono dati strutturati senza legarsi al testo libero del provider.


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `doc/MANUAL_AI_FEEDBACK_WORKFLOW.md` con il flusso operativo completo per feedback AI manuale.
- Collega la nuova guida da `doc/README.md`.
- Rimanda alla guida dalla documentazione dei servizi tecnici.

## Perché

Dopo i comandi `package-from-register`, `parse-response` e `apply-response`, mancava una guida unica per provare il workflow senza GUI e senza API key: registro -> prompt AI -> risposta JSON -> validazione -> registro aggiornato con bozza non approvata.

## Verifica

- `python -m pytest tests/test_manual_ai_feedback.py tests/test_thebitlab_technical_services.py`
- `git diff --check -- doc/MANUAL_AI_FEEDBACK_WORKFLOW.md doc/README.md doc/architecture/technical-services.md`
