### PR TITLE
Aggiunge filtri consegne alla vista studente

### DIFF
--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -76,6 +76,14 @@ Screenshot previsto: `doc/images/dashboard-guides/studente-riepilogo.png`.
 
 La sezione **Consegne** elenca le activity visibili allo studente.
 
+Il filtro **Filtro** permette di restringere la lista senza cambiare lo studente selezionato:
+
+- **Tutte** mostra tutte le consegne trovate;
+- **Da consegnare o mancanti** mostra le consegne non ancora consegnate o segnate come mancanti;
+- **Consegnate** mostra solo le consegne presenti nel registro;
+- **In ritardo** mostra solo le consegne consegnate oltre la scadenza;
+- **Con feedback** mostra solo le consegne con feedback approvato dal docente.
+
 Per ogni consegna controlla:
 
 - titolo o id activity;

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -304,7 +304,9 @@ Da avere per la prima prova:
    - da revisionare.
 4. Vista studente in sola lettura per percorso e calendario:
    - mostrare il percorso didattico pubblicato dal docente con UDA e paragrafi pertinenti;
-   - mostrare il calendario corrente con lab, verifiche, scadenze e finestre di lavoro;
+   - distinguere la programmazione prevista per UDA dalla programmazione reale svolta, evidenziando eventuali ritardi o slittamenti;
+   - mostrare il calendario corrente con UDA, lezioni/lab, verifiche, compiti, consegne da fare, scadenze e finestre di lavoro;
+   - aggiungere piu avanti un riepilogo delle priorita per lo studente, per esempio consegne in scadenza, verifiche vicine e attivita arretrate;
    - non esporre azioni o pagine docente nella navigazione studente;
    - derivare queste viste dai dati docente senza duplicare percorso e calendario.
 5. Profilo studente:

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -51,6 +51,8 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderFeedback,
         renderAssignment,
         renderDashboard,
+        assignmentMatchesFilter,
+        filteredAssignments,
         safeExternalLink,
         studentLabel,
         rosterLabel,
@@ -136,6 +138,41 @@ def test_student_dashboard_hides_unapproved_feedback_payloads() -> None:
         assert.equal(tested.gradeValue({ teacher_grade: null, score: 6 }), 6);
         assert.match(tested.statusBadge({ status: "missing", submitted: false, late: false }), /Mancante/);
         assert.match(tested.gradingBadge({ status: "graded_failed" }), /Test falliti/);
