### PR TITLE
Evidenzia la prossima scadenza nella vista studente

### DIFF
--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -74,7 +74,7 @@ Usalo per capire rapidamente:
 
 Screenshot previsto: `doc/images/dashboard-guides/studente-riepilogo.png`.
 
-La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenza**.
+La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenza**. Se piu consegne aperte hanno la stessa prossima scadenza, il badge compare su tutte.
 
 ## Consegne
 

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -74,6 +74,8 @@ Usalo per capire rapidamente:
 
 Screenshot previsto: `doc/images/dashboard-guides/studente-riepilogo.png`.
 
+La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenza**.
+
 ## Consegne
 
 La sezione **Consegne** elenca le activity visibili allo studente.

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -203,7 +203,7 @@ def test_student_dashboard_sorts_visible_assignments() -> None:
         const submitted = {
           activity_id: "python-base-somma-001",
           title: "Somma in Python",
-          due_at: "2026-10-19T23:59:00+02:00",
+          due_at: "2026-10-10T23:59:00+02:00",
           status: "submitted_on_time",
           submitted: true,
           late: false,
@@ -222,6 +222,7 @@ def test_student_dashboard_sorts_visible_assignments() -> None:
           "c-array-001",
           "python-base-somma-001",
         ]));
+
         """
     )
 
@@ -247,14 +248,20 @@ def test_student_dashboard_summarizes_next_open_due_date() -> None:
           status: "assigned",
           submitted: false,
         };
+        const sameDeadline = {
+          activity_id: "python-stringhe-001",
+          due_at: "2026-10-18T23:59:00+02:00",
+          status: "assigned",
+          submitted: false,
+        };
 
-        assert.equal(tested.nextOpenAssignment([submitted, openLater, openSooner]).activity_id, "c-array-001");
-        assert.equal(tested.nextOpenDueAt([submitted, openLater, openSooner]), "2026-10-18T23:59:00+02:00");
-        tested.renderDashboard({ student_id: "rossi-mario", assignments: [submitted, openLater, openSooner] });
+        assert.equal(tested.nextOpenAssignment([submitted, openLater, openSooner, sameDeadline]).activity_id, "c-array-001");
+        assert.equal(tested.nextOpenDueAt([submitted, openLater, openSooner, sameDeadline]), "2026-10-18T23:59:00+02:00");
+        tested.renderDashboard({ student_id: "rossi-mario", assignments: [submitted, openLater, openSooner, sameDeadline] });
         assert.match(tested.els.summary.innerHTML, /<strong>Prossima attivita<\\/strong>\\s*<span>c-array-001<\\/span>/);
         assert.match(tested.els.summary.innerHTML, /<strong>Prossima scadenza<\\/strong>\\s*<span>18\\/10\\/26, 23:59<\\/span>/);
         assert.match(tested.els.assignments.innerHTML, /Prossima scadenza/);
-        assert.equal((tested.els.assignments.innerHTML.match(/Prossima scadenza/g) || []).length, 1);
+        assert.equal((tested.els.assignments.innerHTML.match(/Prossima scadenza/g) || []).length, 2);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -253,6 +253,8 @@ def test_student_dashboard_summarizes_next_open_due_date() -> None:
         tested.renderDashboard({ student_id: "rossi-mario", assignments: [submitted, openLater, openSooner] });
         assert.match(tested.els.summary.innerHTML, /<strong>Prossima attivita<\\/strong>\\s*<span>c-array-001<\\/span>/);
         assert.match(tested.els.summary.innerHTML, /<strong>Prossima scadenza<\\/strong>\\s*<span>18\\/10\\/26, 23:59<\\/span>/);
+        assert.match(tested.els.assignments.innerHTML, /Prossima scadenza/);
+        assert.equal((tested.els.assignments.innerHTML.match(/Prossima scadenza/g) || []).length, 1);
         """
     )
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -253,6 +253,14 @@ button:hover { transform: translateY(-1px); }
   min-width: 0;
 }
 
