### PR TITLE
Mostra dettagli feedback AI nella dashboard

### DIFF
--- a/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
+++ b/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
@@ -207,4 +207,6 @@ La colonna `AI` deve mostrare:
 | `verdi-anna` | `Respinto` | Feedback respinto dal docente |
 | `neri-giulia` | `Non generato` | Nessun feedback AI disponibile |
 
+Per gli stati diversi da `Non generato`, nella stessa cella e disponibile il dettaglio espandibile `Dettaglio AI`: mostra il feedback per lo studente, le note docente, l'affidabilita dichiarata e l'azione operativa suggerita al docente. Le azioni restano informative nella GUI: approvazione e respinta sono ancora gestite dal workflow manuale `review-feedback`.
+
 La legenda della tabella studenti contiene gli stessi badge, cosi la GUI resta coerente anche quando non si conosce il workflow CLI.

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -222,6 +222,8 @@ def run_dashboard_js(assertions: str) -> None:
         renderStudentsSummaryCards,
         aiFeedbackState,
         aiFeedbackDetails,
+        aiFeedbackReviewDetails,
+        aiFeedbackTeacherAction,
         compactStudentsSummaryItems,
         detailedStudentsSummaryItems,
         applyPanelOrder,
@@ -580,11 +582,22 @@ def test_ai_feedback_helpers_render_teacher_review_states() -> None:
           status: "draft",
           suggested_grade: 7.5,
           summary: "Correggere il caso limite.",
+          student_feedback: "Rivedi il valore zero.",
+          teacher_notes: "Bozza da controllare.",
+          confidence: "medium",
         });
         assert.match(html, /Bozza AI/);
         assert.match(html, /Suggerito: 7.5/);
         assert.match(html, /Correggere il caso limite\\./);
+        assert.match(html, /Dettaglio AI/);
+        assert.match(html, /Rivedi il valore zero\\./);
+        assert.match(html, /Bozza da controllare\\./);
         assert.match(html, /title="Feedback AI generato ma non ancora approvato dal docente\\."/);
+        assert.equal(tested.aiFeedbackReviewDetails({ status: "not_generated" }), "");
+        assert.match(
+          tested.aiFeedbackTeacherAction({ status: "approved" }),
+          /pronto per la pubblicazione allo studente/,
+        );
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -608,6 +608,7 @@ def test_ai_feedback_details_css_limits_expanded_content_height() -> None:
     assert ".aiFeedbackDetails dl" in css
     assert "max-height: 14rem;" in css
     assert "overflow-y: auto;" in css
+    assert "text-align: justify;" in css
 
 
 def test_modal_summary_helpers_include_tooltips() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -602,6 +602,14 @@ def test_ai_feedback_helpers_render_teacher_review_states() -> None:
     )
 
 
