### PR TITLE
Aggiunge vista studente MVP

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -30,6 +30,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 2. [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md)
 3. [`DATA_MODEL_MVP.md`](DATA_MODEL_MVP.md)
 4. [`MANUAL_AI_FEEDBACK_WORKFLOW.md`](MANUAL_AI_FEEDBACK_WORKFLOW.md)
+5. [`STUDENT_DASHBOARD.md`](STUDENT_DASHBOARD.md)
 
 `ASSIGNMENTS.md` descrive il modello leggero per attivita didattiche, uso dei team GitHub come classi, correzione automatica, sandbox, metriche e roadmap delle prossime PR.
 
@@ -38,6 +39,8 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 `DATA_MODEL_MVP.md` inventaria i JSON attuali e definisce il modello dati minimo per classi, activity, assegnazioni, consegne, registri, grading e vista studente.
 
 `MANUAL_AI_FEEDBACK_WORKFLOW.md` spiega il flusso manuale completo per generare un pacchetto AI da registro, validare la risposta e applicarla come bozza non approvata.
+
+`STUDENT_DASHBOARD.md` spiega la prima vista studente MVP per vedere consegne, grading e solo feedback approvato dal docente.
 
 ## Mappa rapida
 
@@ -53,6 +56,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | [`DATA_MODEL_MVP.md`](DATA_MODEL_MVP.md) | Quando devi lavorare su dati JSON, storage, classi, assegnazioni, registri o compatibilita schema |
 | [`ASSIGNMENT_SUBMISSIONS.md`](ASSIGNMENT_SUBMISSIONS.md) | Quando devi progettare il flusso consegne studenti con GitHub, team classe e repository studente |
 | [`MANUAL_AI_FEEDBACK_WORKFLOW.md`](MANUAL_AI_FEEDBACK_WORKFLOW.md) | Quando devi provare il feedback AI manuale da registro senza API key o GUI dedicata |
+| [`STUDENT_DASHBOARD.md`](STUDENT_DASHBOARD.md) | Quando devi provare la vista studente minima su consegne, grading e feedback approvato |
 | [`STUDENT_REPOSITORY_TEMPLATE.md`](STUDENT_REPOSITORY_TEMPLATE.md) | Quando devi creare o mantenere il template repository studente |
 | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) | Quando devi correggere in modo deterministico una consegna TheBitLab |
 | [`ASSIGNMENT_SANDBOX.md`](ASSIGNMENT_SANDBOX.md) | Quando devi eseguire il grading in una sandbox Docker |
@@ -90,6 +94,7 @@ Poi usa:
 | `tools/course_board.html` | Progettare percorsi, UDA e cornici didattiche |
 | `tools/school_calendar.html` | Gestire calendario scolastico, orari e Gantt |
 | `tools/assignment_dashboard.html` | Visualizzare registri consegne docente da `teacher-reports/**/*.json` |
+| `tools/student_dashboard.html` | Vista studente MVP con consegne, grading e feedback approvato |
 
 ## Test e controlli automatici
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -209,6 +209,7 @@ Questa fase serve a togliere al docente la gestione manuale di file e repository
    - sincronizzazione studenti;
    - studenti nuovi, rimossi o non riconosciuti;
    - stato collegamento GitHub.
+   - usare GitHub Team o roster locale come fonte autorevole per la lista studenti, sostituendo i fallback MVP derivati dai registri.
 7. Aggiungere una pagina creazione e modifica activity:
    - creazione da GUI;
    - modifica activity;

