### PR TITLE
Aggiunge azione apri consegna alla vista studente

### DIFF
--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -108,7 +108,7 @@ Per ogni consegna controlla:
 - link repository o file consegna quando disponibile;
 - feedback approvato.
 
-Quando il registro contiene un link valido, il pulsante **Apri consegna** apre il file della consegna; se il file non e disponibile ma il repository si, apre il repository.
+Quando il registro contiene un link valido al file, il pulsante **Apri consegna** apre il file della consegna. Se il file non e disponibile, il repository resta indicato nei dettagli ma il pulsante non viene mostrato.
 
 Screenshot previsto: `doc/images/dashboard-guides/studente-consegne.png`.
 

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -108,6 +108,8 @@ Per ogni consegna controlla:
 - link repository o file consegna quando disponibile;
 - feedback approvato.
 
+Quando il registro contiene un link valido, il pulsante **Apri consegna** apre il file della consegna; se il file non e disponibile ma il repository si, apre il repository.
+
 Screenshot previsto: `doc/images/dashboard-guides/studente-consegne.png`.
 
 ## Stati principali

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -108,7 +108,7 @@ Per ogni consegna controlla:
 - link repository o file consegna quando disponibile;
 - feedback approvato.
 
-Quando il registro contiene un link valido al file, il pulsante **Apri consegna** apre il file della consegna. Se il file non e disponibile, il repository resta indicato nei dettagli ma il pulsante non viene mostrato.
+Quando il registro contiene un link valido al file, il pulsante **Apri consegna** apre il file della consegna. Se il file non e disponibile, il pulsante resta visibile ma disabilitato e mostra il motivo, per esempio **Consegna mancante**.
 
 Screenshot previsto: `doc/images/dashboard-guides/studente-consegne.png`.
 

--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -205,7 +205,7 @@ class AssignmentOverviewService:
                         "submitted_at": submission.get("submitted_at"),
                         "commit": submission.get("commit"),
                         "source_path": submission.get("source_path"),
