### PR TITLE
Aggiunge creazione activity docente MVP

### DIFF
--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -125,7 +125,7 @@ Prerequisiti:
 Passaggi:
 
 1. Apri la dashboard consegne.
-2. Nel pannello **Genera registro**, scegli una activity da **Activity salvate**.
+2. Nel pannello **Genera registro**, scegli una activity da **Scegli activity**.
 3. Scegli una classe da **Classe da roster**.
 4. Controlla il pannello **Roster classe**:
    - classe;

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -217,6 +217,24 @@ Questa fase serve a togliere al docente la gestione manuale di file e repository
    - validazione prima del salvataggio;
    - collegamento a percorso, UDA e argomenti;
    - scelta tipo, modalita, scadenza e visibilita;
+   - authoring assistito da AI, includendo anche provider diversi e Codex quando disponibile:
+     - generazione traccia;
+     - generazione esempi e casi d'uso;
+     - generazione scheletri di codice da completare;
+     - generazione codice con bug intenzionali da diagnosticare;
+     - generazione fixture input/output;
+     - generazione test visibili e nascosti;
+     - generazione soluzione o soluzione di riferimento riservata al docente;
+     - generazione rubrica, criteri di valutazione e feedback attesi;
+     - generazione eventuali Makefile, runner o configurazioni Docker;
+   - mostrare ogni proposta AI come bozza revisionabile:
+     - accettare singole parti;
+     - modificarle manualmente;
+     - scartarle;
+     - rigenerare con istruzioni diverse;
+     - confrontare versioni alternative;
+     - registrare provider/modello/prompt/provenienza quando la bozza viene salvata;
+   - permettere sempre la modalita manuale completa, senza AI;
    - gestione asset dell'activity:
      - file di esempio allegati alla traccia;
      - scheletri di codice da completare;
@@ -545,26 +563,30 @@ Ordine consigliato:
    - allegare o selezionare file di esempio, scheletri, fixture, test e runner;
    - distinguere asset pubblici per lo studente, asset riservati al grading e asset solo docente;
    - copiare gli asset corretti nello scaffold consegna durante l'assegnazione.
-6. Pagina assegnazione activity a classe, gruppo o singolo studente e scaffold consegna.
-7. Interfaccia studente MVP per consegne, stato e feedback deterministico, web oppure TUI se piu rapida da rendere affidabile.
-8. Consolidamento grading Docker per flusso reale di consegna.
-9. Collegamento automatico report/artifact al registro consegne.
-10. Revisione dashboard docente contro il flusso MVP reale.
-11. Event log minimale e provenienza minima per activity/contenuti generati.
-12. Cornice didattica generale e guida operativa docente/studente.
-13. Inserimento activity nel percorso e visualizzazione calendario.
-14. Gestione consuntivi UDA reali:
+6. Generazione AI/Codex di activity e asset:
+   - proporre traccia, esempi, starter code, bug da correggere, soluzione, test e rubrica;
+   - lasciare al docente controllo completo: accetta, modifica, scarta, rigenera o crea manualmente;
+   - registrare provenienza della generazione e policy AI usata.
+7. Pagina assegnazione activity a classe, gruppo o singolo studente e scaffold consegna.
+8. Interfaccia studente MVP per consegne, stato e feedback deterministico, web oppure TUI se piu rapida da rendere affidabile.
+9. Consolidamento grading Docker per flusso reale di consegna.
+10. Collegamento automatico report/artifact al registro consegne.
+11. Revisione dashboard docente contro il flusso MVP reale.
+12. Event log minimale e provenienza minima per activity/contenuti generati.
+13. Cornice didattica generale e guida operativa docente/studente.
+14. Inserimento activity nel percorso e visualizzazione calendario.
+15. Gestione consuntivi UDA reali:
    - mostrare le UDA reali anche nella vista calendario docente;
    - aggiungere un filtro calendario per scegliere tra UDA programmate, UDA reali o entrambe;
    - rendere cliccabili le UDA reali nei calendari docente/studente e aprire un modal di dettaglio coerente;
    - cancellare una UDA reale gia salvata dal calendario docente;
    - ripristinare lo stato pianificato quando il consuntivo e stato inserito per errore;
    - confermare prima della cancellazione e registrare provenienza/eventuale audit log.
-15. Archiviazione/cancellazione sicura di registri e activity.
-16. Catalogo fonti e import paragrafi da piu repository.
-17. Estensione layout pannelli alle altre pagine.
-18. Feedback assistito avanzato lato studente.
-19. Source provider API, indicizzazione frammenti e playground knowledge lab.
+16. Archiviazione/cancellazione sicura di registri e activity.
+17. Catalogo fonti e import paragrafi da piu repository.
+18. Estensione layout pannelli alle altre pagine.
+19. Feedback assistito avanzato lato studente.
+20. Source provider API, indicizzazione frammenti e playground knowledge lab.
 
 ## Criterio di priorita
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -216,7 +216,16 @@ Questa fase serve a togliere al docente la gestione manuale di file e repository
    - duplicazione;
    - validazione prima del salvataggio;
    - collegamento a percorso, UDA e argomenti;
-   - scelta tipo, modalita, scadenza e visibilita.
+   - scelta tipo, modalita, scadenza e visibilita;
+   - gestione asset dell'activity:
+     - file di esempio allegati alla traccia;
+     - scheletri di codice da completare;
+     - fixture di input/output;
+     - test visibili e test nascosti;
+     - eventuali Makefile, script runner o configurazioni Docker;
+     - materiali di supporto opzionali, come README, immagini o dataset piccoli;
+   - definire quali asset vengono mostrati allo studente, quali copiati nello scaffold consegna e quali restano solo al docente/grading;
+   - supportare almeno una cartella sorgente per activity, versionata e validabile insieme al JSON.
 8. Aggiungere assegnazione activity a classi/team da GUI.
 
 ## Priorita 1.5 - Percorso, fonti e calendario didattico
@@ -345,12 +354,17 @@ Il grading attuale e una base, ma il flusso reale richiede altri passi.
 
 1. Supportare consegne multi-file.
 2. Gestire header, fixture, Makefile e directory di progetto.
-3. Aggiungere runner per altri linguaggi previsti dallo schema.
-4. Rendere configurabili limiti di memoria, CPU, timeout, filesystem e file generati.
-5. Integrare GitHub Actions dedicate alle consegne studenti.
-6. Scaricare artifact/report GitHub Actions e collegarli ai registri.
-7. Garantire che i job che eseguono codice studente non abbiano segreti.
-8. Modellare i tentativi (`Attempt`) separatamente dalla consegna finale (`Submission`), cosi lo storico tecnico puo alimentare feedback, analytics e modalita esame senza confondere voto e processo.
+3. Collegare gli asset dell'activity allo scaffold consegna:
+   - copiare scheletri e file di esempio nei repository studenti;
+   - copiare fixture/test visibili quando consentito;
+   - mantenere test nascosti e soluzioni fuori dallo scaffold studente;
+   - registrare nel JSON della consegna quali asset sono stati pubblicati e da quale versione derivano.
+4. Aggiungere runner per altri linguaggi previsti dallo schema.
+5. Rendere configurabili limiti di memoria, CPU, timeout, filesystem e file generati.
+6. Integrare GitHub Actions dedicate alle consegne studenti.
+7. Scaricare artifact/report GitHub Actions e collegarli ai registri.
+8. Garantire che i job che eseguono codice studente non abbiano segreti.
+9. Modellare i tentativi (`Attempt`) separatamente dalla consegna finale (`Submission`), cosi lo storico tecnico puo alimentare feedback, analytics e modalita esame senza confondere voto e processo.
 
 ## Priorita 5 - UI comune e pagine nuove
 
@@ -527,26 +541,30 @@ Ordine consigliato:
 2. Provider layer minimo: interfaccia comune e implementazione GitHub iniziale.
 3. Gestione classi MVP: import/sync da GitHub Team o import manuale controllato.
 4. Pagina creazione/generazione/modifica activity con validazione.
-5. Pagina assegnazione activity a classe, gruppo o singolo studente e scaffold consegna.
-6. Interfaccia studente MVP per consegne, stato e feedback deterministico, web oppure TUI se piu rapida da rendere affidabile.
-7. Consolidamento grading Docker per flusso reale di consegna.
-8. Collegamento automatico report/artifact al registro consegne.
-9. Revisione dashboard docente contro il flusso MVP reale.
-10. Event log minimale e provenienza minima per activity/contenuti generati.
-11. Cornice didattica generale e guida operativa docente/studente.
-12. Inserimento activity nel percorso e visualizzazione calendario.
-13. Gestione consuntivi UDA reali:
+5. Asset activity e scaffold:
+   - allegare o selezionare file di esempio, scheletri, fixture, test e runner;
+   - distinguere asset pubblici per lo studente, asset riservati al grading e asset solo docente;
+   - copiare gli asset corretti nello scaffold consegna durante l'assegnazione.
+6. Pagina assegnazione activity a classe, gruppo o singolo studente e scaffold consegna.
+7. Interfaccia studente MVP per consegne, stato e feedback deterministico, web oppure TUI se piu rapida da rendere affidabile.
+8. Consolidamento grading Docker per flusso reale di consegna.
+9. Collegamento automatico report/artifact al registro consegne.
+10. Revisione dashboard docente contro il flusso MVP reale.
+11. Event log minimale e provenienza minima per activity/contenuti generati.
+12. Cornice didattica generale e guida operativa docente/studente.
+13. Inserimento activity nel percorso e visualizzazione calendario.
+14. Gestione consuntivi UDA reali:
    - mostrare le UDA reali anche nella vista calendario docente;
    - aggiungere un filtro calendario per scegliere tra UDA programmate, UDA reali o entrambe;
    - rendere cliccabili le UDA reali nei calendari docente/studente e aprire un modal di dettaglio coerente;
    - cancellare una UDA reale gia salvata dal calendario docente;
    - ripristinare lo stato pianificato quando il consuntivo e stato inserito per errore;
    - confermare prima della cancellazione e registrare provenienza/eventuale audit log.
-14. Archiviazione/cancellazione sicura di registri e activity.
-15. Catalogo fonti e import paragrafi da piu repository.
-16. Estensione layout pannelli alle altre pagine.
-17. Feedback assistito avanzato lato studente.
-18. Source provider API, indicizzazione frammenti e playground knowledge lab.
+15. Archiviazione/cancellazione sicura di registri e activity.
+16. Catalogo fonti e import paragrafi da piu repository.
+17. Estensione layout pannelli alle altre pagine.
+18. Feedback assistito avanzato lato studente.
+19. Source provider API, indicizzazione frammenti e playground knowledge lab.
 
 ## Criterio di priorita
 

--- a/doc/images/dashboard-guides/README.md
+++ b/doc/images/dashboard-guides/README.md
@@ -31,7 +31,7 @@ Pagina docente:
 
 - URL: `http://localhost:8765/tools/assignment_dashboard.html`
 - Roster: `doc/classes/demo-3a.json`
-- Activity: una activity demo disponibile nella select **Activity salvate**
+- Activity: una activity demo disponibile nella select **Scegli activity**
 - Registro: un registro demo in `teacher-reports/demo` o `teacher-reports/demo-3a`
 
 Pagina studente:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -33,7 +33,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts import manual_ai_feedback, thebitlab_services, thebitlab_storage, track_assignments
+from scripts import create_activity, manual_ai_feedback, thebitlab_services, thebitlab_storage, track_assignments
 
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
@@ -271,6 +271,31 @@ def list_activities() -> list[dict]:
     """List available activity JSON files for the assignment dashboard."""
 
     return assignment_service().list_activities()
+
+
+def save_activity(payload: dict) -> dict:
+    """Create and persist a teacher-authored activity draft."""
+
+    title = str(payload.get("title", "")).strip()
+    activity_id = str(payload.get("id", "")).strip() or create_activity.slugify(title)
+    topics = create_activity.parse_topics(str(payload.get("topics", "")))
+    activity = create_activity.build_activity(
+        activity_id=activity_id,
+        title=title,
+        activity_type=str(payload.get("kind", "")).strip(),
+        difficulty=str(payload.get("difficulty", "")).strip(),
+        topics=topics,
+        prompt=str(payload.get("prompt", "")).strip(),
+        estimated_minutes=create_activity.positive_int(str(payload.get("estimated_minutes", "30"))),
+        context={
+            "classe": str(payload.get("class_id", "")).strip(),
+            "team_github": str(payload.get("github_team", "")).strip(),
+            "percorso": str(payload.get("path_id", "")).strip(),
+            "uda": str(payload.get("uda_id", "")).strip(),
+        },
+    )
+    saved = assignment_service().save_activity(activity, bool(payload.get("overwrite", False)))
+    return {"ok": True, "activity": saved, "activities": list_activities()}
 
 
 def resolve_submission_file_path(student: dict, file_path: str) -> Path:
@@ -1810,6 +1835,15 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/assignment-reports/generate":
             try:
                 self.write_json(generate_assignment_report(payload))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/activities/save":
+            try:
+                self.write_json(save_activity(payload))
             except Exception as error:  # noqa: BLE001
                 self.send_response(400)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -104,6 +104,11 @@ class AssignmentService:
 
         return self.storage.list_activities()
 
