### PR TITLE
Aggiunge revisione docente feedback AI manuale

### DIFF
--- a/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
+++ b/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
@@ -123,6 +123,42 @@ Usa `--force` solo se vuoi rigenerare esplicitamente lo stesso file:
 python -m scripts.manual_ai_feedback apply-response teacher-reports/demo/register.json rossi-mario response.json --output teacher-reports/demo/register-with-ai.json --force
 ```
 
+## 6. Approvare o respingere la bozza
+
+Il provider AI puo solo produrre una bozza. La decisione finale resta del docente.
+
+Per approvare una bozza:
+
+```bash
+python -m scripts.manual_ai_feedback review-feedback teacher-reports/demo/register-with-ai.json rossi-mario approve --output teacher-reports/demo/register-approved.json
+```
+
+Il feedback dello studente passa a:
+
+```json
+{
+  "status": "approved",
+  "approved_by_teacher": true
+}
+```
+
+Per respingere una bozza:
+
+```bash
+python -m scripts.manual_ai_feedback review-feedback teacher-reports/demo/register-with-ai.json rossi-mario reject --output teacher-reports/demo/register-rejected.json
+```
+
+Il feedback dello studente passa a:
+
+```json
+{
+  "status": "rejected",
+  "approved_by_teacher": false
+}
+```
+
+Il comando accetta solo feedback con `status: "draft"`. Se il feedback e gia approvato, respinto o non ancora generato, il registro non viene scritto.
+
 ## Errori comuni
 
 | Errore | Significato | Come risolvere |
@@ -132,6 +168,7 @@ python -m scripts.manual_ai_feedback apply-response teacher-reports/demo/registe
 | `suggested_grade non valido` | Il voto suggerito non e numerico o `null` | Usare un numero, per esempio `7.5`, oppure `null` |
 | `studente non trovato` | Lo studente non esiste nel registro | Controllare `student_id` o `student` nel registro |
 | `file gia esistente` | `--output` punta a un file presente | Cambiare output o usare `--force` |
+| `ai_feedback non e una bozza` | Si sta cercando di approvare o respingere un feedback non modificabile | Applicare prima una risposta AI valida o scegliere uno studente con bozza |
 
 ## Dove si collega alla GUI
 

--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -189,6 +189,7 @@ python -m scripts.manual_ai_feedback package request.json
 python -m scripts.manual_ai_feedback package-from-register teacher-reports/demo/register.json rossi-mario
 python -m scripts.manual_ai_feedback parse-response response.json
 python -m scripts.manual_ai_feedback apply-response teacher-reports/demo/register.json rossi-mario response.json --output updated-register.json
+python -m scripts.manual_ai_feedback review-feedback updated-register.json rossi-mario approve --output approved-register.json
 ```
 
 Il flusso operativo completo e descritto in [`../MANUAL_AI_FEEDBACK_WORKFLOW.md`](../MANUAL_AI_FEEDBACK_WORKFLOW.md).

--- a/scripts/manual_ai_feedback.py
+++ b/scripts/manual_ai_feedback.py
@@ -126,6 +126,32 @@ def apply_feedback_to_register(
     return updated
 
 
+def review_feedback_in_register(register: dict[str, Any], student_id: str, decision: str) -> dict[str, Any]:
+    """Return a register copy with a teacher review decision applied to draft AI feedback."""
+
+    if decision not in {"approve", "reject"}:
+        raise ValueError("review: decision deve essere approve o reject")
+    students = register.get("students")
+    if not isinstance(students, list):
+        raise ValueError("register: campo students mancante o non valido")
+
+    updated = json.loads(json.dumps(register))
+    updated_student = _find_student(updated["students"], student_id)
+    feedback = updated_student.get("ai_feedback")
+    if not isinstance(feedback, dict):
+        raise ValueError(f"register: ai_feedback mancante o non valido per {student_id}")
+    if feedback.get("status") != "draft":
+        raise ValueError(f"register: ai_feedback per {student_id} non e una bozza")
+
+    if decision == "approve":
+        feedback["status"] = "approved"
+        feedback["approved_by_teacher"] = True
+    else:
+        feedback["status"] = "rejected"
+        feedback["approved_by_teacher"] = False
+    return updated
+
+
 def package_command(args: argparse.Namespace) -> int:
     request, activity, policy = request_from_payload(load_json(args.request_json))
     package = manual_ai_feedback_package(request, activity=activity, policy=policy)
@@ -159,6 +185,20 @@ def apply_response_command(args: argparse.Namespace) -> int:
         args.student_id,
         load_json(args.response_json),
     )
