### PR TITLE
Aggiunge demo stati feedback AI

### DIFF
--- a/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
+++ b/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
@@ -181,3 +181,30 @@ Questo workflow e intenzionalmente CLI-first. La GUI docente potra riusare lo st
 5. far approvare o modificare il feedback al docente.
 
 La stessa forma JSON puo essere usata anche dagli adapter automatici futuri.
+
+## Verifica visuale nella dashboard
+
+Per provare la visualizzazione degli stati AI senza chiamare provider esterni, il repository contiene un registro demo:
+
+```text
+teacher-reports/demo/ai-feedback-states.json
+```
+
+Avvia il server locale:
+
+```bash
+python scripts/course_board_server.py
+```
+
+Poi apri `tools/assignment_dashboard.html`, carica il registro `demo/ai-feedback-states.json` e apri la tabella studenti.
+
+La colonna `AI` deve mostrare:
+
+| Studente | Stato atteso | Significato |
+|---|---|---|
+| `rossi-mario` | `Bozza AI` | Feedback generato ma non ancora approvato |
+| `bianchi-luca` | `Approvato` | Feedback controllato e approvato dal docente |
+| `verdi-anna` | `Respinto` | Feedback respinto dal docente |
+| `neri-giulia` | `Non generato` | Nessun feedback AI disponibile |
+
+La legenda della tabella studenti contiene gli stessi badge, cosi la GUI resta coerente anche quando non si conosce il workflow CLI.

--- a/teacher-reports/demo/ai-feedback-states.json
+++ b/teacher-reports/demo/ai-feedback-states.json
@@ -1,0 +1,200 @@
+{
+  "schema_version": "1.0",
+  "id": "register-demo-ai-feedback-states",
+  "assignment_id": "assignment-demo-ai-feedback-states",
+  "activity_id": "demo-ai-feedback-states",
+  "title": "Demo stati feedback AI",
+  "kind": "debug-didattico",
+  "student_support_mode": "feedback-tecnico",
+  "class_id": "demo-ai",
+  "class_label": "Demo AI",
+  "github_team": "team-demo-ai",
+  "assigned_at": "2026-10-20T09:00:00+02:00",
+  "due_at": "2026-10-27T23:59:00+01:00",
+  "students": [
+    {
+      "student": "rossi-mario",
+      "student_id": "rossi-mario",
+      "repo": "TheBitPoets/rossi-mario",
+      "repo_github_url": "https://github.com/TheBitPoets/rossi-mario",
+      "assigned": true,
+      "submitted": true,
+      "status": "submitted_on_time",
+      "late": false,
+      "submission": {
+        "id": "submission-rossi-mario-demo-ai-feedback-states",
+        "assignment_id": "assignment-demo-ai-feedback-states",
+        "activity_id": "demo-ai-feedback-states",
+        "student_id": "rossi-mario",
+        "repo_ref": "TheBitPoets/rossi-mario",
+        "commit": "abc1234",
+        "submitted_at": "2026-10-24T16:35:00+02:00",
+        "status": "submitted_on_time",
+        "late": false,
+        "files": [
+          {
+            "path": "assignments/demo-ai-feedback-states/main.py",
+            "role": "solution"
+          }
+        ]
+      },
+      "grading": {
+        "status": "graded_failed",
+        "passed": false,
+        "tests_passed": 2,
+        "tests_total": 3,
+        "failed_tests": [
+          "caso_zero"
+        ],
+        "score": 6,
+        "teacher_grade": null,
+        "detail": "La soluzione fallisce il caso limite con zero."
+      },
+      "ai_feedback": {
+        "status": "draft",
+        "suggested_grade": 6,
+        "summary": "La soluzione e quasi corretta, ma deve gestire meglio il caso con zero.",
+        "student_feedback": "Rivedi il test sul valore zero e confronta l'output atteso con quello prodotto.",
+        "teacher_notes": "Controllare se lo studente ha gestito solo valori positivi.",
+        "confidence": "medium",
+        "approved_by_teacher": false,
+        "detail": ""
+      }
+    },
+    {
+      "student": "bianchi-luca",
+      "student_id": "bianchi-luca",
+      "repo": "TheBitPoets/bianchi-luca",
+      "repo_github_url": "https://github.com/TheBitPoets/bianchi-luca",
+      "assigned": true,
+      "submitted": true,
+      "status": "submitted_late",
+      "late": true,
+      "submission": {
+        "id": "submission-bianchi-luca-demo-ai-feedback-states",
+        "assignment_id": "assignment-demo-ai-feedback-states",
+        "activity_id": "demo-ai-feedback-states",
+        "student_id": "bianchi-luca",
+        "repo_ref": "TheBitPoets/bianchi-luca",
+        "commit": "def5678",
+        "submitted_at": "2026-10-28T08:10:00+01:00",
+        "status": "submitted_late",
+        "late": true,
+        "files": [
+          {
+            "path": "assignments/demo-ai-feedback-states/main.py",
+            "role": "solution"
+          }
+        ]
+      },
+      "grading": {
+        "status": "graded_passed",
+        "passed": true,
+        "tests_passed": 3,
+        "tests_total": 3,
+        "failed_tests": [],
+        "score": 8,
+        "teacher_grade": 8,
+        "detail": "Tutti i test sono stati superati."
+      },
+      "ai_feedback": {
+        "status": "approved",
+        "suggested_grade": 8,
+        "summary": "Feedback approvato: soluzione corretta, consegnata pero oltre la scadenza.",
+        "student_feedback": "Buon lavoro sui casi di test. Fai attenzione alla gestione dei tempi di consegna.",
+        "teacher_notes": "Feedback controllato e approvato dal docente.",
+        "confidence": "high",
+        "approved_by_teacher": true,
+        "detail": ""
+      }
+    },
+    {
+      "student": "verdi-anna",
+      "student_id": "verdi-anna",
+      "repo": "TheBitPoets/verdi-anna",
+      "repo_github_url": "https://github.com/TheBitPoets/verdi-anna",
+      "assigned": true,
+      "submitted": true,
+      "status": "submitted_on_time",
+      "late": false,
+      "submission": {
+        "id": "submission-verdi-anna-demo-ai-feedback-states",
+        "assignment_id": "assignment-demo-ai-feedback-states",
+        "activity_id": "demo-ai-feedback-states",
+        "student_id": "verdi-anna",
+        "repo_ref": "TheBitPoets/verdi-anna",
+        "commit": "987abcd",
+        "submitted_at": "2026-10-25T11:20:00+02:00",
+        "status": "submitted_on_time",
+        "late": false,
+        "files": [
+          {
+            "path": "assignments/demo-ai-feedback-states/main.py",
+            "role": "solution"
+          }
+        ]
+      },
+      "grading": {
+        "status": "graded_failed",
+        "passed": false,
+        "tests_passed": 1,
+        "tests_total": 3,
+        "failed_tests": [
+          "caso_negativi",
+          "caso_grande"
+        ],
+        "score": 4,
+        "teacher_grade": null,
+        "detail": "La soluzione fallisce due casi limite."
+      },
+      "ai_feedback": {
+        "status": "rejected",
+        "suggested_grade": 4,
+        "summary": "Feedback respinto: la spiegazione generata era troppo generica per essere pubblicata.",
+        "student_feedback": "Rivedi i casi limite segnalati dai test.",
+        "teacher_notes": "Bozza respinta dal docente perche non abbastanza specifica.",
+        "confidence": "low",
+        "approved_by_teacher": false,
+        "detail": ""
+      }
+    },
+    {
+      "student": "neri-giulia",
+      "student_id": "neri-giulia",
+      "repo": "TheBitPoets/neri-giulia",
+      "repo_github_url": "https://github.com/TheBitPoets/neri-giulia",
+      "assigned": true,
+      "submitted": false,
+      "status": "missing",
+      "late": false,
+      "submission": {
+        "id": "",
+        "assignment_id": "assignment-demo-ai-feedback-states",
+        "activity_id": "demo-ai-feedback-states",
+        "student_id": "neri-giulia",
+        "repo_ref": "TheBitPoets/neri-giulia",
+        "commit": null,
+        "submitted_at": null,
+        "status": "missing",
+        "late": false,
+        "files": []
+      },
+      "grading": {
+        "status": "not_run",
+        "passed": null,
+        "tests_passed": null,
+        "tests_total": null,
+        "failed_tests": [],
+        "score": null,
+        "teacher_grade": null,
+        "detail": "Nessuna consegna disponibile."
+      },
+      "ai_feedback": {
+        "status": "not_generated",
+        "suggested_grade": null,
+        "summary": null,
+        "approved_by_teacher": false
+      }
+    }
+  ]
+}

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -169,6 +170,29 @@ def test_read_assignment_report_normalizes_student_booleans(tmp_path) -> None:
     assert student["submission"]["late"] is True
     assert student["grading"]["passed"] is False
     assert student["ai_feedback"]["approved_by_teacher"] is True
