### PR TITLE
Aggiunge pannello roster classe alla dashboard consegne

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -374,6 +374,46 @@ Il pattern della pagina consegne va reso riutilizzabile.
 6. Evitare duplicazione CSS/JS tra pagine.
 7. Migliorare accessibilita di drag/drop e resize.
 
+## Priorita 5.5 - Guide operative dashboard docente e studente
+
+Serve una guida d'uso pratica, separata dalla documentazione tecnica, che accompagni docente e studente in tutti gli scenari principali con passaggi espliciti e immagini.
+
+1. Creare una guida docente per la dashboard consegne:
+   - avvio del server locale;
+   - apertura della dashboard;
+   - scelta activity;
+   - scelta classe/roster;
+   - controllo del pannello roster classe;
+   - generazione registro;
+   - caricamento registro esistente;
+   - lettura riepiloghi;
+   - uso di quadro classe, elenco e matrice;
+   - apertura consegne studenti;
+   - revisione file consegnati;
+   - lettura grading, test falliti, voti e feedback AI;
+   - approvazione, respinta e riapertura bozze AI;
+   - uso di copertura registri;
+   - gestione dei casi mancanti, in ritardo, senza grading o senza feedback.
+2. Creare una guida studente per la vista studente:
+   - apertura della vista;
+   - scelta/riconoscimento dello studente;
+   - lettura consegne aperte e scadute;
+   - lettura stato, scadenze, grading e feedback approvato;
+   - differenza tra feedback visibile, bozza docente e feedback non generato;
+   - collegamento futuro a repository/profilo GitHub;
+   - vista futura del percorso didattico e calendario in sola lettura.
+3. Per ogni scenario includere:
+   - obiettivo dello scenario;
+   - prerequisiti;
+   - dati demo da caricare;
+   - passaggi numerati;
+   - screenshot dettagliati;
+   - cosa controllare a schermo;
+   - errori comuni e come interpretarli;
+   - differenza tra stato demo/MVP e comportamento previsto con dati reali.
+4. Salvare screenshot e immagini in una cartella dedicata, per esempio `doc/images/dashboard-guides/`.
+5. Collegare le guide da `doc/README.md`, `STUDENT_DASHBOARD.md`, `CLASS_ROSTERS.md` e dalla futura cornice didattica.
+
 ## Priorita 6 - Cornice didattica
 
 Serve un documento leggibile che spieghi il progetto dal punto di vista didattico, non solo tecnico.

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -379,6 +379,10 @@ Il pattern della pagina consegne va reso riutilizzabile.
 Serve una guida d'uso pratica, separata dalla documentazione tecnica, che accompagni docente e studente in tutti gli scenari principali con passaggi espliciti e immagini.
 
 1. Creare una guida docente per la dashboard consegne:
+   - panoramica dei pannelli disponibili;
+   - a cosa serve ogni pannello;
+   - quando usare ciascun pannello nel flusso di lavoro docente;
+   - differenza tra pannelli di preparazione, monitoraggio, revisione e riepilogo;
    - avvio del server locale;
    - apertura della dashboard;
    - scelta activity;

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -446,8 +446,10 @@ def test_class_roster_panel_renders_selected_roster_students_and_targets() -> No
           ],
         });
 
-        assert.match(tested.els.rosterPanelStatus.textContent, /3A TPSI - 3 studenti/);
+        assert.match(tested.els.rosterPanelStatus.textContent, /3A TPSI - somma - 3 studenti/);
         assert.match(tested.els.rosterSummary.innerHTML, /<strong>Classe<\\/strong>\\s*<span>3A TPSI<\\/span>/);
+        assert.match(tested.els.rosterSummary.innerHTML, /<strong>Activity<\\/strong>\\s*<span>somma<\\/span>/);
+        assert.match(tested.els.rosterSummary.innerHTML, /<strong>Output registro<\\/strong>\\s*<span>3a-tpsi\\/somma.json<\\/span>/);
         assert.match(tested.els.rosterSummary.innerHTML, /<strong>Attivi<\\/strong>\\s*<span>2<\\/span>/);
         assert.match(tested.els.rosterSummary.innerHTML, /<strong>Target locali<\\/strong>\\s*<span>1<\\/span>/);
         assert.match(tested.els.rosterSummary.innerHTML, /<strong>Fallback demo<\\/strong>\\s*<span>1<\\/span>/);

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -266,6 +266,8 @@ def run_dashboard_js(assertions: str) -> None:
         rosterOptionLabel,
         localTargetFromStudent,
         rosterTargets,
