### PR TITLE
Aggiunge asset activity e scaffold studente

### DIFF
--- a/activities/examples/python_assets_scaffold/activity.json
+++ b/activities/examples/python_assets_scaffold/activity.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "1.0",
+  "id": "python-assets-scaffold-001",
+  "titolo": "Somma con scaffold Python",
+  "tipo": "laboratorio",
+  "difficolta": "B",
+  "argomenti": [
+    "input-output",
+    "funzioni",
+    "test"
+  ],
+  "linguaggio": "python",
+  "consegna": "Completa la funzione somma nel file main.py e verifica il comportamento con il test pubblico.",
+  "assets": [
+    {
+      "type": "starter",
+      "path": "starter/main.py",
+      "target_path": "main.py",
+      "visibility": "student",
+      "description": "Scheletro iniziale da completare"
+    },
+    {
+      "type": "visible_test",
+      "path": "tests/test_public.py",
+      "target_path": "tests/test_public.py",
+      "visibility": "student",
+      "description": "Test pubblico eseguibile dallo studente"
+    },
+    {
+      "type": "hidden_test",
+      "path": "tests/test_hidden.py",
+      "visibility": "teacher",
+      "description": "Test nascosto usato dal docente o dal grader"
+    },
+    {
+      "type": "teacher_only",
+      "path": "solution/main.py",
+      "visibility": "teacher",
+      "description": "Soluzione di riferimento"
+    }
+  ],
+  "correzione": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": false
+  },
+  "metriche": {
+    "tempo_stimato_minuti": 30,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": true
+  }
+}

--- a/activities/examples/python_assets_scaffold/solution/main.py
+++ b/activities/examples/python_assets_scaffold/solution/main.py
@@ -1,0 +1,8 @@
+def somma(a: int, b: int) -> int:
+    return a + b
+
+
+if __name__ == "__main__":
+    primo = int(input())
+    secondo = int(input())
+    print(somma(primo, secondo))

--- a/activities/examples/python_assets_scaffold/starter/main.py
+++ b/activities/examples/python_assets_scaffold/starter/main.py
@@ -1,0 +1,9 @@
+def somma(a: int, b: int) -> int:
+    # Completa la funzione.
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    primo = int(input())
+    secondo = int(input())
+    print(somma(primo, secondo))

--- a/activities/examples/python_assets_scaffold/tests/test_hidden.py
+++ b/activities/examples/python_assets_scaffold/tests/test_hidden.py
@@ -1,0 +1,5 @@
+from main import somma
+
+
+def test_somma_con_numero_negativo():
+    assert somma(-2, 5) == 3

--- a/activities/examples/python_assets_scaffold/tests/test_public.py
+++ b/activities/examples/python_assets_scaffold/tests/test_public.py
@@ -1,0 +1,5 @@
+from main import somma
+
+
+def test_somma_due_numeri_positivi():
+    assert somma(2, 3) == 5

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -203,6 +203,7 @@ Esempio ridotto:
 | `contesto` | No | Collegamento a classe, percorso, UDA e team |
 | `vincoli` | No | Regole tecniche o didattiche |
 | `materiali` | No | File, link o paragrafi collegati |
+| `assets` | No | File allegati alla activity e usati per creare lo scaffold studente o per il grading |
 | `soluzione_attesa` | No | Descrizione della soluzione o output atteso |
 | `correzione` | Si | Regole minime di grading |
 | `metriche` | Si | Metriche da raccogliere |
