### PR TITLE
Aggiunge preview assegnazione activity

### DIFF
--- a/doc/DATA_MODEL_MVP.md
+++ b/doc/DATA_MODEL_MVP.md
@@ -112,6 +112,8 @@ Per l'MVP questa copia va vista come snapshot assegnato allo studente, non come 
 
 Gli asset della activity definiscono quali file entrano nello scaffold. Solo asset con visibilita effettiva `student` e tipo `starter`, `example`, `fixture` o `visible_test` vengono copiati nel repository studente. Test nascosti, runner e file `teacher_only` restano materiale docente/grader.
 
+Prima dell'assegnazione effettiva, il backend puo produrre un piano di assegnazione senza scrivere nei repository: activity, linguaggio, sorgente principale, target, asset visibili allo studente, asset riservati e target gia bloccati. La GUI docente deve usare questo piano per mostrare chiaramente cosa verra copiato e cosa resta riservato.
+
 Campi da preservare nel collegamento:
 
 - `activity_id`;

--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -92,6 +92,12 @@ def collect_targets_from_provider(provider: RepositoryProvider, class_ref: str |
     return paths
 
 
+def normalize_targets(targets: list[Path]) -> list[Path]:
+    """Return stable absolute target paths without requiring them to exist."""
+
+    return [target.resolve(strict=False) for target in targets]
+
+
 def assignment_asset_summary(activity: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Return student-visible and teacher/grader assets for an activity preview."""
 
@@ -135,6 +141,7 @@ def build_assignment_plan(
 
     if not targets:
         raise ValueError("Indica almeno un repository studente.")
+    normalized_targets = normalize_targets(targets)
     activity = create_submission_scaffold.load_activity(activity_path)
     identifier = create_submission_scaffold.activity_id(activity)
     normalized_activity = create_submission_scaffold.validate_activity_contract_or_raise(activity, identifier)
@@ -148,7 +155,7 @@ def build_assignment_plan(
     create_submission_scaffold.student_asset_copy_plan(activity_path, activity)
     blocked_targets = [
         str(target)
-        for target in targets
+        for target in normalized_targets
         if create_submission_scaffold.scaffold_dir(target, identifier).exists()
         and any(create_submission_scaffold.scaffold_dir(target, identifier).iterdir())
     ]
@@ -166,7 +173,7 @@ def build_assignment_plan(
                 "assignment_dir": str(create_submission_scaffold.scaffold_dir(target, identifier)),
                 "exists": str(target) in blocked_targets,
             }
-            for target in targets
+            for target in normalized_targets
         ],
         blocked_targets=blocked_targets,
         overwrite=overwrite,
@@ -197,7 +204,7 @@ def assign_activity_to_targets(
         raise ValueError(f"Consegna gia esistente in questi repository:\n{blocked}\nUsa --force per aggiornare.")
 
     results: list[AssignmentResult] = []
-    for target in targets:
+    for target in normalize_targets(targets):
         assignment_dir = create_submission_scaffold.create_scaffold(
             activity_path=activity_path,
             target_dir=target,

--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from scripts import create_submission_scaffold
 from scripts.thebitlab_repository_providers import RepositoryProvider

--- a/scripts/assign_activity.py
+++ b/scripts/assign_activity.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from scripts import create_submission_scaffold
 from scripts.thebitlab_repository_providers import RepositoryProvider
@@ -14,6 +16,43 @@ class AssignmentResult:
 
     target: Path
     assignment_dir: Path
+
+
+@dataclass(frozen=True)
+class AssignmentPlan:
+    """Preview of assigning one activity to a set of target repositories."""
+
+    activity_id: str
+    title: str
+    language: str
+    source_name: str
+    student_assets: list[dict[str, Any]]
+    teacher_assets: list[dict[str, Any]]
+    targets: list[dict[str, Any]]
+    blocked_targets: list[str]
+    overwrite: bool
+
+    @property
+    def can_assign(self) -> bool:
+        """Return whether the plan can be executed without force."""
+
+        return self.overwrite or not self.blocked_targets
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable plan for CLI/API consumers."""
+
+        return {
+            "activity_id": self.activity_id,
+            "title": self.title,
+            "language": self.language,
+            "source_name": self.source_name,
+            "student_assets": self.student_assets,
+            "teacher_assets": self.teacher_assets,
+            "targets": self.targets,
+            "blocked_targets": self.blocked_targets,
+            "overwrite": self.overwrite,
+            "can_assign": self.can_assign,
+        }
 
 
 def load_targets_file(path: Path) -> list[Path]:
@@ -53,6 +92,87 @@ def collect_targets_from_provider(provider: RepositoryProvider, class_ref: str |
     return paths
 
 
+def assignment_asset_summary(activity: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return student-visible and teacher/grader assets for an activity preview."""
+
+    student_assets = []
+    teacher_assets = []
+    assets = activity.get("assets")
+    if not isinstance(assets, list):
+        return student_assets, teacher_assets
+    student_asset_ids = {id(asset) for asset in create_submission_scaffold.student_assets(activity)}
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        asset_type = str(asset.get("type", ""))
+        path = str(asset.get("path", ""))
+        target_path = str(asset.get("target_path", path))
+        visibility = create_submission_scaffold.asset_visibility(asset)
+        summary = {
+            "type": asset_type,
+            "path": path,
+            "target_path": target_path,
+            "visibility": visibility,
+            "description": str(asset.get("description", "")),
+        }
+        if id(asset) in student_asset_ids:
+            student_assets.append(summary)
+        else:
+            teacher_assets.append(summary)
+    return student_assets, teacher_assets
+
+
+def build_assignment_plan(
+    *,
+    activity_path: Path,
+    targets: list[Path],
+    source_name: str | None = None,
+    language: str | None = None,
+    thebitlab_ref: str = create_submission_scaffold.DEFAULT_THEBITLAB_REF,
+    overwrite: bool = False,
+) -> AssignmentPlan:
+    """Validate an assignment request and return a write-free execution preview."""
+
+    if not targets:
+        raise ValueError("Indica almeno un repository studente.")
+    activity = create_submission_scaffold.load_activity(activity_path)
+    identifier = create_submission_scaffold.activity_id(activity)
+    normalized_activity = create_submission_scaffold.validate_activity_contract_or_raise(activity, identifier)
+    selected_language = create_submission_scaffold.language_for(normalized_activity, language)
+    selected_source_name = create_submission_scaffold.validate_source_name(
+        source_name
+        if source_name is not None
+        else create_submission_scaffold.default_source_name_for(selected_language)
+    )
+    create_submission_scaffold.validate_thebitlab_ref(thebitlab_ref)
+    create_submission_scaffold.student_asset_copy_plan(activity_path, activity)
+    blocked_targets = [
+        str(target)
+        for target in targets
+        if create_submission_scaffold.scaffold_dir(target, identifier).exists()
+        and any(create_submission_scaffold.scaffold_dir(target, identifier).iterdir())
+    ]
+    student_assets, teacher_assets = assignment_asset_summary(activity)
+    return AssignmentPlan(
+        activity_id=identifier,
+        title=str(normalized_activity.get("title") or identifier),
+        language=selected_language,
+        source_name=selected_source_name,
+        student_assets=student_assets,
+        teacher_assets=teacher_assets,
+        targets=[
+            {
+                "target": str(target),
+                "assignment_dir": str(create_submission_scaffold.scaffold_dir(target, identifier)),
+                "exists": str(target) in blocked_targets,
+            }
+            for target in targets
+        ],
+        blocked_targets=blocked_targets,
+        overwrite=overwrite,
+    )
+
+
 def assign_activity_to_targets(
     *,
     activity_path: Path,
@@ -64,25 +184,16 @@ def assign_activity_to_targets(
     overwrite_source: bool = False,
 ) -> list[AssignmentResult]:
     """Create the activity scaffold in each target student repository."""
-    activity = create_submission_scaffold.load_activity(activity_path)
-    identifier = create_submission_scaffold.activity_id(activity)
-    normalized_activity = create_submission_scaffold.validate_activity_contract_or_raise(activity, identifier)
-    selected_language = create_submission_scaffold.language_for(normalized_activity, language)
-    create_submission_scaffold.validate_source_name(
-        source_name
-        if source_name is not None
-        else create_submission_scaffold.default_source_name_for(selected_language)
+    plan = build_assignment_plan(
+        activity_path=activity_path,
+        targets=targets,
+        source_name=source_name,
+        language=language,
+        thebitlab_ref=thebitlab_ref,
+        overwrite=overwrite,
     )
-    create_submission_scaffold.validate_thebitlab_ref(thebitlab_ref)
-    blocked_targets = [
-        target
-        for target in targets
-        if create_submission_scaffold.scaffold_dir(target, identifier).exists()
-        and any(create_submission_scaffold.scaffold_dir(target, identifier).iterdir())
-        and not overwrite
-    ]
-    if blocked_targets:
-        blocked = "\n".join(str(target) for target in blocked_targets)
+    if not plan.can_assign:
+        blocked = "\n".join(plan.blocked_targets)
         raise ValueError(f"Consegna gia esistente in questi repository:\n{blocked}\nUsa --force per aggiornare.")
 
     results: list[AssignmentResult] = []
@@ -124,6 +235,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--force", action="store_true", help="Aggiorna una consegna gia esistente.")
     parser.add_argument("--overwrite-source", action="store_true", help="Sovrascrive anche il sorgente se esiste.")
+    parser.add_argument("--dry-run", action="store_true", help="Mostra il piano di assegnazione senza scrivere nei repository.")
     return parser.parse_args()
 
 
@@ -132,6 +244,17 @@ def main() -> int:
     args = parse_args()
     try:
         targets = collect_targets(args.target, args.targets_file)
+        if args.dry_run:
+            plan = build_assignment_plan(
+                activity_path=args.activity,
+                targets=targets,
+                source_name=args.source_name,
+                language=args.language,
+                thebitlab_ref=args.thebitlab_ref,
+                overwrite=args.force,
+            )
+            print(json.dumps(plan.to_dict(), ensure_ascii=False, indent=2))
+            return 0
         results = assign_activity_to_targets(
             activity_path=args.activity,
             targets=targets,

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -33,7 +33,15 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts import create_activity, manual_ai_feedback, thebitlab_services, thebitlab_storage, track_assignments
+from scripts import (
+    assign_activity,
+    create_activity,
+    create_submission_scaffold,
+    manual_ai_feedback,
+    thebitlab_services,
+    thebitlab_storage,
+    track_assignments,
+)
 
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
@@ -367,6 +375,38 @@ def read_targets_from_text(targets_text: str) -> list[track_assignments.Tracking
     if not targets:
         raise ValueError("Inserisci almeno un repository studente nei target.")
     return targets
+
+
+def read_assignment_target_paths_from_text(targets_text: str) -> list[Path]:
+    """Build assignment target repository paths from one path per line."""
+
+    targets = []
+    for raw_line in targets_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        targets.append(resolve_local_path(line, "target"))
+    if not targets:
+        raise ValueError("Inserisci almeno un repository studente nei target.")
+    return targets
+
+
+def preview_activity_assignment(payload: dict) -> dict:
+    """Return a write-free assignment plan for the local GUI."""
+
+    activity_path = resolve_local_path(payload.get("activity_path", ""), "activity_path")
+    if not activity_path.is_file():
+        raise FileNotFoundError(f"Activity non trovata: {activity_path}")
+    targets = read_assignment_target_paths_from_text(str(payload.get("targets_text", "")))
+    plan = assign_activity.build_assignment_plan(
+        activity_path=activity_path,
+        targets=targets,
+        source_name=payload.get("source_name") or None,
+        language=payload.get("language") or None,
+        thebitlab_ref=payload.get("thebitlab_ref") or create_submission_scaffold.DEFAULT_THEBITLAB_REF,
+        overwrite=bool(payload.get("overwrite", False)),
+    )
+    return {"ok": True, "plan": plan.to_dict()}
 
 
 def generate_assignment_report(payload: dict) -> dict:
@@ -1835,6 +1875,20 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/assignment-reports/generate":
             try:
                 self.write_json(generate_assignment_report(payload))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/activities/assignment-plan":
+            try:
+                self.write_json(preview_activity_assignment(payload))
+            except FileNotFoundError as error:
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
             except Exception as error:  # noqa: BLE001
                 self.send_response(400)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/tests/test_assign_activity.py
+++ b/tests/test_assign_activity.py
@@ -33,10 +33,10 @@ def activity() -> dict:
     }
 
 
-def write_activity(tmp_path):
+def write_activity(tmp_path, payload: dict | None = None):
     """Write a valid activity JSON and return its path."""
     path = tmp_path / "activity.json"
-    path.write_text(json.dumps(activity()), encoding="utf-8")
+    path.write_text(json.dumps(activity() if payload is None else payload), encoding="utf-8")
     return path
 
 
@@ -162,6 +162,64 @@ def test_assign_activity_to_multiple_targets(tmp_path) -> None:
         assert (assignment_dir / "main.py").exists()
         readme = (assignment_dir / "README.md").read_text(encoding="utf-8")
         assert "source_path`: `assignments/python-base-somma-001/main.py`" in readme
+
+
+def test_build_assignment_plan_summarizes_assets_without_writing(tmp_path) -> None:
+    (tmp_path / "starter").mkdir()
+    (tmp_path / "starter" / "main.py").write_text("print('starter')\n", encoding="utf-8")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_public.py").write_text("def test_public():\n    assert True\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_hidden.py").write_text("def test_hidden():\n    assert True\n", encoding="utf-8")
+    activity_path = write_activity(
+        tmp_path,
+        {
+            **activity(),
+            "linguaggio": "python",
+            "assets": [
+                {"type": "starter", "path": "starter/main.py", "target_path": "main.py"},
+                {"type": "visible_test", "path": "tests/test_public.py", "target_path": "tests/test_public.py"},
+                {"type": "hidden_test", "path": "tests/test_hidden.py", "visibility": "teacher"},
+            ],
+        },
+    )
+    target = tmp_path / "student-a"
+
+    plan = assign_activity.build_assignment_plan(activity_path=activity_path, targets=[target])
+
+    assert plan.activity_id == "python-base-somma-001"
+    assert plan.source_name == "main.py"
+    assert plan.can_assign is True
+    assert plan.student_assets == [
+        {
+            "type": "starter",
+            "path": "starter/main.py",
+            "target_path": "main.py",
+            "visibility": "student",
+            "description": "",
+        },
+        {
+            "type": "visible_test",
+            "path": "tests/test_public.py",
+            "target_path": "tests/test_public.py",
+            "visibility": "student",
+            "description": "",
+        },
+    ]
+    assert plan.teacher_assets[0]["type"] == "hidden_test"
+    assert plan.targets[0]["assignment_dir"] == str(target / "assignments" / "python-base-somma-001")
+    assert not (target / "assignments").exists()
+
+
+def test_build_assignment_plan_reports_blocked_targets(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    target = tmp_path / "student-a"
+    assign_activity.assign_activity_to_targets(activity_path=activity_path, targets=[target])
+
+    plan = assign_activity.build_assignment_plan(activity_path=activity_path, targets=[target])
+
+    assert plan.can_assign is False
+    assert plan.blocked_targets == [str(target)]
+    assert plan.targets[0]["exists"] is True
 
 
 def test_assign_activity_supports_canonical_activity_metadata(tmp_path) -> None:

--- a/tests/test_assign_activity.py
+++ b/tests/test_assign_activity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from scripts import assign_activity
 from scripts.thebitlab_repository_providers import LocalRepositoryProvider, StudentRepository
@@ -218,8 +219,23 @@ def test_build_assignment_plan_reports_blocked_targets(tmp_path) -> None:
     plan = assign_activity.build_assignment_plan(activity_path=activity_path, targets=[target])
 
     assert plan.can_assign is False
-    assert plan.blocked_targets == [str(target)]
+    assert plan.blocked_targets == [str(target.resolve())]
     assert plan.targets[0]["exists"] is True
+
+
+def test_build_assignment_plan_normalizes_relative_targets(tmp_path, monkeypatch) -> None:
+    activity_path = write_activity(tmp_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    plan = assign_activity.build_assignment_plan(
+        activity_path=activity_path,
+        targets=[Path("student-a")],
+    )
+
+    assert plan.targets[0]["target"] == str((workspace / "student-a").resolve())
+    assert plan.targets[0]["assignment_dir"] == str((workspace / "student-a" / "assignments" / "python-base-somma-001").resolve())
 
 
 def test_assign_activity_supports_canonical_activity_metadata(tmp_path) -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -113,6 +113,58 @@ def test_list_assignment_reports_counts_late_only_for_submitted_students(tmp_pat
     assert reports[0]["late"] == 1
 
 
+def test_preview_activity_assignment_returns_plan_without_writing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    activities_dir = tmp_path / "activities"
+    activities_dir.mkdir()
+    (activities_dir / "starter").mkdir()
+    (activities_dir / "starter" / "main.py").write_text("print('starter')\n", encoding="utf-8")
+    activity_path = activities_dir / "activity.json"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": "python-base-somma-001",
+                "titolo": "Somma in Python",
+                "tipo": "compito-casa",
+                "difficolta": "B",
+                "argomenti": ["variabili"],
+                "linguaggio": "python",
+                "consegna": "Completa main.py.",
+                "assets": [{"type": "starter", "path": "starter/main.py", "target_path": "main.py"}],
+                "correzione": {
+                    "compila": True,
+                    "test": True,
+                    "sandbox": True,
+                    "ai_feedback": False,
+                },
+                "metriche": {
+                    "tempo_stimato_minuti": 20,
+                    "traccia_tempo_dichiarato": True,
+                    "traccia_sessioni_thebitlab": True,
+                    "traccia_eventi_didattici": True,
+                    "traccia_errori_compilazione": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    target = tmp_path / "students" / "rossi-mario"
+
+    response = course_board_server.preview_activity_assignment(
+        {
+            "activity_path": "activities/activity.json",
+            "targets_text": "students/rossi-mario",
+        }
+    )
+
+    assert response["ok"] is True
+    assert response["plan"]["activity_id"] == "python-base-somma-001"
+    assert response["plan"]["student_assets"][0]["target_path"] == "main.py"
+    assert response["plan"]["targets"][0]["target"] == str(target.resolve())
+    assert not (target / "assignments").exists()
+
+
 def test_review_assignment_ai_feedback_persists_teacher_decision(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")


### PR DESCRIPTION
## Sintesi
- aggiunge un piano di assegnazione riusabile per activity, target e asset
- espone `--dry-run` in `scripts/assign_activity.py` per vedere cosa verrebbe assegnato senza scrivere nei repository studenti
- aggiunge endpoint locale `POST /api/activities/assignment-plan` per la futura GUI docente
- documenta che la GUI deve usare la preview per distinguere asset studente e materiale docente/grader

## Test
- `python -m pytest tests/test_assign_activity.py tests/test_course_board_server.py tests/test_create_submission_scaffold.py tests/test_validate_activity.py tests/test_thebitlab_contracts.py tests/test_track_assignments.py tests/test_thebitlab_storage.py`
- `python -m scripts.validate_activity activities\\examples`