### PR TITLE
Aggiunge pannello percorso alla vista studente

### DIFF
--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -76,6 +76,10 @@ Screenshot previsto: `doc/images/dashboard-guides/studente-riepilogo.png`.
 
 La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenza**. Se piu consegne aperte hanno la stessa prossima scadenza, il badge compare su tutte.
 
+## Percorso
+
+Il pannello **Percorso** mostra in sola lettura una sintesi del percorso didattico corrente: anni, UDA, paragrafi principali e attivita collegate alle consegne dello studente quando il registro usa gli stessi identificativi.
+
 ## Consegne
 
 La sezione **Consegne** elenca le activity visibili allo studente.

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -78,7 +78,7 @@ La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenz
 
 ## Percorso
 
-Il pannello **Percorso** mostra in sola lettura una sintesi del percorso didattico corrente: anni, UDA, paragrafi principali e attivita collegate alle consegne dello studente quando il registro usa gli stessi identificativi.
+Il pannello **Percorso** mostra in sola lettura solo i percorsi associati allo studente o alla sua classe. Ogni percorso puo essere assegnato a una classe intera oppure personalizzato per uno studente specifico; se non ci sono associazioni esplicite, il pannello mostra che il percorso non e ancora associato.
 
 ## Consegne
 

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -78,7 +78,7 @@ La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenz
 
 ## Percorso
 
-Il pannello **Percorso** mostra in sola lettura solo i percorsi associati allo studente o alla sua classe. Ogni percorso puo essere assegnato a una classe intera oppure personalizzato per uno studente specifico; se non ci sono associazioni esplicite, il pannello mostra che il percorso non e ancora associato.
+Il pannello **Percorso** mostra in sola lettura solo i percorsi associati allo studente o al suo gruppo/classe. Ogni percorso puo essere assegnato a un gruppo intero oppure personalizzato per uno studente specifico; se non ci sono associazioni esplicite, il pannello mostra che il percorso non e ancora associato.
 
 ## Consegne
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -304,8 +304,8 @@ Da avere per la prima prova:
    - da revisionare.
 4. Vista studente in sola lettura per percorso e calendario:
    - mostrare il percorso didattico pubblicato dal docente con UDA e paragrafi pertinenti;
-   - mostrare solo percorsi esplicitamente associati allo studente o alla classe;
-   - prevedere lato docente l'associazione di un percorso a una classe intera e l'eventuale assegnazione personalizzata a un singolo studente;
+   - mostrare solo percorsi esplicitamente associati allo studente o al suo gruppo/classe;
+   - prevedere lato docente l'associazione di un percorso a un gruppo intero e l'eventuale assegnazione personalizzata a un singolo studente;
    - distinguere la programmazione prevista per UDA dalla programmazione reale svolta, evidenziando eventuali ritardi o slittamenti;
    - mostrare il calendario corrente con UDA, lezioni/lab, verifiche, compiti, consegne da fare, scadenze e finestre di lavoro;
    - aggiungere piu avanti un riepilogo delle priorita per lo studente, per esempio consegne in scadenza, verifiche vicine e attivita arretrate;

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -304,6 +304,8 @@ Da avere per la prima prova:
    - da revisionare.
 4. Vista studente in sola lettura per percorso e calendario:
    - mostrare il percorso didattico pubblicato dal docente con UDA e paragrafi pertinenti;
+   - mostrare solo percorsi esplicitamente associati allo studente o alla classe;
+   - prevedere lato docente l'associazione di un percorso a una classe intera e l'eventuale assegnazione personalizzata a un singolo studente;
    - distinguere la programmazione prevista per UDA dalla programmazione reale svolta, evidenziando eventuali ritardi o slittamenti;
    - mostrare il calendario corrente con UDA, lezioni/lab, verifiche, compiti, consegne da fare, scadenze e finestre di lavoro;
    - aggiungere piu avanti un riepilogo delle priorita per lo studente, per esempio consegne in scadenza, verifiche vicine e attivita arretrate;

