### PR TITLE
Allinea stile vista studente

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -302,6 +302,11 @@ Da avere per la prima prova:
    - in ritardo;
    - corretta automaticamente;
    - da revisionare.
+4. Vista studente in sola lettura per percorso e calendario:
+   - mostrare il percorso didattico pubblicato dal docente con UDA e paragrafi pertinenti;
+   - mostrare il calendario corrente con lab, verifiche, scadenze e finestre di lavoro;
+   - non esporre azioni o pagine docente nella navigazione studente;
+   - derivare queste viste dai dati docente senza duplicare percorso e calendario.
 
 ### Feedback assistito
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -307,6 +307,10 @@ Da avere per la prima prova:
    - mostrare il calendario corrente con lab, verifiche, scadenze e finestre di lavoro;
    - non esporre azioni o pagine docente nella navigazione studente;
    - derivare queste viste dai dati docente senza duplicare percorso e calendario.
+5. Profilo studente:
+   - collegare `student_id`, nominativo locale, username GitHub e repository studente;
+   - mostrare avatar/profilo studente solo quando la fonte autorevole arriva da GitHub Team o roster locale;
+   - evitare link esterni generici nella navigazione studente.
 
 ### Feedback assistito
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -1,128 +1,195 @@
 :root {
   color-scheme: light;
-  --bg: #f6f7f9;
-  --surface: #ffffff;
-  --ink: #171717;
-  --muted: #68707c;
-  --line: #d9dee7;
+  --ink: #111111;
+  --muted: #666666;
+  --paper: #f6f6f6;
+  --panel: #ffffff;
+  --line: #d7d7d7;
+  --accent: #111111;
   --ok: #147a42;
   --warn: #9a6500;
   --bad: #b42318;
+  --shadow: 0 18px 42px rgba(0, 0, 0, 0.08);
+  --mono: "Cascadia Code", "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, monospace;
 }
 
-* {
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; }
 
 body {
   margin: 0;
-  background: var(--bg);
+  min-height: 100vh;
   color: var(--ink);
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(rgba(0, 0, 0, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.025) 1px, transparent 1px),
+    #f7f7f7;
+  background-size: 24px 24px;
+  font-family: var(--mono);
 }
 
-.topbar {
+.topNav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
   display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1.1rem clamp(1rem, 3vw, 2rem);
-  border-bottom: 1px solid var(--line);
-  background: var(--surface);
+  align-items: center;
+  gap: .35rem;
+  padding: .65rem clamp(1rem, 3vw, 3rem);
+  border-bottom: 1px solid rgba(17, 17, 17, .12);
+  background: rgba(255, 255, 255, .94);
+  backdrop-filter: blur(10px);
 }
 
-.eyebrow {
-  margin: 0 0 .15rem;
-  color: var(--muted);
-  font-size: .75rem;
-  font-weight: 800;
-  text-transform: uppercase;
+.topNavBrand {
+  display: grid;
+  place-items: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  margin-right: .25rem;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: .7rem;
+  background: #ffffff;
+  padding: 0;
+  overflow: hidden;
+}
+
+.topNavBrand img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.topNav a:not(.topNavBrand) {
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--ink);
+  font: 800 .78rem/1.2 var(--mono);
+  padding: .55rem .85rem;
+  text-decoration: none;
+}
+
+.topNav a:not(.topNavBrand)[aria-current="page"] {
+  background: #111111;
+  color: #ffffff;
+}
+
+.hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2rem clamp(1rem, 3vw, 3rem) 1.25rem;
 }
 
 h1,
 h2,
