### PR TITLE
Aggiunge checklist screenshot guide dashboard

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -49,6 +49,8 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 
 `DASHBOARD_STUDENTE_GUIDA.md` raccoglie la guida operativa studente per leggere consegne, stato, grading e feedback approvato.
 
+`images/dashboard-guides/README.md` contiene la checklist degli screenshot da produrre per le guide docente e studente.
+
 `STUDENT_DASHBOARD.md` spiega la prima vista studente MVP per vedere consegne, grading e solo feedback approvato dal docente.
 
 ## Mappa rapida
@@ -68,6 +70,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | [`MANUAL_AI_FEEDBACK_WORKFLOW.md`](MANUAL_AI_FEEDBACK_WORKFLOW.md) | Quando devi provare il feedback AI manuale da registro senza API key o GUI dedicata |
 | [`DASHBOARD_DOCENTE_GUIDA.md`](DASHBOARD_DOCENTE_GUIDA.md) | Quando devi usare o documentare la dashboard consegne docente passo dopo passo |
 | [`DASHBOARD_STUDENTE_GUIDA.md`](DASHBOARD_STUDENTE_GUIDA.md) | Quando devi usare o documentare la vista studente passo dopo passo |
+| [`images/dashboard-guides/README.md`](images/dashboard-guides/README.md) | Quando devi catturare o aggiornare gli screenshot delle guide dashboard |
 | [`STUDENT_DASHBOARD.md`](STUDENT_DASHBOARD.md) | Quando devi provare la vista studente minima su consegne, grading e feedback approvato |
 | [`STUDENT_REPOSITORY_TEMPLATE.md`](STUDENT_REPOSITORY_TEMPLATE.md) | Quando devi creare o mantenere il template repository studente |
 | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) | Quando devi correggere in modo deterministico una consegna TheBitLab |

