### PR TITLE
Aggiunge dettaglio consegna alla vista studente

### DIFF
--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -110,6 +110,8 @@ Per ogni consegna controlla:
 
 Quando il registro contiene un link valido al file, il pulsante **Apri consegna** apre il file della consegna. Se il file non e disponibile, il pulsante resta visibile ma disabilitato e mostra il motivo, per esempio **Consegna mancante**.
 
+Il pulsante **Dettaglio** apre un modal con il quadro completo della consegna selezionata: dati dell'attivita, classe, scadenze, stato della consegna, link al repository o al file, esito del grading, test falliti e feedback approvato dal docente.
+
 Screenshot previsto: `doc/images/dashboard-guides/studente-consegne.png`.
 
 ## Stati principali

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -50,6 +50,9 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderSummary,
         renderFeedback,
         renderAssignment,
+        renderAssignmentDetail,
+        openAssignmentDetail,
+        closeAssignmentDetail,
         renderDashboard,
         assignmentMatchesFilter,
         filteredAssignments,
@@ -133,6 +136,8 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
         assert.match(tested.els.assignments.innerHTML, /Hai gestito correttamente/);
         assert.match(tested.els.assignments.innerHTML, /Test superati/);
         assert.match(tested.els.assignments.innerHTML, /Apri consegna/);
+        assert.match(tested.els.assignments.innerHTML, /Dettaglio/);
+        assert.match(tested.els.assignments.innerHTML, /data-detail-index="0"/);
         assert.match(tested.els.assignments.innerHTML, /href="https:\\/\\/github.com\\/TheBitPoets\\/rossi-mario\\/blob\\/main\\/assignments\\/python-base-somma-001\\/main.py"/);
         """
     )
@@ -304,6 +309,60 @@ def test_student_dashboard_open_assignment_action_requires_source_link() -> None
         assert.match(tested.els.assignments.innerHTML, /disabled/);
         assert.match(tested.els.assignments.innerHTML, /Consegna mancante/);
         assert.match(tested.els.assignments.innerHTML, /Repository/);
+        """
+    )
+
+
+def test_student_dashboard_assignment_detail_modal_renders_selected_assignment() -> None:
+    run_student_dashboard_js(
+        """
+        tested.renderDashboard({
+          student_id: "rossi-mario",
+          assignments: [{
+            activity_id: "python-base-somma-001",
+            title: "Somma in Python",
+            kind: "compito-casa",
+            student_support_mode: "guidato",
+            class_label: "Classe demo 3A",
+            assigned_at: "2026-10-10T08:00:00+02:00",
+            due_at: "2026-10-19T23:59:00+02:00",
+            status: "submitted_late",
+            submitted: true,
+            late: true,
+            submitted_at: "2026-10-20T09:15:00+02:00",
+            source_path: "assignments/python-base-somma-001/main.py",
+            source_github_url: "https://github.com/TheBitPoets/rossi-mario/blob/main/assignments/python-base-somma-001/main.py",
+            repo: "TheBitPoets/rossi-mario",
+            repo_github_url: "https://github.com/TheBitPoets/rossi-mario",
+            commit: "abc1234",
+            grading: {
+              status: "graded_failed",
+              tests_passed: 1,
+              tests_total: 2,
+              teacher_grade: 6,
+              failed_tests: ["somma con negativo"],
+            },
+            approved_feedback: {
+              summary: "Controlla il secondo caso.",
+              student_feedback: "Hai impostato bene la struttura ma devi verificare i negativi.",
+              suggested_grade: 6,
+              confidence: "medium",
+            },
+          }],
+        });
+
+        tested.openAssignmentDetail(0);
+
+        assert.equal(tested.els.assignmentDetailModal.hidden, false);
+        assert.equal(tested.els.assignmentDetailTitle.textContent, "Somma in Python");
+        assert.match(tested.els.assignmentDetailBody.innerHTML, /Classe demo 3A/);
+        assert.match(tested.els.assignmentDetailBody.innerHTML, /submitted_late/);
+        assert.match(tested.els.assignmentDetailBody.innerHTML, /somma con negativo/);
+        assert.match(tested.els.assignmentDetailBody.innerHTML, /Controlla il secondo caso/);
+        assert.match(tested.els.assignmentDetailBody.innerHTML, /Apri consegna/);
+
+        tested.closeAssignmentDetail();
+        assert.equal(tested.els.assignmentDetailModal.hidden, true);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -367,6 +367,36 @@ def test_student_dashboard_assignment_detail_modal_renders_selected_assignment()
     )
 
 
+def test_student_dashboard_closes_assignment_detail_when_dashboard_changes() -> None:
+    run_student_dashboard_js(
+        """
+        tested.renderDashboard({
+          student_id: "rossi-mario",
+          assignments: [{
+            activity_id: "python-base-somma-001",
+            title: "Somma in Python",
+            status: "submitted_on_time",
+            submitted: true,
+          }],
+        });
+        tested.openAssignmentDetail(0);
+        assert.equal(tested.els.assignmentDetailModal.hidden, false);
+
+        tested.renderDashboard({
+          student_id: "bianchi-luca",
+          assignments: [{
+            activity_id: "python-loop-001",
+            title: "Loop in Python",
+            status: "missing",
+            submitted: false,
+          }],
+        });
+
+        assert.equal(tested.els.assignmentDetailModal.hidden, true);
+        """
+    )
+
+
 def test_student_dashboard_populates_students_from_overview_rows() -> None:
     run_student_dashboard_js(
         """

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -347,6 +347,27 @@ button:hover { transform: translateY(-1px); }
   transform: translateY(-1px);
 }
 
