### PR TITLE
Chiarisce stato feedback AI nella dashboard

### DIFF
--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -220,6 +220,8 @@ def run_dashboard_js(assertions: str) -> None:
         renderOverviewSummaryCards,
         summaryCounts,
         renderStudentsSummaryCards,
+        aiFeedbackState,
+        aiFeedbackDetails,
         compactStudentsSummaryItems,
         detailedStudentsSummaryItems,
         applyPanelOrder,
@@ -551,6 +553,38 @@ def test_students_summary_cards_include_tooltips() -> None:
         assert.match(html, /title="Numero di studenti che hanno effettuato una consegna\\."/);
         assert.match(html, /title="Numero di studenti con grading o test falliti\\."/);
         assert.equal(tested.summaryTooltip("Etichetta nuova"), "Valore riepilogativo: Etichetta nuova.");
+        """
+    )
+
+
+def test_ai_feedback_helpers_render_teacher_review_states() -> None:
+    run_dashboard_js(
+        """
+        assert.equal(JSON.stringify(tested.aiFeedbackState({ status: "draft" })), JSON.stringify({
+          label: "Bozza AI",
+          kind: "warn",
+          tooltip: "Feedback AI generato ma non ancora approvato dal docente.",
+        }));
+        assert.equal(JSON.stringify(tested.aiFeedbackState({ status: "approved", approved_by_teacher: true })), JSON.stringify({
+          label: "Approvato",
+          kind: "ok",
+          tooltip: "Feedback AI approvato dal docente.",
+        }));
+        assert.equal(JSON.stringify(tested.aiFeedbackState({ status: "rejected" })), JSON.stringify({
+          label: "Respinto",
+          kind: "bad",
+          tooltip: "Feedback AI respinto dal docente.",
+        }));
+
+        const html = tested.aiFeedbackDetails({
+          status: "draft",
+          suggested_grade: 7.5,
+          summary: "Correggere il caso limite.",
+        });
+        assert.match(html, /Bozza AI/);
+        assert.match(html, /Suggerito: 7.5/);
+        assert.match(html, /Correggere il caso limite\\./);
+        assert.match(html, /title="Feedback AI generato ma non ancora approvato dal docente\\."/);
         """
     )
 

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1327,6 +1327,17 @@ th.isResizableColumn:hover {
 .studentName6 { background: #e1f5f7; color: #006c77; }
 .studentName7 { background: #eceff3; color: #3f4854; }
 
+.aiFeedbackCell {
+  max-width: 14rem;
+}
+
+.aiFeedbackSummary {
+  display: block;
+  margin-top: .25rem;
+  color: #56616f;
+  overflow-wrap: anywhere;
+}
+
 .matrixTable {
   min-width: max-content;
 }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -60,6 +60,10 @@ const LEGEND_SECTIONS = {
       ['<button type="button">In ritardo</button>', "Mostra le consegne oltre la scadenza.", "Filtro consegne"],
       ['<button type="button">Test falliti</button>', "Mostra gli studenti con grading o test falliti.", "Filtro consegne"],
       ['<button type="button" class="smallButton">Apri</button>', "Apre la revisione dei file consegnati dallo studente.", "Colonna Azioni"],
+      ['<span class="badge badgeWarn">Bozza AI</span>', "Feedback AI generato ma non ancora approvato dal docente.", "Colonna AI"],
+      ['<span class="badge badgeOk">Approvato</span>', "Feedback AI approvato dal docente.", "Colonna AI"],
+      ['<span class="badge badgeBad">Respinto</span>', "Feedback AI respinto dal docente.", "Colonna AI"],
+      ['<span class="badge badgeMuted">Non generato</span>', "Nessun feedback AI generato per questa consegna.", "Colonna AI"],
     ],
   },
   states: {
@@ -1669,6 +1673,60 @@ function badge(text, kind = "muted") {
   return `<span class="badge ${className}">${escapeHtml(text || "-")}</span>`;
 }
 
+const AI_FEEDBACK_STATES = {
+  not_generated: {
+    label: "Non generato",
+    kind: "muted",
+    tooltip: "Nessun feedback AI e stato ancora generato per questa consegna.",
+  },
+  draft: {
+    label: "Bozza AI",
+    kind: "warn",
+    tooltip: "Feedback AI generato ma non ancora approvato dal docente.",
+  },
+  approved: {
+    label: "Approvato",
+    kind: "ok",
+    tooltip: "Feedback AI approvato dal docente.",
+  },
+  rejected: {
+    label: "Respinto",
+    kind: "bad",
+    tooltip: "Feedback AI respinto dal docente.",
+  },
+  error: {
+    label: "Errore AI",
+    kind: "bad",
+    tooltip: "Il provider AI non ha prodotto un feedback utilizzabile.",
+  },
+};
+
+function aiFeedbackState(ai) {
+  const status = ai?.status || "not_generated";
+  return AI_FEEDBACK_STATES[status] || {
+    label: status,
+    kind: ai?.approved_by_teacher ? "ok" : "muted",
+    tooltip: `Stato feedback AI: ${status}.`,
+  };
+}
+
+function aiFeedbackDetails(ai) {
+  const state = aiFeedbackState(ai);
+  const grade = ai?.suggested_grade == null || String(ai.suggested_grade).trim() === ""
+    ? "Nessun voto AI"
+    : `Suggerito: ${escapeHtml(ai.suggested_grade)}`;
+  const summary = ai?.summary
+    ? `<small class="aiFeedbackSummary">${escapeHtml(ai.summary)}</small>`
+    : "";
+  return `
+    <div class="aiFeedbackCell" title="${escapeHtml(state.tooltip)}">
+      ${badge(state.label, state.kind)}<br>
+      <small>${grade}</small>
+      ${summary}
+    </div>
+  `;
+}
+
 function gradingDetails(grading) {
   const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
   const tests = Array.isArray(grading.tests) ? grading.tests : [];
@@ -1873,8 +1931,7 @@ function renderStudents(students) {
       </td>
       <td><code>${escapeHtml(grading.teacher_grade ?? grading.score ?? "-")}</code></td>
       <td>
-        ${badge(ai.status || "not_generated", ai.approved_by_teacher ? "ok" : "muted")}<br>
-        <small>${ai.suggested_grade ? `Suggerito: ${escapeHtml(ai.suggested_grade)}` : "Nessun voto AI"}</small>
+        ${aiFeedbackDetails(ai)}
       </td>
       <td>
         <button type="button" class="smallButton" data-review-student="${escapeHtml(student.student)}" title="${escapeHtml(reviewTitle)}" ${canReview ? "" : "disabled"}>


### PR DESCRIPTION
﻿## Cosa cambia

- Rende espliciti gli stati del feedback AI nella tabella studenti della dashboard consegne.
- Mostra badge leggibili per `not_generated`, `draft`, `approved`, `rejected` ed `error`.
- Aggiunge tooltip descrittivi e riepilogo compatto del feedback AI quando presente.
- Aggiorna la legenda studenti con gli stati AI.
- Aggiunge test frontend sugli helper di rendering degli stati AI.

## Perché

Dopo il workflow CLI che applica, approva e respinge feedback AI, la GUI deve rendere leggibile la semantica prima di introdurre azioni di modifica. Questa PR resta in sola visualizzazione.

## Verifica

- `python -m pytest tests/test_assignment_dashboard_frontend.py`
- `python -m pytest tests/test_assignment_dashboard_frontend.py tests/test_thebitlab_storage.py tests/test_thebitlab_contracts.py`
- `git diff --check`

Nota: `tests/test_assignment_dashboard_server.py` non esiste nel repository, quindi non e stato eseguito.
