### PR TITLE
Aggiunge ordinamento consegne alla vista studente

### DIFF
--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -85,6 +85,13 @@ Il filtro **Filtro** permette di restringere la lista senza cambiare lo studente
 - **In ritardo** mostra solo le consegne consegnate oltre la scadenza;
 - **Con feedback** mostra solo le consegne con feedback approvato dal docente.
 
+Il selettore **Ordina** cambia l'ordine della lista:
+
+- **Scadenza vicina** porta in alto le consegne con scadenza piu prossima;
+- **Scadenza lontana** mostra prima le scadenze piu lontane;
+- **Stato** raggruppa prima mancanti, poi in ritardo, poi da consegnare e infine consegnate;
+- **Titolo** ordina alfabeticamente.
+
 Per ogni consegna controlla:
 
 - titolo o id activity;

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -53,6 +53,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderDashboard,
         assignmentMatchesFilter,
         filteredAssignments,
+        sortedAssignments,
         safeExternalLink,
         studentLabel,
         rosterLabel,
@@ -173,6 +174,51 @@ def test_student_dashboard_filters_visible_assignments() -> None:
         assert.match(tested.els.assignments.innerHTML, /Loop in Python/);
         assert.match(tested.els.status.textContent, /1 di 2 consegne visibili/);
         assert.equal(tested.filteredAssignments([submitted, missing], "feedback").length, 1);
+        """
+    )
+
+
+def test_student_dashboard_sorts_visible_assignments() -> None:
+    run_student_dashboard_js(
+        """
+        const late = {
+          activity_id: "c-array-001",
+          title: "Array in C",
+          due_at: "2026-10-20T23:59:00+02:00",
+          status: "submitted_late",
+          submitted: true,
+          late: true,
+        };
+        const missing = {
+          activity_id: "python-loop-001",
+          title: "Loop in Python",
+          due_at: "2026-10-18T23:59:00+02:00",
+          status: "missing",
+          submitted: false,
+          late: false,
+        };
+        const submitted = {
+          activity_id: "python-base-somma-001",
+          title: "Somma in Python",
+          due_at: "2026-10-19T23:59:00+02:00",
+          status: "submitted_on_time",
+          submitted: true,
+          late: false,
+        };
+
+        const byDue = tested.sortedAssignments([late, submitted, missing], "due_asc");
+        assert.equal(JSON.stringify(byDue.map((assignment) => assignment.activity_id)), JSON.stringify([
+          "python-loop-001",
+          "python-base-somma-001",
+          "c-array-001",
+        ]));
+
+        const byStatus = tested.sortedAssignments([submitted, late, missing], "status");
+        assert.equal(JSON.stringify(byStatus.map((assignment) => assignment.activity_id)), JSON.stringify([
+          "python-loop-001",
+          "c-array-001",
+          "python-base-somma-001",
+        ]));
         """
     )
 

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -55,6 +55,15 @@
               <option value="feedback">Con feedback</option>
             </select>
           </label>
+          <label>
+            <span>Ordina</span>
+            <select id="assignmentSort" name="assignment_sort">
+              <option value="due_asc">Scadenza vicina</option>
+              <option value="due_desc">Scadenza lontana</option>
+              <option value="status">Stato</option>
+              <option value="title">Titolo</option>
+            </select>
+          </label>
           <p id="status" class="status" aria-live="polite"></p>
         </div>
       </div>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -3,6 +3,7 @@ const els = {
   classRoster: document.querySelector("#classRoster"),
   studentId: document.querySelector("#studentId"),
   assignmentFilter: document.querySelector("#assignmentFilter"),
+  assignmentSort: document.querySelector("#assignmentSort"),
   summary: document.querySelector("#summary"),
   status: document.querySelector("#status"),
   assignments: document.querySelector("#assignments"),
@@ -288,11 +289,47 @@ function filteredAssignments(assignments, filterValue) {
   return assignments.filter((assignment) => assignmentMatchesFilter(assignment, filterValue));
 }
 
+function timestampOrInfinity(value) {
+  if (!value) return Number.POSITIVE_INFINITY;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? Number.POSITIVE_INFINITY : date.getTime();
+}
+
+function statusRank(assignment) {
+  if (assignment.status === "missing") return 0;
+  if (assignment.late) return 1;
+  if (!assignment.submitted) return 2;
+  return 3;
+}
+
+function assignmentTitle(assignment) {
+  return String(assignment.title || assignment.activity_id || "");
+}
+
+function sortedAssignments(assignments, sortValue) {
+  return [...assignments].sort((left, right) => {
+    if (sortValue === "due_desc") {
+      return timestampOrInfinity(right.due_at) - timestampOrInfinity(left.due_at);
+    }
+    if (sortValue === "status") {
+      return statusRank(left) - statusRank(right)
+        || timestampOrInfinity(left.due_at) - timestampOrInfinity(right.due_at)
+        || assignmentTitle(left).localeCompare(assignmentTitle(right), "it", { numeric: true, sensitivity: "base" });
+    }
+    if (sortValue === "title") {
+      return assignmentTitle(left).localeCompare(assignmentTitle(right), "it", { numeric: true, sensitivity: "base" });
+    }
+    return timestampOrInfinity(left.due_at) - timestampOrInfinity(right.due_at)
+      || assignmentTitle(left).localeCompare(assignmentTitle(right), "it", { numeric: true, sensitivity: "base" });
+  });
+}
+
 function renderDashboard(payload) {
   const assignments = Array.isArray(payload.assignments) ? payload.assignments : [];
   currentDashboardPayload = { ...payload, assignments };
   const filterValue = els.assignmentFilter?.value || "all";
-  const visibleAssignments = filteredAssignments(assignments, filterValue);
+  const sortValue = els.assignmentSort?.value || "due_asc";
+  const visibleAssignments = sortedAssignments(filteredAssignments(assignments, filterValue), sortValue);
   renderSummary(payload.student_id || "-", assignments);
   els.status.textContent = visibleAssignments.length === assignments.length
     ? `${assignments.length} consegne trovate.`
@@ -331,6 +368,10 @@ els.classRoster?.addEventListener("change", () => {
 });
 
 els.assignmentFilter?.addEventListener("change", () => {
+  renderDashboard(currentDashboardPayload);
+});
+
+els.assignmentSort?.addEventListener("change", () => {
   renderDashboard(currentDashboardPayload);
 });
 


### PR DESCRIPTION
## Cosa cambia

- Aggiunge alla vista studente il selettore `Ordina` nella sezione consegne.
- Permette di ordinare per scadenza vicina, scadenza lontana, stato o titolo.
- Mantiene filtro e ordinamento separati: prima filtra, poi ordina la lista visibile.
- Aggiorna la guida operativa studente.
- Aggiunge test frontend per l'ordinamento.

## Perche

Con molte consegne, lo studente deve poter vedere subito quelle piu urgenti o raggrupparle per stato senza cambiare studente o classe.

## Verifiche

- `python -m pytest tests/test_student_dashboard_frontend.py`