+    def save_activity(self, payload: dict[str, Any], overwrite: bool = False) -> dict[str, Any]:
+        """Persist one teacher-authored activity draft."""
+
+        return self.storage.save_activity(payload, overwrite)
+
     def assignment_overview(self) -> list[dict[str, Any]]:
         """Return one row per student/activity across all saved teacher reports."""
 

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from scripts import create_activity, validate_activity
 from scripts.thebitlab_contracts import normalize_activity, normalize_assignment_register
 
 
@@ -182,6 +183,19 @@ class JsonAssignmentStorage:
         path.relative_to(self.teacher_reports_dir.resolve())
         return path
 
+    def activity_drafts_dir(self) -> Path:
+        """Return the folder used for teacher-authored draft activities."""
+
+        return self.root / "activities" / "drafts"
+
+    def safe_activity_draft_path(self, activity_id: str) -> Path:
+        """Return a safe draft activity path below activities/drafts."""
+
+        filename = f"{create_activity.slugify(activity_id)}.json"
+        path = (self.activity_drafts_dir() / filename).resolve()
+        path.relative_to(self.activity_drafts_dir().resolve())
+        return path
+
     def read_json(self, path: Path) -> dict[str, Any]:
         """Read a JSON object from path."""
 
@@ -195,6 +209,30 @@ class JsonAssignmentStorage:
 
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def save_activity(self, payload: dict[str, Any], overwrite: bool = False) -> dict[str, Any]:
+        """Validate and persist a teacher-authored activity draft."""
+
+        activity_id = str(payload.get("id", "")).strip()
+        errors = validate_activity.validate_activity(payload, activity_id or "<activity>")
+        if errors:
+            raise ValueError("\n".join(errors))
+        path = self.safe_activity_draft_path(activity_id)
+        if path.exists() and not overwrite:
+            raise ValueError(f"Activity gia esistente: {self.relative_path(path)}")
+        self.write_json(path, payload)
+        activity = normalize_activity(payload)
+        return {
+            "id": activity.get("id", ""),
+            "title": activity.get("title", ""),
+            "kind": activity.get("kind", ""),
+            "student_support_mode": activity.get("student_support_mode", ""),
+            "class_id": activity.get("class_id", ""),
+            "class_label": activity.get("class_id", ""),
+            "github_team": activity.get("github_team", ""),
+            "language": activity.get("language", ""),
+            "path": self.relative_path(path),
+        }
 
     def list_assignment_reports(self) -> list[dict[str, Any]]:
         """List assignment tracking reports stored in teacher-reports."""

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -231,6 +231,7 @@ class JsonAssignmentStorage:
             "class_label": activity.get("class_id", ""),
             "github_team": activity.get("github_team", ""),
             "language": activity.get("language", ""),
+            "topics": activity.get("topics", []),
             "path": self.relative_path(path),
         }
 
@@ -316,6 +317,7 @@ class JsonAssignmentStorage:
                         "class_label": activity.get("class_id", ""),
                         "github_team": activity.get("github_team", ""),
                         "language": activity.get("language", ""),
+                        "topics": activity.get("topics", []),
                         "path": self.relative_path(path),
                     }
                 )

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -231,7 +231,6 @@ class JsonAssignmentStorage:
             "class_label": activity.get("class_id", ""),
             "github_team": activity.get("github_team", ""),
             "language": activity.get("language", ""),
-            "topics": activity.get("topics", []),
             "path": self.relative_path(path),
         }
 
@@ -317,7 +316,6 @@ class JsonAssignmentStorage:
                         "class_label": activity.get("class_id", ""),
                         "github_team": activity.get("github_team", ""),
                         "language": activity.get("language", ""),
-                        "topics": activity.get("topics", []),
                         "path": self.relative_path(path),
                     }
                 )

--- a/scripts/thebitlab_storage_ports.py
+++ b/scripts/thebitlab_storage_ports.py
@@ -48,6 +48,8 @@ class AssignmentStorage(Protocol):
 
     def list_activities(self) -> list[dict[str, Any]]: ...
 
+    def save_activity(self, payload: dict[str, Any], overwrite: bool = False) -> dict[str, Any]: ...
+
 
 class ClassRosterStorage(Protocol):
     """Storage port used by class and student roster services."""

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -512,6 +512,14 @@ def test_activity_authoring_selects_show_option_count_badges() -> None:
     assert 'id="activityAuthorUdaCount"' in html
 
 
+def test_activity_authoring_difficulty_options_include_readable_labels() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
+    difficulty_section = html.split('id="activityAuthorDifficulty"', 1)[1].split("</select>", 1)[0]
+
+    assert '<option value="B" selected>B - facile: modifica piccola</option>' in difficulty_section
+    assert '<option value="F">F - ninja: produzione</option>' in difficulty_section
+
+
 def test_legend_renders_static_marks_but_escapes_descriptions() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -99,6 +99,10 @@ def run_dashboard_js(assertions: str) -> None:
         this.parentElement = null;
         this.nextSibling = null;
       }}
+      replaceChildren(...children) {{
+        this.children = [];
+        this.append(...children);
+      }}
       syncSiblings() {{
         this.children.forEach((child, index) => {{
           child.nextSibling = this.children[index + 1] || null;
@@ -279,6 +283,7 @@ def run_dashboard_js(assertions: str) -> None:
         setupPanelDragAndDrop,
         renderLegend,
         saveActivityDraft,
+        renderActivityAuthorMetadataSelects,
         rosterOptionLabel,
         localTargetFromStudent,
         rosterTargets,
@@ -401,6 +406,67 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           assert.match(tested.els.activityAuthorStatus.textContent, /Activity salvata/);
         })();
         """
+    )
+
+
+def test_activity_authoring_filters_metadata_by_path_and_uda() -> None:
+    run_dashboard_js(
+        """
+        const optionValue = (option) => typeof option.value === "object" ? option.value.value : option.value;
+        tested.state.classRosters = [
+          { id: "3A", label: "Classe 3A", name: "3a.json", github_team: "team-3a", students: 3 },
+          { id: "4A", label: "Classe 4A", name: "4a.json", github_team: "team-4a", students: 2 },
+        ];
+        tested.state.courseDesign = {
+          years: [
+            {
+              id: "percorso-a",
+              title: "Percorso A",
+              audience: { class_ids: ["3A"], github_teams: ["team-3a"] },
+              udas: [
+                {
+                  id: "uda-a1",
+                  title: "UDA A1",
+                  items: [
+                    { id: "a-intro", title: "A intro" },
+                    { id: "a-loop", title: "A loop" },
+                  ],
+                },
+                {
+                  id: "uda-a2",
+                  title: "UDA A2",
+                  items: [{ id: "a-array", title: "A array" }],
+                },
+              ],
+            },
+            {
+              id: "percorso-b",
+              title: "Percorso B",
+              audience: { class_ids: ["4A"], github_teams: ["team-4a"] },
+              udas: [
+                {
+                  id: "uda-b1",
+                  title: "UDA B1",
+                  items: [{ id: "b-file", title: "B file" }],
+                },
+              ],
+            },
+          ],
+        };
+
+        tested.els.activityAuthorPath.value = "percorso-a";
+        tested.renderActivityAuthorMetadataSelects();
+
+        assert.deepEqual(tested.els.activityAuthorClass.children.map(optionValue), ["3A"]);
+        assert.deepEqual(tested.els.activityAuthorTeam.children.map(optionValue), ["team-3a"]);
+        assert.deepEqual(tested.els.activityAuthorUda.children.map(optionValue), ["uda-a1", "uda-a2"]);
+        assert.deepEqual(tested.els.activityAuthorTopics.children.map(optionValue), ["a-array", "a-intro", "a-loop"]);
+
+        tested.els.activityAuthorUda.value = "uda-a1";
+        tested.renderActivityAuthorMetadataSelects();
+
+        assert.deepEqual(tested.els.activityAuthorTopics.children.map(optionValue), ["a-intro", "a-loop"]);
+      """
     )
 
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -206,13 +206,38 @@ def run_dashboard_js(assertions: str) -> None:
               id: "somma-in-python",
               title: "Somma in Python",
               kind: "compito-casa",
+              topics: ["variabili", "operatori"],
               path: "activities/drafts/somma-in-python.json",
             }},
             activities: [{{
               id: "somma-in-python",
               title: "Somma in Python",
               kind: "compito-casa",
+              topics: ["variabili", "operatori"],
               path: "activities/drafts/somma-in-python.json",
+            }}],
+          }};
+          if (path === "/api/class-rosters") return {{
+            rosters: [{{
+              id: "3A-TPSI",
+              label: "3A TPSI",
+              school_year: "2026-2027",
+              github_team: "team-3a",
+              students: 3,
+            }}],
+          }};
+          if (path === "/api/course-design") return {{
+            years: [{{
+              id: "base",
+              title: "Percorso base",
+              udas: [{{
+                id: "uda-1",
+                title: "Input e variabili",
+                items: [
+                  {{ id: "variabili", title: "Variabili" }},
+                  {{ id: "operatori", title: "Operatori" }},
+                ],
+              }}],
             }}],
           }};
           if (path === "/api/assignment-overview") return {{ rows: [] }};
@@ -279,6 +304,7 @@ def run_dashboard_js(assertions: str) -> None:
         setupPanelDragAndDrop,
         renderLegend,
         saveActivityDraft,
+        renderActivityAuthorOptions,
         rosterOptionLabel,
         localTargetFromStudent,
         rosterTargets,
@@ -400,6 +426,55 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
           assert.match(tested.els.activityAuthorStatus.textContent, /Activity salvata/);
         })();
+        """
+    )
+
+
+def test_activity_authoring_metadata_selects_use_available_values() -> None:
+    run_dashboard_js(
+        """
+        tested.state.classRosters = [
+          {
+            id: "3A-TPSI",
+            label: "3A TPSI",
+            school_year: "2026-2027",
+            github_team: "team-3a",
+            students: 3,
+          },
+        ];
+        tested.state.activities = [
+          { id: "somma", topics: ["liste"] },
+        ];
+        tested.state.courseDesign = {
+          years: [
+            {
+              id: "base",
+              title: "Percorso base",
+              udas: [
+                {
+                  id: "uda-1",
+                  title: "Input e variabili",
+                  items: [
+                    { id: "variabili", title: "Variabili" },
+                    { id: "operatori", title: "Operatori" },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        tested.renderActivityAuthorOptions();
+        const optionValue = (option) => typeof option.value === "object" ? option.value.value : option.value;
+
+        assert.equal(optionValue(tested.els.activityAuthorClass.children[0]), "3A-TPSI");
+        assert.equal(optionValue(tested.els.activityAuthorTeam.children[0]), "team-3a");
+        assert.equal(optionValue(tested.els.activityAuthorPath.children[0]), "base");
+        assert.equal(optionValue(tested.els.activityAuthorUda.children[0]), "uda-1");
+        assert.deepEqual(
+          tested.els.activityAuthorTopics.children.map(optionValue),
+          ["liste", "operatori", "variabili"],
+        );
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -283,6 +283,7 @@ def run_dashboard_js(assertions: str) -> None:
         setupPanelDragAndDrop,
         renderLegend,
         saveActivityDraft,
+        activityAuthorTopicValue,
         suggestedActivityId,
         syncActivityAuthorIdSuggestion,
         renderActivityAuthorMetadataSelects,
@@ -387,7 +388,11 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           tested.els.activityAuthorId.value = "";
           tested.els.activityAuthorKind.value = "compito-casa";
           tested.els.activityAuthorDifficulty.value = "B";
-          tested.els.activityAuthorTopics.value = "variabili, operatori";
+          tested.els.activityAuthorTopics.value = "Variabili";
+          const topicOption = new tested.FakeElement("option");
+          topicOption.value = "Variabili";
+          topicOption.dataset.topicValue = "variabili";
+          tested.els.activityAuthorTopicsList.append(topicOption);
           tested.els.activityAuthorMinutes.value = "25";
           tested.els.activityAuthorClass.value = "3A-TPSI";
           tested.els.activityAuthorTeam.value = "team-3a";
@@ -401,7 +406,7 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           const body = JSON.parse(call.options.body);
           assert.equal(call.options.method, "POST");
           assert.equal(body.title, "Somma in Python");
-          assert.equal(body.topics, "variabili, operatori");
+          assert.equal(body.topics, "variabili");
           assert.equal(body.class_id, "3A-TPSI");
           assert.equal(tested.state.activities.length, 1);
           assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
@@ -490,21 +495,40 @@ def test_activity_authoring_filters_metadata_by_path_and_uda() -> None:
         assert.equal(tested.els.activityAuthorTeamCount.textContent, "1");
         assert.deepEqual(tested.els.activityAuthorUda.children.map(optionValue), ["uda-a1", "uda-a2"]);
         assert.equal(tested.els.activityAuthorUdaCount.textContent, "2");
-        assert.deepEqual(tested.els.activityAuthorTopics.children.map(optionValue), ["a-array", "a-intro", "a-loop"]);
+        assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["A array", "A intro", "A loop"]);
         assert.equal(tested.els.activityAuthorTopicsCount.textContent, "3");
 
         tested.els.activityAuthorUda.value = "uda-a1";
         tested.renderActivityAuthorMetadataSelects();
 
-        assert.deepEqual(tested.els.activityAuthorTopics.children.map(optionValue), ["a-intro", "a-loop"]);
+        assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["A intro", "A loop"]);
         assert.equal(tested.els.activityAuthorTopicsCount.textContent, "2");
       """
+    )
+
+
+def test_activity_authoring_topic_search_maps_labels_to_topic_values() -> None:
+    run_dashboard_js(
+        """
+        const topicOption = new tested.FakeElement("option");
+        topicOption.value = "Variabili";
+        topicOption.dataset.topicValue = "README.md#variabili";
+        tested.els.activityAuthorTopicsList.append(topicOption);
+
+        tested.els.activityAuthorTopics.value = "Variabili";
+        assert.equal(tested.activityAuthorTopicValue(), "README.md#variabili");
+
+        tested.els.activityAuthorTopics.value = "argomento nuovo";
+        assert.equal(tested.activityAuthorTopicValue(), "argomento nuovo");
+        """
     )
 
 
 def test_activity_authoring_selects_show_option_count_badges() -> None:
     html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
 
+    assert 'list="activityAuthorTopicsList"' in html
+    assert 'id="activityAuthorTopicsList"' in html
     assert 'id="activityAuthorTopicsCount"' in html
     assert 'id="activityAuthorClassCount"' in html
     assert 'id="activityAuthorTeamCount"' in html

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -284,6 +284,8 @@ def run_dashboard_js(assertions: str) -> None:
         renderLegend,
         saveActivityDraft,
         activityAuthorTopicValue,
+        activityAuthorTopicOptions,
+        renderTopicSearch,
         suggestedActivityId,
         syncActivityAuthorIdSuggestion,
         renderActivityAuthorMetadataSelects,
@@ -462,6 +464,7 @@ def test_activity_authoring_filters_metadata_by_path_and_uda() -> None:
                   items: [
                     { id: "a-intro", title: "A intro" },
                     { id: "a-loop", title: "A loop" },
+                    { id: "README.md#il-processo-di-compilazione", title: "Il processo di compilazione", href: "../README.md#il-processo-di-compilazione" },
                   ],
                 },
                 {
@@ -495,14 +498,14 @@ def test_activity_authoring_filters_metadata_by_path_and_uda() -> None:
         assert.equal(tested.els.activityAuthorTeamCount.textContent, "1");
         assert.deepEqual(tested.els.activityAuthorUda.children.map(optionValue), ["uda-a1", "uda-a2"]);
         assert.equal(tested.els.activityAuthorUdaCount.textContent, "2");
-        assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["A array", "A intro", "A loop"]);
-        assert.equal(tested.els.activityAuthorTopicsCount.textContent, "3");
+        assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["A array", "A intro", "A loop", "Il processo di compilazione"]);
+        assert.equal(tested.els.activityAuthorTopicsCount.textContent, "4");
 
         tested.els.activityAuthorUda.value = "uda-a1";
         tested.renderActivityAuthorMetadataSelects();
 
