### PR TITLE
Revisiona feedback AI dalla dashboard

### DIFF
--- a/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
+++ b/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
@@ -157,7 +157,22 @@ Il feedback dello studente passa a:
 }
 ```
 
-Il comando accetta solo feedback con `status: "draft"`. Se il feedback e gia approvato, respinto o non ancora generato, il registro non viene scritto.
+Il comando accetta `approve` e `reject` solo su feedback con `status: "draft"`. Se il feedback e gia approvato, respinto o non ancora generato, il registro non viene scritto.
+
+Se la decisione e stata presa per errore, puoi riaprire il feedback come bozza:
+
+```bash
+python -m scripts.manual_ai_feedback review-feedback teacher-reports/demo/register-approved.json rossi-mario reopen --output teacher-reports/demo/register-draft.json
+```
+
+La riapertura e consentita solo da `approved` o `rejected` e riporta:
+
+```json
+{
+  "status": "draft",
+  "approved_by_teacher": false
+}
+```
 
 ## Errori comuni
 
@@ -209,6 +224,6 @@ La colonna `AI` deve mostrare:
 
 Per gli stati diversi da `Non generato`, nella stessa cella e disponibile il dettaglio espandibile `Dettaglio AI`: mostra il feedback per lo studente, le note docente, l'affidabilita dichiarata e l'azione operativa suggerita al docente.
 
-Quando lo stato e `Bozza AI`, il dettaglio mostra anche i bottoni `Approva` e `Respingi`: aggiornano il registro JSON selezionato usando la stessa regola del comando CLI `review-feedback`. Gli stati gia approvati, respinti o non generati non mostrano azioni di review.
+Quando lo stato e `Bozza AI`, il dettaglio mostra anche i bottoni `Approva` e `Respingi`: aggiornano il registro JSON selezionato usando la stessa regola del comando CLI `review-feedback`. Quando lo stato e `Approvato` o `Respinto`, il dettaglio mostra `Riapri bozza`, utile per correggere una decisione docente presa per errore. Gli stati non generati non mostrano azioni di review.
 
 La legenda della tabella studenti contiene gli stessi badge, cosi la GUI resta coerente anche quando non si conosce il workflow CLI.

--- a/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
+++ b/doc/MANUAL_AI_FEEDBACK_WORKFLOW.md
@@ -207,6 +207,8 @@ La colonna `AI` deve mostrare:
 | `verdi-anna` | `Respinto` | Feedback respinto dal docente |
 | `neri-giulia` | `Non generato` | Nessun feedback AI disponibile |
 
-Per gli stati diversi da `Non generato`, nella stessa cella e disponibile il dettaglio espandibile `Dettaglio AI`: mostra il feedback per lo studente, le note docente, l'affidabilita dichiarata e l'azione operativa suggerita al docente. Le azioni restano informative nella GUI: approvazione e respinta sono ancora gestite dal workflow manuale `review-feedback`.
+Per gli stati diversi da `Non generato`, nella stessa cella e disponibile il dettaglio espandibile `Dettaglio AI`: mostra il feedback per lo studente, le note docente, l'affidabilita dichiarata e l'azione operativa suggerita al docente.
+
+Quando lo stato e `Bozza AI`, il dettaglio mostra anche i bottoni `Approva` e `Respingi`: aggiornano il registro JSON selezionato usando la stessa regola del comando CLI `review-feedback`. Gli stati gia approvati, respinti o non generati non mostrano azioni di review.
 
 La legenda della tabella studenti contiene gli stessi badge, cosi la GUI resta coerente anche quando non si conosce il workflow CLI.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -33,7 +33,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts import thebitlab_services, thebitlab_storage, track_assignments
+from scripts import manual_ai_feedback, thebitlab_services, thebitlab_storage, track_assignments
 
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
@@ -220,6 +220,15 @@ def read_assignment_report(name: str) -> dict:
     """Read one assignment tracking report from teacher-reports."""
 
     return assignment_service().read_assignment_report(name)
+
+
+def review_assignment_ai_feedback(name: str, student_id: str, decision: str) -> dict:
+    """Apply a teacher review decision to draft AI feedback in a report."""
+
+    storage = assignment_storage()
+    register = storage.read_assignment_report(name)
+    updated = manual_ai_feedback.review_feedback_in_register(register, student_id, decision)
+    return storage.write_assignment_report(name, updated)
 
 
 def assignment_overview() -> list[dict]:
@@ -1728,6 +1737,20 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 self.write_json({"report": read_assignment_report(payload.get("name", ""))})
             except Exception as error:  # noqa: BLE001
                 self.send_response(404)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/assignment-reports/ai-feedback/review":
+            try:
+                report = review_assignment_ai_feedback(
+                    payload.get("name", ""),
+                    payload.get("student_id", ""),
+                    payload.get("decision", ""),
+                )
+                self.write_json({"ok": True, "report": report})
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
                 self.send_header("Content-Type", "application/json; charset=utf-8")
                 self.end_headers()
                 self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))

--- a/scripts/manual_ai_feedback.py
+++ b/scripts/manual_ai_feedback.py
@@ -129,8 +129,8 @@ def apply_feedback_to_register(
 def review_feedback_in_register(register: dict[str, Any], student_id: str, decision: str) -> dict[str, Any]:
     """Return a register copy with a teacher review decision applied to draft AI feedback."""
 
-    if decision not in {"approve", "reject"}:
-        raise ValueError("review: decision deve essere approve o reject")
+    if decision not in {"approve", "reject", "reopen"}:
+        raise ValueError("review: decision deve essere approve, reject o reopen")
     students = register.get("students")
     if not isinstance(students, list):
         raise ValueError("register: campo students mancante o non valido")
@@ -140,14 +140,20 @@ def review_feedback_in_register(register: dict[str, Any], student_id: str, decis
     feedback = updated_student.get("ai_feedback")
     if not isinstance(feedback, dict):
         raise ValueError(f"register: ai_feedback mancante o non valido per {student_id}")
-    if feedback.get("status") != "draft":
+    current_status = feedback.get("status")
+    if decision in {"approve", "reject"} and current_status != "draft":
         raise ValueError(f"register: ai_feedback per {student_id} non e una bozza")
+    if decision == "reopen" and current_status not in {"approved", "rejected"}:
+        raise ValueError(f"register: ai_feedback per {student_id} non e approvato o respinto")
 
     if decision == "approve":
         feedback["status"] = "approved"
         feedback["approved_by_teacher"] = True
-    else:
+    elif decision == "reject":
         feedback["status"] = "rejected"
+        feedback["approved_by_teacher"] = False
+    else:
+        feedback["status"] = "draft"
         feedback["approved_by_teacher"] = False
     return updated
 
@@ -256,7 +262,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     review_parser.add_argument("register_json", type=Path, help="File JSON del registro consegne.")
     review_parser.add_argument("student_id", help="Studente da aggiornare nel registro.")
-    review_parser.add_argument("decision", choices=["approve", "reject"], help="Decisione docente sulla bozza AI.")
+    review_parser.add_argument("decision", choices=["approve", "reject", "reopen"], help="Decisione docente sul feedback AI.")
     review_parser.add_argument("--output", required=True, type=Path, help="File registro aggiornato da scrivere.")
     review_parser.add_argument("--force", action="store_true", help="Sovrascrive --output se esiste gia.")
     review_parser.set_defaults(func=review_feedback_command)

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -190,6 +190,12 @@ class JsonAssignmentStorage:
             raise ValueError(f"JSON non valido: {path}")
         return payload
 
+    def write_json(self, path: Path, payload: dict[str, Any]) -> None:
+        """Write a JSON object with stable formatting."""
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
     def list_assignment_reports(self) -> list[dict[str, Any]]:
         """List assignment tracking reports stored in teacher-reports."""
 
@@ -233,6 +239,13 @@ class JsonAssignmentStorage:
         payload = self.read_json(path)
         if not isinstance(payload.get("students"), list):
             raise ValueError("Registro consegne non valido: students deve essere una lista.")
+        return normalize_assignment_register(payload)
+
+    def write_assignment_report(self, name: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Persist one assignment tracking report below teacher-reports."""
+
+        path = self.safe_teacher_report_path(name)
+        self.write_json(path, payload)
         return normalize_assignment_register(payload)
 
     def list_activities(self) -> list[dict[str, Any]]:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -161,6 +161,7 @@ def run_dashboard_js(assertions: str) -> None:
       return button;
     }});
 
+    const fetchCalls = [];
     const context = {{
       console,
       setTimeout,
@@ -189,7 +190,10 @@ def run_dashboard_js(assertions: str) -> None:
           return [];
         }},
       }},
-      fetch: async (path) => ({{
+      fetchCalls,
+      fetch: async (path, options = {{}}) => {{
+        fetchCalls.push({{ path, options }});
+        return {{
         ok: true,
         status: 200,
         statusText: "OK",
@@ -197,10 +201,25 @@ def run_dashboard_js(assertions: str) -> None:
           if (path === "/api/assignment-reports") return {{ reports: [] }};
           if (path === "/api/activities") return {{ activities: [] }};
           if (path === "/api/assignment-overview") return {{ rows: [] }};
+          if (path === "/api/assignment-reports/ai-feedback/review") {{
+            return {{
+              ok: true,
+              report: {{
+                students: [
+                  {{
+                    student: "rossi-mario",
+                    student_id: "rossi-mario",
+                    ai_feedback: {{ status: "approved", approved_by_teacher: true }},
+                  }},
+                ],
+              }},
+            }};
+          }}
           return {{}};
         }},
         text: async () => "",
-      }}),
+      }};
+      }},
     }};
     context.globalThis = context;
     context.layout = layout;
@@ -244,6 +263,7 @@ def run_dashboard_js(assertions: str) -> None:
         layout,
         FakeElement,
         localStorage,
+        fetchCalls,
         window,
       }};
     `, context);