+h3,
+h4,
 p {
   margin-top: 0;
 }
 
 h1 {
+  margin-bottom: .35rem;
+  font-size: 3.2rem;
+  line-height: .92;
+  letter-spacing: 0;
+}
+
+.subtitle {
+  max-width: 52rem;
   margin-bottom: 0;
-  font-size: clamp(1.45rem, 3vw, 2.1rem);
+  color: var(--muted);
+  font-size: 1.05rem;
 }
 
 main {
   display: grid;
   gap: 1rem;
-  padding: 1rem clamp(1rem, 3vw, 2rem) 2rem;
+  padding: 0 clamp(1rem, 3vw, 3rem) 2rem;
 }
 
 .studentForm {
   display: flex;
   align-items: end;
-  gap: .65rem;
+  gap: .55rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 label {
   display: grid;
-  gap: .25rem;
+  gap: .32rem;
+  min-width: 0;
   color: var(--muted);
-  font-size: .75rem;
-  font-weight: 800;
-  text-transform: uppercase;
+  font-size: .72rem;
+  font-weight: 700;
 }
 
-input,
-select,
-button {
-  min-height: 2.35rem;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  font: inherit;
-}
-
-input,
+button,
 select {
-  min-width: min(18rem, 50vw);
-  padding: .45rem .65rem;
+  min-height: 2.35rem;
+  max-width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 999px;
   background: #ffffff;
+  color: var(--ink);
+  font: 700 .88rem/1.2 var(--mono);
+}
+
+select {
+  min-width: min(18rem, 55vw);
+  padding: .72rem .9rem;
 }
 
 button {
-  padding: .45rem .85rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: .72rem 1rem;
   background: #111111;
+  border-color: #111111;
   color: #ffffff;
   cursor: pointer;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
   font-weight: 800;
 }
+
+button:hover { transform: translateY(-1px); }
 
 .summary,
 .assignments {
-  border: 1px solid var(--line);
+  border: 1px solid rgba(17, 17, 17, .12);
   border-radius: 8px;
-  background: var(--surface);
+  background: rgba(255, 255, 255, .94);
+  box-shadow: var(--shadow);
 }
 
 .summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
-  gap: .8rem;
+  gap: .75rem;
   padding: 1rem;
 }
 
 .summaryCard {
   min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: .8rem;
 }
 
 .summaryCard strong {
   display: block;
   color: var(--muted);
   font-size: .72rem;
-  text-transform: uppercase;
 }
 
 .summaryCard span {
   display: block;
-  margin-top: .2rem;
+  margin-top: .22rem;
   overflow-wrap: anywhere;
   font-size: 1.35rem;
   font-weight: 900;
@@ -134,7 +201,7 @@ button {
   justify-content: space-between;
   gap: 1rem;
   padding: 1rem;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid rgba(17, 17, 17, .12);
 }
 
 .sectionHead h2 {
@@ -149,7 +216,7 @@ button {
   display: grid;
   gap: .85rem;
   padding: 1rem;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid rgba(17, 17, 17, .12);
 }
 
 .assignmentCard:last-child {
@@ -164,7 +231,7 @@ button {
 }
 
 .assignmentHead h3 {
-  margin: 0 0 .2rem;
+  margin: 0 0 .25rem;
   overflow-wrap: anywhere;
 }
 
@@ -184,8 +251,8 @@ button {
   width: max-content;
   border-radius: 999px;
   padding: .2rem .55rem;
-  background: #eef1f5;
-  color: #343a40;
+  background: #f1f1f1;
+  color: #333333;
   font-size: .78rem;
   font-weight: 800;
 }
@@ -208,6 +275,7 @@ button {
 .feedback {
   max-width: 70rem;
   border-left: 4px solid var(--ok);
+  border-radius: 0 8px 8px 0;
   padding: .75rem .85rem;
   background: #f7fbf8;
 }
@@ -232,15 +300,24 @@ button {
 }
 
 @media (max-width: 720px) {
-  .topbar,
+  .topNav {
+    overflow-x: auto;
+  }
+
+  .hero,
   .studentForm,
   .assignmentHead {
     display: grid;
     align-items: stretch;
   }
 
-  input,
-  select {
+  h1 {
+    font-size: 2.1rem;
+    line-height: 1;
+  }
+
+  select,
+  button {
     min-width: 0;
     width: 100%;
   }

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -107,6 +107,7 @@ h1 {
 main {
   display: grid;
   gap: 1rem;
+  min-width: 0;
   padding: 0 clamp(1rem, 3vw, 3rem) 2rem;
 }
 
@@ -160,6 +161,7 @@ button:hover { transform: translateY(-1px); }
 
 .summary,
 .assignments {
+  min-width: 0;
   border: 1px solid rgba(17, 17, 17, .12);
   border-radius: 8px;
   background: rgba(255, 255, 255, .94);
@@ -200,6 +202,7 @@ button:hover { transform: translateY(-1px); }
   align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
+  min-width: 0;
   padding: 1rem;
   border-bottom: 1px solid rgba(17, 17, 17, .12);
 }
@@ -210,11 +213,13 @@ button:hover { transform: translateY(-1px); }
 
 .assignmentList {
   display: grid;
+  min-width: 0;
 }
 
 .assignmentCard {
   display: grid;
   gap: .85rem;
+  min-width: 0;
   padding: 1rem;
   border-bottom: 1px solid rgba(17, 17, 17, .12);
 }
@@ -228,6 +233,11 @@ button:hover { transform: translateY(-1px); }
   align-items: start;
   justify-content: space-between;
   gap: 1rem;
+  min-width: 0;
+}
+
+.assignmentHead > div {
+  min-width: 0;
 }
 
 .assignmentHead h3 {
@@ -240,21 +250,30 @@ button:hover { transform: translateY(-1px); }
   display: flex;
   flex-wrap: wrap;
   gap: .45rem .8rem;
+  min-width: 0;
   margin: 0;
   color: var(--muted);
   font-size: .86rem;
 }
 
+.details > span,
+.meta > span {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;
-  width: max-content;
+  max-width: 100%;
   border-radius: 999px;
   padding: .2rem .55rem;
   background: #f1f1f1;
   color: #333333;
   font-size: .78rem;
   font-weight: 800;
+  overflow-wrap: anywhere;
 }
 
 .badgeOk {
@@ -273,6 +292,7 @@ button:hover { transform: translateY(-1px); }
 }
 
 .feedback {
+  min-width: 0;
   max-width: 70rem;
   border-left: 4px solid var(--ok);
   border-radius: 0 8px 8px 0;
@@ -304,11 +324,20 @@ button:hover { transform: translateY(-1px); }
     overflow-x: auto;
   }
 
+  main {
+    padding-inline: 1rem;
+  }
+
   .hero,
   .studentForm,
+  .sectionHead,
   .assignmentHead {
     display: grid;
     align-items: stretch;
+  }
+
+  .summary {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   h1 {
@@ -320,5 +349,9 @@ button:hover { transform: translateY(-1px); }
   button {
     min-width: 0;
     width: 100%;
+  }
+
+  .badge {
+    width: fit-content;
   }
 }

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -11,9 +11,6 @@
     <a class="topNavBrand" href="https://github.com/TheBitPoets" target="_blank" rel="noreferrer" aria-label="Apri TheBitPoets su GitHub">
       <img src="https://github.com/TheBitPoets.png" alt="TheBitPoets">
     </a>
-    <a href="course_board.html">Percorso</a>
-    <a href="school_calendar.html">Calendario</a>
-    <a href="assignment_dashboard.html">Consegne</a>
     <a href="student_dashboard.html" aria-current="page">Studente</a>
   </nav>
 

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -8,9 +8,9 @@
 </head>
 <body>
   <nav class="topNav" aria-label="Navigazione strumenti">
-    <a class="topNavBrand" href="https://github.com/TheBitPoets" target="_blank" rel="noreferrer" aria-label="Apri TheBitPoets su GitHub">
+    <span class="topNavBrand" aria-label="TheBitPoets">
       <img src="https://github.com/TheBitPoets.png" alt="TheBitPoets">
-    </a>
+    </span>
     <a href="student_dashboard.html" aria-current="page">Studente</a>
   </nav>
 

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -7,14 +7,24 @@
   <link rel="stylesheet" href="student_dashboard.css">
 </head>
 <body>
-  <header class="topbar">
+  <nav class="topNav" aria-label="Navigazione strumenti">
+    <a class="topNavBrand" href="https://github.com/TheBitPoets" target="_blank" rel="noreferrer" aria-label="Apri TheBitPoets su GitHub">
+      <img src="https://github.com/TheBitPoets.png" alt="TheBitPoets">
+    </a>
+    <a href="course_board.html">Percorso</a>
+    <a href="school_calendar.html">Calendario</a>
+    <a href="assignment_dashboard.html">Consegne</a>
+    <a href="student_dashboard.html" aria-current="page">Studente</a>
+  </nav>
+
+  <header class="hero">
     <div>
-      <p class="eyebrow">TheBitLab</p>
       <h1>Vista studente</h1>
+      <p class="subtitle">Consulta consegne, stato, grading e feedback approvato dal docente.</p>
     </div>
     <form id="studentForm" class="studentForm">
       <label>
-        Studente
+        <span>Studente</span>
         <select id="studentId" name="student_id">
           <option value="bianchi-luca" selected>Caricamento studenti...</option>
         </select>


### PR DESCRIPTION
## Cosa cambia
- Allinea la vista studente al linguaggio visuale della dashboard docente: top nav, font monospace, fondo a griglia, hero e controlli pill.
- Mantiene nella navigazione studente solo la voce `Studente`, senza link diretti alle pagine docente.
- Rende il brand statico nella vista studente, senza link esterni generici.
- Rende riepilogo e lista consegne piu simili ai pannelli della dashboard consegne.
- Corregge il layout mobile della vista studente evitando overflow orizzontale dei riquadri e dei dettagli.
- Aggiorna la roadmap: percorso/calendario studente in sola lettura e futuro profilo studente da GitHub Team o roster locale.

## Cosa non cambia
- Nessuna modifica ad API, service o contratto dati.
- Nessuna modifica alla dashboard docente.

## Test
- `python -m pytest tests/test_thebitlab_services.py tests/test_course_board_server.py tests/test_student_dashboard_frontend.py tests/test_assignment_dashboard_frontend.py tests/test_thebitlab_storage.py`
- `python -m pytest tests/test_student_dashboard_frontend.py tests/test_course_board_server.py tests/test_thebitlab_services.py`
- `git diff --check`

## Come verificare in GUI
1. Avvia `python scripts/course_board_server.py`.
2. Apri `http://localhost:8765/tools/student_dashboard.html`.
3. Controlla che nav, hero, font, bottoni e pannelli siano coerenti con `assignment_dashboard.html`.
4. Verifica che nella vista studente non compaiano link a `Percorso`, `Calendario` o `Consegne` docente e che il brand non sia cliccabile.
5. Riduci la finestra a larghezza smartphone: riepilogo, pannello consegne, card, badge e dettagli devono impilarsi in una sola colonna senza elementi invisibili a destra.