-                        "source_github_url": submission.get("source_github_url"),
+                        "source_github_url": _submission_source_github_url(submission),
                         "grading": {
                             "status": grading.get("status", ""),
                             "passed": grading.get("passed"),
@@ -225,6 +225,53 @@ class AssignmentOverviewService:
 
 def _matches_student(student: dict[str, Any], student_id: str) -> bool:
     return student.get("student_id") == student_id or student.get("student") == student_id
+
+
+def _submission_source_github_url(submission: dict[str, Any]) -> str | None:
+    source_url = _clean_optional_string(submission.get("source_github_url"))
+    file_urls = _submission_file_github_urls(submission)
+    if source_url and not _looks_like_broken_demo_url(source_url):
+        return source_url
+    for file_url in file_urls:
+        if not _looks_like_broken_demo_url(file_url):
+            return file_url
+    return source_url
+
+
+def _submission_file_github_urls(submission: dict[str, Any]) -> list[str]:
+    files = submission.get("files")
+    if not isinstance(files, list):
+        return []
+    source_path = _normalized_path(submission.get("source_path"))
+    urls = []
+    for file_entry in files:
+        if not isinstance(file_entry, dict):
+            continue
+        file_url = _clean_optional_string(file_entry.get("github_url"))
+        if not file_url:
+            continue
+        file_path = _normalized_path(file_entry.get("path"))
+        if (
+            not source_path
+            or file_path == source_path
+            or file_path.endswith(f"/{source_path}")
+            or source_path.endswith(f"/{file_path}")
+        ):
+            urls.append(file_url)
+    return urls
+
+
+def _normalized_path(value: Any) -> str:
+    return str(value or "").replace("\\", "/").lstrip("./")
+
+
+def _clean_optional_string(value: Any) -> str | None:
+    clean_value = str(value or "").strip()
+    return clean_value or None
+
+
+def _looks_like_broken_demo_url(url: str) -> bool:
+    return "/blob/main/scripts/examples/assignment_tracking/" in url or "/blob/master/scripts/examples/assignment_tracking/" in url
 
 
 def _approved_student_feedback(ai_feedback: dict[str, Any]) -> dict[str, Any] | None:

--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -271,7 +271,7 @@ def _clean_optional_string(value: Any) -> str | None:
 
 
 def _looks_like_broken_demo_url(url: str) -> bool:
-    return "/blob/main/scripts/examples/assignment_tracking/" in url or "/blob/master/scripts/examples/assignment_tracking/" in url
+    return "/blob/" in url and "/scripts/examples/assignment_tracking/" in url
 
 
 def _approved_student_feedback(ai_feedback: dict[str, Any]) -> dict[str, Any] | None:

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -25,6 +25,7 @@ EXCLUDED_SUBMISSION_SUFFIXES = {".pyc", ".pyo", ".o", ".obj", ".exe", ".dll", ".
 GITHUB_RE = re.compile(r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^/\s]+?)(?:\.git)?/?$")
 OWNER_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 @dataclass(frozen=True)
@@ -93,7 +94,7 @@ def relative_to_root_or_repo(path: Path, repo: Path) -> str:
     """Return a stable relative path for JSON output."""
     resolved = path.resolve()
     try:
-        return str(resolved.relative_to(Path.cwd().resolve())).replace("\\", "/")
+        return str(resolved.relative_to(PROJECT_ROOT)).replace("\\", "/")
     except ValueError:
         try:
             return str(resolved.relative_to(repo.resolve())).replace("\\", "/")
@@ -151,7 +152,7 @@ def github_file_path(target: TrackingTarget, file_path: str | None) -> str | Non
         resolved = raw_path.resolve()
     else:
         target_candidate = (target.path / raw_path).resolve()
-        resolved = target_candidate if target_candidate.exists() else (Path.cwd() / raw_path).resolve()
+        resolved = target_candidate if target_candidate.exists() else (PROJECT_ROOT / raw_path).resolve()
     root = git_root(target.path) or target.path.resolve()
     try:
         return str(resolved.relative_to(root)).replace("\\", "/")

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -286,6 +286,26 @@ def test_student_dashboard_rejects_unsafe_external_links() -> None:
     )
 
 
+def test_student_dashboard_open_assignment_action_requires_source_link() -> None:
+    run_student_dashboard_js(
+        """
+        tested.renderDashboard({
+          student_id: "rossi-mario",
+          assignments: [{
+            activity_id: "python-base-somma-001",
+            title: "Somma in Python",
+            status: "assigned",
+            submitted: false,
+            repo_github_url: "https://github.com/TheBitPoets/2cornot2c",
+          }],
+        });
+
+        assert.doesNotMatch(tested.els.assignments.innerHTML, /Apri consegna/);
+        assert.match(tested.els.assignments.innerHTML, /Repository/);
+        """
+    )
+
+
 def test_student_dashboard_populates_students_from_overview_rows() -> None:
     run_student_dashboard_js(
         """

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -56,6 +56,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         sortedAssignments,
         nextOpenAssignment,
         nextOpenDueAt,
+        safeExternalHref,
         safeExternalLink,
         studentLabel,
         rosterLabel,
@@ -96,7 +97,9 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
           late: false,
           submitted_at: "2026-10-18T18:22:10+02:00",
           repo: "TheBitPoets/rossi-mario",
+          repo_github_url: "https://github.com/TheBitPoets/rossi-mario",
           source_path: "assignments/python-base-somma-001/main.py",
+          source_github_url: "https://github.com/TheBitPoets/rossi-mario/blob/main/assignments/python-base-somma-001/main.py",
           commit: "abc1234",
           grading: {
             status: "graded_passed",
@@ -129,6 +132,8 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
         assert.match(tested.els.assignments.innerHTML, /Feedback docente/);
         assert.match(tested.els.assignments.innerHTML, /Hai gestito correttamente/);
         assert.match(tested.els.assignments.innerHTML, /Test superati/);
+        assert.match(tested.els.assignments.innerHTML, /Apri consegna/);
+        assert.match(tested.els.assignments.innerHTML, /href="https:\\/\\/github.com\\/TheBitPoets\\/rossi-mario\\/blob\\/main\\/assignments\\/python-base-somma-001\\/main.py"/);
         """
     )
 