@@ -614,6 +634,28 @@ def test_ai_feedback_details_css_limits_expanded_content_height() -> None:
     assert "overflow-y: auto;" in css
     assert "text-align: justify;" in css
     assert ".aiFeedbackActions" in css
+
+
+def test_review_ai_feedback_posts_decision_and_updates_modal_status() -> None:
+    run_dashboard_js(
+        """
+        tested.state.reportName = "demo/ai-feedback-states.json";
+        tested.state.report = { students: [] };
+
+        tested.reviewAiFeedback("rossi-mario", "approve").then(() => {
+          const call = tested.fetchCalls.find((item) => item.path === "/api/assignment-reports/ai-feedback/review");
+          assert.ok(call);
+          assert.equal(call.options.method, "POST");
+          assert.deepEqual(JSON.parse(call.options.body), {
+            name: "demo/ai-feedback-states.json",
+            student_id: "rossi-mario",
+            decision: "approve",
+          });
+          assert.equal(tested.state.report.students[0].ai_feedback.status, "approved");
+          assert.match(tested.els.studentsDialogStatus.textContent, /approvato per rossi-mario/);
+        });
+        """
+    )
 
 
 def test_modal_summary_helpers_include_tooltips() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -617,10 +617,11 @@ def test_ai_feedback_helpers_render_teacher_review_states() -> None:
         assert.match(html, /data-ai-feedback-decision="reject"/);
         assert.match(html, /title="Feedback AI generato ma non ancora approvato dal docente\\."/);
         assert.equal(tested.aiFeedbackReviewDetails({ status: "not_generated" }), "");