--- a/doc/STUDENT_DASHBOARD.md
+++ b/doc/STUDENT_DASHBOARD.md
@@ -16,7 +16,7 @@ Poi apri:
 tools/student_dashboard.html
 ```
 
-Per la demo puoi usare `bianchi-luca` come `student_id`: nel registro demo degli stati AI ha un feedback gia approvato e quindi visibile nella vista studente.
+Per la demo puoi usare `bianchi-luca`: nel registro demo degli stati AI ha un feedback gia approvato e quindi visibile nella vista studente.
 
 ## Cosa mostra
 
@@ -25,6 +25,14 @@ La pagina legge i registri in `teacher-reports/**/*.json` tramite:
 ```text
 /api/student-dashboard?student_id=<id>
 ```
+
+La lista studenti della UI viene popolata dai dati gia disponibili in:
+
+```text
+/api/assignment-overview
+```
+
+Questo e un compromesso MVP: evita una nuova fonte dati mentre stiamo stabilizzando i registri. Quando passeremo a classi reali, la fonte autorevole degli studenti dovra essere il provider classe, per esempio GitHub Team oppure un roster locale importato/sincronizzato.
 
 Per ogni consegna dello studente mostra:
 
@@ -57,7 +65,8 @@ Questo mantiene separato il lavoro di revisione docente dalla comunicazione allo
 Questa e una vista MVP:
 
 - non ha login;
-- lo studente viene scelto manualmente tramite campo `student_id`;
+- lo studente viene scelto da una lista derivata dai registri, con fallback demo;
+- la lista studenti non arriva ancora da GitHub Team o da un roster locale autorevole;
 - non permette ancora consegna file o esecuzione test;
 - non distingue ancora tentativi multipli;
 - non applica permessi reali lato server.

--- a/doc/STUDENT_DASHBOARD.md
+++ b/doc/STUDENT_DASHBOARD.md
@@ -1,0 +1,65 @@
+# Vista studente MVP
+
+La vista studente minima serve a verificare il flusso docente -> consegna -> grading -> feedback approvato senza introdurre ancora login, permessi o provider esterni.
+
+## Avvio
+
+Avvia il server locale:
+
+```bash
+python scripts/course_board_server.py
+```
+
+Poi apri:
+
+```text
+tools/student_dashboard.html
+```
+
+Per la demo puoi usare `bianchi-luca` come `student_id`: nel registro demo degli stati AI ha un feedback gia approvato e quindi visibile nella vista studente.
+
+## Cosa mostra
+
+La pagina legge i registri in `teacher-reports/**/*.json` tramite:
+
+```text
+/api/student-dashboard?student_id=<id>
+```
+
+Per ogni consegna dello studente mostra:
+
+- activity e titolo;
+- tipo consegna e modalita di supporto;
+- scadenza;
+- stato consegna;
+- esito grading e test;
+- voto docente o score se presente;
+- link repository o file consegna quando disponibili;
+- feedback AI/didattico solo se approvato dal docente.
+
+## Regola feedback
+
+La vista studente non mostra bozze AI, feedback respinti o feedback non generati.
+
+Un feedback diventa visibile solo quando nel registro dello studente:
+
+```json
+{
+  "status": "approved",
+  "approved_by_teacher": true
+}
+```
+
+Questo mantiene separato il lavoro di revisione docente dalla comunicazione allo studente.
+
+## Limiti attuali
+
+Questa e una vista MVP:
+
+- non ha login;
+- lo studente viene scelto manualmente tramite campo `student_id`;
+- non permette ancora consegna file o esecuzione test;
+- non distingue ancora tentativi multipli;
+- non applica permessi reali lato server.
+
+Questi limiti sono intenzionali: la pagina serve prima a stabilizzare il contratto dati e il flusso di feedback approvato.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -27,7 +27,7 @@ import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import unquote, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -235,6 +235,12 @@ def assignment_overview() -> list[dict]:
     """Return one row per student/activity across all saved teacher reports."""
 
     return assignment_service().assignment_overview()
+
+
+def student_dashboard(student_id: str) -> dict:
+    """Return the minimal student-facing assignment dashboard."""
+
+    return assignment_service().student_dashboard(student_id)
 
 
 def list_activities() -> list[dict]:
@@ -1656,6 +1662,16 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/api/assignment-overview":
             self.write_json({"rows": assignment_overview()})
+            return
+        if parsed.path == "/api/student-dashboard":
+            try:
+                query = parse_qs(parsed.query)
+                self.write_json(student_dashboard(query.get("student_id", [""])[0]))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
             return
         if parsed.path == "/api/activities":
             self.write_json({"activities": list_activities()})

--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -109,6 +109,11 @@ class AssignmentService:
 
         return AssignmentOverviewService(self.storage).assignment_overview()
 
+    def student_dashboard(self, student_id: str) -> dict[str, Any]:
+        """Return the minimal student-facing assignment dashboard."""
+
+        return AssignmentOverviewService(self.storage).student_dashboard(student_id)
+
 
 class AssignmentOverviewService:
     """Query service for derived assignment dashboard rows."""
@@ -162,3 +167,72 @@ class AssignmentOverviewService:
                     }
                 )
         return rows
+
+    def student_dashboard(self, student_id: str) -> dict[str, Any]:
+        """Return assignment rows visible to one student."""
+
+        clean_student_id = student_id.strip()
+        if not clean_student_id:
+            raise ValueError("student_id mancante.")
+        assignments = []
+        for report in self.storage.list_assignment_reports():
+            try:
+                payload = self.storage.read_assignment_report(report["name"])
+            except Exception:  # noqa: BLE001
+                continue
+            for student in payload.get("students", []):
+                if not isinstance(student, dict) or not _matches_student(student, clean_student_id):
+                    continue
+                submission = student.get("submission") if isinstance(student.get("submission"), dict) else {}
+                grading = student.get("grading") if isinstance(student.get("grading"), dict) else {}
+                ai_feedback = student.get("ai_feedback") if isinstance(student.get("ai_feedback"), dict) else {}
+                assignments.append(
+                    {
+                        "report_name": report["name"],
+                        "activity_id": payload.get("activity_id", ""),
+                        "title": payload.get("title", "") or payload.get("activity_id", ""),
+                        "kind": payload.get("kind", ""),
+                        "student_support_mode": payload.get("student_support_mode", ""),
+                        "class_id": payload.get("class_id", ""),
+                        "class_label": payload.get("class_label", ""),
+                        "assigned_at": payload.get("assigned_at") or "",
+                        "due_at": payload.get("due_at") or "",
+                        "status": student.get("status", ""),
+                        "submitted": bool(student.get("submitted", False)),
+                        "late": bool(student.get("late", False)),
+                        "repo": student.get("repo", ""),
+                        "repo_github_url": student.get("repo_github_url", ""),
+                        "submitted_at": submission.get("submitted_at"),
+                        "commit": submission.get("commit"),
+                        "source_path": submission.get("source_path"),
+                        "source_github_url": submission.get("source_github_url"),
+                        "grading": {
+                            "status": grading.get("status", ""),
+                            "passed": grading.get("passed"),
+                            "tests_passed": grading.get("tests_passed"),
+                            "tests_total": grading.get("tests_total"),
+                            "failed_tests": grading.get("failed_tests", []),
+                            "teacher_grade": grading.get("teacher_grade"),
+                            "score": grading.get("score"),
+                            "detail": grading.get("detail", ""),
+                        },
+                        "approved_feedback": _approved_student_feedback(ai_feedback),
+                    }
+                )
+        assignments.sort(key=lambda row: (row.get("due_at") or "", row.get("activity_id") or ""))
+        return {"student_id": clean_student_id, "assignments": assignments}
+
+
+def _matches_student(student: dict[str, Any], student_id: str) -> bool:
+    return student.get("student_id") == student_id or student.get("student") == student_id
+
+
+def _approved_student_feedback(ai_feedback: dict[str, Any]) -> dict[str, Any] | None:
+    if ai_feedback.get("status") != "approved" or ai_feedback.get("approved_by_teacher") is not True:
+        return None
+    return {
+        "summary": ai_feedback.get("summary"),
+        "student_feedback": ai_feedback.get("student_feedback"),
+        "suggested_grade": ai_feedback.get("suggested_grade"),
+        "confidence": ai_feedback.get("confidence"),
+    }

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -207,6 +207,44 @@ def test_review_assignment_ai_feedback_rejects_approve_on_non_draft_feedback(tmp
         raise AssertionError("La review deve rifiutare approve su feedback AI non in bozza")
 
 
+def test_student_dashboard_endpoint_filters_to_requested_student(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+
+    report_dir = tmp_path / "teacher-reports"
+    report_dir.mkdir(parents=True)
+    (report_dir / "activity.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "activity",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "student_id": "rossi-mario",
+                        "ai_feedback": {
+                            "status": "approved",
+                            "approved_by_teacher": True,
+                            "student_feedback": "Feedback visibile.",
+                        },
+                    },
+                    {
+                        "student": "bianchi-luca",
+                        "student_id": "bianchi-luca",
+                        "ai_feedback": {"status": "approved", "approved_by_teacher": True},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dashboard = course_board_server.student_dashboard("rossi-mario")
+
+    assert dashboard["student_id"] == "rossi-mario"
+    assert len(dashboard["assignments"]) == 1
+    assert dashboard["assignments"][0]["approved_feedback"]["student_feedback"] == "Feedback visibile."
+
+
 def test_ai_secret_status_reports_paths_and_configured_keys_without_values(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "AI_SECRET_PATH", tmp_path / ".secrets" / "ai.secret")

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -49,6 +49,9 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderAssignment,
         renderDashboard,
         safeExternalLink,
+        studentLabel,
+        uniqueStudentsFromOverview,
+        populateStudentOptions,
         statusBadge,
         gradingBadge,
         gradeValue,
@@ -126,5 +129,38 @@ def test_student_dashboard_rejects_unsafe_external_links() -> None:
         const unsafe = tested.safeExternalLink("javascript:alert(1)", "Repository", "repo-name");
         assert.doesNotMatch(unsafe, /href=/);
         assert.match(unsafe, /repo-name/);
+        """
+    )
+
+
+def test_student_dashboard_populates_students_from_overview_rows() -> None:
+    run_student_dashboard_js(
+        """
+        const students = tested.uniqueStudentsFromOverview([
+          { student: "verdi-anna" },
+          { student_id: "rossi-mario", student: "legacy-name" },
+          { student: "verdi-anna" },
+          { student: "" },
+        ]);
+
+        assert.equal(JSON.stringify(students), JSON.stringify(["rossi-mario", "verdi-anna"]));
+        const selected = tested.populateStudentOptions(students, "verdi-anna");
+        assert.equal(selected, "verdi-anna");
+        assert.equal(tested.els.studentId.value, "verdi-anna");
+        assert.match(tested.els.studentId.innerHTML, /Rossi Mario/);
+        assert.match(tested.els.studentId.innerHTML, /Verdi Anna/);
+        """
+    )
+
+
+def test_student_dashboard_uses_demo_students_when_overview_is_empty() -> None:
+    run_student_dashboard_js(
+        """
+        const selected = tested.populateStudentOptions([], "bianchi-luca");
+
+        assert.equal(selected, "bianchi-luca");
+        assert.match(tested.els.studentId.innerHTML, /Bianchi Luca/);
+        assert.match(tested.els.studentId.innerHTML, /Rossi Mario/);
+        assert.equal(tested.studentLabel("neri-giulia"), "Neri Giulia");
         """
     )

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import subprocess
+import textwrap
+
+
+def run_student_dashboard_js(assertions: str) -> None:
+    script = rf"""
+    const assert = require("node:assert/strict");
+    const fs = require("node:fs");
+    const vm = require("node:vm");
+
+    class FakeElement {{
+      constructor(selector = "") {{
+        this.selector = selector;
+        this.value = selector === "#studentId" ? "rossi-mario" : "";
+        this.textContent = "";
+        this.innerHTML = "";
+      }}
+      addEventListener() {{}}
+    }}
+
+    const elements = new Map();
+    function elementFor(selector) {{
+      if (!elements.has(selector)) elements.set(selector, new FakeElement(selector));
+      return elements.get(selector);
+    }}
+
+    const context = {{
+      console,
+      document: {{ querySelector: elementFor }},
+      fetch: async () => ({{
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({{ student_id: "rossi-mario", assignments: [] }}),
+        text: async () => "",
+      }}),
+      window: {{}},
+    }};
+    context.globalThis = context;
+
+    const source = fs.readFileSync("tools/student_dashboard.js", "utf8");
+    vm.runInNewContext(`${{source}}
+      globalThis.__studentDashboardTest = {{
+        renderSummary,
+        renderFeedback,
+        renderAssignment,
+        renderDashboard,
+        statusBadge,
+        gradingBadge,
+        gradeValue,
+        els,
+      }};
+    `, context);
+
+    const tested = context.__studentDashboardTest;
+    {assertions}
+    """
+    subprocess.run(["node", "-e", textwrap.dedent(script)], check=True)
+
+
+def test_student_dashboard_renders_summary_and_assignment_card() -> None:
+    run_student_dashboard_js(
+        """
+        const assignment = {
+          activity_id: "python-base-somma-001",
+          title: "Somma in Python",
+          kind: "compito-casa",
+          student_support_mode: "guidato",
+          due_at: "2026-10-19T23:59:00+02:00",
+          status: "submitted_on_time",
+          submitted: true,
+          late: false,
+          submitted_at: "2026-10-18T18:22:10+02:00",
+          repo: "TheBitPoets/rossi-mario",
+          source_path: "assignments/python-base-somma-001/main.py",
+          commit: "abc1234",
+          grading: {
+            status: "graded_passed",
+            tests_passed: 2,
+            tests_total: 2,
+            teacher_grade: 9,
+            failed_tests: [],
+          },
+          approved_feedback: {
+            summary: "Buon lavoro.",
+            student_feedback: "Hai gestito correttamente i casi base.",
+            suggested_grade: 9,
+            confidence: "high",
+          },
+        };
+
+        tested.renderDashboard({ student_id: "rossi-mario", assignments: [assignment] });
+
+        assert.match(tested.els.summary.innerHTML, /rossi-mario/);
+        assert.match(tested.els.assignments.innerHTML, /Somma in Python/);
+        assert.match(tested.els.assignments.innerHTML, /Feedback docente/);
+        assert.match(tested.els.assignments.innerHTML, /Hai gestito correttamente/);
+        assert.match(tested.els.assignments.innerHTML, /Test superati/);
+        """
+    )
+
+
+def test_student_dashboard_hides_unapproved_feedback_payloads() -> None:
+    run_student_dashboard_js(
+        """
+        const empty = tested.renderFeedback(null);
+        assert.match(empty, /Nessun feedback approvato/);
+        assert.doesNotMatch(empty, /Bozza/);
+        assert.equal(tested.gradeValue({ teacher_grade: null, score: 6 }), 6);
+        assert.match(tested.statusBadge({ status: "missing", submitted: false, late: false }), /Mancante/);
+        assert.match(tested.gradingBadge({ status: "graded_failed" }), /Test falliti/);
+        """
+    )

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -28,6 +28,7 @@ def run_student_dashboard_js(assertions: str) -> None:
 
     const context = {{
       console,
+      URL,
       document: {{ querySelector: elementFor }},
       fetch: async () => ({{
         ok: true,
@@ -36,7 +37,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         json: async () => ({{ student_id: "rossi-mario", assignments: [] }}),
         text: async () => "",
       }}),
-      window: {{}},
+      window: {{ location: {{ href: "http://localhost:8765/tools/student_dashboard.html" }} }},
     }};
     context.globalThis = context;
 
@@ -47,6 +48,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderFeedback,
         renderAssignment,
         renderDashboard,
+        safeExternalLink,
         statusBadge,
         gradingBadge,
         gradeValue,
@@ -111,5 +113,18 @@ def test_student_dashboard_hides_unapproved_feedback_payloads() -> None:
         assert.equal(tested.gradeValue({ teacher_grade: null, score: 6 }), 6);
         assert.match(tested.statusBadge({ status: "missing", submitted: false, late: false }), /Mancante/);
         assert.match(tested.gradingBadge({ status: "graded_failed" }), /Test falliti/);
+        """
+    )
+
+
+def test_student_dashboard_rejects_unsafe_external_links() -> None:
+    run_student_dashboard_js(
+        """
+        const safe = tested.safeExternalLink("https://github.com/TheBitPoets/2cornot2c", "Repository", "repo");
+        assert.match(safe, /href="https:\\/\\/github.com\\/TheBitPoets\\/2cornot2c"/);
+
+        const unsafe = tested.safeExternalLink("javascript:alert(1)", "Repository", "repo-name");
+        assert.doesNotMatch(unsafe, /href=/);
+        assert.match(unsafe, /repo-name/);
         """
     )

--- a/tests/test_thebitlab_services.py
+++ b/tests/test_thebitlab_services.py
@@ -206,6 +206,67 @@ def test_assignment_service_accepts_protocol_compatible_storage(tmp_path) -> Non
     assert service.assignment_overview()[0]["student"] == "rossi-mario"
 
 
+def test_student_dashboard_filters_student_and_only_approved_feedback(tmp_path) -> None:
+    service = assignment_overview_service(tmp_path)
+    reports_dir = tmp_path / "teacher-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "activity.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "title": "Somma in Python",
+                "kind": "compito-casa",
+                "student_support_mode": "guidato",
+                "due_at": "2026-10-19T23:59:00+02:00",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "student_id": "rossi-mario",
+                        "status": "submitted_on_time",
+                        "submitted": True,
+                        "submission": {"submitted_at": "2026-10-18T18:22:10+02:00", "commit": "abc1234"},
+                        "grading": {"status": "graded_passed", "tests_passed": 2, "tests_total": 2, "teacher_grade": 9},
+                        "ai_feedback": {
+                            "status": "approved",
+                            "approved_by_teacher": True,
+                            "summary": "Buon lavoro.",
+                            "student_feedback": "Hai gestito correttamente i casi base.",
+                            "suggested_grade": 9,
+                            "confidence": "high",
+                        },
+                    },
+                    {
+                        "student": "bianchi-luca",
+                        "student_id": "bianchi-luca",
+                        "status": "submitted_on_time",
+                        "submitted": True,
+                        "ai_feedback": {
+                            "status": "draft",
+                            "approved_by_teacher": False,
+                            "summary": "Bozza non visibile.",
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dashboard = service.student_dashboard("rossi-mario")
+
+    assert dashboard["student_id"] == "rossi-mario"
+    assert len(dashboard["assignments"]) == 1
+    assignment = dashboard["assignments"][0]
+    assert assignment["activity_id"] == "python-base-somma-001"
+    assert assignment["grading"]["teacher_grade"] == 9
+    assert assignment["approved_feedback"] == {
+        "summary": "Buon lavoro.",
+        "student_feedback": "Hai gestito correttamente i casi base.",
+        "suggested_grade": 9,
+        "confidence": "high",
+    }
+
+
 def test_assignment_overview_service_accepts_protocol_compatible_storage(tmp_path) -> None:
     class FakeAssignmentStorage:
         def safe_teacher_report_path(self, name: str) -> Path:

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -1,0 +1,244 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7f9;
+  --surface: #ffffff;
+  --ink: #171717;
+  --muted: #68707c;
+  --line: #d9dee7;
+  --ok: #147a42;
+  --warn: #9a6500;
+  --bad: #b42318;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.topbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem clamp(1rem, 3vw, 2rem);
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.eyebrow {
+  margin: 0 0 .15rem;
+  color: var(--muted);
+  font-size: .75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: clamp(1.45rem, 3vw, 2.1rem);
+}
+
+main {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem clamp(1rem, 3vw, 2rem) 2rem;
+}
+
+.studentForm {
+  display: flex;
+  align-items: end;
+  gap: .65rem;
+}
+
+label {
+  display: grid;
+  gap: .25rem;
+  color: var(--muted);
+  font-size: .75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+input,
+button {
+  min-height: 2.35rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font: inherit;
+}
+
+input {
+  min-width: min(18rem, 50vw);
+  padding: .45rem .65rem;
+  background: #ffffff;
+}
+
+button {
+  padding: .45rem .85rem;
+  background: #111111;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.summary,
+.assignments {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: .8rem;
+  padding: 1rem;
+}
+
+.summaryCard {
+  min-width: 0;
+}
+
+.summaryCard strong {
+  display: block;
+  color: var(--muted);
+  font-size: .72rem;
+  text-transform: uppercase;
+}
+
+.summaryCard span {
+  display: block;
+  margin-top: .2rem;
+  overflow-wrap: anywhere;
+  font-size: 1.35rem;
+  font-weight: 900;
+}
+
+.sectionHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.sectionHead h2 {
+  margin-bottom: 0;
+}
+
+.assignmentList {
+  display: grid;
+}
+
+.assignmentCard {
+  display: grid;
+  gap: .85rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.assignmentCard:last-child {
+  border-bottom: 0;
+}
+
+.assignmentHead {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.assignmentHead h3 {
+  margin: 0 0 .2rem;
+  overflow-wrap: anywhere;
+}
+
+.meta,
+.details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .45rem .8rem;
+  margin: 0;
+  color: var(--muted);
+  font-size: .86rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  border-radius: 999px;
+  padding: .2rem .55rem;
+  background: #eef1f5;
+  color: #343a40;
+  font-size: .78rem;
+  font-weight: 800;
+}
+
+.badgeOk {
+  background: #e7f6ec;
+  color: var(--ok);
+}
+
+.badgeWarn {
+  background: #fff3d8;
+  color: var(--warn);
+}
+
+.badgeBad {
+  background: #fde8e6;
+  color: var(--bad);
+}
+
+.feedback {
+  max-width: 70rem;
+  border-left: 4px solid var(--ok);
+  padding: .75rem .85rem;
+  background: #f7fbf8;
+}
+
+.feedback h4 {
+  margin: 0 0 .35rem;
+}
+
+.feedback p {
+  margin-bottom: .45rem;
+  text-align: justify;
+}
+
+.emptyFeedback {
+  color: var(--muted);
+}
+
+.status {
+  margin-bottom: 0;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 720px) {
+  .topbar,
+  .studentForm,
+  .assignmentHead {
+    display: grid;
+    align-items: stretch;
+  }
+
+  input {
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -72,6 +72,7 @@ label {
 }
 
 input,
+select,
 button {
   min-height: 2.35rem;
   border: 1px solid var(--line);
@@ -79,7 +80,8 @@ button {
   font: inherit;
 }
 
-input {
+input,
+select {
   min-width: min(18rem, 50vw);
   padding: .45rem .65rem;
   background: #ffffff;
@@ -237,7 +239,8 @@ button {
     align-items: stretch;
   }
 
-  input {
+  input,
+  select {
     min-width: 0;
     width: 100%;
   }

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -15,14 +15,13 @@
     <form id="studentForm" class="studentForm">
       <label>
         Studente
-        <input id="studentId" name="student_id" value="bianchi-luca" list="demoStudents" autocomplete="off">
+        <select id="studentId" name="student_id">
+          <option value="bianchi-luca" selected>Bianchi Luca</option>
+          <option value="rossi-mario">Rossi Mario</option>
+          <option value="verdi-anna">Verdi Anna</option>
+          <option value="neri-giulia">Neri Giulia</option>
+        </select>
       </label>
-      <datalist id="demoStudents">
-        <option value="rossi-mario"></option>
-        <option value="bianchi-luca"></option>
-        <option value="verdi-anna"></option>
-        <option value="neri-giulia"></option>
-      </datalist>
       <button type="submit">Carica</button>
     </form>
   </header>

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TheBitLab - Vista studente</title>
+  <link rel="stylesheet" href="student_dashboard.css">
+</head>
+<body>
+  <header class="topbar">
+    <div>
+      <p class="eyebrow">TheBitLab</p>
+      <h1>Vista studente</h1>
+    </div>
+    <form id="studentForm" class="studentForm">
+      <label>
+        Studente
+        <input id="studentId" name="student_id" value="bianchi-luca" list="demoStudents" autocomplete="off">
+      </label>
+      <datalist id="demoStudents">
+        <option value="rossi-mario"></option>
+        <option value="bianchi-luca"></option>
+        <option value="verdi-anna"></option>
+        <option value="neri-giulia"></option>
+      </datalist>
+      <button type="submit">Carica</button>
+    </form>
+  </header>
+
+  <main>
+    <section class="summary" id="summary" aria-live="polite">
+      <p class="status">Carica uno studente per vedere consegne, stato e feedback approvato.</p>
+    </section>
+
+    <section class="assignments">
+      <div class="sectionHead">
+        <h2>Consegne</h2>
+        <p id="status" class="status" aria-live="polite"></p>
+      </div>
+      <div id="assignments" class="assignmentList"></div>
+    </section>
+  </main>
+
+  <script src="student_dashboard.js"></script>
+</body>
+</html>

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -16,10 +16,7 @@
       <label>
         Studente
         <select id="studentId" name="student_id">
-          <option value="bianchi-luca" selected>Bianchi Luca</option>
-          <option value="rossi-mario">Rossi Mario</option>
-          <option value="verdi-anna">Verdi Anna</option>
-          <option value="neri-giulia">Neri Giulia</option>
+          <option value="bianchi-luca" selected>Caricamento studenti...</option>
         </select>
       </label>
       <button type="submit">Carica</button>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -1,0 +1,168 @@
+const els = {
+  form: document.querySelector("#studentForm"),
+  studentId: document.querySelector("#studentId"),
+  summary: document.querySelector("#summary"),
+  status: document.querySelector("#status"),
+  assignments: document.querySelector("#assignments"),
+};
+
+async function api(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    const body = await response.text();
+    let detail = body;
+    try {
+      detail = JSON.parse(body).error || body;
+    } catch {
+      detail = body;
+    }
+    throw new Error(`${response.status} ${response.statusText}${detail ? `: ${detail}` : ""}`);
+  }
+  return response.json();
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function formatDate(value) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString("it-IT", { dateStyle: "short", timeStyle: "short" });
+}
+
+function badge(text, kind = "") {
+  return `<span class="badge ${kind}">${escapeHtml(text || "-")}</span>`;
+}
+
+function statusBadge(assignment) {
+  if (assignment.status === "missing") return badge("Mancante", "badgeBad");
+  if (assignment.late) return badge("In ritardo", "badgeWarn");
+  if (assignment.submitted) return badge("Consegnata", "badgeOk");
+  return badge("Da consegnare");
+}
+
+function gradingBadge(grading) {
+  if (grading?.status === "graded_passed") return badge("Test superati", "badgeOk");
+  if (grading?.status === "graded_failed") return badge("Test falliti", "badgeBad");
+  if (grading?.status === "not_run") return badge("Test non eseguiti");
+  return badge(grading?.status || "Grading non disponibile");
+}
+
+function gradeValue(grading) {
+  const grade = grading?.teacher_grade ?? grading?.score;
+  return grade == null || String(grade).trim() === "" ? "-" : grade;
+}
+
+function renderSummary(studentId, assignments) {
+  const submitted = assignments.filter((item) => item.submitted).length;
+  const late = assignments.filter((item) => item.late).length;
+  const approvedFeedback = assignments.filter((item) => item.approved_feedback).length;
+  const cards = [
+    ["Studente", studentId],
+    ["Consegne", assignments.length],
+    ["Consegnate", submitted],
+    ["In ritardo", late],
+    ["Feedback", approvedFeedback],
+  ];
+  els.summary.innerHTML = cards.map(([label, value]) => `
+    <article class="summaryCard">
+      <strong>${escapeHtml(label)}</strong>
+      <span>${escapeHtml(value)}</span>
+    </article>
+  `).join("");
+}
+
+function renderFeedback(feedback) {
+  if (!feedback) {
+    return '<p class="emptyFeedback">Nessun feedback approvato dal docente per questa consegna.</p>';
+  }
+  return `
+    <section class="feedback">
+      <h4>Feedback docente</h4>
+      ${feedback.summary ? `<p><strong>Sintesi:</strong> ${escapeHtml(feedback.summary)}</p>` : ""}
+      ${feedback.student_feedback ? `<p>${escapeHtml(feedback.student_feedback)}</p>` : ""}
+      <p class="details">
+        <span>Voto suggerito AI: ${escapeHtml(feedback.suggested_grade ?? "-")}</span>
+        <span>Affidabilita: ${escapeHtml(feedback.confidence ?? "-")}</span>
+      </p>
+    </section>
+  `;
+}
+
+function renderAssignment(assignment) {
+  const grading = assignment.grading || {};
+  const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
+  const repoLink = assignment.repo_github_url
+    ? `<a href="${escapeHtml(assignment.repo_github_url)}" target="_blank" rel="noreferrer">Repository</a>`
+    : escapeHtml(assignment.repo || "-");
+  const sourceLink = assignment.source_github_url
+    ? `<a href="${escapeHtml(assignment.source_github_url)}" target="_blank" rel="noreferrer">Consegna</a>`
+    : escapeHtml(assignment.source_path || "-");
+  return `
+    <article class="assignmentCard">
+      <div class="assignmentHead">
+        <div>
+          <h3>${escapeHtml(assignment.title || assignment.activity_id)}</h3>
+          <p class="meta">
+            <span>${escapeHtml(assignment.kind || "tipo non indicato")}</span>
+            <span>${escapeHtml(assignment.student_support_mode || "modalita non indicata")}</span>
+            <span>Scadenza: ${escapeHtml(formatDate(assignment.due_at))}</span>
+          </p>
+        </div>
+        ${statusBadge(assignment)}
+      </div>
+      <p class="details">
+        <span>${gradingBadge(grading)}</span>
+        <span>Test: ${escapeHtml(grading.tests_passed ?? "-")}/${escapeHtml(grading.tests_total ?? "-")}</span>
+        <span>Voto: ${escapeHtml(gradeValue(grading))}</span>
+        <span>Consegnato: ${escapeHtml(formatDate(assignment.submitted_at))}</span>
+      </p>
+      ${failedTests.length ? `<p class="details">Test falliti: ${failedTests.map(escapeHtml).join(", ")}</p>` : ""}
+      <p class="details">
+        <span>Repository: ${repoLink}</span>
+        <span>File: ${sourceLink}</span>
+        <span>Commit: ${escapeHtml(assignment.commit || "-")}</span>
+      </p>
+      ${renderFeedback(assignment.approved_feedback)}
+    </article>
+  `;
+}
+
+function renderDashboard(payload) {
+  const assignments = Array.isArray(payload.assignments) ? payload.assignments : [];
+  renderSummary(payload.student_id || "-", assignments);
+  els.status.textContent = assignments.length
+    ? `${assignments.length} consegne trovate.`
+    : "Nessuna consegna trovata per questo studente.";
+  els.assignments.innerHTML = assignments.length
+    ? assignments.map(renderAssignment).join("")
+    : '<p class="status">Nessuna consegna disponibile.</p>';
+}
+
+async function loadStudentDashboard(studentId) {
+  const cleanStudentId = studentId.trim();
+  if (!cleanStudentId) {
+    els.status.textContent = "Inserisci uno studente.";
+    return;
+  }
+  els.status.textContent = `Caricamento consegne per ${cleanStudentId}...`;
+  const payload = await api(`/api/student-dashboard?student_id=${encodeURIComponent(cleanStudentId)}`);
+  renderDashboard(payload);
+}
+
+els.form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  loadStudentDashboard(els.studentId.value).catch((error) => {
+    els.status.textContent = `Errore: ${error.message}`;
+  });
+});
+
+loadStudentDashboard(els.studentId.value).catch((error) => {
+  els.status.textContent = `Errore: ${error.message}`;
+});

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -6,6 +6,8 @@ const els = {
   assignments: document.querySelector("#assignments"),
 };
 
+const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
+
 async function api(path) {
   const response = await fetch(path);
   if (!response.ok) {
@@ -22,6 +24,42 @@ async function api(path) {
     throw new Error(`${response.status} ${response.statusText}${detail ? `: ${detail}` : ""}`);
   }
   return response.json();
+}
+
+function studentLabel(studentId) {
+  return String(studentId ?? "")
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toLocaleUpperCase("it-IT") + part.slice(1))
+    .join(" ") || "-";
+}
+
+function uniqueStudentsFromOverview(rows) {
+  const students = new Set();
+  for (const row of rows) {
+    const student = String(row?.student_id || row?.student || "").trim();
+    if (student) students.add(student);
+  }
+  return [...students].sort((a, b) => a.localeCompare(b, "it", { numeric: true, sensitivity: "base" }));
+}
+
+function populateStudentOptions(students, preferredStudentId = "") {
+  const options = students.length ? students : DEMO_STUDENTS;
+  const selected = options.includes(preferredStudentId) ? preferredStudentId : options[0];
+  els.studentId.innerHTML = options.map((student) => `
+    <option value="${escapeHtml(student)}"${student === selected ? " selected" : ""}>${escapeHtml(studentLabel(student))}</option>
+  `).join("");
+  els.studentId.value = selected;
+  return selected;
+}
+
+async function loadStudentOptions(preferredStudentId = "") {
+  try {
+    const payload = await api("/api/assignment-overview");
+    return populateStudentOptions(uniqueStudentsFromOverview(payload.rows || []), preferredStudentId);
+  } catch {
+    return populateStudentOptions([], preferredStudentId);
+  }
 }
 
 function escapeHtml(value) {
@@ -180,6 +218,8 @@ els.form.addEventListener("submit", (event) => {
   });
 });
 
-loadStudentDashboard(els.studentId.value).catch((error) => {
-  els.status.textContent = `Errore: ${error.message}`;
-});
+loadStudentOptions(els.studentId.value)
+  .then((studentId) => loadStudentDashboard(studentId))
+  .catch((error) => {
+    els.status.textContent = `Errore: ${error.message}`;
+  });

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -32,6 +32,20 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
+function safeExternalLink(url, label, fallback = "-") {
+  const cleanUrl = String(url ?? "").trim();
+  if (!cleanUrl) return escapeHtml(fallback);
+  try {
+    const parsed = new URL(cleanUrl, window.location.href);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return `<a href="${escapeHtml(parsed.href)}" target="_blank" rel="noreferrer">${escapeHtml(label)}</a>`;
+    }
+  } catch {
+    // Fall back to non-clickable text below.
+  }
+  return escapeHtml(fallback);
+}
+
 function formatDate(value) {
   if (!value) return "-";
   const date = new Date(value);
@@ -102,10 +116,10 @@ function renderAssignment(assignment) {
   const grading = assignment.grading || {};
   const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
   const repoLink = assignment.repo_github_url
-    ? `<a href="${escapeHtml(assignment.repo_github_url)}" target="_blank" rel="noreferrer">Repository</a>`
+    ? safeExternalLink(assignment.repo_github_url, "Repository", assignment.repo || "-")
     : escapeHtml(assignment.repo || "-");
   const sourceLink = assignment.source_github_url
-    ? `<a href="${escapeHtml(assignment.source_github_url)}" target="_blank" rel="noreferrer">Consegna</a>`
+    ? safeExternalLink(assignment.source_github_url, "Consegna", assignment.source_path || "-")
     : escapeHtml(assignment.source_path || "-");
   return `
     <article class="assignmentCard">

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -16,6 +16,9 @@ async function api(path) {
     } catch {
       detail = body;
     }