+    output_path.write_text(
+        json.dumps(updated, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(str(output_path))
+    return 0
+
+
+def review_feedback_command(args: argparse.Namespace) -> int:
+    output_path = args.output
+    if output_path.exists() and not args.force:
+        raise ValueError(f"{output_path}: file gia esistente, usa --force per sovrascrivere")
+
+    updated = review_feedback_in_register(load_json(args.register_json), args.student_id, args.decision)
     output_path.write_text(
         json.dumps(updated, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -209,6 +249,17 @@ def build_parser() -> argparse.ArgumentParser:
     apply_parser.add_argument("--output", required=True, type=Path, help="File registro aggiornato da scrivere.")
     apply_parser.add_argument("--force", action="store_true", help="Sovrascrive --output se esiste gia.")
     apply_parser.set_defaults(func=apply_response_command)
+
+    review_parser = subparsers.add_parser(
+        "review-feedback",
+        help="Approva o respinge una bozza di feedback AI gia applicata al registro.",
+    )
+    review_parser.add_argument("register_json", type=Path, help="File JSON del registro consegne.")
+    review_parser.add_argument("student_id", help="Studente da aggiornare nel registro.")
+    review_parser.add_argument("decision", choices=["approve", "reject"], help="Decisione docente sulla bozza AI.")
+    review_parser.add_argument("--output", required=True, type=Path, help="File registro aggiornato da scrivere.")
+    review_parser.add_argument("--force", action="store_true", help="Sovrascrive --output se esiste gia.")
+    review_parser.set_defaults(func=review_feedback_command)
 
     parse_parser = subparsers.add_parser("parse-response", help="Valida una risposta JSON del provider AI.")
     parse_parser.add_argument("response_json", type=Path, help="File JSON restituito/incollato dal provider AI.")

--- a/tests/test_manual_ai_feedback.py
+++ b/tests/test_manual_ai_feedback.py
@@ -165,6 +165,66 @@ def test_apply_response_command_accepts_utf8_bom_response(tmp_path) -> None:
     assert updated["students"][0]["ai_feedback"]["summary"] == "Feedback salvato da editor Windows."
 
 
+def test_review_feedback_command_approves_draft_feedback(tmp_path) -> None:
+    register = json.loads(REGISTER_FIXTURE.read_text(encoding="utf-8"))
+    register["students"][0]["ai_feedback"] = {
+        "status": "draft",
+        "summary": "Feedback da approvare.",
+        "approved_by_teacher": False,
+    }
+    register_path = tmp_path / "register.json"
+    output_path = tmp_path / "approved-register.json"
+    register_path.write_text(json.dumps(register), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(
+        ["review-feedback", str(register_path), "rossi-mario", "approve", "--output", str(output_path)]
+    )
+
+    assert exit_code == 0
+    updated = json.loads(output_path.read_text(encoding="utf-8"))
+    feedback = updated["students"][0]["ai_feedback"]
+    assert feedback["status"] == "approved"
+    assert feedback["approved_by_teacher"] is True
+    assert feedback["summary"] == "Feedback da approvare."
+
+
+def test_review_feedback_command_rejects_draft_feedback(tmp_path) -> None:
+    register = json.loads(REGISTER_FIXTURE.read_text(encoding="utf-8"))
+    register["students"][0]["ai_feedback"] = {
+        "status": "draft",
+        "summary": "Feedback da respingere.",
+        "approved_by_teacher": False,
+    }
+    register_path = tmp_path / "register.json"
+    output_path = tmp_path / "rejected-register.json"
+    register_path.write_text(json.dumps(register), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(
+        ["review-feedback", str(register_path), "rossi-mario", "reject", "--output", str(output_path)]
+    )
+
+    assert exit_code == 0
+    updated = json.loads(output_path.read_text(encoding="utf-8"))
+    feedback = updated["students"][0]["ai_feedback"]
+    assert feedback["status"] == "rejected"
+    assert feedback["approved_by_teacher"] is False
+    assert feedback["summary"] == "Feedback da respingere."
+
+
+def test_review_feedback_command_requires_draft_feedback(tmp_path, capsys) -> None:
+    register_path = tmp_path / "register.json"
+    output_path = tmp_path / "approved-register.json"
+    register_path.write_text(REGISTER_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(
+        ["review-feedback", str(register_path), "rossi-mario", "approve", "--output", str(output_path)]
+    )
+
+    assert exit_code == 1
+    assert "non e una bozza" in capsys.readouterr().err
+    assert not output_path.exists()
+
+
 def test_parse_response_command_prints_normalized_feedback(tmp_path, capsys) -> None:
     response_path = tmp_path / "response.json"
     response_path.write_text(


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge il comando `review-feedback` al CLI manuale AI.
- Permette al docente di approvare o respingere solo feedback AI in stato `draft`.
- Scrive sempre un nuovo registro via `--output`, con protezione da overwrite e `--force` opzionale.
- Aggiorna la guida operativa e la doc tecnica con il nuovo passaggio.
- Aggiunge test per approvazione, respingimento e rifiuto di feedback non in bozza.

## Perché

Chiude il ciclo docente del workflow manuale: dopo aver applicato una risposta AI come bozza, serve una decisione esplicita del docente prima di considerare quel feedback pubblicabile o utilizzabile.

## Semantica

- `approve` imposta `status: approved` e `approved_by_teacher: true`.
- `reject` imposta `status: rejected` e `approved_by_teacher: false`.
- feedback non `draft` non vengono modificati.

## Verifica

- `python -m pytest tests/test_manual_ai_feedback.py tests/test_thebitlab_technical_services.py tests/test_track_assignments.py`
- `git diff --check`
