### PR TITLE
Collega roster locali alla vista studente

### DIFF
--- a/doc/STUDENT_DASHBOARD.md
+++ b/doc/STUDENT_DASHBOARD.md
@@ -17,6 +17,7 @@ tools/student_dashboard.html
 ```
 
 Per la demo puoi usare `bianchi-luca`: nel registro demo degli stati AI ha un feedback gia approvato e quindi visibile nella vista studente.
+La select classe usa il roster locale `doc/classes/demo-3a.json` quando il server e avviato.
 
 ## Cosa mostra
 
@@ -29,10 +30,13 @@ La pagina legge i registri in `teacher-reports/**/*.json` tramite:
 La lista studenti della UI viene popolata dai dati gia disponibili in:
 
 ```text
+/api/class-rosters
+/api/class-rosters/load
 /api/assignment-overview
 ```
 
-Questo e un compromesso MVP: evita una nuova fonte dati mentre stiamo stabilizzando i registri. Quando passeremo a classi reali, la fonte autorevole degli studenti dovra essere il provider classe, per esempio GitHub Team oppure un roster locale importato/sincronizzato.
+La fonte primaria e il roster locale in `doc/classes/*.json`. Se i roster non sono disponibili, la pagina mantiene il fallback MVP sui registri consegne tramite `/api/assignment-overview`.
+Quando passeremo a classi reali, lo stesso contratto dovra essere alimentato da GitHub Team, GitLab, un import locale o un provider interno.
 
 Per ogni consegna dello studente mostra:
 
@@ -65,8 +69,8 @@ Questo mantiene separato il lavoro di revisione docente dalla comunicazione allo
 Questa e una vista MVP:
 
 - non ha login;
-- lo studente viene scelto da una lista derivata dai registri, con fallback demo;
-- la lista studenti non arriva ancora da GitHub Team o da un roster locale autorevole;
+- lo studente viene scelto da un roster locale, con fallback sui registri e poi sui dati demo;
+- la lista studenti non arriva ancora da GitHub Team o da un provider classe sincronizzato;
 - non permette ancora consegna file o esecuzione test;
 - non distingue ancora tentativi multipli;
 - non applica permessi reali lato server.

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -42,7 +42,9 @@ def run_student_dashboard_js(assertions: str) -> None:
     }};
     context.globalThis = context;
 
-    const source = fs.readFileSync("tools/student_dashboard.js", "utf8");
+    let source = fs.readFileSync("tools/student_dashboard.js", "utf8");
+    const startupIndex = source.lastIndexOf("loadStudentOptions(els.studentId.value)");
+    if (startupIndex >= 0) source = source.slice(0, startupIndex);
     vm.runInNewContext(`${{source}}
       globalThis.__studentDashboardTest = {{
         renderSummary,
@@ -54,6 +56,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         rosterLabel,
         activeStudentsFromRoster,
         populateClassRosterOptions,
+        loadStudentOptions,
         uniqueStudentsFromOverview,
         populateStudentOptions,
         statusBadge,
@@ -64,7 +67,12 @@ def run_student_dashboard_js(assertions: str) -> None:
     `, context);
 
     const tested = context.__studentDashboardTest;
-    {assertions}
+    (async () => {{
+      {assertions}
+    }})().catch((error) => {{
+      console.error(error);
+      process.exit(1);
+    }});
     """
     subprocess.run(["node", "-e", textwrap.dedent(script)], check=True)
 
@@ -194,6 +202,44 @@ def test_student_dashboard_disables_class_roster_when_missing() -> None:
         assert.equal(tested.els.classRoster.value, "");
         assert.equal(tested.els.classRoster.disabled, true);
         assert.match(tested.els.classRoster.innerHTML, /Dai registri consegne/);
+        """
+    )
+
+
+def test_student_dashboard_does_not_hide_selected_roster_load_errors() -> None:
+    run_student_dashboard_js(
+        """
+        const calls = [];
+        context.fetch = async (path) => {
+          calls.push(path);
+          if (path === "/api/class-rosters") {
+            return {
+              ok: true,
+              status: 200,
+              statusText: "OK",
+              json: async () => ({ rosters: [{ name: "broken.json", label: "Classe rotta" }] }),
+              text: async () => "",
+            };
+          }
+          if (path === "/api/class-rosters/load") {
+            return {
+              ok: false,
+              status: 404,
+              statusText: "Not Found",
+              json: async () => ({}),
+              text: async () => JSON.stringify({ error: "Roster classe non trovato: broken.json" }),
+            };
+          }
+          throw new Error(`Fallback non atteso: ${path}`);
+        };
+
+        await assert.rejects(
+          () => tested.loadStudentOptions("", "broken.json"),
+          /Roster classe non trovato/
+        );
+
+        assert.equal(calls.includes("/api/assignment-overview"), false);
+        assert.match(tested.els.status.textContent, /Errore roster classe/);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -16,6 +16,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         this.value = selector === "#studentId" ? "rossi-mario" : "";
         this.textContent = "";
         this.innerHTML = "";
+        this.disabled = false;
       }}
       addEventListener() {{}}
     }}
@@ -50,6 +51,9 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderDashboard,
         safeExternalLink,
         studentLabel,
+        rosterLabel,
+        activeStudentsFromRoster,
+        populateClassRosterOptions,
         uniqueStudentsFromOverview,
         populateStudentOptions,
         statusBadge,
@@ -149,6 +153,47 @@ def test_student_dashboard_populates_students_from_overview_rows() -> None:
         assert.equal(tested.els.studentId.value, "verdi-anna");
         assert.match(tested.els.studentId.innerHTML, /Rossi Mario/);
         assert.match(tested.els.studentId.innerHTML, /Verdi Anna/);
+        """
+    )
+
+
+def test_student_dashboard_populates_students_from_class_roster() -> None:
+    run_student_dashboard_js(
+        """
+        const selectedRoster = tested.populateClassRosterOptions([
+          { name: "demo-3a.json", label: "Classe demo 3A", school_year: "2026-2027" },
+        ], "");
+        const students = tested.activeStudentsFromRoster({
+          students: [
+            { id: "rossi-mario", display_name: "Rossi Mario", active: true },
+            { id: "bianchi-luca", display_name: "Bianchi Luca", active: true },
+            { id: "verdi-anna", display_name: "Verdi Anna", active: false },
+          ],
+        });
+        const selectedStudent = tested.populateStudentOptions(students, "rossi-mario");
+
+        assert.equal(selectedRoster, "demo-3a.json");
+        assert.equal(tested.els.classRoster.disabled, false);
+        assert.match(tested.els.classRoster.innerHTML, /Classe demo 3A \\(2026-2027\\)/);
+        assert.equal(JSON.stringify(students.map((student) => student.id)), JSON.stringify(["bianchi-luca", "rossi-mario"]));
+        assert.equal(selectedStudent, "rossi-mario");
+        assert.match(tested.els.studentId.innerHTML, /Bianchi Luca/);
+        assert.match(tested.els.studentId.innerHTML, /Rossi Mario/);
+        assert.doesNotMatch(tested.els.studentId.innerHTML, /Verdi Anna/);
+        assert.equal(tested.rosterLabel({ label: "4A", school_year: "2026-2027" }), "4A (2026-2027)");
+        """
+    )
+
+
+def test_student_dashboard_disables_class_roster_when_missing() -> None:
+    run_student_dashboard_js(
+        """
+        const selectedRoster = tested.populateClassRosterOptions([], "");
+
+        assert.equal(selectedRoster, "");
+        assert.equal(tested.els.classRoster.value, "");
+        assert.equal(tested.els.classRoster.disabled, true);
+        assert.match(tested.els.classRoster.innerHTML, /Dai registri consegne/);
         """
     )
 

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -21,6 +21,12 @@
     </div>
     <form id="studentForm" class="studentForm">
       <label>
+        <span>Classe</span>
+        <select id="classRoster" name="class_roster">
+          <option value="">Caricamento classi...</option>
+        </select>
+      </label>
+      <label>
         <span>Studente</span>
         <select id="studentId" name="student_id">
           <option value="bianchi-luca" selected>Caricamento studenti...</option>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -101,9 +101,8 @@ function populateStudentOptions(students, preferredStudentId = "") {
   return selected;
 }
 
-async function loadRosterStudentOptions(preferredStudentId = "", preferredRosterName = "") {
-  const rostersPayload = await api("/api/class-rosters");
-  const rosterName = populateClassRosterOptions(rostersPayload.rosters || [], preferredRosterName);
+async function loadRosterDetailStudentOptions(rosters, preferredStudentId = "", preferredRosterName = "") {
+  const rosterName = populateClassRosterOptions(rosters || [], preferredRosterName);
   if (!rosterName) return "";
   const payload = await api("/api/class-rosters/load", {
     method: "POST",
@@ -114,12 +113,25 @@ async function loadRosterStudentOptions(preferredStudentId = "", preferredRoster
 }
 
 async function loadStudentOptions(preferredStudentId = "", preferredRosterName = "") {
+  let rostersPayload;
   try {
-    const rosterStudentId = await loadRosterStudentOptions(preferredStudentId, preferredRosterName);
-    if (rosterStudentId) return rosterStudentId;
+    rostersPayload = await api("/api/class-rosters");
   } catch {
     populateClassRosterOptions([], "");
+    return loadOverviewStudentOptions(preferredStudentId);
   }
+  const rosters = rostersPayload.rosters || [];
+  const rosterName = populateClassRosterOptions(rosters, preferredRosterName);
+  if (!rosterName) return loadOverviewStudentOptions(preferredStudentId);
+  try {
+    return await loadRosterDetailStudentOptions(rosters, preferredStudentId, rosterName);
+  } catch (error) {
+    els.status.textContent = `Errore roster classe: ${error.message}`;
+    throw error;
+  }
+}
+
+async function loadOverviewStudentOptions(preferredStudentId = "") {
   try {
     const payload = await api("/api/assignment-overview");
     return populateStudentOptions(uniqueStudentsFromOverview(payload.rows || []), preferredStudentId);

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -1,5 +1,6 @@
 const els = {
   form: document.querySelector("#studentForm"),
+  classRoster: document.querySelector("#classRoster"),
   studentId: document.querySelector("#studentId"),
   summary: document.querySelector("#summary"),
   status: document.querySelector("#status"),
@@ -8,8 +9,8 @@ const els = {
 
 const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
 
-async function api(path) {
-  const response = await fetch(path);
+async function api(path, options = {}) {
+  const response = await fetch(path, options);
   if (!response.ok) {
     const body = await response.text();
     let detail = body;
@@ -43,17 +44,82 @@ function uniqueStudentsFromOverview(rows) {
   return [...students].sort((a, b) => a.localeCompare(b, "it", { numeric: true, sensitivity: "base" }));
 }
 
+function rosterLabel(roster) {
+  const label = String(roster?.label || roster?.id || roster?.name || "").trim();
+  const year = String(roster?.school_year || "").trim();
+  return year ? `${label} (${year})` : label || "Classe senza nome";
+}
+
+function activeStudentsFromRoster(roster) {
+  const students = Array.isArray(roster?.students) ? roster.students : [];
+  return students
+    .filter((student) => student && student.active !== false && String(student.id || "").trim())
+    .map((student) => ({
+      id: String(student.id).trim(),
+      label: String(student.display_name || student.id).trim(),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label, "it", { numeric: true, sensitivity: "base" }));
+}
+
+function studentOptionValue(student) {
+  if (typeof student === "string") return student;
+  return String(student?.id || "").trim();
+}
+
+function studentOptionLabel(student) {
+  if (typeof student === "string") return studentLabel(student);
+  return String(student?.label || student?.display_name || student?.id || "").trim() || "-";
+}
+
+function populateClassRosterOptions(rosters, preferredRosterName = "") {
+  const options = Array.isArray(rosters) ? rosters.filter((roster) => roster?.name) : [];
+  if (!els.classRoster) return "";
+  if (!options.length) {
+    els.classRoster.innerHTML = '<option value="">Dai registri consegne</option>';
+    els.classRoster.value = "";
+    els.classRoster.disabled = true;
+    return "";
+  }
+  const names = options.map((roster) => roster.name);
+  const selected = names.includes(preferredRosterName) ? preferredRosterName : names[0];
+  els.classRoster.disabled = false;
+  els.classRoster.innerHTML = options.map((roster) => `
+    <option value="${escapeHtml(roster.name)}"${roster.name === selected ? " selected" : ""}>${escapeHtml(rosterLabel(roster))}</option>
+  `).join("");
+  els.classRoster.value = selected;
+  return selected;
+}
+
 function populateStudentOptions(students, preferredStudentId = "") {
   const options = students.length ? students : DEMO_STUDENTS;
-  const selected = options.includes(preferredStudentId) ? preferredStudentId : options[0];
+  const values = options.map(studentOptionValue).filter(Boolean);
+  const selected = values.includes(preferredStudentId) ? preferredStudentId : values[0];
   els.studentId.innerHTML = options.map((student) => `
-    <option value="${escapeHtml(student)}"${student === selected ? " selected" : ""}>${escapeHtml(studentLabel(student))}</option>
+    <option value="${escapeHtml(studentOptionValue(student))}"${studentOptionValue(student) === selected ? " selected" : ""}>${escapeHtml(studentOptionLabel(student))}</option>
   `).join("");
   els.studentId.value = selected;
   return selected;
 }
 
-async function loadStudentOptions(preferredStudentId = "") {
+async function loadRosterStudentOptions(preferredStudentId = "", preferredRosterName = "") {
+  const rostersPayload = await api("/api/class-rosters");
+  const rosterName = populateClassRosterOptions(rostersPayload.rosters || [], preferredRosterName);
+  if (!rosterName) return "";
+  const payload = await api("/api/class-rosters/load", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: rosterName }),
+  });
+  return populateStudentOptions(activeStudentsFromRoster(payload.roster), preferredStudentId);
+}
+
+async function loadStudentOptions(preferredStudentId = "", preferredRosterName = "") {
+  try {
+    const rosterStudentId = await loadRosterStudentOptions(preferredStudentId, preferredRosterName);
+    if (rosterStudentId) return rosterStudentId;
+  } catch {
+    populateClassRosterOptions([], "");
+  }
   try {
     const payload = await api("/api/assignment-overview");
     return populateStudentOptions(uniqueStudentsFromOverview(payload.rows || []), preferredStudentId);
@@ -216,6 +282,14 @@ els.form.addEventListener("submit", (event) => {
   loadStudentDashboard(els.studentId.value).catch((error) => {
     els.status.textContent = `Errore: ${error.message}`;
   });
+});
+
+els.classRoster?.addEventListener("change", () => {
+  loadStudentOptions(els.studentId.value, els.classRoster.value)
+    .then((studentId) => loadStudentDashboard(studentId))
+    .catch((error) => {
+      els.status.textContent = `Errore: ${error.message}`;
+    });
 });
 
 loadStudentOptions(els.studentId.value)


### PR DESCRIPTION
﻿## Cosa cambia

- La vista studente carica i roster locali da `/api/class-rosters`.
- Aggiunge la select `Classe` e popola la select `Studente` dal roster selezionato.
- Mantiene il fallback attuale: se i roster non sono disponibili usa `/api/assignment-overview`, poi i dati demo.
- Aggiorna la documentazione della vista studente.

## Perche'

Dopo l'introduzione del roster locale, la vista studente non deve dipendere solo dai registri consegne per sapere quali studenti esistono. Questo e' il primo collegamento reale tra contratto classi/studenti e UI studente.

## Verifiche

- `python -m pytest tests/test_student_dashboard_frontend.py tests/test_assignment_dashboard_frontend.py tests/test_course_board_server.py tests/test_thebitlab_storage.py tests/test_thebitlab_services.py` -> 57 passed
- `git diff --check`