+        """
+    )
+
+
+def test_student_dashboard_filters_visible_assignments() -> None:
+    run_student_dashboard_js(
+        """
+        const submitted = {
+          activity_id: "python-base-somma-001",
+          title: "Somma in Python",
+          status: "submitted_on_time",
+          submitted: true,
+          late: false,
+          approved_feedback: { summary: "Ok" },
+        };
+        const missing = {
+          activity_id: "python-loop-001",
+          title: "Loop in Python",
+          status: "missing",
+          submitted: false,
+          late: false,
+        };
+
+        tested.els.assignmentFilter.value = "all";
+        tested.renderDashboard({ student_id: "rossi-mario", assignments: [submitted, missing] });
+        assert.match(tested.els.assignments.innerHTML, /Somma in Python/);
+        assert.match(tested.els.assignments.innerHTML, /Loop in Python/);
+        assert.match(tested.els.status.textContent, /2 consegne trovate/);
+
+        tested.els.assignmentFilter.value = "open";
+        tested.renderDashboard({ student_id: "rossi-mario", assignments: [submitted, missing] });
+        assert.doesNotMatch(tested.els.assignments.innerHTML, /Somma in Python/);
+        assert.match(tested.els.assignments.innerHTML, /Loop in Python/);
+        assert.match(tested.els.status.textContent, /1 di 2 consegne visibili/);
+        assert.equal(tested.filteredAssignments([submitted, missing], "feedback").length, 1);
         """
     )
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -211,6 +211,19 @@ button:hover { transform: translateY(-1px); }
   margin-bottom: 0;
 }
 
+.assignmentTools {
+  display: flex;
+  align-items: end;
+  justify-content: flex-end;
+  gap: .75rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.assignmentTools select {
+  min-width: min(16rem, 45vw);
+}
+
 .assignmentList {
   display: grid;
   min-width: 0;
@@ -331,6 +344,7 @@ button:hover { transform: translateY(-1px); }
   .hero,
   .studentForm,
   .sectionHead,
+  .assignmentTools,
   .assignmentHead {
     display: grid;
     align-items: stretch;

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -44,7 +44,19 @@
     <section class="assignments">
       <div class="sectionHead">
         <h2>Consegne</h2>
-        <p id="status" class="status" aria-live="polite"></p>
+        <div class="assignmentTools">
+          <label>
+            <span>Filtro</span>
+            <select id="assignmentFilter" name="assignment_filter">
+              <option value="all">Tutte</option>
+              <option value="open">Da consegnare o mancanti</option>
+              <option value="submitted">Consegnate</option>
+              <option value="late">In ritardo</option>
+              <option value="feedback">Con feedback</option>
+            </select>
+          </label>
+          <p id="status" class="status" aria-live="polite"></p>
+        </div>
       </div>
       <div id="assignments" class="assignmentList"></div>
     </section>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -2,12 +2,14 @@ const els = {
   form: document.querySelector("#studentForm"),
   classRoster: document.querySelector("#classRoster"),
   studentId: document.querySelector("#studentId"),
+  assignmentFilter: document.querySelector("#assignmentFilter"),
   summary: document.querySelector("#summary"),
   status: document.querySelector("#status"),
   assignments: document.querySelector("#assignments"),
 };
 
 const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
+let currentDashboardPayload = { student_id: "", assignments: [] };
 
 async function api(path, options = {}) {
   const response = await fetch(path, options);
@@ -269,15 +271,32 @@ function renderAssignment(assignment) {
   `;
 }
 
+function assignmentMatchesFilter(assignment, filterValue) {
+  if (filterValue === "open") return assignment.status === "missing" || !assignment.submitted;
+  if (filterValue === "submitted") return Boolean(assignment.submitted);
+  if (filterValue === "late") return Boolean(assignment.late);
+  if (filterValue === "feedback") return Boolean(assignment.approved_feedback);
+  return true;
+}
+
+function filteredAssignments(assignments, filterValue) {
+  return assignments.filter((assignment) => assignmentMatchesFilter(assignment, filterValue));
+}
+
 function renderDashboard(payload) {
   const assignments = Array.isArray(payload.assignments) ? payload.assignments : [];
+  currentDashboardPayload = { ...payload, assignments };
+  const filterValue = els.assignmentFilter?.value || "all";
+  const visibleAssignments = filteredAssignments(assignments, filterValue);
   renderSummary(payload.student_id || "-", assignments);
-  els.status.textContent = assignments.length
+  els.status.textContent = visibleAssignments.length === assignments.length
     ? `${assignments.length} consegne trovate.`
-    : "Nessuna consegna trovata per questo studente.";
-  els.assignments.innerHTML = assignments.length
-    ? assignments.map(renderAssignment).join("")
-    : '<p class="status">Nessuna consegna disponibile.</p>';
+    : `${visibleAssignments.length} di ${assignments.length} consegne visibili.`;
+  els.assignments.innerHTML = visibleAssignments.length
+    ? visibleAssignments.map(renderAssignment).join("")
+    : assignments.length
+      ? '<p class="status">Nessuna consegna corrisponde al filtro selezionato.</p>'
+      : '<p class="status">Nessuna consegna disponibile.</p>';
 }
 
 async function loadStudentDashboard(studentId) {
@@ -304,6 +323,10 @@ els.classRoster?.addEventListener("change", () => {
     .catch((error) => {
       els.status.textContent = `Errore: ${error.message}`;
     });
+});
+
+els.assignmentFilter?.addEventListener("change", () => {
+  renderDashboard(currentDashboardPayload);
 });
 
 loadStudentOptions(els.studentId.value)


### PR DESCRIPTION
## Cosa cambia

- Aggiunge nella vista studente un filtro sulle consegne: tutte, da consegnare o mancanti, consegnate, in ritardo, con feedback.
- Mantiene il riepilogo studente sul totale delle consegne, mentre filtra solo la lista sotto.
- Aggiorna la guida operativa della vista studente.
- Aggiunge un test frontend per il filtro.

## Perche

Quando lo studente ha molte activity, la lista unica diventa poco leggibile. Il filtro permette di concentrarsi rapidamente sulle consegne piu rilevanti senza cambiare classe o studente.

## Verifiche

- `python -m pytest tests/test_student_dashboard_frontend.py`