+        rosterSummaryItems,
+        renderRosterPanel,
         applyRosterToGenerateForm,
         els,
         layout,
@@ -423,6 +425,36 @@ def test_class_roster_option_label_includes_year_and_students() -> None:
           JSON.stringify(tested.rosterTargets({ students: [{ id: "rossi-mario", active: false }] })),
           JSON.stringify({ targets: [], warnings: [] }),
         );
+        """
+    )
+
+
+def test_class_roster_panel_renders_selected_roster_students_and_targets() -> None:
+    run_dashboard_js(
+        """
+        tested.state.activities = [
+          { id: "somma", path: "activities/somma.json" },
+        ];
+        tested.els.activityPath.value = "activities/somma.json";
+        tested.applyRosterToGenerateForm({
+          id: "3A-TPSI",
+          label: "3A TPSI",
+          students: [
+            { id: "rossi-mario", display_name: "Rossi Mario", local_path: "studenti/rossi-mario", github_username: "rossi-gh", active: true },
+            { id: "bianchi-luca", display_name: "Bianchi Luca", repo_ref: "TheBitPoets/bianchi-luca", active: true },
+            { id: "verdi-anna", display_name: "Verdi Anna", repo_path: "studenti/verdi-anna", active: false },
+          ],
+        });
+
+        assert.match(tested.els.rosterPanelStatus.textContent, /3A TPSI - 3 studenti/);
+        assert.match(tested.els.rosterSummary.innerHTML, /<strong>Classe<\\/strong>\\s*<span>3A TPSI<\\/span>/);
+        assert.match(tested.els.rosterSummary.innerHTML, /<strong>Attivi<\\/strong>\\s*<span>2<\\/span>/);
+        assert.match(tested.els.rosterSummary.innerHTML, /<strong>Target locali<\\/strong>\\s*<span>1<\\/span>/);
+        assert.match(tested.els.rosterSummary.innerHTML, /<strong>Fallback demo<\\/strong>\\s*<span>1<\\/span>/);
+        assert.match(tested.els.rosterBody.innerHTML, /studenti\\/rossi-mario/);
+        assert.match(tested.els.rosterBody.innerHTML, /examples\\/assignment_tracking\\/student_repos\\/bianchi-luca/);
+        assert.match(tested.els.rosterBody.innerHTML, /Fallback demo/);
+        assert.match(tested.els.rosterBody.innerHTML, /Non attivo/);
         """
     )
 
@@ -770,6 +802,15 @@ def test_report_loader_controls_live_in_selected_report_panel() -> None:
     assert 'id="loadReportBtn"' in selected_report_section
     assert 'id="reloadBtn"' in selected_report_section
     assert 'id="reportSelect"' not in hero_section
+
+
+def test_class_roster_panel_is_available_on_assignment_dashboard() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
+    roster_section = html.split('data-panel-key="class-roster"', 1)[1].split('data-panel-key="selected-report"', 1)[0]
+
+    assert 'id="rosterPanelStatus"' in roster_section
+    assert 'id="rosterSummary"' in roster_section
+    assert 'id="rosterBody"' in roster_section
 
 
 def test_review_ai_feedback_posts_decision_and_updates_modal_status() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -457,6 +457,10 @@ def test_class_roster_panel_renders_selected_roster_students_and_targets() -> No
         assert.match(tested.els.rosterBody.innerHTML, /examples\\/assignment_tracking\\/student_repos\\/bianchi-luca/);
         assert.match(tested.els.rosterBody.innerHTML, /Fallback demo/);
         assert.match(tested.els.rosterBody.innerHTML, /Non attivo/);
+
+        tested.els.outputName.value = "3a-tpsi/somma-personalizzato.json";
+        tested.renderRosterPanel();
+        assert.match(tested.els.rosterSummary.innerHTML, /<strong>Output registro<\\/strong>\\s*<span>3a-tpsi\\/somma-personalizzato.json<\\/span>/);
         """
     )
 

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -232,6 +232,10 @@ label > textarea {
   min-width: min(18rem, 100%);
 }
 
