### PR TITLE
Aggiunge calendario readonly alla vista studente

### DIFF
--- a/doc/ASSIGNMENTS.md
+++ b/doc/ASSIGNMENTS.md
@@ -85,6 +85,29 @@ Le alternative restano possibili, ma non sono la strada iniziale.
 
 La CLI futura di TheBitLab potra automatizzare la creazione dei repository studenti a partire da classe, team GitHub e template scelto.
 
+## Nomenclatura: attivita, assegnazione e consegna
+
+Per evitare ambiguita tra modello dati, dashboard docente e vista studente, TheBitLab usa questi concetti.
+
+**Attivita** e il template didattico preparato dal docente. Descrive cosa bisogna fare: titolo, testo, tipo, obiettivi, argomenti, modalita di supporto, test, rubrica e collegamenti a percorso o UDA.
+
+**Assegnazione** e l'atto di associare una attivita a una classe, a un gruppo o a uno studente. Contiene dati come classe, data di assegnazione, scadenza e regole applicate a quella pubblicazione.
+
+**Consegna** e la relazione tra uno studente e una assegnazione. Contiene stato personale, file, commit, data di consegna, ritardo, grading, voto e feedback.
+
+Una consegna puo esistere anche prima che lo studente carichi file: in quel caso rappresenta una consegna attesa o **da consegnare**. Se la scadenza passa senza file, diventa **mancante**. Se lo studente carica file, diventa **consegnata** o **consegnata in ritardo**.
+
+Quindi:
+
+```text
+attivita progettata dal docente
+-> assegnazione a classe/gruppo/studente
+-> consegne attese per gli studenti coinvolti
+-> consegne effettive quando arrivano file, commit o report
+```
+
+Nella GUI docente conviene mostrare sia il livello attivita/assegnazione sia il quadro delle consegne. Nella GUI studente conviene parlare soprattutto di consegne, anche quando derivano da attivita future assegnate e non ancora svolte.
+
 ## Tipi di attivita
 
 Il sistema dovrebbe distinguere almeno questi tipi di attivita.

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -58,6 +58,25 @@ Screenshot previsto: `doc/images/dashboard-guides/studente-selezione.png`.
 
 Con dati reali, la selezione manuale sara sostituita o limitata da login, profilo studente o provider classe.
 
+## Nomenclatura: attivita e consegna
+
+Nella vista studente e importante distinguere due concetti.
+
+**Attivita** indica cio che il docente progetta o assegna: titolo, testo, tipo, modalita di supporto, scadenza, test, rubrica e collegamento al percorso.
+
+**Consegna** indica la relazione tra uno studente e una specifica attivita assegnata: stato personale, file caricati, commit, data di consegna, ritardo, grading, voto e feedback.
+
+Quando un'attivita viene assegnata a una classe o a uno studente, per ogni studente nasce gia una consegna attesa, anche se non sono ancora stati caricati file. Nella GUI studente questa situazione viene mostrata come **Da consegnare**. Dopo la scadenza, se non arriva nessun file, diventa **Mancante**.
+
+Quindi il calendario studente mostra:
+
+- consegne gia inviate;
+- consegne da fare, cioe attivita assegnate ma non ancora consegnate;
+- consegne future programmate, se hanno una data di assegnazione o una scadenza;
+- UDA o eventi del percorso, quando pubblicati.
+
+In sintesi: lato docente si parla spesso di **attivita**; lato studente si parla soprattutto di **consegne**, anche quando la consegna e ancora attesa.
+
 ## Riepilogo studente
 
 Dopo il caricamento, la pagina mostra un riepilogo dello studente.

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -78,7 +78,9 @@ La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenz
 
 ## Calendario
 
-Il pannello **Calendario** mostra in sola lettura una vista mensile simile a quella docente: mese centrale, mesi laterali di contesto e filtri per tipo di evento.
+Il pannello **Calendario** mostra in sola lettura una vista simile a quella docente.
+
+La modalità **Mese** mostra un mese centrale con i mesi laterali di contesto e le frecce per passare al mese precedente o successivo. La modalità **Settimana** mostra solo la settimana selezionata, anche qui con frecce avanti e indietro. La modalità **Anno** mostra tutti i mesi dell'intervallo pubblicato.
 
 La vista puo mostrare:
 
@@ -88,7 +90,7 @@ La vista puo mostrare:
 - badge **Prossima scadenza** sulle consegne aperte con la scadenza piu vicina.
 - UDA reali svolte, quando il percorso contiene date consuntive pubblicate.
 
-Il filtro **Mostra** permette di visualizzare tutto, solo consegne, solo UDA o solo scadenze. La vista resta in sola lettura: lo studente puo consultare la programmazione e le scadenze, ma non modificarle.
+I controlli **Mese** e **Settimana** compaiono solo quando servono alla modalità scelta. Il filtro **Mostra** permette di visualizzare tutto, solo consegne, solo UDA o solo scadenze. La vista resta in sola lettura: lo studente puo consultare la programmazione e le scadenze, ma non modificarle.
 
 ## Percorso
 

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -80,6 +80,11 @@ La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenz
 
 Il pannello **Calendario** mostra in sola lettura una vista simile a quella docente.
 
+Il selettore **Vista** permette di scegliere tra:
+
+- **Calendario**, utile per vedere la distribuzione nel tempo;
+- **Lista**, utile per leggere gli eventi in ordine cronologico.
+
 La modalità **Mese** mostra un mese centrale con i mesi laterali di contesto e le frecce per passare al mese precedente o successivo. La modalità **Settimana** mostra solo la settimana selezionata, anche qui con frecce avanti e indietro. La modalità **Anno** mostra tutti i mesi dell'intervallo pubblicato.
 
 La vista puo mostrare:

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -104,7 +104,7 @@ Il selettore **Vista** permette di scegliere tra:
 - **Calendario**, utile per vedere la distribuzione nel tempo;
 - **Lista**, utile per leggere gli eventi in ordine cronologico.
 
-La modalità **Mese** mostra un mese centrale con i mesi laterali di contesto e le frecce per passare al mese precedente o successivo. La modalità **Settimana** mostra solo la settimana selezionata, anche qui con frecce avanti e indietro. La modalità **Anno** mostra tutti i mesi dell'intervallo pubblicato.
+La modalità **Mese** mostra un mese centrale con i mesi laterali di contesto e le frecce per passare al mese precedente o successivo. Le frecce sono presenti anche nei mesi laterali, come nella vista docente. La modalità **Settimana** mostra solo la settimana selezionata, anche qui con frecce avanti e indietro. La modalità **Anno** mostra tutti i mesi dell'intervallo pubblicato.
 
 La vista puo mostrare:
 
@@ -115,6 +115,8 @@ La vista puo mostrare:
 - UDA reali svolte, quando il percorso contiene date consuntive pubblicate.
 
 I controlli **Mese** e **Settimana** compaiono solo quando servono alla modalità scelta. Il filtro **Mostra** permette di visualizzare tutto, solo consegne, solo UDA o solo scadenze. La vista resta in sola lettura: lo studente puo consultare la programmazione e le scadenze, ma non modificarle.
+
+Il filtro **Percorsi visibili** permette di mostrare o nascondere gli eventi UDA dei percorsi associati allo studente o alla sua classe. Il comportamento ricalca il filtro dei percorsi nella vista calendario docente: **Tutti** mostra tutti i percorsi disponibili, **Nessuno** nasconde gli eventi dei percorsi lasciando visibili le consegne.
 
 Gli eventi collegati a una consegna sono cliccabili sia nella vista calendario sia nella vista lista. Il click apre lo stesso modal **Dettaglio** usato nel pannello **Consegne**, cosi lo studente vede sempre la stessa scheda completa: dati attivita, scadenze, stato, grading, link e feedback approvato. Gli eventi UDA o di percorso restano solo informativi finche non avranno una scheda dedicata.
 

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -76,6 +76,17 @@ Screenshot previsto: `doc/images/dashboard-guides/studente-riepilogo.png`.
 
 La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenza**. Se piu consegne aperte hanno la stessa prossima scadenza, il badge compare su tutte.
 
+## Calendario
+
+Il pannello **Calendario** mostra in sola lettura le date ricavate dalle consegne dello studente:
+
+- data di assegnazione, quando disponibile;
+- data di scadenza, quando disponibile;
+- stato della consegna;
+- badge **Prossima scadenza** sulle consegne aperte con la scadenza piu vicina.
+
+Questa prima versione non sostituisce il calendario docente completo: serve a dare allo studente una timeline semplice delle consegne gia associate al suo profilo. In una PR successiva il pannello potra integrare anche eventi del calendario pubblicato, UDA, laboratori, verifiche e priorita.
+
 ## Percorso
 
 Il pannello **Percorso** mostra in sola lettura solo i percorsi associati allo studente o al suo gruppo/classe. Ogni percorso puo essere assegnato a un gruppo intero oppure personalizzato per uno studente specifico; se non ci sono associazioni esplicite, il pannello mostra che il percorso non e ancora associato.

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -78,14 +78,17 @@ La stessa consegna viene evidenziata nella lista con il badge **Prossima scadenz
 
 ## Calendario
 
-Il pannello **Calendario** mostra in sola lettura le date ricavate dalle consegne dello studente:
+Il pannello **Calendario** mostra in sola lettura una vista mensile simile a quella docente: mese centrale, mesi laterali di contesto e filtri per tipo di evento.
+
+La vista puo mostrare:
 
 - data di assegnazione, quando disponibile;
 - data di scadenza, quando disponibile;
 - stato della consegna;
 - badge **Prossima scadenza** sulle consegne aperte con la scadenza piu vicina.
+- UDA reali svolte, quando il percorso contiene date consuntive pubblicate.
 
-Questa prima versione non sostituisce il calendario docente completo: serve a dare allo studente una timeline semplice delle consegne gia associate al suo profilo. In una PR successiva il pannello potra integrare anche eventi del calendario pubblicato, UDA, laboratori, verifiche e priorita.
+Il filtro **Mostra** permette di visualizzare tutto, solo consegne, solo UDA o solo scadenze. La vista resta in sola lettura: lo studente puo consultare la programmazione e le scadenze, ma non modificarle.
 
 ## Percorso
 

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -113,8 +113,9 @@ La vista puo mostrare:
 - stato della consegna;
 - badge **Prossima scadenza** sulle consegne aperte con la scadenza piu vicina.
 - UDA reali svolte, quando il percorso contiene date consuntive pubblicate.
+- festivita, vacanze e interruzioni impostate dal docente nel calendario pubblicato.
 
-I controlli **Mese** e **Settimana** compaiono solo quando servono alla modalità scelta. Il filtro **Mostra** permette di visualizzare tutto, solo consegne, solo UDA o solo scadenze. La vista resta in sola lettura: lo studente puo consultare la programmazione e le scadenze, ma non modificarle.
+I controlli **Mese** e **Settimana** compaiono solo quando servono alla modalità scelta. Il filtro **Mostra** permette di visualizzare tutto, solo consegne, solo UDA, solo festivita/interruzioni o solo scadenze. La vista resta in sola lettura: lo studente puo consultare la programmazione e le scadenze, ma non modificarle.
 
 Il filtro **Percorsi visibili** permette di mostrare o nascondere gli eventi UDA dei percorsi associati allo studente o alla sua classe. Il comportamento ricalca il filtro dei percorsi nella vista calendario docente: **Tutti** mostra tutti i percorsi disponibili, **Nessuno** nasconde gli eventi dei percorsi lasciando visibili le consegne.
 

--- a/doc/DASHBOARD_STUDENTE_GUIDA.md
+++ b/doc/DASHBOARD_STUDENTE_GUIDA.md
@@ -116,6 +116,8 @@ La vista puo mostrare:
 
 I controlli **Mese** e **Settimana** compaiono solo quando servono alla modalità scelta. Il filtro **Mostra** permette di visualizzare tutto, solo consegne, solo UDA o solo scadenze. La vista resta in sola lettura: lo studente puo consultare la programmazione e le scadenze, ma non modificarle.
 
+Gli eventi collegati a una consegna sono cliccabili sia nella vista calendario sia nella vista lista. Il click apre lo stesso modal **Dettaglio** usato nel pannello **Consegne**, cosi lo studente vede sempre la stessa scheda completa: dati attivita, scadenze, stato, grading, link e feedback approvato. Gli eventi UDA o di percorso restano solo informativi finche non avranno una scheda dedicata.
+
 ## Percorso
 
 Il pannello **Percorso** mostra in sola lettura solo i percorsi associati allo studente o al suo gruppo/classe. Ogni percorso puo essere assegnato a un gruppo intero oppure personalizzato per uno studente specifico; se non ci sono associazioni esplicite, il pannello mostra che il percorso non e ancora associato.

