### PR TITLE
Mostra consegne mancanti nel riepilogo studente

### DIFF
--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -66,6 +66,7 @@ Usalo per capire rapidamente:
 
 - quante consegne risultano associate allo studente;
 - quante sono consegnate;
+- quante risultano mancanti;
 - quante risultano in ritardo;
 - se ci sono feedback approvati visibili.
 

--- a/doc/images/dashboard-guides/README.md
+++ b/doc/images/dashboard-guides/README.md
@@ -70,7 +70,7 @@ Pagina studente:
 |---|---|---|---|
 | `studente-panoramica.png` | da fare | Vista studente | Header, select classe/studente, riepilogo e lista consegne |
 | `studente-selezione.png` | da fare | Vista studente | Select **Classe** e **Studente** con dati demo caricati |
-| `studente-riepilogo.png` | da fare | Vista studente | Card riepilogo con studente, consegne, consegnate, in ritardo e feedback |
+| `studente-riepilogo.png` | da fare | Vista studente | Card riepilogo con studente, consegne, consegnate, mancanti, in ritardo e feedback |
 | `studente-consegne.png` | da fare | Vista studente | Lista consegne con stato, scadenza, grading e link |
 | `studente-grading.png` | da fare | Vista studente | Dettaglio grading/test visibile in una consegna |
 | `studente-feedback.png` | da fare | Vista studente | Feedback approvato visibile allo studente |

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -108,9 +108,17 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
           },
         };
 
-        tested.renderDashboard({ student_id: "rossi-mario", assignments: [assignment] });
+        tested.renderDashboard({
+          student_id: "rossi-mario",
+          assignments: [assignment, { activity_id: "python-loop-001", status: "missing", submitted: false, late: false }],
+        });
 
         assert.match(tested.els.summary.innerHTML, /rossi-mario/);
+        assert.match(tested.els.summary.innerHTML, /<strong>Consegne<\\/strong>\\s*<span>2<\\/span>/);
+        assert.match(tested.els.summary.innerHTML, /<strong>Consegnate<\\/strong>\\s*<span>1<\\/span>/);
+        assert.match(tested.els.summary.innerHTML, /<strong>Mancanti<\\/strong>\\s*<span>1<\\/span>/);
+        assert.match(tested.els.summary.innerHTML, /<strong>In ritardo<\\/strong>\\s*<span>0<\\/span>/);
+        assert.match(tested.els.summary.innerHTML, /<strong>Feedback<\\/strong>\\s*<span>1<\\/span>/);
         assert.match(tested.els.assignments.innerHTML, /Somma in Python/);
         assert.match(tested.els.assignments.innerHTML, /Feedback docente/);
         assert.match(tested.els.assignments.innerHTML, /Hai gestito correttamente/);

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -194,12 +194,14 @@ function gradeValue(grading) {
 
 function renderSummary(studentId, assignments) {
   const submitted = assignments.filter((item) => item.submitted).length;
+  const missing = assignments.filter((item) => item.status === "missing").length;
   const late = assignments.filter((item) => item.late).length;
   const approvedFeedback = assignments.filter((item) => item.approved_feedback).length;
   const cards = [
     ["Studente", studentId],
     ["Consegne", assignments.length],
     ["Consegnate", submitted],
+    ["Mancanti", missing],
     ["In ritardo", late],
     ["Feedback", approvedFeedback],
   ];


### PR DESCRIPTION
﻿## Cosa cambia

Aggiunge la card `Mancanti` al riepilogo della vista studente.

Aggiorna anche:
- test frontend della vista studente;
- guida operativa studente;
- checklist screenshot delle guide dashboard.

## Perche'

Il concetto di consegna mancante era gia presente negli stati delle singole consegne, ma non nel riepilogo. Questa PR rende il riepilogo piu coerente con la vista docente e con la guida operativa.

## Validazione

- `python -m pytest tests/test_student_dashboard_frontend.py`
