### PR TITLE
Mostra la classe nel riepilogo studente

### DIFF
--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -64,6 +64,7 @@ Dopo il caricamento, la pagina mostra un riepilogo dello studente.
 
 Usalo per capire rapidamente:
 
+- quale classe o fonte roster e attiva;
 - quante consegne risultano associate allo studente;
 - quante sono consegnate;
 - quante risultano mancanti;

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -228,6 +228,8 @@ def test_student_dashboard_populates_students_from_class_roster() -> None:
         assert.equal(selectedRoster, "demo-3a.json");
         assert.equal(tested.els.classRoster.disabled, false);
         assert.match(tested.els.classRoster.innerHTML, /Classe demo 3A \\(2026-2027\\)/);
+        tested.renderDashboard({ student_id: "rossi-mario", assignments: [] });
+        assert.match(tested.els.summary.innerHTML, /<strong>Classe<\\/strong>\\s*<span>Classe demo 3A \\(2026-2027\\)<\\/span>/);
         assert.equal(JSON.stringify(students.map((student) => student.id)), JSON.stringify(["bianchi-luca", "rossi-mario"]));
         assert.equal(selectedStudent, "rossi-mario");
         assert.match(tested.els.studentId.innerHTML, /Bianchi Luca/);
@@ -247,6 +249,8 @@ def test_student_dashboard_disables_class_roster_when_missing() -> None:
         assert.equal(tested.els.classRoster.value, "");
         assert.equal(tested.els.classRoster.disabled, true);
         assert.match(tested.els.classRoster.innerHTML, /Dai registri consegne/);
+        tested.renderDashboard({ student_id: "rossi-mario", assignments: [] });
+        assert.match(tested.els.summary.innerHTML, /<strong>Classe<\\/strong>\\s*<span>Dai registri consegne<\\/span>/);
         """
     )
 

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -10,6 +10,7 @@ const els = {
 
 const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
 let currentDashboardPayload = { student_id: "", assignments: [] };
+let currentClassLabel = "Dai registri consegne";
 
 async function api(path, options = {}) {
   const response = await fetch(path, options);
@@ -80,10 +81,13 @@ function populateClassRosterOptions(rosters, preferredRosterName = "") {
     els.classRoster.innerHTML = '<option value="">Dai registri consegne</option>';
     els.classRoster.value = "";
     els.classRoster.disabled = true;
+    currentClassLabel = "Dai registri consegne";
     return "";
   }
   const names = options.map((roster) => roster.name);
   const selected = names.includes(preferredRosterName) ? preferredRosterName : names[0];
+  const selectedRoster = options.find((roster) => roster.name === selected);
+  currentClassLabel = rosterLabel(selectedRoster);
   els.classRoster.disabled = false;
   els.classRoster.innerHTML = options.map((roster) => `
     <option value="${escapeHtml(roster.name)}"${roster.name === selected ? " selected" : ""}>${escapeHtml(rosterLabel(roster))}</option>
@@ -201,6 +205,7 @@ function renderSummary(studentId, assignments) {
   const approvedFeedback = assignments.filter((item) => item.approved_feedback).length;
   const cards = [
     ["Studente", studentId],
+    ["Classe", currentClassLabel],
     ["Consegne", assignments.length],
     ["Consegnate", submitted],
     ["Mancanti", missing],


### PR DESCRIPTION
## Cosa cambia

- Mostra nel riepilogo della vista studente anche la classe/fonte roster attiva.
- Usa l'etichetta del roster selezionato quando disponibile.
- Mostra `Dai registri consegne` quando la vista usa il fallback MVP senza roster.
- Aggiorna la guida operativa studente.
- Aggiunge copertura nei test frontend.

## Perche

La vista studente permette di cambiare classe sopra, ma il riepilogo mostrava solo lo studente. Rendere esplicita la classe riduce ambiguita quando si lavora con piu roster o con fallback dai registri.

## Verifiche

- `python -m pytest tests/test_student_dashboard_frontend.py`