+    if (response.status === 404 && detail.includes("<!DOCTYPE")) {
+      detail = "endpoint non trovato. Avvia la pagina con python scripts/course_board_server.py e apri http://localhost:8765/tools/student_dashboard.html.";
+    }
     throw new Error(`${response.status} ${response.statusText}${detail ? `: ${detail}` : ""}`);
   }
   return response.json();


### PR DESCRIPTION
## Cosa cambia
- Aggiunge l'endpoint `GET /api/student-dashboard?student_id=...`.
- Aggiunge la pagina `tools/student_dashboard.html` per vedere consegne, stato, grading e feedback approvato dello studente selezionato.
- Espone solo feedback approvati dal docente (`status: approved`, `approved_by_teacher: true`), nascondendo bozze, respinti e feedback non generati.
- Documenta la vista studente MVP e la aggiunge all'indice della documentazione.

## Test
- `python -m pytest tests/test_thebitlab_services.py tests/test_course_board_server.py tests/test_student_dashboard_frontend.py tests/test_assignment_dashboard_frontend.py tests/test_thebitlab_storage.py`
- `git diff --check HEAD~1..HEAD`

## Come verificare in GUI
1. Avvia `python scripts/course_board_server.py`.
2. Apri `tools/student_dashboard.html`.
3. Usa `bianchi-luca` per vedere almeno un feedback approvato nella demo.
4. Prova `rossi-mario`: le bozze AI non devono comparire come feedback studente.