+def test_ai_feedback_details_css_limits_expanded_content_height() -> None:
+    css = open("tools/assignment_dashboard.css", encoding="utf-8").read()
+
+    assert ".aiFeedbackDetails dl" in css
+    assert "max-height: 14rem;" in css
+    assert "overflow-y: auto;" in css
+
+
 def test_modal_summary_helpers_include_tooltips() -> None:
     run_dashboard_js(
         """

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1093,6 +1093,13 @@ label > textarea {
   display: grid;
   gap: .45rem;
   margin: .45rem 0 0;
+  max-height: 14rem;
+  overflow-y: auto;
+  padding: .55rem;
+  border: 1px solid rgba(17, 17, 17, .12);
+  border-radius: 8px;
+  background: #fafafa;
+  scrollbar-gutter: stable;
 }
 
 .aiFeedbackDetails div {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1116,6 +1116,7 @@ label > textarea {
 .aiFeedbackDetails dd {
   margin: .12rem 0 0;
   overflow-wrap: anywhere;
+  text-align: justify;
 }
 
 .status {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1074,6 +1074,43 @@ label > textarea {
   box-shadow: inset 0 -1px 0 var(--line);
 }
 
+.aiFeedbackCell {
+  min-width: 0;
+}
+
+.aiFeedbackDetails {
+  margin-top: .45rem;
+  font-size: .78rem;
+}
+
+.aiFeedbackDetails summary {
+  cursor: pointer;
+  color: #111111;
+  font-weight: 800;
+}
+
+.aiFeedbackDetails dl {
+  display: grid;
+  gap: .45rem;
+  margin: .45rem 0 0;
+}
+
+.aiFeedbackDetails div {
+  min-width: 0;
+}
+
+.aiFeedbackDetails dt {
+  color: var(--muted);
+  font-size: .68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.aiFeedbackDetails dd {
+  margin: .12rem 0 0;
+  overflow-wrap: anywhere;
+}
+
 .status {
   margin: 0;
   color: var(--muted);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1723,7 +1723,51 @@ function aiFeedbackDetails(ai) {
       ${badge(state.label, state.kind)}<br>
       <small>${grade}</small>
       ${summary}
+      ${aiFeedbackReviewDetails(ai)}
     </div>
+  `;
+}
+
+function aiFeedbackText(value) {
+  if (value == null || String(value).trim() === "") return "-";
+  return String(value);
+}
+
+function aiFeedbackTeacherAction(ai) {
+  const status = ai?.status || "not_generated";
+  if (status === "draft") return "Da controllare: approvare o respingere con il workflow manuale.";
+  if (status === "approved") return "Feedback controllato dal docente e pronto per la pubblicazione allo studente.";
+  if (status === "rejected") return "Feedback respinto: rigenerare o riscrivere prima di pubblicarlo.";
+  if (status === "error") return "Errore provider: controllare il dettaglio tecnico prima di riprovare.";
+  return "Nessuna azione disponibile finche il feedback AI non viene generato.";
+}
+
+function aiFeedbackReviewDetails(ai) {
+  const hasFeedback = Boolean(ai && ai.status && ai.status !== "not_generated");
+  if (!hasFeedback) return "";
+  const confidence = aiFeedbackText(ai.confidence);
+  return `
+    <details class="aiFeedbackDetails">
+      <summary>Dettaglio AI</summary>
+      <dl>
+        <div>
+          <dt>Feedback studente</dt>
+          <dd>${escapeHtml(aiFeedbackText(ai.student_feedback))}</dd>
+        </div>
+        <div>
+          <dt>Note docente</dt>
+          <dd>${escapeHtml(aiFeedbackText(ai.teacher_notes))}</dd>
+        </div>
+        <div>
+          <dt>Affidabilita</dt>
+          <dd>${escapeHtml(confidence)}</dd>
+        </div>
+        <div>
+          <dt>Azione docente</dt>
+          <dd>${escapeHtml(aiFeedbackTeacherAction(ai))}</dd>
+        </div>
+      </dl>
+    </details>
   `;
 }
 


### PR DESCRIPTION
## Cosa cambia
- Aggiunge un dettaglio espandibile `Dettaglio AI` nella cella AI della tabella studenti.
- Mostra feedback per lo studente, note docente, affidabilita e azione operativa suggerita.
- Mantiene le azioni solo informative: approvazione e respinta restano nel workflow manuale `review-feedback`.
- Aggiorna test frontend e documentazione di verifica visuale.

## Test
- `python -m pytest tests/test_assignment_dashboard_frontend.py tests/test_thebitlab_storage.py tests/test_thebitlab_contracts.py`
- `git diff --check`

## Come verificare in GUI
1. Avvia `python scripts/course_board_server.py`.
2. Apri `tools/assignment_dashboard.html`.
3. Carica `demo/ai-feedback-states.json`.
4. Apri il modal `Studenti`.
5. Nella colonna `AI`, per Rossi/Bianchi/Verdi apri `Dettaglio AI`.
6. Controlla che Giulia, con `Non generato`, non mostri dettagli espandibili.
