### PR TITLE
Aggiunge guida operativa dashboard docente

### DIFF
--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -1,0 +1,302 @@
+# Guida operativa dashboard docente
+
+Questa guida descrive come usare la dashboard consegne docente durante la preparazione, il monitoraggio e la revisione delle activity.
+
+Stato attuale: guida scheletro MVP. Gli screenshot saranno aggiunti in `doc/images/dashboard-guides/` quando la UI sara stabile.
+
+## Avvio
+
+Avvia il server locale dalla root del repository:
+
+```bash
+python scripts/course_board_server.py
+```
+
+Poi apri:
+
+```text
+http://localhost:8765/tools/assignment_dashboard.html
+```
+
+## Pannelli
+
+### Genera registro
+
+Serve a preparare o aggiornare un registro consegne.
+
+Usalo quando devi:
+
+- scegliere una activity;
+- scegliere la classe tramite roster;
+- controllare o modificare il nome del registro JSON;
+- impostare classe, team, assegnazione e scadenza;
+- generare il registro in `teacher-reports`.
+
+Screenshot previsto: `doc/images/dashboard-guides/docente-genera-registro.png`.
+
+### Roster classe
+
+Serve a controllare quali studenti saranno usati per generare il registro della activity selezionata.
+
+Usalo prima di premere **Genera registro**, soprattutto quando:
+
+- vuoi verificare che la classe selezionata sia corretta;
+- vuoi controllare gli studenti attivi;
+- vuoi vedere quali target sono pronti;
+- vuoi individuare fallback demo o target mancanti;
+- vuoi confermare activity e output registro associati al roster.
+
+Screenshot previsto: `doc/images/dashboard-guides/docente-roster-classe.png`.
+
+### Registro selezionato
+
+Serve a caricare e leggere un registro gia generato.
+
+Usalo quando:
+
+- vuoi aprire un registro esistente;
+- vuoi ricaricare la lista dei registri disponibili;
+- vuoi vedere il riepilogo generale di una activity gia tracciata.
+
+Screenshot previsto: `doc/images/dashboard-guides/docente-registro-selezionato.png`.
+
+### Quadro classe
+
+Serve a vedere tutte le activity e consegne della classe in forma aggregata.
+
+Usalo quando:
+
+- vuoi controllare lo stato complessivo della classe;
+- vuoi filtrare per classe, studente, activity, tipo, stato o modalita;
+- vuoi confrontare consegne diverse;
+- vuoi usare la vista elenco per ordinare righe;
+- vuoi usare la matrice per vedere rapidamente studenti x activity.
+
+Screenshot previsto: `doc/images/dashboard-guides/docente-quadro-classe.png`.
+
+### Studenti
+
+Serve a leggere il dettaglio degli studenti nel registro selezionato.
+
+Usalo quando:
+
+- vuoi filtrare consegne mancanti, in ritardo, consegnate o con test falliti;
+- vuoi aprire la consegna di uno studente;
+- vuoi controllare grading, voti, feedback AI e stato revisione.
+
+Screenshot previsto: `doc/images/dashboard-guides/docente-studenti.png`.
+
+### Copertura registri
+
+Serve a capire quali activity hanno gia un registro generato e quali no.
+
+Usalo quando:
+
+- vuoi evitare di rigenerare registri per activity gia coperte;
+- vuoi vedere registri multipli per la stessa activity e classi diverse;
+- vuoi aprire il dettaglio studenti di un registro;
+- vuoi capire se una activity e scaduta o ancora aperta.
+
+Screenshot previsto: `doc/images/dashboard-guides/docente-copertura-registri.png`.
+
+### Revisione consegna
+
+Serve a vedere i file caricati dallo studente.
+
+Usalo quando:
+
+- vuoi leggere il contenuto di un file consegnato;
+- vuoi passare alla consegna precedente o successiva;
+- vuoi controllare syntax highlighting, file multipli e link repository.
+
+Screenshot previsto: `doc/images/dashboard-guides/docente-revisione-consegna.png`.
+
+## Scenario 1 - Generare un registro per activity e classe
+
+Obiettivo: creare un registro consegne per una activity assegnata a una classe.
+
+Prerequisiti:
+
+- il server locale e avviato;
+- esiste almeno una activity JSON;
+- esiste almeno un roster classe in `doc/classes`;
+- i repository o target studenti sono disponibili oppure accettano fallback demo.
+
+Passaggi:
+
+1. Apri la dashboard consegne.
+2. Nel pannello **Genera registro**, scegli una activity da **Activity salvate**.
+3. Scegli una classe da **Classe da roster**.
+4. Controlla il pannello **Roster classe**:
+   - classe;
+   - activity;
+   - output registro;
+   - studenti attivi;
+   - target locali;
+   - fallback demo.
+5. Se serve, modifica **Output registro**.
+6. Controlla scadenza e data di assegnazione.
+7. Premi **Genera registro**.
+8. Verifica il pannello **Registro selezionato**.
+9. Apri **Studenti** o **Quadro classe** per controllare il risultato.
+
+Cosa controllare a schermo:
+
+- il roster mostra la classe corretta;
+- l'activity mostrata nel roster e quella scelta;
+- l'output registro contiene la classe o un prefisso riconoscibile;
+- gli studenti attivi corrispondono alla classe;
+- non ci sono fallback demo inattesi.
+
+Screenshot previsti:
+
+- `doc/images/dashboard-guides/scenario-genera-registro-01.png`;
+- `doc/images/dashboard-guides/scenario-genera-registro-02.png`;
+- `doc/images/dashboard-guides/scenario-genera-registro-03.png`.
+
+## Scenario 2 - Caricare un registro esistente
+
+Obiettivo: aprire un registro gia salvato in `teacher-reports`.
+
+Passaggi:
+
+1. Nel pannello **Registro selezionato**, scegli un registro dalla select.
+2. Premi **Carica registro**.
+3. Controlla il riepilogo del registro.
+4. Apri **Studenti** per vedere i dettagli.
+5. Apri **Quadro classe** se vuoi confrontarlo con altri registri.
+
+Cosa controllare a schermo:
+
+- classe;
+- activity;
+- scadenza;
+- numero studenti;
+- consegnati, mancanti e ritardi.
+
+Screenshot previsto: `doc/images/dashboard-guides/scenario-carica-registro.png`.
+
+## Scenario 3 - Controllare il quadro classe
+
+Obiettivo: avere una vista aggregata di tutte le consegne disponibili.
+
+Passaggi:
+
+1. Apri il pannello **Quadro classe**.
+2. Premi **Apri quadro classe**.
+3. Usa i filtri:
+   - classe;
+   - studente;
+   - activity;
+   - tipo;
+   - stato;
+   - modalita.
+4. Usa la tab **Elenco** per ordinare colonne e aprire singole consegne.
+5. Usa la tab **Matrice** per vedere rapidamente copertura e ritardi.
+
+Cosa controllare a schermo:
+
+- i filtri attivi;
+- righe mostrate rispetto al totale;
+- colori e badge;
+- bottoni **Consegna** disabilitati quando la consegna manca.
+
+Screenshot previsto: `doc/images/dashboard-guides/scenario-quadro-classe.png`.
+
+## Scenario 4 - Revisionare una consegna studente
+
+Obiettivo: aprire i file consegnati da uno studente e leggerli.
+
+Passaggi:
+
+1. Carica un registro.
+2. Apri il pannello **Studenti**.
+3. Filtra se necessario.
+4. Premi **Apri** sulla riga dello studente.
+5. Nel modal **Revisione consegna**, scegli il file nella colonna sinistra.
+6. Leggi il contenuto nella colonna destra.
+7. Usa precedente/successiva per cambiare studente.
+
+Cosa controllare a schermo:
+
+- nome studente;
+- file disponibili;
+- contenuto del file;
+- grading e test falliti;
+- link repository quando disponibile.
+
+Screenshot previsto: `doc/images/dashboard-guides/scenario-revisione-consegna.png`.
+
+## Scenario 5 - Leggere e approvare feedback AI
+
+Obiettivo: distinguere feedback non generato, bozza AI, feedback approvato e respinto.
+
+Passaggi:
+
+1. Carica un registro con feedback AI.
+2. Apri **Studenti**.
+3. Cerca la colonna AI.
+4. Apri il dettaglio se il feedback e in bozza.
+5. Approva o respingi la bozza.
+6. Ricarica il registro se serve verificare la persistenza.
+
+Cosa controllare a schermo:
+
+- **Non generato**: nessun feedback disponibile;
+- **Bozza AI**: feedback generato ma non visibile allo studente;
+- **Approvato**: feedback visibile nella vista studente;
+- **Respinto**: feedback non pubblicato.
+
+Screenshot previsto: `doc/images/dashboard-guides/scenario-feedback-ai.png`.
+
+## Errori comuni
+
+### Endpoint non trovato
+
+Se compare un errore `404 endpoint non trovato`, probabilmente la pagina non e stata aperta tramite il server locale.
+
+Avvia:
+
+```bash
+python scripts/course_board_server.py
+```
+
+Poi usa l'URL `http://localhost:8765/...`.
+
+### Roster non disponibile
+
+Se la select roster e vuota:
+
+- controlla che esista almeno un file JSON in `doc/classes`;
+- controlla che il JSON abbia `id` e `students`;
+- ricarica la pagina.
+
+### Target demo inatteso
+
+Se il pannello roster mostra fallback demo, significa che per uno studente manca un path locale o repo path risolvibile.
+
+Nel MVP il fallback usa:
+
+```text
+examples/assignment_tracking/student_repos/<student-id>
+```
+
+Con dati reali dovra essere sostituito da provider GitHub/GitLab o da un mapping locale esplicito.
+
+## Stato demo e comportamento atteso con dati reali
+
+Nel demo/MVP:
+
+- alcuni target possono usare path demo;
+- i roster sono JSON locali;
+- i registri sono snapshot JSON;
+- non ci sono ancora permessi reali;
+- la vista studente non ha login.
+
+Con dati reali:
+
+- classi e studenti dovrebbero arrivare da GitHub Team, GitLab, import locale o provider interno;
+- i repository studenti dovrebbero essere risolti dal provider;
+- le activity dovrebbero essere assegnate dalla GUI;
+- feedback e grading dovrebbero essere tracciati come workflow docente-studente;
+- gli screenshot della guida dovrebbero essere aggiornati su dati realistici.