+.secondaryActionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  max-width: 100%;
+  border: 1px solid rgba(17, 17, 17, .24);
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--ink);
+  padding: .45rem .75rem;
+  font-size: .8rem;
+  font-weight: 800;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.secondaryActionButton:hover {
+  transform: translateY(-1px);
+}
+
 .actionButtonDisabled,
 .actionButtonDisabled:hover {
   border-color: rgba(17, 17, 17, .18);
@@ -392,6 +413,112 @@ button:hover { transform: translateY(-1px); }
   overflow-wrap: anywhere;
 }
 
+.modalOpen {
+  overflow: hidden;
+}
+
+.modalOverlay[hidden] {
+  display: none;
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 3vw, 2rem);
+  background: rgba(17, 17, 17, .46);
+}
+
+.detailModal {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  width: min(72rem, 100%);
+  max-height: min(46rem, calc(100vh - 2rem));
+  min-width: min(100%, 18rem);
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, .22);
+  overflow: hidden;
+  resize: both;
+}
+
+.detailModalHead {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+  min-width: 0;
+  padding: 1rem;
+  border-bottom: 1px solid rgba(17, 17, 17, .12);
+}
+
+.detailModalHead > div {
+  min-width: 0;
+}
+
+.modalEyebrow {
+  margin: 0 0 .25rem;
+  color: var(--muted);
+  font-size: .72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.detailModalHead h2 {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.detailModalBody {
+  display: grid;
+  gap: 1rem;
+  min-height: 0;
+  overflow: auto;
+  padding: 1rem;
+}
+
+.detailSection {
+  display: grid;
+  gap: .75rem;
+  min-width: 0;
+}
+
+.detailSection h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.detailGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: .65rem;
+  min-width: 0;
+}
+
+.detailItem {
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-radius: 8px;
+  padding: .75rem;
+  background: #fafafa;
+}
+
+.detailItem strong {
+  display: block;
+  color: var(--muted);
+  font-size: .72rem;
+}
+
+.detailItem span {
+  display: block;
+  margin-top: .25rem;
+  overflow-wrap: anywhere;
+  font-weight: 800;
+}
+
 @media (max-width: 720px) {
   .topNav {
     overflow-x: auto;
@@ -427,5 +554,19 @@ button:hover { transform: translateY(-1px); }
 
   .badge {
     width: fit-content;
+  }
+
+  .modalOverlay {
+    place-items: stretch;
+  }
+
+  .detailModal {
+    width: 100%;
+    max-height: calc(100vh - 2rem);
+    resize: none;
+  }
+
+  .detailModalHead {
+    display: grid;
   }
 }

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -71,6 +71,19 @@
     </section>
   </main>
 
+  <div id="assignmentDetailModal" class="modalOverlay" hidden>
+    <section class="detailModal" role="dialog" aria-modal="true" aria-labelledby="assignmentDetailTitle">
+      <header class="detailModalHead">
+        <div>
+          <p class="modalEyebrow">Dettaglio consegna</p>
+          <h2 id="assignmentDetailTitle">Consegna</h2>
+        </div>
+        <button id="assignmentDetailClose" type="button" class="secondaryActionButton">Chiudi</button>
+      </header>
+      <div id="assignmentDetailBody" class="detailModalBody"></div>
+    </section>
+  </div>
+
   <script src="student_dashboard.js"></script>
 </body>
 </html>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -461,6 +461,7 @@ function isNextDeadlineAssignment(assignment, nextAssignment) {
 }
 
 function renderDashboard(payload) {
+  closeAssignmentDetail();
   const assignments = Array.isArray(payload.assignments) ? payload.assignments : [];
   currentDashboardPayload = { ...payload, assignments };
   const filterValue = els.assignmentFilter?.value || "all";

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -7,6 +7,10 @@ const els = {
   summary: document.querySelector("#summary"),
   status: document.querySelector("#status"),
   assignments: document.querySelector("#assignments"),
+  assignmentDetailModal: document.querySelector("#assignmentDetailModal"),
+  assignmentDetailTitle: document.querySelector("#assignmentDetailTitle"),
+  assignmentDetailBody: document.querySelector("#assignmentDetailBody"),
+  assignmentDetailClose: document.querySelector("#assignmentDetailClose"),
 };
 
 const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
@@ -265,13 +269,22 @@ function renderFeedback(feedback) {
   `;
 }
 
-function renderAssignment(assignment, isNext = false) {
-  const grading = assignment.grading || {};
-  const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
-  const actionHref = safeExternalHref(assignment.source_github_url);
-  const unavailableLabel = assignment.status === "missing" || !assignment.submitted
+function actionUnavailableLabel(assignment) {
+  return assignment.status === "missing" || !assignment.submitted
     ? "Consegna mancante"
     : "File consegna non disponibile";
+}
+
+function assignmentOpenAction(assignment) {
+  const actionHref = safeExternalHref(assignment.source_github_url);
+  return actionHref
+    ? `<a class="actionButton" href="${escapeHtml(actionHref)}" target="_blank" rel="noreferrer">Apri consegna</a>`
+    : `<button type="button" class="actionButton actionButtonDisabled" disabled>Apri consegna</button><span class="actionUnavailable">${escapeHtml(actionUnavailableLabel(assignment))}</span>`;
+}
+
+function renderAssignment(assignment, isNext = false, assignmentIndex = -1) {
+  const grading = assignment.grading || {};
+  const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
   const repoLink = assignment.repo_github_url
     ? safeExternalLink(assignment.repo_github_url, "Repository", assignment.repo || "-")
     : escapeHtml(assignment.repo || "-");
@@ -295,9 +308,8 @@ function renderAssignment(assignment, isNext = false) {
         </div>
       </div>
       <p class="assignmentActions">
-        ${actionHref
-          ? `<a class="actionButton" href="${escapeHtml(actionHref)}" target="_blank" rel="noreferrer">Apri consegna</a>`
-          : `<button type="button" class="actionButton actionButtonDisabled" disabled>Apri consegna</button><span class="actionUnavailable">${escapeHtml(unavailableLabel)}</span>`}
+        ${assignmentOpenAction(assignment)}
+        <button type="button" class="secondaryActionButton" data-detail-index="${escapeHtml(assignmentIndex)}">Dettaglio</button>
       </p>
       <p class="details">
         <span>${gradingBadge(grading)}</span>
@@ -314,6 +326,84 @@ function renderAssignment(assignment, isNext = false) {
       ${renderFeedback(assignment.approved_feedback)}
     </article>
   `;
+}
+
+function detailItem(label, value) {
+  return `
+    <article class="detailItem">
+      <strong>${escapeHtml(label)}</strong>
+      <span>${escapeHtml(value ?? "-")}</span>
+    </article>
+  `;
+}
+
+function renderAssignmentDetail(assignment) {
+  const grading = assignment.grading || {};
+  const failedTests = Array.isArray(grading.failed_tests) && grading.failed_tests.length
+    ? grading.failed_tests.join(", ")
+    : "-";
+  const repoLink = assignment.repo_github_url
+    ? safeExternalLink(assignment.repo_github_url, "Repository", assignment.repo || "-")
+    : escapeHtml(assignment.repo || "-");
+  const sourceLink = assignment.source_github_url
+    ? safeExternalLink(assignment.source_github_url, "Consegna", assignment.source_path || "-")
+    : escapeHtml(assignment.source_path || "-");
+  return `
+    <section class="detailSection">
+      <h3>Attivita</h3>
+      <div class="detailGrid">
+        ${detailItem("Titolo", assignment.title || assignment.activity_id)}
+        ${detailItem("Classe", assignment.class_label || assignment.class_id || currentClassLabel)}
+        ${detailItem("Tipo", assignment.kind || "tipo non indicato")}
+        ${detailItem("Modalita", assignment.student_support_mode || "modalita non indicata")}
+        ${detailItem("Assegnata", formatDate(assignment.assigned_at))}
+        ${detailItem("Scadenza", formatDate(assignment.due_at))}
+      </div>
+    </section>
+    <section class="detailSection">
+      <h3>Consegna</h3>
+      <div class="detailGrid">
+        ${detailItem("Stato", assignment.status || "-")}
+        ${detailItem("Consegnata", assignment.submitted ? "Si" : "No")}
+        ${detailItem("In ritardo", assignment.late ? "Si" : "No")}
+        ${detailItem("Consegnato il", formatDate(assignment.submitted_at))}
+        ${detailItem("Commit", assignment.commit || "-")}
+      </div>
+      <p class="assignmentActions">${assignmentOpenAction(assignment)}</p>
+      <p class="details">
+        <span>Repository: ${repoLink}</span>
+        <span>File: ${sourceLink}</span>
+      </p>
+    </section>
+    <section class="detailSection">
+      <h3>Grading</h3>
+      <div class="detailGrid">
+        ${detailItem("Stato test", grading.status || "Grading non disponibile")}
+        ${detailItem("Test", `${grading.tests_passed ?? "-"}/${grading.tests_total ?? "-"}`)}
+        ${detailItem("Voto", gradeValue(grading))}
+        ${detailItem("Test falliti", failedTests)}
+      </div>
+      ${grading.detail ? `<p class="details">${escapeHtml(grading.detail)}</p>` : ""}
+    </section>
+    ${renderFeedback(assignment.approved_feedback)}
+  `;
+}
+
+function openAssignmentDetail(assignmentIndex) {
+  const index = Number(assignmentIndex);
+  const assignment = currentDashboardPayload.assignments[index];
+  if (!assignment || !els.assignmentDetailModal || !els.assignmentDetailBody || !els.assignmentDetailTitle) return;
+  els.assignmentDetailTitle.textContent = assignment.title || assignment.activity_id || "Consegna";
+  els.assignmentDetailBody.innerHTML = renderAssignmentDetail(assignment);
+  els.assignmentDetailModal.hidden = false;
+  document.body?.classList?.add("modalOpen");
+  els.assignmentDetailClose?.focus?.();
+}
+
+function closeAssignmentDetail() {
+  if (!els.assignmentDetailModal) return;
+  els.assignmentDetailModal.hidden = true;
+  document.body?.classList?.remove("modalOpen");
 }
 
 function assignmentMatchesFilter(assignment, filterValue) {
@@ -382,7 +472,11 @@ function renderDashboard(payload) {
     ? `${assignments.length} consegne trovate.`
     : `${visibleAssignments.length} di ${assignments.length} consegne visibili.`;
   els.assignments.innerHTML = visibleAssignments.length
-    ? visibleAssignments.map((assignment) => renderAssignment(assignment, isNextDeadlineAssignment(assignment, nextAssignment))).join("")
+    ? visibleAssignments.map((assignment) => renderAssignment(
+      assignment,
+      isNextDeadlineAssignment(assignment, nextAssignment),
+      assignments.indexOf(assignment),
+    )).join("")
     : assignments.length
       ? '<p class="status">Nessuna consegna corrisponde al filtro selezionato.</p>'
       : '<p class="status">Nessuna consegna disponibile.</p>';
@@ -420,6 +514,22 @@ els.assignmentFilter?.addEventListener("change", () => {
 
 els.assignmentSort?.addEventListener("change", () => {
   renderDashboard(currentDashboardPayload);
+});
+
+els.assignments?.addEventListener("click", (event) => {
+  const detailButton = event.target.closest?.("[data-detail-index]");
+  if (!detailButton) return;
+  openAssignmentDetail(detailButton.dataset.detailIndex);
+});
+
+els.assignmentDetailClose?.addEventListener("click", closeAssignmentDetail);
+
+els.assignmentDetailModal?.addEventListener("click", (event) => {
+  if (event.target === els.assignmentDetailModal) closeAssignmentDetail();
+});
+
+document.addEventListener?.("keydown", (event) => {
+  if (event.key === "Escape") closeAssignmentDetail();
 });
 
 loadStudentOptions(els.studentId.value)


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge il pulsante **Dettaglio** a ogni consegna nella vista studente.
- Introduce un modal con dati attivita, classe, scadenze, stato consegna, link, grading, test falliti e feedback approvato.
- Mantiene **Apri consegna** come azione separata, con lo stesso comportamento per consegne mancanti o file non disponibili.
- Aggiorna la guida della dashboard studente.

## Perche

Le card della vista studente stavano diventando dense: il modal permette di vedere il quadro completo della singola consegna senza allungare troppo l'elenco.

## Verifica

```powershell
python -m pytest tests/test_student_dashboard_frontend.py tests/test_course_board_server.py
```

Risultato locale: `21 passed`.