@@ -275,6 +280,8 @@ def test_student_dashboard_rejects_unsafe_external_links() -> None:
         const unsafe = tested.safeExternalLink("javascript:alert(1)", "Repository", "repo-name");
         assert.doesNotMatch(unsafe, /href=/);
         assert.match(unsafe, /repo-name/);
+        assert.equal(tested.safeExternalHref("javascript:alert(1)"), "");
+        assert.equal(tested.safeExternalHref("https://github.com/TheBitPoets/2cornot2c"), "https://github.com/TheBitPoets/2cornot2c");
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -300,7 +300,9 @@ def test_student_dashboard_open_assignment_action_requires_source_link() -> None
           }],
         });
 
-        assert.doesNotMatch(tested.els.assignments.innerHTML, /Apri consegna/);
+        assert.match(tested.els.assignments.innerHTML, /Apri consegna/);
+        assert.match(tested.els.assignments.innerHTML, /disabled/);
+        assert.match(tested.els.assignments.innerHTML, /Consegna mancante/);
         assert.match(tested.els.assignments.innerHTML, /Repository/);
         """
     )

--- a/tests/test_thebitlab_services.py
+++ b/tests/test_thebitlab_services.py
@@ -272,6 +272,55 @@ def test_student_dashboard_filters_student_and_only_approved_feedback(tmp_path) 
     }
 
 
+def test_student_dashboard_prefers_file_manifest_url_when_source_url_is_broken_demo_path(tmp_path) -> None:
+    service = assignment_overview_service(tmp_path)
+    reports_dir = tmp_path / "teacher-reports"
+    reports_dir.mkdir(parents=True)
+    good_url = (
+        "https://github.com/TheBitPoets/2cornot2c/blob/main/"
+        "examples/assignment_tracking/student_repos/bianchi-luca/assignments/python-base-somma-001/main.py"
+    )
+    (reports_dir / "activity.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "title": "Somma in Python",
+                "students": [
+                    {
+                        "student": "bianchi-luca",
+                        "student_id": "bianchi-luca",
+                        "status": "submitted_on_time",
+                        "submitted": True,
+                        "submission": {
+                            "source_path": (
+                                "examples/assignment_tracking/student_repos/bianchi-luca/"
+                                "assignments/python-base-somma-001/main.py"
+                            ),
+                            "source_github_url": (
+                                "https://github.com/TheBitPoets/2cornot2c/blob/main/scripts/"
+                                "examples/assignment_tracking/student_repos/bianchi-luca/"
+                                "assignments/python-base-somma-001/main.py"
+                            ),
+                            "files": [
+                                {
+                                    "path": "assignments/python-base-somma-001/main.py",
+                                    "role": "solution",
+                                    "github_url": good_url,
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dashboard = service.student_dashboard("bianchi-luca")
+
+    assert dashboard["assignments"][0]["source_github_url"] == good_url
+
+
 def test_assignment_overview_service_accepts_protocol_compatible_storage(tmp_path) -> None:
     class FakeAssignmentStorage:
         def safe_teacher_report_path(self, name: str) -> Path:

--- a/tests/test_thebitlab_services.py
+++ b/tests/test_thebitlab_services.py
@@ -297,7 +297,7 @@ def test_student_dashboard_prefers_file_manifest_url_when_source_url_is_broken_d
                                 "assignments/python-base-somma-001/main.py"
                             ),
                             "source_github_url": (
-                                "https://github.com/TheBitPoets/2cornot2c/blob/main/scripts/"
+                                "https://github.com/TheBitPoets/2cornot2c/blob/abc1234/scripts/"
                                 "examples/assignment_tracking/student_repos/bianchi-luca/"
                                 "assignments/python-base-somma-001/main.py"
                             ),

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -46,6 +46,39 @@ def target(tmp_path, name: str) -> track_assignments.TrackingTarget:
     return track_assignments.TrackingTarget(student=name, repo=f"TheBitPoets/{name}", path=root)
 
 
+def test_github_file_path_uses_project_root_for_repo_relative_paths(tmp_path, monkeypatch) -> None:
+    project_root = tmp_path / "project"
+    source_path = (
+        project_root
+        / "examples"
+        / "assignment_tracking"
+        / "student_repos"
+        / "bianchi-luca"
+        / "assignments"
+        / "python-base-somma-001"
+        / "main.py"
+    )
+    scripts_dir = project_root / "scripts"
+    source_path.parent.mkdir(parents=True)
+    scripts_dir.mkdir()
+    source_path.write_text("print(3)\n", encoding="utf-8")
+    student = track_assignments.TrackingTarget(
+        student="bianchi-luca",
+        repo="TheBitPoets/2cornot2c",
+        path=project_root / "examples" / "assignment_tracking" / "student_repos" / "bianchi-luca",
+    )
+    monkeypatch.setattr(track_assignments, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(track_assignments, "git_root", lambda path: project_root)
+    monkeypatch.chdir(scripts_dir)
+
+    path = track_assignments.github_file_path(
+        student,
+        "examples/assignment_tracking/student_repos/bianchi-luca/assignments/python-base-somma-001/main.py",
+    )
+
+    assert path == "examples/assignment_tracking/student_repos/bianchi-luca/assignments/python-base-somma-001/main.py"
+
+
 class MissingPathProvider:
     provider_name = "missing-path"
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -317,6 +317,31 @@ button:hover { transform: translateY(-1px); }
   color: #164a9f;
 }
 
+.assignmentActions {
+  margin: 0;
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  max-width: 100%;
+  border: 1px solid #111111;
+  border-radius: 999px;
+  background: #111111;
+  color: #ffffff;
+  padding: .45rem .75rem;
+  font-size: .8rem;
+  font-weight: 800;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.actionButton:hover {
+  transform: translateY(-1px);
+}
+
 .feedback {
   min-width: 0;
   max-width: 70rem;

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -318,6 +318,11 @@ button:hover { transform: translateY(-1px); }
 }
 
 .assignmentActions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: .45rem;
+  min-width: 0;
   margin: 0;
 }
 
@@ -340,6 +345,23 @@ button:hover { transform: translateY(-1px); }
 
 .actionButton:hover {
   transform: translateY(-1px);
+}
+
+.actionButtonDisabled,
+.actionButtonDisabled:hover {
+  border-color: rgba(17, 17, 17, .18);
+  background: #eeeeee;
+  color: #777777;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.actionUnavailable {
+  color: var(--bad);
+  font-size: .78rem;
+  font-weight: 800;
+  overflow-wrap: anywhere;
 }
 
 .feedback {

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -268,7 +268,7 @@ function renderFeedback(feedback) {
 function renderAssignment(assignment, isNext = false) {
   const grading = assignment.grading || {};
   const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
-  const actionHref = safeExternalHref(assignment.source_github_url || assignment.repo_github_url);
+  const actionHref = safeExternalHref(assignment.source_github_url);
   const repoLink = assignment.repo_github_url
     ? safeExternalLink(assignment.repo_github_url, "Repository", assignment.repo || "-")
     : escapeHtml(assignment.repo || "-");

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -269,6 +269,9 @@ function renderAssignment(assignment, isNext = false) {
   const grading = assignment.grading || {};
   const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
   const actionHref = safeExternalHref(assignment.source_github_url);
+  const unavailableLabel = assignment.status === "missing" || !assignment.submitted
+    ? "Consegna mancante"
+    : "File consegna non disponibile";
   const repoLink = assignment.repo_github_url
     ? safeExternalLink(assignment.repo_github_url, "Repository", assignment.repo || "-")
     : escapeHtml(assignment.repo || "-");
@@ -291,7 +294,11 @@ function renderAssignment(assignment, isNext = false) {
           ${statusBadge(assignment)}
         </div>
       </div>
-      ${actionHref ? `<p class="assignmentActions"><a class="actionButton" href="${escapeHtml(actionHref)}" target="_blank" rel="noreferrer">Apri consegna</a></p>` : ""}
+      <p class="assignmentActions">
+        ${actionHref
+          ? `<a class="actionButton" href="${escapeHtml(actionHref)}" target="_blank" rel="noreferrer">Apri consegna</a>`
+          : `<button type="button" class="actionButton actionButtonDisabled" disabled>Apri consegna</button><span class="actionUnavailable">${escapeHtml(unavailableLabel)}</span>`}
+      </p>
       <p class="details">
         <span>${gradingBadge(grading)}</span>
         <span>Test: ${escapeHtml(grading.tests_passed ?? "-")}/${escapeHtml(grading.tests_total ?? "-")}</span>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -156,17 +156,24 @@ function escapeHtml(value) {
 }
 
 function safeExternalLink(url, label, fallback = "-") {
+  const href = safeExternalHref(url);
+  return href
+    ? `<a href="${escapeHtml(href)}" target="_blank" rel="noreferrer">${escapeHtml(label)}</a>`
+    : escapeHtml(fallback);
+}
+
+function safeExternalHref(url) {
   const cleanUrl = String(url ?? "").trim();
-  if (!cleanUrl) return escapeHtml(fallback);
+  if (!cleanUrl) return "";
   try {
     const parsed = new URL(cleanUrl, window.location.href);
     if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-      return `<a href="${escapeHtml(parsed.href)}" target="_blank" rel="noreferrer">${escapeHtml(label)}</a>`;
+      return parsed.href;
     }
   } catch {
-    // Fall back to non-clickable text below.
+    // Fall back to no clickable URL below.
   }
-  return escapeHtml(fallback);
+  return "";
 }
 
 function formatDate(value) {
@@ -261,6 +268,7 @@ function renderFeedback(feedback) {
 function renderAssignment(assignment, isNext = false) {
   const grading = assignment.grading || {};
   const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
+  const actionHref = safeExternalHref(assignment.source_github_url || assignment.repo_github_url);
   const repoLink = assignment.repo_github_url
     ? safeExternalLink(assignment.repo_github_url, "Repository", assignment.repo || "-")
     : escapeHtml(assignment.repo || "-");
@@ -283,6 +291,7 @@ function renderAssignment(assignment, isNext = false) {
           ${statusBadge(assignment)}
         </div>
       </div>
+      ${actionHref ? `<p class="assignmentActions"><a class="actionButton" href="${escapeHtml(actionHref)}" target="_blank" rel="noreferrer">Apri consegna</a></p>` : ""}
       <p class="details">
         <span>${gradingBadge(grading)}</span>
         <span>Test: ${escapeHtml(grading.tests_passed ?? "-")}/${escapeHtml(grading.tests_total ?? "-")}</span>


### PR DESCRIPTION
## Cosa cambia

- Aggiunge il pulsante `Apri consegna` nelle card della vista studente quando e disponibile un link sicuro.
- Usa prima il link al file della consegna, poi il repository come fallback.
- Estrae `safeExternalHref()` per riusare la validazione degli URL `http/https`.
- Mantiene non cliccabili URL non sicuri, come `javascript:`.
- Aggiorna guida operativa e test frontend.

## Perche

Lo studente vedeva i link solo nei dettagli della card. Un comando esplicito rende piu chiaro quale azione fare per aprire la consegna, senza introdurre funzioni di modifica o gestione docente.

## Verifiche

- `python -m pytest tests/test_student_dashboard_frontend.py`
- `TZ=UTC python -m pytest tests/test_student_dashboard_frontend.py`