-        assert.doesNotMatch(tested.aiFeedbackReviewDetails({ status: "approved" }), /data-ai-feedback-decision/);
+        assert.match(tested.aiFeedbackReviewDetails({ status: "approved" }), /data-ai-feedback-decision="reopen"/);
+        assert.match(tested.aiFeedbackReviewDetails({ status: "rejected" }), /data-ai-feedback-decision="reopen"/);
         assert.match(
           tested.aiFeedbackTeacherAction({ status: "approved" }),
-          /pronto per la pubblicazione allo studente/,
+          /riaprirlo come bozza/,
         );
         """
     )

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -224,6 +224,7 @@ def run_dashboard_js(assertions: str) -> None:
         aiFeedbackDetails,
         aiFeedbackReviewDetails,
         aiFeedbackTeacherAction,
+        reviewAiFeedback,
         compactStudentsSummaryItems,
         detailedStudentsSummaryItems,
         applyPanelOrder,
@@ -592,8 +593,11 @@ def test_ai_feedback_helpers_render_teacher_review_states() -> None:
         assert.match(html, /Dettaglio AI/);
         assert.match(html, /Rivedi il valore zero\\./);
         assert.match(html, /Bozza da controllare\\./);
+        assert.match(html, /data-ai-feedback-decision="approve"/);
+        assert.match(html, /data-ai-feedback-decision="reject"/);
         assert.match(html, /title="Feedback AI generato ma non ancora approvato dal docente\\."/);
         assert.equal(tested.aiFeedbackReviewDetails({ status: "not_generated" }), "");
+        assert.doesNotMatch(tested.aiFeedbackReviewDetails({ status: "approved" }), /data-ai-feedback-decision/);
         assert.match(
           tested.aiFeedbackTeacherAction({ status: "approved" }),
           /pronto per la pubblicazione allo studente/,
@@ -609,6 +613,7 @@ def test_ai_feedback_details_css_limits_expanded_content_height() -> None:
     assert "max-height: 14rem;" in css
     assert "overflow-y: auto;" in css
     assert "text-align: justify;" in css
+    assert ".aiFeedbackActions" in css
 
 
 def test_modal_summary_helpers_include_tooltips() -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -149,7 +149,35 @@ def test_review_assignment_ai_feedback_persists_teacher_decision(tmp_path, monke
     assert saved["students"][0]["ai_feedback"]["approved_by_teacher"] is True
 
 
-def test_review_assignment_ai_feedback_rejects_non_draft_feedback(tmp_path, monkeypatch) -> None:
+def test_review_assignment_ai_feedback_reopens_reviewed_feedback(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+
+    report_dir = tmp_path / "teacher-reports"
+    report_dir.mkdir(parents=True)
+    (report_dir / "activity.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "activity",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "student_id": "rossi-mario",
+                        "ai_feedback": {"status": "approved", "approved_by_teacher": True},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = course_board_server.review_assignment_ai_feedback("activity.json", "rossi-mario", "reopen")
+
+    assert report["students"][0]["ai_feedback"]["status"] == "draft"
+    assert report["students"][0]["ai_feedback"]["approved_by_teacher"] is False
+
+
+def test_review_assignment_ai_feedback_rejects_approve_on_non_draft_feedback(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
 
@@ -172,11 +200,11 @@ def test_review_assignment_ai_feedback_rejects_non_draft_feedback(tmp_path, monk
     )
 
     try:
-        course_board_server.review_assignment_ai_feedback("activity.json", "rossi-mario", "reject")
+        course_board_server.review_assignment_ai_feedback("activity.json", "rossi-mario", "approve")
     except ValueError as error:
         assert "non e una bozza" in str(error)
     else:
-        raise AssertionError("La review deve rifiutare feedback AI non in bozza")
+        raise AssertionError("La review deve rifiutare approve su feedback AI non in bozza")
 
 
 def test_ai_secret_status_reports_paths_and_configured_keys_without_values(tmp_path, monkeypatch) -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -113,6 +113,72 @@ def test_list_assignment_reports_counts_late_only_for_submitted_students(tmp_pat
     assert reports[0]["late"] == 1
 
 
+def test_review_assignment_ai_feedback_persists_teacher_decision(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+
+    report_dir = tmp_path / "teacher-reports" / "demo"
+    report_dir.mkdir(parents=True)
+    report_path = report_dir / "activity.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "activity_id": "activity",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "student_id": "rossi-mario",
+                        "ai_feedback": {
+                            "status": "draft",
+                            "summary": "Bozza",
+                            "approved_by_teacher": False,
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = course_board_server.review_assignment_ai_feedback("demo/activity.json", "rossi-mario", "approve")
+    saved = json.loads(report_path.read_text(encoding="utf-8"))
+
+    assert report["students"][0]["ai_feedback"]["status"] == "approved"
+    assert report["students"][0]["ai_feedback"]["approved_by_teacher"] is True
+    assert saved["students"][0]["ai_feedback"]["status"] == "approved"
+    assert saved["students"][0]["ai_feedback"]["approved_by_teacher"] is True
+
+
+def test_review_assignment_ai_feedback_rejects_non_draft_feedback(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+
+    report_dir = tmp_path / "teacher-reports"
+    report_dir.mkdir(parents=True)
+    (report_dir / "activity.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "activity",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "student_id": "rossi-mario",
+                        "ai_feedback": {"status": "approved", "approved_by_teacher": True},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        course_board_server.review_assignment_ai_feedback("activity.json", "rossi-mario", "reject")
+    except ValueError as error:
+        assert "non e una bozza" in str(error)
+    else:
+        raise AssertionError("La review deve rifiutare feedback AI non in bozza")
+
+
 def test_ai_secret_status_reports_paths_and_configured_keys_without_values(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "AI_SECRET_PATH", tmp_path / ".secrets" / "ai.secret")

--- a/tests/test_manual_ai_feedback.py
+++ b/tests/test_manual_ai_feedback.py
@@ -211,6 +211,29 @@ def test_review_feedback_command_rejects_draft_feedback(tmp_path) -> None:
     assert feedback["summary"] == "Feedback da respingere."
 
 
+def test_review_feedback_command_reopens_reviewed_feedback(tmp_path) -> None:
+    register = json.loads(REGISTER_FIXTURE.read_text(encoding="utf-8"))
+    register["students"][0]["ai_feedback"] = {
+        "status": "approved",
+        "summary": "Feedback da riaprire.",
+        "approved_by_teacher": True,
+    }
+    register_path = tmp_path / "register.json"
+    output_path = tmp_path / "draft-register.json"
+    register_path.write_text(json.dumps(register), encoding="utf-8")
+
+    exit_code = manual_ai_feedback.main(
+        ["review-feedback", str(register_path), "rossi-mario", "reopen", "--output", str(output_path)]
+    )
+
+    assert exit_code == 0
+    updated = json.loads(output_path.read_text(encoding="utf-8"))
+    feedback = updated["students"][0]["ai_feedback"]
+    assert feedback["status"] == "draft"
+    assert feedback["approved_by_teacher"] is False
+    assert feedback["summary"] == "Feedback da riaprire."
+
+
 def test_review_feedback_command_requires_draft_feedback(tmp_path, capsys) -> None:
     register_path = tmp_path / "register.json"
     output_path = tmp_path / "approved-register.json"

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1119,6 +1119,13 @@ label > textarea {
   text-align: justify;
 }
 
+.aiFeedbackActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem;
+  margin-top: .55rem;
+}
+
 .status {
   margin: 0;
   color: var(--muted);

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1179,6 +1179,10 @@ label > textarea {
   padding: .85rem 1rem;
 }
 
+.studentsDialogStatus {
+  padding: 0 1rem .75rem;
+}
+
 .coverageDialogSummary,
 .overviewDialogSummary {
   padding: .85rem 1rem;

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -305,6 +305,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
     <div id="studentsDialogSummary" class="studentsSummary studentsDialogSummary" aria-live="polite">
       <p class="status">Carica un registro per vedere il riepilogo studenti.</p>
     </div>
+    <p id="studentsDialogStatus" class="status studentsDialogStatus" aria-live="polite"></p>
     <div class="tableWrap studentsDialogTable">
       <table id="studentsTable" class="resizableTable">
         <thead>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1741,8 +1741,8 @@ function aiFeedbackText(value) {
 function aiFeedbackTeacherAction(ai) {
   const status = ai?.status || "not_generated";
   if (status === "draft") return "Da controllare: approvare o respingere con il workflow manuale.";
-  if (status === "approved") return "Feedback controllato dal docente e pronto per la pubblicazione allo studente.";
-  if (status === "rejected") return "Feedback respinto: rigenerare o riscrivere prima di pubblicarlo.";
+  if (status === "approved") return "Feedback controllato dal docente. Puoi riaprirlo come bozza se devi cambiare decisione.";
+  if (status === "rejected") return "Feedback respinto. Puoi riaprirlo come bozza se vuoi rivederlo.";
   if (status === "error") return "Errore provider: controllare il dettaglio tecnico prima di riprovare.";
   return "Nessuna azione disponibile finche il feedback AI non viene generato.";
 }
@@ -1752,6 +1752,7 @@ function aiFeedbackReviewDetails(ai) {
   if (!hasFeedback) return "";
   const confidence = aiFeedbackText(ai.confidence);
   const canReview = ai.status === "draft";
+  const canReopen = ai.status === "approved" || ai.status === "rejected";
   return `
     <details class="aiFeedbackDetails">
       <summary>Dettaglio AI</summary>
@@ -1777,6 +1778,11 @@ function aiFeedbackReviewDetails(ai) {
         <div class="aiFeedbackActions">
           <button type="button" class="smallButton" data-ai-feedback-decision="approve">Approva</button>
           <button type="button" class="smallButton" data-ai-feedback-decision="reject">Respingi</button>
+        </div>
+      ` : ""}
+      ${canReopen ? `
+        <div class="aiFeedbackActions">
+          <button type="button" class="smallButton" data-ai-feedback-decision="reopen">Riapri bozza</button>
         </div>
       ` : ""}
     </details>
@@ -2010,7 +2016,11 @@ async function reviewAiFeedback(studentId, decision) {
     setStudentsDialogStatus(message);
     return;
   }
-  const label = decision === "approve" ? "approvazione" : "respinta";
+  const label = {
+    approve: "approvazione",
+    reject: "respinta",
+    reopen: "riapertura bozza",
+  }[decision] || "revisione";
   const progressMessage = `Salvataggio ${label} feedback AI per ${studentId}...`;
   setStatus(progressMessage);
   setStudentsDialogStatus(progressMessage);
@@ -2024,7 +2034,12 @@ async function reviewAiFeedback(studentId, decision) {
   });
   state.report = payload.report;
   renderDashboard();
-  const doneMessage = `Feedback AI ${decision === "approve" ? "approvato" : "respinto"} per ${studentId}.`;
+  const outcome = {
+    approve: "approvato",
+    reject: "respinto",
+    reopen: "riaperto come bozza",
+  }[decision] || "revisionato";
+  const doneMessage = `Feedback AI ${outcome} per ${studentId}.`;
   setStatus(doneMessage);
   setStudentsDialogStatus(doneMessage);
 }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -154,6 +154,7 @@ const els = {
   studentsCloseBtn: document.querySelector("#studentsCloseBtn"),
   studentsTable: document.querySelector("#studentsTable"),
   studentsBody: document.querySelector("#studentsBody"),
+  studentsDialogStatus: document.querySelector("#studentsDialogStatus"),
   reviewDialog: document.querySelector("#reviewDialog"),
   reviewBreadcrumb: document.querySelector("#reviewBreadcrumb"),
   reviewPrevBtn: document.querySelector("#reviewPrevBtn"),
@@ -202,6 +203,10 @@ async function api(path, options = {}) {
 
 function setStatus(message) {
   els.status.textContent = message;
+}
+
+function setStudentsDialogStatus(message) {
+  if (els.studentsDialogStatus) els.studentsDialogStatus.textContent = message;
 }
 
 function escapeHtml(value) {
@@ -2000,11 +2005,15 @@ function renderStudents(students) {
 
 async function reviewAiFeedback(studentId, decision) {
   if (!state.reportName) {
-    setStatus("Carica un registro prima di revisionare il feedback AI.");
+    const message = "Carica un registro prima di revisionare il feedback AI.";
+    setStatus(message);
+    setStudentsDialogStatus(message);
     return;
   }
   const label = decision === "approve" ? "approvazione" : "respinta";
-  setStatus(`Salvataggio ${label} feedback AI per ${studentId}...`);
+  const progressMessage = `Salvataggio ${label} feedback AI per ${studentId}...`;
+  setStatus(progressMessage);
+  setStudentsDialogStatus(progressMessage);
   const payload = await api("/api/assignment-reports/ai-feedback/review", {
     method: "POST",
     body: JSON.stringify({
@@ -2015,7 +2024,9 @@ async function reviewAiFeedback(studentId, decision) {
   });
   state.report = payload.report;
   renderDashboard();
-  setStatus(`Feedback AI ${decision === "approve" ? "approvato" : "respinto"} per ${studentId}.`);
+  const doneMessage = `Feedback AI ${decision === "approve" ? "approvato" : "respinto"} per ${studentId}.`;
+  setStatus(doneMessage);
+  setStudentsDialogStatus(doneMessage);
 }
 
 function submissionFiles(student) {
@@ -2420,12 +2431,16 @@ els.overviewMatrixBody.addEventListener("click", async (event) => {
 els.studentsBody.addEventListener("click", (event) => {
   const aiButton = event.target.closest("[data-ai-feedback-decision]");
   if (aiButton && !aiButton.disabled) {
+    event.preventDefault();
+    event.stopPropagation();
     const container = aiButton.closest("[data-ai-feedback-student]");
     if (!container?.dataset.aiFeedbackStudent) return;
     aiButton.disabled = true;
     reviewAiFeedback(container.dataset.aiFeedbackStudent, aiButton.dataset.aiFeedbackDecision).catch((error) => {
       aiButton.disabled = false;
-      setStatus(`Errore feedback AI: ${error.message}`);
+      const message = `Errore feedback AI: ${error.message}`;
+      setStatus(message);
+      setStudentsDialogStatus(message);
     });
     return;
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1746,6 +1746,7 @@ function aiFeedbackReviewDetails(ai) {
   const hasFeedback = Boolean(ai && ai.status && ai.status !== "not_generated");
   if (!hasFeedback) return "";
   const confidence = aiFeedbackText(ai.confidence);
+  const canReview = ai.status === "draft";
   return `
     <details class="aiFeedbackDetails">
       <summary>Dettaglio AI</summary>
@@ -1767,6 +1768,12 @@ function aiFeedbackReviewDetails(ai) {
           <dd>${escapeHtml(aiFeedbackTeacherAction(ai))}</dd>
         </div>
       </dl>
+      ${canReview ? `
+        <div class="aiFeedbackActions">
+          <button type="button" class="smallButton" data-ai-feedback-decision="approve">Approva</button>
+          <button type="button" class="smallButton" data-ai-feedback-decision="reject">Respingi</button>
+        </div>
+      ` : ""}
     </details>
   `;
 }
@@ -1975,7 +1982,9 @@ function renderStudents(students) {
       </td>
       <td><code>${escapeHtml(grading.teacher_grade ?? grading.score ?? "-")}</code></td>
       <td>
-        ${aiFeedbackDetails(ai)}
+        <div data-ai-feedback-student="${escapeHtml(student.student_id || student.student)}">
+          ${aiFeedbackDetails(ai)}
+        </div>
       </td>
       <td>
         <button type="button" class="smallButton" data-review-student="${escapeHtml(student.student)}" title="${escapeHtml(reviewTitle)}" ${canReview ? "" : "disabled"}>
@@ -1987,6 +1996,26 @@ function renderStudents(students) {
     els.studentsBody.append(row);
   }
   setupResizableTable(els.studentsTable, "students");
+}
+
+async function reviewAiFeedback(studentId, decision) {
+  if (!state.reportName) {
+    setStatus("Carica un registro prima di revisionare il feedback AI.");
+    return;
+  }
+  const label = decision === "approve" ? "approvazione" : "respinta";
+  setStatus(`Salvataggio ${label} feedback AI per ${studentId}...`);
+  const payload = await api("/api/assignment-reports/ai-feedback/review", {
+    method: "POST",
+    body: JSON.stringify({
+      name: state.reportName,
+      student_id: studentId,
+      decision,
+    }),
+  });
+  state.report = payload.report;
+  renderDashboard();
+  setStatus(`Feedback AI ${decision === "approve" ? "approvato" : "respinto"} per ${studentId}.`);
 }
 
 function submissionFiles(student) {
@@ -2389,6 +2418,17 @@ els.overviewMatrixBody.addEventListener("click", async (event) => {
   }
 });
 els.studentsBody.addEventListener("click", (event) => {
+  const aiButton = event.target.closest("[data-ai-feedback-decision]");
+  if (aiButton && !aiButton.disabled) {
+    const container = aiButton.closest("[data-ai-feedback-student]");
+    if (!container?.dataset.aiFeedbackStudent) return;
+    aiButton.disabled = true;
+    reviewAiFeedback(container.dataset.aiFeedbackStudent, aiButton.dataset.aiFeedbackDecision).catch((error) => {
+      aiButton.disabled = false;
+      setStatus(`Errore feedback AI: ${error.message}`);
+    });
+    return;
+  }
   const button = event.target.closest("[data-review-student]");
   if (!button || button.disabled) return;
   openSubmission(button.dataset.reviewStudent, "", "students");


### PR DESCRIPTION
## Cosa cambia
- Aggiunge l'endpoint `POST /api/assignment-reports/ai-feedback/review` per approvare o respingere bozze AI nel registro selezionato.
- Riusa la stessa regola del comando CLI `review-feedback`: solo i feedback in stato `draft` sono modificabili.
- Aggiunge i bottoni `Approva` e `Respingi` nel dettaglio AI del modal studenti.
- Dopo il salvataggio la dashboard aggiorna il registro in memoria e rerenderizza la tabella.
- Aggiorna documentazione e test backend/frontend.

## Test
- `python -m pytest tests/test_course_board_server.py tests/test_assignment_dashboard_frontend.py tests/test_manual_ai_feedback.py tests/test_thebitlab_storage.py`
- `git diff --check HEAD~1..HEAD`

## Come verificare in GUI
1. Avvia `python scripts/course_board_server.py`.
2. Apri `tools/assignment_dashboard.html`.
3. Carica `demo/ai-feedback-states.json`.
4. Apri il modal `Studenti`.
5. Su `rossi-mario`, apri `Dettaglio AI`: devono comparire `Approva` e `Respingi`.
6. Clicca `Approva`: lo stato deve diventare `Approvato` e i bottoni devono sparire.
7. Ricarica lo stesso registro: lo stato deve restare persistito nel JSON.
8. Su studenti gia `Approvato`, `Respinto` o `Non generato`, non devono comparire bottoni di review.

Nota: questa prova modifica il file demo caricato. Per ripetere il test partendo da `Bozza AI`, ripristina il registro demo da git o usa una copia temporanea.