--- a/doc/PERCORSO_DIDATTICO.md
+++ b/doc/PERCORSO_DIDATTICO.md
@@ -1174,7 +1174,7 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Strumenti, primo programma e rappresentazione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Strumenti, primo programma e rappresentazione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
@@ -1184,7 +1184,7 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Costanti", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "costanti", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
@@ -1194,7 +1194,7 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Operatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Operatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
@@ -1204,7 +1204,7 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Costanti" (../README.md#costanti). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Costanti" (../README.md#costanti). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -1237,37 +1237,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su operatori aritmetici, logici, relazionali e loro precedenza. I sottoparagrafi collegati sono: Operatore di assegnamento: =. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su operatori aritmetici, logici, relazionali e sulla loro precedenza. I sottoparagrafi collegati sono: Operatore di assegnamento: =. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Operatori" lo studente dovrebbe aver seguito il lavoro precedente su "Costanti", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Operatori", lo studente dovrebbe aver seguito il lavoro precedente su "Costanti", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Operatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Costanti" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Costanti" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Operatore di assegnamento: =". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Operatore di assegnamento: =". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Operatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Operatore di assegnamento: =" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Operatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Operatore di assegnamento: =" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Operatori" (../README.md#operatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Operatori" (../README.md#operatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   - <details>
@@ -1279,37 +1279,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Operatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per il Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "Operatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Operatore di assegnamento: =" lo studente dovrebbe aver seguito il lavoro precedente su "Operatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Operatore di assegnamento: =" lo studente dovrebbe aver seguito il lavoro precedente su "Operatori", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatore di assegnamento: =", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo dell'"Operatore di assegnamento: =", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Operatori" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Operatori" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Operatore somma: +". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Operatore somma: +". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Operatore di assegnamento: =", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Operatore somma: +" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Operatore di assegnamento: =", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Operatore somma: +" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Operatore di assegnamento: =" (../README.md#operatore-di-assegnamento). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Operatore di assegnamento: =" (../README.md#operatore-di-assegnamento). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -1323,37 +1323,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Operatore somma: +" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore di assegnamento: =", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Operatore somma: +" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore di assegnazione: =", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatore somma: +", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo dell'"Operatore somma: +", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Operatore di assegnamento: =" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Operatore di assegnamento: =" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Operatore differenza: -". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Operatore differenza: -". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Operatore somma: +", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Operatore differenza: -" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Operatore somma: +", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Operatore differenza: -" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Operatore somma: +" (../README.md#operatore-somma). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Operatore somma: +" (../README.md#operatore-somma). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -1366,32 +1366,32 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Operatore differenza: -" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore somma: +", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Operatore differenza: -" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore somma: +", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatore differenza: -", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Operatore differenza: -", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Operatore somma: +" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Operatore somma: +" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Operatore segno: - e +". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Operatore segno: - e +". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Operatore differenza: -", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Operatore segno: - e +" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Operatore differenza: -", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Operatore segno: - e +" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
@@ -1409,37 +1409,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Operatore segno: - e +" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore differenza: -", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Operatore segno: - e +", lo studente dovrebbe aver seguito il lavoro precedente su "Operatore differenza: -", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatore segno: - e +", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Operatore segno: - e +", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Operatore differenza: -" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Operatore differenza: -" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Operatore moltiplicazione: *". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Operatore moltiplicazione: *". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Operatore segno: - e +", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Operatore moltiplicazione: *" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Operatore segno: - e +", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Operatore moltiplicazione: *" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Operatore segno: - e +" (../README.md#operatore-segno---e). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Operatore segno: - e +" (../README.md#operatore-segno---e). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -1452,37 +1452,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Operatore moltiplicazione: *" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore segno: - e +", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Operatore moltiplicazione: *", lo studente dovrebbe aver seguito il lavoro precedente su "Operatore segno: - e +", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatore moltiplicazione: *", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Operatore moltiplicazione: *", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Operatore segno: - e +" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Operatore segno: - e +" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Operatore divisione: /". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Operatore divisione: /". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Operatore moltiplicazione: *", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Operatore divisione: /" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Operatore moltiplicazione: *", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Operatore divisione: /" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Operatore moltiplicazione: *" (../README.md#operatore-moltiplicazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Operatore moltiplicazione: *" (../README.md#operatore-moltiplicazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -1495,37 +1495,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Operatore divisione: /" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore moltiplicazione: *", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Operatore divisione: /" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore moltiplicazione: *", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatore divisione: /", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo dell'"Operatore divisione: /", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Operatore moltiplicazione: *" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Operatore moltiplicazione: *" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Operatore %". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Operatore %". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Operatore divisione: /", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Operatore %" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Operatore divisione: /", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Operatore %" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Operatore divisione: /" (../README.md#operatore-divisione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Operatore divisione: /" (../README.md#operatore-divisione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -1538,37 +1538,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Operatore %" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore divisione: /", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Operatore %" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore divisione: /", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatore %", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione lo studente deve saper spiegare il ruolo dell'"Operatore %", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Operatore divisione: /" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Operatore divisione: /" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Operatore incremento/decremento ++ --". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Operatore incremento/decremento ++ --". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Operatore %", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Operatore incremento/decremento ++ --" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Operatore %", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Operatore incremento/decremento ++ --" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Operatore %" (../README.md#operatore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Operatore %" (../README.md#operatore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -1581,37 +1581,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Operatore incremento/decremento ++ --" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore %", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Operatore incremento/decremento ++ --" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore %", saper compilare ed eseguire piccoli programmi in C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatore incremento/decremento ++ --", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo dell'"Operatore incremento/decremento ++ --", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Operatore %" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Operatore %" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Operatore `sizeof`". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Operatore `sizeof`". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Operatore incremento/decremento ++ --", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Operatore `sizeof`" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Operatore incremento/decremento ++ --", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Operatore `sizeof`" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Operatore incremento/decremento ++ --" (../README.md#operatore-incrementodecremento). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Operatore incremento/decremento ++ --" (../README.md#operatore-incrementodecremento). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -1624,37 +1624,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per il Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Operatore `sizeof`" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore incremento/decremento ++ --", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Operatore `sizeof`" lo studente dovrebbe aver seguito il lavoro precedente su "Operatori incremento/decremento ++ --", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Operatore `sizeof`", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve saper spiegare il ruolo dell'"Operatore `sizeof`", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Operatore incremento/decremento ++ --" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Operatore incremento/decremento ++ --" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Cast". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Cast". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Operatore `sizeof`", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Cast" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proporrò un esempio minimo su "Operatore `sizeof`", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Cast" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Operatore `sizeof`" (../README.md#operatore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Operatore `sizeof`" (../README.md#operatore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -1667,37 +1667,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Cast tra `signed` e `unsigned`. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Cast tra `signed` e `unsigned`. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Cast" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore `sizeof`", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Cast" lo studente dovrebbe aver seguito il lavoro precedente su "Operatore `sizeof`", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Cast", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Cast", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Operatore `sizeof`" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Operatore `sizeof`" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Cast tra `signed` e `unsigned`". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Cast tra `signed` e `unsigned`". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Cast", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Cast tra `signed` e `unsigned`" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Cast", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Cast tra `signed` e `unsigned`" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Cast" (../README.md#cast). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Cast" (../README.md#cast). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   - <details>
@@ -1709,37 +1709,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su numeri con segno, complemento a due, range e casi limite. Si collega al blocco superiore Cast. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su numeri con segno, complemento a due, range e casi limite. Si collega al blocco superiore Cast. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Cast tra `signed` e `unsigned`" lo studente dovrebbe aver seguito il lavoro precedente su "Cast", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Cast tra `signed` e `unsigned`" lo studente dovrebbe aver seguito il lavoro precedente su "Cast", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Cast tra `signed` e `unsigned`", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "cast tra `signed` e `unsigned`", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Cast" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Cast" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Controllo del flusso". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Controllo del flusso". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Cast tra `signed` e `unsigned`", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Controllo del flusso" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Cast tra `signed` e `unsigned`", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Controllo del flusso" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Cast tra `signed` e `unsigned`" (../README.md#cast-tra-signed-e-unsigned). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Cast tra `signed` e `unsigned`" (../README.md#cast-tra-signed-e-unsigned). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -1753,37 +1753,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su if, switch, cicli e costruzione del flusso di esecuzione. I sottoparagrafi collegati sono: if o if-else, Condizioni complesse con l'uso di operatori logici e condizionali, for, while, do-while, switch, break e continue. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per il Terzo anno. Serve a lavorare su if, switch, cicli e costruzione del flusso di esecuzione. I sottoparagrafi collegati sono: if o if-else, Condizioni complesse con l'uso di operatori logici e condizionali, for, while, do-while, switch, break e continue. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Controllo del flusso" lo studente dovrebbe aver seguito il lavoro precedente su "Cast tra `signed` e `unsigned`", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Controllo del flusso", lo studente dovrebbe aver seguito il lavoro precedente su "Cast tra `signed` e `unsigned`", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Controllo del flusso", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Controllo del flusso", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Cast tra `signed` e `unsigned`" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Cast tra `signed` e `unsigned`" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "if o if-else". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "if o if-else". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Controllo del flusso", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "if o if-else" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Controllo del flusso", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "if o if-else" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Controllo del flusso" (../README.md#controllo-del-flusso). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Controllo del flusso" (../README.md#controllo-del-flusso). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   - <details>
@@ -1795,37 +1795,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "if o if-else" lo studente dovrebbe aver seguito il lavoro precedente su "Controllo del flusso", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "if o if-else", lo studente dovrebbe aver seguito il lavoro precedente su "Controllo del flusso", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "if o if-else", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "if" o "if-else", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Controllo del flusso" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Controllo del flusso" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Condizioni complesse con l'uso di operatori logici e condizionali". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Condizioni complesse con l'uso di operatori logici e condizionali". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "if o if-else", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Condizioni complesse con l'uso di operatori logici e condizionali" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "if o if-else", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Condizioni complesse con l'uso di operatori logici e condizionali" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "if o if-else" (../README.md#if-o-if-else). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "if o if-else" (../README.md#if-o-if-else). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -1838,37 +1838,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su operatori aritmetici, logici, relazionali e loro precedenza. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su operatori aritmetici, logici, relazionali e sulla loro precedenza. Si collega al blocco superiore "Controllo del flusso". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Condizioni complesse con l'uso di operatori logici e condizionali" lo studente dovrebbe aver seguito il lavoro precedente su "if o if-else", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Condizioni complesse con l'uso di operatori logici e condizionali", lo studente dovrebbe aver seguito il lavoro precedente su "if o if-else", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Condizioni complesse con l'uso di operatori logici e condizionali", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Condizioni complesse con l'uso di operatori logici e condizionali", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "if o if-else" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "if o if-else" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "for". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "for". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Condizioni complesse con l'uso di operatori logici e condizionali", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "for" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Condizioni complesse con l'uso di operatori logici e condizionali", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è quello di collegare questo argomento a "for" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Condizioni complesse con l'uso di operatori logici e condizionali" (../README.md#condizioni-complesse-con-luso-di-operatori-logici-e-condizionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Condizioni complesse con l'uso di operatori logici e condizionali" (../README.md#condizioni-complesse-con-luso-di-operatori-logici-e-condizionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -1881,37 +1881,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "Controllo del flusso". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "for" lo studente dovrebbe aver seguito il lavoro precedente su "Condizioni complesse con l'uso di operatori logici e condizionali", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "for", lo studente dovrebbe aver seguito il lavoro precedente su "Condizioni complesse con l'uso di operatori logici e condizionali", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "for", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere come spiegare il ruolo di "for", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere come indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Condizioni complesse con l'uso di operatori logici e condizionali" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Condizioni complesse con l'uso di operatori logici e condizionali" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "while". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "while". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "for", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "while" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "for", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "while" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "for" (../README.md#for). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "for" (../README.md#for). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -1924,37 +1924,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "Controllo del flusso". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "while" lo studente dovrebbe aver seguito il lavoro precedente su "for", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "while" lo studente dovrebbe aver seguito il lavoro precedente su "for", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "while", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "while", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "for" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "for" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "do-while". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "do-while". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "while", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "do-while" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "while", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "do-while" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "while" (../README.md#while). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "while" (../README.md#while). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -1967,37 +1967,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "Controllo del flusso". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "do-while" lo studente dovrebbe aver seguito il lavoro precedente su "while", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "do-while", lo studente dovrebbe aver seguito il lavoro precedente su "while", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "do-while", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "do-while", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "while" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "while" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "switch". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "switch". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "do-while", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "switch" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "do-while", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "switch" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "do-while" (../README.md#do-while). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "do-while" (../README.md#do-while). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -2010,37 +2010,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "switch" lo studente dovrebbe aver seguito il lavoro precedente su "do-while", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "switch" lo studente dovrebbe aver seguito il lavoro precedente su "do-while", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "switch", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "switch", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "do-while" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "do-while" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "break e continue". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "break e continue". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "switch", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "break e continue" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "switch", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "break e continue" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "switch" (../README.md#switch). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "switch" (../README.md#switch). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -2053,12 +2053,12 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Operatori, condizioni e selezione" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "Controllo del flusso". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "break e continue" lo studente dovrebbe aver seguito il lavoro precedente su "switch", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "break e continue", lo studente dovrebbe aver seguito il lavoro precedente su "switch", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
@@ -2068,22 +2068,22 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "switch" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "switch" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "break e continue", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "break e continue", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "break e continue" (../README.md#break-e-continue). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "break e continue" (../README.md#break-e-continue). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -2117,37 +2117,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "break e continue", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "break e continue", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "break e continue" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "break e continue" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Dichiarazione di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Dichiarazione di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Dichiarazione di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Dichiarazione di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Funzioni" (../README.md#funzioni-1). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Funzioni" (../README.md#funzioni-1). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -2160,37 +2160,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Dichiarazione di funzione" lo studente dovrebbe aver seguito il lavoro precedente su "Funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Dichiarazione di funzione" lo studente dovrebbe aver seguito il lavoro precedente su "Funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Dichiarazione di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Dichiarazione di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Funzioni" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Funzioni" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Uso di void nelle funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Uso di void nelle funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Dichiarazione di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Uso di void nelle funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Dichiarazione di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Uso di void nelle funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Dichiarazione di funzione" (../README.md#dichiarazione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Dichiarazione di funzione" (../README.md#dichiarazione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -2203,32 +2203,32 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Uso di void nelle funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "Dichiarazione di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Uso di void nelle funzioni", lo studente dovrebbe aver seguito il lavoro precedente su "Dichiarazione di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Uso di void nelle funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Uso di void nelle funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Dichiarazione di funzione" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Dichiarazione di funzione" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Definizione di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Definizione di funzione". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Uso di void nelle funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Definizione di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Uso di void nelle funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Definizione di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
@@ -2246,37 +2246,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Definizione di funzione" lo studente dovrebbe aver seguito il lavoro precedente su "Uso di void nelle funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Definizione di funzione", lo studente dovrebbe aver seguito il lavoro precedente su "Uso di void nelle funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Definizione di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Definizione di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Uso di void nelle funzioni" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Uso di void nelle funzioni" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Chiamata di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Chiamata di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Definizione di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Chiamata di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Definizione di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Chiamata di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Definizione di funzione" (../README.md#definizione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Definizione di funzione" (../README.md#definizione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -2289,37 +2289,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare su un concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Chiamata di funzione" lo studente dovrebbe aver seguito il lavoro precedente su "Definizione di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Chiamata di funzione" lo studente dovrebbe aver seguito il lavoro precedente su "Definizione di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Chiamata di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione lo studente deve saper spiegare il ruolo di "chiamata di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Definizione di funzione" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Definizione di funzione" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Passaggio di parametri per valore". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Passaggio di parametri per valore". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Chiamata di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Passaggio di parametri per valore" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Chiamata di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Passaggio di parametri per valore" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Chiamata di funzione" (../README.md#chiamata-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Chiamata di funzione" (../README.md#chiamata-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -2332,37 +2332,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Cicli e funzioni" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Passaggio di parametri per valore" lo studente dovrebbe aver seguito il lavoro precedente su "Chiamata di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Passaggio di parametri per valore", lo studente dovrebbe aver seguito il lavoro precedente su "Chiamata di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Passaggio di parametri per valore", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Passaggio di parametri per valore", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Chiamata di funzione" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Chiamata di funzione" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Vettori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Vettori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Passaggio di parametri per valore", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Vettori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proporia un esempio minimo su "Passaggio di parametri per valore", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Vettori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Passaggio di parametri per valore" (../README.md#passaggio-di-parametri-per-valore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Passaggio di parametri per valore" (../README.md#passaggio-di-parametri-per-valore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -2395,37 +2395,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Inizializzare un vettore, Dimensione vettore (`sizeof`). La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Inizializzare un vettore, Dimensione vettore (`sizeof`). La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Vettori" lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di parametri per valore", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Vettori", lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di parametri per valore", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Vettori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Vettori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Passaggio di parametri per valore" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Passaggio di parametri per valore" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Inizializzare un vettore". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Inizializzare un vettore". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Vettori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Inizializzare un vettore" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Vettori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Inizializzare un vettore" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Vettori" (../README.md#vettori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Vettori" (../README.md#vettori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   - <details>
@@ -2437,12 +2437,12 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Vettori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "Vettori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Inizializzare un vettore" lo studente dovrebbe aver seguito il lavoro precedente su "Vettori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Inizializzare un vettore", lo studente dovrebbe aver seguito il lavoro precedente su "Vettori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
@@ -2452,22 +2452,22 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Vettori" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Vettori" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Dimensione vettore (`sizeof`)". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Dimensione vettore (`sizeof`)". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Inizializzare un vettore", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Dimensione vettore (`sizeof`)" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Inizializzare un vettore", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Dimensione vettore (`sizeof`)" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Inizializzare un vettore" (../README.md#inizializzare-un-vettore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Inizializzare un vettore" (../README.md#inizializzare-un-vettore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -2480,37 +2480,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Vettori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su concetti tecnici previsti dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Vettori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Dimensione vettore (`sizeof`)" lo studente dovrebbe aver seguito il lavoro precedente su "Inizializzare un vettore", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Dimensione vettore (`sizeof`)", lo studente dovrebbe aver seguito il lavoro precedente su "Inizializzare un vettore", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Dimensione vettore (`sizeof`)", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Dimensione vettore (`sizeof`)", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Inizializzare un vettore" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Inizializzare un vettore" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Le stringhe". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Le stringhe". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Dimensione vettore (`sizeof`)", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Le stringhe" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Dimensione vettore (`sizeof`)", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Le stringhe" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Dimensione vettore (`sizeof`)" (../README.md#dimensione-vettore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Dimensione vettore (`sizeof`)" (../README.md#dimensione-vettore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -2524,37 +2524,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su array di char terminati da carattere nullo e funzioni di libreria associate. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su array di char terminati da carattere nullo e funzioni di libreria associate. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Le stringhe" lo studente dovrebbe aver seguito il lavoro precedente su "Dimensione vettore (`sizeof`)", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Le stringhe", lo studente dovrebbe aver seguito il lavoro precedente su "Dimensione vettore (`sizeof`)", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Le stringhe", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Le stringhe", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Dimensione vettore (`sizeof`)" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Dimensione vettore (`sizeof`)", e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Dettagli sull'inizializzazione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Dettagli sull'inizializzazione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Le stringhe", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Dettagli sull'inizializzazione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Le stringhe", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Dettagli sull'inizializzazione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Le stringhe" (../README.md#le-stringhe). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Le stringhe" (../README.md#le-stringhe). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -2567,37 +2567,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Dettagli sull'inizializzazione" lo studente dovrebbe aver seguito il lavoro precedente su "Le stringhe", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Dettagli sull'inizializzazione", lo studente dovrebbe aver seguito il lavoro precedente su "Le stringhe", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Dettagli sull'inizializzazione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Dettagli sull'inizializzazione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Le stringhe" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Le stringhe" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Stampare una stringa". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Stampare una stringa". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Dettagli sull'inizializzazione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Stampare una stringa" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Dettagli sull'inizializzazione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Stampare una stringa" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Dettagli sull'inizializzazione" (../README.md#dettagli-sullinizializzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Dettagli sull'inizializzazione" (../README.md#dettagli-sull-inizializzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -2610,37 +2610,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Stampare una stringa" lo studente dovrebbe aver seguito il lavoro precedente su "Dettagli sull'inizializzazione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Stampare una stringa", lo studente dovrebbe aver seguito il lavoro precedente su "Dettagli sull'inizializzazione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Stampare una stringa", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Stampare una stringa", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Dettagli sull'inizializzazione" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Dettagli sull'inizializzazione" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Array come parametri a funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Array come parametri a funzioni". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Stampare una stringa", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Array come parametri a funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Stampare una stringa", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Array come parametri a funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Stampare una stringa" (../README.md#stampare-una-stringa). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Stampare una stringa" (../README.md#stampare-una-stringa). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -2653,32 +2653,32 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Array e stringhe semplici" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Array come parametri a funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "Stampare una stringa", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Array come parametri a funzioni", lo studente dovrebbe aver seguito il lavoro precedente su "Stampare una stringa", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Array come parametri a funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Array come parametri a funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Stampare una stringa" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Stampare una stringa" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Le strutture". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Le strutture". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Array come parametri a funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Le strutture" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Array come parametri a funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Le strutture" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
@@ -2716,37 +2716,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Struct e consolidamento" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Passaggio di strutture a funzioni. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Struct e consolidamento" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Passaggio di strutture a funzioni. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Le strutture" lo studente dovrebbe aver seguito il lavoro precedente su "Array come parametri a funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Le strutture" lo studente dovrebbe aver seguito il lavoro precedente su "Array come parametri a funzioni", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Le strutture", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Le strutture", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Array come parametri a funzioni" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Array come parametri a funzioni" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Passaggio di strutture a funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Passaggio di strutture a funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Le strutture", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Passaggio di strutture a funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Le strutture", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Passaggio di strutture a funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Le strutture" (../README.md#le-strutture). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Le strutture" (../README.md#le-strutture). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   - <details>
@@ -2758,37 +2758,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Struct e consolidamento" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore Le strutture. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Struct e consolidamento" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riutilizzo del codice. Si collega al blocco superiore "Le strutture". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Passaggio di strutture a funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "Le strutture", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Passaggio di strutture a funzioni", lo studente dovrebbe aver seguito il lavoro precedente su "Le strutture", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Passaggio di strutture a funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Passaggio di strutture a funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Le strutture" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Le strutture" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Array bidimensionali". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Array bidimensionali". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Passaggio di strutture a funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Array bidimensionali" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Passaggio di strutture a funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Array bidimensionali" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Passaggio di strutture a funzioni" (../README.md#passaggio-di-strutture-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Passaggio di strutture a funzioni" (../README.md#passaggio-di-strutture-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -2802,37 +2802,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Struct e consolidamento" del percorso Base per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Struct e consolidamento" del percorso Base per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Array bidimensionali" lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di strutture a funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Array bidimensionali", lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di strutture a funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Array bidimensionali", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      alla fine della lezione lo studente deve saper spiegare il ruolo di "Array bidimensionali", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Passaggio di strutture a funzioni" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Passaggio di strutture a funzioni" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "I puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "I puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Array bidimensionali", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "I puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Array bidimensionali", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "I puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Array bidimensionali" (../README.md#array-bidimensionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Array bidimensionali" (../README.md#array-bidimensionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -2865,37 +2865,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. I sottoparagrafi collegati sono: Puntatori non inizializzati, Il puntatore nullo (NULL), Vettori, Relazione tra array e puntatori, Differenza tra puntatori, Le stringhe, Dettagli sull'inizializzazione, Stampare una stringa, Funzioni, Dichiarazione di funzione, Uso di void nelle funzioni, Definizione di funzione, Chiamata di funzione, Passaggio di parametri per valore, Passaggio di parametri per indirizzo, Passaggio di puntatori const, Array come parametri a funzioni, Allocazione dinamica della memoria, Array bidimensionali, Array di puntatori, Differenza tra array bidimensionali e array di puntatori, Sezioni di memoria di un programma C, L'inizializzazione delle variabili, Allocazione dinamica di matrici, Le strutture. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. I sottoparagrafi collegati sono: Puntatori non inizializzati, Il puntatore nullo (NULL), Vettori, Relazione tra array e puntatori, Differenza tra puntatori, Le stringhe, Dettagli sull'inizializzazione, Stampare una stringa, Funzioni, Dichiarazione di funzione, Uso di void nelle funzioni, Definizione di funzione, Chiamata di funzione, Passaggio di parametri per valore, Passaggio di parametri per indirizzo, Passaggio di puntatori const, Array come parametri a funzioni, Allocazione dinamica della memoria, Array bidimensionali, Array di puntatori, Differenza tra array bidimensionali e array di puntatori, Sezioni di memoria di un programma C, L'inizializzazione delle variabili, Allocazione dinamica di matrici, Le strutture. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "I puntatori" lo studente dovrebbe aver seguito il lavoro precedente su "Array bidimensionali", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "I puntatori", lo studente dovrebbe aver seguito il lavoro precedente su "Array bidimensionali", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "I puntatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione lo studente deve sapere spiegare il ruolo di "I puntatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Array bidimensionali" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Array bidimensionali" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Puntatori non inizializzati". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Puntatori non inizializzati". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "I puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Puntatori non inizializzati" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "I puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Puntatori non inizializzati" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "I puntatori" (../README.md#i-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "I puntatori" (../README.md#i-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   - <details>
@@ -2907,37 +2907,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Puntatori non inizializzati" lo studente dovrebbe aver seguito il lavoro precedente su "I puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Puntatori non inizializzati" lo studente dovrebbe aver seguito il lavoro precedente su "I puntatori", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Puntatori non inizializzati", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Puntatori non inizializzati", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "I puntatori" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "I puntatori" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Il puntatore nullo (NULL)". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Il puntatore nullo (NULL)". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Puntatori non inizializzati", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Il puntatore nullo (NULL)" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Puntatori non inizializzati", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Il puntatore nullo (NULL)" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Puntatori non inizializzati" (../README.md#puntatori-non-inizializzati). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Puntatori non inizializzati" (../README.md#puntatori-non-inizializzati). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -2950,37 +2950,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. I sottoparagrafi collegati sono: Aritmetica puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". I sottoparagrafi collegati sono: "Aritmetica puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Il puntatore nullo (NULL)" lo studente dovrebbe aver seguito il lavoro precedente su "Puntatori non inizializzati", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Il puntatore nullo (NULL)" lo studente dovrebbe aver seguito il lavoro precedente su "Puntatori non inizializzati", sapere come compilare ed eseguire piccoli programmi C, saper leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Il puntatore nullo (NULL)", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Il puntatore nullo (NULL)", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Puntatori non inizializzati" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Puntatori non inizializzati" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Aritmetica puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Aritmetica dei puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Il puntatore nullo (NULL)", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Aritmetica puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Il puntatore nullo (NULL)", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Aritmetica puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Il puntatore nullo (NULL)" (../README.md#il-puntatore-nullo-null). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Il puntatore nullo (NULL)" (../README.md#il-puntatore-nullo-null). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     - <details>
@@ -2992,37 +2992,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
         - <details>
           <summary><strong>Contesto</strong></summary>
 
-          Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore I puntatori > Il puntatore nullo (NULL). La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+          Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore "I puntatori" > "Il puntatore nullo (NULL)". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
           </details>
         - <details>
           <summary><strong>Prerequisiti</strong></summary>
 
-          Prima di affrontare "Aritmetica puntatori" lo studente dovrebbe aver seguito il lavoro precedente su "Il puntatore nullo (NULL)", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+          Prima di affrontare "Aritmetica dei puntatori" lo studente dovrebbe aver seguito il lavoro precedente su "Il puntatore nullo (NULL)", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
           </details>
         - <details>
           <summary><strong>Obiettivi</strong></summary>
 
-          Alla fine della lezione lo studente deve saper spiegare il ruolo di "Aritmetica puntatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+          Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Aritmetica dei puntatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
           </details>
         - <details>
           <summary><strong>Richiamo</strong></summary>
 
-          Richiama il passaggio precedente su "Il puntatore nullo (NULL)" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+          Richiama il passaggio precedente su "Il puntatore nullo (NULL)" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
           </details>
         - <details>
           <summary><strong>Anticipazione</strong></summary>
 
-          Questo argomento prepara il lavoro successivo su "Vettori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+          Questo argomento prepara il lavoro successivo su "Vettori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
           </details>
         - <details>
           <summary><strong>Prossimo passo</strong></summary>
 
-          Dopo la spiegazione, proponi un esempio minimo su "Aritmetica puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Vettori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+          Dopo la spiegazione, proponi un esempio minimo su "Aritmetica dei puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Vettori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
           </details>
         - <details>
           <summary><strong>Rimando</strong></summary>
 
-          Riferimento principale: README.md sezione "Aritmetica puntatori" (../README.md#aritmetica-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+          Riferimento principale: README.md, sezione "Aritmetica puntatori" (../README.md#aritmetica-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
           </details>
         </details>
       </details>
@@ -3036,37 +3036,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. I sottoparagrafi collegati sono: Inizializzare un vettore, Dimensione vettore (`sizeof`). La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". I sottoparagrafi collegati sono: Inizializzare un vettore, Dimensione vettore (`sizeof`). La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Vettori" lo studente dovrebbe aver seguito il lavoro precedente su "Aritmetica puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Vettori" lo studente dovrebbe aver seguito il lavoro precedente su "Aritmetica dei puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Vettori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Vettori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collejarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Aritmetica puntatori" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Aritmetica puntatori" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Inizializzare un vettore". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Inizializzare un vettore". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Vettori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Inizializzare un vettore" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Vettori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Inizializzare un vettore" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Vettori" (../README.md#vettori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Vettori" (../README.md#vettori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     - <details>
@@ -3078,37 +3078,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
         - <details>
           <summary><strong>Contesto</strong></summary>
 
-          Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori > Vettori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+          Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori > Vettori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
           </details>
         - <details>
           <summary><strong>Prerequisiti</strong></summary>
 
-          Prima di affrontare "Inizializzare un vettore" lo studente dovrebbe aver seguito il lavoro precedente su "Vettori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+          Prima di affrontare "Inizializzare un vettore", lo studente dovrebbe aver seguito il lavoro precedente su "Vettori", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
           </details>
         - <details>
           <summary><strong>Obiettivi</strong></summary>
 
-          Alla fine della lezione lo studente deve saper spiegare il ruolo di "Inizializzare un vettore", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+          Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Inizializzare un vettore", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
           </details>
         - <details>
           <summary><strong>Richiamo</strong></summary>
 
-          Richiama il passaggio precedente su "Vettori" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+          Richiama il passaggio precedente su "Vettori" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
           </details>
         - <details>
           <summary><strong>Anticipazione</strong></summary>
 
-          Questo argomento prepara il lavoro successivo su "Dimensione vettore (`sizeof`)". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+          Questo argomento prepara il lavoro successivo su "Dimensione vettore (`sizeof`)". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
           </details>
         - <details>
           <summary><strong>Prossimo passo</strong></summary>
 
-          Dopo la spiegazione, proponi un esempio minimo su "Inizializzare un vettore", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Dimensione vettore (`sizeof`)" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+          Dopo la spiegazione, proponi un esempio minimo su "Inizializzare un vettore", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Dimensione vettore (`sizeof`)" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
           </details>
         - <details>
           <summary><strong>Rimando</strong></summary>
 
-          Riferimento principale: README.md sezione "Inizializzare un vettore" (../README.md#inizializzare-un-vettore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+          Riferimento principale: README.md, sezione "Inizializzare un vettore" (../README.md#inizializzare-un-vettore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
           </details>
         </details>
       </details>
@@ -3121,37 +3121,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
         - <details>
           <summary><strong>Contesto</strong></summary>
 
-          Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori > Vettori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+          Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per il Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori > Vettori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
           </details>
         - <details>
           <summary><strong>Prerequisiti</strong></summary>
 
-          Prima di affrontare "Dimensione vettore (`sizeof`)" lo studente dovrebbe aver seguito il lavoro precedente su "Inizializzare un vettore", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+          Prima di affrontare "Dimensione vettore (`sizeof`)", lo studente dovrebbe aver seguito il lavoro precedente su "Inizializzare un vettore", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
           </details>
         - <details>
           <summary><strong>Obiettivi</strong></summary>
 
-          Alla fine della lezione lo studente deve saper spiegare il ruolo di "Dimensione vettore (`sizeof`)", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+          Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Dimensione vettore (`sizeof`)", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
           </details>
         - <details>
           <summary><strong>Richiamo</strong></summary>
 
-          Richiama il passaggio precedente su "Inizializzare un vettore" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+          Richiama il passaggio precedente su "Inizializzare un vettore" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
           </details>
         - <details>
           <summary><strong>Anticipazione</strong></summary>
 
-          Questo argomento prepara il lavoro successivo su "Relazione tra array e puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+          Questo argomento prepara il lavoro successivo su "Relazione tra array e puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
           </details>
         - <details>
           <summary><strong>Prossimo passo</strong></summary>
 
-          Dopo la spiegazione, proponi un esempio minimo su "Dimensione vettore (`sizeof`)", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Relazione tra array e puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+          Dopo la spiegazione, proponi un esempio minimo su "Dimensione vettore (`sizeof`)", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Relazione tra array e puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
           </details>
         - <details>
           <summary><strong>Rimando</strong></summary>
 
-          Riferimento principale: README.md sezione "Dimensione vettore (`sizeof`)" (../README.md#dimensione-vettore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+          Riferimento principale: README.md, sezione "Dimensione vettore (`sizeof`)" (../README.md#dimensione-vettore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
           </details>
         </details>
       </details>
@@ -3165,12 +3165,12 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Relazione tra array e puntatori" lo studente dovrebbe aver seguito il lavoro precedente su "Dimensione vettore (`sizeof`)", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Relazione tra array e puntatori" lo studente dovrebbe aver seguito il lavoro precedente su "Dimensione vettore (`sizeof`)", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
@@ -3180,22 +3180,22 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Dimensione vettore (`sizeof`)" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Dimensione vettore (`sizeof`)" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Differenza tra puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Differenza tra puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Relazione tra array e puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Differenza tra puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Relazione tra array e puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Differenza tra puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Relazione tra array e puntatori" (../README.md#relazione-tra-array-e-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Relazione tra array e puntatori" (../README.md#relazione-tra-array-e-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3208,12 +3208,12 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per il Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Differenza tra puntatori" lo studente dovrebbe aver seguito il lavoro precedente su "Relazione tra array e puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Differenza tra puntatori" lo studente dovrebbe aver seguito il lavoro precedente su "Relazione tra array e puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
@@ -3223,22 +3223,22 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Relazione tra array e puntatori" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Relazione tra array e puntatori" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Le stringhe". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Le stringhe". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Differenza tra puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Le stringhe" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Differenza tra puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Le stringhe" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Differenza tra puntatori" (../README.md#differenza-tra-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Differenza tra puntatori" (../README.md#differenza-tra-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3251,37 +3251,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su array di char terminati da carattere nullo e funzioni di libreria associate. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su array di char terminati da carattere nullo e funzioni di libreria associate. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Le stringhe" lo studente dovrebbe aver seguito il lavoro precedente su "Differenza tra puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Le stringhe", lo studente dovrebbe aver seguito il lavoro precedente su "Differenza tra puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Le stringhe", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione lo studente deve saper spiegare il ruolo delle "stringhe", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Differenza tra puntatori" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Differenza tra puntatori" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Dettagli sull'inizializzazione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Dettagli sull'inizializzazione". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Le stringhe", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Dettagli sull'inizializzazione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Le stringhe", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Dettagli sull'inizializzazione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Le stringhe" (../README.md#le-stringhe). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Le stringhe" (../README.md#le-stringhe). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3294,37 +3294,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Dettagli sull'inizializzazione" lo studente dovrebbe aver seguito il lavoro precedente su "Le stringhe", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Dettagli sull'inizializzazione", lo studente dovrebbe aver seguito il lavoro precedente su "Le stringhe", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Dettagli sull'inizializzazione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Dettagli sull'inizializzazione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Le stringhe" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Le stringhe" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Stampare una stringa". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Stampare una stringa". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Dettagli sull'inizializzazione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Stampare una stringa" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Dettagli sull'inizializzazione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Stampare una stringa" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Dettagli sull'inizializzazione" (../README.md#dettagli-sullinizializzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Dettagli sull'inizializzazione" (../README.md#dettagli-sull-inizializzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3337,37 +3337,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Stampare una stringa" lo studente dovrebbe aver seguito il lavoro precedente su "Dettagli sull'inizializzazione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Stampare una stringa", lo studente dovrebbe aver seguito il lavoro precedente su "Dettagli sull'inizializzazione", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Stampare una stringa", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Stampare una stringa", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Dettagli sull'inizializzazione" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Dettagli sull'inizializzazione" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Stampare una stringa", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Stampare una stringa", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Stampare una stringa" (../README.md#stampare-una-stringa). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Stampare una stringa" (../README.md#stampare-una-stringa). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3380,37 +3380,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sulla scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "Stampare una stringa", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Funzioni", lo studente dovrebbe aver seguito il lavoro precedente su "Stampare una stringa", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Stampare una stringa" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Stampare una stringa" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Dichiarazione di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Dichiarazione di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Dichiarazione di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Dichiarazione di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Funzioni" (../README.md#funzioni-1). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Funzioni" (../README.md#funzioni-1). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3423,37 +3423,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore: i puntatori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Dichiarazione di funzione" lo studente dovrebbe aver seguito il lavoro precedente su "Funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Dichiarazione di funzione", lo studente dovrebbe aver seguito il lavoro precedente su "Funzioni", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Dichiarazione di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Dichiarazione di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Funzioni" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Funzioni" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Uso di void nelle funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Uso di void nelle funzioni". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Dichiarazione di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Uso di void nelle funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Dichiarazione di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è quello di collegare questo argomento a "Uso di void nelle funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Dichiarazione di funzione" (../README.md#dichiarazione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Dichiarazione di funzione" (../README.md#dichiarazione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3466,37 +3466,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sulla scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Uso di void nelle funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "Dichiarazione di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Uso di void nelle funzioni", lo studente dovrebbe aver seguito il lavoro precedente su "Dichiarazione di funzione", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Uso di void nelle funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Uso di void nelle funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Dichiarazione di funzione" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Dichiarazione di funzione" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Definizione di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Definizione di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Uso di void nelle funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Definizione di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Uso di void nelle funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Definizione di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Uso di void nelle funzioni" (../README.md#uso-di-void-nelle-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Uso di void nelle funzioni" (../README.md#uso-di-void-nelle-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3509,12 +3509,12 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Definizione di funzione" lo studente dovrebbe aver seguito il lavoro precedente su "Uso di void nelle funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Definizione di funzione", lo studente dovrebbe aver seguito il lavoro precedente su "Uso di void nelle funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
@@ -3524,22 +3524,22 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Uso di void nelle funzioni" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Uso di void nelle funzioni" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Chiamata di funzione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Chiamata di funzione". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Definizione di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Chiamata di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Definizione di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Chiamata di funzione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Definizione di funzione" (../README.md#definizione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Definizione di funzione" (../README.md#definizione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3552,37 +3552,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per il Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Chiamata di funzione" lo studente dovrebbe aver seguito il lavoro precedente su "Definizione di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Chiamata di funzione", lo studente dovrebbe aver seguito il lavoro precedente su "Definizione di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Chiamata di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Chiamata di funzione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Definizione di funzione" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Definizione di funzione" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Passaggio di parametri per valore". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Passaggio di parametri per valore". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Chiamata di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Passaggio di parametri per valore" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Chiamata di funzione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Passaggio di parametri per valore" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Chiamata di funzione" (../README.md#chiamata-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Chiamata di funzione" (../README.md#chiamata-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3595,37 +3595,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Passaggio di parametri per valore" lo studente dovrebbe aver seguito il lavoro precedente su "Chiamata di funzione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Passaggio di parametri per valore", lo studente dovrebbe aver seguito il lavoro precedente su "Chiamata di funzione", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Passaggio di parametri per valore", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Passaggio di parametri per valore", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Chiamata di funzione" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Chiamata di funzione" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Passaggio di parametri per indirizzo". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Passaggio di parametri per indirizzo". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Passaggio di parametri per valore", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Passaggio di parametri per indirizzo" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Passaggio di parametri per valore", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Passaggio di parametri per indirizzo" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Passaggio di parametri per valore" (../README.md#passaggio-di-parametri-per-valore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Passaggio di parametri per valore" (../README.md#passaggio-di-parametri-per-valore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3638,37 +3638,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Passaggio di parametri per indirizzo" lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di parametri per valore", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Passaggio di parametri per indirizzo", lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di parametri per valore", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Passaggio di parametri per indirizzo", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Passaggio di parametri per indirizzo", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Passaggio di parametri per valore" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Passaggio di parametri per valore" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Passaggio di puntatori const". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Passaggio di puntatori const". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Passaggio di parametri per indirizzo", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Passaggio di puntatori const" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Passaggio di parametri per indirizzo", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Passaggio di puntatori const" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Passaggio di parametri per indirizzo" (../README.md#passaggio-di-parametri-per-indirizzo). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Passaggio di parametri per indirizzo" (../README.md#passaggio-di-parametri-per-indirizzo). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3681,37 +3681,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore: I puntatori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Passaggio di puntatori const" lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di parametri per indirizzo", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Passaggio di puntatori const" lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di parametri per indirizzo", saper compilare ed eseguire piccoli programmi in C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Passaggio di puntatori const", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo di "Passaggio di puntatori const", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Passaggio di parametri per indirizzo" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Passaggio di parametri per indirizzo" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Array come parametri a funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Array come parametri a funzioni". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Passaggio di puntatori const", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Array come parametri a funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Passaggio di puntatori const", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Array come parametri a funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Passaggio di puntatori const" (../README.md#passaggio-di-puntatori-const). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Passaggio di puntatori const" (../README.md#passaggio-di-puntatori-const). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3724,37 +3724,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sulla scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore: I puntatori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Array come parametri a funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di puntatori const", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Array come parametri a funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di puntatori const", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Array come parametri a funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Array come parametri a funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Passaggio di puntatori const" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Passaggio di puntatori const" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Allocazione dinamica della memoria". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Allocazione dinamica della memoria". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Array come parametri a funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Allocazione dinamica della memoria" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Array come parametri a funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Allocazione dinamica della memoria", oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Array come parametri a funzioni" (../README.md#array-come-parametri-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Array come parametri a funzioni" (../README.md#array-come-parametri-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3767,37 +3767,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore: i puntatori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Allocazione dinamica della memoria" lo studente dovrebbe aver seguito il lavoro precedente su "Array come parametri a funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Allocazione dinamica della memoria", lo studente dovrebbe aver seguito il lavoro precedente su "Array come parametri a funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Allocazione dinamica della memoria", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Allocazione dinamica della memoria", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Array come parametri a funzioni" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Array come parametri a funzioni" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Array bidimensionali". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Array bidimensionali". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Allocazione dinamica della memoria", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Array bidimensionali" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Allocazione dinamica della memoria", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Array bidimensionali" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Allocazione dinamica della memoria" (../README.md#allocazione-dinamica-della-memoria). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Allocazione dinamica della memoria" (../README.md#allocazione-dinamica-della-memoria). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3810,37 +3810,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per il Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Array bidimensionali" lo studente dovrebbe aver seguito il lavoro precedente su "Allocazione dinamica della memoria", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Array bidimensionali", lo studente dovrebbe aver seguito il lavoro precedente su "Allocazione dinamica della memoria", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Array bidimensionali", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Array bidimensionali", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Allocazione dinamica della memoria" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Allocazione dinamica della memoria" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Array di puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Array di puntatori". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Array bidimensionali", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Array di puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Array bidimensionali", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Array di puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Array bidimensionali" (../README.md#array-bidimensionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Array bidimensionali" (../README.md#array-bidimensionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3853,37 +3853,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Array di puntatori" lo studente dovrebbe aver seguito il lavoro precedente su "Array bidimensionali", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Array di puntatori", lo studente dovrebbe aver seguito il lavoro precedente su "Array bidimensionali", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Array di puntatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Array di puntatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Array bidimensionali" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Array bidimensionali" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Differenza tra array bidimensionali e array di puntatori". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Differenza tra array bidimensionali e array di puntatori". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Array di puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Differenza tra array bidimensionali e array di puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Array di puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Differenza tra array bidimensionali e array di puntatori" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Array di puntatori" (../README.md#array-di-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Array di puntatori" (../README.md#array-di-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3896,37 +3896,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Differenza tra array bidimensionali e array di puntatori" lo studente dovrebbe aver seguito il lavoro precedente su "Array di puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Differenza tra array bidimensionali e array di puntatori", lo studente dovrebbe aver seguito il lavoro precedente su "Array di puntatori", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Differenza tra array bidimensionali e array di puntatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Differenza tra array bidimensionali e array di puntatori", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Array di puntatori" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Array di puntatori" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Sezioni di memoria di un programma C". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Sezioni di memoria di un programma C". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Differenza tra array bidimensionali e array di puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Sezioni di memoria di un programma C" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Differenza tra array bidimensionali e array di puntatori", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Sezioni di memoria di un programma C" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Differenza tra array bidimensionali e array di puntatori" (../README.md#differenza-tra-array-bidimensionali-e-array-di-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Differenza tra array bidimensionali e array di puntatori" (../README.md#differenza-tra-array-bidimensionali-e-array-di-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3939,37 +3939,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su struttura minima di un programma C, funzione main, include e stampa a video. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sulla struttura minima di un programma C, la funzione main, include e la stampa a video. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Sezioni di memoria di un programma C" lo studente dovrebbe aver seguito il lavoro precedente su "Differenza tra array bidimensionali e array di puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Sezioni di memoria di un programma C" lo studente dovrebbe aver seguito il lavoro precedente su "Differenza tra array bidimensionali e array di puntatori", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Sezioni di memoria di un programma C", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve saper spiegare il ruolo delle "sezioni di memoria di un programma C", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Differenza tra array bidimensionali e array di puntatori" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Differenza tra array bidimensionali e array di puntatori" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "L'inizializzazione delle variabili". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "L'inizializzazione delle variabili". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Sezioni di memoria di un programma C", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "L'inizializzazione delle variabili" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Sezioni di memoria di un programma C", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "L'inizializzazione delle variabili" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "Sezioni di memoria di un programma C" (../README.md#sezioni-di-memoria-di-un-programma-c). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "Sezioni di memoria di un programma C" (../README.md#sezioni-di-memoria-di-un-programma-c). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -3982,37 +3982,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su dichiarazione, tipo, valore, memoria e uso dei dati durante l'esecuzione. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su dichiarazione, tipo, valore, memoria e uso dei dati durante l'esecuzione. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "L'inizializzazione delle variabili" lo studente dovrebbe aver seguito il lavoro precedente su "Sezioni di memoria di un programma C", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "L'inizializzazione delle variabili", lo studente dovrebbe aver seguito il lavoro precedente su "Sezioni di memoria di un programma C", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "L'inizializzazione delle variabili", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere spiegare il ruolo dell'inizializzazione delle variabili, riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Sezioni di memoria di un programma C" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Sezioni di memoria di un programma C" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Allocazione dinamica di matrici". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Allocazione dinamica di matrici". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "L'inizializzazione delle variabili", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Allocazione dinamica di matrici" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "L'inizializzazione delle variabili", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Allocazione dinamica di matrici" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
 
-        Riferimento principale: README.md sezione "L'inizializzazione delle variabili" (../README.md#linizializzazione-delle-variabili). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+        Riferimento principale: README.md, sezione "L'inizializzazione delle variabili" (../README.md#linizializzazione-delle-variabili). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
         </details>
       </details>
     </details>
@@ -4025,32 +4025,32 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Allocazione dinamica di matrici" lo studente dovrebbe aver seguito il lavoro precedente su "L'inizializzazione delle variabili", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Allocazione dinamica di matrici", lo studente dovrebbe aver seguito il lavoro precedente su "L'inizializzazione delle variabili", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
 
-        Alla fine della lezione lo studente deve saper spiegare il ruolo di "Allocazione dinamica di matrici", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+        Alla fine della lezione, lo studente deve sapere spiegare il ruolo di "Allocazione dinamica di matrici", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
         </details>
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "L'inizializzazione delle variabili" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "L'inizializzazione delle variabili" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Le strutture". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Le strutture". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Allocazione dinamica di matrici", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Le strutture" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Allocazione dinamica di matrici", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Le strutture" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
@@ -4068,12 +4068,12 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Contesto</strong></summary>
 
-        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. I sottoparagrafi collegati sono: Passaggio di strutture a funzioni. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+        Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore "I puntatori". I sottoparagrafi collegati sono: Passaggio di strutture a funzioni. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
         </details>
       - <details>
         <summary><strong>Prerequisiti</strong></summary>
 
-        Prima di affrontare "Le strutture" lo studente dovrebbe aver seguito il lavoro precedente su "Allocazione dinamica di matrici", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+        Prima di affrontare "Le strutture", lo studente dovrebbe aver seguito il lavoro precedente su "Allocazione dinamica di matrici", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
         </details>
       - <details>
         <summary><strong>Obiettivi</strong></summary>
@@ -4083,17 +4083,17 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
       - <details>
         <summary><strong>Richiamo</strong></summary>
 
-        Richiama il passaggio precedente su "Allocazione dinamica di matrici" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+        Richiama il passaggio precedente su "Allocazione dinamica di matrici" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
         </details>
       - <details>
         <summary><strong>Anticipazione</strong></summary>
 
-        Questo argomento prepara il lavoro successivo su "Passaggio di strutture a funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+        Questo argomento prepara il lavoro successivo su "Passaggio di strutture a funzioni". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
         </details>
       - <details>
         <summary><strong>Prossimo passo</strong></summary>
 
-        Dopo la spiegazione, proponi un esempio minimo su "Le strutture", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Passaggio di strutture a funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+        Dopo la spiegazione, proponi un esempio minimo su "Le strutture", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Passaggio di strutture a funzioni" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
         </details>
       - <details>
         <summary><strong>Rimando</strong></summary>
@@ -4110,37 +4110,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
         - <details>
           <summary><strong>Contesto</strong></summary>
 
-          Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore I puntatori > Le strutture. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+          Questo argomento si colloca nell'UDA "Puntatori, array e indirizzi" del percorso Intermedio per terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore "I puntatori > Le strutture". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
           </details>
         - <details>
           <summary><strong>Prerequisiti</strong></summary>
 
-          Prima di affrontare "Passaggio di strutture a funzioni" lo studente dovrebbe aver seguito il lavoro precedente su "Le strutture", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+          Prima di affrontare "Passaggio di strutture a funzioni", lo studente dovrebbe aver seguito il lavoro precedente su "Le strutture", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
           </details>
         - <details>
           <summary><strong>Obiettivi</strong></summary>
 
-          Alla fine della lezione lo studente deve saper spiegare il ruolo di "Passaggio di strutture a funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+          Alla fine della lezione lo studente deve sapere spiegare il ruolo di "Passaggio di strutture a funzioni", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
           </details>
         - <details>
           <summary><strong>Richiamo</strong></summary>
 
-          Richiama il passaggio precedente su "Le strutture" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+          Richiama il passaggio precedente su "Le strutture" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
           </details>
         - <details>
           <summary><strong>Anticipazione</strong></summary>
 
-          Questo argomento prepara il lavoro successivo su "Classi di memorizzazione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+          Questo argomento prepara il lavoro successivo su "Classi di memorizzazione". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
           </details>
         - <details>
           <summary><strong>Prossimo passo</strong></summary>
 
-          Dopo la spiegazione, proponi un esempio minimo su "Passaggio di strutture a funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Classi di memorizzazione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+          Dopo la spiegazione, proponi un esempio minimo su "Passaggio di strutture a funzioni", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è quello di collegare questo argomento a "Classi di memorizzazione" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
           </details>
         - <details>
           <summary><strong>Rimando</strong></summary>
 
-          Riferimento principale: README.md sezione "Passaggio di strutture a funzioni" (../README.md#passaggio-di-strutture-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+          Riferimento principale: README.md, sezione "Passaggio di strutture a funzioni" (../README.md#passaggio-di-strutture-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
           </details>
         </details>
       </details>
@@ -4175,37 +4175,37 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Contesto</strong></summary>
 
-      Questo argomento si colloca nell'UDA "Memoria automatica, statica e dinamica" del percorso Intermedio per Terzo anno. Serve a lavorare su durata, visibilita e collegamento degli identificatori in C. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.
+      Questo argomento si colloca nell'UDA "Memoria automatica, statica e dinamica" del percorso Intermedio per Terzo anno. Serve a lavorare su durata, visibilità e collegamento degli identificatori in C. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.
       </details>
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Classi di memorizzazione" lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di strutture a funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Classi di memorizzazione" lo studente dovrebbe aver seguito il lavoro precedente su "Passaggio di strutture a funzioni", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>
 
-      Alla fine della lezione lo studente deve saper spiegare il ruolo di "Classi di memorizzazione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
+      Alla fine della lezione lo studente deve sapere spiegare il ruolo di "classi di memorizzazione", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.
       </details>
     - <details>
       <summary><strong>Richiamo</strong></summary>
 
-      Richiama il passaggio precedente su "Passaggio di strutture a funzioni" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
+      Richiama il passaggio precedente su "Passaggio di strutture a funzioni" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.
       </details>
     - <details>
       <summary><strong>Anticipazione</strong></summary>
 
-      Questo argomento prepara il lavoro successivo su "Block scope". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.
+      Questo argomento prepara il lavoro successivo su "Block scope". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.
       </details>
     - <details>
       <summary><strong>Prossimo passo</strong></summary>
 
-      Dopo la spiegazione, proponi un esempio minimo su "Classi di memorizzazione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a "Block scope" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
+      Dopo la spiegazione, proponi un esempio minimo su "Classi di memorizzazione", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a "Block scope" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.
       </details>
     - <details>
       <summary><strong>Rimando</strong></summary>
 
-      Riferimento principale: README.md sezione "Classi di memorizzazione" (../README.md#classi-di-memorizzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
+      Riferimento principale: README.md, sezione "Classi di memorizzazione" (../README.md#classi-di-memorizzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug.
       </details>
     </details>
   </details>
@@ -4223,7 +4223,7 @@ Corso di C base e intermedio focalizzato sulla logica di programmazione e la ges
     - <details>
       <summary><strong>Prerequisiti</strong></summary>
 
-      Prima di affrontare "Block scope" lo studente dovrebbe aver seguito il lavoro precedente su "Classi di memorizzazione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
+      Prima di affrontare "Block scope" lo studente dovrebbe aver seguito il lavoro precedente su "Classi di memorizzazione", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.
       </details>
     - <details>
       <summary><strong>Obiettivi</strong></summary>

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -517,6 +517,9 @@ Passi progressivi:
 Ordine consigliato:
 
 1. Storage layer iniziale sopra JSON, con `schema_version` e root configurabile.
+   - chiarire e stabilizzare la relazione tra percorso didattico, calendario, consuntivi UDA e file fisici oggi separati (`doc/course_design.json`, `doc/course_designs/*.json`, `doc/calendars/*.json`);
+   - definire una vista dati canonica che possa essere salvata prima su JSON e poi su SQLite senza cambiare le dashboard;
+   - evitare che docente e studente leggano versioni diverse dello stesso percorso/calendario.
 2. Provider layer minimo: interfaccia comune e implementazione GitHub iniziale.
 3. Gestione classi MVP: import/sync da GitHub Team o import manuale controllato.
 4. Pagina creazione/generazione/modifica activity con validazione.

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -518,6 +518,7 @@ Ordine consigliato:
 
 1. Storage layer iniziale sopra JSON, con `schema_version` e root configurabile.
    - chiarire e stabilizzare la relazione tra percorso didattico, calendario, consuntivi UDA e file fisici oggi separati (`doc/course_design.json`, `doc/course_designs/*.json`, `doc/calendars/*.json`);
+   - modellare la relazione percorso-calendario come molti-a-molti: lo stesso percorso puo essere associato a piu calendari, riproposto in periodi diversi, non coprire l'intero anno o ripetersi in finestre temporali diverse;
    - definire una vista dati canonica che possa essere salvata prima su JSON e poi su SQLite senza cambiare le dashboard;
    - evitare che docente e studente leggano versioni diverse dello stesso percorso/calendario.
 2. Provider layer minimo: interfaccia comune e implementazione GitHub iniziale.

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -533,6 +533,7 @@ Ordine consigliato:
 11. Cornice didattica generale e guida operativa docente/studente.
 12. Inserimento activity nel percorso e visualizzazione calendario.
 13. Gestione consuntivi UDA reali:
+   - rendere cliccabili le UDA reali nei calendari docente/studente e aprire un modal di dettaglio coerente;
    - cancellare una UDA reale gia salvata dal calendario docente;
    - ripristinare lo stato pianificato quando il consuntivo e stato inserito per errore;
    - confermare prima della cancellazione e registrare provenienza/eventuale audit log.

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -376,7 +376,7 @@ Il pattern della pagina consegne va reso riutilizzabile.
    - course board;
    - pagina classi;
    - pagina activity;
-   - dashboard studente.
+   - dashboard studente, con pannelli spostabili via drag and drop come nella pagina consegne docente.
 5. Mantenere una colonna su smartphone.
 6. Evitare duplicazione CSS/JS tra pagine.
 7. Migliorare accessibilita di drag/drop e resize.

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -528,11 +528,15 @@ Ordine consigliato:
 10. Event log minimale e provenienza minima per activity/contenuti generati.
 11. Cornice didattica generale e guida operativa docente/studente.
 12. Inserimento activity nel percorso e visualizzazione calendario.
-13. Archiviazione/cancellazione sicura di registri e activity.
-14. Catalogo fonti e import paragrafi da piu repository.
-15. Estensione layout pannelli alle altre pagine.
-16. Feedback assistito avanzato lato studente.
-17. Source provider API, indicizzazione frammenti e playground knowledge lab.
+13. Gestione consuntivi UDA reali:
+   - cancellare una UDA reale gia salvata dal calendario docente;
+   - ripristinare lo stato pianificato quando il consuntivo e stato inserito per errore;
+   - confermare prima della cancellazione e registrare provenienza/eventuale audit log.
+14. Archiviazione/cancellazione sicura di registri e activity.
+15. Catalogo fonti e import paragrafi da piu repository.
+16. Estensione layout pannelli alle altre pagine.
+17. Feedback assistito avanzato lato studente.
+18. Source provider API, indicizzazione frammenti e playground knowledge lab.
 
 ## Criterio di priorita
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -309,6 +309,7 @@ Da avere per la prima prova:
    - mostrare solo percorsi esplicitamente associati allo studente o al suo gruppo/classe;
    - prevedere lato docente l'associazione di un percorso a un gruppo intero e l'eventuale assegnazione personalizzata a un singolo studente;
    - distinguere la programmazione prevista per UDA dalla programmazione reale svolta, evidenziando eventuali ritardi o slittamenti;
+   - mostrare allo studente, in sola lettura, il diagramma di Gantt della programmazione prevista e quello della programmazione reale del docente;
    - mostrare il calendario corrente con UDA, lezioni/lab, verifiche, compiti, consegne da fare, scadenze e finestre di lavoro;
    - aggiungere piu avanti un riepilogo delle priorita per lo studente, per esempio consegne in scadenza, verifiche vicine e attivita arretrate;
    - non esporre azioni o pagine docente nella navigazione studente;

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -238,9 +238,11 @@ La pagina del percorso deve poter costruire UDA e argomenti usando paragrafi pro
 5. Aggiungere activity nel percorso:
    - come elementi autonomi tra gli argomenti;
    - dentro una UDA;
+   - agganciate a una lezione/UDA programmata o reale, per collegare lab, prove pratiche, prove scritte ed esercitazioni al momento didattico in cui vengono svolte;
    - come verifiche o prove collegate alla UDA;
    - come esercizi di laboratorio, casa o classe collegati a uno o piu argomenti.
 6. Mostrare le activity anche nel calendario quando hanno data, finestra temporale o scadenza.
+   - lato studente, visualizzare come consegne le activity agganciate alla lezione/UDA e mantenere anche consegne autonome fuori lezione, per esempio compiti a casa o recuperi.
 7. Decidere come visualizzare nel calendario:
    - le lezioni teoriche;
    - i laboratori;

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -533,6 +533,8 @@ Ordine consigliato:
 11. Cornice didattica generale e guida operativa docente/studente.
 12. Inserimento activity nel percorso e visualizzazione calendario.
 13. Gestione consuntivi UDA reali:
+   - mostrare le UDA reali anche nella vista calendario docente;
+   - aggiungere un filtro calendario per scegliere tra UDA programmate, UDA reali o entrambe;
    - rendere cliccabili le UDA reali nei calendari docente/studente e aprire un modal di dettaglio coerente;
    - cancellare una UDA reale gia salvata dal calendario docente;
    - ripristinare lo stato pianificato quando il consuntivo e stato inserito per errore;

--- a/doc/course_design.json
+++ b/doc/course_design.json
@@ -24,6 +24,13 @@
           "title": "Strumenti, primo programma e rappresentazione",
           "path": "Base",
           "weeks": "3",
+          "actual": {
+            "status": "done",
+            "start_date": "2026-09-07",
+            "end_date": "2026-09-25",
+            "hours_done": 9,
+            "notes": "Demo: consuntivo inserito come se fosse stato salvato dal pannello calendario docente."
+          },
           "items": [
             {
               "id": "README.md#introduzione",
@@ -690,22 +697,22 @@
               "line": 6917,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Strumenti, primo programma e rappresentazione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
+                "context": "Questo argomento si colloca nell'UDA \"Strumenti, primo programma e rappresentazione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
                 "prerequisites": "Prima di affrontare \"Costanti\", lo studente dovrebbe aver seguito il lavoro precedente su \"Stampare un `char`\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Costanti\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"costanti\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
                 "recall": "Richiama il passaggio precedente su \"Stampare un `char`\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Operatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Operatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
                 "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Costanti\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Costanti\" (../README.md#costanti). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "references": "Riferimento principale: README.md, sezione \"Costanti\" (../README.md#costanti). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "local",
+                "context": "ai",
                 "prerequisites": "ai",
-                "objectives": "none",
+                "objectives": "ai",
                 "recall": "ai",
-                "preview": "none",
+                "preview": "ai",
                 "next_step": "ai",
-                "references": "none"
+                "references": "ai"
               }
             }
           ]
@@ -715,6 +722,13 @@
           "title": "Operatori, condizioni e selezione",
           "path": "Base",
           "weeks": "3",
+          "actual": {
+            "status": "in_progress",
+            "start_date": "2026-09-28",
+            "end_date": "2026-10-16",
+            "hours_done": 7,
+            "notes": "Demo: consuntivo parziale per verificare la resa nel calendario docente e studente."
+          },
           "items": [
             {
               "id": "README.md#operatori",
@@ -725,13 +739,13 @@
               "line": 6923,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su operatori aritmetici, logici, relazionali e loro precedenza. I sottoparagrafi collegati sono: Operatore di assegnamento: =. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Operatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Costanti\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Costanti\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore di assegnamento: =\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Operatore di assegnamento: =\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Operatori\" (../README.md#operatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su operatori aritmetici, logici, relazionali e sulla loro precedenza. I sottoparagrafi collegati sono: Operatore di assegnamento: =. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Operatori\", lo studente dovrebbe aver seguito il lavoro precedente su \"Costanti\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Operatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Costanti\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore di assegnamento: =\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatore di assegnamento: =\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Operatori\" (../README.md#operatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "children": [
                 {
@@ -743,33 +757,33 @@
                   "line": 6929,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Operatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Operatore di assegnamento: =\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatore di assegnamento: =\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Operatori\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Operatore somma: +\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore di assegnamento: =\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Operatore somma: +\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Operatore di assegnamento: =\" (../README.md#operatore-di-assegnamento). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per il Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"Operatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Operatore di assegnamento: =\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatori\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo dell'\"Operatore di assegnamento: =\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Operatori\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Operatore somma: +\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore di assegnamento: =\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatore somma: +\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Operatore di assegnamento: =\" (../README.md#operatore-di-assegnamento). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 }
               ],
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -781,22 +795,22 @@
               "line": 7043,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Operatore somma: +\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore di assegnamento: =\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatore somma: +\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Operatore di assegnamento: =\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore differenza: -\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore somma: +\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Operatore differenza: -\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Operatore somma: +\" (../README.md#operatore-somma). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Operatore somma: +\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore di assegnazione: =\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo dell'\"Operatore somma: +\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Operatore di assegnamento: =\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore differenza: -\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore somma: +\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatore differenza: -\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Operatore somma: +\" (../README.md#operatore-somma). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -808,22 +822,22 @@
               "line": 7058,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Operatore differenza: -\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore somma: +\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatore differenza: -\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Operatore somma: +\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore segno: - e +\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore differenza: -\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Operatore segno: - e +\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Operatore differenza: -\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore somma: +\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Operatore differenza: -\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Operatore somma: +\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore segno: - e +\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore differenza: -\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatore segno: - e +\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
                 "references": "Riferimento principale: README.md sezione \"Operatore differenza: -\" (../README.md#operatore-differenza). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -835,22 +849,22 @@
               "line": 7064,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Operatore segno: - e +\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore differenza: -\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatore segno: - e +\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Operatore differenza: -\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore moltiplicazione: *\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore segno: - e +\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Operatore moltiplicazione: *\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Operatore segno: - e +\" (../README.md#operatore-segno---e). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Operatore segno: - e +\", lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore differenza: -\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Operatore segno: - e +\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Operatore differenza: -\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore moltiplicazione: *\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore segno: - e +\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatore moltiplicazione: *\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Operatore segno: - e +\" (../README.md#operatore-segno---e). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -862,22 +876,22 @@
               "line": 7077,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Operatore moltiplicazione: *\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore segno: - e +\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatore moltiplicazione: *\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Operatore segno: - e +\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore divisione: /\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore moltiplicazione: *\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Operatore divisione: /\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Operatore moltiplicazione: *\" (../README.md#operatore-moltiplicazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Operatore moltiplicazione: *\", lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore segno: - e +\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Operatore moltiplicazione: *\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Operatore segno: - e +\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore divisione: /\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore moltiplicazione: *\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatore divisione: /\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Operatore moltiplicazione: *\" (../README.md#operatore-moltiplicazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -889,22 +903,22 @@
               "line": 7089,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Operatore divisione: /\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore moltiplicazione: *\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatore divisione: /\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Operatore moltiplicazione: *\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore %\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore divisione: /\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Operatore %\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Operatore divisione: /\" (../README.md#operatore-divisione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Operatore divisione: /\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore moltiplicazione: *\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo dell'\"Operatore divisione: /\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Operatore moltiplicazione: *\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore %\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore divisione: /\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatore %\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Operatore divisione: /\" (../README.md#operatore-divisione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -916,22 +930,22 @@
               "line": 7284,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Operatore %\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore divisione: /\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatore %\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Operatore divisione: /\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore incremento/decremento ++ --\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore %\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Operatore incremento/decremento ++ --\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Operatore %\" (../README.md#operatore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Operatore %\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore divisione: /\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo dell'\"Operatore %\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Operatore divisione: /\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore incremento/decremento ++ --\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore %\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatore incremento/decremento ++ --\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Operatore %\" (../README.md#operatore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -943,22 +957,22 @@
               "line": 7381,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Operatore incremento/decremento ++ --\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore %\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatore incremento/decremento ++ --\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Operatore %\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore `sizeof`\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore incremento/decremento ++ --\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Operatore `sizeof`\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Operatore incremento/decremento ++ --\" (../README.md#operatore-incrementodecremento). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Operatore incremento/decremento ++ --\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore %\", saper compilare ed eseguire piccoli programmi in C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo dell'\"Operatore incremento/decremento ++ --\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Operatore %\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Operatore `sizeof`\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore incremento/decremento ++ --\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Operatore `sizeof`\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Operatore incremento/decremento ++ --\" (../README.md#operatore-incrementodecremento). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -970,22 +984,22 @@
               "line": 7182,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Operatore `sizeof`\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore incremento/decremento ++ --\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Operatore `sizeof`\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Operatore incremento/decremento ++ --\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Cast\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Operatore `sizeof`\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Cast\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Operatore `sizeof`\" (../README.md#operatore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per il Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Operatore `sizeof`\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatori incremento/decremento ++ --\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo dell'\"Operatore `sizeof`\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Operatore incremento/decremento ++ --\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Cast\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proporrò un esempio minimo su \"Operatore `sizeof`\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Cast\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Operatore `sizeof`\" (../README.md#operatore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -997,13 +1011,13 @@
               "line": 5819,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Cast tra `signed` e `unsigned`. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Cast\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore `sizeof`\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Cast\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Operatore `sizeof`\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Cast tra `signed` e `unsigned`\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Cast\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Cast tra `signed` e `unsigned`\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Cast\" (../README.md#cast). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Cast tra `signed` e `unsigned`. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Cast\" lo studente dovrebbe aver seguito il lavoro precedente su \"Operatore `sizeof`\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Cast\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Operatore `sizeof`\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Cast tra `signed` e `unsigned`\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Cast\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Cast tra `signed` e `unsigned`\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Cast\" (../README.md#cast). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "children": [
                 {
@@ -1015,33 +1029,33 @@
                   "line": 6110,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su numeri con segno, complemento a due, range e casi limite. Si collega al blocco superiore Cast. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Cast tra `signed` e `unsigned`\" lo studente dovrebbe aver seguito il lavoro precedente su \"Cast\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Cast tra `signed` e `unsigned`\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Cast\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Controllo del flusso\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Cast tra `signed` e `unsigned`\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Controllo del flusso\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Cast tra `signed` e `unsigned`\" (../README.md#cast-tra-signed-e-unsigned). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su numeri con segno, complemento a due, range e casi limite. Si collega al blocco superiore Cast. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Cast tra `signed` e `unsigned`\" lo studente dovrebbe aver seguito il lavoro precedente su \"Cast\", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"cast tra `signed` e `unsigned`\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Cast\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Controllo del flusso\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Cast tra `signed` e `unsigned`\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Controllo del flusso\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Cast tra `signed` e `unsigned`\" (../README.md#cast-tra-signed-e-unsigned). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 }
               ],
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1053,13 +1067,13 @@
               "line": 7626,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su if, switch, cicli e costruzione del flusso di esecuzione. I sottoparagrafi collegati sono: if o if-else, Condizioni complesse con l'uso di operatori logici e condizionali, for, while, do-while, switch, break e continue. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Controllo del flusso\" lo studente dovrebbe aver seguito il lavoro precedente su \"Cast tra `signed` e `unsigned`\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Controllo del flusso\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Cast tra `signed` e `unsigned`\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"if o if-else\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Controllo del flusso\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"if o if-else\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Controllo del flusso\" (../README.md#controllo-del-flusso). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per il Terzo anno. Serve a lavorare su if, switch, cicli e costruzione del flusso di esecuzione. I sottoparagrafi collegati sono: if o if-else, Condizioni complesse con l'uso di operatori logici e condizionali, for, while, do-while, switch, break e continue. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Controllo del flusso\", lo studente dovrebbe aver seguito il lavoro precedente su \"Cast tra `signed` e `unsigned`\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Controllo del flusso\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Cast tra `signed` e `unsigned`\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"if o if-else\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Controllo del flusso\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"if o if-else\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Controllo del flusso\" (../README.md#controllo-del-flusso). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "children": [
                 {
@@ -1071,22 +1085,22 @@
                   "line": 7651,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"if o if-else\" lo studente dovrebbe aver seguito il lavoro precedente su \"Controllo del flusso\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"if o if-else\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Controllo del flusso\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Condizioni complesse con l'uso di operatori logici e condizionali\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"if o if-else\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Condizioni complesse con l'uso di operatori logici e condizionali\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"if o if-else\" (../README.md#if-o-if-else). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"if o if-else\", lo studente dovrebbe aver seguito il lavoro precedente su \"Controllo del flusso\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"if\" o \"if-else\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Controllo del flusso\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Condizioni complesse con l'uso di operatori logici e condizionali\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"if o if-else\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Condizioni complesse con l'uso di operatori logici e condizionali\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"if o if-else\" (../README.md#if-o-if-else). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1098,22 +1112,22 @@
                   "line": 7792,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su operatori aritmetici, logici, relazionali e loro precedenza. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Condizioni complesse con l'uso di operatori logici e condizionali\" lo studente dovrebbe aver seguito il lavoro precedente su \"if o if-else\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Condizioni complesse con l'uso di operatori logici e condizionali\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"if o if-else\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"for\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Condizioni complesse con l'uso di operatori logici e condizionali\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"for\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Condizioni complesse con l'uso di operatori logici e condizionali\" (../README.md#condizioni-complesse-con-luso-di-operatori-logici-e-condizionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su operatori aritmetici, logici, relazionali e sulla loro precedenza. Si collega al blocco superiore \"Controllo del flusso\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Condizioni complesse con l'uso di operatori logici e condizionali\", lo studente dovrebbe aver seguito il lavoro precedente su \"if o if-else\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Condizioni complesse con l'uso di operatori logici e condizionali\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"if o if-else\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"for\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Condizioni complesse con l'uso di operatori logici e condizionali\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è quello di collegare questo argomento a \"for\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Condizioni complesse con l'uso di operatori logici e condizionali\" (../README.md#condizioni-complesse-con-luso-di-operatori-logici-e-condizionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1125,22 +1139,22 @@
                   "line": 7921,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"for\" lo studente dovrebbe aver seguito il lavoro precedente su \"Condizioni complesse con l'uso di operatori logici e condizionali\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"for\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Condizioni complesse con l'uso di operatori logici e condizionali\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"while\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"for\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"while\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"for\" (../README.md#for). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"Controllo del flusso\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"for\", lo studente dovrebbe aver seguito il lavoro precedente su \"Condizioni complesse con l'uso di operatori logici e condizionali\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere come spiegare il ruolo di \"for\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere come indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Condizioni complesse con l'uso di operatori logici e condizionali\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"while\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"for\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"while\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"for\" (../README.md#for). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1152,22 +1166,22 @@
                   "line": 8014,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"while\" lo studente dovrebbe aver seguito il lavoro precedente su \"for\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"while\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"for\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"do-while\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"while\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"do-while\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"while\" (../README.md#while). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"Controllo del flusso\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"while\" lo studente dovrebbe aver seguito il lavoro precedente su \"for\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"while\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"for\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"do-while\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"while\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"do-while\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"while\" (../README.md#while). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1179,22 +1193,22 @@
                   "line": 8111,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"do-while\" lo studente dovrebbe aver seguito il lavoro precedente su \"while\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"do-while\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"while\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"switch\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"do-while\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"switch\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"do-while\" (../README.md#do-while). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"Controllo del flusso\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"do-while\", lo studente dovrebbe aver seguito il lavoro precedente su \"while\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"do-while\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"while\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"switch\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"do-while\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"switch\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"do-while\" (../README.md#do-while). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1206,22 +1220,22 @@
                   "line": 8214,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"switch\" lo studente dovrebbe aver seguito il lavoro precedente su \"do-while\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"switch\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"do-while\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"break e continue\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"switch\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"break e continue\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"switch\" (../README.md#switch). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"switch\" lo studente dovrebbe aver seguito il lavoro precedente su \"do-while\", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"switch\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"do-while\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"break e continue\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"switch\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"break e continue\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"switch\" (../README.md#switch). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1233,33 +1247,33 @@
                   "line": 8400,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Controllo del flusso. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"break e continue\" lo studente dovrebbe aver seguito il lavoro precedente su \"switch\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "context": "Questo argomento si colloca nell'UDA \"Operatori, condizioni e selezione\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"Controllo del flusso\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"break e continue\", lo studente dovrebbe aver seguito il lavoro precedente su \"switch\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
                     "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"break e continue\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"switch\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"break e continue\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"break e continue\" (../README.md#break-e-continue). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "recall": "Richiama il passaggio precedente su \"switch\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"break e continue\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"break e continue\" (../README.md#break-e-continue). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 }
               ],
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             }
           ]
@@ -1279,22 +1293,22 @@
               "line": 11039,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"break e continue\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"break e continue\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Dichiarazione di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Dichiarazione di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Funzioni\" (../README.md#funzioni-1). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"break e continue\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"break e continue\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Dichiarazione di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Dichiarazione di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Funzioni\" (../README.md#funzioni-1). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1306,22 +1320,22 @@
               "line": 11134,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Dichiarazione di funzione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Dichiarazione di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Funzioni\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Uso di void nelle funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dichiarazione di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Uso di void nelle funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Dichiarazione di funzione\" (../README.md#dichiarazione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Dichiarazione di funzione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Dichiarazione di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Funzioni\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Uso di void nelle funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dichiarazione di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Uso di void nelle funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Dichiarazione di funzione\" (../README.md#dichiarazione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1333,22 +1347,22 @@
               "line": 11236,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Uso di void nelle funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"Dichiarazione di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Uso di void nelle funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Dichiarazione di funzione\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Definizione di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Uso di void nelle funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Definizione di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Uso di void nelle funzioni\", lo studente dovrebbe aver seguito il lavoro precedente su \"Dichiarazione di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Uso di void nelle funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Dichiarazione di funzione\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Definizione di funzione\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Uso di void nelle funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Definizione di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
                 "references": "Riferimento principale: README.md sezione \"Uso di void nelle funzioni\" (../README.md#uso-di-void-nelle-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1360,22 +1374,22 @@
               "line": 11262,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Definizione di funzione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Uso di void nelle funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Definizione di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Uso di void nelle funzioni\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Chiamata di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Definizione di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Chiamata di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Definizione di funzione\" (../README.md#definizione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Definizione di funzione\", lo studente dovrebbe aver seguito il lavoro precedente su \"Uso di void nelle funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Definizione di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Uso di void nelle funzioni\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Chiamata di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Definizione di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Chiamata di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Definizione di funzione\" (../README.md#definizione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1387,22 +1401,22 @@
               "line": 11282,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Chiamata di funzione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Definizione di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Chiamata di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Definizione di funzione\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di parametri per valore\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Chiamata di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Passaggio di parametri per valore\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Chiamata di funzione\" (../README.md#chiamata-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare su un concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Chiamata di funzione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Definizione di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"chiamata di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Definizione di funzione\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di parametri per valore\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Chiamata di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Passaggio di parametri per valore\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Chiamata di funzione\" (../README.md#chiamata-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1414,22 +1428,22 @@
               "line": 11335,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Passaggio di parametri per valore\" lo studente dovrebbe aver seguito il lavoro precedente su \"Chiamata di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Passaggio di parametri per valore\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Chiamata di funzione\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Vettori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di parametri per valore\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Vettori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Passaggio di parametri per valore\" (../README.md#passaggio-di-parametri-per-valore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Cicli e funzioni\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Passaggio di parametri per valore\", lo studente dovrebbe aver seguito il lavoro precedente su \"Chiamata di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Passaggio di parametri per valore\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Chiamata di funzione\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Vettori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proporia un esempio minimo su \"Passaggio di parametri per valore\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Vettori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Passaggio di parametri per valore\" (../README.md#passaggio-di-parametri-per-valore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             }
           ]
@@ -1449,13 +1463,13 @@
               "line": 9280,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Inizializzare un vettore, Dimensione vettore (`sizeof`). La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Vettori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di parametri per valore\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Vettori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Passaggio di parametri per valore\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Inizializzare un vettore\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Vettori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Inizializzare un vettore\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Vettori\" (../README.md#vettori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Inizializzare un vettore, Dimensione vettore (`sizeof`). La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Vettori\", lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di parametri per valore\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Vettori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Passaggio di parametri per valore\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Inizializzare un vettore\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Vettori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Inizializzare un vettore\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Vettori\" (../README.md#vettori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "children": [
                 {
@@ -1467,22 +1481,22 @@
                   "line": 9568,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Vettori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Inizializzare un vettore\" lo studente dovrebbe aver seguito il lavoro precedente su \"Vettori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"Vettori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Inizializzare un vettore\", lo studente dovrebbe aver seguito il lavoro precedente su \"Vettori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
                     "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Inizializzare un vettore\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Vettori\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Dimensione vettore (`sizeof`)\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Inizializzare un vettore\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Dimensione vettore (`sizeof`)\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Inizializzare un vettore\" (../README.md#inizializzare-un-vettore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "recall": "Richiama il passaggio precedente su \"Vettori\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Dimensione vettore (`sizeof`)\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Inizializzare un vettore\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Dimensione vettore (`sizeof`)\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Inizializzare un vettore\" (../README.md#inizializzare-un-vettore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1494,33 +1508,33 @@
                   "line": 9894,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Vettori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Dimensione vettore (`sizeof`)\" lo studente dovrebbe aver seguito il lavoro precedente su \"Inizializzare un vettore\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Dimensione vettore (`sizeof`)\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Inizializzare un vettore\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Le stringhe\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dimensione vettore (`sizeof`)\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Le stringhe\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Dimensione vettore (`sizeof`)\" (../README.md#dimensione-vettore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su concetti tecnici previsti dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore Vettori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Dimensione vettore (`sizeof`)\", lo studente dovrebbe aver seguito il lavoro precedente su \"Inizializzare un vettore\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Dimensione vettore (`sizeof`)\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Inizializzare un vettore\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Le stringhe\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dimensione vettore (`sizeof`)\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Le stringhe\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Dimensione vettore (`sizeof`)\" (../README.md#dimensione-vettore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 }
               ],
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1532,22 +1546,22 @@
               "line": 10492,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su array di char terminati da carattere nullo e funzioni di libreria associate. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Le stringhe\" lo studente dovrebbe aver seguito il lavoro precedente su \"Dimensione vettore (`sizeof`)\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Le stringhe\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Dimensione vettore (`sizeof`)\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Dettagli sull'inizializzazione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Le stringhe\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Dettagli sull'inizializzazione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Le stringhe\" (../README.md#le-stringhe). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su array di char terminati da carattere nullo e funzioni di libreria associate. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Le stringhe\", lo studente dovrebbe aver seguito il lavoro precedente su \"Dimensione vettore (`sizeof`)\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Le stringhe\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Dimensione vettore (`sizeof`)\", e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Dettagli sull'inizializzazione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Le stringhe\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Dettagli sull'inizializzazione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Le stringhe\" (../README.md#le-stringhe). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1559,22 +1573,22 @@
               "line": 10732,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Dettagli sull'inizializzazione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Le stringhe\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Dettagli sull'inizializzazione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Le stringhe\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Stampare una stringa\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dettagli sull'inizializzazione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Stampare una stringa\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Dettagli sull'inizializzazione\" (../README.md#dettagli-sullinizializzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Dettagli sull'inizializzazione\", lo studente dovrebbe aver seguito il lavoro precedente su \"Le stringhe\", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Dettagli sull'inizializzazione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Le stringhe\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Stampare una stringa\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dettagli sull'inizializzazione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Stampare una stringa\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Dettagli sull'inizializzazione\" (../README.md#dettagli-sull-inizializzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1586,22 +1600,22 @@
               "line": 11008,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Stampare una stringa\" lo studente dovrebbe aver seguito il lavoro precedente su \"Dettagli sull'inizializzazione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Stampare una stringa\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Dettagli sull'inizializzazione\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Array come parametri a funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Stampare una stringa\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Array come parametri a funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Stampare una stringa\" (../README.md#stampare-una-stringa). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Stampare una stringa\", lo studente dovrebbe aver seguito il lavoro precedente su \"Dettagli sull'inizializzazione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Stampare una stringa\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Dettagli sull'inizializzazione\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Array come parametri a funzioni\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Stampare una stringa\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Array come parametri a funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Stampare una stringa\" (../README.md#stampare-una-stringa). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1613,22 +1627,22 @@
               "line": 11789,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Array come parametri a funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"Stampare una stringa\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Array come parametri a funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Stampare una stringa\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Le strutture\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array come parametri a funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Le strutture\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "context": "Questo argomento si colloca nell'UDA \"Array e stringhe semplici\" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Array come parametri a funzioni\", lo studente dovrebbe aver seguito il lavoro precedente su \"Stampare una stringa\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Array come parametri a funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Stampare una stringa\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Le strutture\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array come parametri a funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Le strutture\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
                 "references": "Riferimento principale: README.md sezione \"Array come parametri a funzioni\" (../README.md#array-come-parametri-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             }
           ]
@@ -1648,13 +1662,13 @@
               "line": 13330,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Struct e consolidamento\" del percorso Base per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Passaggio di strutture a funzioni. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Le strutture\" lo studente dovrebbe aver seguito il lavoro precedente su \"Array come parametri a funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Le strutture\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Array come parametri a funzioni\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di strutture a funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Le strutture\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Passaggio di strutture a funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Le strutture\" (../README.md#le-strutture). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Struct e consolidamento\" del percorso Base per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. I sottoparagrafi collegati sono: Passaggio di strutture a funzioni. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Le strutture\" lo studente dovrebbe aver seguito il lavoro precedente su \"Array come parametri a funzioni\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Le strutture\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Array come parametri a funzioni\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di strutture a funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Le strutture\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Passaggio di strutture a funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Le strutture\" (../README.md#le-strutture). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "children": [
                 {
@@ -1666,33 +1680,33 @@
                   "line": 13502,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Struct e consolidamento\" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore Le strutture. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Passaggio di strutture a funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"Le strutture\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Passaggio di strutture a funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Le strutture\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Array bidimensionali\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di strutture a funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Array bidimensionali\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Passaggio di strutture a funzioni\" (../README.md#passaggio-di-strutture-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Struct e consolidamento\" del percorso Base per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riutilizzo del codice. Si collega al blocco superiore \"Le strutture\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Passaggio di strutture a funzioni\", lo studente dovrebbe aver seguito il lavoro precedente su \"Le strutture\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Passaggio di strutture a funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Le strutture\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Array bidimensionali\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di strutture a funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Array bidimensionali\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Passaggio di strutture a funzioni\" (../README.md#passaggio-di-strutture-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 }
               ],
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -1704,22 +1718,22 @@
               "line": 12141,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Struct e consolidamento\" del percorso Base per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Array bidimensionali\" lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di strutture a funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Array bidimensionali\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Passaggio di strutture a funzioni\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"I puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array bidimensionali\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"I puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Array bidimensionali\" (../README.md#array-bidimensionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Struct e consolidamento\" del percorso Base per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Array bidimensionali\", lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di strutture a funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "alla fine della lezione lo studente deve saper spiegare il ruolo di \"Array bidimensionali\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Passaggio di strutture a funzioni\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"I puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array bidimensionali\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"I puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Array bidimensionali\" (../README.md#array-bidimensionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             }
           ]
@@ -1739,13 +1753,13 @@
               "line": 8539,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. I sottoparagrafi collegati sono: Puntatori non inizializzati, Il puntatore nullo (NULL), Vettori, Relazione tra array e puntatori, Differenza tra puntatori, Le stringhe, Dettagli sull'inizializzazione, Stampare una stringa, Funzioni, Dichiarazione di funzione, Uso di void nelle funzioni, Definizione di funzione, Chiamata di funzione, Passaggio di parametri per valore, Passaggio di parametri per indirizzo, Passaggio di puntatori const, Array come parametri a funzioni, Allocazione dinamica della memoria, Array bidimensionali, Array di puntatori, Differenza tra array bidimensionali e array di puntatori, Sezioni di memoria di un programma C, L'inizializzazione delle variabili, Allocazione dinamica di matrici, Le strutture. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"I puntatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Array bidimensionali\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"I puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Array bidimensionali\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Puntatori non inizializzati\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"I puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Puntatori non inizializzati\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"I puntatori\" (../README.md#i-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. I sottoparagrafi collegati sono: Puntatori non inizializzati, Il puntatore nullo (NULL), Vettori, Relazione tra array e puntatori, Differenza tra puntatori, Le stringhe, Dettagli sull'inizializzazione, Stampare una stringa, Funzioni, Dichiarazione di funzione, Uso di void nelle funzioni, Definizione di funzione, Chiamata di funzione, Passaggio di parametri per valore, Passaggio di parametri per indirizzo, Passaggio di puntatori const, Array come parametri a funzioni, Allocazione dinamica della memoria, Array bidimensionali, Array di puntatori, Differenza tra array bidimensionali e array di puntatori, Sezioni di memoria di un programma C, L'inizializzazione delle variabili, Allocazione dinamica di matrici, Le strutture. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"I puntatori\", lo studente dovrebbe aver seguito il lavoro precedente su \"Array bidimensionali\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"I puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Array bidimensionali\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Puntatori non inizializzati\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"I puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Puntatori non inizializzati\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"I puntatori\" (../README.md#i-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "children": [
                 {
@@ -1757,22 +1771,22 @@
                   "line": 8894,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Puntatori non inizializzati\" lo studente dovrebbe aver seguito il lavoro precedente su \"I puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Puntatori non inizializzati\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"I puntatori\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Il puntatore nullo (NULL)\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Puntatori non inizializzati\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Il puntatore nullo (NULL)\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Puntatori non inizializzati\" (../README.md#puntatori-non-inizializzati). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Puntatori non inizializzati\" lo studente dovrebbe aver seguito il lavoro precedente su \"I puntatori\", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Puntatori non inizializzati\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"I puntatori\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Il puntatore nullo (NULL)\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Puntatori non inizializzati\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Il puntatore nullo (NULL)\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Puntatori non inizializzati\" (../README.md#puntatori-non-inizializzati). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1784,13 +1798,13 @@
                   "line": 8999,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. I sottoparagrafi collegati sono: Aritmetica puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Il puntatore nullo (NULL)\" lo studente dovrebbe aver seguito il lavoro precedente su \"Puntatori non inizializzati\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Il puntatore nullo (NULL)\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Puntatori non inizializzati\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Aritmetica puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Il puntatore nullo (NULL)\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Aritmetica puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Il puntatore nullo (NULL)\" (../README.md#il-puntatore-nullo-null). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". I sottoparagrafi collegati sono: \"Aritmetica puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Il puntatore nullo (NULL)\" lo studente dovrebbe aver seguito il lavoro precedente su \"Puntatori non inizializzati\", sapere come compilare ed eseguire piccoli programmi C, saper leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Il puntatore nullo (NULL)\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Puntatori non inizializzati\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Aritmetica dei puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Il puntatore nullo (NULL)\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Aritmetica puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Il puntatore nullo (NULL)\" (../README.md#il-puntatore-nullo-null). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "children": [
                     {
@@ -1802,33 +1816,33 @@
                       "line": 9092,
                       "frame": {
                         "status": "draft",
-                        "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore I puntatori > Il puntatore nullo (NULL). La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                        "prerequisites": "Prima di affrontare \"Aritmetica puntatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Il puntatore nullo (NULL)\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                        "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Aritmetica puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                        "recall": "Richiama il passaggio precedente su \"Il puntatore nullo (NULL)\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                        "preview": "Questo argomento prepara il lavoro successivo su \"Vettori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                        "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Aritmetica puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Vettori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                        "references": "Riferimento principale: README.md sezione \"Aritmetica puntatori\" (../README.md#aritmetica-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                        "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore \"I puntatori\" > \"Il puntatore nullo (NULL)\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                        "prerequisites": "Prima di affrontare \"Aritmetica dei puntatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Il puntatore nullo (NULL)\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                        "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Aritmetica dei puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                        "recall": "Richiama il passaggio precedente su \"Il puntatore nullo (NULL)\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                        "preview": "Questo argomento prepara il lavoro successivo su \"Vettori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                        "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Aritmetica dei puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Vettori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                        "references": "Riferimento principale: README.md, sezione \"Aritmetica puntatori\" (../README.md#aritmetica-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                       },
                       "frame_quality": {
-                        "context": "none",
-                        "prerequisites": "none",
-                        "objectives": "none",
-                        "recall": "none",
-                        "preview": "none",
-                        "next_step": "none",
-                        "references": "none"
+                        "context": "ai",
+                        "prerequisites": "ai",
+                        "objectives": "ai",
+                        "recall": "ai",
+                        "preview": "ai",
+                        "next_step": "ai",
+                        "references": "ai"
                       }
                     }
                   ],
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1840,13 +1854,13 @@
                   "line": 9280,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. I sottoparagrafi collegati sono: Inizializzare un vettore, Dimensione vettore (`sizeof`). La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Vettori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Aritmetica puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Vettori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Aritmetica puntatori\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Inizializzare un vettore\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Vettori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Inizializzare un vettore\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Vettori\" (../README.md#vettori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". I sottoparagrafi collegati sono: Inizializzare un vettore, Dimensione vettore (`sizeof`). La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Vettori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Aritmetica dei puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Vettori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collejarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Aritmetica puntatori\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Inizializzare un vettore\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Vettori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Inizializzare un vettore\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Vettori\" (../README.md#vettori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "children": [
                     {
@@ -1858,22 +1872,22 @@
                       "line": 9568,
                       "frame": {
                         "status": "draft",
-                        "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori > Vettori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                        "prerequisites": "Prima di affrontare \"Inizializzare un vettore\" lo studente dovrebbe aver seguito il lavoro precedente su \"Vettori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                        "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Inizializzare un vettore\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                        "recall": "Richiama il passaggio precedente su \"Vettori\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                        "preview": "Questo argomento prepara il lavoro successivo su \"Dimensione vettore (`sizeof`)\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                        "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Inizializzare un vettore\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Dimensione vettore (`sizeof`)\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                        "references": "Riferimento principale: README.md sezione \"Inizializzare un vettore\" (../README.md#inizializzare-un-vettore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                        "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori > Vettori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                        "prerequisites": "Prima di affrontare \"Inizializzare un vettore\", lo studente dovrebbe aver seguito il lavoro precedente su \"Vettori\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                        "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Inizializzare un vettore\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                        "recall": "Richiama il passaggio precedente su \"Vettori\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                        "preview": "Questo argomento prepara il lavoro successivo su \"Dimensione vettore (`sizeof`)\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                        "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Inizializzare un vettore\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Dimensione vettore (`sizeof`)\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                        "references": "Riferimento principale: README.md, sezione \"Inizializzare un vettore\" (../README.md#inizializzare-un-vettore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                       },
                       "frame_quality": {
-                        "context": "none",
-                        "prerequisites": "none",
-                        "objectives": "none",
-                        "recall": "none",
-                        "preview": "none",
-                        "next_step": "none",
-                        "references": "none"
+                        "context": "ai",
+                        "prerequisites": "ai",
+                        "objectives": "ai",
+                        "recall": "ai",
+                        "preview": "ai",
+                        "next_step": "ai",
+                        "references": "ai"
                       }
                     },
                     {
@@ -1885,33 +1899,33 @@
                       "line": 9894,
                       "frame": {
                         "status": "draft",
-                        "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori > Vettori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                        "prerequisites": "Prima di affrontare \"Dimensione vettore (`sizeof`)\" lo studente dovrebbe aver seguito il lavoro precedente su \"Inizializzare un vettore\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                        "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Dimensione vettore (`sizeof`)\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                        "recall": "Richiama il passaggio precedente su \"Inizializzare un vettore\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                        "preview": "Questo argomento prepara il lavoro successivo su \"Relazione tra array e puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                        "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dimensione vettore (`sizeof`)\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Relazione tra array e puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                        "references": "Riferimento principale: README.md sezione \"Dimensione vettore (`sizeof`)\" (../README.md#dimensione-vettore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                        "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per il Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori > Vettori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                        "prerequisites": "Prima di affrontare \"Dimensione vettore (`sizeof`)\", lo studente dovrebbe aver seguito il lavoro precedente su \"Inizializzare un vettore\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                        "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Dimensione vettore (`sizeof`)\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                        "recall": "Richiama il passaggio precedente su \"Inizializzare un vettore\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                        "preview": "Questo argomento prepara il lavoro successivo su \"Relazione tra array e puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                        "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dimensione vettore (`sizeof`)\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Relazione tra array e puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                        "references": "Riferimento principale: README.md, sezione \"Dimensione vettore (`sizeof`)\" (../README.md#dimensione-vettore-sizeof). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                       },
                       "frame_quality": {
-                        "context": "none",
-                        "prerequisites": "none",
-                        "objectives": "none",
-                        "recall": "none",
-                        "preview": "none",
-                        "next_step": "none",
-                        "references": "none"
+                        "context": "ai",
+                        "prerequisites": "ai",
+                        "objectives": "ai",
+                        "recall": "ai",
+                        "preview": "ai",
+                        "next_step": "ai",
+                        "references": "ai"
                       }
                     }
                   ],
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1923,22 +1937,22 @@
                   "line": 10094,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Relazione tra array e puntatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Dimensione vettore (`sizeof`)\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Relazione tra array e puntatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Dimensione vettore (`sizeof`)\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
                     "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Relazione tra array e puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Dimensione vettore (`sizeof`)\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Differenza tra puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Relazione tra array e puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Differenza tra puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Relazione tra array e puntatori\" (../README.md#relazione-tra-array-e-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "recall": "Richiama il passaggio precedente su \"Dimensione vettore (`sizeof`)\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Differenza tra puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Relazione tra array e puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Differenza tra puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Relazione tra array e puntatori\" (../README.md#relazione-tra-array-e-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1950,22 +1964,22 @@
                   "line": 10341,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Differenza tra puntatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Relazione tra array e puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per il Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Differenza tra puntatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Relazione tra array e puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
                     "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Differenza tra puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Relazione tra array e puntatori\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Le stringhe\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Differenza tra puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Le stringhe\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Differenza tra puntatori\" (../README.md#differenza-tra-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "recall": "Richiama il passaggio precedente su \"Relazione tra array e puntatori\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Le stringhe\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Differenza tra puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Le stringhe\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Differenza tra puntatori\" (../README.md#differenza-tra-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -1977,22 +1991,22 @@
                   "line": 10492,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su array di char terminati da carattere nullo e funzioni di libreria associate. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Le stringhe\" lo studente dovrebbe aver seguito il lavoro precedente su \"Differenza tra puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Le stringhe\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Differenza tra puntatori\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Dettagli sull'inizializzazione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Le stringhe\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Dettagli sull'inizializzazione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Le stringhe\" (../README.md#le-stringhe). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su array di char terminati da carattere nullo e funzioni di libreria associate. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Le stringhe\", lo studente dovrebbe aver seguito il lavoro precedente su \"Differenza tra puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo delle \"stringhe\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Differenza tra puntatori\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Dettagli sull'inizializzazione\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Le stringhe\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Dettagli sull'inizializzazione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Le stringhe\" (../README.md#le-stringhe). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2004,22 +2018,22 @@
                   "line": 10732,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Dettagli sull'inizializzazione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Le stringhe\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Dettagli sull'inizializzazione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Le stringhe\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Stampare una stringa\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dettagli sull'inizializzazione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Stampare una stringa\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Dettagli sull'inizializzazione\" (../README.md#dettagli-sullinizializzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Dettagli sull'inizializzazione\", lo studente dovrebbe aver seguito il lavoro precedente su \"Le stringhe\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Dettagli sull'inizializzazione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Le stringhe\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Stampare una stringa\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dettagli sull'inizializzazione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Stampare una stringa\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Dettagli sull'inizializzazione\" (../README.md#dettagli-sull-inizializzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2031,22 +2045,22 @@
                   "line": 11008,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Stampare una stringa\" lo studente dovrebbe aver seguito il lavoro precedente su \"Dettagli sull'inizializzazione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Stampare una stringa\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Dettagli sull'inizializzazione\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Stampare una stringa\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Stampare una stringa\" (../README.md#stampare-una-stringa). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Stampare una stringa\", lo studente dovrebbe aver seguito il lavoro precedente su \"Dettagli sull'inizializzazione\", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Stampare una stringa\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Dettagli sull'inizializzazione\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Stampare una stringa\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Stampare una stringa\" (../README.md#stampare-una-stringa). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2058,22 +2072,22 @@
                   "line": 11039,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"Stampare una stringa\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Stampare una stringa\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Dichiarazione di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Dichiarazione di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Funzioni\" (../README.md#funzioni-1). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sulla scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Funzioni\", lo studente dovrebbe aver seguito il lavoro precedente su \"Stampare una stringa\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Stampare una stringa\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Dichiarazione di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Dichiarazione di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Funzioni\" (../README.md#funzioni-1). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2085,22 +2099,22 @@
                   "line": 11134,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Dichiarazione di funzione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Dichiarazione di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Funzioni\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Uso di void nelle funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dichiarazione di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Uso di void nelle funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Dichiarazione di funzione\" (../README.md#dichiarazione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore: i puntatori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Dichiarazione di funzione\", lo studente dovrebbe aver seguito il lavoro precedente su \"Funzioni\", sapere compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Dichiarazione di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Funzioni\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Uso di void nelle funzioni\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Dichiarazione di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è quello di collegare questo argomento a \"Uso di void nelle funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Dichiarazione di funzione\" (../README.md#dichiarazione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2112,22 +2126,22 @@
                   "line": 11236,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Uso di void nelle funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"Dichiarazione di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Uso di void nelle funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Dichiarazione di funzione\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Definizione di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Uso di void nelle funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Definizione di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Uso di void nelle funzioni\" (../README.md#uso-di-void-nelle-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sulla scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Uso di void nelle funzioni\", lo studente dovrebbe aver seguito il lavoro precedente su \"Dichiarazione di funzione\", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Uso di void nelle funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Dichiarazione di funzione\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Definizione di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Uso di void nelle funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Definizione di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Uso di void nelle funzioni\" (../README.md#uso-di-void-nelle-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2139,22 +2153,22 @@
                   "line": 11262,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Definizione di funzione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Uso di void nelle funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Definizione di funzione\", lo studente dovrebbe aver seguito il lavoro precedente su \"Uso di void nelle funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
                     "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Definizione di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Uso di void nelle funzioni\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Chiamata di funzione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Definizione di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Chiamata di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Definizione di funzione\" (../README.md#definizione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "recall": "Richiama il passaggio precedente su \"Uso di void nelle funzioni\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Chiamata di funzione\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Definizione di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Chiamata di funzione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Definizione di funzione\" (../README.md#definizione-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2166,22 +2180,22 @@
                   "line": 11282,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Chiamata di funzione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Definizione di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Chiamata di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Definizione di funzione\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di parametri per valore\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Chiamata di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Passaggio di parametri per valore\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Chiamata di funzione\" (../README.md#chiamata-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per il Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Chiamata di funzione\", lo studente dovrebbe aver seguito il lavoro precedente su \"Definizione di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Chiamata di funzione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Definizione di funzione\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di parametri per valore\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Chiamata di funzione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Passaggio di parametri per valore\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Chiamata di funzione\" (../README.md#chiamata-di-funzione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2193,22 +2207,22 @@
                   "line": 11335,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Passaggio di parametri per valore\" lo studente dovrebbe aver seguito il lavoro precedente su \"Chiamata di funzione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Passaggio di parametri per valore\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Chiamata di funzione\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di parametri per indirizzo\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di parametri per valore\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Passaggio di parametri per indirizzo\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Passaggio di parametri per valore\" (../README.md#passaggio-di-parametri-per-valore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Passaggio di parametri per valore\", lo studente dovrebbe aver seguito il lavoro precedente su \"Chiamata di funzione\", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Passaggio di parametri per valore\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Chiamata di funzione\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di parametri per indirizzo\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di parametri per valore\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Passaggio di parametri per indirizzo\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Passaggio di parametri per valore\" (../README.md#passaggio-di-parametri-per-valore). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2220,22 +2234,22 @@
                   "line": 11501,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Passaggio di parametri per indirizzo\" lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di parametri per valore\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Passaggio di parametri per indirizzo\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Passaggio di parametri per valore\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di puntatori const\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di parametri per indirizzo\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Passaggio di puntatori const\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Passaggio di parametri per indirizzo\" (../README.md#passaggio-di-parametri-per-indirizzo). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Passaggio di parametri per indirizzo\", lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di parametri per valore\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Passaggio di parametri per indirizzo\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Passaggio di parametri per valore\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di puntatori const\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di parametri per indirizzo\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Passaggio di puntatori const\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Passaggio di parametri per indirizzo\" (../README.md#passaggio-di-parametri-per-indirizzo). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2247,22 +2261,22 @@
                   "line": 11676,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Passaggio di puntatori const\" lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di parametri per indirizzo\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Passaggio di puntatori const\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Passaggio di parametri per indirizzo\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Array come parametri a funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di puntatori const\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Array come parametri a funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Passaggio di puntatori const\" (../README.md#passaggio-di-puntatori-const). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su indirizzi, dereferenziazione, aritmetica dei puntatori e relazione con gli array. Si collega al blocco superiore: I puntatori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Passaggio di puntatori const\" lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di parametri per indirizzo\", saper compilare ed eseguire piccoli programmi in C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo di \"Passaggio di puntatori const\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Passaggio di parametri per indirizzo\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Array come parametri a funzioni\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di puntatori const\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Array come parametri a funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Passaggio di puntatori const\" (../README.md#passaggio-di-puntatori-const). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2274,22 +2288,22 @@
                   "line": 11789,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Array come parametri a funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di puntatori const\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Array come parametri a funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Passaggio di puntatori const\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Allocazione dinamica della memoria\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array come parametri a funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Allocazione dinamica della memoria\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Array come parametri a funzioni\" (../README.md#array-come-parametri-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sulla scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore: I puntatori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Array come parametri a funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di puntatori const\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Array come parametri a funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Passaggio di puntatori const\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Allocazione dinamica della memoria\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array come parametri a funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Allocazione dinamica della memoria\", oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Array come parametri a funzioni\" (../README.md#array-come-parametri-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2301,22 +2315,22 @@
                   "line": 11920,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Allocazione dinamica della memoria\" lo studente dovrebbe aver seguito il lavoro precedente su \"Array come parametri a funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Allocazione dinamica della memoria\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Array come parametri a funzioni\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Array bidimensionali\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Allocazione dinamica della memoria\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Array bidimensionali\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Allocazione dinamica della memoria\" (../README.md#allocazione-dinamica-della-memoria). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore: i puntatori. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Allocazione dinamica della memoria\", lo studente dovrebbe aver seguito il lavoro precedente su \"Array come parametri a funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Allocazione dinamica della memoria\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Array come parametri a funzioni\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Array bidimensionali\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Allocazione dinamica della memoria\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Array bidimensionali\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Allocazione dinamica della memoria\" (../README.md#allocazione-dinamica-della-memoria). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2328,22 +2342,22 @@
                   "line": 12141,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Array bidimensionali\" lo studente dovrebbe aver seguito il lavoro precedente su \"Allocazione dinamica della memoria\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Array bidimensionali\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Allocazione dinamica della memoria\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Array di puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array bidimensionali\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Array di puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Array bidimensionali\" (../README.md#array-bidimensionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per il Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Array bidimensionali\", lo studente dovrebbe aver seguito il lavoro precedente su \"Allocazione dinamica della memoria\", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Array bidimensionali\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Allocazione dinamica della memoria\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Array di puntatori\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array bidimensionali\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Array di puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Array bidimensionali\" (../README.md#array-bidimensionali). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2355,22 +2369,22 @@
                   "line": 12352,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Array di puntatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Array bidimensionali\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Array di puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Array bidimensionali\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Differenza tra array bidimensionali e array di puntatori\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array di puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Differenza tra array bidimensionali e array di puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Array di puntatori\" (../README.md#array-di-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Array di puntatori\", lo studente dovrebbe aver seguito il lavoro precedente su \"Array bidimensionali\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Array di puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Array bidimensionali\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Differenza tra array bidimensionali e array di puntatori\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Array di puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Differenza tra array bidimensionali e array di puntatori\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Array di puntatori\" (../README.md#array-di-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2382,22 +2396,22 @@
                   "line": 12586,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Differenza tra array bidimensionali e array di puntatori\" lo studente dovrebbe aver seguito il lavoro precedente su \"Array di puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Differenza tra array bidimensionali e array di puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Array di puntatori\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Sezioni di memoria di un programma C\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Differenza tra array bidimensionali e array di puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Sezioni di memoria di un programma C\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Differenza tra array bidimensionali e array di puntatori\" (../README.md#differenza-tra-array-bidimensionali-e-array-di-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su sequenze contigue di elementi, indici, dimensione e accesso in memoria. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Differenza tra array bidimensionali e array di puntatori\", lo studente dovrebbe aver seguito il lavoro precedente su \"Array di puntatori\", sapere come compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Differenza tra array bidimensionali e array di puntatori\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Array di puntatori\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Sezioni di memoria di un programma C\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Differenza tra array bidimensionali e array di puntatori\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Sezioni di memoria di un programma C\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Differenza tra array bidimensionali e array di puntatori\" (../README.md#differenza-tra-array-bidimensionali-e-array-di-puntatori). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2409,22 +2423,22 @@
                   "line": 12801,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su struttura minima di un programma C, funzione main, include e stampa a video. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Sezioni di memoria di un programma C\" lo studente dovrebbe aver seguito il lavoro precedente su \"Differenza tra array bidimensionali e array di puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Sezioni di memoria di un programma C\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Differenza tra array bidimensionali e array di puntatori\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"L'inizializzazione delle variabili\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Sezioni di memoria di un programma C\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"L'inizializzazione delle variabili\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"Sezioni di memoria di un programma C\" (../README.md#sezioni-di-memoria-di-un-programma-c). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sulla struttura minima di un programma C, la funzione main, include e la stampa a video. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Sezioni di memoria di un programma C\" lo studente dovrebbe aver seguito il lavoro precedente su \"Differenza tra array bidimensionali e array di puntatori\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve saper spiegare il ruolo delle \"sezioni di memoria di un programma C\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Differenza tra array bidimensionali e array di puntatori\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"L'inizializzazione delle variabili\". Durante la spiegazione, conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Sezioni di memoria di un programma C\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"L'inizializzazione delle variabili\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"Sezioni di memoria di un programma C\" (../README.md#sezioni-di-memoria-di-un-programma-c). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2436,22 +2450,22 @@
                   "line": 12867,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su dichiarazione, tipo, valore, memoria e uso dei dati durante l'esecuzione. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"L'inizializzazione delle variabili\" lo studente dovrebbe aver seguito il lavoro precedente su \"Sezioni di memoria di un programma C\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"L'inizializzazione delle variabili\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Sezioni di memoria di un programma C\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Allocazione dinamica di matrici\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"L'inizializzazione delle variabili\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Allocazione dinamica di matrici\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                    "references": "Riferimento principale: README.md sezione \"L'inizializzazione delle variabili\" (../README.md#linizializzazione-delle-variabili). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su dichiarazione, tipo, valore, memoria e uso dei dati durante l'esecuzione. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"L'inizializzazione delle variabili\", lo studente dovrebbe aver seguito il lavoro precedente su \"Sezioni di memoria di un programma C\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo dell'inizializzazione delle variabili, riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"Sezioni di memoria di un programma C\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Allocazione dinamica di matrici\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"L'inizializzazione delle variabili\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Allocazione dinamica di matrici\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "references": "Riferimento principale: README.md, sezione \"L'inizializzazione delle variabili\" (../README.md#linizializzazione-delle-variabili). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2463,22 +2477,22 @@
                   "line": 12896,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Allocazione dinamica di matrici\" lo studente dovrebbe aver seguito il lavoro precedente su \"L'inizializzazione delle variabili\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                    "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Allocazione dinamica di matrici\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"L'inizializzazione delle variabili\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Le strutture\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Allocazione dinamica di matrici\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Le strutture\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Allocazione dinamica di matrici\", lo studente dovrebbe aver seguito il lavoro precedente su \"L'inizializzazione delle variabili\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "objectives": "Alla fine della lezione, lo studente deve sapere spiegare il ruolo di \"Allocazione dinamica di matrici\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                    "recall": "Richiama il passaggio precedente su \"L'inizializzazione delle variabili\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Le strutture\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Allocazione dinamica di matrici\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Le strutture\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
                     "references": "Riferimento principale: README.md sezione \"Allocazione dinamica di matrici\" (../README.md#allocazione-dinamica-di-matrici). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 },
                 {
@@ -2490,12 +2504,12 @@
                   "line": 13330,
                   "frame": {
                     "status": "draft",
-                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore I puntatori. I sottoparagrafi collegati sono: Passaggio di strutture a funzioni. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                    "prerequisites": "Prima di affrontare \"Le strutture\" lo studente dovrebbe aver seguito il lavoro precedente su \"Allocazione dinamica di matrici\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                    "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare sul concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. Si collega al blocco superiore \"I puntatori\". I sottoparagrafi collegati sono: Passaggio di strutture a funzioni. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                    "prerequisites": "Prima di affrontare \"Le strutture\", lo studente dovrebbe aver seguito il lavoro precedente su \"Allocazione dinamica di matrici\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
                     "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Le strutture\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                    "recall": "Richiama il passaggio precedente su \"Allocazione dinamica di matrici\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                    "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di strutture a funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Le strutture\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Passaggio di strutture a funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                    "recall": "Richiama il passaggio precedente su \"Allocazione dinamica di matrici\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                    "preview": "Questo argomento prepara il lavoro successivo su \"Passaggio di strutture a funzioni\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                    "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Le strutture\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Passaggio di strutture a funzioni\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
                     "references": "Riferimento principale: README.md sezione \"Le strutture\" (../README.md#le-strutture). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                   },
                   "children": [
@@ -2508,44 +2522,44 @@
                       "line": 13502,
                       "frame": {
                         "status": "draft",
-                        "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per Terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore I puntatori > Le strutture. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                        "prerequisites": "Prima di affrontare \"Passaggio di strutture a funzioni\" lo studente dovrebbe aver seguito il lavoro precedente su \"Le strutture\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                        "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Passaggio di strutture a funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                        "recall": "Richiama il passaggio precedente su \"Le strutture\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                        "preview": "Questo argomento prepara il lavoro successivo su \"Classi di memorizzazione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                        "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di strutture a funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Classi di memorizzazione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                        "references": "Riferimento principale: README.md sezione \"Passaggio di strutture a funzioni\" (../README.md#passaggio-di-strutture-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                        "context": "Questo argomento si colloca nell'UDA \"Puntatori, array e indirizzi\" del percorso Intermedio per terzo anno. Serve a lavorare su scomposizione del programma, parametri, valore di ritorno e riuso del codice. Si collega al blocco superiore \"I puntatori > Le strutture\". La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                        "prerequisites": "Prima di affrontare \"Passaggio di strutture a funzioni\", lo studente dovrebbe aver seguito il lavoro precedente su \"Le strutture\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                        "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"Passaggio di strutture a funzioni\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre sapere indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                        "recall": "Richiama il passaggio precedente su \"Le strutture\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                        "preview": "Questo argomento prepara il lavoro successivo su \"Classi di memorizzazione\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                        "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Passaggio di strutture a funzioni\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è quello di collegare questo argomento a \"Classi di memorizzazione\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                        "references": "Riferimento principale: README.md, sezione \"Passaggio di strutture a funzioni\" (../README.md#passaggio-di-strutture-a-funzioni). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
                       },
                       "frame_quality": {
-                        "context": "none",
-                        "prerequisites": "none",
-                        "objectives": "none",
-                        "recall": "none",
-                        "preview": "none",
-                        "next_step": "none",
-                        "references": "none"
+                        "context": "ai",
+                        "prerequisites": "ai",
+                        "objectives": "ai",
+                        "recall": "ai",
+                        "preview": "ai",
+                        "next_step": "ai",
+                        "references": "ai"
                       }
                     }
                   ],
                   "frame_quality": {
-                    "context": "none",
-                    "prerequisites": "none",
-                    "objectives": "none",
-                    "recall": "none",
-                    "preview": "none",
-                    "next_step": "none",
-                    "references": "none"
+                    "context": "ai",
+                    "prerequisites": "ai",
+                    "objectives": "ai",
+                    "recall": "ai",
+                    "preview": "ai",
+                    "next_step": "ai",
+                    "references": "ai"
                   }
                 }
               ],
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             }
           ]
@@ -2565,22 +2579,22 @@
               "line": 1812,
               "frame": {
                 "status": "draft",
-                "context": "Questo argomento si colloca nell'UDA \"Memoria automatica, statica e dinamica\" del percorso Intermedio per Terzo anno. Serve a lavorare su durata, visibilita e collegamento degli identificatori in C. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Classi di memorizzazione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di strutture a funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
-                "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Classi di memorizzazione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
-                "recall": "Richiama il passaggio precedente su \"Passaggio di strutture a funzioni\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
-                "preview": "Questo argomento prepara il lavoro successivo su \"Block scope\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
-                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Classi di memorizzazione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso e collegare questo argomento a \"Block scope\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
-                "references": "Riferimento principale: README.md sezione \"Classi di memorizzazione\" (../README.md#classi-di-memorizzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
+                "context": "Questo argomento si colloca nell'UDA \"Memoria automatica, statica e dinamica\" del percorso Intermedio per Terzo anno. Serve a lavorare su durata, visibilità e collegamento degli identificatori in C. La cornice è pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo però il filo sequenziale della dispensa.",
+                "prerequisites": "Prima di affrontare \"Classi di memorizzazione\" lo studente dovrebbe aver seguito il lavoro precedente su \"Passaggio di strutture a funzioni\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "objectives": "Alla fine della lezione lo studente deve sapere spiegare il ruolo di \"classi di memorizzazione\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
+                "recall": "Richiama il passaggio precedente su \"Passaggio di strutture a funzioni\" e riprendi il vocabolario già consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo è far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
+                "preview": "Questo argomento prepara il lavoro successivo su \"Block scope\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi più avanti, così da non sovraccaricare la prima lettura, ma lasciare già una mappa mentale del percorso.",
+                "next_step": "Dopo la spiegazione, proponi un esempio minimo su \"Classi di memorizzazione\", poi un piccolo esercizio di modifica e infine una domanda di controllo. Il passo successivo nel percorso è collegare questo argomento a \"Block scope\" oppure, se l'argomento ha sottoparagrafi, affrontarli in ordine.",
+                "references": "Riferimento principale: README.md, sezione \"Classi di memorizzazione\" (../README.md#classi-di-memorizzazione). Usare gli eventuali laboratori collegati nel README come esercizi di osservazione, modifica, scrittura autonoma e debug."
               },
               "frame_quality": {
-                "context": "none",
-                "prerequisites": "none",
-                "objectives": "none",
-                "recall": "none",
-                "preview": "none",
-                "next_step": "none",
-                "references": "none"
+                "context": "ai",
+                "prerequisites": "ai",
+                "objectives": "ai",
+                "recall": "ai",
+                "preview": "ai",
+                "next_step": "ai",
+                "references": "ai"
               }
             },
             {
@@ -2593,7 +2607,7 @@
               "frame": {
                 "status": "draft",
                 "context": "Questo argomento si colloca nell'UDA \"Memoria automatica, statica e dinamica\" del percorso Intermedio per Terzo anno. Serve a lavorare su concetto tecnico previsto dal percorso, con attenzione al legame tra teoria, esempi e laboratorio. La cornice e pensata per rendere il paragrafo leggibile anche singolarmente, mantenendo pero il filo sequenziale della dispensa.",
-                "prerequisites": "Prima di affrontare \"Block scope\" lo studente dovrebbe aver seguito il lavoro precedente su \"Classi di memorizzazione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico gia introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
+                "prerequisites": "Prima di affrontare \"Block scope\" lo studente dovrebbe aver seguito il lavoro precedente su \"Classi di memorizzazione\", saper compilare ed eseguire piccoli programmi C, leggere esempi guidati e riconoscere il lessico tecnico già introdotto. Se il tema richiama concetti non ancora pienamente sviluppati, questi vanno trattati come anticipazioni e non come prerequisiti rigidi.",
                 "objectives": "Alla fine della lezione lo studente deve saper spiegare il ruolo di \"Block scope\", riconoscere gli elementi tecnici principali, leggere un esempio minimo, modificarlo in modo controllato e collegarlo agli esercizi di laboratorio. Deve inoltre saper indicare almeno un errore tipico collegato all'argomento e descrivere come diagnosticarlo.",
                 "recall": "Richiama il passaggio precedente su \"Classi di memorizzazione\" e riprendi il vocabolario gia consolidato: sorgente, compilazione, variabile, tipo, memoria, funzione, input/output o controllo del flusso, a seconda del punto del percorso. L'obiettivo e far percepire l'argomento come prosecuzione naturale, non come blocco isolato.",
                 "preview": "Questo argomento prepara il lavoro successivo su \"File scope\". Durante la spiegazione conviene evidenziare quali dettagli verranno approfonditi piu avanti, cosi da non sovraccaricare la prima lettura ma lasciare gia una mappa mentale del percorso.",
@@ -2602,7 +2616,7 @@
               },
               "frame_quality": {
                 "context": "none",
-                "prerequisites": "none",
+                "prerequisites": "local",
                 "objectives": "none",
                 "recall": "none",
                 "preview": "none",

--- a/doc/course_designs/course_design_code.json
+++ b/doc/course_designs/course_design_code.json
@@ -17,6 +17,13 @@
           "title": "Strumenti, primo programma e rappresentazione",
           "path": "Base",
           "weeks": "3",
+          "actual": {
+            "status": "done",
+            "start_date": "2026-09-07",
+            "end_date": "2026-09-25",
+            "hours_done": 9,
+            "notes": "Demo: consuntivo inserito come se fosse stato salvato dal pannello calendario docente."
+          },
           "items": [
             {
               "id": "README.md#introduzione",
@@ -483,6 +490,13 @@
           "title": "Operatori, condizioni e selezione",
           "path": "Base",
           "weeks": "3",
+          "actual": {
+            "status": "in_progress",
+            "start_date": "2026-09-28",
+            "end_date": "2026-10-16",
+            "hours_done": 7,
+            "notes": "Demo: consuntivo parziale per verificare la resa nel calendario docente e studente."
+          },
           "items": [
             {
               "id": "README.md#operatori",

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -17,6 +17,14 @@ def run_student_dashboard_js(assertions: str) -> None:
         this.textContent = "";
         this.innerHTML = "";
         this.disabled = false;
+        this.classList = {{
+          values: new Set(),
+          toggle: (name, force) => {{
+            if (force) this.classList.values.add(name);
+            else this.classList.values.delete(name);
+          }},
+          contains: (name) => this.classList.values.has(name),
+        }};
       }}
       addEventListener() {{}}
     }}
@@ -319,9 +327,41 @@ def test_student_dashboard_renders_readonly_calendar_events() -> None:
         assert.match(tested.els.studentCalendar.innerHTML, /Loop in Python/);
         assert.match(tested.els.studentCalendar.innerHTML, /studentMonthGrid/);
         assert.match(tested.els.studentCalendar.innerHTML, /studentMonthMainCard/);
+        assert.match(tested.els.studentCalendar.innerHTML, /data-student-calendar-nav="previous"/);
+        assert.equal(tested.els.studentCalendarMonthField.classList.contains("isHidden"), false);
+        assert.equal(tested.els.studentCalendarWeekField.classList.contains("isHidden"), true);
         assert.equal((tested.els.studentCalendar.innerHTML.match(/Prossima scadenza/g) || []).length, 2);
         assert.match(tested.els.studentCalendarStatus.textContent, /6 eventi .* 3 scadenze/);
         assert.equal(tested.studentCalendarEvents([openSooner, sameDeadline, submitted]).at(-1).title, "Somma in Python");
+        """
+    )
+
+
+def test_student_dashboard_calendar_supports_week_and_year_modes() -> None:
+    run_student_dashboard_js(
+        """
+        const assignment = {
+          activity_id: "python-base-somma-001",
+          title: "Somma in Python",
+          assigned_at: "2026-10-10T08:00:00+02:00",
+          due_at: "2026-10-18T23:59:00+02:00",
+          status: "assigned",
+          submitted: false,
+        };
+
+        tested.els.studentCalendarViewMode.value = "week";
+        tested.renderStudentCalendar([assignment]);
+        assert.match(tested.els.studentCalendar.innerHTML, /Settimana:/);
+        assert.match(tested.els.studentCalendar.innerHTML, /data-student-calendar-nav="next"/);
+        assert.equal(tested.els.studentCalendarMonthField.classList.contains("isHidden"), true);
+        assert.equal(tested.els.studentCalendarWeekField.classList.contains("isHidden"), false);
+
+        tested.els.studentCalendarViewMode.value = "year";
+        tested.renderStudentCalendar([assignment]);
+        assert.match(tested.els.studentCalendar.innerHTML, /studentMonthGrid/);
+        assert.doesNotMatch(tested.els.studentCalendar.innerHTML, /data-student-calendar-nav="next"/);
+        assert.equal(tested.els.studentCalendarMonthField.classList.contains("isHidden"), true);
+        assert.equal(tested.els.studentCalendarWeekField.classList.contains("isHidden"), true);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -48,6 +48,7 @@ def run_student_dashboard_js(assertions: str) -> None:
     vm.runInNewContext(`${{source}}
       globalThis.__studentDashboardTest = {{
         renderSummary,
+        renderStudentCalendar,
         renderCoursePath,
         renderFeedback,
         renderAssignment,
@@ -60,6 +61,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         sortedAssignments,
         nextOpenAssignment,
         nextOpenDueAt,
+        studentCalendarEvents,
         collectCourseItems,
         courseItemHref,
         safeExternalHref,
@@ -275,6 +277,59 @@ def test_student_dashboard_summarizes_next_open_due_date() -> None:
         assert.match(tested.els.summary.innerHTML, /<strong>Prossima scadenza<\\/strong>\\s*<span>18\\/10\\/26, 23:59<\\/span>/);
         assert.match(tested.els.assignments.innerHTML, /Prossima scadenza/);
         assert.equal((tested.els.assignments.innerHTML.match(/Prossima scadenza/g) || []).length, 2);
+        """
+    )
+
+
+def test_student_dashboard_renders_readonly_calendar_events() -> None:
+    run_student_dashboard_js(
+        """
+        const openSooner = {
+          activity_id: "python-base-somma-001",
+          title: "Somma in Python",
+          kind: "compito-casa",
+          student_support_mode: "feedback-tecnico",
+          assigned_at: "2026-10-10T08:00:00+02:00",
+          due_at: "2026-10-18T23:59:00+02:00",
+          status: "assigned",
+          submitted: false,
+        };
+        const sameDeadline = {
+          activity_id: "python-loop-001",
+          title: "Loop in Python",
+          assigned_at: "2026-10-12T08:00:00+02:00",
+          due_at: "2026-10-18T23:59:00+02:00",
+          status: "missing",
+          submitted: false,
+        };
+        const submitted = {
+          activity_id: "python-stringhe-001",
+          title: "Stringhe in Python",
+          assigned_at: "2026-10-01T08:00:00+02:00",
+          due_at: "2026-10-15T23:59:00+02:00",
+          status: "submitted_on_time",
+          submitted: true,
+        };
+
+        tested.renderDashboard({ student_id: "rossi-mario", assignments: [openSooner, sameDeadline, submitted] });
+
+        assert.match(tested.els.studentCalendar.innerHTML, /Stringhe in Python/);
+        assert.match(tested.els.studentCalendar.innerHTML, /Somma in Python/);
+        assert.match(tested.els.studentCalendar.innerHTML, /Loop in Python/);
+        assert.equal((tested.els.studentCalendar.innerHTML.match(/Prossima scadenza/g) || []).length, 2);
+        assert.match(tested.els.studentCalendarStatus.textContent, /6 eventi .* 3 scadenze/);
+        assert.equal(tested.studentCalendarEvents([openSooner, sameDeadline, submitted]).at(-1).title, "Somma in Python");
+        """
+    )
+
+
+def test_student_dashboard_renders_empty_calendar_message() -> None:
+    run_student_dashboard_js(
+        """
+        tested.renderStudentCalendar([{ title: "Senza date" }]);
+
+        assert.match(tested.els.studentCalendar.innerHTML, /Nessuna data disponibile/);
+        assert.equal(tested.els.studentCalendarStatus.textContent, "");
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -17,6 +17,11 @@ def run_student_dashboard_js(assertions: str) -> None:
         this.textContent = "";
         this.innerHTML = "";
         this.disabled = false;
+        this.dataset = selector.includes("list")
+          ? {{ studentCalendarDisplay: "list" }}
+          : selector.includes("calendar")
+            ? {{ studentCalendarDisplay: "calendar" }}
+            : {{}};
         this.classList = {{
           values: new Set(),
           toggle: (name, force) => {{
@@ -27,6 +32,8 @@ def run_student_dashboard_js(assertions: str) -> None:
         }};
       }}
       addEventListener() {{}}
+      setAttribute(name, value) {{ this[name] = value; }}
+      closest() {{ return this; }}
     }}
 
     const elements = new Map();
@@ -38,7 +45,12 @@ def run_student_dashboard_js(assertions: str) -> None:
     const context = {{
       console,
       URL,
-      document: {{ querySelector: elementFor }},
+      document: {{
+        querySelector: elementFor,
+        querySelectorAll: (selector) => selector === "[data-student-calendar-display]"
+          ? [elementFor("[data-student-calendar-display=calendar]"), elementFor("[data-student-calendar-display=list]")]
+          : [],
+      }},
       fetch: async () => ({{
         ok: true,
         status: 200,
@@ -85,6 +97,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         gradingBadge,
         gradeValue,
         setCurrentCourseDesign: (design) => {{ currentCourseDesign = design; }},
+        setStudentCalendarDisplay: (display) => {{ currentStudentCalendarView.display = display; }},
         els,
       }};
     `, context);
@@ -330,9 +343,35 @@ def test_student_dashboard_renders_readonly_calendar_events() -> None:
         assert.match(tested.els.studentCalendar.innerHTML, /data-student-calendar-nav="previous"/);
         assert.equal(tested.els.studentCalendarMonthField.classList.contains("isHidden"), false);
         assert.equal(tested.els.studentCalendarWeekField.classList.contains("isHidden"), true);
+        assert.equal(tested.els.studentCalendarViewMode.closest().classList.contains("isHidden"), false);
         assert.equal((tested.els.studentCalendar.innerHTML.match(/Prossima scadenza/g) || []).length, 2);
         assert.match(tested.els.studentCalendarStatus.textContent, /6 eventi .* 3 scadenze/);
         assert.equal(tested.studentCalendarEvents([openSooner, sameDeadline, submitted]).at(-1).title, "Somma in Python");
+        """
+    )
+
+
+def test_student_dashboard_calendar_can_render_list_view() -> None:
+    run_student_dashboard_js(
+        """
+        const assignment = {
+          activity_id: "python-base-somma-001",
+          title: "Somma in Python",
+          assigned_at: "2026-10-10T08:00:00+02:00",
+          due_at: "2026-10-18T23:59:00+02:00",
+          status: "assigned",
+          submitted: false,
+        };
+
+        tested.setStudentCalendarDisplay("list");
+        tested.renderStudentCalendar([assignment]);
+
+        assert.match(tested.els.studentCalendar.innerHTML, /studentCalendarList/);
+        assert.match(tested.els.studentCalendar.innerHTML, /Somma in Python/);
+        assert.doesNotMatch(tested.els.studentCalendar.innerHTML, /studentMonthGrid/);
+        assert.equal(tested.els.studentCalendarMonthField.classList.contains("isHidden"), true);
+        assert.equal(tested.els.studentCalendarWeekField.classList.contains("isHidden"), true);
+        assert.equal(tested.els.studentCalendarViewMode.closest().classList.contains("isHidden"), true);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -337,12 +337,17 @@ def test_student_dashboard_renders_readonly_calendar_events() -> None:
           submitted: true,
         };
 
-        tested.setCurrentSchoolCalendar({ start_date: "2026-09-01", end_date: "2026-11-30" });
+        tested.setCurrentSchoolCalendar({
+          start_date: "2026-09-01",
+          end_date: "2026-11-30",
+          closures: [{ label: "Ognissanti", from: "2026-11-01", to: "2026-11-01" }],
+        });
         tested.renderDashboard({ student_id: "rossi-mario", assignments: [openSooner, sameDeadline, submitted] });
 
         assert.match(tested.els.studentCalendar.innerHTML, /Stringhe in Python/);
         assert.match(tested.els.studentCalendar.innerHTML, /Somma in Python/);
         assert.match(tested.els.studentCalendar.innerHTML, /Loop in Python/);
+        assert.match(tested.els.studentCalendar.innerHTML, /Ognissanti/);
         assert.match(tested.els.studentCalendar.innerHTML, /studentMonthGrid/);
         assert.match(tested.els.studentCalendar.innerHTML, /studentMonthMainCard/);
         assert.match(tested.els.studentCalendar.innerHTML, /data-student-calendar-nav="previous"/);
@@ -352,7 +357,7 @@ def test_student_dashboard_renders_readonly_calendar_events() -> None:
         assert.equal(tested.els.studentCalendarWeekField.classList.contains("isHidden"), true);
         assert.equal(tested.els.studentCalendarViewMode.closest().classList.contains("isHidden"), false);
         assert.equal((tested.els.studentCalendar.innerHTML.match(/Prossima scadenza/g) || []).length, 2);
-        assert.match(tested.els.studentCalendarStatus.textContent, /6 eventi .* 3 scadenze/);
+        assert.match(tested.els.studentCalendarStatus.textContent, /7 eventi .* 3 scadenze .* 1 chiusure/);
         assert.equal(tested.studentCalendarEvents([openSooner, sameDeadline, submitted]).at(-1).title, "Somma in Python");
         """
     )
@@ -479,6 +484,29 @@ def test_student_dashboard_calendar_filters_visible_paths() -> None:
         tested.setVisibleStudentPathIds([]);
         tested.renderStudentCalendar([]);
         assert.doesNotMatch(tested.els.studentCalendar.innerHTML, /UDA-1 Fondamenti/);
+        """
+    )
+
+
+def test_student_dashboard_calendar_can_filter_closures() -> None:
+    run_student_dashboard_js(
+        """
+        tested.setCurrentSchoolCalendar({
+          start_date: "2026-10-01",
+          end_date: "2026-11-30",
+          closures: [{ label: "Ognissanti", from: "2026-11-01", to: "2026-11-01" }],
+        });
+        tested.els.studentCalendarFilter.value = "closures";
+        tested.renderStudentCalendar([{
+          title: "Somma in Python",
+          assigned_at: "2026-10-10T08:00:00+02:00",
+          due_at: "2026-10-18T23:59:00+02:00",
+          status: "assigned",
+          submitted: false,
+        }]);
+
+        assert.match(tested.els.studentCalendar.innerHTML, /Ognissanti/);
+        assert.doesNotMatch(tested.els.studentCalendar.innerHTML, /Somma in Python/);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -341,6 +341,7 @@ def test_student_dashboard_renders_readonly_calendar_events() -> None:
         assert.match(tested.els.studentCalendar.innerHTML, /studentMonthGrid/);
         assert.match(tested.els.studentCalendar.innerHTML, /studentMonthMainCard/);
         assert.match(tested.els.studentCalendar.innerHTML, /data-student-calendar-nav="previous"/);
+        assert.match(tested.els.studentCalendar.innerHTML, /data-calendar-detail-index="0"/);
         assert.equal(tested.els.studentCalendarMonthField.classList.contains("isHidden"), false);
         assert.equal(tested.els.studentCalendarWeekField.classList.contains("isHidden"), true);
         assert.equal(tested.els.studentCalendarViewMode.closest().classList.contains("isHidden"), false);
@@ -368,6 +369,7 @@ def test_student_dashboard_calendar_can_render_list_view() -> None:
 
         assert.match(tested.els.studentCalendar.innerHTML, /studentCalendarList/);
         assert.match(tested.els.studentCalendar.innerHTML, /Somma in Python/);
+        assert.match(tested.els.studentCalendar.innerHTML, /data-calendar-detail-index="0"/);
         assert.doesNotMatch(tested.els.studentCalendar.innerHTML, /studentMonthGrid/);
         assert.equal(tested.els.studentCalendarMonthField.classList.contains("isHidden"), true);
         assert.equal(tested.els.studentCalendarWeekField.classList.contains("isHidden"), true);

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -76,6 +76,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         statusBadge,
         gradingBadge,
         gradeValue,
+        setCurrentCourseDesign: (design) => {{ currentCourseDesign = design; }},
         els,
       }};
     `, context);
@@ -316,9 +317,46 @@ def test_student_dashboard_renders_readonly_calendar_events() -> None:
         assert.match(tested.els.studentCalendar.innerHTML, /Stringhe in Python/);
         assert.match(tested.els.studentCalendar.innerHTML, /Somma in Python/);
         assert.match(tested.els.studentCalendar.innerHTML, /Loop in Python/);
+        assert.match(tested.els.studentCalendar.innerHTML, /studentMonthGrid/);
+        assert.match(tested.els.studentCalendar.innerHTML, /studentMonthMainCard/);
         assert.equal((tested.els.studentCalendar.innerHTML.match(/Prossima scadenza/g) || []).length, 2);
         assert.match(tested.els.studentCalendarStatus.textContent, /6 eventi .* 3 scadenze/);
         assert.equal(tested.studentCalendarEvents([openSooner, sameDeadline, submitted]).at(-1).title, "Somma in Python");
+        """
+    )
+
+
+def test_student_dashboard_calendar_includes_actual_uda_events() -> None:
+    run_student_dashboard_js(
+        """
+        tested.populateClassRosterOptions([{
+          name: "demo-3a.json",
+          id: "demo-3a",
+          label: "Classe demo 3A",
+        }], "demo-3a.json");
+        tested.setCurrentCourseDesign({
+          paths: [{
+            id: "percorso-demo",
+            title: "Percorso demo",
+            audience: { class_ids: ["demo-3a"] },
+            udas: [{
+              id: "uda-1",
+              title: "Fondamenti",
+              actual: {
+                status: "done",
+                start_date: "2026-10-07",
+                end_date: "2026-10-09",
+              },
+              items: [],
+            }],
+          }],
+        });
+
+        tested.renderStudentCalendar([]);
+
+        assert.match(tested.els.studentCalendar.innerHTML, /UDA-1 Fondamenti/);
+        assert.match(tested.els.studentCalendar.innerHTML, /UDA reale/);
+        assert.match(tested.els.studentCalendarStatus.textContent, /2 eventi .* 0 scadenze .* 2 UDA/);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -34,6 +34,8 @@ def run_student_dashboard_js(assertions: str) -> None:
       addEventListener() {{}}
       setAttribute(name, value) {{ this[name] = value; }}
       closest() {{ return this; }}
+      querySelector(selector) {{ return elementFor(`${{this.selector}} ${{selector}}`); }}
+      querySelectorAll() {{ return []; }}
     }}
 
     const elements = new Map();
@@ -97,7 +99,9 @@ def run_student_dashboard_js(assertions: str) -> None:
         gradingBadge,
         gradeValue,
         setCurrentCourseDesign: (design) => {{ currentCourseDesign = design; }},
+        setCurrentSchoolCalendar: (calendar) => {{ currentSchoolCalendar = calendar; }},
         setStudentCalendarDisplay: (display) => {{ currentStudentCalendarView.display = display; }},
+        setVisibleStudentPathIds: (ids) => {{ visibleStudentPathIds = new Set(ids); }},
         els,
       }};
     `, context);
@@ -333,6 +337,7 @@ def test_student_dashboard_renders_readonly_calendar_events() -> None:
           submitted: true,
         };
 
+        tested.setCurrentSchoolCalendar({ start_date: "2026-09-01", end_date: "2026-11-30" });
         tested.renderDashboard({ student_id: "rossi-mario", assignments: [openSooner, sameDeadline, submitted] });
 
         assert.match(tested.els.studentCalendar.innerHTML, /Stringhe in Python/);
@@ -341,6 +346,7 @@ def test_student_dashboard_renders_readonly_calendar_events() -> None:
         assert.match(tested.els.studentCalendar.innerHTML, /studentMonthGrid/);
         assert.match(tested.els.studentCalendar.innerHTML, /studentMonthMainCard/);
         assert.match(tested.els.studentCalendar.innerHTML, /data-student-calendar-nav="previous"/);
+        assert.equal((tested.els.studentCalendar.innerHTML.match(/data-student-calendar-nav="previous"/g) || []).length, 3);
         assert.match(tested.els.studentCalendar.innerHTML, /data-calendar-detail-index="0"/);
         assert.equal(tested.els.studentCalendarMonthField.classList.contains("isHidden"), false);
         assert.equal(tested.els.studentCalendarWeekField.classList.contains("isHidden"), true);
@@ -438,6 +444,41 @@ def test_student_dashboard_calendar_includes_actual_uda_events() -> None:
         assert.match(tested.els.studentCalendar.innerHTML, /UDA-1 Fondamenti/);
         assert.match(tested.els.studentCalendar.innerHTML, /UDA reale/);
         assert.match(tested.els.studentCalendarStatus.textContent, /2 eventi .* 0 scadenze .* 2 UDA/);
+        """
+    )
+
+
+def test_student_dashboard_calendar_filters_visible_paths() -> None:
+    run_student_dashboard_js(
+        """
+        tested.populateClassRosterOptions([{
+          name: "demo-3a.json",
+          id: "demo-3a",
+          label: "Classe demo 3A",
+        }], "demo-3a.json");
+        tested.setCurrentCourseDesign({
+          paths: [{
+            id: "percorso-demo",
+            title: "Percorso demo",
+            audience: { class_ids: ["demo-3a"] },
+            udas: [{
+              id: "uda-1",
+              title: "Fondamenti",
+              actual: {
+                status: "done",
+                start_date: "2026-10-07",
+              },
+              items: [],
+            }],
+          }],
+        });
+
+        tested.renderStudentCalendar([]);
+        assert.match(tested.els.studentCalendar.innerHTML, /UDA-1 Fondamenti/);
+
+        tested.setVisibleStudentPathIds([]);
+        tested.renderStudentCalendar([]);
+        assert.doesNotMatch(tested.els.studentCalendar.innerHTML, /UDA-1 Fondamenti/);
         """
     )
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -92,9 +92,9 @@ p {
 
 h1 {
   margin-bottom: .35rem;
-  font-size: 3.2rem;
+  font-size: clamp(2rem, 5vw, 4.6rem);
   line-height: .92;
-  letter-spacing: 0;
+  letter-spacing: -.06em;
 }
 
 .subtitle {
@@ -164,10 +164,12 @@ button:hover { transform: translateY(-1px); }
 .coursePath,
 .assignments {
   min-width: 0;
-  border: 1px solid rgba(17, 17, 17, .12);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, .94);
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, .92);
   box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+  overflow: hidden;
 }
 
 .summary {
@@ -179,10 +181,10 @@ button:hover { transform: translateY(-1px); }
 
 .summaryCard {
   min-width: 0;
-  border: 1px solid rgba(17, 17, 17, .1);
-  border-radius: 8px;
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 18px;
   background: #ffffff;
-  padding: .8rem;
+  padding: .9rem;
 }
 
 .summaryCard strong {
@@ -201,16 +203,18 @@ button:hover { transform: translateY(-1px); }
 
 .sectionHead {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 1rem;
   min-width: 0;
-  padding: 1rem;
-  border-bottom: 1px solid rgba(17, 17, 17, .12);
+  padding: 1.1rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, .72);
 }
 
 .sectionHead h2 {
   margin-bottom: 0;
+  font-size: 1.25rem;
 }
 
 .assignmentTools {
@@ -235,17 +239,20 @@ button:hover { transform: translateY(-1px); }
   display: grid;
   gap: .85rem;
   min-width: 0;
-  padding: 1rem;
+  padding: 1.1rem;
 }
 
 .studentCalendarControls {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: .75rem;
   align-items: end;
   min-width: 0;
-  padding: 1rem;
-  border-bottom: 1px solid rgba(17, 17, 17, .12);
+  margin: 1.1rem 1.1rem 0;
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 18px;
+  background: #ffffff;
+  padding: .9rem;
 }
 
 .studentCalendarControls label.isHidden {
@@ -277,14 +284,14 @@ button:hover { transform: translateY(-1px); }
 
 .studentMonthCard {
   min-width: 0;
-  border: 1px solid rgba(17, 17, 17, .12);
-  border-radius: 8px;
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 18px;
   background: #ffffff;
   overflow: hidden;
 }
 
 .studentMonthMainCard {
-  box-shadow: 0 14px 32px rgba(0, 0, 0, .08);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, .1);
 }
 
 .studentMonthContextCard {
@@ -298,8 +305,8 @@ button:hover { transform: translateY(-1px); }
 }
 
 .studentMonthTitle {
-  border-bottom: 1px solid rgba(17, 17, 17, .12);
-  background: rgba(255, 255, 255, .82);
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, .78);
   padding: .75rem;
 }
 
@@ -394,7 +401,7 @@ button:hover { transform: translateY(-1px); }
 .calendarPill {
   display: block;
   margin-top: .16rem;
-  border-radius: 6px;
+  border-radius: 8px;
   background: rgba(17, 17, 17, .07);
   color: var(--ink);
   font-size: .62rem;
@@ -439,7 +446,7 @@ button:hover { transform: translateY(-1px); }
   display: grid;
   gap: 1rem;
   min-width: 0;
-  padding: 1rem;
+  padding: 1.1rem;
 }
 
 .courseSection {
@@ -465,8 +472,8 @@ button:hover { transform: translateY(-1px); }
   display: grid;
   gap: .75rem;
   min-width: 0;
-  border: 1px solid rgba(17, 17, 17, .1);
-  border-radius: 8px;
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 18px;
   background: #ffffff;
   padding: .9rem;
 }
@@ -786,8 +793,8 @@ button:hover { transform: translateY(-1px); }
 
 .detailItem {
   min-width: 0;
-  border: 1px solid rgba(17, 17, 17, .1);
-  border-radius: 8px;
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 18px;
   padding: .75rem;
   background: #fafafa;
 }
@@ -832,6 +839,10 @@ button:hover { transform: translateY(-1px); }
   }
 
   .courseItemList li {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .studentCalendarControls {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -233,50 +233,170 @@ button:hover { transform: translateY(-1px); }
 
 .studentCalendarBody {
   display: grid;
-  gap: .65rem;
+  gap: .85rem;
   min-width: 0;
   padding: 1rem;
 }
 
-.calendarEvent {
-  display: grid;
-  grid-template-columns: minmax(8.5rem, auto) minmax(0, 1fr) auto;
-  align-items: start;
-  gap: .85rem;
+.studentCalendarControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  align-items: end;
   min-width: 0;
-  border: 1px solid rgba(17, 17, 17, .1);
-  border-left: 4px solid var(--line);
+  padding: 1rem;
+  border-bottom: 1px solid rgba(17, 17, 17, .12);
+}
+
+.studentCalendarControls select {
+  min-width: min(16rem, 45vw);
+}
+
+.studentCalendarLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+  min-width: 0;
+}
+
+.studentMonthGrid {
+  display: grid;
+  grid-template-columns: minmax(10rem, .72fr) minmax(20rem, 1.35fr) minmax(10rem, .72fr);
+  gap: 1rem;
+  align-items: start;
+  min-width: 0;
+}
+
+.studentMonthCard {
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .12);
   border-radius: 8px;
   background: #ffffff;
-  padding: .85rem;
+  overflow: hidden;
 }
 
-.calendarEventDue {
-  border-left-color: var(--bad);
+.studentMonthMainCard {
+  box-shadow: 0 14px 32px rgba(0, 0, 0, .08);
 }
 
-.calendarEventAssigned {
-  border-left-color: var(--accent);
+.studentMonthContextCard {
+  opacity: .74;
+  transform: scale(.94);
+  transform-origin: top center;
 }
 
-.calendarEvent time {
+.studentMonthPlaceholder {
+  min-height: 1px;
+}
+
+.studentMonthTitle {
+  border-bottom: 1px solid rgba(17, 17, 17, .12);
+  background: rgba(255, 255, 255, .82);
+  padding: .75rem;
+}
+
+.studentMonthTitle h3 {
+  margin: 0;
+  font-size: .9rem;
+}
+
+.studentMonthWeekdays,
+.studentMonthDays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.studentMonthWeekdays span {
   color: var(--muted);
-  font-size: .78rem;
+  font-size: .64rem;
+  font-weight: 900;
+  padding: .42rem .25rem;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.studentDayCell {
+  min-height: 4.2rem;
+  border-top: 1px solid rgba(17, 17, 17, .08);
+  border-left: 1px solid rgba(17, 17, 17, .08);
+  background: #ffffff;
+  padding: .32rem;
+  overflow: hidden;
+}
+
+.studentDayCell:nth-child(7n + 1) {
+  border-left: 0;
+}
+
+.studentDayOutsideMonth,
+.studentDayOutsideRange {
+  background: #f3f3f3;
+  color: #999999;
+}
+
+.studentDayHasEvents {
+  background: #f9fbf8;
+}
+
+.studentDayNumber {
+  display: block;
+  margin-bottom: .18rem;
+  font-size: .72rem;
   font-weight: 900;
 }
 
-.calendarEvent h3 {
-  margin: 0 0 .28rem;
-  overflow-wrap: anywhere;
-  font-size: .98rem;
+.studentMonthContextCard .studentDayCell {
+  min-height: 2.55rem;
+  padding: .22rem;
 }
 
-.calendarEventBadges {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: .35rem;
-  min-width: 0;
+.studentMonthContextCard .calendarPill {
+  max-height: 1.6rem;
+  overflow: hidden;
+}
+
+.calendarPill {
+  display: block;
+  margin-top: .16rem;
+  border-radius: 6px;
+  background: rgba(17, 17, 17, .07);
+  color: var(--ink);
+  font-size: .62rem;
+  font-weight: 800;
+  line-height: 1.18;
+  overflow-wrap: anywhere;
+  padding: .18rem .22rem;
+}
+
+.calendarPill strong {
+  display: inline-grid;
+  place-items: center;
+  width: .9rem;
+  height: .9rem;
+  margin-right: .15rem;
+  border-radius: 999px;
+  background: var(--bad);
+  color: #ffffff;
+  font-size: .62rem;
+}
+
+.calendarPriorityText {
+  margin-right: .2rem;
+  font-weight: 900;
+}
+
+.calendarPillDue {
+  background: rgba(180, 35, 24, .09);
+  color: var(--bad);
+}
+
+.calendarPillAssigned {
+  background: rgba(17, 17, 17, .07);
+}
+
+.calendarPillUda {
+  background: rgba(20, 122, 66, .1);
+  color: var(--ok);
 }
 
 .coursePathBody {
@@ -679,12 +799,12 @@ button:hover { transform: translateY(-1px); }
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .calendarEvent {
+  .studentMonthGrid {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .calendarEventBadges {
-    justify-content: flex-start;
+  .studentMonthContextCard {
+    transform: none;
   }
 
   h1 {

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -556,8 +556,8 @@ button:hover { transform: translateY(-1px); }
 }
 
 .calendarPillClosure {
-  background: rgba(63, 63, 70, .12);
-  color: #3f3f46;
+  background: rgba(154, 45, 35, .11);
+  color: #8a2d24;
 }
 
 .studentCalendarList {

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -447,6 +447,21 @@ button:hover { transform: translateY(-1px); }
   padding: .18rem .22rem;
 }
 
+.calendarPillButton {
+  width: 100%;
+  min-height: 0;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: none;
+}
+
+.calendarPillButton:hover,
+.studentCalendarListItemButton:hover {
+  outline: 2px solid rgba(17, 17, 17, .18);
+  transform: none;
+}
+
 .calendarPill strong {
   display: inline-grid;
   place-items: center;
@@ -507,6 +522,10 @@ button:hover { transform: translateY(-1px); }
   margin: 0 0 .28rem;
   overflow-wrap: anywhere;
   font-size: .98rem;
+}
+
+.studentCalendarListItemButton {
+  cursor: pointer;
 }
 
 .coursePathBody {

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -259,6 +259,39 @@ button:hover { transform: translateY(-1px); }
   display: none;
 }
 
+.studentCalendarDisplayToggle {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .35rem;
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+.studentCalendarDisplayToggle legend {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: .72rem;
+  font-weight: 700;
+  padding: 0;
+}
+
+.studentCalendarDisplayToggle button {
+  min-height: 2.35rem;
+  border: 1px solid var(--line);
+  background: #ffffff;
+  color: var(--ink);
+  box-shadow: none;
+  padding: .45rem .7rem;
+}
+
+.studentCalendarDisplayToggle button[aria-pressed="true"] {
+  border-color: #111111;
+  background: #111111;
+  color: #ffffff;
+}
+
 .studentCalendarControls select {
   min-width: min(16rem, 45vw);
 }
@@ -443,6 +476,37 @@ button:hover { transform: translateY(-1px); }
 .calendarPillUda {
   background: rgba(20, 122, 66, .1);
   color: var(--ok);
+}
+
+.studentCalendarList {
+  display: grid;
+  gap: .65rem;
+  min-width: 0;
+}
+
+.studentCalendarListItem {
+  display: grid;
+  grid-template-columns: minmax(8.5rem, auto) minmax(0, 1fr);
+  gap: .85rem;
+  align-items: start;
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-left: 4px solid var(--line);
+  border-radius: 18px;
+  background: #ffffff;
+  padding: .85rem;
+}
+
+.studentCalendarListItem time {
+  color: var(--muted);
+  font-size: .78rem;
+  font-weight: 900;
+}
+
+.studentCalendarListItem h3 {
+  margin: 0 0 .28rem;
+  overflow-wrap: anywhere;
+  font-size: .98rem;
 }
 
 .coursePathBody {
@@ -856,6 +920,10 @@ button:hover { transform: translateY(-1px); }
 
   .studentMonthContextCard {
     transform: none;
+  }
+
+  .studentCalendarListItem {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   h1 {

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -160,6 +160,7 @@ button {
 button:hover { transform: translateY(-1px); }
 
 .summary,
+.studentCalendar,
 .coursePath,
 .assignments {
   min-width: 0;
@@ -227,6 +228,54 @@ button:hover { transform: translateY(-1px); }
 
 .assignmentList {
   display: grid;
+  min-width: 0;
+}
+
+.studentCalendarBody {
+  display: grid;
+  gap: .65rem;
+  min-width: 0;
+  padding: 1rem;
+}
+
+.calendarEvent {
+  display: grid;
+  grid-template-columns: minmax(8.5rem, auto) minmax(0, 1fr) auto;
+  align-items: start;
+  gap: .85rem;
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-left: 4px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: .85rem;
+}
+
+.calendarEventDue {
+  border-left-color: var(--bad);
+}
+
+.calendarEventAssigned {
+  border-left-color: var(--accent);
+}
+
+.calendarEvent time {
+  color: var(--muted);
+  font-size: .78rem;
+  font-weight: 900;
+}
+
+.calendarEvent h3 {
+  margin: 0 0 .28rem;
+  overflow-wrap: anywhere;
+  font-size: .98rem;
+}
+
+.calendarEventBadges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: .35rem;
   min-width: 0;
 }
 
@@ -628,6 +677,14 @@ button:hover { transform: translateY(-1px); }
 
   .courseItemList li {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .calendarEvent {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .calendarEventBadges {
+    justify-content: flex-start;
   }
 
   h1 {

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -556,7 +556,14 @@ button:hover { transform: translateY(-1px); }
 }
 
 .calendarPillClosure {
-  background: rgba(154, 45, 35, .11);
+  background:
+    repeating-linear-gradient(
+      135deg,
+      rgba(154, 45, 35, .14) 0,
+      rgba(154, 45, 35, .14) 6px,
+      #ffffff 6px,
+      #ffffff 11px
+    );
   color: #8a2d24;
 }
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -329,7 +329,10 @@ button:hover { transform: translateY(-1px); }
 .studentMonthTitleNav button {
   width: 2.1rem;
   height: 2.1rem;
+  border: 1px solid var(--line);
   border-radius: 999px;
+  background: #ffffff;
+  color: var(--ink);
   box-shadow: none;
   font-size: 1rem;
   padding: 0;

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -296,6 +296,68 @@ button:hover { transform: translateY(-1px); }
   min-width: min(16rem, 45vw);
 }
 
+.studentPathFilters {
+  display: grid;
+  gap: .8rem;
+  min-width: 0;
+  margin: 1.1rem 1.1rem 0;
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 18px;
+  background: #ffffff;
+  padding: .9rem;
+}
+
+.studentPathFilters[hidden] {
+  display: none;
+}
+
+.studentPathFiltersHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.studentPathFilterActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .45rem;
+}
+
+.studentPathFilterActions button {
+  min-height: 0;
+  border: 1px solid var(--line);
+  background: #ffffff;
+  color: var(--ink);
+  box-shadow: none;
+  font-size: .72rem;
+  padding: .45rem .7rem;
+}
+
+.studentPathFilterList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+}
+
+.studentPathFilter {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 999px;
+  background: #f8f8f8;
+  color: var(--ink);
+  font-size: .78rem;
+  font-weight: 800;
+  padding: .45rem .7rem;
+}
+
+.studentPathFilter input {
+  width: auto;
+  accent-color: #111111;
+}
+
 .studentCalendarLegend {
   display: flex;
   flex-wrap: wrap;

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -248,6 +248,10 @@ button:hover { transform: translateY(-1px); }
   border-bottom: 1px solid rgba(17, 17, 17, .12);
 }
 
+.studentCalendarControls label.isHidden {
+  display: none;
+}
+
 .studentCalendarControls select {
   min-width: min(16rem, 45vw);
 }
@@ -261,10 +265,14 @@ button:hover { transform: translateY(-1px); }
 
 .studentMonthGrid {
   display: grid;
-  grid-template-columns: minmax(10rem, .72fr) minmax(20rem, 1.35fr) minmax(10rem, .72fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
   align-items: start;
   min-width: 0;
+}
+
+.studentMonthGrid.studentMonthFocusGrid {
+  grid-template-columns: minmax(10rem, .72fr) minmax(20rem, 1.35fr) minmax(10rem, .72fr);
 }
 
 .studentMonthCard {
@@ -298,6 +306,30 @@ button:hover { transform: translateY(-1px); }
 .studentMonthTitle h3 {
   margin: 0;
   font-size: .9rem;
+}
+
+.studentMonthTitleNav {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: .65rem;
+}
+
+.studentMonthTitleNav h3 {
+  text-align: center;
+}
+
+.studentMonthTitleNav button {
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 999px;
+  box-shadow: none;
+  font-size: 1rem;
+  padding: 0;
+}
+
+.studentWeekCard {
+  min-width: 0;
 }
 
 .studentMonthWeekdays,
@@ -348,6 +380,10 @@ button:hover { transform: translateY(-1px); }
 .studentMonthContextCard .studentDayCell {
   min-height: 2.55rem;
   padding: .22rem;
+}
+
+.studentWeekDays .studentDayCell {
+  min-height: 8rem;
 }
 
 .studentMonthContextCard .calendarPill {
@@ -799,7 +835,8 @@ button:hover { transform: translateY(-1px); }
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .studentMonthGrid {
+  .studentMonthGrid,
+  .studentMonthGrid.studentMonthFocusGrid {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -555,6 +555,11 @@ button:hover { transform: translateY(-1px); }
   color: var(--ok);
 }
 
+.calendarPillClosure {
+  background: rgba(63, 63, 70, .12);
+  color: #3f3f46;
+}
+
 .studentCalendarList {
   display: grid;
   gap: .65rem;

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -78,6 +78,7 @@
           </select>
         </label>
       </div>
+      <section id="studentPathFilters" class="studentPathFilters" hidden></section>
       <div id="studentCalendar" class="studentCalendarBody">
         <p class="status">Carica uno studente per vedere scadenze e finestre di lavoro.</p>
       </div>

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -48,8 +48,20 @@
       </div>
       <div class="studentCalendarControls">
         <label>
+          <span>Modalita</span>
+          <select id="studentCalendarViewMode" name="student_calendar_view_mode">
+            <option value="year">Anno</option>
+            <option value="month" selected>Mese</option>
+            <option value="week">Settimana</option>
+          </select>
+        </label>
+        <label id="studentCalendarMonthField">
           <span>Mese</span>
           <select id="studentCalendarMonth" name="student_calendar_month"></select>
+        </label>
+        <label id="studentCalendarWeekField" class="isHidden">
+          <span>Settimana</span>
+          <select id="studentCalendarWeek" name="student_calendar_week"></select>
         </label>
         <label>
           <span>Mostra</span>

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -74,6 +74,7 @@
             <option value="all">Tutto</option>
             <option value="assignments">Consegne</option>
             <option value="udas">UDA</option>
+            <option value="closures">Festivita e interruzioni</option>
             <option value="due">Scadenze</option>
           </select>
         </label>

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -46,6 +46,21 @@
         <h2>Calendario</h2>
         <p id="studentCalendarStatus" class="status" aria-live="polite"></p>
       </div>
+      <div class="studentCalendarControls">
+        <label>
+          <span>Mese</span>
+          <select id="studentCalendarMonth" name="student_calendar_month"></select>
+        </label>
+        <label>
+          <span>Mostra</span>
+          <select id="studentCalendarFilter" name="student_calendar_filter">
+            <option value="all">Tutto</option>
+            <option value="assignments">Consegne</option>
+            <option value="udas">UDA</option>
+            <option value="due">Scadenze</option>
+          </select>
+        </label>
+      </div>
       <div id="studentCalendar" class="studentCalendarBody">
         <p class="status">Carica uno studente per vedere scadenze e finestre di lavoro.</p>
       </div>

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -41,6 +41,16 @@
       <p class="status">Carica uno studente per vedere consegne, stato e feedback approvato.</p>
     </section>
 
+    <section class="studentCalendar">
+      <div class="sectionHead">
+        <h2>Calendario</h2>
+        <p id="studentCalendarStatus" class="status" aria-live="polite"></p>
+      </div>
+      <div id="studentCalendar" class="studentCalendarBody">
+        <p class="status">Carica uno studente per vedere scadenze e finestre di lavoro.</p>
+      </div>
+    </section>
+
     <section class="coursePath">
       <div class="sectionHead">
         <h2>Percorso</h2>

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -47,6 +47,11 @@
         <p id="studentCalendarStatus" class="status" aria-live="polite"></p>
       </div>
       <div class="studentCalendarControls">
+        <fieldset class="studentCalendarDisplayToggle" aria-label="Vista calendario">
+          <legend>Vista</legend>
+          <button type="button" data-student-calendar-display="calendar" aria-pressed="true">Calendario</button>
+          <button type="button" data-student-calendar-display="list" aria-pressed="false">Lista</button>
+        </fieldset>
         <label>
           <span>Modalita</span>
           <select id="studentCalendarViewMode" name="student_calendar_view_mode">

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -7,6 +7,8 @@ const els = {
   summary: document.querySelector("#summary"),
   status: document.querySelector("#status"),
   assignments: document.querySelector("#assignments"),
+  studentCalendar: document.querySelector("#studentCalendar"),
+  studentCalendarStatus: document.querySelector("#studentCalendarStatus"),
   coursePath: document.querySelector("#coursePath"),
   coursePathStatus: document.querySelector("#coursePathStatus"),
   assignmentDetailModal: document.querySelector("#assignmentDetailModal"),
@@ -284,6 +286,85 @@ function renderSummary(studentId, assignments) {
       <span>${escapeHtml(value)}</span>
     </article>
   `).join("");
+}
+
+function calendarEventTimestamp(value) {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function studentCalendarEvents(assignments) {
+  const nextAssignment = nextOpenAssignment(assignments);
+  const nextDue = nextAssignment ? timestampOrInfinity(nextAssignment.due_at) : Number.POSITIVE_INFINITY;
+  return assignments.flatMap((assignment) => {
+    const title = assignmentTitle(assignment) || "-";
+    const events = [];
+    const assignedTimestamp = calendarEventTimestamp(assignment.assigned_at);
+    if (assignedTimestamp != null) {
+      events.push({
+        kind: "assigned",
+        label: "Assegnata",
+        date: assignment.assigned_at,
+        timestamp: assignedTimestamp,
+        title,
+        assignment,
+        priority: false,
+      });
+    }
+    const dueTimestamp = calendarEventTimestamp(assignment.due_at);
+    if (dueTimestamp != null) {
+      events.push({
+        kind: "due",
+        label: "Scadenza",
+        date: assignment.due_at,
+        timestamp: dueTimestamp,
+        title,
+        assignment,
+        priority: isOpenAssignment(assignment) && dueTimestamp === nextDue,
+      });
+    }
+    return events;
+  }).sort((left, right) => (
+    left.timestamp - right.timestamp
+    || left.title.localeCompare(right.title, "it", { numeric: true, sensitivity: "base" })
+    || left.label.localeCompare(right.label, "it", { numeric: true, sensitivity: "base" })
+  ));
+}
+
+function renderCalendarEvent(event) {
+  const kindClass = event.kind === "due" ? "calendarEventDue" : "calendarEventAssigned";
+  return `
+    <article class="calendarEvent ${kindClass}">
+      <time datetime="${escapeHtml(event.date)}">${escapeHtml(formatDate(event.date))}</time>
+      <div>
+        <h3>${escapeHtml(event.title)}</h3>
+        <p class="meta">
+          <span>${escapeHtml(event.label)}</span>
+          <span>${escapeHtml(event.assignment.kind || "tipo non indicato")}</span>
+          <span>${escapeHtml(event.assignment.student_support_mode || "modalita non indicata")}</span>
+        </p>
+      </div>
+      <div class="calendarEventBadges">
+        ${event.priority ? badge("Prossima scadenza", "badgePriority") : ""}
+        ${event.kind === "due" ? statusBadge(event.assignment) : badge("Finestra di lavoro")}
+      </div>
+    </article>
+  `;
+}
+
+function renderStudentCalendar(assignments) {
+  if (!els.studentCalendar) return;
+  const events = studentCalendarEvents(assignments);
+  if (els.studentCalendarStatus) {
+    const dueCount = events.filter((event) => event.kind === "due").length;
+    els.studentCalendarStatus.textContent = events.length
+      ? `${events.length} eventi · ${dueCount} scadenze`
+      : "";
+  }
+  els.studentCalendar.innerHTML = events.length
+    ? events.map(renderCalendarEvent).join("")
+    : '<p class="status">Nessuna data disponibile per le consegne di questo studente.</p>';
 }
 
 function collectCourseItems(items, depth = 0) {
@@ -683,6 +764,7 @@ function renderDashboard(payload) {
   const nextAssignment = nextOpenAssignment(assignments);
   const visibleAssignments = sortedAssignments(filteredAssignments(assignments, filterValue), sortValue);
   renderSummary(payload.student_id || "-", assignments);
+  renderStudentCalendar(assignments);
   renderCoursePath(currentCourseDesign, assignments, payload.student_id);
   els.status.textContent = visibleAssignments.length === assignments.length
     ? `${assignments.length} consegne trovate.`

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -31,6 +31,7 @@ let currentClassRoster = null;
 let currentCourseDesign = null;
 let currentSchoolCalendar = null;
 let currentStudentCalendarView = {
+  display: "calendar",
   mode: "month",
   month: "",
   week: "",
@@ -601,6 +602,35 @@ function renderStudentCalendarLegend(events) {
   `;
 }
 
+function renderStudentCalendarList(events) {
+  if (!events.length) {
+    return '<p class="status">Nessun evento corrisponde ai filtri selezionati.</p>';
+  }
+  return `
+    <div class="studentCalendarList">
+      ${events.map((event) => {
+        const badgeClass = event.kind === "due"
+          ? "calendarPillDue"
+          : event.category === "udas"
+            ? "calendarPillUda"
+            : "calendarPillAssigned";
+        return `
+          <article class="studentCalendarListItem">
+            <time datetime="${escapeHtml(event.iso || event.date || "")}">${escapeHtml(formatDate(event.date || event.iso))}</time>
+            <div>
+              <h3>${escapeHtml(event.title)}</h3>
+              <p class="meta">
+                <span class="calendarPill ${badgeClass}">${escapeHtml(event.label)}</span>
+                ${event.priority ? '<span class="calendarPill calendarPillDue"><strong>!</strong><span class="calendarPriorityText">Prossima scadenza</span></span>' : ""}
+              </p>
+            </div>
+          </article>
+        `;
+      }).join("")}
+    </div>
+  `;
+}
+
 function renderStudentCalendar(assignments) {
   if (!els.studentCalendar) return;
   const baseEvents = [
@@ -609,6 +639,7 @@ function renderStudentCalendar(assignments) {
   ].sort((left, right) => left.timestamp - right.timestamp || left.title.localeCompare(right.title, "it", { numeric: true, sensitivity: "base" }));
   const mode = els.studentCalendarViewMode?.value || currentStudentCalendarView.mode || "month";
   currentStudentCalendarView.mode = ["year", "month", "week"].includes(mode) ? mode : "month";
+  currentStudentCalendarView.display = currentStudentCalendarView.display === "list" ? "list" : "calendar";
   const filterValue = els.studentCalendarFilter?.value || "all";
   const events = filteredStudentCalendarEvents(baseEvents, filterValue);
   const range = calendarDateRange(baseEvents);
@@ -626,8 +657,13 @@ function renderStudentCalendar(assignments) {
     currentStudentCalendarView.week = firstEventWeek ? isoDate(firstEventWeek.start) : isoDate(weeks[0]?.start || range.start);
   }
   if (els.studentCalendarViewMode) els.studentCalendarViewMode.value = currentStudentCalendarView.mode;
-  els.studentCalendarMonthField?.classList.toggle("isHidden", currentStudentCalendarView.mode !== "month");
-  els.studentCalendarWeekField?.classList.toggle("isHidden", currentStudentCalendarView.mode !== "week");
+  const showCalendarControls = currentStudentCalendarView.display === "calendar";
+  els.studentCalendarMonthField?.classList.toggle("isHidden", !showCalendarControls || currentStudentCalendarView.mode !== "month");
+  els.studentCalendarWeekField?.classList.toggle("isHidden", !showCalendarControls || currentStudentCalendarView.mode !== "week");
+  els.studentCalendarViewMode?.closest?.("label")?.classList.toggle("isHidden", !showCalendarControls);
+  document.querySelectorAll?.("[data-student-calendar-display]").forEach((button) => {
+    button.setAttribute("aria-pressed", String(button.dataset.studentCalendarDisplay === currentStudentCalendarView.display));
+  });
   if (els.studentCalendarMonth) {
     els.studentCalendarMonth.innerHTML = months.map((month) => {
       const value = monthKey(month);
@@ -658,7 +694,9 @@ function renderStudentCalendar(assignments) {
     eventsByDate.get(event.iso).push(event);
   }
   const selectedWeek = selectedStudentCalendarWeek(weeks, currentStudentCalendarView.week);
-  const renderedCalendar = currentStudentCalendarView.mode === "week" && selectedWeek
+  const renderedCalendar = currentStudentCalendarView.display === "list"
+    ? renderStudentCalendarList(events)
+    : currentStudentCalendarView.mode === "week" && selectedWeek
     ? renderStudentCalendarWeek(selectedWeek, eventsByDate, range, months, weeks)
     : `
       <div class="studentMonthGrid ${currentStudentCalendarView.mode === "month" ? "studentMonthFocusGrid" : ""}">
@@ -1161,6 +1199,13 @@ els.studentCalendarWeek?.addEventListener("change", () => {
 
 els.studentCalendarFilter?.addEventListener("change", () => {
   renderStudentCalendar(currentDashboardPayload.assignments || []);
+});
+
+document.querySelectorAll?.("[data-student-calendar-display]").forEach((button) => {
+  button.addEventListener("click", () => {
+    currentStudentCalendarView.display = button.dataset.studentCalendarDisplay === "list" ? "list" : "calendar";
+    renderStudentCalendar(currentDashboardPayload.assignments || []);
+  });
 });
 
 els.studentCalendar?.addEventListener("click", (event) => {

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -36,6 +36,7 @@ let currentStudentCalendarView = {
   month: "",
   week: "",
 };
+let visibleStudentPathIds = null;
 
 async function api(path, options = {}) {
   const response = await fetch(path, options);
@@ -443,8 +444,7 @@ function studentCalendarEvents(assignments) {
 }
 
 function visibleUdasForStudent(assignments, studentId = currentDashboardPayload.student_id) {
-  const context = visibilityContext(studentId, assignments);
-  return visibleCourseSections(courseSections(currentCourseDesign), context)
+  return visibleStudentPathSections(assignments, studentId)
     .flatMap((section) => Array.isArray(section?.udas) ? section.udas : []);
 }
 
@@ -569,7 +569,7 @@ function renderStudentCalendarWeek(week, eventsByDate, range, months, weeks) {
 function renderStudentCalendarMonth(month, role, eventsByDate, range, months = [], weeks = []) {
   if (role === "placeholder") return '<div class="studentMonthPlaceholder"></div>';
   const title = month.toLocaleDateString("it-IT", { month: "long", year: "numeric" });
-  const isMonthFocus = currentStudentCalendarView.mode === "month" && role === "main";
+  const hasMonthNav = currentStudentCalendarView.mode === "month";
   const first = new Date(month.getFullYear(), month.getMonth(), 1);
   const startOffset = (first.getDay() + 6) % 7;
   const cursor = new Date(first);
@@ -593,10 +593,10 @@ function renderStudentCalendarMonth(month, role, eventsByDate, range, months = [
   }
   return `
     <article class="studentMonthCard ${role === "context" ? "studentMonthContextCard" : "studentMonthMainCard"}">
-      <div class="studentMonthTitle ${isMonthFocus ? "studentMonthTitleNav" : ""}">
-        ${isMonthFocus ? renderStudentCalendarNavButton(-1, months, weeks, "Vai al mese precedente.") : ""}
+      <div class="studentMonthTitle ${hasMonthNav ? "studentMonthTitleNav" : ""}">
+        ${hasMonthNav ? renderStudentCalendarNavButton(-1, months, weeks, "Vai al mese precedente.") : ""}
         <h3>${escapeHtml(title)}</h3>
-        ${isMonthFocus ? renderStudentCalendarNavButton(1, months, weeks, "Vai al mese successivo.") : ""}
+        ${hasMonthNav ? renderStudentCalendarNavButton(1, months, weeks, "Vai al mese successivo.") : ""}
       </div>
       <div class="studentMonthWeekdays">
         <span>Lun</span><span>Mar</span><span>Mer</span><span>Gio</span><span>Ven</span><span>Sab</span><span>Dom</span>
@@ -817,6 +817,84 @@ function visibleCourseSections(sections, context) {
     .filter(Boolean);
 }
 
+function studentPathId(section, index) {
+  return String(section?.id || section?.title || `path-${index}`).trim();
+}
+
+function visibleStudentPathOptions(assignments = currentDashboardPayload.assignments || [], studentId = currentDashboardPayload.student_id) {
+  const context = visibilityContext(studentId, assignments);
+  return visibleCourseSections(courseSections(currentCourseDesign), context)
+    .map((section, index) => ({
+      id: studentPathId(section, index),
+      label: section?.title || section?.id || "Percorso senza titolo",
+      section,
+    }));
+}
+
+function ensureVisibleStudentPathIds(options) {
+  const ids = new Set(options.map((option) => option.id));
+  if (!visibleStudentPathIds) {
+    visibleStudentPathIds = new Set(ids);
+    return;
+  }
+  for (const id of [...visibleStudentPathIds]) {
+    if (!ids.has(id)) visibleStudentPathIds.delete(id);
+  }
+}
+
+function visibleStudentPathSections(assignments = currentDashboardPayload.assignments || [], studentId = currentDashboardPayload.student_id) {
+  const options = visibleStudentPathOptions(assignments, studentId);
+  ensureVisibleStudentPathIds(options);
+  return options.filter((option) => visibleStudentPathIds.has(option.id)).map((option) => option.section);
+}
+
+function renderStudentPathFilters(assignments = currentDashboardPayload.assignments || [], studentId = currentDashboardPayload.student_id) {
+  const panel = document.querySelector("#studentPathFilters");
+  if (!panel) return;
+  const options = visibleStudentPathOptions(assignments, studentId);
+  ensureVisibleStudentPathIds(options);
+  if (!options.length) {
+    panel.innerHTML = "";
+    panel.hidden = true;
+    return;
+  }
+  panel.hidden = false;
+  panel.innerHTML = `
+    <div class="studentPathFiltersHead">
+      <strong>Percorsi visibili</strong>
+      <div class="studentPathFilterActions">
+        <button type="button" data-student-path-action="all" title="Mostra tutti i percorsi nel calendario.">Tutti</button>
+        <button type="button" data-student-path-action="none" title="Nasconde gli eventi UDA dei percorsi.">Nessuno</button>
+      </div>
+    </div>
+    <div class="studentPathFilterList">
+      ${options.map((option) => `
+        <label class="studentPathFilter">
+          <input type="checkbox" value="${escapeHtml(option.id)}"${visibleStudentPathIds.has(option.id) ? " checked" : ""}>
+          <span>${escapeHtml(option.label)}</span>
+        </label>
+      `).join("")}
+    </div>
+  `;
+  panel.querySelectorAll("input").forEach((input) => {
+    input.addEventListener("change", () => {
+      if (input.checked) visibleStudentPathIds.add(input.value);
+      else visibleStudentPathIds.delete(input.value);
+      renderStudentCalendar(currentDashboardPayload.assignments || []);
+    });
+  });
+  panel.querySelector('[data-student-path-action="all"]')?.addEventListener("click", () => {
+    visibleStudentPathIds = new Set(options.map((option) => option.id));
+    renderStudentPathFilters(assignments, studentId);
+    renderStudentCalendar(currentDashboardPayload.assignments || []);
+  });
+  panel.querySelector('[data-student-path-action="none"]')?.addEventListener("click", () => {
+    visibleStudentPathIds = new Set();
+    renderStudentPathFilters(assignments, studentId);
+    renderStudentCalendar(currentDashboardPayload.assignments || []);
+  });
+}
+
 function courseItemActivities(item) {
   return Array.isArray(item?.activity_ids)
     ? item.activity_ids.map((activityId) => String(activityId || "").trim()).filter(Boolean)
@@ -903,9 +981,12 @@ async function loadCoursePath() {
   try {
     currentCourseDesign = await api("/api/course-design");
     renderCoursePath(currentCourseDesign, currentDashboardPayload.assignments, currentDashboardPayload.student_id);
+    renderStudentPathFilters(currentDashboardPayload.assignments, currentDashboardPayload.student_id);
     renderStudentCalendar(currentDashboardPayload.assignments);
   } catch (error) {
     currentCourseDesign = null;
+    visibleStudentPathIds = null;
+    renderStudentPathFilters(currentDashboardPayload.assignments, currentDashboardPayload.student_id);
     if (els.coursePath) {
       els.coursePath.innerHTML = '<p class="status">Percorso non disponibile.</p>';
     }
@@ -1152,6 +1233,7 @@ function renderDashboard(payload) {
   renderSummary(payload.student_id || "-", assignments);
   renderStudentCalendar(assignments);
   renderCoursePath(currentCourseDesign, assignments, payload.student_id);
+  renderStudentPathFilters(assignments, payload.student_id);
   els.status.textContent = visibleAssignments.length === assignments.length
     ? `${assignments.length} consegne trovate.`
     : `${visibleAssignments.length} di ${assignments.length} consegne visibili.`;

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -9,7 +9,11 @@ const els = {
   assignments: document.querySelector("#assignments"),
   studentCalendar: document.querySelector("#studentCalendar"),
   studentCalendarStatus: document.querySelector("#studentCalendarStatus"),
+  studentCalendarViewMode: document.querySelector("#studentCalendarViewMode"),
   studentCalendarMonth: document.querySelector("#studentCalendarMonth"),
+  studentCalendarMonthField: document.querySelector("#studentCalendarMonthField"),
+  studentCalendarWeek: document.querySelector("#studentCalendarWeek"),
+  studentCalendarWeekField: document.querySelector("#studentCalendarWeekField"),
   studentCalendarFilter: document.querySelector("#studentCalendarFilter"),
   coursePath: document.querySelector("#coursePath"),
   coursePathStatus: document.querySelector("#coursePathStatus"),
@@ -26,6 +30,11 @@ let currentClassLabel = "Dai registri consegne";
 let currentClassRoster = null;
 let currentCourseDesign = null;
 let currentSchoolCalendar = null;
+let currentStudentCalendarView = {
+  mode: "month",
+  month: "",
+  week: "",
+};
 
 async function api(path, options = {}) {
   const response = await fetch(path, options);
@@ -305,6 +314,12 @@ function isoDate(date) {
   return `${year}-${month}-${day}`;
 }
 
+function addDays(date, days) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
 function monthKey(date) {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
 }
@@ -320,6 +335,21 @@ function calendarMonths(start, end) {
   return months;
 }
 
+function calendarWeeks(start, end) {
+  const weeks = [];
+  if (!start || !end || start > end) return weeks;
+  const cursor = new Date(start);
+  const offset = (cursor.getDay() + 6) % 7;
+  cursor.setDate(cursor.getDate() - offset);
+  while (cursor <= end) {
+    const weekStart = new Date(cursor);
+    const weekEnd = addDays(weekStart, 6);
+    weeks.push({ start: weekStart, end: weekEnd });
+    cursor.setDate(cursor.getDate() + 7);
+  }
+  return weeks;
+}
+
 function selectedStudentCalendarMonthContext(months, selectedMonth) {
   if (!months.length) return [];
   const selectedIndex = months.findIndex((month) => monthKey(month) === selectedMonth);
@@ -329,6 +359,40 @@ function selectedStudentCalendarMonthContext(months, selectedMonth) {
     months[index] ? { month: months[index], role: "main" } : null,
     months[index + 1] ? { month: months[index + 1], role: "context" } : { role: "placeholder" },
   ].filter(Boolean);
+}
+
+function selectedStudentCalendarWeek(weeks, selectedWeek) {
+  return weeks.find((week) => isoDate(week.start) === selectedWeek) || weeks[0] || null;
+}
+
+function studentCalendarViewValues(months, weeks) {
+  if (currentStudentCalendarView.mode === "month") return months.map(monthKey);
+  if (currentStudentCalendarView.mode === "week") return weeks.map((week) => isoDate(week.start));
+  return [];
+}
+
+function currentStudentCalendarViewValue() {
+  if (currentStudentCalendarView.mode === "month") return currentStudentCalendarView.month;
+  if (currentStudentCalendarView.mode === "week") return currentStudentCalendarView.week;
+  return "";
+}
+
+function moveStudentCalendarView(direction, months, weeks) {
+  const values = studentCalendarViewValues(months, weeks);
+  const current = currentStudentCalendarViewValue();
+  const index = values.indexOf(current);
+  const nextIndex = Math.max(0, Math.min(values.length - 1, index + direction));
+  const nextValue = values[nextIndex];
+  if (!nextValue || nextValue === current) return;
+  if (currentStudentCalendarView.mode === "month") currentStudentCalendarView.month = nextValue;
+  if (currentStudentCalendarView.mode === "week") currentStudentCalendarView.week = nextValue;
+  renderStudentCalendar(currentDashboardPayload.assignments || []);
+}
+
+function studentCalendarNavDisabled(direction, months, weeks) {
+  const values = studentCalendarViewValues(months, weeks);
+  const index = values.indexOf(currentStudentCalendarViewValue());
+  return direction < 0 ? index <= 0 : index < 0 || index >= values.length - 1;
 }
 
 function studentCalendarEvents(assignments) {
@@ -448,9 +512,48 @@ function renderCalendarEventPill(event) {
   `;
 }
 
-function renderStudentCalendarMonth(month, role, eventsByDate, range) {
+function renderStudentCalendarNavButton(direction, months, weeks, title) {
+  const disabled = studentCalendarNavDisabled(direction, months, weeks) ? " disabled" : "";
+  const action = direction < 0 ? "previous" : "next";
+  const label = direction < 0 ? "&larr;" : "&rarr;";
+  return `<button type="button" data-student-calendar-nav="${action}" title="${escapeHtml(title)}"${disabled}>${label}</button>`;
+}
+
+function renderStudentCalendarWeek(week, eventsByDate, range, months, weeks) {
+  const cells = [];
+  for (let offset = 0; offset < 7; offset += 1) {
+    const day = addDays(week.start, offset);
+    const iso = isoDate(day);
+    const dayEvents = eventsByDate.get(iso) || [];
+    const classes = ["studentDayCell"];
+    if (day < range.start || day > range.end) classes.push("studentDayOutsideRange");
+    if (dayEvents.length) classes.push("studentDayHasEvents");
+    cells.push(`
+      <div class="${classes.join(" ")}">
+        <span class="studentDayNumber">${day.getDate()}</span>
+        ${dayEvents.map(renderCalendarEventPill).join("")}
+      </div>
+    `);
+  }
+  return `
+    <article class="studentMonthCard studentWeekCard">
+      <div class="studentMonthTitle studentMonthTitleNav">
+        ${renderStudentCalendarNavButton(-1, months, weeks, "Vai alla settimana precedente.")}
+        <h3>Settimana: ${escapeHtml(week.start.toLocaleDateString("it-IT"))} - ${escapeHtml(week.end.toLocaleDateString("it-IT"))}</h3>
+        ${renderStudentCalendarNavButton(1, months, weeks, "Vai alla settimana successiva.")}
+      </div>
+      <div class="studentMonthWeekdays">
+        <span>Lun</span><span>Mar</span><span>Mer</span><span>Gio</span><span>Ven</span><span>Sab</span><span>Dom</span>
+      </div>
+      <div class="studentMonthDays studentWeekDays">${cells.join("")}</div>
+    </article>
+  `;
+}
+
+function renderStudentCalendarMonth(month, role, eventsByDate, range, months = [], weeks = []) {
   if (role === "placeholder") return '<div class="studentMonthPlaceholder"></div>';
   const title = month.toLocaleDateString("it-IT", { month: "long", year: "numeric" });
+  const isMonthFocus = currentStudentCalendarView.mode === "month" && role === "main";
   const first = new Date(month.getFullYear(), month.getMonth(), 1);
   const startOffset = (first.getDay() + 6) % 7;
   const cursor = new Date(first);
@@ -474,8 +577,10 @@ function renderStudentCalendarMonth(month, role, eventsByDate, range) {
   }
   return `
     <article class="studentMonthCard ${role === "context" ? "studentMonthContextCard" : "studentMonthMainCard"}">
-      <div class="studentMonthTitle">
+      <div class="studentMonthTitle ${isMonthFocus ? "studentMonthTitleNav" : ""}">
+        ${isMonthFocus ? renderStudentCalendarNavButton(-1, months, weeks, "Vai al mese precedente.") : ""}
         <h3>${escapeHtml(title)}</h3>
+        ${isMonthFocus ? renderStudentCalendarNavButton(1, months, weeks, "Vai al mese successivo.") : ""}
       </div>
       <div class="studentMonthWeekdays">
         <span>Lun</span><span>Mar</span><span>Mer</span><span>Gio</span><span>Ven</span><span>Sab</span><span>Dom</span>
@@ -502,21 +607,42 @@ function renderStudentCalendar(assignments) {
     ...studentCalendarEvents(assignments),
     ...udaDateEvents(assignments),
   ].sort((left, right) => left.timestamp - right.timestamp || left.title.localeCompare(right.title, "it", { numeric: true, sensitivity: "base" }));
+  const mode = els.studentCalendarViewMode?.value || currentStudentCalendarView.mode || "month";
+  currentStudentCalendarView.mode = ["year", "month", "week"].includes(mode) ? mode : "month";
   const filterValue = els.studentCalendarFilter?.value || "all";
   const events = filteredStudentCalendarEvents(baseEvents, filterValue);
   const range = calendarDateRange(baseEvents);
   const months = calendarMonths(range.start, range.end);
+  const weeks = calendarWeeks(range.start, range.end);
+  const firstEventMonth = monthKey(months.find((month) => events.some((event) => event.iso?.startsWith(monthKey(month)))) || months[0]);
+  if (!currentStudentCalendarView.month || !months.some((month) => monthKey(month) === currentStudentCalendarView.month)) {
+    currentStudentCalendarView.month = firstEventMonth;
+  }
+  const firstEventWeek = weeks.find((week) => events.some((event) => {
+    const eventDate = dateFromInput(event.iso);
+    return eventDate && eventDate >= week.start && eventDate <= week.end;
+  }));
+  if (!currentStudentCalendarView.week || !weeks.some((week) => isoDate(week.start) === currentStudentCalendarView.week)) {
+    currentStudentCalendarView.week = firstEventWeek ? isoDate(firstEventWeek.start) : isoDate(weeks[0]?.start || range.start);
+  }
+  if (els.studentCalendarViewMode) els.studentCalendarViewMode.value = currentStudentCalendarView.mode;
+  els.studentCalendarMonthField?.classList.toggle("isHidden", currentStudentCalendarView.mode !== "month");
+  els.studentCalendarWeekField?.classList.toggle("isHidden", currentStudentCalendarView.mode !== "week");
   if (els.studentCalendarMonth) {
-    const currentValue = els.studentCalendarMonth.value;
-    const selectedValue = currentValue && months.some((month) => monthKey(month) === currentValue)
-      ? currentValue
-      : monthKey(months.find((month) => events.some((event) => event.iso?.startsWith(monthKey(month)))) || months[0]);
     els.studentCalendarMonth.innerHTML = months.map((month) => {
       const value = monthKey(month);
       const label = month.toLocaleDateString("it-IT", { month: "long", year: "numeric" });
-      return `<option value="${value}"${value === selectedValue ? " selected" : ""}>${escapeHtml(label)}</option>`;
+      return `<option value="${value}"${value === currentStudentCalendarView.month ? " selected" : ""}>${escapeHtml(label)}</option>`;
     }).join("");
-    els.studentCalendarMonth.value = selectedValue;
+    els.studentCalendarMonth.value = currentStudentCalendarView.month;
+  }
+  if (els.studentCalendarWeek) {
+    els.studentCalendarWeek.innerHTML = weeks.map((week, index) => {
+      const value = isoDate(week.start);
+      const label = `Settimana ${index + 1}: ${week.start.toLocaleDateString("it-IT")} - ${week.end.toLocaleDateString("it-IT")}`;
+      return `<option value="${value}"${value === currentStudentCalendarView.week ? " selected" : ""}>${escapeHtml(label)}</option>`;
+    }).join("");
+    els.studentCalendarWeek.value = currentStudentCalendarView.week;
   }
   if (els.studentCalendarStatus) {
     const dueCount = baseEvents.filter((event) => event.kind === "due").length;
@@ -531,13 +657,21 @@ function renderStudentCalendar(assignments) {
     if (!eventsByDate.has(event.iso)) eventsByDate.set(event.iso, []);
     eventsByDate.get(event.iso).push(event);
   }
-  const contextMonths = selectedStudentCalendarMonthContext(months, els.studentCalendarMonth?.value || monthKey(months[0]));
+  const selectedWeek = selectedStudentCalendarWeek(weeks, currentStudentCalendarView.week);
+  const renderedCalendar = currentStudentCalendarView.mode === "week" && selectedWeek
+    ? renderStudentCalendarWeek(selectedWeek, eventsByDate, range, months, weeks)
+    : `
+      <div class="studentMonthGrid ${currentStudentCalendarView.mode === "month" ? "studentMonthFocusGrid" : ""}">
+        ${(currentStudentCalendarView.mode === "month"
+          ? selectedStudentCalendarMonthContext(months, currentStudentCalendarView.month)
+          : months.map((month) => ({ month, role: "main" }))
+        ).map((item) => renderStudentCalendarMonth(item.month, item.role, eventsByDate, range, months, weeks)).join("")}
+      </div>
+    `;
   els.studentCalendar.innerHTML = baseEvents.length
     ? `
       ${renderStudentCalendarLegend(baseEvents)}
-      <div class="studentMonthGrid">
-        ${contextMonths.map((item) => renderStudentCalendarMonth(item.month, item.role, eventsByDate, range)).join("")}
-      </div>
+      ${renderedCalendar}
     `
     : '<p class="status">Nessuna data disponibile per le consegne di questo studente.</p>';
 }
@@ -1010,12 +1144,34 @@ els.assignmentSort?.addEventListener("change", () => {
   renderDashboard(currentDashboardPayload);
 });
 
+els.studentCalendarViewMode?.addEventListener("change", () => {
+  currentStudentCalendarView.mode = els.studentCalendarViewMode.value;
+  renderStudentCalendar(currentDashboardPayload.assignments || []);
+});
+
 els.studentCalendarMonth?.addEventListener("change", () => {
+  currentStudentCalendarView.month = els.studentCalendarMonth.value;
+  renderStudentCalendar(currentDashboardPayload.assignments || []);
+});
+
+els.studentCalendarWeek?.addEventListener("change", () => {
+  currentStudentCalendarView.week = els.studentCalendarWeek.value;
   renderStudentCalendar(currentDashboardPayload.assignments || []);
 });
 
 els.studentCalendarFilter?.addEventListener("change", () => {
   renderStudentCalendar(currentDashboardPayload.assignments || []);
+});
+
+els.studentCalendar?.addEventListener("click", (event) => {
+  const navButton = event.target.closest?.("[data-student-calendar-nav]");
+  if (!navButton || navButton.disabled) return;
+  const direction = navButton.dataset.studentCalendarNav === "previous" ? -1 : 1;
+  const range = calendarDateRange([
+    ...studentCalendarEvents(currentDashboardPayload.assignments || []),
+    ...udaDateEvents(currentDashboardPayload.assignments || []),
+  ]);
+  moveStudentCalendarView(direction, calendarMonths(range.start, range.end), calendarWeeks(range.start, range.end));
 });
 
 els.assignments?.addEventListener("click", (event) => {

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -400,7 +400,7 @@ function studentCalendarEvents(assignments) {
   const nextAssignment = nextOpenAssignment(assignments);
   const nextDueDate = dateFromInput(nextAssignment?.due_at || "");
   const nextDueIso = nextDueDate ? isoDate(nextDueDate) : "";
-  return assignments.flatMap((assignment) => {
+  return assignments.flatMap((assignment, assignmentIndex) => {
     const title = assignmentTitle(assignment) || "-";
     const events = [];
     const assignedDate = dateFromInput(assignment.assigned_at);
@@ -414,6 +414,7 @@ function studentCalendarEvents(assignments) {
         timestamp: assignedDate.getTime(),
         title,
         assignment,
+        assignmentIndex,
         priority: false,
       });
     }
@@ -429,6 +430,7 @@ function studentCalendarEvents(assignments) {
         timestamp: dueTimestamp,
         title,
         assignment,
+        assignmentIndex,
         priority: isOpenAssignment(assignment) && isoDate(dueDate) === nextDueIso,
       });
     }
@@ -505,10 +507,23 @@ function renderCalendarEventPill(event) {
     : event.category === "udas"
       ? "calendarPillUda"
       : "calendarPillAssigned";
+  const content = `
+    ${event.priority ? '<strong>!</strong><span class="calendarPriorityText">Prossima scadenza</span>' : ""}
+    ${escapeHtml(event.title)}
+  `;
+  if (event.assignment && event.assignmentIndex != null) {
+    return `
+      <button
+        type="button"
+        class="calendarPill calendarPillButton ${kindClass}"
+        data-calendar-detail-index="${escapeHtml(event.assignmentIndex)}"
+        title="${escapeHtml(`Apri dettaglio consegna: ${event.title}`)}"
+      >${content}</button>
+    `;
+  }
   return `
     <span class="calendarPill ${kindClass}" title="${escapeHtml(`${event.label}: ${event.title}`)}">
-      ${event.priority ? '<strong>!</strong><span class="calendarPriorityText">Prossima scadenza</span>' : ""}
-      ${escapeHtml(event.title)}
+      ${content}
     </span>
   `;
 }
@@ -614,8 +629,11 @@ function renderStudentCalendarList(events) {
           : event.category === "udas"
             ? "calendarPillUda"
             : "calendarPillAssigned";
+        const detailAttrs = event.assignment && event.assignmentIndex != null
+          ? ` role="button" tabindex="0" data-calendar-detail-index="${escapeHtml(event.assignmentIndex)}" title="${escapeHtml(`Apri dettaglio consegna: ${event.title}`)}"`
+          : "";
         return `
-          <article class="studentCalendarListItem">
+          <article class="studentCalendarListItem${detailAttrs ? " studentCalendarListItemButton" : ""}"${detailAttrs}>
             <time datetime="${escapeHtml(event.iso || event.date || "")}">${escapeHtml(formatDate(event.date || event.iso))}</time>
             <div>
               <h3>${escapeHtml(event.title)}</h3>
@@ -1209,6 +1227,11 @@ document.querySelectorAll?.("[data-student-calendar-display]").forEach((button) 
 });
 
 els.studentCalendar?.addEventListener("click", (event) => {
+  const detailTarget = event.target.closest?.("[data-calendar-detail-index]");
+  if (detailTarget) {
+    openAssignmentDetail(detailTarget.dataset.calendarDetailIndex);
+    return;
+  }
   const navButton = event.target.closest?.("[data-student-calendar-nav]");
   if (!navButton || navButton.disabled) return;
   const direction = navButton.dataset.studentCalendarNav === "previous" ? -1 : 1;
@@ -1217,6 +1240,14 @@ els.studentCalendar?.addEventListener("click", (event) => {
     ...udaDateEvents(currentDashboardPayload.assignments || []),
   ]);
   moveStudentCalendarView(direction, calendarMonths(range.start, range.end), calendarWeeks(range.start, range.end));
+});
+
+els.studentCalendar?.addEventListener("keydown", (event) => {
+  if (event.key !== "Enter" && event.key !== " ") return;
+  const detailTarget = event.target.closest?.("[data-calendar-detail-index]");
+  if (!detailTarget) return;
+  event.preventDefault();
+  openAssignmentDetail(detailTarget.dataset.calendarDetailIndex);
 });
 
 els.assignments?.addEventListener("click", (event) => {

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -9,6 +9,8 @@ const els = {
   assignments: document.querySelector("#assignments"),
   studentCalendar: document.querySelector("#studentCalendar"),
   studentCalendarStatus: document.querySelector("#studentCalendarStatus"),
+  studentCalendarMonth: document.querySelector("#studentCalendarMonth"),
+  studentCalendarFilter: document.querySelector("#studentCalendarFilter"),
   coursePath: document.querySelector("#coursePath"),
   coursePathStatus: document.querySelector("#coursePathStatus"),
   assignmentDetailModal: document.querySelector("#assignmentDetailModal"),
@@ -23,6 +25,7 @@ let currentDashboardPayload = { student_id: "", assignments: [] };
 let currentClassLabel = "Dai registri consegne";
 let currentClassRoster = null;
 let currentCourseDesign = null;
+let currentSchoolCalendar = null;
 
 async function api(path, options = {}) {
   const response = await fetch(path, options);
@@ -288,40 +291,80 @@ function renderSummary(studentId, assignments) {
   `).join("");
 }
 
-function calendarEventTimestamp(value) {
+function dateFromInput(value) {
   if (!value) return null;
-  const timestamp = Date.parse(value);
-  return Number.isNaN(timestamp) ? null : timestamp;
+  const [year, month, day] = String(value || "").slice(0, 10).split("-").map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day);
+}
+
+function isoDate(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function monthKey(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function calendarMonths(start, end) {
+  const months = [];
+  const cursor = new Date(start.getFullYear(), start.getMonth(), 1);
+  const last = new Date(end.getFullYear(), end.getMonth(), 1);
+  while (cursor <= last) {
+    months.push(new Date(cursor));
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+  return months;
+}
+
+function selectedStudentCalendarMonthContext(months, selectedMonth) {
+  if (!months.length) return [];
+  const selectedIndex = months.findIndex((month) => monthKey(month) === selectedMonth);
+  const index = selectedIndex >= 0 ? selectedIndex : 0;
+  return [
+    months[index - 1] ? { month: months[index - 1], role: "context" } : { role: "placeholder" },
+    months[index] ? { month: months[index], role: "main" } : null,
+    months[index + 1] ? { month: months[index + 1], role: "context" } : { role: "placeholder" },
+  ].filter(Boolean);
 }
 
 function studentCalendarEvents(assignments) {
   const nextAssignment = nextOpenAssignment(assignments);
-  const nextDue = nextAssignment ? timestampOrInfinity(nextAssignment.due_at) : Number.POSITIVE_INFINITY;
+  const nextDueDate = dateFromInput(nextAssignment?.due_at || "");
+  const nextDueIso = nextDueDate ? isoDate(nextDueDate) : "";
   return assignments.flatMap((assignment) => {
     const title = assignmentTitle(assignment) || "-";
     const events = [];
-    const assignedTimestamp = calendarEventTimestamp(assignment.assigned_at);
-    if (assignedTimestamp != null) {
+    const assignedDate = dateFromInput(assignment.assigned_at);
+    if (assignedDate) {
       events.push({
         kind: "assigned",
+        category: "assignments",
         label: "Assegnata",
         date: assignment.assigned_at,
-        timestamp: assignedTimestamp,
+        iso: isoDate(assignedDate),
+        timestamp: assignedDate.getTime(),
         title,
         assignment,
         priority: false,
       });
     }
-    const dueTimestamp = calendarEventTimestamp(assignment.due_at);
-    if (dueTimestamp != null) {
+    const dueDate = dateFromInput(assignment.due_at);
+    if (dueDate) {
+      const dueTimestamp = dueDate.getTime();
       events.push({
         kind: "due",
+        category: "assignments",
         label: "Scadenza",
         date: assignment.due_at,
+        iso: isoDate(dueDate),
         timestamp: dueTimestamp,
         title,
         assignment,
-        priority: isOpenAssignment(assignment) && dueTimestamp === nextDue,
+        priority: isOpenAssignment(assignment) && isoDate(dueDate) === nextDueIso,
       });
     }
     return events;
@@ -332,38 +375,170 @@ function studentCalendarEvents(assignments) {
   ));
 }
 
-function renderCalendarEvent(event) {
-  const kindClass = event.kind === "due" ? "calendarEventDue" : "calendarEventAssigned";
+function visibleUdasForStudent(assignments, studentId = currentDashboardPayload.student_id) {
+  const context = visibilityContext(studentId, assignments);
+  return visibleCourseSections(courseSections(currentCourseDesign), context)
+    .flatMap((section) => Array.isArray(section?.udas) ? section.udas : []);
+}
+
+function udaDateEvents(assignments, studentId = currentDashboardPayload.student_id) {
+  return visibleUdasForStudent(assignments, studentId).flatMap((uda) => {
+    const actual = uda.actual || {};
+    const start = dateFromInput(actual.start_date || "");
+    const end = dateFromInput(actual.end_date || actual.start_date || "");
+    if (!start) return [];
+    const title = `${String(uda.id || "").toUpperCase()} ${uda.title || "UDA senza titolo"}`.trim();
+    const events = [{
+      kind: "uda_actual_start",
+      category: "udas",
+      label: actual.status === "done" ? "UDA svolta" : "UDA reale",
+      date: actual.start_date,
+      iso: isoDate(start),
+      timestamp: start.getTime(),
+      title,
+      uda,
+      priority: false,
+    }];
+    if (end && isoDate(end) !== isoDate(start)) {
+      events.push({
+        kind: "uda_actual_end",
+        category: "udas",
+        label: "Fine UDA reale",
+        date: actual.end_date || actual.start_date,
+        iso: isoDate(end),
+        timestamp: end.getTime(),
+        title,
+        uda,
+        priority: false,
+      });
+    }
+    return events;
+  });
+}
+
+function calendarDateRange(events) {
+  const eventDates = events.map((event) => dateFromInput(event.iso)).filter(Boolean);
+  const calendarStart = dateFromInput(currentSchoolCalendar?.start_date || "");
+  const calendarEnd = dateFromInput(currentSchoolCalendar?.end_date || "");
+  const start = calendarStart || eventDates.reduce((min, date) => (!min || date < min ? date : min), null);
+  const end = calendarEnd || eventDates.reduce((max, date) => (!max || date > max ? date : max), null);
+  if (start && end) return { start, end };
+  const today = new Date();
+  return { start: new Date(today.getFullYear(), today.getMonth(), 1), end: new Date(today.getFullYear(), today.getMonth() + 1, 0) };
+}
+
+function filteredStudentCalendarEvents(events, filterValue) {
+  if (filterValue === "assignments") return events.filter((event) => event.category === "assignments");
+  if (filterValue === "udas") return events.filter((event) => event.category === "udas");
+  if (filterValue === "due") return events.filter((event) => event.kind === "due");
+  return events;
+}
+
+function renderCalendarEventPill(event) {
+  const kindClass = event.kind === "due"
+    ? "calendarPillDue"
+    : event.category === "udas"
+      ? "calendarPillUda"
+      : "calendarPillAssigned";
   return `
-    <article class="calendarEvent ${kindClass}">
-      <time datetime="${escapeHtml(event.date)}">${escapeHtml(formatDate(event.date))}</time>
-      <div>
-        <h3>${escapeHtml(event.title)}</h3>
-        <p class="meta">
-          <span>${escapeHtml(event.label)}</span>
-          <span>${escapeHtml(event.assignment.kind || "tipo non indicato")}</span>
-          <span>${escapeHtml(event.assignment.student_support_mode || "modalita non indicata")}</span>
-        </p>
+    <span class="calendarPill ${kindClass}" title="${escapeHtml(`${event.label}: ${event.title}`)}">
+      ${event.priority ? '<strong>!</strong><span class="calendarPriorityText">Prossima scadenza</span>' : ""}
+      ${escapeHtml(event.title)}
+    </span>
+  `;
+}
+
+function renderStudentCalendarMonth(month, role, eventsByDate, range) {
+  if (role === "placeholder") return '<div class="studentMonthPlaceholder"></div>';
+  const title = month.toLocaleDateString("it-IT", { month: "long", year: "numeric" });
+  const first = new Date(month.getFullYear(), month.getMonth(), 1);
+  const startOffset = (first.getDay() + 6) % 7;
+  const cursor = new Date(first);
+  cursor.setDate(cursor.getDate() - startOffset);
+  const cells = [];
+  for (let index = 0; index < 42; index += 1) {
+    const day = new Date(cursor);
+    const iso = isoDate(day);
+    const dayEvents = eventsByDate.get(iso) || [];
+    const classes = ["studentDayCell"];
+    if (day.getMonth() !== month.getMonth()) classes.push("studentDayOutsideMonth");
+    if (day < range.start || day > range.end) classes.push("studentDayOutsideRange");
+    if (dayEvents.length) classes.push("studentDayHasEvents");
+    cells.push(`
+      <div class="${classes.join(" ")}">
+        <span class="studentDayNumber">${day.getDate()}</span>
+        ${dayEvents.map(renderCalendarEventPill).join("")}
       </div>
-      <div class="calendarEventBadges">
-        ${event.priority ? badge("Prossima scadenza", "badgePriority") : ""}
-        ${event.kind === "due" ? statusBadge(event.assignment) : badge("Finestra di lavoro")}
+    `);
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return `
+    <article class="studentMonthCard ${role === "context" ? "studentMonthContextCard" : "studentMonthMainCard"}">
+      <div class="studentMonthTitle">
+        <h3>${escapeHtml(title)}</h3>
       </div>
+      <div class="studentMonthWeekdays">
+        <span>Lun</span><span>Mar</span><span>Mer</span><span>Gio</span><span>Ven</span><span>Sab</span><span>Dom</span>
+      </div>
+      <div class="studentMonthDays">${cells.join("")}</div>
     </article>
+  `;
+}
+
+function renderStudentCalendarLegend(events) {
+  if (!events.length) return "";
+  return `
+    <div class="studentCalendarLegend">
+      <span class="calendarPill calendarPillAssigned">Assegnata</span>
+      <span class="calendarPill calendarPillDue">Scadenza</span>
+      <span class="calendarPill calendarPillUda">UDA reale</span>
+    </div>
   `;
 }
 
 function renderStudentCalendar(assignments) {
   if (!els.studentCalendar) return;
-  const events = studentCalendarEvents(assignments);
+  const baseEvents = [
+    ...studentCalendarEvents(assignments),
+    ...udaDateEvents(assignments),
+  ].sort((left, right) => left.timestamp - right.timestamp || left.title.localeCompare(right.title, "it", { numeric: true, sensitivity: "base" }));
+  const filterValue = els.studentCalendarFilter?.value || "all";
+  const events = filteredStudentCalendarEvents(baseEvents, filterValue);
+  const range = calendarDateRange(baseEvents);
+  const months = calendarMonths(range.start, range.end);
+  if (els.studentCalendarMonth) {
+    const currentValue = els.studentCalendarMonth.value;
+    const selectedValue = currentValue && months.some((month) => monthKey(month) === currentValue)
+      ? currentValue
+      : monthKey(months.find((month) => events.some((event) => event.iso?.startsWith(monthKey(month)))) || months[0]);
+    els.studentCalendarMonth.innerHTML = months.map((month) => {
+      const value = monthKey(month);
+      const label = month.toLocaleDateString("it-IT", { month: "long", year: "numeric" });
+      return `<option value="${value}"${value === selectedValue ? " selected" : ""}>${escapeHtml(label)}</option>`;
+    }).join("");
+    els.studentCalendarMonth.value = selectedValue;
+  }
   if (els.studentCalendarStatus) {
-    const dueCount = events.filter((event) => event.kind === "due").length;
-    els.studentCalendarStatus.textContent = events.length
-      ? `${events.length} eventi · ${dueCount} scadenze`
+    const dueCount = baseEvents.filter((event) => event.kind === "due").length;
+    const udaCount = baseEvents.filter((event) => event.category === "udas").length;
+    els.studentCalendarStatus.textContent = baseEvents.length
+      ? `${baseEvents.length} eventi · ${dueCount} scadenze · ${udaCount} UDA`
       : "";
   }
-  els.studentCalendar.innerHTML = events.length
-    ? events.map(renderCalendarEvent).join("")
+  const eventsByDate = new Map();
+  for (const event of events) {
+    if (!event.iso) continue;
+    if (!eventsByDate.has(event.iso)) eventsByDate.set(event.iso, []);
+    eventsByDate.get(event.iso).push(event);
+  }
+  const contextMonths = selectedStudentCalendarMonthContext(months, els.studentCalendarMonth?.value || monthKey(months[0]));
+  els.studentCalendar.innerHTML = baseEvents.length
+    ? `
+      ${renderStudentCalendarLegend(baseEvents)}
+      <div class="studentMonthGrid">
+        ${contextMonths.map((item) => renderStudentCalendarMonth(item.month, item.role, eventsByDate, range)).join("")}
+      </div>
+    `
     : '<p class="status">Nessuna data disponibile per le consegne di questo studente.</p>';
 }
 
@@ -538,12 +713,33 @@ async function loadCoursePath() {
   try {
     currentCourseDesign = await api("/api/course-design");
     renderCoursePath(currentCourseDesign, currentDashboardPayload.assignments, currentDashboardPayload.student_id);
+    renderStudentCalendar(currentDashboardPayload.assignments);
   } catch (error) {
     currentCourseDesign = null;
     if (els.coursePath) {
       els.coursePath.innerHTML = '<p class="status">Percorso non disponibile.</p>';
     }
     if (els.coursePathStatus) els.coursePathStatus.textContent = `Errore: ${error.message}`;
+  }
+}
+
+async function loadSchoolCalendar() {
+  try {
+    const payload = await api("/api/school-calendars");
+    const calendars = Array.isArray(payload.calendars) ? payload.calendars : [];
+    const selected = calendars.find((calendar) => calendar.course_design_name)
+      || calendars.find((calendar) => calendar.name)
+      || null;
+    if (!selected?.name) return;
+    const detail = await api("/api/school-calendars/load", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: selected.name }),
+    });
+    currentSchoolCalendar = detail.calendar || null;
+    renderStudentCalendar(currentDashboardPayload.assignments);
+  } catch {
+    currentSchoolCalendar = null;
   }
 }
 
@@ -814,6 +1010,14 @@ els.assignmentSort?.addEventListener("change", () => {
   renderDashboard(currentDashboardPayload);
 });
 
+els.studentCalendarMonth?.addEventListener("change", () => {
+  renderStudentCalendar(currentDashboardPayload.assignments || []);
+});
+
+els.studentCalendarFilter?.addEventListener("change", () => {
+  renderStudentCalendar(currentDashboardPayload.assignments || []);
+});
+
 els.assignments?.addEventListener("click", (event) => {
   const detailButton = event.target.closest?.("[data-detail-index]");
   if (!detailButton) return;
@@ -837,3 +1041,4 @@ loadStudentOptions(els.studentId.value)
   });
 
 loadCoursePath();
+loadSchoolCalendar();

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -483,6 +483,30 @@ function udaDateEvents(assignments, studentId = currentDashboardPayload.student_
   });
 }
 
+function closureDateEvents() {
+  return (Array.isArray(currentSchoolCalendar?.closures) ? currentSchoolCalendar.closures : []).flatMap((closure) => {
+    const from = dateFromInput(closure.from || "");
+    const to = dateFromInput(closure.to || closure.from || "");
+    if (!from || !to || from > to) return [];
+    const events = [];
+    for (const cursor = new Date(from); cursor <= to; cursor.setDate(cursor.getDate() + 1)) {
+      const day = new Date(cursor);
+      events.push({
+        kind: "closure",
+        category: "closures",
+        label: closure.label || closure.type || "Chiusura",
+        date: isoDate(day),
+        iso: isoDate(day),
+        timestamp: day.getTime(),
+        title: closure.label || closure.type || "Chiusura",
+        closure,
+        priority: false,
+      });
+    }
+    return events;
+  });
+}
+
 function calendarDateRange(events) {
   const eventDates = events.map((event) => dateFromInput(event.iso)).filter(Boolean);
   const calendarStart = dateFromInput(currentSchoolCalendar?.start_date || "");
@@ -497,6 +521,7 @@ function calendarDateRange(events) {
 function filteredStudentCalendarEvents(events, filterValue) {
   if (filterValue === "assignments") return events.filter((event) => event.category === "assignments");
   if (filterValue === "udas") return events.filter((event) => event.category === "udas");
+  if (filterValue === "closures") return events.filter((event) => event.category === "closures");
   if (filterValue === "due") return events.filter((event) => event.kind === "due");
   return events;
 }
@@ -506,7 +531,9 @@ function renderCalendarEventPill(event) {
     ? "calendarPillDue"
     : event.category === "udas"
       ? "calendarPillUda"
-      : "calendarPillAssigned";
+      : event.category === "closures"
+        ? "calendarPillClosure"
+        : "calendarPillAssigned";
   const content = `
     ${event.priority ? '<strong>!</strong><span class="calendarPriorityText">Prossima scadenza</span>' : ""}
     ${escapeHtml(event.title)}
@@ -613,6 +640,7 @@ function renderStudentCalendarLegend(events) {
       <span class="calendarPill calendarPillAssigned">Assegnata</span>
       <span class="calendarPill calendarPillDue">Scadenza</span>
       <span class="calendarPill calendarPillUda">UDA reale</span>
+      <span class="calendarPill calendarPillClosure">Festivita/interruzione</span>
     </div>
   `;
 }
@@ -628,7 +656,9 @@ function renderStudentCalendarList(events) {
           ? "calendarPillDue"
           : event.category === "udas"
             ? "calendarPillUda"
-            : "calendarPillAssigned";
+            : event.category === "closures"
+              ? "calendarPillClosure"
+              : "calendarPillAssigned";
         const detailAttrs = event.assignment && event.assignmentIndex != null
           ? ` role="button" tabindex="0" data-calendar-detail-index="${escapeHtml(event.assignmentIndex)}" title="${escapeHtml(`Apri dettaglio consegna: ${event.title}`)}"`
           : "";
@@ -654,6 +684,7 @@ function renderStudentCalendar(assignments) {
   const baseEvents = [
     ...studentCalendarEvents(assignments),
     ...udaDateEvents(assignments),
+    ...closureDateEvents(),
   ].sort((left, right) => left.timestamp - right.timestamp || left.title.localeCompare(right.title, "it", { numeric: true, sensitivity: "base" }));
   const mode = els.studentCalendarViewMode?.value || currentStudentCalendarView.mode || "month";
   currentStudentCalendarView.mode = ["year", "month", "week"].includes(mode) ? mode : "month";
@@ -701,8 +732,9 @@ function renderStudentCalendar(assignments) {
   if (els.studentCalendarStatus) {
     const dueCount = baseEvents.filter((event) => event.kind === "due").length;
     const udaCount = baseEvents.filter((event) => event.category === "udas").length;
+    const closureCount = baseEvents.filter((event) => event.category === "closures").length;
     els.studentCalendarStatus.textContent = baseEvents.length
-      ? `${baseEvents.length} eventi · ${dueCount} scadenze · ${udaCount} UDA`
+      ? `${baseEvents.length} eventi · ${dueCount} scadenze · ${udaCount} UDA · ${closureCount} chiusure`
       : "";
   }
   const eventsByDate = new Map();
@@ -1320,6 +1352,7 @@ els.studentCalendar?.addEventListener("click", (event) => {
   const range = calendarDateRange([
     ...studentCalendarEvents(currentDashboardPayload.assignments || []),
     ...udaDateEvents(currentDashboardPayload.assignments || []),
+    ...closureDateEvents(),
   ]);
   moveStudentCalendarView(direction, calendarMonths(range.start, range.end), calendarWeeks(range.start, range.end));
 });


### PR DESCRIPTION
## Cosa cambia

- Aggiunge alla vista studente un calendario mensile in sola lettura, coerente con la vista docente: mese centrale e mesi laterali di contesto.
- Introduce i filtri del calendario studente: tutto, consegne, UDA, scadenze.
- Mostra eventi di assegnazione e scadenza delle consegne, con badge sulle prossime scadenze aperte.
- Mostra anche le UDA reali quando il percorso contiene date consuntive pubblicate.
- Carica il calendario salvato, quando disponibile, per usare l'intervallo pubblicato; altrimenti usa l'intervallo degli eventi dello studente.
- Aggiorna la guida studente con il comportamento del nuovo calendario.

## Test

- `python -m pytest tests/test_student_dashboard_frontend.py tests/test_course_board_server.py` -> 29 passed

## Note

Restano fuori dalla PR i file locali/demo gia sporchi nel working tree (`doc/course_design.json`, report demo e calendario demo non tracciato).