@@ -226,6 +227,59 @@ Esempio:
 ```
 
 Questi campi non sono obbligatori perche TheBitLab deve poter descrivere anche attivita non scolastiche o non ancora associate a un corso.
+
+## Asset e scaffold
+
+Il campo opzionale `assets` descrive i file collegati alla activity. Serve per distinguere in modo esplicito:
+
+- file da consegnare allo studente, come scheletri, esempi, fixture e test pubblici;
+- file riservati al docente o al grader, come test nascosti, runner e soluzioni.
+
+Esempio:
+
+```json
+{
+  "assets": [
+    {
+      "type": "starter",
+      "path": "starter/main.py",
+      "target_path": "main.py",
+      "visibility": "student",
+      "description": "Scheletro iniziale da completare"
+    },
+    {
+      "type": "visible_test",
+      "path": "tests/test_public.py",
+      "target_path": "tests/test_public.py",
+      "visibility": "student"
+    },
+    {
+      "type": "hidden_test",
+      "path": "tests/test_hidden.py",
+      "visibility": "teacher"
+    }
+  ]
+}
+```
+
+Tipi ammessi:
+
+| Tipo | Uso previsto |
+|---|---|
+| `starter` | File iniziale modificabile dallo studente |
+| `example` | Esempio o materiale di supporto copiato nello scaffold |
+| `fixture` | Dati di input o file necessari per provare l'esercizio |
+| `visible_test` | Test pubblico copiato nello scaffold studente |
+| `hidden_test` | Test riservato a docente/grader |
+| `runner` | Script o configurazione di esecuzione riservata al grading |
+| `teacher_only` | Soluzioni, note o file non destinati allo studente |
+
+Regole dello scaffold:
+
+- `path` e `target_path` devono essere path relativi sicuri, senza `..` e senza path assoluti;
+- se `target_path` manca, il file viene copiato nello stesso path dichiarato in `path`;
+- lo scaffold studente copia solo asset con visibilita effettiva `student` e tipo `starter`, `example`, `fixture` o `visible_test`;
+- `hidden_test`, `runner` e `teacher_only` restano fuori dal repository studente.
 
 ## Correzione
 
@@ -295,6 +349,7 @@ Il validatore controlla:
 - valori booleani in `correzione`;
 - oggetto `metriche` completo;
 - campi obbligatori e tipi in `metriche`;
+- tipi, visibilita e path degli `assets`;
 - rubrica ben formata quando presente.
 
 Il validatore non esegue codice e non valuta la qualita didattica dell'attivita.

--- a/doc/DATA_MODEL_MVP.md
+++ b/doc/DATA_MODEL_MVP.md
@@ -86,6 +86,7 @@ Campi gia importanti:
 - `correzione`;
 - `metriche`;
 - `test_cases`;
+- `assets`, per file starter, esempi, fixture, test pubblici/nascosti, runner e materiali riservati;
 - `contesto`, quando presente;
 - modalita studente in varianti legacy: `student_support_mode`, `support_mode`, `modalita_studente`.
 
@@ -103,10 +104,13 @@ Lo scaffold crea:
 assignments/<activity_id>/
   activity.json
   <source-file>
+  <student-visible-assets>
   README.md
 ```
 
 Per l'MVP questa copia va vista come snapshot assegnato allo studente, non come sorgente unica dell'activity.
+
+Gli asset della activity definiscono quali file entrano nello scaffold. Solo asset con visibilita effettiva `student` e tipo `starter`, `example`, `fixture` o `visible_test` vengono copiati nel repository studente. Test nascosti, runner e file `teacher_only` restano materiale docente/grader.
 
 Campi da preservare nel collegamento:
 

--- a/doc/architecture/data-contracts.md
+++ b/doc/architecture/data-contracts.md
@@ -107,6 +107,7 @@ Campi minimi canonici:
 | `grading_policy` | object | Regole correzione. |
 | `test_cases` | array | Test deterministici, se presenti. |
 | `source_refs` | array | Fonti/paragrafi collegati. |
+| `assets` | array | File allegati alla activity, con tipo, path, target e visibilita. |
 
 Alias legacy letti oggi:
 
@@ -128,6 +129,7 @@ Fase di transizione:
 - I writer attuali possono continuare a produrre campi legacy italiani.
 - I lettori operativi devono usare `scripts/thebitlab_contracts.py` per normalizzare verso i campi canonici senza rompere i dati esistenti.
 - Scaffold, assegnazione, tracking e storage consegne usano gia helper condivisi per activity canoniche/legacy.