+
+
+def test_ai_feedback_demo_report_exposes_teacher_review_states() -> None:
+    root = Path(__file__).resolve().parents[1]
+    storage = JsonAssignmentStorage(root, root / "teacher-reports", [])
+
+    report = storage.read_assignment_report("demo/ai-feedback-states.json")
+    statuses = {student["student"]: student["ai_feedback"]["status"] for student in report["students"]}
+    approvals = {student["student"]: student["ai_feedback"]["approved_by_teacher"] for student in report["students"]}
+
+    assert report["activity_id"] == "demo-ai-feedback-states"
+    assert statuses == {
+        "rossi-mario": "draft",
+        "bianchi-luca": "approved",
+        "verdi-anna": "rejected",
+        "neri-giulia": "not_generated",
+    }
+    assert approvals == {
+        "rossi-mario": False,
+        "bianchi-luca": True,
+        "verdi-anna": False,
+        "neri-giulia": False,
+    }
 
 
 def test_assignment_report_rejects_unsafe_or_invalid_reports(tmp_path) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `teacher-reports/demo/ai-feedback-states.json`, un registro demo versionato per provare gli stati AI nella dashboard.
- Il registro copre `draft`, `approved`, `rejected` e `not_generated`.
- Aggiunge un test storage che verifica che gli stati docente/AI restino leggibili dal registro demo.
- Aggiorna la guida del workflow manuale con una sezione di verifica visuale nella dashboard e riferimento alla legenda studenti.

## Perché

Dopo la PR sulla visualizzazione degli stati AI, serviva un dataset demo stabile per vedere davvero `Bozza AI`, `Approvato`, `Respinto` e `Non generato` senza chiamare provider AI reali.

## Come provarla in GUI

1. Avvia `python scripts/course_board_server.py`.
2. Apri `tools/assignment_dashboard.html`.
3. Carica `demo/ai-feedback-states.json`.
4. Apri la tabella studenti.
5. Controlla la colonna `AI` e la legenda studenti.

## Verifica

- `python -m json.tool teacher-reports/demo/ai-feedback-states.json`
- `python -m pytest tests/test_thebitlab_storage.py tests/test_assignment_dashboard_frontend.py tests/test_thebitlab_contracts.py`
- `git diff --check --cached`
