### PR TITLE
Mostra la prossima scadenza nella vista studente

### DIFF
--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -70,7 +70,7 @@ Usalo per capire rapidamente:
 - quante risultano mancanti;
 - quante risultano in ritardo;
 - se ci sono feedback approvati visibili.
-- qual e la prossima scadenza tra le consegne non ancora consegnate o mancanti.
+- qual e la prossima attivita da gestire e quando scade.
 
 Screenshot previsto: `doc/images/dashboard-guides/studente-riepilogo.png`.
 

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -70,6 +70,7 @@ Usalo per capire rapidamente:
 - quante risultano mancanti;
 - quante risultano in ritardo;
 - se ci sono feedback approvati visibili.
+- qual e la prossima scadenza tra le consegne non ancora consegnate o mancanti.
 
 Screenshot previsto: `doc/images/dashboard-guides/studente-riepilogo.png`.
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -54,6 +54,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         assignmentMatchesFilter,
         filteredAssignments,
         sortedAssignments,
+        nextOpenDueAt,
         safeExternalLink,
         studentLabel,
         rosterLabel,
@@ -122,6 +123,7 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
         assert.match(tested.els.summary.innerHTML, /<strong>Mancanti<\\/strong>\\s*<span>1<\\/span>/);
         assert.match(tested.els.summary.innerHTML, /<strong>In ritardo<\\/strong>\\s*<span>0<\\/span>/);
         assert.match(tested.els.summary.innerHTML, /<strong>Feedback<\\/strong>\\s*<span>1<\\/span>/);
+        assert.match(tested.els.summary.innerHTML, /<strong>Prossima scadenza<\\/strong>/);
         assert.match(tested.els.assignments.innerHTML, /Somma in Python/);
         assert.match(tested.els.assignments.innerHTML, /Feedback docente/);
         assert.match(tested.els.assignments.innerHTML, /Hai gestito correttamente/);
@@ -219,6 +221,35 @@ def test_student_dashboard_sorts_visible_assignments() -> None:
           "c-array-001",
           "python-base-somma-001",
         ]));
+        """
+    )
+
+
+def test_student_dashboard_summarizes_next_open_due_date() -> None:
+    run_student_dashboard_js(
+        """
+        const submitted = {
+          activity_id: "python-base-somma-001",
+          due_at: "2026-10-12T23:59:00+02:00",
+          status: "submitted_on_time",
+          submitted: true,
+        };
+        const openLater = {
+          activity_id: "python-loop-001",
+          due_at: "2026-10-20T23:59:00+02:00",
+          status: "assigned",
+          submitted: false,
+        };
+        const openSooner = {
+          activity_id: "c-array-001",
+          due_at: "2026-10-18T23:59:00+02:00",
+          status: "assigned",
+          submitted: false,
+        };
+
+        assert.equal(tested.nextOpenDueAt([submitted, openLater, openSooner]), "2026-10-18T23:59:00+02:00");
+        tested.renderDashboard({ student_id: "rossi-mario", assignments: [submitted, openLater, openSooner] });
+        assert.match(tested.els.summary.innerHTML, /<strong>Prossima scadenza<\\/strong>\\s*<span>18\\/10\\/26, 23:59<\\/span>/);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -54,6 +54,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         assignmentMatchesFilter,
         filteredAssignments,
         sortedAssignments,
+        nextOpenAssignment,
         nextOpenDueAt,
         safeExternalLink,
         studentLabel,
@@ -247,8 +248,10 @@ def test_student_dashboard_summarizes_next_open_due_date() -> None:
           submitted: false,
         };
 
+        assert.equal(tested.nextOpenAssignment([submitted, openLater, openSooner]).activity_id, "c-array-001");
         assert.equal(tested.nextOpenDueAt([submitted, openLater, openSooner]), "2026-10-18T23:59:00+02:00");
         tested.renderDashboard({ student_id: "rossi-mario", assignments: [submitted, openLater, openSooner] });