+- Gli asset con visibilita studente entrano nello scaffold; asset nascosti, runner e `teacher_only` restano riservati a docente/grader.
 
 ### AssignmentRegister
 

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -276,20 +276,29 @@ def copy_student_assets(
     return copied_paths
 
 
+def assignment_file_lines(activity: dict[str, Any], source_name: str) -> list[str]:
+    """Return README lines for files the student should notice in the scaffold."""
+    assets = student_assets(activity)
+    asset_targets = [
+        str(asset.get("target_path", asset.get("path")))
+        for asset in assets
+    ]
+    lines: list[str] = []
+    if source_name not in asset_targets:
+        lines.append(f"- `{source_name}`")
+    lines.extend(
+        f"- `{target}` ({asset.get('type')})"
+        for target, asset in zip(asset_targets, assets)
+    )
+    return lines
+
+
 def assignment_readme(activity: dict[str, Any], identifier: str, source_name: str, language: str, thebitlab_ref: str) -> str:
     """Build the README for one student assignment scaffold."""
     normalized_activity = normalize_activity(activity)
     title = str(normalized_activity.get("title") or identifier)
     prompt = str(normalized_activity.get("instructions") or "Segui le indicazioni del docente.")
-    assets = student_assets(activity)
-    asset_lines = ""
-    if assets:
-        asset_lines = "\n".join(
-            f"- `{asset.get('target_path', asset.get('path'))}` ({asset.get('type')})"
-            for asset in assets
-        )
-    else:
-        asset_lines = f"- `{source_name}`"
+    file_lines = "\n".join(assignment_file_lines(activity, source_name))
     return (
         f"# {title}\n\n"
         f"Activity ID: `{identifier}`\n\n"
@@ -297,7 +306,7 @@ def assignment_readme(activity: dict[str, Any], identifier: str, source_name: st
         "## Consegna\n\n"
         f"{prompt}\n\n"
         "## File da modificare\n\n"
-        f"{asset_lines}\n\n"
+        f"{file_lines}\n\n"
         "## Grading manuale\n\n"
         "Apri la scheda **Actions**, scegli **TheBitLab grading** e usa questi valori:\n\n"
         f"- `activity_id`: `{identifier}`\n"

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -240,15 +240,9 @@ def student_assets(activity: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
-def copy_student_assets(
-    *,
-    activity_path: Path,
-    destination: Path,
-    activity: dict[str, Any],
-    overwrite_source: bool,
-) -> list[Path]:
-    """Copy student-visible assets from the activity bundle into the scaffold."""
-    copied_paths: list[Path] = []
+def student_asset_copy_plan(activity_path: Path, activity: dict[str, Any]) -> list[tuple[Path, Path]]:
+    """Validate student-visible assets and return source/target relative paths."""
+    planned_assets: list[tuple[Path, Path]] = []
     activity_root = activity_path.parent
     for index, asset in enumerate(student_assets(activity)):
         source_rel = validate_relative_path(asset.get("path"), f"assets[{index}].path")
@@ -260,6 +254,19 @@ def copy_student_assets(
         if not source_path.is_file():
             raise ValueError(f"Asset non trovato: {source_path}")
 
+        planned_assets.append((source_path, target_rel))
+    return planned_assets
+
+
+def copy_student_assets(
+    *,
+    destination: Path,
+    asset_plan: list[tuple[Path, Path]],
+    overwrite_source: bool,
+) -> list[Path]:
+    """Copy a validated set of student-visible assets into the scaffold."""
+    copied_paths: list[Path] = []
+    for source_path, target_rel in asset_plan:
         target_path = destination / target_rel
         target_path.parent.mkdir(parents=True, exist_ok=True)
         if target_path.exists() and not overwrite_source:
@@ -321,6 +328,7 @@ def create_scaffold(
     )
     thebitlab_ref = validate_thebitlab_ref(thebitlab_ref)
     destination = scaffold_dir(target_dir, identifier)
+    asset_plan = student_asset_copy_plan(activity_path, activity)
 
     if destination.exists() and any(destination.iterdir()) and not overwrite:
         raise ValueError(f"Consegna gia esistente: {destination}. Usa --force per sovrascrivere.")
@@ -333,9 +341,8 @@ def create_scaffold(
     )
 
     copy_student_assets(
-        activity_path=activity_path,
         destination=destination,
-        activity=activity,
+        asset_plan=asset_plan,
         overwrite_source=overwrite_source,
     )
 

--- a/scripts/create_submission_scaffold.py
+++ b/scripts/create_submission_scaffold.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -50,6 +51,8 @@ LANGUAGE_ALIASES = {
     "node": "nodejs",
     "py": "python",
 }
+STUDENT_ASSET_TYPES = {"starter", "example", "fixture", "visible_test"}
+TEACHER_ASSET_TYPES = {"hidden_test", "runner", "teacher_only"}
 
 
 def is_safe_slug(value: str) -> bool:
@@ -149,6 +152,13 @@ def validate_source_name(source_name: str) -> str:
     return value
 
 
+def validate_relative_path(value: Any, field_name: str) -> Path:
+    """Validate a relative asset path used inside an activity bundle or scaffold."""
+    if not validate_activity.is_safe_relative_path(value):
+        raise ValueError(f"{field_name} deve essere un path relativo sicuro.")
+    return Path(str(value))
+
+
 def validate_thebitlab_ref(value: str) -> str:
     """Validate a TheBitLab git ref for README usage."""
     clean_value = value.strip()
@@ -205,11 +215,74 @@ def starter_source(language: str) -> str:
     return ""
 
 
+def asset_visibility(asset: dict[str, Any]) -> str:
+    """Return the effective visibility for an activity asset."""
+    explicit_visibility = asset.get("visibility")
+    if isinstance(explicit_visibility, str) and explicit_visibility:
+        return explicit_visibility
+    asset_type = asset.get("type")
+    if asset_type in TEACHER_ASSET_TYPES:
+        return "teacher"
+    return "student"
+
+
+def student_assets(activity: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return assets that must be copied to the student assignment scaffold."""
+    assets = activity.get("assets")
+    if not isinstance(assets, list):
+        return []
+    return [
+        asset
+        for asset in assets
+        if isinstance(asset, dict)
+        and asset.get("type") in STUDENT_ASSET_TYPES
+        and asset_visibility(asset) == "student"
+    ]
+
+
+def copy_student_assets(
+    *,
+    activity_path: Path,
+    destination: Path,
+    activity: dict[str, Any],
+    overwrite_source: bool,
+) -> list[Path]:
+    """Copy student-visible assets from the activity bundle into the scaffold."""
+    copied_paths: list[Path] = []
+    activity_root = activity_path.parent
+    for index, asset in enumerate(student_assets(activity)):
+        source_rel = validate_relative_path(asset.get("path"), f"assets[{index}].path")
+        target_rel = validate_relative_path(
+            asset.get("target_path", asset.get("path")),
+            f"assets[{index}].target_path",
+        )
+        source_path = activity_root / source_rel
+        if not source_path.is_file():
+            raise ValueError(f"Asset non trovato: {source_path}")
+
+        target_path = destination / target_rel
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if target_path.exists() and not overwrite_source:
+            continue
+        shutil.copyfile(source_path, target_path)
+        copied_paths.append(target_path)
+    return copied_paths
+
+
 def assignment_readme(activity: dict[str, Any], identifier: str, source_name: str, language: str, thebitlab_ref: str) -> str:
     """Build the README for one student assignment scaffold."""
     normalized_activity = normalize_activity(activity)
     title = str(normalized_activity.get("title") or identifier)
     prompt = str(normalized_activity.get("instructions") or "Segui le indicazioni del docente.")
+    assets = student_assets(activity)
+    asset_lines = ""
+    if assets:
+        asset_lines = "\n".join(
+            f"- `{asset.get('target_path', asset.get('path'))}` ({asset.get('type')})"
+            for asset in assets
+        )
+    else:
+        asset_lines = f"- `{source_name}`"
     return (
         f"# {title}\n\n"
         f"Activity ID: `{identifier}`\n\n"
@@ -217,7 +290,7 @@ def assignment_readme(activity: dict[str, Any], identifier: str, source_name: st
         "## Consegna\n\n"
         f"{prompt}\n\n"
         "## File da modificare\n\n"
-        f"- `{source_name}`\n\n"
+        f"{asset_lines}\n\n"
         "## Grading manuale\n\n"
         "Apri la scheda **Actions**, scegli **TheBitLab grading** e usa questi valori:\n\n"
         f"- `activity_id`: `{identifier}`\n"
@@ -257,6 +330,13 @@ def create_scaffold(
         json.dumps(activity, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
         newline="\n",
+    )
+
+    copy_student_assets(
+        activity_path=activity_path,
+        destination=destination,
+        activity=activity,
+        overwrite_source=overwrite_source,
     )
 
     source_path = destination / source_name

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -81,6 +81,7 @@ def normalize_activity(payload: dict[str, Any]) -> dict[str, Any]:
     normalized["grading_policy"] = first_dict(payload, "grading_policy", "correzione")
     normalized["test_cases"] = first_list(payload, "test_cases")
     normalized["source_refs"] = first_list(payload, "source_refs")
+    normalized["assets"] = first_list(payload, "assets")
     normalized["class_id"] = first_text(payload, "class_id") or first_text(context, "classe")
     normalized["github_team"] = first_text(payload, "github_team") or first_text(context, "team_github")
     return normalized

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -10,6 +10,16 @@ from scripts.thebitlab_contracts import ALLOWED_ACTIVITY_KINDS
 ALLOWED_TYPES = ALLOWED_ACTIVITY_KINDS
 
 ALLOWED_DIFFICULTIES = {"A", "B", "C", "D", "E", "F"}
+ALLOWED_ASSET_TYPES = {
+    "starter",
+    "example",
+    "fixture",
+    "visible_test",
+    "hidden_test",
+    "runner",
+    "teacher_only",
+}
+ALLOWED_ASSET_VISIBILITIES = {"student", "teacher", "grading"}
 SUPPORTED_SCHEMA_VERSION = "1.0"
 
 REQUIRED_FIELDS = {
@@ -101,6 +111,57 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
     rubric = data.get("rubrica")
     if rubric is not None:
         errors.extend(validate_rubric(rubric, source))
+
+    assets = data.get("assets")
+    if assets is not None:
+        errors.extend(validate_assets(assets, source))
+
+    return errors
+
+
+def is_safe_relative_path(value: Any) -> bool:
+    """Return whether a path stays relative and inside the activity bundle."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+    if value.startswith(("/", "\\")):
+        return False
+    path = Path(value)
+    return (
+        not path.is_absolute()
+        and path.drive == ""
+        and all(part not in {"", ".", ".."} for part in path.parts)
+    )
+
+
+def validate_assets(assets: Any, source: str) -> list[str]:
+    """Validate optional files attached to an activity."""
+    if not isinstance(assets, list):
+        return [f"{source}: assets deve essere una lista"]
+
+    errors: list[str] = []
+    for index, asset in enumerate(assets):
+        prefix = f"{source}: assets[{index}]"
+        if not isinstance(asset, dict):
+            errors.append(f"{prefix} deve essere un oggetto")
+            continue
+
+        asset_type = asset.get("type")
+        if asset_type not in ALLOWED_ASSET_TYPES:
+            errors.append(f"{prefix}.type non ammesso: {asset_type}")
+
+        if not is_safe_relative_path(asset.get("path")):
+            errors.append(f"{prefix}.path deve essere un path relativo sicuro")
+
+        if "target_path" in asset and not is_safe_relative_path(asset.get("target_path")):
+            errors.append(f"{prefix}.target_path deve essere un path relativo sicuro")
+
+        visibility = asset.get("visibility")
+        if visibility is not None and visibility not in ALLOWED_ASSET_VISIBILITIES:
+            errors.append(f"{prefix}.visibility non ammessa: {visibility}")
+
+        description = asset.get("description")
+        if description is not None and not isinstance(description, str):
+            errors.append(f"{prefix}.description deve essere una stringa")
 
     return errors
 

--- a/tests/fixtures/contracts/activity.json
+++ b/tests/fixtures/contracts/activity.json
@@ -52,6 +52,21 @@
       "href": "README.md#input-e-output"
     }
   ],
+  "assets": [
+    {
+      "type": "starter",
+      "path": "starter/main.py",
+      "target_path": "main.py",
+      "visibility": "student",
+      "description": "Scheletro iniziale consegnato allo studente"
+    },
+    {
+      "type": "hidden_test",
+      "path": "tests/test_hidden.py",
+      "visibility": "teacher",
+      "description": "Test riservato al docente"
+    }
+  ],
   "contesto": {
     "classe": "3A-TPSI",
     "team_github": "team-3a-tpsi",

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -84,6 +84,57 @@ def test_create_scaffold_supports_canonical_activity_metadata(tmp_path) -> None:
     assert "language`: `python`" in readme
 
 
+def test_create_scaffold_copies_student_assets_only(tmp_path) -> None:
+    (tmp_path / "starter").mkdir()
+    (tmp_path / "starter" / "main.py").write_text("print('starter')\n", encoding="utf-8")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_public.py").write_text("def test_public():\n    assert True\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_hidden.py").write_text("def test_hidden():\n    assert True\n", encoding="utf-8")
+    (tmp_path / "solution").mkdir()
+    (tmp_path / "solution" / "main.py").write_text("print('solution')\n", encoding="utf-8")
+    activity_path = write_activity(
+        tmp_path,
+        {
+            **activity(),
+            "id": "python-assets-001",
+            "linguaggio": "python",
+            "assets": [
+                {"type": "starter", "path": "starter/main.py", "target_path": "main.py"},
+                {"type": "visible_test", "path": "tests/test_public.py", "target_path": "tests/test_public.py"},
+                {"type": "hidden_test", "path": "tests/test_hidden.py"},
+                {"type": "teacher_only", "path": "solution/main.py", "visibility": "teacher"},
+            ],
+        },
+    )
+
+    destination = create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+
+    assert (destination / "main.py").read_text(encoding="utf-8") == "print('starter')\n"
+    assert (destination / "tests" / "test_public.py").exists()
+    assert not (destination / "tests" / "test_hidden.py").exists()
+    assert not (destination / "solution" / "main.py").exists()
+    readme = (destination / "README.md").read_text(encoding="utf-8")
+    assert "`main.py` (starter)" in readme
+    assert "`tests/test_public.py` (visible_test)" in readme
+
+
+def test_create_scaffold_rejects_missing_student_asset(tmp_path) -> None:
+    activity_path = write_activity(
+        tmp_path,
+        {
+            **activity(),
+            "assets": [{"type": "starter", "path": "starter/missing.c", "target_path": "main.c"}],
+        },
+    )
+
+    try:
+        create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+    except ValueError as error:
+        assert "Asset non trovato" in str(error)
+    else:
+        raise AssertionError("create_scaffold should reject missing student assets")
+
+
 def test_create_scaffold_rejects_invalid_canonical_kind(tmp_path) -> None:
     activity_path = write_activity(
         tmp_path,

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -134,6 +134,8 @@ def test_create_scaffold_rejects_missing_student_asset(tmp_path) -> None:
     else:
         raise AssertionError("create_scaffold should reject missing student assets")
 
+    assert not (tmp_path / "assignments").exists()
+
 
 def test_create_scaffold_rejects_invalid_canonical_kind(tmp_path) -> None:
     activity_path = write_activity(

--- a/tests/test_create_submission_scaffold.py
+++ b/tests/test_create_submission_scaffold.py
@@ -118,6 +118,28 @@ def test_create_scaffold_copies_student_assets_only(tmp_path) -> None:
     assert "`tests/test_public.py` (visible_test)" in readme
 
 
+def test_create_scaffold_readme_keeps_default_source_when_assets_are_support_files(tmp_path) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_public.py").write_text("def test_public():\n    assert True\n", encoding="utf-8")
+    activity_path = write_activity(
+        tmp_path,
+        {
+            **activity(),
+            "id": "python-public-test-001",
+            "linguaggio": "python",
+            "assets": [
+                {"type": "visible_test", "path": "tests/test_public.py", "target_path": "tests/test_public.py"},
+            ],
+        },
+    )
+
+    destination = create_submission_scaffold.create_scaffold(activity_path=activity_path, target_dir=tmp_path)
+
+    readme = (destination / "README.md").read_text(encoding="utf-8")
+    assert "- `main.py`" in readme
+    assert "- `tests/test_public.py` (visible_test)" in readme
+
+
 def test_create_scaffold_rejects_missing_student_asset(tmp_path) -> None:
     activity_path = write_activity(
         tmp_path,

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -27,6 +27,7 @@ def test_normalize_activity_preserves_contract_fixture() -> None:
     assert normalized["topics"] == ["variabili", "input-output"]
     assert normalized["instructions"] == "Scrivi un programma che legge due numeri e stampa la somma."
     assert normalized["grading_policy"] == payload["correzione"]
+    assert normalized["assets"] == payload["assets"]
     assert normalized["class_id"] == "3A-TPSI"
     assert normalized["github_team"] == "team-3a-tpsi"
 

--- a/tests/test_validate_activity.py
+++ b/tests/test_validate_activity.py
@@ -120,6 +120,49 @@ def test_rubric_points_must_not_be_boolean() -> None:
     assert "activity.json: rubrica[0].punti deve essere un numero non negativo" in errors
 
 
+def test_activity_assets_are_validated() -> None:
+    activity = valid_activity()
+    activity["assets"] = [
+        {
+            "type": "starter",
+            "path": "starter/main.c",
+            "target_path": "main.c",
+            "visibility": "student",
+            "description": "Scheletro iniziale",
+        },
+        {
+            "type": "hidden_test",
+            "path": "tests/test_hidden.py",
+            "visibility": "teacher",
+        },
+    ]
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert errors == []
+
+
+def test_activity_assets_reject_unknown_type_and_unsafe_paths() -> None:
+    activity = valid_activity()
+    activity["assets"] = [
+        {
+            "type": "soluzione-magica",
+            "path": "../solution/main.c",
+            "target_path": "/tmp/main.c",
+            "visibility": "pubblica",
+        },
+        "non-oggetto",
+    ]
+
+    errors = validate_activity.validate_activity(activity, "activity.json")
+
+    assert "activity.json: assets[0].type non ammesso: soluzione-magica" in errors
+    assert "activity.json: assets[0].path deve essere un path relativo sicuro" in errors
+    assert "activity.json: assets[0].target_path deve essere un path relativo sicuro" in errors
+    assert "activity.json: assets[0].visibility non ammessa: pubblica" in errors
+    assert "activity.json: assets[1] deve essere un oggetto" in errors
+
+
 def test_cli_validation_fails_on_invalid_file(tmp_path, monkeypatch) -> None:
     invalid_file = tmp_path / "invalid.json"
     invalid_file.write_text(json.dumps({"id": "troppo-poco"}), encoding="utf-8")


### PR DESCRIPTION
## Sintesi
- aggiunge il campo `assets` allo schema activity con tipi e visibilita per starter, esempi, fixture, test pubblici/nascosti, runner e materiali docente
- aggiorna lo scaffold per copiare solo gli asset visibili allo studente, lasciando fuori hidden test e teacher-only
- aggiunge una activity demo con starter Python, test pubblico, test nascosto e soluzione docente
- aggiorna documentazione e contratti dati MVP

## Test
- `python -m pytest tests/test_validate_activity.py tests/test_create_submission_scaffold.py tests/test_thebitlab_contracts.py tests/test_assign_activity.py tests/test_track_assignments.py tests/test_course_board_server.py tests/test_thebitlab_storage.py`
- `python -m scripts.validate_activity activities\\examples`