--- a/doc/images/dashboard-guides/README.md
+++ b/doc/images/dashboard-guides/README.md
@@ -1,0 +1,93 @@
+# Screenshot guide dashboard
+
+Questa cartella conterra gli screenshot usati dalle guide operative:
+
+- [`../../DASHBOARD_DOCENTE_GUIDA.md`](../../DASHBOARD_DOCENTE_GUIDA.md)
+- [`../../DASHBOARD_STUDENTE_GUIDA.md`](../../DASHBOARD_STUDENTE_GUIDA.md)
+
+Per ora e una checklist: gli screenshot sono **da fare**.
+
+## Regole di cattura
+
+1. Avviare sempre il server locale:
+
+   ```bash
+   python scripts/course_board_server.py
+   ```
+
+2. Aprire le pagine tramite `http://localhost:8765/...`, non come file locali.
+3. Usare dati demo coerenti e ripetibili.
+4. Preferire viewport desktop per i flussi docente e almeno uno screenshot mobile per la vista studente.
+5. Prima di catturare, controllare che:
+   - non ci siano errori visibili;
+   - il pannello o modal descritto sia aperto;
+   - filtri, select e riepiloghi mostrino dati significativi;
+   - non siano visibili token, path personali non necessari o dati sensibili.
+6. Aggiornare lo stato da `da fare` a `fatto` quando l'immagine viene salvata.
+
+## Dati demo consigliati
+
+Pagina docente:
+
+- URL: `http://localhost:8765/tools/assignment_dashboard.html`
+- Roster: `doc/classes/demo-3a.json`
+- Activity: una activity demo disponibile nella select **Activity salvate**
+- Registro: un registro demo in `teacher-reports/demo` o `teacher-reports/demo-3a`
+
+Pagina studente:
+
+- URL: `http://localhost:8765/tools/student_dashboard.html`
+- Classe: roster demo disponibile nella select **Classe**
+- Studente: uno studente demo con consegne visibili, preferibilmente con almeno un feedback approvato
+
+## Screenshot docente
+
+| File | Stato | Pagina | Cosa deve mostrare |
+|---|---|---|---|
+| `docente-genera-registro.png` | da fare | Dashboard docente | Pannello **Genera registro** con activity, roster, output registro, scadenza e target studenti visibili |
+| `docente-roster-classe.png` | da fare | Dashboard docente | Pannello **Roster classe** con classe, activity, output registro, studenti attivi, target locali e fallback demo |
+| `docente-registro-selezionato.png` | da fare | Dashboard docente | Pannello **Registro selezionato** con registro caricato e riepilogo compilato |
+| `docente-quadro-classe.png` | da fare | Dashboard docente | Pannello **Quadro classe** con riepilogo e bottone per aprire il modal |
+| `docente-studenti.png` | da fare | Dashboard docente | Pannello **Studenti** con riepilogo del registro selezionato |
+| `docente-copertura-registri.png` | da fare | Dashboard docente | Copertura registri con riepilogo e gruppi activity riconoscibili |
+| `docente-revisione-consegna.png` | da fare | Dashboard docente | Modal revisione consegna con lista file a sinistra e contenuto file a destra |
+
+## Scenari docente
+
+| File | Stato | Scenario | Cosa deve mostrare |
+|---|---|---|---|
+| `scenario-genera-registro-01.png` | da fare | Generazione registro | Activity e roster selezionati prima della generazione |
+| `scenario-genera-registro-02.png` | da fare | Generazione registro | Pannello roster classe con target verificabili |
+| `scenario-genera-registro-03.png` | da fare | Generazione registro | Registro generato e caricato in **Registro selezionato** |
+| `scenario-carica-registro.png` | da fare | Caricare registro | Select registri, registro scelto e riepilogo dopo caricamento |
+| `scenario-quadro-classe.png` | da fare | Quadro classe | Modal quadro classe con filtri, elenco o matrice visibili |
+| `scenario-revisione-consegna.png` | da fare | Revisione consegna | Modal revisione con file consegnati e contenuto syntax-highlighted |
+| `scenario-feedback-ai.png` | da fare | Feedback AI | Stato feedback AI e azioni docente su bozza/approvazione/respinta |
+
+## Screenshot studente
+
+| File | Stato | Pagina | Cosa deve mostrare |
+|---|---|---|---|
+| `studente-panoramica.png` | da fare | Vista studente | Header, select classe/studente, riepilogo e lista consegne |
+| `studente-selezione.png` | da fare | Vista studente | Select **Classe** e **Studente** con dati demo caricati |
+| `studente-riepilogo.png` | da fare | Vista studente | Card riepilogo con studente, consegne, consegnate, in ritardo e feedback |
+| `studente-consegne.png` | da fare | Vista studente | Lista consegne con stato, scadenza, grading e link |
+| `studente-grading.png` | da fare | Vista studente | Dettaglio grading/test visibile in una consegna |
+| `studente-feedback.png` | da fare | Vista studente | Feedback approvato visibile allo studente |
+
+## Scenari studente
+
+| File | Stato | Scenario | Cosa deve mostrare |
+|---|---|---|---|
+| `scenario-studente-demo.png` | da fare | Apertura demo | Classe e studente selezionati, riepilogo non vuoto |
+| `scenario-studente-consegna.png` | da fare | Lettura consegna | Una consegna con stato, scadenza e grading leggibili |
+| `scenario-studente-feedback.png` | da fare | Feedback approvato | Feedback pubblicato e nessuna bozza AI visibile |
+
+## Dopo aver aggiunto immagini
+
+Quando uno screenshot viene salvato:
+
+1. aggiornare lo stato in questa checklist;
+2. verificare che il nome file corrisponda a quello citato nelle guide;
+3. controllare dimensione e leggibilita;
+4. valutare se inserirlo direttamente nella guida o lasciarlo come riferimento linkato.


### PR DESCRIPTION
﻿## Cosa cambia

Aggiunge `doc/images/dashboard-guides/README.md`, una checklist per produrre gli screenshot delle guide dashboard docente e studente.

La checklist include:
- regole di cattura;
- dati demo consigliati;
- elenco screenshot docente;
- elenco scenari docente;
- elenco screenshot studente;
- elenco scenari studente;
- criteri da verificare dopo aver aggiunto immagini.

Aggiorna `doc/README.md` per collegare la checklist.

## Validazione

- controllo manuale dei link Markdown introdotti;
- PR solo documentale, nessun test codice necessario.