+.assignmentBadges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: .35rem;
+  min-width: 0;
+}
+
 .assignmentHead h3 {
   margin: 0 0 .25rem;
   overflow-wrap: anywhere;
@@ -302,6 +310,11 @@ button:hover { transform: translateY(-1px); }
 .badgeBad {
   background: #fde8e6;
   color: var(--bad);
+}
+
+.badgePriority {
+  background: #e8f0ff;
+  color: #164a9f;
 }
 
 .feedback {

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -199,9 +199,13 @@ function gradeValue(grading) {
   return grade == null || String(grade).trim() === "" ? "-" : grade;
 }
 
+function isOpenAssignment(assignment) {
+  return !assignment.submitted || assignment.status === "missing";
+}
+
 function nextOpenAssignment(assignments) {
   const upcoming = assignments
-    .filter((item) => !item.submitted || item.status === "missing")
+    .filter(isOpenAssignment)
     .map((item) => ({ assignment: item, timestamp: timestampOrInfinity(item.due_at) }))
     .filter((item) => Number.isFinite(item.timestamp))
     .sort((left, right) => left.timestamp - right.timestamp);
@@ -297,7 +301,7 @@ function renderAssignment(assignment, isNext = false) {
 }
 
 function assignmentMatchesFilter(assignment, filterValue) {
-  if (filterValue === "open") return assignment.status === "missing" || !assignment.submitted;
+  if (filterValue === "open") return isOpenAssignment(assignment);
   if (filterValue === "submitted") return Boolean(assignment.submitted);
   if (filterValue === "late") return Boolean(assignment.late);
   if (filterValue === "feedback") return Boolean(assignment.approved_feedback);
@@ -338,9 +342,16 @@ function sortedAssignments(assignments, sortValue) {
     if (sortValue === "title") {
       return assignmentTitle(left).localeCompare(assignmentTitle(right), "it", { numeric: true, sensitivity: "base" });
     }
-    return timestampOrInfinity(left.due_at) - timestampOrInfinity(right.due_at)
+    return Number(isOpenAssignment(right)) - Number(isOpenAssignment(left))
+      || timestampOrInfinity(left.due_at) - timestampOrInfinity(right.due_at)
       || assignmentTitle(left).localeCompare(assignmentTitle(right), "it", { numeric: true, sensitivity: "base" });
   });
+}
+
+function isNextDeadlineAssignment(assignment, nextAssignment) {
+  if (!nextAssignment || !isOpenAssignment(assignment)) return false;
+  const nextTimestamp = timestampOrInfinity(nextAssignment.due_at);
+  return Number.isFinite(nextTimestamp) && timestampOrInfinity(assignment.due_at) === nextTimestamp;
 }
 
 function renderDashboard(payload) {
@@ -355,7 +366,7 @@ function renderDashboard(payload) {
     ? `${assignments.length} consegne trovate.`
     : `${visibleAssignments.length} di ${assignments.length} consegne visibili.`;
   els.assignments.innerHTML = visibleAssignments.length
-    ? visibleAssignments.map((assignment) => renderAssignment(assignment, assignment === nextAssignment)).join("")
+    ? visibleAssignments.map((assignment) => renderAssignment(assignment, isNextDeadlineAssignment(assignment, nextAssignment))).join("")
     : assignments.length
       ? '<p class="status">Nessuna consegna corrisponde al filtro selezionato.</p>'
       : '<p class="status">Nessuna consegna disponibile.</p>';

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -254,7 +254,7 @@ function renderFeedback(feedback) {
   `;
 }
 
-function renderAssignment(assignment) {
+function renderAssignment(assignment, isNext = false) {
   const grading = assignment.grading || {};
   const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
   const repoLink = assignment.repo_github_url
@@ -274,7 +274,10 @@ function renderAssignment(assignment) {
             <span>Scadenza: ${escapeHtml(formatDate(assignment.due_at))}</span>
           </p>
         </div>
-        ${statusBadge(assignment)}
+        <div class="assignmentBadges">
+          ${isNext ? badge("Prossima scadenza", "badgePriority") : ""}
+          ${statusBadge(assignment)}
+        </div>
       </div>
       <p class="details">
         <span>${gradingBadge(grading)}</span>
@@ -345,13 +348,14 @@ function renderDashboard(payload) {
   currentDashboardPayload = { ...payload, assignments };
   const filterValue = els.assignmentFilter?.value || "all";
   const sortValue = els.assignmentSort?.value || "due_asc";
+  const nextAssignment = nextOpenAssignment(assignments);
   const visibleAssignments = sortedAssignments(filteredAssignments(assignments, filterValue), sortValue);
   renderSummary(payload.student_id || "-", assignments);
   els.status.textContent = visibleAssignments.length === assignments.length
     ? `${assignments.length} consegne trovate.`
     : `${visibleAssignments.length} di ${assignments.length} consegne visibili.`;
   els.assignments.innerHTML = visibleAssignments.length
-    ? visibleAssignments.map(renderAssignment).join("")
+    ? visibleAssignments.map((assignment) => renderAssignment(assignment, assignment === nextAssignment)).join("")
     : assignments.length
       ? '<p class="status">Nessuna consegna corrisponde al filtro selezionato.</p>'
       : '<p class="status">Nessuna consegna disponibile.</p>';


### PR DESCRIPTION
## Cosa cambia

- Evidenzia nella lista consegne la stessa activity mostrata nel riepilogo come prossima da gestire.
- Aggiunge un badge `Prossima scadenza` sulla card corrispondente.
- Mantiene il badge stato esistente accanto al nuovo indicatore.
- Aggiorna la guida operativa studente.
- Estende il test frontend della prossima scadenza.

## Perche

Il riepilogo ora mostra la prossima attivita e la prossima scadenza, ma nella lista lo studente doveva comunque cercare manualmente la card corrispondente. Il badge chiude questo collegamento visivo senza introdurre una vista priorita completa.

## Verifiche

- `python -m pytest tests/test_student_dashboard_frontend.py`