-        assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["A intro", "A loop"]);
-        assert.equal(tested.els.activityAuthorTopicsCount.textContent, "2");
+        assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["A intro", "A loop", "Il processo di compilazione"]);
+        assert.equal(tested.els.activityAuthorTopicsCount.textContent, "3");
 
         tested.els.activityAuthorUda.value = "";
         tested.els.activityAuthorTopics.value = "A intro";
@@ -510,6 +513,12 @@ def test_activity_authoring_filters_metadata_by_path_and_uda() -> None:
 
         assert.deepEqual(tested.els.activityAuthorUda.children.map(optionValue), ["uda-a1"]);
         assert.equal(tested.els.activityAuthorUdaCount.textContent, "1");
+
+        tested.renderTopicSearch(tested.activityAuthorTopicOptions("percorso-a", "", "processo"), true);
+        assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["Il processo di compilazione"]);
+
+        tested.renderTopicSearch(tested.activityAuthorTopicOptions("percorso-a", "", "compilazione"), true);
+        assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["Il processo di compilazione"]);
       """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -283,6 +283,8 @@ def run_dashboard_js(assertions: str) -> None:
         setupPanelDragAndDrop,
         renderLegend,
         saveActivityDraft,
+        suggestedActivityId,
+        syncActivityAuthorIdSuggestion,
         renderActivityAuthorMetadataSelects,
         rosterOptionLabel,
         localTargetFromStudent,
@@ -405,6 +407,31 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
           assert.match(tested.els.activityAuthorStatus.textContent, /Activity salvata/);
         })();
+        """
+    )
+
+
+def test_activity_author_id_is_suggested_from_title_but_editable() -> None:
+    run_dashboard_js(
+        """
+        tested.els.activityAuthorTitle.value = "Somma in Python!";
+        tested.els.activityAuthorId.value = "";
+        tested.syncActivityAuthorIdSuggestion();
+
+        assert.equal(tested.els.activityAuthorId.value, "somma-in-python");
+        assert.equal(tested.suggestedActivityId("Array e stringhe"), "array-e-stringhe");
+
+        tested.els.activityAuthorId.value = "id-personalizzato";
+        tested.els.activityAuthorTitle.value = "Titolo cambiato";
+        tested.syncActivityAuthorIdSuggestion();
+
+        assert.equal(tested.els.activityAuthorId.value, "id-personalizzato");
+
+        tested.els.activityAuthorId.value = "";
+        tested.els.activityAuthorTitle.value = "Titolo finale";
+        tested.syncActivityAuthorIdSuggestion();
+
+        assert.equal(tested.els.activityAuthorId.value, "titolo-finale");
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -519,6 +519,15 @@ def test_activity_authoring_filters_metadata_by_path_and_uda() -> None:
 
         tested.renderTopicSearch(tested.activityAuthorTopicOptions("percorso-a", "", "compilazione"), true);
         assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["Il processo di compilazione"]);
+
+        tested.els.activityAuthorPath.value = "percorso-b";
+        tested.els.activityAuthorUda.value = "";
+        tested.els.activityAuthorTopics.value = "A intro";
+        tested.renderActivityAuthorMetadataSelects();
+
+        assert.equal(tested.els.activityAuthorTopics.value, "");
+        assert.deepEqual(tested.els.activityAuthorUda.children.map(optionValue), ["uda-b1"]);
+        assert.equal(tested.els.activityAuthorUdaCount.textContent, "1");
       """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -200,6 +200,21 @@ def run_dashboard_js(assertions: str) -> None:
         json: async () => {{
           if (path === "/api/assignment-reports") return {{ reports: [] }};
           if (path === "/api/activities") return {{ activities: [] }};
+          if (path === "/api/activities/save") return {{
+            ok: true,
+            activity: {{
+              id: "somma-in-python",
+              title: "Somma in Python",
+              kind: "compito-casa",
+              path: "activities/drafts/somma-in-python.json",
+            }},
+            activities: [{{
+              id: "somma-in-python",
+              title: "Somma in Python",
+              kind: "compito-casa",
+              path: "activities/drafts/somma-in-python.json",
+            }}],
+          }};
           if (path === "/api/assignment-overview") return {{ rows: [] }};
           if (path === "/api/assignment-reports/ai-feedback/review") {{
             return {{
@@ -263,6 +278,7 @@ def run_dashboard_js(assertions: str) -> None:
         resetPanelOrder,
         setupPanelDragAndDrop,
         renderLegend,
+        saveActivityDraft,
         rosterOptionLabel,
         localTargetFromStudent,
         rosterTargets,
@@ -352,6 +368,38 @@ def test_overview_activity_filter_limits_rows() -> None:
         const rows = tested.filteredOverviewRows();
         assert.equal(rows.length, 1);
         assert.equal(rows[0].activity_id, "somma");
+        """
+    )
+
+
+def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityAuthorTitle.value = "Somma in Python";
+          tested.els.activityAuthorId.value = "";
+          tested.els.activityAuthorKind.value = "compito-casa";
+          tested.els.activityAuthorDifficulty.value = "B";
+          tested.els.activityAuthorTopics.value = "variabili, operatori";
+          tested.els.activityAuthorMinutes.value = "25";
+          tested.els.activityAuthorClass.value = "3A-TPSI";
+          tested.els.activityAuthorTeam.value = "team-3a";
+          tested.els.activityAuthorPath.value = "base";
+          tested.els.activityAuthorUda.value = "uda-1";
+          tested.els.activityAuthorPrompt.value = "Scrivi un programma che somma due numeri.";
+
+          await tested.saveActivityDraft();
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/activities/save");
+          const body = JSON.parse(call.options.body);
+          assert.equal(call.options.method, "POST");
+          assert.equal(body.title, "Somma in Python");
+          assert.equal(body.topics, "variabili, operatori");
+          assert.equal(body.class_id, "3A-TPSI");
+          assert.equal(tested.state.activities.length, 1);
+          assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
+          assert.match(tested.els.activityAuthorStatus.textContent, /Activity salvata/);
+        })();
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -206,38 +206,13 @@ def run_dashboard_js(assertions: str) -> None:
               id: "somma-in-python",
               title: "Somma in Python",
               kind: "compito-casa",
-              topics: ["variabili", "operatori"],
               path: "activities/drafts/somma-in-python.json",
             }},
             activities: [{{
               id: "somma-in-python",
               title: "Somma in Python",
               kind: "compito-casa",
-              topics: ["variabili", "operatori"],
               path: "activities/drafts/somma-in-python.json",
-            }}],
-          }};
-          if (path === "/api/class-rosters") return {{
-            rosters: [{{
-              id: "3A-TPSI",
-              label: "3A TPSI",
-              school_year: "2026-2027",
-              github_team: "team-3a",
-              students: 3,
-            }}],
-          }};
-          if (path === "/api/course-design") return {{
-            years: [{{
-              id: "base",
-              title: "Percorso base",
-              udas: [{{
-                id: "uda-1",
-                title: "Input e variabili",
-                items: [
-                  {{ id: "variabili", title: "Variabili" }},
-                  {{ id: "operatori", title: "Operatori" }},
-                ],
-              }}],
             }}],
           }};
           if (path === "/api/assignment-overview") return {{ rows: [] }};
@@ -304,7 +279,6 @@ def run_dashboard_js(assertions: str) -> None:
         setupPanelDragAndDrop,
         renderLegend,
         saveActivityDraft,
-        renderActivityAuthorOptions,
         rosterOptionLabel,
         localTargetFromStudent,
         rosterTargets,
@@ -426,55 +400,6 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
           assert.match(tested.els.activityAuthorStatus.textContent, /Activity salvata/);
         })();
-        """
-    )
-
-
-def test_activity_authoring_metadata_selects_use_available_values() -> None:
-    run_dashboard_js(
-        """
-        tested.state.classRosters = [
-          {
-            id: "3A-TPSI",
-            label: "3A TPSI",
-            school_year: "2026-2027",
-            github_team: "team-3a",
-            students: 3,
-          },
-        ];
-        tested.state.activities = [
-          { id: "somma", topics: ["liste"] },
-        ];
-        tested.state.courseDesign = {
-          years: [
-            {
-              id: "base",
-              title: "Percorso base",
-              udas: [
-                {
-                  id: "uda-1",
-                  title: "Input e variabili",
-                  items: [
-                    { id: "variabili", title: "Variabili" },
-                    { id: "operatori", title: "Operatori" },
-                  ],
-                },
-              ],
-            },
-          ],
-        };
-
-        tested.renderActivityAuthorOptions();
-        const optionValue = (option) => typeof option.value === "object" ? option.value.value : option.value;
-
-        assert.equal(optionValue(tested.els.activityAuthorClass.children[0]), "3A-TPSI");
-        assert.equal(optionValue(tested.els.activityAuthorTeam.children[0]), "team-3a");
-        assert.equal(optionValue(tested.els.activityAuthorPath.children[0]), "base");
-        assert.equal(optionValue(tested.els.activityAuthorUda.children[0]), "uda-1");
-        assert.deepEqual(
-          tested.els.activityAuthorTopics.children.map(optionValue),
-          ["liste", "operatori", "variabili"],
-        );
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -458,16 +458,31 @@ def test_activity_authoring_filters_metadata_by_path_and_uda() -> None:
         tested.renderActivityAuthorMetadataSelects();
 
         assert.deepEqual(tested.els.activityAuthorClass.children.map(optionValue), ["3A"]);
+        assert.equal(tested.els.activityAuthorClassCount.textContent, "1");
         assert.deepEqual(tested.els.activityAuthorTeam.children.map(optionValue), ["team-3a"]);
+        assert.equal(tested.els.activityAuthorTeamCount.textContent, "1");
         assert.deepEqual(tested.els.activityAuthorUda.children.map(optionValue), ["uda-a1", "uda-a2"]);
+        assert.equal(tested.els.activityAuthorUdaCount.textContent, "2");
         assert.deepEqual(tested.els.activityAuthorTopics.children.map(optionValue), ["a-array", "a-intro", "a-loop"]);
+        assert.equal(tested.els.activityAuthorTopicsCount.textContent, "3");
 
         tested.els.activityAuthorUda.value = "uda-a1";
         tested.renderActivityAuthorMetadataSelects();
 
         assert.deepEqual(tested.els.activityAuthorTopics.children.map(optionValue), ["a-intro", "a-loop"]);
+        assert.equal(tested.els.activityAuthorTopicsCount.textContent, "2");
       """
     )
+
+
+def test_activity_authoring_selects_show_option_count_badges() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
+
+    assert 'id="activityAuthorTopicsCount"' in html
+    assert 'id="activityAuthorClassCount"' in html
+    assert 'id="activityAuthorTeamCount"' in html
+    assert 'id="activityAuthorPathCount"' in html
+    assert 'id="activityAuthorUdaCount"' in html
 
 
 def test_legend_renders_static_marks_but_escapes_descriptions() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -503,6 +503,13 @@ def test_activity_authoring_filters_metadata_by_path_and_uda() -> None:
 
         assert.deepEqual(tested.els.activityAuthorTopicsList.children.map(optionValue), ["A intro", "A loop"]);
         assert.equal(tested.els.activityAuthorTopicsCount.textContent, "2");
+
+        tested.els.activityAuthorUda.value = "";
+        tested.els.activityAuthorTopics.value = "A intro";
+        tested.renderActivityAuthorMetadataSelects();
+
+        assert.deepEqual(tested.els.activityAuthorUda.children.map(optionValue), ["uda-a1"]);
+        assert.equal(tested.els.activityAuthorUdaCount.textContent, "1");
       """
     )
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -277,6 +277,36 @@ def test_class_roster_helpers_use_local_roster_storage(tmp_path, monkeypatch) ->
     assert roster["students"][0]["local_path"] == "studenti/rossi-mario"
 
 
+def test_save_activity_builds_valid_draft_from_gui_payload(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "ACTIVITY_DIRS", [tmp_path / "activities"])
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+
+    result = course_board_server.save_activity({
+        "title": "Somma in Python",
+        "kind": "compito-casa",
+        "difficulty": "B",
+        "topics": "variabili, operatori",
+        "prompt": "Scrivi un programma che somma due numeri.",
+        "estimated_minutes": "25",
+        "class_id": "3A-TPSI",
+        "github_team": "team-3a",
+        "uda_id": "uda-1",
+    })
+
+    activity_path = tmp_path / "activities" / "drafts" / "somma-in-python.json"
+    saved_payload = json.loads(activity_path.read_text(encoding="utf-8"))
+    assert result["ok"] is True
+    assert result["activity"]["path"] == "activities/drafts/somma-in-python.json"
+    assert result["activities"] == [result["activity"]]
+    assert saved_payload["id"] == "somma-in-python"
+    assert saved_payload["titolo"] == "Somma in Python"
+    assert saved_payload["tipo"] == "compito-casa"
+    assert saved_payload["argomenti"] == ["variabili", "operatori"]
+    assert saved_payload["metriche"]["tempo_stimato_minuti"] == 25
+    assert saved_payload["contesto"] == {"classe": "3A-TPSI", "team_github": "team-3a", "uda": "uda-1"}
+
+
 def test_ai_secret_status_reports_paths_and_configured_keys_without_values(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "AI_SECRET_PATH", tmp_path / ".secrets" / "ai.secret")

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -242,6 +242,41 @@ def test_list_activities_skips_invalid_json_and_deduplicates_paths(tmp_path) -> 
     ]
 
 
+def test_save_activity_persists_valid_draft_and_lists_it(tmp_path) -> None:
+    storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [tmp_path / "activities"])
+    activity = {
+        "schema_version": "1.0",
+        "id": "python-base-somma-001",
+        "titolo": "Somma in Python",
+        "tipo": "compito-casa",
+        "difficolta": "B",
+        "argomenti": ["variabili", "operatori"],
+        "consegna": "Scrivi un programma che somma due numeri.",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": True,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 30,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "contesto": {"classe": "3A-TPSI", "team_github": "team-3a"},
+    }
+
+    saved = storage.save_activity(activity)
+
+    assert saved["path"] == "activities/drafts/python-base-somma-001.json"
+    assert (tmp_path / "activities" / "drafts" / "python-base-somma-001.json").is_file()
+    assert storage.list_activities() == [saved]
+    with pytest.raises(ValueError, match="gia esistente"):
+        storage.save_activity(activity)
+
+
 def test_class_rosters_are_normalized_and_listed(tmp_path) -> None:
     storage = JsonClassRosterStorage(tmp_path)
     classes_dir = tmp_path / "doc" / "classes"

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -237,6 +237,7 @@ def test_list_activities_skips_invalid_json_and_deduplicates_paths(tmp_path) -> 
             "class_label": "3A-TPSI",
             "github_team": "team-3a-tpsi",
             "language": "python",
+            "topics": [],
             "path": "activities/activity.json",
         }
     ]
@@ -271,6 +272,7 @@ def test_save_activity_persists_valid_draft_and_lists_it(tmp_path) -> None:
     saved = storage.save_activity(activity)
 
     assert saved["path"] == "activities/drafts/python-base-somma-001.json"
+    assert saved["topics"] == ["variabili", "operatori"]
     assert (tmp_path / "activities" / "drafts" / "python-base-somma-001.json").is_file()
     assert storage.list_activities() == [saved]
     with pytest.raises(ValueError, match="gia esistente"):

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -237,7 +237,6 @@ def test_list_activities_skips_invalid_json_and_deduplicates_paths(tmp_path) -> 
             "class_label": "3A-TPSI",
             "github_team": "team-3a-tpsi",
             "language": "python",
-            "topics": [],
             "path": "activities/activity.json",
         }
     ]
@@ -272,7 +271,6 @@ def test_save_activity_persists_valid_draft_and_lists_it(tmp_path) -> None:
     saved = storage.save_activity(activity)
 
     assert saved["path"] == "activities/drafts/python-base-somma-001.json"
-    assert saved["topics"] == ["variabili", "operatori"]
     assert (tmp_path / "activities" / "drafts" / "python-base-somma-001.json").is_file()
     assert storage.list_activities() == [saved]
     with pytest.raises(ValueError, match="gia esistente"):

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -216,7 +216,8 @@ label > textarea {
   min-width: 0;
 }
 
-.selectWithCount > select {
+.selectWithCount > select,
+.selectWithCount > input {
   width: 100%;
   min-width: 0;
   padding-right: 4.2rem;

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -216,8 +216,22 @@ label > textarea {
 
 .generateActions {
   display: flex;
+  align-items: center;
+  gap: .75rem;
   justify-content: flex-end;
   padding: 0 1.1rem 1.1rem;
+}
+
+.inlineCheck {
+  display: inline-flex;
+  grid-template-columns: none;
+  align-items: center;
+  gap: .4rem;
+  margin-right: auto;
+}
+
+.inlineCheck input {
+  width: auto;
 }
 
 .reportLoadControls {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -210,6 +210,32 @@ label > textarea {
   min-width: 0;
 }
 
+.selectWithCount {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: .35rem;
+  min-width: 0;
+}
+
+.selectWithCount > select {
+  width: 100%;
+  min-width: 0;
+}
+
+.selectCountBadge {
+  display: inline-grid;
+  place-items: center;
+  min-width: 1.55rem;
+  height: 1.55rem;
+  padding: 0 .35rem;
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-radius: 999px;
+  background: #111111;
+  color: #ffffff;
+  font: 800 .68rem/1 var(--mono);
+}
+
 .wideField {
   grid-column: 1 / -1;
 }

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -211,19 +211,22 @@ label > textarea {
 }
 
 .selectWithCount {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: .35rem;
+  position: relative;
+  display: block;
   min-width: 0;
 }
 
 .selectWithCount > select {
   width: 100%;
   min-width: 0;
+  padding-right: 4.2rem;
 }
 
 .selectCountBadge {
+  position: absolute;
+  top: 50%;
+  right: 2.1rem;
+  transform: translateY(-50%);
   display: inline-grid;
   place-items: center;
   min-width: 1.55rem;
@@ -234,6 +237,7 @@ label > textarea {
   background: #111111;
   color: #ffffff;
   font: 800 .68rem/1 var(--mono);
+  pointer-events: none;
 }
 
 .wideField {

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -60,12 +60,12 @@
         <label>
           <span>Difficolta</span>
           <select id="activityAuthorDifficulty">
-            <option value="A">A</option>
-            <option value="B" selected>B</option>
-            <option value="C">C</option>
-            <option value="D">D</option>
-            <option value="E">E</option>
-            <option value="F">F</option>
+            <option value="A">A - base: copia e osserva</option>
+            <option value="B" selected>B - facile: modifica piccola</option>
+            <option value="C">C - medio: scrivi da zero</option>
+            <option value="D">D - debug: trova il bug</option>
+            <option value="E">E - difficile: mini-progetto</option>
+            <option value="F">F - ninja: produzione</option>
           </select>
         </label>
         <label>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -70,7 +70,7 @@
         </label>
         <label>
           <span>Argomenti</span>
-          <input id="activityAuthorTopics" type="text" placeholder="variabili, operatori">
+          <select id="activityAuthorTopics" aria-label="Argomenti"></select>
         </label>
         <label>
           <span>Tempo stimato</span>
@@ -78,19 +78,19 @@
         </label>
         <label>
           <span>Classe opzionale</span>
-          <input id="activityAuthorClass" type="text" placeholder="3A-TPSI">
+          <select id="activityAuthorClass" aria-label="Classe opzionale"></select>
         </label>
         <label>
           <span>Team GitHub opzionale</span>
-          <input id="activityAuthorTeam" type="text" placeholder="team-3a">
+          <select id="activityAuthorTeam" aria-label="Team GitHub opzionale"></select>
         </label>
         <label>
           <span>Percorso opzionale</span>
-          <input id="activityAuthorPath" type="text" placeholder="percorso-base">
+          <select id="activityAuthorPath" aria-label="Percorso opzionale"></select>
         </label>
         <label>
           <span>UDA opzionale</span>
-          <input id="activityAuthorUda" type="text" placeholder="uda-1">
+          <select id="activityAuthorUda" aria-label="UDA opzionale"></select>
         </label>
         <label class="wideField">
           <span>Consegna</span>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -70,7 +70,7 @@
         </label>
         <label>
           <span>Argomenti</span>
-          <select id="activityAuthorTopics" multiple size="4" aria-label="Argomenti"></select>
+          <input id="activityAuthorTopics" type="text" placeholder="variabili, operatori">
         </label>
         <label>
           <span>Tempo stimato</span>
@@ -78,19 +78,19 @@
         </label>
         <label>
           <span>Classe opzionale</span>
-          <select id="activityAuthorClass" aria-label="Classe opzionale"></select>
+          <input id="activityAuthorClass" type="text" placeholder="3A-TPSI">
         </label>
         <label>
           <span>Team GitHub opzionale</span>
-          <select id="activityAuthorTeam" aria-label="Team GitHub opzionale"></select>
+          <input id="activityAuthorTeam" type="text" placeholder="team-3a">
         </label>
         <label>
           <span>Percorso opzionale</span>
-          <select id="activityAuthorPath" aria-label="Percorso opzionale"></select>
+          <input id="activityAuthorPath" type="text" placeholder="percorso-base">
         </label>
         <label>
           <span>UDA opzionale</span>
-          <select id="activityAuthorUda" aria-label="UDA opzionale"></select>
+          <input id="activityAuthorUda" type="text" placeholder="uda-1">
         </label>
         <label class="wideField">
           <span>Consegna</span>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -70,7 +70,7 @@
         </label>
         <label>
           <span>Argomenti</span>
-          <input id="activityAuthorTopics" type="text" placeholder="variabili, operatori">
+          <select id="activityAuthorTopics" multiple size="4" aria-label="Argomenti"></select>
         </label>
         <label>
           <span>Tempo stimato</span>
@@ -78,19 +78,19 @@
         </label>
         <label>
           <span>Classe opzionale</span>
-          <input id="activityAuthorClass" type="text" placeholder="3A-TPSI">
+          <select id="activityAuthorClass" aria-label="Classe opzionale"></select>
         </label>
         <label>
           <span>Team GitHub opzionale</span>
-          <input id="activityAuthorTeam" type="text" placeholder="team-3a">
+          <select id="activityAuthorTeam" aria-label="Team GitHub opzionale"></select>
         </label>
         <label>
           <span>Percorso opzionale</span>
-          <input id="activityAuthorPath" type="text" placeholder="percorso-base">
+          <select id="activityAuthorPath" aria-label="Percorso opzionale"></select>
         </label>
         <label>
           <span>UDA opzionale</span>
-          <input id="activityAuthorUda" type="text" placeholder="uda-1">
+          <select id="activityAuthorUda" aria-label="UDA opzionale"></select>
         </label>
         <label class="wideField">
           <span>Consegna</span>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -71,7 +71,8 @@
         <label>
           <span>Argomenti</span>
           <span class="selectWithCount">
-            <select id="activityAuthorTopics" aria-label="Argomenti"></select>
+            <input id="activityAuthorTopics" type="search" list="activityAuthorTopicsList" placeholder="Cerca argomento" autocomplete="off" aria-label="Argomenti">
+            <datalist id="activityAuthorTopicsList"></datalist>
             <span id="activityAuthorTopicsCount" class="selectCountBadge" title="Numero di argomenti disponibili con i filtri correnti.">0</span>
           </span>
         </label>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -70,7 +70,10 @@
         </label>
         <label>
           <span>Argomenti</span>
-          <select id="activityAuthorTopics" aria-label="Argomenti"></select>
+          <span class="selectWithCount">
+            <select id="activityAuthorTopics" aria-label="Argomenti"></select>
+            <span id="activityAuthorTopicsCount" class="selectCountBadge" title="Numero di argomenti disponibili con i filtri correnti.">0</span>
+          </span>
         </label>
         <label>
           <span>Tempo stimato</span>
@@ -78,19 +81,31 @@
         </label>
         <label>
           <span>Classe opzionale</span>
-          <select id="activityAuthorClass" aria-label="Classe opzionale"></select>
+          <span class="selectWithCount">
+            <select id="activityAuthorClass" aria-label="Classe opzionale"></select>
+            <span id="activityAuthorClassCount" class="selectCountBadge" title="Numero di classi disponibili con i filtri correnti.">0</span>
+          </span>
         </label>
         <label>
           <span>Team GitHub opzionale</span>
-          <select id="activityAuthorTeam" aria-label="Team GitHub opzionale"></select>
+          <span class="selectWithCount">
+            <select id="activityAuthorTeam" aria-label="Team GitHub opzionale"></select>
+            <span id="activityAuthorTeamCount" class="selectCountBadge" title="Numero di team disponibili con i filtri correnti.">0</span>
+          </span>
         </label>
         <label>
           <span>Percorso opzionale</span>
-          <select id="activityAuthorPath" aria-label="Percorso opzionale"></select>
+          <span class="selectWithCount">
+            <select id="activityAuthorPath" aria-label="Percorso opzionale"></select>
+            <span id="activityAuthorPathCount" class="selectCountBadge" title="Numero di percorsi disponibili.">0</span>
+          </span>
         </label>
         <label>
           <span>UDA opzionale</span>
-          <select id="activityAuthorUda" aria-label="UDA opzionale"></select>
+          <span class="selectWithCount">
+            <select id="activityAuthorUda" aria-label="UDA opzionale"></select>
+            <span id="activityAuthorUdaCount" class="selectCountBadge" title="Numero di UDA disponibili con i filtri correnti.">0</span>
+          </span>
         </label>
         <label class="wideField">
           <span>Consegna</span>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -29,6 +29,83 @@
   </header>
 
   <main class="layout">
+    <section class="panel" data-panel-key="activity-authoring">
+      <div class="panelHead">
+        <div>
+          <h2>Activity</h2>
+          <p id="activityAuthorStatus" class="status">Crea una bozza activity locale da validare e poi assegnare.</p>
+        </div>
+      </div>
+      <div class="generateGrid">
+        <label>
+          <span>Titolo</span>
+          <input id="activityAuthorTitle" type="text" placeholder="Somma in Python">
+        </label>
+        <label>
+          <span>ID opzionale</span>
+          <input id="activityAuthorId" type="text" placeholder="somma-in-python">
+        </label>
+        <label>
+          <span>Tipo</span>
+          <select id="activityAuthorKind">
+            <option value="compito-casa">compito-casa</option>
+            <option value="laboratorio">laboratorio</option>
+            <option value="esercizio-classe">esercizio-classe</option>
+            <option value="studio-guidato">studio-guidato</option>
+            <option value="verifica-pratica">verifica-pratica</option>
+            <option value="verifica-scritta">verifica-scritta</option>
+            <option value="debug-didattico">debug-didattico</option>
+          </select>
+        </label>
+        <label>
+          <span>Difficolta</span>
+          <select id="activityAuthorDifficulty">
+            <option value="A">A</option>
+            <option value="B" selected>B</option>
+            <option value="C">C</option>
+            <option value="D">D</option>
+            <option value="E">E</option>
+            <option value="F">F</option>
+          </select>
+        </label>
+        <label>
+          <span>Argomenti</span>
+          <input id="activityAuthorTopics" type="text" placeholder="variabili, operatori">
+        </label>
+        <label>
+          <span>Tempo stimato</span>
+          <input id="activityAuthorMinutes" type="number" min="1" step="1" value="30">
+        </label>
+        <label>
+          <span>Classe opzionale</span>
+          <input id="activityAuthorClass" type="text" placeholder="3A-TPSI">
+        </label>
+        <label>
+          <span>Team GitHub opzionale</span>
+          <input id="activityAuthorTeam" type="text" placeholder="team-3a">
+        </label>
+        <label>
+          <span>Percorso opzionale</span>
+          <input id="activityAuthorPath" type="text" placeholder="percorso-base">
+        </label>
+        <label>
+          <span>UDA opzionale</span>
+          <input id="activityAuthorUda" type="text" placeholder="uda-1">
+        </label>
+        <label class="wideField">
+          <span>Consegna</span>
+          <textarea id="activityAuthorPrompt" rows="4" placeholder="Scrivi la traccia che vedra lo studente."></textarea>
+        </label>
+      </div>
+      <div class="generateActions">
+        <label class="inlineCheck">
+          <input id="activityAuthorOverwrite" type="checkbox">
+          <span>Sovrascrivi bozza esistente</span>
+        </label>
+        <button id="saveActivityBtn" type="button" class="primary" title="Valida e salva la bozza activity in activities/drafts.">Salva activity</button>
+      </div>
+    </section>
+
     <section class="panel" data-panel-key="generate">
       <div class="panelHead">
         <div>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -115,8 +115,8 @@
       </div>
       <div class="generateGrid">
         <label>
-          <span>Activity salvate</span>
-          <select id="activitySelect" aria-label="Activity salvate">
+          <span>Scegli activity</span>
+          <select id="activitySelect" aria-label="Scegli activity">
             <option value="">Caricamento activity...</option>
           </select>
         </label>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -188,11 +188,16 @@ const els = {
   activityAuthorKind: document.querySelector("#activityAuthorKind"),
   activityAuthorDifficulty: document.querySelector("#activityAuthorDifficulty"),
   activityAuthorTopics: document.querySelector("#activityAuthorTopics"),
+  activityAuthorTopicsCount: document.querySelector("#activityAuthorTopicsCount"),
   activityAuthorMinutes: document.querySelector("#activityAuthorMinutes"),
   activityAuthorClass: document.querySelector("#activityAuthorClass"),
+  activityAuthorClassCount: document.querySelector("#activityAuthorClassCount"),
   activityAuthorTeam: document.querySelector("#activityAuthorTeam"),
+  activityAuthorTeamCount: document.querySelector("#activityAuthorTeamCount"),
   activityAuthorPath: document.querySelector("#activityAuthorPath"),
+  activityAuthorPathCount: document.querySelector("#activityAuthorPathCount"),
   activityAuthorUda: document.querySelector("#activityAuthorUda"),
+  activityAuthorUdaCount: document.querySelector("#activityAuthorUdaCount"),
   activityAuthorPrompt: document.querySelector("#activityAuthorPrompt"),
   activityAuthorOverwrite: document.querySelector("#activityAuthorOverwrite"),
   saveActivityBtn: document.querySelector("#saveActivityBtn"),
@@ -628,7 +633,7 @@ function activityAuthorTopicOptions(pathId = els.activityAuthorPath?.value || ""
     .sort((a, b) => a.label.localeCompare(b.label, "it", { numeric: true, sensitivity: "base" }));
 }
 
-function renderCompactSelect(select, options, placeholder) {
+function renderCompactSelect(select, options, placeholder, countBadge = null) {
   if (!select) return;
   const selected = select.value;
   select.replaceChildren?.();
@@ -640,25 +645,32 @@ function renderCompactSelect(select, options, placeholder) {
     select.append(option);
   }
   select.value = options.some((option) => option.value === selected) ? selected : "";
+  if (countBadge) {
+    countBadge.textContent = String(options.length);
+    countBadge.title = `${options.length} valori disponibili con i filtri correnti.`;
+  }
 }
 
 function renderActivityAuthorMetadataSelects() {
-  renderCompactSelect(els.activityAuthorPath, activityAuthorPathOptions(), "Nessun percorso");
-  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
+  renderCompactSelect(els.activityAuthorPath, activityAuthorPathOptions(), "Nessun percorso", els.activityAuthorPathCount);
+  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA", els.activityAuthorUdaCount);
   renderCompactSelect(
     els.activityAuthorTopics,
     activityAuthorTopicOptions(),
     "Scegli argomento",
+    els.activityAuthorTopicsCount,
   );
   renderCompactSelect(
     els.activityAuthorClass,
     activityAuthorClassOptions(),
     "Nessuna classe",
+    els.activityAuthorClassCount,
   );
   renderCompactSelect(
     els.activityAuthorTeam,
     activityAuthorTeamOptions(),
     "Nessun team",
+    els.activityAuthorTeamCount,
   );
 }
 
@@ -2846,7 +2858,7 @@ els.activityAuthorPath?.addEventListener("change", () => {
   renderActivityAuthorMetadataSelects();
 });
 els.activityAuthorUda?.addEventListener("change", () => {
-  renderCompactSelect(els.activityAuthorTopics, activityAuthorTopicOptions(), "Scegli argomento");
+  renderCompactSelect(els.activityAuthorTopics, activityAuthorTopicOptions(), "Scegli argomento", els.activityAuthorTopicsCount);
 });
 els.activityAuthorClass?.addEventListener("change", () => {
   const roster = state.classRosters.find((candidate) => (

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1196,7 +1196,7 @@ async function saveActivityDraft() {
 }
 
 function renderActivitySelect() {
-  els.activitySelect.innerHTML = '<option value="">Activity salvate</option>';
+  els.activitySelect.innerHTML = '<option value="">Scegli activity</option>';
   for (const activity of state.activities) {
     const option = document.createElement("option");
     option.value = activity.path;

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -189,6 +189,7 @@ const els = {
   activityAuthorKind: document.querySelector("#activityAuthorKind"),
   activityAuthorDifficulty: document.querySelector("#activityAuthorDifficulty"),
   activityAuthorTopics: document.querySelector("#activityAuthorTopics"),
+  activityAuthorTopicsList: document.querySelector("#activityAuthorTopicsList"),
   activityAuthorTopicsCount: document.querySelector("#activityAuthorTopicsCount"),
   activityAuthorMinutes: document.querySelector("#activityAuthorMinutes"),
   activityAuthorClass: document.querySelector("#activityAuthorClass"),
@@ -656,15 +657,40 @@ function renderCompactSelect(select, options, placeholder, countBadge = null) {
   }
 }
 
+function renderTopicSearch(options) {
+  if (!els.activityAuthorTopics || !els.activityAuthorTopicsList) return;
+  const selected = els.activityAuthorTopics.value;
+  els.activityAuthorTopicsList.replaceChildren?.();
+  els.activityAuthorTopicsList.innerHTML = "";
+  for (const optionData of options) {
+    const option = document.createElement("option");
+    option.value = optionData.label;
+    option.dataset.topicValue = optionData.value;
+    els.activityAuthorTopicsList.append(option);
+  }
+  if (!options.some((option) => option.label === selected || option.value === selected)) {
+    els.activityAuthorTopics.value = "";
+  }
+  if (els.activityAuthorTopicsCount) {
+    els.activityAuthorTopicsCount.textContent = String(options.length);
+    els.activityAuthorTopicsCount.title = `${options.length} argomenti disponibili con i filtri correnti.`;
+  }
+}
+
+function activityAuthorTopicValue() {
+  const rawValue = String(els.activityAuthorTopics?.value || "").trim();
+  if (!rawValue) return "";
+  const options = Array.from(els.activityAuthorTopicsList?.children || []);
+  const match = options.find((option) => (
+    option.value === rawValue || option.dataset.topicValue === rawValue
+  ));
+  return match?.dataset.topicValue || rawValue;
+}
+
 function renderActivityAuthorMetadataSelects() {
   renderCompactSelect(els.activityAuthorPath, activityAuthorPathOptions(), "Nessun percorso", els.activityAuthorPathCount);
   renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA", els.activityAuthorUdaCount);
-  renderCompactSelect(
-    els.activityAuthorTopics,
-    activityAuthorTopicOptions(),
-    "Scegli argomento",
-    els.activityAuthorTopicsCount,
-  );
+  renderTopicSearch(activityAuthorTopicOptions());
   renderCompactSelect(
     els.activityAuthorClass,
     activityAuthorClassOptions(),
@@ -1370,7 +1396,7 @@ async function saveActivityDraft() {
         id: els.activityAuthorId?.value || "",
         kind: els.activityAuthorKind?.value || "",
         difficulty: els.activityAuthorDifficulty?.value || "",
-        topics: els.activityAuthorTopics?.value || "",
+        topics: activityAuthorTopicValue(),
         prompt: els.activityAuthorPrompt?.value || "",
         estimated_minutes: els.activityAuthorMinutes?.value || "30",
         class_id: els.activityAuthorClass?.value || "",
@@ -2878,7 +2904,7 @@ els.activityAuthorPath?.addEventListener("change", () => {
   renderActivityAuthorMetadataSelects();
 });
 els.activityAuthorUda?.addEventListener("change", () => {
-  renderCompactSelect(els.activityAuthorTopics, activityAuthorTopicOptions(), "Scegli argomento", els.activityAuthorTopicsCount);
+  renderTopicSearch(activityAuthorTopicOptions());
 });
 els.activityAuthorClass?.addEventListener("change", () => {
   const roster = state.classRosters.find((candidate) => (

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -181,6 +181,20 @@ const els = {
   legendButtons: document.querySelectorAll("[data-legend-topic]"),
   legendTabButtons: document.querySelectorAll("[data-legend-tab]"),
   filterButtons: document.querySelectorAll("[data-filter]"),
+  activityAuthorStatus: document.querySelector("#activityAuthorStatus"),
+  activityAuthorTitle: document.querySelector("#activityAuthorTitle"),
+  activityAuthorId: document.querySelector("#activityAuthorId"),
+  activityAuthorKind: document.querySelector("#activityAuthorKind"),
+  activityAuthorDifficulty: document.querySelector("#activityAuthorDifficulty"),
+  activityAuthorTopics: document.querySelector("#activityAuthorTopics"),
+  activityAuthorMinutes: document.querySelector("#activityAuthorMinutes"),
+  activityAuthorClass: document.querySelector("#activityAuthorClass"),
+  activityAuthorTeam: document.querySelector("#activityAuthorTeam"),
+  activityAuthorPath: document.querySelector("#activityAuthorPath"),
+  activityAuthorUda: document.querySelector("#activityAuthorUda"),
+  activityAuthorPrompt: document.querySelector("#activityAuthorPrompt"),
+  activityAuthorOverwrite: document.querySelector("#activityAuthorOverwrite"),
+  saveActivityBtn: document.querySelector("#saveActivityBtn"),
   activitySelect: document.querySelector("#activitySelect"),
   activityPath: document.querySelector("#activityPath"),
   classRosterSelect: document.querySelector("#classRosterSelect"),
@@ -1141,6 +1155,44 @@ async function loadActivities() {
   state.activities = payload.activities || [];
   renderActivitySelect();
   renderCoverage();
+}
+
+async function saveActivityDraft() {
+  if (!els.saveActivityBtn) return;
+  els.saveActivityBtn.disabled = true;
+  if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = "Salvataggio activity...";
+  try {
+    const payload = await api("/api/activities/save", {
+      method: "POST",
+      body: JSON.stringify({
+        title: els.activityAuthorTitle?.value || "",
+        id: els.activityAuthorId?.value || "",
+        kind: els.activityAuthorKind?.value || "",
+        difficulty: els.activityAuthorDifficulty?.value || "",
+        topics: els.activityAuthorTopics?.value || "",
+        prompt: els.activityAuthorPrompt?.value || "",
+        estimated_minutes: els.activityAuthorMinutes?.value || "30",
+        class_id: els.activityAuthorClass?.value || "",
+        github_team: els.activityAuthorTeam?.value || "",
+        path_id: els.activityAuthorPath?.value || "",
+        uda_id: els.activityAuthorUda?.value || "",
+        overwrite: Boolean(els.activityAuthorOverwrite?.checked),
+      }),
+    });
+    state.activities = payload.activities || [];
+    renderActivitySelect();
+    renderCoverage();
+    if (payload.activity?.path) selectActivity(payload.activity.path);
+    if (els.activityAuthorStatus) {
+      els.activityAuthorStatus.textContent = `Activity salvata: ${payload.activity?.path || "-"}.`;
+    }
+    setStatus(`Activity salvata: ${payload.activity?.title || payload.activity?.id || "-"}.`);
+  } catch (error) {
+    if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = `Errore: ${error.message}`;
+    setStatus(`Errore salvataggio activity: ${error.message}`);
+  } finally {
+    els.saveActivityBtn.disabled = false;
+  }
 }
 
 function renderActivitySelect() {
@@ -2615,6 +2667,7 @@ els.reviewCloseBtn.addEventListener("click", closeReviewDialog);
 els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) selectActivity(els.activitySelect.value);
 });
+els.saveActivityBtn?.addEventListener("click", saveActivityDraft);
 els.classRosterSelect?.addEventListener("change", loadSelectedClassRoster);
 els.activityPath.addEventListener("input", () => {
   renderActivitySelect();

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -92,7 +92,6 @@ const state = {
   activities: [],
   reports: [],
   classRosters: [],
-  courseDesign: null,
   selectedClassRoster: null,
   overviewRows: [],
   report: null,
@@ -444,26 +443,15 @@ async function loadClassRosters() {
     const payload = await api("/api/class-rosters");
     state.classRosters = payload.rosters || [];
     renderClassRosterSelect();
-    renderActivityAuthorOptions();
     renderRosterPanel();
     setRosterStatus(state.classRosters.length ? `Roster disponibili: ${state.classRosters.length}.` : "Nessun roster locale disponibile.");
   } catch (error) {
     state.classRosters = [];
     state.selectedClassRoster = null;
     renderClassRosterSelect();
-    renderActivityAuthorOptions();
     renderRosterPanel();
     setRosterStatus(`Roster non disponibili: ${error.message}`);
   }
-}
-
-async function loadCourseDesignForActivityAuthoring() {
-  try {
-    state.courseDesign = await api("/api/course-design");
-  } catch {
-    state.courseDesign = null;
-  }
-  renderActivityAuthorOptions();
 }
 
 function renderReportSelect() {
@@ -499,98 +487,6 @@ function renderClassRosterSelect() {
   }
   els.classRosterSelect.value = state.classRosters.some((roster) => roster.name === selected) ? selected : "";
   els.classRosterSelect.disabled = state.classRosters.length === 0;
-}
-
-function courseSections(design = state.courseDesign) {
-  if (Array.isArray(design?.paths)) return design.paths;
-  if (Array.isArray(design?.sections)) return design.sections;
-  return Array.isArray(design?.years) ? design.years : [];
-}
-
-function collectCourseItems(items, rows = []) {
-  for (const item of Array.isArray(items) ? items : []) {
-    if (!item || typeof item !== "object") continue;
-    rows.push(item);
-    collectCourseItems(item.children, rows);
-  }
-  return rows;
-}
-
-function activityAuthorPathOptions() {
-  return courseSections().map((section) => ({
-    value: String(section?.id || section?.title || "").trim(),
-    label: String(section?.title || section?.id || "Percorso senza titolo").trim(),
-  })).filter((option) => option.value);
-}
-
-function activityAuthorUdaOptions(pathId = els.activityAuthorPath?.value || "") {
-  return courseSections()
-    .filter((section) => !pathId || String(section?.id || section?.title || "").trim() === pathId)
-    .flatMap((section) => (Array.isArray(section?.udas) ? section.udas : []).map((uda) => ({
-      value: String(uda?.id || uda?.title || "").trim(),
-      label: `${section?.title || section?.id || "Percorso"} - ${uda?.title || uda?.id || "UDA senza titolo"}`,
-    })))
-    .filter((option) => option.value);
-}
-
-function activityAuthorTopicOptions() {
-  const topics = new Map();
-  for (const section of courseSections()) {
-    for (const uda of Array.isArray(section?.udas) ? section.udas : []) {
-      for (const item of collectCourseItems(uda.items)) {
-        const value = String(item?.id || item?.title || "").trim();
-        if (value && !topics.has(value)) topics.set(value, item?.title || value);
-      }
-    }
-  }
-  for (const activity of state.activities) {
-    for (const topic of Array.isArray(activity?.topics) ? activity.topics : []) {
-      const value = String(topic || "").trim();
-      if (value && !topics.has(value)) topics.set(value, value);
-    }
-  }
-  return [...topics.entries()]
-    .map(([value, label]) => ({ value, label }))
-    .sort((a, b) => a.label.localeCompare(b.label, "it", { numeric: true, sensitivity: "base" }));
-}
-
-function selectedSelectValues(select) {
-  const selected = Array.from(select?.selectedOptions || []).map((option) => option.value).filter(Boolean);
-  if (selected.length) return selected;
-  return String(select?.value || "").split(",").map((value) => value.trim()).filter(Boolean);
-}
-
-function renderSelectOptions(select, options, placeholder, selectedValues = []) {
-  if (!select) return;
-  const selected = new Set(selectedValues.length ? selectedValues : selectedSelectValues(select));
-  select.innerHTML = placeholder === null ? "" : `<option value="">${escapeHtml(placeholder)}</option>`;
-  for (const optionData of options) {
-    const option = document.createElement("option");
-    option.value = optionData.value;
-    option.textContent = optionData.label;
-    if (selected.has(option.value)) option.selected = true;
-    select.append(option);
-  }
-}
-
-function renderActivityAuthorOptions() {
-  renderSelectOptions(
-    els.activityAuthorClass,
-    state.classRosters.map((roster) => ({
-      value: String(roster.id || roster.label || roster.name || "").trim(),
-      label: rosterOptionLabel(roster),
-    })).filter((option) => option.value),
-    "Nessuna classe",
-  );
-  renderSelectOptions(
-    els.activityAuthorTeam,
-    [...new Set(state.classRosters.map((roster) => String(roster.github_team || "").trim()).filter(Boolean))]
-      .map((team) => ({ value: team, label: team })),
-    "Nessun team",
-  );
-  renderSelectOptions(els.activityAuthorPath, activityAuthorPathOptions(), "Nessun percorso");
-  renderSelectOptions(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
-  renderSelectOptions(els.activityAuthorTopics, activityAuthorTopicOptions(), null);
 }
 
 function setRosterStatus(message) {
@@ -1258,7 +1154,6 @@ async function loadActivities() {
   const payload = await api("/api/activities");
   state.activities = payload.activities || [];
   renderActivitySelect();
-  renderActivityAuthorOptions();
   renderCoverage();
 }
 
@@ -1274,7 +1169,7 @@ async function saveActivityDraft() {
         id: els.activityAuthorId?.value || "",
         kind: els.activityAuthorKind?.value || "",
         difficulty: els.activityAuthorDifficulty?.value || "",
-        topics: selectedSelectValues(els.activityAuthorTopics).join(", "),
+        topics: els.activityAuthorTopics?.value || "",
         prompt: els.activityAuthorPrompt?.value || "",
         estimated_minutes: els.activityAuthorMinutes?.value || "30",
         class_id: els.activityAuthorClass?.value || "",
@@ -2773,15 +2668,6 @@ els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) selectActivity(els.activitySelect.value);
 });
 els.saveActivityBtn?.addEventListener("click", saveActivityDraft);
-els.activityAuthorPath?.addEventListener("change", () => {
-  renderSelectOptions(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
-});
-els.activityAuthorClass?.addEventListener("change", () => {
-  const roster = state.classRosters.find((candidate) => (
-    String(candidate.id || candidate.label || candidate.name || "").trim() === els.activityAuthorClass.value
-  ));
-  if (roster?.github_team && els.activityAuthorTeam) els.activityAuthorTeam.value = roster.github_team;
-});
 els.classRosterSelect?.addEventListener("change", loadSelectedClassRoster);
 els.activityPath.addEventListener("input", () => {
   renderActivitySelect();
@@ -2935,10 +2821,4 @@ setupCollapsiblePanels();
 setupPanelDragAndDrop();
 setFilter("all");
 setupResizableTables();
-Promise.all([
-  loadReports(),
-  loadActivities(),
-  loadOverview(),
-  loadClassRosters(),
-  loadCourseDesignForActivityAuthoring(),
-]).catch((error) => setStatus(`Errore: ${error.message}`));
+Promise.all([loadReports(), loadActivities(), loadOverview(), loadClassRosters()]).catch((error) => setStatus(`Errore: ${error.message}`));

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -530,6 +530,68 @@ function activityAuthorPathOptions() {
     .filter((option) => option.value);
 }
 
+function selectedActivityAuthorPath() {
+  const pathId = els.activityAuthorPath?.value || "";
+  return courseSections().find((section) => (
+    String(section?.id || section?.title || "").trim() === pathId
+  )) || null;
+}
+
+function pathAudienceValues(section, keys) {
+  const audience = section?.audience || {};
+  const values = [];
+  for (const source of [section, audience]) {
+    for (const key of keys) {
+      const value = source?.[key];
+      if (Array.isArray(value)) values.push(...value);
+      else if (value) values.push(value);
+    }
+  }
+  return [...new Set(values.map((value) => String(value || "").trim()).filter(Boolean))];
+}
+
+function pathClassIds(section = selectedActivityAuthorPath()) {
+  return pathAudienceValues(section, ["class_ids", "classes", "class_id", "class"]);
+}
+
+function pathTeams(section = selectedActivityAuthorPath()) {
+  return pathAudienceValues(section, ["github_teams", "teams", "github_team", "team_github", "team"]);
+}
+
+function rosterMatchesPath(roster, classIds) {
+  if (!classIds.length) return true;
+  const aliases = [
+    roster?.id,
+    roster?.label,
+    roster?.name,
+    roster?.path,
+    roster?.github_team,
+  ].map((value) => String(value || "").trim()).filter(Boolean);
+  return aliases.some((alias) => classIds.includes(alias));
+}
+
+function activityAuthorClassOptions() {
+  const classIds = pathClassIds();
+  return state.classRosters
+    .filter((roster) => rosterMatchesPath(roster, classIds))
+    .map((roster) => ({
+      value: String(roster.id || roster.label || roster.name || "").trim(),
+      label: rosterOptionLabel(roster),
+    }))
+    .filter((option) => option.value);
+}
+
+function activityAuthorTeamOptions() {
+  const section = selectedActivityAuthorPath();
+  const explicitTeams = pathTeams(section);
+  if (explicitTeams.length) return selectOptionsFromValues(explicitTeams);
+  return selectOptionsFromValues(
+    state.classRosters
+      .filter((roster) => rosterMatchesPath(roster, pathClassIds(section)))
+      .map((roster) => roster.github_team),
+  );
+}
+
 function activityAuthorUdaOptions(pathId = els.activityAuthorPath?.value || "") {
   return courseSections()
     .filter((section) => !pathId || String(section?.id || section?.title || "").trim() === pathId)
@@ -540,20 +602,25 @@ function activityAuthorUdaOptions(pathId = els.activityAuthorPath?.value || "") 
     .filter((option) => option.value);
 }
 
-function activityAuthorTopicOptions() {
+function activityAuthorTopicOptions(pathId = els.activityAuthorPath?.value || "", udaId = els.activityAuthorUda?.value || "") {
   const topics = new Map();
-  for (const section of courseSections()) {
+  for (const section of courseSections().filter((candidate) => (
+    !pathId || String(candidate?.id || candidate?.title || "").trim() === pathId
+  ))) {
     for (const uda of Array.isArray(section?.udas) ? section.udas : []) {
+      if (udaId && String(uda?.id || uda?.title || "").trim() !== udaId) continue;
       for (const item of collectCourseItems(uda.items)) {
         const value = String(item?.id || item?.title || "").trim();
         if (value && !topics.has(value)) topics.set(value, item?.title || value);
       }
     }
   }
-  for (const activity of state.activities) {
-    for (const topic of Array.isArray(activity?.topics) ? activity.topics : []) {
-      const value = String(topic || "").trim();
-      if (value && !topics.has(value)) topics.set(value, value);
+  if (!pathId && !udaId) {
+    for (const activity of state.activities) {
+      for (const topic of Array.isArray(activity?.topics) ? activity.topics : []) {
+        const value = String(topic || "").trim();
+        if (value && !topics.has(value)) topics.set(value, value);
+      }
     }
   }
   return [...topics.entries()]
@@ -564,6 +631,7 @@ function activityAuthorTopicOptions() {
 function renderCompactSelect(select, options, placeholder) {
   if (!select) return;
   const selected = select.value;
+  select.replaceChildren?.();
   select.innerHTML = `<option value="">${escapeHtml(placeholder)}</option>`;
   for (const optionData of options) {
     const option = document.createElement("option");
@@ -575,6 +643,8 @@ function renderCompactSelect(select, options, placeholder) {
 }
 
 function renderActivityAuthorMetadataSelects() {
+  renderCompactSelect(els.activityAuthorPath, activityAuthorPathOptions(), "Nessun percorso");
+  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
   renderCompactSelect(
     els.activityAuthorTopics,
     activityAuthorTopicOptions(),
@@ -582,19 +652,14 @@ function renderActivityAuthorMetadataSelects() {
   );
   renderCompactSelect(
     els.activityAuthorClass,
-    state.classRosters.map((roster) => ({
-      value: String(roster.id || roster.label || roster.name || "").trim(),
-      label: rosterOptionLabel(roster),
-    })).filter((option) => option.value),
+    activityAuthorClassOptions(),
     "Nessuna classe",
   );
   renderCompactSelect(
     els.activityAuthorTeam,
-    selectOptionsFromValues(state.classRosters.map((roster) => roster.github_team)),
+    activityAuthorTeamOptions(),
     "Nessun team",
   );
-  renderCompactSelect(els.activityAuthorPath, activityAuthorPathOptions(), "Nessun percorso");
-  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
 }
 
 function setRosterStatus(message) {
@@ -2778,7 +2843,10 @@ els.activitySelect.addEventListener("change", () => {
 });
 els.saveActivityBtn?.addEventListener("click", saveActivityDraft);
 els.activityAuthorPath?.addEventListener("change", () => {
-  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
+  renderActivityAuthorMetadataSelects();
+});
+els.activityAuthorUda?.addEventListener("change", () => {
+  renderCompactSelect(els.activityAuthorTopics, activityAuthorTopicOptions(), "Scegli argomento");
 });
 els.activityAuthorClass?.addEventListener("change", () => {
   const roster = state.classRosters.find((candidate) => (

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -119,6 +119,7 @@ const state = {
   reviewFile: null,
   reviewSplit: readReviewSplit(),
   draggedPanelKey: "",
+  activityAuthorLastSuggestedId: "",
 };
 
 const els = {
@@ -425,6 +426,10 @@ function slugPathSegment(value, fallback = "classe-non-indicata") {
     .replace(/^-+|-+$/g, "") || fallback;
 }
 
+function suggestedActivityId(title) {
+  return slugPathSegment(title, "");
+}
+
 async function loadReports() {
   setStatus("Caricamento registri...");
   const payload = await api("/api/assignment-reports");
@@ -672,6 +677,16 @@ function renderActivityAuthorMetadataSelects() {
     "Nessun team",
     els.activityAuthorTeamCount,
   );
+}
+
+function syncActivityAuthorIdSuggestion() {
+  if (!els.activityAuthorTitle || !els.activityAuthorId) return;
+  const suggestion = suggestedActivityId(els.activityAuthorTitle.value);
+  const current = els.activityAuthorId.value.trim();
+  if (!current || current === state.activityAuthorLastSuggestedId) {
+    els.activityAuthorId.value = suggestion;
+    state.activityAuthorLastSuggestedId = suggestion;
+  }
 }
 
 function setRosterStatus(message) {
@@ -2854,6 +2869,11 @@ els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) selectActivity(els.activitySelect.value);
 });
 els.saveActivityBtn?.addEventListener("click", saveActivityDraft);
+els.activityAuthorTitle?.addEventListener("input", syncActivityAuthorIdSuggestion);
+els.activityAuthorId?.addEventListener("input", () => {
+  const current = els.activityAuthorId.value.trim();
+  if (!current) state.activityAuthorLastSuggestedId = "";
+});
 els.activityAuthorPath?.addEventListener("change", () => {
   renderActivityAuthorMetadataSelects();
 });

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -737,8 +737,9 @@ function activityAuthorTopicValue() {
 
 function renderActivityAuthorMetadataSelects() {
   renderCompactSelect(els.activityAuthorPath, activityAuthorPathOptions(), "Nessun percorso", els.activityAuthorPathCount);
-  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA", els.activityAuthorUdaCount);
+  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(els.activityAuthorPath?.value || "", ""), "Nessuna UDA", els.activityAuthorUdaCount);
   renderTopicSearch(activityAuthorTopicOptions());
+  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA", els.activityAuthorUdaCount);
   renderCompactSelect(
     els.activityAuthorClass,
     activityAuthorClassOptions(),

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -92,6 +92,7 @@ const state = {
   activities: [],
   reports: [],
   classRosters: [],
+  courseDesign: null,
   selectedClassRoster: null,
   overviewRows: [],
   report: null,
@@ -443,15 +444,26 @@ async function loadClassRosters() {
     const payload = await api("/api/class-rosters");
     state.classRosters = payload.rosters || [];
     renderClassRosterSelect();
+    renderActivityAuthorMetadataSelects();
     renderRosterPanel();
     setRosterStatus(state.classRosters.length ? `Roster disponibili: ${state.classRosters.length}.` : "Nessun roster locale disponibile.");
   } catch (error) {
     state.classRosters = [];
     state.selectedClassRoster = null;
     renderClassRosterSelect();
+    renderActivityAuthorMetadataSelects();
     renderRosterPanel();
     setRosterStatus(`Roster non disponibili: ${error.message}`);
   }
+}
+
+async function loadCourseDesignForActivityAuthoring() {
+  try {
+    state.courseDesign = await api("/api/course-design");
+  } catch {
+    state.courseDesign = null;
+  }
+  renderActivityAuthorMetadataSelects();
 }
 
 function renderReportSelect() {
@@ -487,6 +499,102 @@ function renderClassRosterSelect() {
   }
   els.classRosterSelect.value = state.classRosters.some((roster) => roster.name === selected) ? selected : "";
   els.classRosterSelect.disabled = state.classRosters.length === 0;
+}
+
+function courseSections(design = state.courseDesign) {
+  if (Array.isArray(design?.paths)) return design.paths;
+  if (Array.isArray(design?.sections)) return design.sections;
+  return Array.isArray(design?.years) ? design.years : [];
+}
+
+function collectCourseItems(items, rows = []) {
+  for (const item of Array.isArray(items) ? items : []) {
+    if (!item || typeof item !== "object") continue;
+    rows.push(item);
+    collectCourseItems(item.children, rows);
+  }
+  return rows;
+}
+
+function selectOptionsFromValues(values) {
+  return [...new Set(values.map((value) => String(value || "").trim()).filter(Boolean))]
+    .map((value) => ({ value, label: value }));
+}
+
+function activityAuthorPathOptions() {
+  return courseSections()
+    .map((section) => ({
+      value: String(section?.id || section?.title || "").trim(),
+      label: String(section?.title || section?.id || "Percorso senza titolo").trim(),
+    }))
+    .filter((option) => option.value);
+}
+
+function activityAuthorUdaOptions(pathId = els.activityAuthorPath?.value || "") {
+  return courseSections()
+    .filter((section) => !pathId || String(section?.id || section?.title || "").trim() === pathId)
+    .flatMap((section) => (Array.isArray(section?.udas) ? section.udas : []).map((uda) => ({
+      value: String(uda?.id || uda?.title || "").trim(),
+      label: String(uda?.title || uda?.id || "UDA senza titolo").trim(),
+    })))
+    .filter((option) => option.value);
+}
+
+function activityAuthorTopicOptions() {
+  const topics = new Map();
+  for (const section of courseSections()) {
+    for (const uda of Array.isArray(section?.udas) ? section.udas : []) {
+      for (const item of collectCourseItems(uda.items)) {
+        const value = String(item?.id || item?.title || "").trim();
+        if (value && !topics.has(value)) topics.set(value, item?.title || value);
+      }
+    }
+  }
+  for (const activity of state.activities) {
+    for (const topic of Array.isArray(activity?.topics) ? activity.topics : []) {
+      const value = String(topic || "").trim();
+      if (value && !topics.has(value)) topics.set(value, value);
+    }
+  }
+  return [...topics.entries()]
+    .map(([value, label]) => ({ value, label }))
+    .sort((a, b) => a.label.localeCompare(b.label, "it", { numeric: true, sensitivity: "base" }));
+}
+
+function renderCompactSelect(select, options, placeholder) {
+  if (!select) return;
+  const selected = select.value;
+  select.innerHTML = `<option value="">${escapeHtml(placeholder)}</option>`;
+  for (const optionData of options) {
+    const option = document.createElement("option");
+    option.value = optionData.value;
+    option.textContent = optionData.label;
+    select.append(option);
+  }
+  select.value = options.some((option) => option.value === selected) ? selected : "";
+}
+
+function renderActivityAuthorMetadataSelects() {
+  renderCompactSelect(
+    els.activityAuthorTopics,
+    activityAuthorTopicOptions(),
+    "Scegli argomento",
+  );
+  renderCompactSelect(
+    els.activityAuthorClass,
+    state.classRosters.map((roster) => ({
+      value: String(roster.id || roster.label || roster.name || "").trim(),
+      label: rosterOptionLabel(roster),
+    })).filter((option) => option.value),
+    "Nessuna classe",
+  );
+  renderCompactSelect(
+    els.activityAuthorTeam,
+    selectOptionsFromValues(state.classRosters.map((roster) => roster.github_team)),
+    "Nessun team",
+  );
+  renderCompactSelect(els.activityAuthorPath, activityAuthorPathOptions(), "Nessun percorso");
+  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
 }
 
 function setRosterStatus(message) {
@@ -1154,6 +1262,7 @@ async function loadActivities() {
   const payload = await api("/api/activities");
   state.activities = payload.activities || [];
   renderActivitySelect();
+  renderActivityAuthorMetadataSelects();
   renderCoverage();
 }
 
@@ -2668,6 +2777,15 @@ els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) selectActivity(els.activitySelect.value);
 });
 els.saveActivityBtn?.addEventListener("click", saveActivityDraft);
+els.activityAuthorPath?.addEventListener("change", () => {
+  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
+});
+els.activityAuthorClass?.addEventListener("change", () => {
+  const roster = state.classRosters.find((candidate) => (
+    String(candidate.id || candidate.label || candidate.name || "").trim() === els.activityAuthorClass.value
+  ));
+  if (roster?.github_team && els.activityAuthorTeam) els.activityAuthorTeam.value = roster.github_team;
+});
 els.classRosterSelect?.addEventListener("change", loadSelectedClassRoster);
 els.activityPath.addEventListener("input", () => {
   renderActivitySelect();
@@ -2821,4 +2939,10 @@ setupCollapsiblePanels();
 setupPanelDragAndDrop();
 setFilter("all");
 setupResizableTables();
-Promise.all([loadReports(), loadActivities(), loadOverview(), loadClassRosters()]).catch((error) => setStatus(`Errore: ${error.message}`));
+Promise.all([
+  loadReports(),
+  loadActivities(),
+  loadOverview(),
+  loadClassRosters(),
+  loadCourseDesignForActivityAuthoring(),
+]).catch((error) => setStatus(`Errore: ${error.message}`));

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -92,6 +92,7 @@ const state = {
   activities: [],
   reports: [],
   classRosters: [],
+  courseDesign: null,
   selectedClassRoster: null,
   overviewRows: [],
   report: null,
@@ -443,15 +444,26 @@ async function loadClassRosters() {
     const payload = await api("/api/class-rosters");
     state.classRosters = payload.rosters || [];
     renderClassRosterSelect();
+    renderActivityAuthorOptions();
     renderRosterPanel();
     setRosterStatus(state.classRosters.length ? `Roster disponibili: ${state.classRosters.length}.` : "Nessun roster locale disponibile.");
   } catch (error) {
     state.classRosters = [];
     state.selectedClassRoster = null;
     renderClassRosterSelect();
+    renderActivityAuthorOptions();
     renderRosterPanel();
     setRosterStatus(`Roster non disponibili: ${error.message}`);
   }
+}
+
+async function loadCourseDesignForActivityAuthoring() {
+  try {
+    state.courseDesign = await api("/api/course-design");
+  } catch {
+    state.courseDesign = null;
+  }
+  renderActivityAuthorOptions();
 }
 
 function renderReportSelect() {
@@ -487,6 +499,98 @@ function renderClassRosterSelect() {
   }
   els.classRosterSelect.value = state.classRosters.some((roster) => roster.name === selected) ? selected : "";
   els.classRosterSelect.disabled = state.classRosters.length === 0;
+}
+
+function courseSections(design = state.courseDesign) {
+  if (Array.isArray(design?.paths)) return design.paths;
+  if (Array.isArray(design?.sections)) return design.sections;
+  return Array.isArray(design?.years) ? design.years : [];
+}
+
+function collectCourseItems(items, rows = []) {
+  for (const item of Array.isArray(items) ? items : []) {
+    if (!item || typeof item !== "object") continue;
+    rows.push(item);
+    collectCourseItems(item.children, rows);
+  }
+  return rows;
+}
+
+function activityAuthorPathOptions() {
+  return courseSections().map((section) => ({
+    value: String(section?.id || section?.title || "").trim(),
+    label: String(section?.title || section?.id || "Percorso senza titolo").trim(),
+  })).filter((option) => option.value);
+}
+
+function activityAuthorUdaOptions(pathId = els.activityAuthorPath?.value || "") {
+  return courseSections()
+    .filter((section) => !pathId || String(section?.id || section?.title || "").trim() === pathId)
+    .flatMap((section) => (Array.isArray(section?.udas) ? section.udas : []).map((uda) => ({
+      value: String(uda?.id || uda?.title || "").trim(),
+      label: `${section?.title || section?.id || "Percorso"} - ${uda?.title || uda?.id || "UDA senza titolo"}`,
+    })))
+    .filter((option) => option.value);
+}
+
+function activityAuthorTopicOptions() {
+  const topics = new Map();
+  for (const section of courseSections()) {
+    for (const uda of Array.isArray(section?.udas) ? section.udas : []) {
+      for (const item of collectCourseItems(uda.items)) {
+        const value = String(item?.id || item?.title || "").trim();
+        if (value && !topics.has(value)) topics.set(value, item?.title || value);
+      }
+    }
+  }
+  for (const activity of state.activities) {
+    for (const topic of Array.isArray(activity?.topics) ? activity.topics : []) {
+      const value = String(topic || "").trim();
+      if (value && !topics.has(value)) topics.set(value, value);
+    }
+  }
+  return [...topics.entries()]
+    .map(([value, label]) => ({ value, label }))
+    .sort((a, b) => a.label.localeCompare(b.label, "it", { numeric: true, sensitivity: "base" }));
+}
+
+function selectedSelectValues(select) {
+  const selected = Array.from(select?.selectedOptions || []).map((option) => option.value).filter(Boolean);
+  if (selected.length) return selected;
+  return String(select?.value || "").split(",").map((value) => value.trim()).filter(Boolean);
+}
+
+function renderSelectOptions(select, options, placeholder, selectedValues = []) {
+  if (!select) return;
+  const selected = new Set(selectedValues.length ? selectedValues : selectedSelectValues(select));
+  select.innerHTML = placeholder === null ? "" : `<option value="">${escapeHtml(placeholder)}</option>`;
+  for (const optionData of options) {
+    const option = document.createElement("option");
+    option.value = optionData.value;
+    option.textContent = optionData.label;
+    if (selected.has(option.value)) option.selected = true;
+    select.append(option);
+  }
+}
+
+function renderActivityAuthorOptions() {
+  renderSelectOptions(
+    els.activityAuthorClass,
+    state.classRosters.map((roster) => ({
+      value: String(roster.id || roster.label || roster.name || "").trim(),
+      label: rosterOptionLabel(roster),
+    })).filter((option) => option.value),
+    "Nessuna classe",
+  );
+  renderSelectOptions(
+    els.activityAuthorTeam,
+    [...new Set(state.classRosters.map((roster) => String(roster.github_team || "").trim()).filter(Boolean))]
+      .map((team) => ({ value: team, label: team })),
+    "Nessun team",
+  );
+  renderSelectOptions(els.activityAuthorPath, activityAuthorPathOptions(), "Nessun percorso");
+  renderSelectOptions(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
+  renderSelectOptions(els.activityAuthorTopics, activityAuthorTopicOptions(), null);
 }
 
 function setRosterStatus(message) {
@@ -1154,6 +1258,7 @@ async function loadActivities() {
   const payload = await api("/api/activities");
   state.activities = payload.activities || [];
   renderActivitySelect();
+  renderActivityAuthorOptions();
   renderCoverage();
 }
 
@@ -1169,7 +1274,7 @@ async function saveActivityDraft() {
         id: els.activityAuthorId?.value || "",
         kind: els.activityAuthorKind?.value || "",
         difficulty: els.activityAuthorDifficulty?.value || "",
-        topics: els.activityAuthorTopics?.value || "",
+        topics: selectedSelectValues(els.activityAuthorTopics).join(", "),
         prompt: els.activityAuthorPrompt?.value || "",
         estimated_minutes: els.activityAuthorMinutes?.value || "30",
         class_id: els.activityAuthorClass?.value || "",
@@ -2668,6 +2773,15 @@ els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) selectActivity(els.activitySelect.value);
 });
 els.saveActivityBtn?.addEventListener("click", saveActivityDraft);
+els.activityAuthorPath?.addEventListener("change", () => {
+  renderSelectOptions(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA");
+});
+els.activityAuthorClass?.addEventListener("change", () => {
+  const roster = state.classRosters.find((candidate) => (
+    String(candidate.id || candidate.label || candidate.name || "").trim() === els.activityAuthorClass.value
+  ));
+  if (roster?.github_team && els.activityAuthorTeam) els.activityAuthorTeam.value = roster.github_team;
+});
 els.classRosterSelect?.addEventListener("change", loadSelectedClassRoster);
 els.activityPath.addEventListener("input", () => {
   renderActivitySelect();
@@ -2821,4 +2935,10 @@ setupCollapsiblePanels();
 setupPanelDragAndDrop();
 setFilter("all");
 setupResizableTables();
-Promise.all([loadReports(), loadActivities(), loadOverview(), loadClassRosters()]).catch((error) => setStatus(`Errore: ${error.message}`));
+Promise.all([
+  loadReports(),
+  loadActivities(),
+  loadOverview(),
+  loadClassRosters(),
+  loadCourseDesignForActivityAuthoring(),
+]).catch((error) => setStatus(`Errore: ${error.message}`));

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -532,6 +532,28 @@ function selectOptionsFromValues(values) {
     .map((value) => ({ value, label: value }));
 }
 
+function normalizedSearchText(value) {
+  return String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+function topicAliases(item) {
+  return [
+    item?.id,
+    item?.title,
+    item?.href,
+  ].map((value) => String(value || "").trim()).filter(Boolean);
+}
+
+function topicMatchesQuery(option, query) {
+  const normalizedQuery = normalizedSearchText(query);
+  if (!normalizedQuery) return true;
+  return [option?.value, option?.label, option?.search]
+    .some((value) => normalizedSearchText(value).includes(normalizedQuery));
+}
+
 function activityAuthorPathOptions() {
   return courseSections()
     .map((section) => ({
@@ -605,12 +627,11 @@ function activityAuthorTeamOptions() {
 
 function itemMatchesTopic(item, topicValue) {
   if (!topicValue) return true;
-  const aliases = [
-    item?.id,
-    item?.title,
-    item?.href,
-  ].map((value) => String(value || "").trim()).filter(Boolean);
-  return aliases.includes(topicValue);
+  const normalizedTopic = normalizedSearchText(topicValue);
+  return topicAliases(item).some((alias) => {
+    const normalizedAlias = normalizedSearchText(alias);
+    return normalizedAlias === normalizedTopic || normalizedAlias.includes(normalizedTopic);
+  });
 }
 
 function udaHasTopic(uda, topicValue) {
@@ -630,7 +651,11 @@ function activityAuthorUdaOptions(pathId = els.activityAuthorPath?.value || "", 
     .filter((option) => option.value);
 }
 
-function activityAuthorTopicOptions(pathId = els.activityAuthorPath?.value || "", udaId = els.activityAuthorUda?.value || "") {
+function activityAuthorTopicOptions(
+  pathId = els.activityAuthorPath?.value || "",
+  udaId = els.activityAuthorUda?.value || "",
+  query = "",
+) {
   const topics = new Map();
   for (const section of courseSections().filter((candidate) => (
     !pathId || String(candidate?.id || candidate?.title || "").trim() === pathId
@@ -639,7 +664,13 @@ function activityAuthorTopicOptions(pathId = els.activityAuthorPath?.value || ""
       if (udaId && String(uda?.id || uda?.title || "").trim() !== udaId) continue;
       for (const item of collectCourseItems(uda.items)) {
         const value = String(item?.id || item?.title || "").trim();
-        if (value && !topics.has(value)) topics.set(value, item?.title || value);
+        if (value && !topics.has(value)) {
+          topics.set(value, {
+            value,
+            label: item?.title || value,
+            search: topicAliases(item).join(" "),
+          });
+        }
       }
     }
   }
@@ -647,12 +678,12 @@ function activityAuthorTopicOptions(pathId = els.activityAuthorPath?.value || ""
     for (const activity of state.activities) {
       for (const topic of Array.isArray(activity?.topics) ? activity.topics : []) {
         const value = String(topic || "").trim();
-        if (value && !topics.has(value)) topics.set(value, value);
+        if (value && !topics.has(value)) topics.set(value, { value, label: value, search: value });
       }
     }
   }
-  return [...topics.entries()]
-    .map(([value, label]) => ({ value, label }))
+  return [...topics.values()]
+    .filter((option) => topicMatchesQuery(option, query))
     .sort((a, b) => a.label.localeCompare(b.label, "it", { numeric: true, sensitivity: "base" }));
 }
 
@@ -674,7 +705,7 @@ function renderCompactSelect(select, options, placeholder, countBadge = null) {
   }
 }
 
-function renderTopicSearch(options) {
+function renderTopicSearch(options, preservePartial = false) {
   if (!els.activityAuthorTopics || !els.activityAuthorTopicsList) return;
   const selected = els.activityAuthorTopics.value;
   els.activityAuthorTopicsList.replaceChildren?.();
@@ -685,7 +716,7 @@ function renderTopicSearch(options) {
     option.dataset.topicValue = optionData.value;
     els.activityAuthorTopicsList.append(option);
   }
-  if (!options.some((option) => option.label === selected || option.value === selected)) {
+  if (!preservePartial && !options.some((option) => option.label === selected || option.value === selected)) {
     els.activityAuthorTopics.value = "";
   }
   if (els.activityAuthorTopicsCount) {
@@ -2924,6 +2955,10 @@ els.activityAuthorUda?.addEventListener("change", () => {
   renderTopicSearch(activityAuthorTopicOptions());
 });
 els.activityAuthorTopics?.addEventListener("input", () => {
+  renderTopicSearch(
+    activityAuthorTopicOptions(els.activityAuthorPath?.value || "", els.activityAuthorUda?.value || "", els.activityAuthorTopics.value),
+    true,
+  );
   renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA", els.activityAuthorUdaCount);
 });
 els.activityAuthorClass?.addEventListener("change", () => {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -603,13 +603,30 @@ function activityAuthorTeamOptions() {
   );
 }
 
-function activityAuthorUdaOptions(pathId = els.activityAuthorPath?.value || "") {
+function itemMatchesTopic(item, topicValue) {
+  if (!topicValue) return true;
+  const aliases = [
+    item?.id,
+    item?.title,
+    item?.href,
+  ].map((value) => String(value || "").trim()).filter(Boolean);
+  return aliases.includes(topicValue);
+}
+
+function udaHasTopic(uda, topicValue) {
+  if (!topicValue) return true;
+  return collectCourseItems(uda?.items).some((item) => itemMatchesTopic(item, topicValue));
+}
+
+function activityAuthorUdaOptions(pathId = els.activityAuthorPath?.value || "", topicValue = activityAuthorTopicValue()) {
   return courseSections()
     .filter((section) => !pathId || String(section?.id || section?.title || "").trim() === pathId)
-    .flatMap((section) => (Array.isArray(section?.udas) ? section.udas : []).map((uda) => ({
-      value: String(uda?.id || uda?.title || "").trim(),
-      label: String(uda?.title || uda?.id || "UDA senza titolo").trim(),
-    })))
+    .flatMap((section) => (Array.isArray(section?.udas) ? section.udas : [])
+      .filter((uda) => udaHasTopic(uda, topicValue))
+      .map((uda) => ({
+        value: String(uda?.id || uda?.title || "").trim(),
+        label: String(uda?.title || uda?.id || "UDA senza titolo").trim(),
+      })))
     .filter((option) => option.value);
 }
 
@@ -2905,6 +2922,9 @@ els.activityAuthorPath?.addEventListener("change", () => {
 });
 els.activityAuthorUda?.addEventListener("change", () => {
   renderTopicSearch(activityAuthorTopicOptions());
+});
+els.activityAuthorTopics?.addEventListener("input", () => {
+  renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA", els.activityAuthorUdaCount);
 });
 els.activityAuthorClass?.addEventListener("change", () => {
   const roster = state.classRosters.find((candidate) => (


### PR DESCRIPTION
Aggiunge un pannello Activity nella dashboard consegne per creare bozze activity locali validate e salvarle in activities/drafts. Backend: POST /api/activities/save su storage/service JSON. Test: python -m pytest tests/test_thebitlab_storage.py tests/test_course_board_server.py tests/test_assignment_dashboard_frontend.py -> 49 passed; python -m scripts.validate_activity activities/examples -> passed.