+        assert.match(tested.els.summary.innerHTML, /<strong>Prossima attivita<\\/strong>\\s*<span>c-array-001<\\/span>/);
         assert.match(tested.els.summary.innerHTML, /<strong>Prossima scadenza<\\/strong>\\s*<span>18\\/10\\/26, 23:59<\\/span>/);
         """
     )

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -173,7 +173,7 @@ function formatDate(value) {
   if (!value) return "-";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString("it-IT", { dateStyle: "short", timeStyle: "short" });
+  return date.toLocaleString("it-IT", { dateStyle: "short", timeStyle: "short", timeZone: "Europe/Rome" });
 }
 
 function badge(text, kind = "") {

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -199,6 +199,15 @@ function gradeValue(grading) {
   return grade == null || String(grade).trim() === "" ? "-" : grade;
 }
 
+function nextOpenDueAt(assignments) {
+  const upcoming = assignments
+    .filter((item) => !item.submitted || item.status === "missing")
+    .map((item) => ({ dueAt: item.due_at, timestamp: timestampOrInfinity(item.due_at) }))
+    .filter((item) => Number.isFinite(item.timestamp))
+    .sort((left, right) => left.timestamp - right.timestamp);
+  return upcoming[0]?.dueAt || "";
+}
+
 function renderSummary(studentId, assignments) {
   const submitted = assignments.filter((item) => item.submitted).length;
   const missing = assignments.filter((item) => item.status === "missing").length;
@@ -212,6 +221,7 @@ function renderSummary(studentId, assignments) {
     ["Mancanti", missing],
     ["In ritardo", late],
     ["Feedback", approvedFeedback],
+    ["Prossima scadenza", formatDate(nextOpenDueAt(assignments))],
   ];
   els.summary.innerHTML = cards.map(([label, value]) => `
     <article class="summaryCard">

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -199,16 +199,21 @@ function gradeValue(grading) {
   return grade == null || String(grade).trim() === "" ? "-" : grade;
 }
 
-function nextOpenDueAt(assignments) {
+function nextOpenAssignment(assignments) {
   const upcoming = assignments
     .filter((item) => !item.submitted || item.status === "missing")
-    .map((item) => ({ dueAt: item.due_at, timestamp: timestampOrInfinity(item.due_at) }))
+    .map((item) => ({ assignment: item, timestamp: timestampOrInfinity(item.due_at) }))
     .filter((item) => Number.isFinite(item.timestamp))
     .sort((left, right) => left.timestamp - right.timestamp);
-  return upcoming[0]?.dueAt || "";
+  return upcoming[0]?.assignment || null;
+}
+
+function nextOpenDueAt(assignments) {
+  return nextOpenAssignment(assignments)?.due_at || "";
 }
 
 function renderSummary(studentId, assignments) {
+  const nextAssignment = nextOpenAssignment(assignments);
   const submitted = assignments.filter((item) => item.submitted).length;
   const missing = assignments.filter((item) => item.status === "missing").length;
   const late = assignments.filter((item) => item.late).length;
@@ -221,7 +226,8 @@ function renderSummary(studentId, assignments) {
     ["Mancanti", missing],
     ["In ritardo", late],
     ["Feedback", approvedFeedback],
-    ["Prossima scadenza", formatDate(nextOpenDueAt(assignments))],
+    ["Prossima attivita", nextAssignment ? assignmentTitle(nextAssignment) : "-"],
+    ["Prossima scadenza", formatDate(nextAssignment?.due_at)],
   ];
   els.summary.innerHTML = cards.map(([label, value]) => `
     <article class="summaryCard">


### PR DESCRIPTION
## Cosa cambia

- Aggiunge nel riepilogo della vista studente la card `Prossima scadenza`.
- La scadenza viene calcolata sulle consegne non ancora consegnate o segnate come mancanti.
- Aggiorna la guida operativa studente.
- Aggiunge test frontend per il calcolo della prossima scadenza aperta.

## Perche

Dopo filtro e ordinamento, allo studente serve un primo segnale semplice su quale consegna guardare prima. Questa card non sostituisce una futura vista priorita, ma rende subito piu leggibile il riepilogo.

## Verifiche

- `python -m pytest tests/test_student_dashboard_frontend.py`