+.rosterTableWrap {
+  padding-top: 0;
+}
+
 .coverageBlock {
   border-top: 1px solid var(--line);
 }

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -105,6 +105,33 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       </div>
     </section>
 
+    <section class="panel" data-panel-key="class-roster">
+      <div class="panelHead">
+        <div>
+          <h2>Roster classe</h2>
+          <p id="rosterPanelStatus" class="status">Seleziona un roster in Genera registro per vedere studenti e target.</p>
+        </div>
+      </div>
+      <div id="rosterSummary" class="summaryGrid">
+        <p class="status">Nessun roster selezionato.</p>
+      </div>
+      <div class="tableWrap rosterTableWrap">
+        <table id="rosterTable" class="resizableTable">
+          <thead>
+            <tr>
+              <th>Studente</th>
+              <th>Account</th>
+              <th>Target registro</th>
+              <th>Stato</th>
+            </tr>
+          </thead>
+          <tbody id="rosterBody">
+            <tr><td colspan="4">Seleziona un roster per vedere gli studenti.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
     <section class="panel" data-panel-key="selected-report">
       <div class="panelHead">
         <div>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -92,6 +92,7 @@ const state = {
   activities: [],
   reports: [],
   classRosters: [],
+  selectedClassRoster: null,
   overviewRows: [],
   report: null,
   reportName: "",
@@ -184,6 +185,9 @@ const els = {
   activityPath: document.querySelector("#activityPath"),
   classRosterSelect: document.querySelector("#classRosterSelect"),
   rosterStatus: document.querySelector("#rosterStatus"),
+  rosterPanelStatus: document.querySelector("#rosterPanelStatus"),
+  rosterSummary: document.querySelector("#rosterSummary"),
+  rosterBody: document.querySelector("#rosterBody"),
   outputName: document.querySelector("#outputName"),
   classId: document.querySelector("#classId"),
   classLabel: document.querySelector("#classLabel"),
@@ -376,6 +380,10 @@ function classValue(entity) {
   return entity?.class_label || entity?.class_id || entity?.github_team || "classe non indicata";
 }
 
+function rosterClassValue(roster) {
+  return roster?.label || roster?.id || classValue(roster);
+}
+
 function classBadge(entity) {
   return `<span class="classBadge">${escapeHtml(classValue(entity))}</span>`;
 }
@@ -421,10 +429,13 @@ async function loadClassRosters() {
     const payload = await api("/api/class-rosters");
     state.classRosters = payload.rosters || [];
     renderClassRosterSelect();
+    renderRosterPanel();
     setRosterStatus(state.classRosters.length ? `Roster disponibili: ${state.classRosters.length}.` : "Nessun roster locale disponibile.");
   } catch (error) {
     state.classRosters = [];
+    state.selectedClassRoster = null;
     renderClassRosterSelect();
+    renderRosterPanel();
     setRosterStatus(`Roster non disponibili: ${error.message}`);
   }
 }
@@ -466,6 +477,76 @@ function renderClassRosterSelect() {
 
 function setRosterStatus(message) {
   if (els.rosterStatus) els.rosterStatus.textContent = message;
+}
+
+function setRosterPanelStatus(message) {
+  if (els.rosterPanelStatus) els.rosterPanelStatus.textContent = message;
+}
+
+function rosterSummaryItems(roster) {
+  const students = Array.isArray(roster?.students) ? roster.students : [];
+  const activeStudents = students.filter((student) => student?.active !== false);
+  const targets = activeStudents.map(localTargetFromStudent);
+  return [
+    ["Classe", rosterClassValue(roster)],
+    ["Studenti", students.length],
+    ["Attivi", activeStudents.length],
+    ["Target locali", targets.filter((target) => target.target && !target.warning).length],
+    ["Fallback demo", targets.filter((target) => target.warning).length],
+  ];
+}
+
+function renderRosterSummaryCards(items) {
+  return items.map(([label, value]) => `
+    <article class="summaryCard" title="${escapeHtml(summaryTooltip(label))}">
+      <strong>${escapeHtml(label)}</strong>
+      <span>${escapeHtml(value)}</span>
+    </article>
+  `).join("");
+}
+
+function studentAccountLabel(student) {
+  const github = student?.github_username ? `GitHub: ${student.github_username}` : "";
+  const repoRef = student?.repo_ref ? `Repo: ${student.repo_ref}` : "";
+  return [github, repoRef].filter(Boolean).join(" - ") || "-";
+}
+
+function targetBadgeForStudent(student, target) {
+  if (student?.active === false) return badge("Non attivo", "muted");
+  if (!target.target) return badge("Target mancante", "bad");
+  if (target.warning) return badge("Fallback demo", "warn");
+  return badge("Pronto", "ok");
+}
+
+function renderRosterPanel() {
+  const roster = state.selectedClassRoster;
+  if (!els.rosterSummary || !els.rosterBody) return;
+  if (!roster) {
+    setRosterPanelStatus(state.classRosters.length ? "Seleziona un roster in Genera registro per vedere studenti e target." : "Nessun roster locale disponibile.");
+    els.rosterSummary.innerHTML = '<p class="status">Nessun roster selezionato.</p>';
+    els.rosterBody.innerHTML = '<tr><td colspan="4">Seleziona un roster per vedere gli studenti.</td></tr>';
+    return;
+  }
+  const students = Array.isArray(roster.students) ? roster.students : [];
+  setRosterPanelStatus(`${rosterClassValue(roster)} - ${students.length} studenti nel roster.`);
+  els.rosterSummary.innerHTML = renderRosterSummaryCards(rosterSummaryItems(roster));
+  if (!students.length) {
+    els.rosterBody.innerHTML = '<tr><td colspan="4">Roster senza studenti.</td></tr>';
+    return;
+  }
+  els.rosterBody.innerHTML = students.map((student) => {
+    const target = localTargetFromStudent(student);
+    const studentName = student.display_name || student.id || "-";
+    const statusTitle = student.active === false ? "Studente escluso dalla generazione del registro." : (target.warning || "Target disponibile per la generazione del registro.");
+    return `
+      <tr>
+        <td>${studentLabel(studentName)}<br><small>${escapeHtml(student.id || "-")}</small></td>
+        <td>${escapeHtml(studentAccountLabel(student))}</td>
+        <td><code>${escapeHtml(target.target || "-")}</code></td>
+        <td title="${escapeHtml(statusTitle)}">${targetBadgeForStudent(student, target)}</td>
+      </tr>
+    `;
+  }).join("");
 }
 
 async function loadSelectedReport() {
@@ -1147,6 +1228,7 @@ function rosterTargets(roster) {
 
 function applyRosterToGenerateForm(roster) {
   if (!roster) return { targets: [], warnings: ["Roster non valido."] };
+  state.selectedClassRoster = roster;
   els.classId.value = roster.id || "";
   els.classLabel.value = roster.label || roster.id || "";
   els.githubTeam.value = roster.github_team || "";
@@ -1157,12 +1239,15 @@ function applyRosterToGenerateForm(roster) {
   setRosterStatus(result.warnings.length
     ? `Roster applicato con avvisi: ${result.warnings.join(" ")}`
     : `Roster applicato: ${result.targets.length} target studenti.`);
+  renderRosterPanel();
   return result;
 }
 
 async function loadSelectedClassRoster() {
   const name = els.classRosterSelect?.value || "";
   if (!name) {
+    state.selectedClassRoster = null;
+    renderRosterPanel();
     setRosterStatus("Seleziona un roster per compilare classe e target.");
     return;
   }
@@ -1962,6 +2047,9 @@ const SUMMARY_TOOLTIPS = {
   Righe: "Righe activity-studente mostrate rispetto al totale disponibile.",
   Filtri: "Filtri attivi nella vista corrente.",
   Classe: "Classe associata al registro consegne selezionato.",
+  Attivi: "Numero di studenti attivi nel roster e inclusi nella generazione del registro.",
+  "Target locali": "Numero di studenti attivi con un target locale o repo path gia disponibile.",
+  "Fallback demo": "Numero di studenti attivi per cui la GUI usera temporaneamente il path demo locale.",
   Scadenza: "Data e ora di scadenza del registro consegne selezionato.",
   Consegnati: "Numero di studenti che hanno effettuato una consegna.",
   Mancanti: "Numero di studenti senza consegna registrata.",

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2620,6 +2620,7 @@ els.activityPath.addEventListener("input", () => {
   renderActivitySelect();
   renderRosterPanel();
 });
+els.outputName.addEventListener("input", renderRosterPanel);
 els.classId.addEventListener("change", updateOutputNameForCurrentActivity);
 els.coverageBody.addEventListener("click", async (event) => {
   const toggleButton = event.target.closest("[data-coverage-toggle]");

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -489,6 +489,8 @@ function rosterSummaryItems(roster) {
   const targets = activeStudents.map(localTargetFromStudent);
   return [
     ["Classe", rosterClassValue(roster)],
+    ["Activity", currentActivityLabel()],
+    ["Output registro", els.outputName.value.trim() || "-"],
     ["Studenti", students.length],
     ["Attivi", activeStudents.length],
     ["Target locali", targets.filter((target) => target.target && !target.warning).length],
@@ -528,7 +530,7 @@ function renderRosterPanel() {
     return;
   }
   const students = Array.isArray(roster.students) ? roster.students : [];
-  setRosterPanelStatus(`${rosterClassValue(roster)} - ${students.length} studenti nel roster.`);
+  setRosterPanelStatus(`${rosterClassValue(roster)} - ${currentActivityLabel()} - ${students.length} studenti nel roster.`);
   els.rosterSummary.innerHTML = renderRosterSummaryCards(rosterSummaryItems(roster));
   if (!students.length) {
     els.rosterBody.innerHTML = '<tr><td colspan="4">Roster senza studenti.</td></tr>';
@@ -1194,6 +1196,11 @@ function defaultOutputName(activity) {
 
 function currentActivity() {
   return state.activities.find((candidate) => candidate.path === els.activityPath.value.trim().replaceAll("\\", "/"));
+}
+
+function currentActivityLabel() {
+  const activity = currentActivity();
+  return activity?.title || activity?.id || els.activityPath.value.trim() || "-";
 }
 
 function localTargetFromStudent(student) {
@@ -2048,6 +2055,7 @@ const SUMMARY_TOOLTIPS = {
   Filtri: "Filtri attivi nella vista corrente.",
   Classe: "Classe associata al registro consegne selezionato.",
   Attivi: "Numero di studenti attivi nel roster e inclusi nella generazione del registro.",
+  "Output registro": "Nome del file JSON che verra generato per l'activity e la classe selezionate.",
   "Target locali": "Numero di studenti attivi con un target locale o repo path gia disponibile.",
   "Fallback demo": "Numero di studenti attivi per cui la GUI usera temporaneamente il path demo locale.",
   Scadenza: "Data e ora di scadenza del registro consegne selezionato.",
@@ -2479,12 +2487,14 @@ function selectActivity(path) {
     els.classLabel.value = activity.class_label || activity.class_id || "";
     els.githubTeam.value = activity.github_team || "";
     els.outputName.value = defaultOutputName(activity);
+    renderRosterPanel();
   }
 }
 
 function updateOutputNameForCurrentActivity() {
   const activity = state.activities.find((candidate) => candidate.path === els.activityPath.value.trim().replaceAll("\\", "/"));
   if (activity?.id) els.outputName.value = defaultOutputName(activity);
+  renderRosterPanel();
 }
 
 function renderLegend() {
@@ -2606,7 +2616,10 @@ els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) selectActivity(els.activitySelect.value);
 });
 els.classRosterSelect?.addEventListener("change", loadSelectedClassRoster);
-els.activityPath.addEventListener("input", renderActivitySelect);
+els.activityPath.addEventListener("input", () => {
+  renderActivitySelect();
+  renderRosterPanel();
+});
 els.classId.addEventListener("change", updateOutputNameForCurrentActivity);
 els.coverageBody.addEventListener("click", async (event) => {
   const toggleButton = event.target.closest("[data-coverage-toggle]");


### PR DESCRIPTION
﻿## Cosa cambia

Aggiunge alla dashboard consegne un pannello read-only `Roster classe`.

Il pannello mostra:
- classe del roster selezionato;
- numero studenti totali e attivi;
- quanti target sono locali/pronti;
- quanti studenti usano ancora fallback demo;
- tabella studenti con account, target registro e stato.

## Perche'

Dopo aver collegato i roster alla generazione dei registri, mancava un punto visivo in cui il docente potesse capire da quali dati vengono compilati classe e target studenti.

## Validazione

- `python -m pytest tests/test_assignment_dashboard_frontend.py tests/test_course_board_server.py tests/test_thebitlab_storage.py tests/test_thebitlab_services.py`