--- a/doc/course_design.json
+++ b/doc/course_design.json
@@ -8,6 +8,13 @@
     {
       "id": "terzo-anno",
       "title": "Terzo anno",
+      "audience": {
+        "class_ids": [
+          "demo-3a",
+          "demo-3a.json",
+          "Classe demo 3A"
+        ]
+      },
       "description": "Corso di C base e intermedio focalizzato sulla logica di programmazione e la gestione della memoria, con integrazione di attività di laboratorio.",
       "weekly_hours": 3,
       "weeks": 33,

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -48,6 +48,7 @@ def run_student_dashboard_js(assertions: str) -> None:
     vm.runInNewContext(`${{source}}
       globalThis.__studentDashboardTest = {{
         renderSummary,
+        renderCoursePath,
         renderFeedback,
         renderAssignment,
         renderAssignmentDetail,
@@ -59,6 +60,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         sortedAssignments,
         nextOpenAssignment,
         nextOpenDueAt,
+        collectCourseItems,
         safeExternalHref,
         safeExternalLink,
         studentLabel,
@@ -272,6 +274,62 @@ def test_student_dashboard_summarizes_next_open_due_date() -> None:
         assert.match(tested.els.summary.innerHTML, /<strong>Prossima scadenza<\\/strong>\\s*<span>18\\/10\\/26, 23:59<\\/span>/);
         assert.match(tested.els.assignments.innerHTML, /Prossima scadenza/);
         assert.equal((tested.els.assignments.innerHTML.match(/Prossima scadenza/g) || []).length, 2);
+        """
+    )
+
+
+def test_student_dashboard_renders_readonly_course_path_panel() -> None:
+    run_student_dashboard_js(
+        """
+        const assignment = {
+          activity_id: "python-base-somma-001",
+          title: "Somma in Python",
+          status: "submitted_on_time",
+          submitted: true,
+        };
+        tested.renderCoursePath({
+          years: [{
+            id: "terzo",
+            title: "Terzo anno",
+            description: "Programmazione di base.",
+            udas: [{
+              id: "uda-base",
+              title: "Programmazione di base",
+              path: "Base",
+              weeks: "3",
+              items: [{
+                id: "item-input-output",
+                title: "Input e output",
+                source_id: "readme-main",
+                href: "README.md#input-e-output",
+                activity_ids: ["python-base-somma-001"],
+                children: [{
+                  id: "item-somma",
+                  title: "Somma",
+                  source: "README.md",
+                }],
+              }],
+            }],
+          }],
+        }, [assignment]);
+
+        assert.match(tested.els.coursePath.innerHTML, /Terzo anno/);
+        assert.match(tested.els.coursePath.innerHTML, /Programmazione di base/);
+        assert.match(tested.els.coursePath.innerHTML, /Input e output/);
+        assert.match(tested.els.coursePath.innerHTML, /Somma in Python/);
+        assert.match(tested.els.coursePathStatus.textContent, /1 anni .* 1 UDA/);
+        assert.equal(tested.collectCourseItems([{ title: "Padre", children: [{ title: "Figlio" }] }]).length, 2);
+        """
+    )
+
+
+def test_student_dashboard_renders_missing_course_path_message() -> None:
+    run_student_dashboard_js(
+        """
+        tested.renderCoursePath({ years: [] }, []);
+
+        assert.match(tested.els.coursePath.innerHTML, /Percorso non disponibile/);
+        assert.equal(tested.els.coursePathStatus.textContent, "");
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -321,6 +321,19 @@ def test_student_dashboard_renders_readonly_course_path_panel() -> None:
                   source: "README.md",
                 }],
               }],
+            }, {
+              id: "uda-completa",
+              title: "UDA completa",
+              path: "Base",
+              items: [
+                { id: "p-1", title: "Paragrafo 1" },
+                { id: "p-2", title: "Paragrafo 2" },
+                { id: "p-3", title: "Paragrafo 3" },
+                { id: "p-4", title: "Paragrafo 4" },
+                { id: "p-5", title: "Paragrafo 5" },
+                { id: "p-6", title: "Paragrafo 6" },
+                { id: "p-7", title: "Paragrafo 7" },
+              ],
             }],
           }],
         }, [assignment]);
@@ -330,8 +343,10 @@ def test_student_dashboard_renders_readonly_course_path_panel() -> None:
         assert.match(tested.els.coursePath.innerHTML, /Programmazione di base/);
         assert.match(tested.els.coursePath.innerHTML, /Input e output/);
         assert.match(tested.els.coursePath.innerHTML, /href="https:\\/\\/github.com\\/TheBitPoets\\/2cornot2c\\/blob\\/main\\/README.md#input-e-output"/);
+        assert.match(tested.els.coursePath.innerHTML, /Paragrafo 7/);
+        assert.doesNotMatch(tested.els.coursePath.innerHTML, /Altri 1 paragrafi/);
         assert.match(tested.els.coursePath.innerHTML, /Somma in Python/);
-        assert.match(tested.els.coursePathStatus.textContent, /1 percorsi .* 1 UDA/);
+        assert.match(tested.els.coursePathStatus.textContent, /1 percorsi .* 2 UDA/);
         assert.equal(tested.collectCourseItems([{ title: "Padre", children: [{ title: "Figlio" }] }]).length, 2);
         """
     )

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -61,6 +61,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         nextOpenAssignment,
         nextOpenDueAt,
         collectCourseItems,
+        courseItemHref,
         safeExternalHref,
         safeExternalLink,
         studentLabel,
@@ -328,6 +329,7 @@ def test_student_dashboard_renders_readonly_course_path_panel() -> None:
         assert.match(tested.els.coursePath.innerHTML, /Percorso corrente/);
         assert.match(tested.els.coursePath.innerHTML, /Programmazione di base/);
         assert.match(tested.els.coursePath.innerHTML, /Input e output/);
+        assert.match(tested.els.coursePath.innerHTML, /href="https:\\/\\/github.com\\/TheBitPoets\\/2cornot2c\\/blob\\/main\\/README.md#input-e-output"/);
         assert.match(tested.els.coursePath.innerHTML, /Somma in Python/);
         assert.match(tested.els.coursePathStatus.textContent, /1 percorsi .* 1 UDA/);
         assert.equal(tested.collectCourseItems([{ title: "Padre", children: [{ title: "Figlio" }] }]).length, 2);
@@ -387,6 +389,26 @@ def test_student_dashboard_rejects_unsafe_external_links() -> None:
         assert.match(unsafe, /repo-name/);
         assert.equal(tested.safeExternalHref("javascript:alert(1)"), "");
         assert.equal(tested.safeExternalHref("https://github.com/TheBitPoets/2cornot2c"), "https://github.com/TheBitPoets/2cornot2c");
+        """
+    )
+
+
+def test_student_dashboard_resolves_course_item_links_to_github_anchors() -> None:
+    run_student_dashboard_js(
+        """
+        assert.equal(
+          tested.courseItemHref({ href: "../README.md#introduzione", source: "README.md" }),
+          "https://github.com/TheBitPoets/2cornot2c/blob/main/README.md#introduzione",
+        );
+        assert.equal(
+          tested.courseItemHref({ href: "#laboratori", source: "README.md" }),
+          "https://github.com/TheBitPoets/2cornot2c/blob/main/README.md#laboratori",
+        );
+        assert.equal(
+          tested.courseItemHref({ github_url: "https://github.com/example/repo/blob/main/doc.md#x" }),
+          "https://github.com/example/repo/blob/main/doc.md#x",
+        );
+        assert.equal(tested.courseItemHref({ href: "javascript:alert(1)" }), "");
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -346,6 +346,36 @@ def test_student_dashboard_renders_missing_course_path_message() -> None:
     )
 
 
+def test_student_dashboard_uses_selected_roster_for_course_path_visibility() -> None:
+    run_student_dashboard_js(
+        """
+        tested.populateClassRosterOptions([{
+          name: "demo-3a.json",
+          id: "demo-3a",
+          label: "Classe demo 3A",
+          school_year: "2026-2027",
+        }], "demo-3a.json");
+
+        tested.renderCoursePath({
+          paths: [{
+            id: "percorso-demo-3a",
+            title: "Percorso demo 3A",
+            audience: { class_ids: ["demo-3a"] },
+            udas: [{
+              id: "uda-base",
+              title: "Fondamenti",
+              items: [{ id: "item-1", title: "Primo argomento" }],
+            }],
+          }],
+        }, [], "bianchi-luca");
+
+        assert.match(tested.els.coursePath.innerHTML, /Percorso demo 3A/);
+        assert.match(tested.els.coursePath.innerHTML, /Fondamenti/);
+        assert.match(tested.els.coursePathStatus.textContent, /1 percorsi .* 1 UDA/);
+        """
+    )
+
+
 def test_student_dashboard_rejects_unsafe_external_links() -> None:
     run_student_dashboard_js(
         """

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -289,18 +289,18 @@ def test_student_dashboard_renders_readonly_course_path_panel() -> None:
           submitted: true,
         };
         tested.renderCoursePath({
-          years: [{
-            id: "terzo",
-            title: "Terzo anno",
+          paths: [{
+            id: "base-precedente",
+            title: "Percorso precedente",
             class_ids: ["3A"],
             udas: [{
-              id: "uda-terzo",
-              title: "Percorso precedente",
+              id: "uda-precedente",
+              title: "Modulo precedente",
               items: [],
             }],
           }, {
-            id: "quarto",
-            title: "Quarto anno",
+            id: "base-corrente",
+            title: "Percorso corrente",
             audience: { class_ids: ["4A"] },
             description: "Programmazione di base.",
             udas: [{
@@ -324,8 +324,8 @@ def test_student_dashboard_renders_readonly_course_path_panel() -> None:
           }],
         }, [assignment]);
 
-        assert.doesNotMatch(tested.els.coursePath.innerHTML, /Terzo anno/);
-        assert.match(tested.els.coursePath.innerHTML, /Quarto anno/);
+        assert.doesNotMatch(tested.els.coursePath.innerHTML, /Percorso precedente/);
+        assert.match(tested.els.coursePath.innerHTML, /Percorso corrente/);
         assert.match(tested.els.coursePath.innerHTML, /Programmazione di base/);
         assert.match(tested.els.coursePath.innerHTML, /Input e output/);
         assert.match(tested.els.coursePath.innerHTML, /Somma in Python/);
@@ -338,7 +338,7 @@ def test_student_dashboard_renders_readonly_course_path_panel() -> None:
 def test_student_dashboard_renders_missing_course_path_message() -> None:
     run_student_dashboard_js(
         """
-        tested.renderCoursePath({ years: [] }, []);
+        tested.renderCoursePath({ paths: [] }, []);
 
         assert.match(tested.els.coursePath.innerHTML, /Percorso non associato/);
         assert.equal(tested.els.coursePathStatus.textContent, "");

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -284,6 +284,7 @@ def test_student_dashboard_renders_readonly_course_path_panel() -> None:
         const assignment = {
           activity_id: "python-base-somma-001",
           title: "Somma in Python",
+          class_id: "4A",
           status: "submitted_on_time",
           submitted: true,
         };
@@ -291,6 +292,16 @@ def test_student_dashboard_renders_readonly_course_path_panel() -> None:
           years: [{
             id: "terzo",
             title: "Terzo anno",
+            class_ids: ["3A"],
+            udas: [{
+              id: "uda-terzo",
+              title: "Percorso precedente",
+              items: [],
+            }],
+          }, {
+            id: "quarto",
+            title: "Quarto anno",
+            audience: { class_ids: ["4A"] },
             description: "Programmazione di base.",
             udas: [{
               id: "uda-base",
@@ -313,11 +324,12 @@ def test_student_dashboard_renders_readonly_course_path_panel() -> None:
           }],
         }, [assignment]);
 
-        assert.match(tested.els.coursePath.innerHTML, /Terzo anno/);
+        assert.doesNotMatch(tested.els.coursePath.innerHTML, /Terzo anno/);
+        assert.match(tested.els.coursePath.innerHTML, /Quarto anno/);
         assert.match(tested.els.coursePath.innerHTML, /Programmazione di base/);
         assert.match(tested.els.coursePath.innerHTML, /Input e output/);
         assert.match(tested.els.coursePath.innerHTML, /Somma in Python/);
-        assert.match(tested.els.coursePathStatus.textContent, /1 anni .* 1 UDA/);
+        assert.match(tested.els.coursePathStatus.textContent, /1 percorsi .* 1 UDA/);
         assert.equal(tested.collectCourseItems([{ title: "Padre", children: [{ title: "Figlio" }] }]).length, 2);
         """
     )
@@ -328,7 +340,7 @@ def test_student_dashboard_renders_missing_course_path_message() -> None:
         """
         tested.renderCoursePath({ years: [] }, []);
 
-        assert.match(tested.els.coursePath.innerHTML, /Percorso non disponibile/);
+        assert.match(tested.els.coursePath.innerHTML, /Percorso non associato/);
         assert.equal(tested.els.coursePathStatus.textContent, "");
         """
     )

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -277,8 +277,11 @@ button:hover { transform: translateY(-1px); }
   display: grid;
   gap: .35rem;
   min-width: 0;
+  max-height: 14rem;
   margin: 0;
   padding: 0;
+  padding-right: .35rem;
+  overflow-y: auto;
   list-style: none;
 }
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -160,6 +160,7 @@ button {
 button:hover { transform: translateY(-1px); }
 
 .summary,
+.coursePath,
 .assignments {
   min-width: 0;
   border: 1px solid rgba(17, 17, 17, .12);
@@ -227,6 +228,83 @@ button:hover { transform: translateY(-1px); }
 .assignmentList {
   display: grid;
   min-width: 0;
+}
+
+.coursePathBody {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  padding: 1rem;
+}
+
+.courseYear {
+  display: grid;
+  gap: .85rem;
+  min-width: 0;
+}
+
+.courseYear h3,
+.courseYear p,
+.courseUda h4 {
+  margin: 0;
+}
+
+.courseUdaGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: .75rem;
+  min-width: 0;
+}
+
+.courseUda {
+  display: grid;
+  gap: .75rem;
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: .9rem;
+}
+
+.courseLinkedActivities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+  min-width: 0;
+}
+
+.courseItemList {
+  display: grid;
+  gap: .35rem;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.courseItemList li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: .5rem;
+  min-width: 0;
+  padding-left: calc(var(--depth, 0) * .85rem);
+  color: var(--ink);
+  font-size: .84rem;
+}
+
+.courseItemList a,
+.courseItemList span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.courseItemList a {
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.courseItemList span {
+  color: var(--muted);
 }
 
 .assignmentCard {
@@ -538,6 +616,14 @@ button:hover { transform: translateY(-1px); }
   }
 
   .summary {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .courseUdaGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .courseItemList li {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -237,14 +237,14 @@ button:hover { transform: translateY(-1px); }
   padding: 1rem;
 }
 
-.courseYear {
+.courseSection {
   display: grid;
   gap: .85rem;
   min-width: 0;
 }
 
-.courseYear h3,
-.courseYear p,
+.courseSection h3,
+.courseSection p,
 .courseUda h4 {
   margin: 0;
 }

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -41,6 +41,16 @@
       <p class="status">Carica uno studente per vedere consegne, stato e feedback approvato.</p>
     </section>
 
+    <section class="coursePath">
+      <div class="sectionHead">
+        <h2>Percorso</h2>
+        <p id="coursePathStatus" class="status" aria-live="polite"></p>
+      </div>
+      <div id="coursePath" class="coursePathBody">
+        <p class="status">Caricamento percorso didattico...</p>
+      </div>
+    </section>
+
     <section class="assignments">
       <div class="sectionHead">
         <h2>Consegne</h2>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -410,7 +410,6 @@ function renderCoursePath(design, assignments = [], studentId = currentDashboard
     const udaCards = udas.map((uda) => {
       const items = collectCourseItems(uda.items);
       const linkedActivities = [...new Set(items.flatMap(({ item }) => courseItemActivities(item)))];
-      const visibleItems = items.slice(0, 6);
       return `
         <article class="courseUda">
           <header>
@@ -429,14 +428,13 @@ function renderCoursePath(design, assignments = [], studentId = currentDashboard
               : '<span class="status">Nessuna attivita collegata.</span>'}
           </div>
           <ul class="courseItemList">
-            ${visibleItems.map(({ item, depth }) => `
+            ${items.map(({ item, depth }) => `
               <li style="--depth: ${escapeHtml(depth)}">
                 ${courseItemHref(item) ? safeExternalLink(courseItemHref(item), item.title || item.id || "-") : escapeHtml(item.title || item.id || "-")}
                 <span>${escapeHtml(item.source || item.source_id || "")}</span>
               </li>
             `).join("")}
           </ul>
-          ${items.length > visibleItems.length ? `<p class="status">Altri ${items.length - visibleItems.length} paragrafi nel percorso.</p>` : ""}
         </article>
       `;
     }).join("");

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -16,6 +16,7 @@ const els = {
 };
 
 const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
+const DEFAULT_COURSE_REPO_URL = "https://github.com/TheBitPoets/2cornot2c";
 let currentDashboardPayload = { student_id: "", assignments: [] };
 let currentClassLabel = "Dai registri consegne";
 let currentClassRoster = null;
@@ -185,6 +186,32 @@ function safeExternalHref(url) {
     // Fall back to no clickable URL below.
   }
   return "";
+}
+
+function normalizeCoursePath(path) {
+  return String(path ?? "")
+    .trim()
+    .replaceAll("\\", "/")
+    .replace(/^(\.\/)+/, "")
+    .replace(/^(\.\.\/)+/, "")
+    .replace(/^\/+/, "");
+}
+
+function courseItemHref(item) {
+  const githubUrl = safeExternalHref(item?.github_url || item?.source_github_url);
+  if (githubUrl) return githubUrl;
+
+  const rawHref = String(item?.href || "").trim();
+  const absoluteHref = safeExternalHref(rawHref);
+  const currentOrigin = new URL(window.location.href).origin;
+  if (absoluteHref && !absoluteHref.startsWith(currentOrigin)) return absoluteHref;
+  if (/^[a-zA-Z][\w+.-]*:/.test(rawHref)) return "";
+
+  const [hrefPath, hrefAnchor = ""] = rawHref.split("#", 2);
+  const sourcePath = normalizeCoursePath(hrefPath || item?.source || item?.source_id);
+  if (!sourcePath) return "";
+  const anchor = hrefAnchor ? `#${hrefAnchor}` : "";
+  return `${DEFAULT_COURSE_REPO_URL}/blob/main/${sourcePath}${anchor}`;
 }
 
 function formatDate(value) {
@@ -404,7 +431,7 @@ function renderCoursePath(design, assignments = [], studentId = currentDashboard
           <ul class="courseItemList">
             ${visibleItems.map(({ item, depth }) => `
               <li style="--depth: ${escapeHtml(depth)}">
-                ${item.href ? safeExternalLink(item.href, item.title || item.id || "-") : escapeHtml(item.title || item.id || "-")}
+                ${courseItemHref(item) ? safeExternalLink(courseItemHref(item), item.title || item.id || "-") : escapeHtml(item.title || item.id || "-")}
                 <span>${escapeHtml(item.source || item.source_id || "")}</span>
               </li>
             `).join("")}

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -18,6 +18,7 @@ const els = {
 const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
 let currentDashboardPayload = { student_id: "", assignments: [] };
 let currentClassLabel = "Dai registri consegne";
+let currentClassRoster = null;
 let currentCourseDesign = null;
 
 async function api(path, options = {}) {
@@ -90,12 +91,14 @@ function populateClassRosterOptions(rosters, preferredRosterName = "") {
     els.classRoster.value = "";
     els.classRoster.disabled = true;
     currentClassLabel = "Dai registri consegne";
+    currentClassRoster = null;
     return "";
   }
   const names = options.map((roster) => roster.name);
   const selected = names.includes(preferredRosterName) ? preferredRosterName : names[0];
   const selectedRoster = options.find((roster) => roster.name === selected);
   currentClassLabel = rosterLabel(selectedRoster);
+  currentClassRoster = selectedRoster || null;
   els.classRoster.disabled = false;
   els.classRoster.innerHTML = options.map((roster) => `
     <option value="${escapeHtml(roster.name)}"${roster.name === selected ? " selected" : ""}>${escapeHtml(rosterLabel(roster))}</option>
@@ -123,6 +126,7 @@ async function loadRosterDetailStudentOptions(rosters, preferredStudentId = "", 
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ name: rosterName }),
   });
+  currentClassRoster = { ...(currentClassRoster || {}), ...(payload.roster || {}), name: rosterName };
   return populateStudentOptions(activeStudentsFromRoster(payload.roster), preferredStudentId);
 }
 
@@ -287,10 +291,15 @@ function visibilityValues(entity, key) {
   ];
 }
 
-function visibilityContext(studentId, assignments) {
+function visibilityContext(studentId, assignments, roster = currentClassRoster) {
   return {
     studentIds: normalizedIdSet([studentId]),
-    classIds: normalizedIdSet(assignments.flatMap((assignment) => [assignment?.class_id, assignment?.class_label])),
+    classIds: normalizedIdSet([
+      roster?.id,
+      roster?.name,
+      roster?.label,
+      ...(assignments.flatMap((assignment) => [assignment?.class_id, assignment?.class_label])),
+    ]),
   };
 }
 

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -274,6 +274,61 @@ function assignmentByActivityId(assignments) {
   return byId;
 }
 
+function normalizedIdSet(values) {
+  const list = Array.isArray(values) ? values : values ? [values] : [];
+  return new Set(list.map((value) => String(value || "").trim()).filter(Boolean));
+}
+
+function visibilityValues(entity, key) {
+  const audience = entity?.audience && typeof entity.audience === "object" ? entity.audience : {};
+  return [
+    ...(Array.isArray(entity?.[key]) ? entity[key] : entity?.[key] ? [entity[key]] : []),
+    ...(Array.isArray(audience?.[key]) ? audience[key] : audience?.[key] ? [audience[key]] : []),
+  ];
+}
+
+function visibilityContext(studentId, assignments) {
+  return {
+    studentIds: normalizedIdSet([studentId]),
+    classIds: normalizedIdSet(assignments.flatMap((assignment) => [assignment?.class_id, assignment?.class_label])),
+  };
+}
+
+function hasVisibilityRule(entity) {
+  return visibilityValues(entity, "student_ids").length > 0
+    || visibilityValues(entity, "students").length > 0
+    || visibilityValues(entity, "class_ids").length > 0
+    || visibilityValues(entity, "classes").length > 0;
+}
+
+function matchesVisibility(entity, context) {
+  const studentIds = [
+    ...visibilityValues(entity, "student_ids"),
+    ...visibilityValues(entity, "students"),
+  ];
+  const classIds = [
+    ...visibilityValues(entity, "class_ids"),
+    ...visibilityValues(entity, "classes"),
+  ];
+  return studentIds.some((studentId) => context.studentIds.has(String(studentId).trim()))
+    || classIds.some((classId) => context.classIds.has(String(classId).trim()));
+}
+
+function visibleCourseYears(years, context) {
+  return years
+    .map((year) => {
+      const visibleUdas = (Array.isArray(year?.udas) ? year.udas : []).filter((uda) => (
+        matchesVisibility(uda, context)
+        || collectCourseItems(uda.items).some(({ item }) => matchesVisibility(item, context))
+      ));
+      if (matchesVisibility(year, context)) {
+        return { ...year, udas: Array.isArray(year?.udas) ? year.udas : [] };
+      }
+      return visibleUdas.length ? { ...year, udas: visibleUdas } : null;
+    })
+    .filter(Boolean);
+}
+
 function courseItemActivities(item) {
   return Array.isArray(item?.activity_ids)
     ? item.activity_ids.map((activityId) => String(activityId || "").trim()).filter(Boolean)
@@ -293,16 +348,22 @@ function courseActivityBadge(activityId, assignmentsById) {
   return `<span class="badge ${kind}">${escapeHtml(label)}</span>`;
 }
 
-function renderCoursePath(design, assignments = []) {
+function renderCoursePath(design, assignments = [], studentId = currentDashboardPayload.student_id) {
   if (!els.coursePath) return;
   const years = Array.isArray(design?.years) ? design.years : [];
-  if (!years.length) {
-    els.coursePath.innerHTML = '<p class="status">Percorso non disponibile per questa classe.</p>';
+  const context = visibilityContext(studentId, assignments);
+  const visibleYears = visibleCourseYears(years, context);
+  const hasRules = years.some((year) => hasVisibilityRule(year)
+    || (Array.isArray(year?.udas) ? year.udas : []).some((uda) => (
+      hasVisibilityRule(uda) || collectCourseItems(uda.items).some(({ item }) => hasVisibilityRule(item))
+    )));
+  if (!years.length || !hasRules || !visibleYears.length) {
+    els.coursePath.innerHTML = '<p class="status">Percorso non associato a questo studente o alla sua classe.</p>';
     if (els.coursePathStatus) els.coursePathStatus.textContent = "";
     return;
   }
   const assignmentsById = assignmentByActivityId(assignments);
-  const yearCards = years.map((year) => {
+  const yearCards = visibleYears.map((year) => {
     const udas = Array.isArray(year?.udas) ? year.udas : [];
     const udaCards = udas.map((uda) => {
       const items = collectCourseItems(uda.items);
@@ -347,15 +408,15 @@ function renderCoursePath(design, assignments = []) {
   }).join("");
   els.coursePath.innerHTML = yearCards;
   if (els.coursePathStatus) {
-    const udaCount = years.reduce((total, year) => total + (Array.isArray(year?.udas) ? year.udas.length : 0), 0);
-    els.coursePathStatus.textContent = `${years.length} anni · ${udaCount} UDA`;
+    const udaCount = visibleYears.reduce((total, year) => total + (Array.isArray(year?.udas) ? year.udas.length : 0), 0);
+    els.coursePathStatus.textContent = `${visibleYears.length} percorsi · ${udaCount} UDA`;
   }
 }
 
 async function loadCoursePath() {
   try {
     currentCourseDesign = await api("/api/course-design");
-    renderCoursePath(currentCourseDesign, currentDashboardPayload.assignments);
+    renderCoursePath(currentCourseDesign, currentDashboardPayload.assignments, currentDashboardPayload.student_id);
   } catch (error) {
     currentCourseDesign = null;
     if (els.coursePath) {
@@ -582,7 +643,7 @@ function renderDashboard(payload) {
   const nextAssignment = nextOpenAssignment(assignments);
   const visibleAssignments = sortedAssignments(filteredAssignments(assignments, filterValue), sortValue);
   renderSummary(payload.student_id || "-", assignments);
-  renderCoursePath(currentCourseDesign, assignments);
+  renderCoursePath(currentCourseDesign, assignments, payload.student_id);
   els.status.textContent = visibleAssignments.length === assignments.length
     ? `${assignments.length} consegne trovate.`
     : `${visibleAssignments.length} di ${assignments.length} consegne visibili.`;

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -7,6 +7,8 @@ const els = {
   summary: document.querySelector("#summary"),
   status: document.querySelector("#status"),
   assignments: document.querySelector("#assignments"),
+  coursePath: document.querySelector("#coursePath"),
+  coursePathStatus: document.querySelector("#coursePathStatus"),
   assignmentDetailModal: document.querySelector("#assignmentDetailModal"),
   assignmentDetailTitle: document.querySelector("#assignmentDetailTitle"),
   assignmentDetailBody: document.querySelector("#assignmentDetailBody"),
@@ -16,6 +18,7 @@ const els = {
 const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
 let currentDashboardPayload = { student_id: "", assignments: [] };
 let currentClassLabel = "Dai registri consegne";
+let currentCourseDesign = null;
 
 async function api(path, options = {}) {
   const response = await fetch(path, options);
@@ -252,6 +255,116 @@ function renderSummary(studentId, assignments) {
   `).join("");
 }
 
+function collectCourseItems(items, depth = 0) {
+  const rows = [];
+  for (const item of Array.isArray(items) ? items : []) {
+    if (!item || typeof item !== "object") continue;
+    rows.push({ item, depth });
+    rows.push(...collectCourseItems(item.children, depth + 1));
+  }
+  return rows;
+}
+
+function assignmentByActivityId(assignments) {
+  const byId = new Map();
+  for (const assignment of assignments) {
+    const activityId = String(assignment?.activity_id || "").trim();
+    if (activityId && !byId.has(activityId)) byId.set(activityId, assignment);
+  }
+  return byId;
+}
+
+function courseItemActivities(item) {
+  return Array.isArray(item?.activity_ids)
+    ? item.activity_ids.map((activityId) => String(activityId || "").trim()).filter(Boolean)
+    : [];
+}
+
+function courseActivityBadge(activityId, assignmentsById) {
+  const assignment = assignmentsById.get(activityId);
+  const label = assignment ? assignmentTitle(assignment) || activityId : activityId;
+  const kind = assignment?.status === "missing"
+    ? "badgeBad"
+    : assignment?.late
+      ? "badgeWarn"
+      : assignment?.submitted
+        ? "badgeOk"
+        : "";
+  return `<span class="badge ${kind}">${escapeHtml(label)}</span>`;
+}
+
+function renderCoursePath(design, assignments = []) {
+  if (!els.coursePath) return;
+  const years = Array.isArray(design?.years) ? design.years : [];
+  if (!years.length) {
+    els.coursePath.innerHTML = '<p class="status">Percorso non disponibile per questa classe.</p>';
+    if (els.coursePathStatus) els.coursePathStatus.textContent = "";
+    return;
+  }
+  const assignmentsById = assignmentByActivityId(assignments);
+  const yearCards = years.map((year) => {
+    const udas = Array.isArray(year?.udas) ? year.udas : [];
+    const udaCards = udas.map((uda) => {
+      const items = collectCourseItems(uda.items);
+      const linkedActivities = [...new Set(items.flatMap(({ item }) => courseItemActivities(item)))];
+      const visibleItems = items.slice(0, 6);
+      return `
+        <article class="courseUda">
+          <header>
+            <div>
+              <h4>${escapeHtml(uda.title || uda.id || "UDA senza titolo")}</h4>
+              <p class="meta">
+                <span>${escapeHtml(uda.path || "percorso non indicato")}</span>
+                <span>${escapeHtml(uda.weeks ? `${uda.weeks} settimane` : "durata non indicata")}</span>
+                <span>${items.length} paragrafi</span>
+              </p>
+            </div>
+          </header>
+          <div class="courseLinkedActivities">
+            ${linkedActivities.length
+              ? linkedActivities.map((activityId) => courseActivityBadge(activityId, assignmentsById)).join("")
+              : '<span class="status">Nessuna attivita collegata.</span>'}
+          </div>
+          <ul class="courseItemList">
+            ${visibleItems.map(({ item, depth }) => `
+              <li style="--depth: ${escapeHtml(depth)}">
+                ${item.href ? safeExternalLink(item.href, item.title || item.id || "-") : escapeHtml(item.title || item.id || "-")}
+                <span>${escapeHtml(item.source || item.source_id || "")}</span>
+              </li>
+            `).join("")}
+          </ul>
+          ${items.length > visibleItems.length ? `<p class="status">Altri ${items.length - visibleItems.length} paragrafi nel percorso.</p>` : ""}
+        </article>
+      `;
+    }).join("");
+    return `
+      <article class="courseYear">
+        <h3>${escapeHtml(year.title || year.id || "Anno senza titolo")}</h3>
+        ${year.description ? `<p>${escapeHtml(year.description)}</p>` : ""}
+        <div class="courseUdaGrid">${udaCards || '<p class="status">Nessuna UDA disponibile.</p>'}</div>
+      </article>
+    `;
+  }).join("");
+  els.coursePath.innerHTML = yearCards;
+  if (els.coursePathStatus) {
+    const udaCount = years.reduce((total, year) => total + (Array.isArray(year?.udas) ? year.udas.length : 0), 0);
+    els.coursePathStatus.textContent = `${years.length} anni · ${udaCount} UDA`;
+  }
+}
+
+async function loadCoursePath() {
+  try {
+    currentCourseDesign = await api("/api/course-design");
+    renderCoursePath(currentCourseDesign, currentDashboardPayload.assignments);
+  } catch (error) {
+    currentCourseDesign = null;
+    if (els.coursePath) {
+      els.coursePath.innerHTML = '<p class="status">Percorso non disponibile per questa classe.</p>';
+    }
+    if (els.coursePathStatus) els.coursePathStatus.textContent = `Errore: ${error.message}`;
+  }
+}
+
 function renderFeedback(feedback) {
   if (!feedback) {
     return '<p class="emptyFeedback">Nessun feedback approvato dal docente per questa consegna.</p>';
@@ -469,6 +582,7 @@ function renderDashboard(payload) {
   const nextAssignment = nextOpenAssignment(assignments);
   const visibleAssignments = sortedAssignments(filteredAssignments(assignments, filterValue), sortValue);
   renderSummary(payload.student_id || "-", assignments);
+  renderCoursePath(currentCourseDesign, assignments);
   els.status.textContent = visibleAssignments.length === assignments.length
     ? `${assignments.length} consegne trovate.`
     : `${visibleAssignments.length} di ${assignments.length} consegne visibili.`;
@@ -538,3 +652,5 @@ loadStudentOptions(els.studentId.value)
   .catch((error) => {
     els.status.textContent = `Errore: ${error.message}`;
   });
+
+loadCoursePath();

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -314,17 +314,23 @@ function matchesVisibility(entity, context) {
     || classIds.some((classId) => context.classIds.has(String(classId).trim()));
 }
 
-function visibleCourseYears(years, context) {
-  return years
-    .map((year) => {
-      const visibleUdas = (Array.isArray(year?.udas) ? year.udas : []).filter((uda) => (
+function courseSections(design) {
+  if (Array.isArray(design?.paths)) return design.paths;
+  if (Array.isArray(design?.sections)) return design.sections;
+  return Array.isArray(design?.years) ? design.years : [];
+}
+
+function visibleCourseSections(sections, context) {
+  return sections
+    .map((section) => {
+      const visibleUdas = (Array.isArray(section?.udas) ? section.udas : []).filter((uda) => (
         matchesVisibility(uda, context)
         || collectCourseItems(uda.items).some(({ item }) => matchesVisibility(item, context))
       ));
-      if (matchesVisibility(year, context)) {
-        return { ...year, udas: Array.isArray(year?.udas) ? year.udas : [] };
+      if (matchesVisibility(section, context)) {
+        return { ...section, udas: Array.isArray(section?.udas) ? section.udas : [] };
       }
-      return visibleUdas.length ? { ...year, udas: visibleUdas } : null;
+      return visibleUdas.length ? { ...section, udas: visibleUdas } : null;
     })
     .filter(Boolean);
 }
@@ -350,21 +356,21 @@ function courseActivityBadge(activityId, assignmentsById) {
 
 function renderCoursePath(design, assignments = [], studentId = currentDashboardPayload.student_id) {
   if (!els.coursePath) return;
-  const years = Array.isArray(design?.years) ? design.years : [];
+  const sections = courseSections(design);
   const context = visibilityContext(studentId, assignments);
-  const visibleYears = visibleCourseYears(years, context);
-  const hasRules = years.some((year) => hasVisibilityRule(year)
-    || (Array.isArray(year?.udas) ? year.udas : []).some((uda) => (
+  const visibleSections = visibleCourseSections(sections, context);
+  const hasRules = sections.some((section) => hasVisibilityRule(section)
+    || (Array.isArray(section?.udas) ? section.udas : []).some((uda) => (
       hasVisibilityRule(uda) || collectCourseItems(uda.items).some(({ item }) => hasVisibilityRule(item))
     )));
-  if (!years.length || !hasRules || !visibleYears.length) {
-    els.coursePath.innerHTML = '<p class="status">Percorso non associato a questo studente o alla sua classe.</p>';
+  if (!sections.length || !hasRules || !visibleSections.length) {
+    els.coursePath.innerHTML = '<p class="status">Percorso non associato a questo studente o al suo gruppo/classe.</p>';
     if (els.coursePathStatus) els.coursePathStatus.textContent = "";
     return;
   }
   const assignmentsById = assignmentByActivityId(assignments);
-  const yearCards = visibleYears.map((year) => {
-    const udas = Array.isArray(year?.udas) ? year.udas : [];
+  const sectionCards = visibleSections.map((section) => {
+    const udas = Array.isArray(section?.udas) ? section.udas : [];
     const udaCards = udas.map((uda) => {
       const items = collectCourseItems(uda.items);
       const linkedActivities = [...new Set(items.flatMap(({ item }) => courseItemActivities(item)))];
@@ -399,17 +405,17 @@ function renderCoursePath(design, assignments = [], studentId = currentDashboard
       `;
     }).join("");
     return `
-      <article class="courseYear">
-        <h3>${escapeHtml(year.title || year.id || "Anno senza titolo")}</h3>
-        ${year.description ? `<p>${escapeHtml(year.description)}</p>` : ""}
+      <article class="courseSection">
+        <h3>${escapeHtml(section.title || section.id || "Percorso senza titolo")}</h3>
+        ${section.description ? `<p>${escapeHtml(section.description)}</p>` : ""}
         <div class="courseUdaGrid">${udaCards || '<p class="status">Nessuna UDA disponibile.</p>'}</div>
       </article>
     `;
   }).join("");
-  els.coursePath.innerHTML = yearCards;
+  els.coursePath.innerHTML = sectionCards;
   if (els.coursePathStatus) {
-    const udaCount = visibleYears.reduce((total, year) => total + (Array.isArray(year?.udas) ? year.udas.length : 0), 0);
-    els.coursePathStatus.textContent = `${visibleYears.length} percorsi · ${udaCount} UDA`;
+    const udaCount = visibleSections.reduce((total, section) => total + (Array.isArray(section?.udas) ? section.udas.length : 0), 0);
+    els.coursePathStatus.textContent = `${visibleSections.length} percorsi · ${udaCount} UDA`;
   }
 }
 
@@ -420,7 +426,7 @@ async function loadCoursePath() {
   } catch (error) {
     currentCourseDesign = null;
     if (els.coursePath) {
-      els.coursePath.innerHTML = '<p class="status">Percorso non disponibile per questa classe.</p>';
+      els.coursePath.innerHTML = '<p class="status">Percorso non disponibile.</p>';
     }
     if (els.coursePathStatus) els.coursePathStatus.textContent = `Errore: ${error.message}`;
   }


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge il pannello **Percorso** alla vista studente.
- Legge il percorso didattico corrente da `/api/course-design` in sola lettura.
- Mostra anni, UDA, paragrafi principali e attivita collegate quando gli `activity_ids` coincidono con le consegne dello studente.
- Mantiene un messaggio chiaro quando il percorso non e disponibile.
- Aggiorna la guida della dashboard studente.

## Perche

E un primo scheletro per permettere allo studente di orientarsi tra percorso didattico, UDA e consegne senza introdurre ancora modifica dati, sincronizzazione calendario o una vista percorso completa.

## Verifica

```powershell
python -m pytest tests/test_student_dashboard_frontend.py tests/test_course_board_server.py
```

Risultato locale: `24 passed`.