--- a/doc/README.md
+++ b/doc/README.md
@@ -31,7 +31,8 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 3. [`DATA_MODEL_MVP.md`](DATA_MODEL_MVP.md)
 4. [`CLASS_ROSTERS.md`](CLASS_ROSTERS.md)
 5. [`MANUAL_AI_FEEDBACK_WORKFLOW.md`](MANUAL_AI_FEEDBACK_WORKFLOW.md)
-6. [`STUDENT_DASHBOARD.md`](STUDENT_DASHBOARD.md)
+6. [`DASHBOARD_DOCENTE_GUIDA.md`](DASHBOARD_DOCENTE_GUIDA.md)
+7. [`STUDENT_DASHBOARD.md`](STUDENT_DASHBOARD.md)
 
 `ASSIGNMENTS.md` descrive il modello leggero per attivita didattiche, uso dei team GitHub come classi, correzione automatica, sandbox, metriche e roadmap delle prossime PR.
 
@@ -42,6 +43,8 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 `CLASS_ROSTERS.md` descrive il primo contratto JSON locale per classi e studenti, in attesa di GitHub Team o roster locali sincronizzati.
 
 `MANUAL_AI_FEEDBACK_WORKFLOW.md` spiega il flusso manuale completo per generare un pacchetto AI da registro, validare la risposta e applicarla come bozza non approvata.
+
+`DASHBOARD_DOCENTE_GUIDA.md` raccoglie la guida operativa docente per usare la dashboard consegne, con pannelli, scenari e placeholder per screenshot dettagliati.
 
 `STUDENT_DASHBOARD.md` spiega la prima vista studente MVP per vedere consegne, grading e solo feedback approvato dal docente.
 
@@ -60,6 +63,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | [`CLASS_ROSTERS.md`](CLASS_ROSTERS.md) | Quando devi lavorare su classi, studenti, roster locali o futuro mapping GitHub Team |
 | [`ASSIGNMENT_SUBMISSIONS.md`](ASSIGNMENT_SUBMISSIONS.md) | Quando devi progettare il flusso consegne studenti con GitHub, team classe e repository studente |
 | [`MANUAL_AI_FEEDBACK_WORKFLOW.md`](MANUAL_AI_FEEDBACK_WORKFLOW.md) | Quando devi provare il feedback AI manuale da registro senza API key o GUI dedicata |
+| [`DASHBOARD_DOCENTE_GUIDA.md`](DASHBOARD_DOCENTE_GUIDA.md) | Quando devi usare o documentare la dashboard consegne docente passo dopo passo |
 | [`STUDENT_DASHBOARD.md`](STUDENT_DASHBOARD.md) | Quando devi provare la vista studente minima su consegne, grading e feedback approvato |
 | [`STUDENT_REPOSITORY_TEMPLATE.md`](STUDENT_REPOSITORY_TEMPLATE.md) | Quando devi creare o mantenere il template repository studente |
 | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) | Quando devi correggere in modo deterministico una consegna TheBitLab |


### PR DESCRIPTION
﻿## Cosa cambia

Aggiunge `doc/DASHBOARD_DOCENTE_GUIDA.md`, una guida operativa scheletro per la dashboard consegne docente.

La guida copre:
- panoramica dei pannelli;
- a cosa serve ogni pannello e quando usarlo;
- scenario generazione registro activity + classe;
- scenario caricamento registro esistente;
- scenario quadro classe;
- scenario revisione consegna studente;
- scenario feedback AI;
- errori comuni;
- differenza tra demo/MVP e dati reali;
- placeholder per screenshot futuri.

Aggiorna anche `doc/README.md` per collegare la nuova guida.

## Validazione

- controllo manuale dei link Markdown introdotti;
- PR solo documentale, nessun test codice necessario.
