### PR TITLE
Aggiunge anteprima assegnazione activity

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -516,13 +516,13 @@ Campi del registro:
 }
 ```
 
-La GUI usa questi campi in generazione registro, selettore registri, riepilogo del registro selezionato, copertura registri, filtri del quadro classe e matrice. Se la classe non viene indicata durante la generazione, il sistema prova a usare `contesto.classe` e `contesto.team_github` presenti nella activity.
+La GUI usa questi campi in creazione registro consegne, selettore registri, riepilogo del registro selezionato, copertura registri, filtri del quadro classe e matrice. Se la classe non viene indicata durante la creazione, il sistema prova a usare `contesto.classe` e `contesto.team_github` presenti nella activity.
 
-### Generare il registro dalla GUI
+### Creare il registro consegne dalla GUI
 
-La pagina `Consegne` puo anche generare un registro senza usare direttamente la CLI.
+La pagina `Consegne` puo anche creare un registro consegne senza usare direttamente la CLI.
 
-Nel riquadro `Genera registro` compila:
+Nel riquadro `Assegnazione e registro` compila:
 
 | Campo | Significato |
 |---|---|
@@ -536,7 +536,9 @@ Nel riquadro `Genera registro` compila:
 | Ora simulata opzionale | Data ISO usata per simulare il momento attuale |
 | Repository studenti locali | Un path per riga verso i repository/cartelle studente |
 
-Quando clicchi `Genera registro`, il server locale:
+Nota: questa azione crea o aggiorna il registro consegne per tracciare stato, ritardi e grading. Non distribuisce ancora gli asset agli studenti; l'assegnazione reale dell'activity avra un flusso dedicato.
+
+Quando clicchi `Crea registro consegne`, il server locale:
 
 1. legge la activity;
 2. costruisce i target studenti;
@@ -577,7 +579,7 @@ Per testare dalla GUI:
 1. avvia il server con `python scripts/course_board_server.py`;
 2. apri `http://localhost:8765/tools/assignment_dashboard.html`;
 3. scegli una activity demo dal menu;
-4. clicca `Genera registro`;
+4. clicca `Crea registro consegne`;
 5. ripeti per piu activity, usando un output diverso in `teacher-reports`;
 6. verifica che la dashboard mostri consegnati, mancanti, ritardi, test falliti e voti;
 7. usa i filtri del `Quadro classe` per controllare studente, tipo, stato e modalita.

--- a/doc/CLASS_ROSTERS.md
+++ b/doc/CLASS_ROSTERS.md
@@ -68,7 +68,7 @@ POST /api/class-rosters/load
 
 La vista studente usa il roster come fonte primaria della lista studenti.
 
-La dashboard consegne usa il roster nel pannello `Genera registro`:
+La dashboard consegne usa il roster nel pannello `Assegnazione e registro`:
 
 - compila `Classe`, `Etichetta classe` e `Team GitHub`;
 - genera la textarea dei target dagli studenti attivi;

--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -20,9 +20,11 @@ http://localhost:8765/tools/assignment_dashboard.html
 
 ## Pannelli
 
-### Genera registro
+### Assegnazione e registro
 
-Serve a preparare o aggiornare un registro consegne.
+Serve a preparare l'associazione tra una activity, i destinatari e le date, poi creare o aggiornare il registro consegne.
+
+Nota di nomenclatura: il registro non e l'assegnazione completa dell'activity e non assegna voti. Il registro e il documento di tracciamento che permette di vedere consegne attese, mancanti, in ritardo, grading, voti e feedback per una activity associata a una classe, un team o uno studente. La distribuzione reale degli asset agli studenti avra un flusso dedicato.
 
 Usalo quando devi:
 
@@ -30,7 +32,7 @@ Usalo quando devi:
 - scegliere la classe tramite roster;
 - controllare o modificare il nome del registro JSON;
 - impostare classe, team, assegnazione e scadenza;
-- generare il registro in `teacher-reports`.
+- creare il registro in `teacher-reports`.
 
 Screenshot previsto: `doc/images/dashboard-guides/docente-genera-registro.png`.
 
@@ -38,7 +40,7 @@ Screenshot previsto: `doc/images/dashboard-guides/docente-genera-registro.png`.
 
 Serve a controllare quali studenti saranno usati per generare il registro della activity selezionata.
 
-Usalo prima di premere **Genera registro**, soprattutto quando:
+Usalo prima di premere **Crea registro consegne**, soprattutto quando:
 
 - vuoi verificare che la classe selezionata sia corretta;
 - vuoi controllare gli studenti attivi;
@@ -111,7 +113,7 @@ Usalo quando:
 
 Screenshot previsto: `doc/images/dashboard-guides/docente-revisione-consegna.png`.
 
-## Scenario 1 - Generare un registro per activity e classe
+## Scenario 1 - Creare un registro per activity e classe
 
 Obiettivo: creare un registro consegne per una activity assegnata a una classe.
 
@@ -125,7 +127,7 @@ Prerequisiti:
 Passaggi:
 
 1. Apri la dashboard consegne.
-2. Nel pannello **Genera registro**, scegli una activity da **Scegli activity**.
+2. Nel pannello **Assegnazione e registro**, scegli una activity da **Scegli activity**.
 3. Scegli una classe da **Classe da roster**.
 4. Controlla il pannello **Roster classe**:
    - classe;
@@ -136,7 +138,7 @@ Passaggi:
    - fallback demo.
 5. Se serve, modifica **Output registro**.
 6. Controlla scadenza e data di assegnazione.
-7. Premi **Genera registro**.
+7. Premi **Crea registro consegne**.
 8. Verifica il pannello **Registro selezionato**.
 9. Apri **Studenti** o **Quadro classe** per controllare il risultato.
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -568,6 +568,8 @@ Ordine consigliato:
    - lasciare al docente controllo completo: accetta, modifica, scarta, rigenera o crea manualmente;
    - registrare provenienza della generazione e policy AI usata.
 7. Pagina assegnazione activity a classe, gruppo o singolo studente e scaffold consegna.
+   - separare esplicitamente i flussi GUI: `Assegna activity` distribuisce/aggancia asset e destinatari, `Crea/Aggiorna registro consegne` traccia lo stato delle consegne, `Valuta consegne` gestisce grading, voti e feedback;
+   - evitare che il registro venga percepito come il comando che assegna l'activity o attribuisce voti definitivi.
 8. Interfaccia studente MVP per consegne, stato e feedback deterministico, web oppure TUI se piu rapida da rendere affidabile.
 9. Consolidamento grading Docker per flusso reale di consegna.
 10. Collegamento automatico report/artifact al registro consegne.

--- a/doc/images/dashboard-guides/README.md
+++ b/doc/images/dashboard-guides/README.md
@@ -44,7 +44,7 @@ Pagina studente:
 
 | File | Stato | Pagina | Cosa deve mostrare |
 |---|---|---|---|
-| `docente-genera-registro.png` | da fare | Dashboard docente | Pannello **Genera registro** con activity, roster, output registro, scadenza e target studenti visibili |
+| `docente-genera-registro.png` | da fare | Dashboard docente | Pannello **Assegnazione e registro** con activity, roster, output registro, scadenza e target studenti visibili |
 | `docente-roster-classe.png` | da fare | Dashboard docente | Pannello **Roster classe** con classe, activity, output registro, studenti attivi, target locali e fallback demo |
 | `docente-registro-selezionato.png` | da fare | Dashboard docente | Pannello **Registro selezionato** con registro caricato e riepilogo compilato |
 | `docente-quadro-classe.png` | da fare | Dashboard docente | Pannello **Quadro classe** con riepilogo e bottone per aprire il modal |
@@ -56,9 +56,9 @@ Pagina studente:
 
 | File | Stato | Scenario | Cosa deve mostrare |
 |---|---|---|---|
-| `scenario-genera-registro-01.png` | da fare | Generazione registro | Activity e roster selezionati prima della generazione |
-| `scenario-genera-registro-02.png` | da fare | Generazione registro | Pannello roster classe con target verificabili |
-| `scenario-genera-registro-03.png` | da fare | Generazione registro | Registro generato e caricato in **Registro selezionato** |
+| `scenario-genera-registro-01.png` | da fare | Creazione registro consegne | Activity e roster selezionati prima della creazione del registro |
+| `scenario-genera-registro-02.png` | da fare | Creazione registro consegne | Pannello roster classe con target verificabili |
+| `scenario-genera-registro-03.png` | da fare | Creazione registro consegne | Registro creato e caricato in **Registro selezionato** |
 | `scenario-carica-registro.png` | da fare | Caricare registro | Select registri, registro scelto e riepilogo dopo caricamento |
 | `scenario-quadro-classe.png` | da fare | Quadro classe | Modal quadro classe con filtri, elenco o matrice visibili |
 | `scenario-revisione-consegna.png` | da fare | Revisione consegna | Modal revisione con file consegnati e contenuto syntax-highlighted |

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -166,6 +166,7 @@ def run_dashboard_js(assertions: str) -> None:
     }});
 
     const fetchCalls = [];
+    const fetchResponses = {{}};
     const context = {{
       console,
       setTimeout,
@@ -195,6 +196,7 @@ def run_dashboard_js(assertions: str) -> None:
         }},
       }},
       fetchCalls,
+      fetchResponses,
       fetch: async (path, options = {{}}) => {{
         fetchCalls.push({{ path, options }});
         return {{
@@ -202,6 +204,7 @@ def run_dashboard_js(assertions: str) -> None:
         status: 200,
         statusText: "OK",
         json: async () => {{
+          if (fetchResponses[path]) return fetchResponses[path];
           if (path === "/api/assignment-reports") return {{ reports: [] }};
           if (path === "/api/activities") return {{ activities: [] }};
           if (path === "/api/activities/save") return {{
@@ -289,6 +292,11 @@ def run_dashboard_js(assertions: str) -> None:
         suggestedActivityId,
         syncActivityAuthorIdSuggestion,
         renderActivityAuthorMetadataSelects,
+        assignmentPlanPayload,
+        renderAssignmentAssetList,
+        renderAssignmentTargetList,
+        renderAssignmentPlan,
+        previewAssignmentPlan,
         rosterOptionLabel,
         localTargetFromStudent,
         rosterTargets,
@@ -300,6 +308,7 @@ def run_dashboard_js(assertions: str) -> None:
         FakeElement,
         localStorage,
         fetchCalls,
+        fetchResponses,
         window,
       }};
     `, context);
@@ -413,6 +422,70 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           assert.equal(tested.state.activities.length, 1);
           assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
           assert.match(tested.els.activityAuthorStatus.textContent, /Activity salvata/);
+        })();
+        """
+    )
+
+
+def test_assignment_preview_posts_plan_and_renders_assets() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityPath.value = "activities/examples/python_assets_scaffold/activity.json";
+          tested.els.targetsText.value = "students/rossi-mario\\nstudents/bianchi-luca";
+          tested.fetchResponses["/api/activities/assignment-plan"] = {
+            ok: true,
+            plan: {
+              activity_id: "python-assets-scaffold-001",
+              title: "Somma con scaffold Python",
+              language: "python",
+              source_name: "main.py",
+              can_assign: false,
+              student_assets: [
+                {
+                  type: "starter",
+                  target_path: "main.py",
+                  path: "starter/main.py",
+                  visibility: "student",
+                  description: "Scheletro",
+                },
+              ],
+              teacher_assets: [
+                {
+                  type: "hidden_test",
+                  target_path: "tests/test_hidden.py",
+                  path: "tests/test_hidden.py",
+                  visibility: "teacher",
+                  description: "Riservato",
+                },
+              ],
+              targets: [
+                {
+                  target: "students/rossi-mario",
+                  assignment_dir: "students/rossi-mario/assignments/python-assets-scaffold-001",
+                  exists: false,
+                },
+                {
+                  target: "students/bianchi-luca",
+                  assignment_dir: "students/bianchi-luca/assignments/python-assets-scaffold-001",
+                  exists: true,
+                },
+              ],
+            },
+          };
+
+          await tested.previewAssignmentPlan();
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/activities/assignment-plan");
+          const body = JSON.parse(call.options.body);
+          assert.equal(call.options.method, "POST");
+          assert.equal(body.activity_path, "activities/examples/python_assets_scaffold/activity.json");
+          assert.equal(body.targets_text, "students/rossi-mario\\nstudents/bianchi-luca");
+          assert.match(tested.els.assignmentPlanPreview.innerHTML, /Somma con scaffold Python/);
+          assert.match(tested.els.assignmentPlanPreview.innerHTML, /main.py/);
+          assert.match(tested.els.assignmentPlanPreview.innerHTML, /tests\\/test_hidden.py/);
+          assert.match(tested.els.assignmentPlanPreview.innerHTML, /target bloccati/);
+          assert.match(tested.els.status.textContent, /alcuni target/);
         })();
         """
     )

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -199,12 +199,14 @@ def run_dashboard_js(assertions: str) -> None:
       fetchResponses,
       fetch: async (path, options = {{}}) => {{
         fetchCalls.push({{ path, options }});
+        const fakeResponse = fetchResponses[path];
         return {{
-        ok: true,
-        status: 200,
-        statusText: "OK",
+        ok: fakeResponse?.ok ?? true,
+        status: fakeResponse?.status ?? 200,
+        statusText: fakeResponse?.statusText ?? "OK",
         json: async () => {{
-          if (fetchResponses[path]) return fetchResponses[path];
+          if (fakeResponse?.json) return fakeResponse.json;
+          if (fakeResponse) return fakeResponse;
           if (path === "/api/assignment-reports") return {{ reports: [] }};
           if (path === "/api/activities") return {{ activities: [] }};
           if (path === "/api/activities/save") return {{
@@ -239,7 +241,7 @@ def run_dashboard_js(assertions: str) -> None:
           }}
           return {{}};
         }},
-        text: async () => "",
+        text: async () => fakeResponse?.text ?? "",
       }};
       }},
     }};
@@ -296,6 +298,7 @@ def run_dashboard_js(assertions: str) -> None:
         renderAssignmentAssetList,
         renderAssignmentTargetList,
         renderAssignmentPlan,
+        assignmentPlanErrorMessage,
         previewAssignmentPlan,
         rosterOptionLabel,
         localTargetFromStudent,
@@ -486,6 +489,29 @@ def test_assignment_preview_posts_plan_and_renders_assets() -> None:
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /tests\\/test_hidden.py/);
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /target bloccati/);
           assert.match(tested.els.status.textContent, /alcuni target/);
+        })();
+        """
+    )
+
+
+def test_assignment_preview_explains_missing_server_endpoint() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityPath.value = "activities/examples/python_assets_scaffold/activity.json";
+          tested.els.targetsText.value = "students/rossi-mario";
+          tested.fetchResponses["/api/activities/assignment-plan"] = {
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            text: '<html><body><p>Nothing matches the given URI.</p></body></html>',
+          };
+
+          await tested.previewAssignmentPlan();
+
+          assert.match(tested.els.assignmentPlanPreview.innerHTML, /endpoint non trovato/);
+          assert.match(tested.els.assignmentPlanPreview.innerHTML, /course_board_server.py/);
+          assert.match(tested.els.status.textContent, /endpoint non trovato/);
         })();
         """
     )

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -253,6 +253,81 @@ label > textarea {
   padding: 0 1.1rem 1.1rem;
 }
 
+.assignmentPlanPreview {
+  border-top: 1px solid var(--line);
+  padding: .85rem 1.1rem 1.1rem;
+}
+
+.assignmentPlanHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: .75rem;
+  margin-bottom: .75rem;
+}
+
+.assignmentPlanHeader strong,
+.assignmentPlanHeader small {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.assignmentPlanHeader small {
+  color: var(--muted);
+  margin-top: .18rem;
+}
+
+.assignmentPlanGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: .75rem;
+}
+
+.assignmentPlanGrid section {
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 14px;
+  background: #ffffff;
+  padding: .75rem;
+}
+
+.assignmentPlanGrid h3 {
+  margin-bottom: .55rem;
+  color: var(--muted);
+  font-size: .8rem;
+  text-transform: uppercase;
+}
+
+.assignmentPlanList {
+  display: grid;
+  gap: .55rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.assignmentPlanList li {
+  min-width: 0;
+  padding-bottom: .55rem;
+  border-bottom: 1px solid rgba(17, 17, 17, .08);
+}
+
+.assignmentPlanList li:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.assignmentPlanList strong,
+.assignmentPlanList small {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.assignmentPlanList small {
+  margin-top: .25rem;
+  color: var(--muted);
+}
+
 .inlineCheck {
   display: inline-flex;
   grid-template-columns: none;
@@ -1838,6 +1913,10 @@ code {
   }
 
   .generateGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .assignmentPlanGrid {
     grid-template-columns: 1fr;
   }
 

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -125,8 +125,8 @@
     <section class="panel" data-panel-key="generate">
       <div class="panelHead">
         <div>
-          <h2>Genera registro</h2>
-          <p class="status">Crea o aggiorna un registro consegne partendo da activity, target locali e scadenza.</p>
+          <h2>Assegnazione e registro</h2>
+          <p class="status">Prepara l'associazione tra activity, destinatari e scadenza, poi crea il registro consegne per tracciarne lo stato.</p>
         </div>
       </div>
       <div class="generateGrid">
@@ -184,7 +184,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       </div>
       <div class="generateActions">
         <button id="previewAssignmentBtn" type="button" title="Mostra cosa verrebbe assegnato agli studenti senza scrivere nei repository.">Anteprima assegnazione</button>
-        <button id="generateReportBtn" type="button" class="primary" title="Genera il registro, lo salva in teacher-reports e lo carica nella dashboard.">Genera registro</button>
+        <button id="generateReportBtn" type="button" class="primary" title="Crea il registro consegne, lo salva in teacher-reports e lo carica nella dashboard. Non distribuisce ancora gli asset agli studenti.">Crea registro consegne</button>
       </div>
       <div id="assignmentPlanPreview" class="assignmentPlanPreview" aria-live="polite">
         <p class="status">Usa l'anteprima per verificare target e asset prima di assegnare una activity.</p>
@@ -206,7 +206,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       <div class="panelHead">
         <div>
           <h2>Roster classe</h2>
-          <p id="rosterPanelStatus" class="status">Seleziona un roster in Genera registro per vedere studenti e target.</p>
+          <p id="rosterPanelStatus" class="status">Seleziona un roster in Assegnazione e registro per vedere studenti e target.</p>
         </div>
       </div>
       <div id="rosterSummary" class="summaryGrid">

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -183,7 +183,11 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         <p id="rosterStatus" class="status wideField" aria-live="polite"></p>
       </div>
       <div class="generateActions">
+        <button id="previewAssignmentBtn" type="button" title="Mostra cosa verrebbe assegnato agli studenti senza scrivere nei repository.">Anteprima assegnazione</button>
         <button id="generateReportBtn" type="button" class="primary" title="Genera il registro, lo salva in teacher-reports e lo carica nella dashboard.">Genera registro</button>
+      </div>
+      <div id="assignmentPlanPreview" class="assignmentPlanPreview" aria-live="polite">
+        <p class="status">Usa l'anteprima per verificare target e asset prima di assegnare una activity.</p>
       </div>
       <div class="coverageBlock" data-panel-key="coverage-registers">
         <div class="coverageHead">

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2220,6 +2220,14 @@ function renderAssignmentPlan(plan) {
   `;
 }
 
+function assignmentPlanErrorMessage(error) {
+  const message = error?.message || String(error);
+  if (message.startsWith("404 ") && message.includes("Nothing matches the given URI")) {
+    return "endpoint non trovato. Riavvia il server con python scripts/course_board_server.py dalla branch aggiornata.";
+  }
+  return message;
+}
+
 async function previewAssignmentPlan() {
   if (!els.previewAssignmentBtn) return;
   els.previewAssignmentBtn.disabled = true;
@@ -2237,10 +2245,11 @@ async function previewAssignmentPlan() {
       ? "Anteprima assegnazione pronta."
       : "Anteprima pronta: alcuni target sono gia assegnati.");
   } catch (error) {
+    const message = assignmentPlanErrorMessage(error);
     if (els.assignmentPlanPreview) {
-      els.assignmentPlanPreview.innerHTML = `<p class="status">Anteprima non disponibile: ${escapeHtml(error.message)}</p>`;
+      els.assignmentPlanPreview.innerHTML = `<p class="status">Anteprima non disponibile: ${escapeHtml(message)}</p>`;
     }
-    setStatus(`Anteprima assegnazione non disponibile: ${error.message}`);
+    setStatus(`Anteprima assegnazione non disponibile: ${message}`);
   } finally {
     els.previewAssignmentBtn.disabled = false;
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -815,7 +815,7 @@ function renderRosterPanel() {
   const roster = state.selectedClassRoster;
   if (!els.rosterSummary || !els.rosterBody) return;
   if (!roster) {
-    setRosterPanelStatus(state.classRosters.length ? "Seleziona un roster in Genera registro per vedere studenti e target." : "Nessun roster locale disponibile.");
+    setRosterPanelStatus(state.classRosters.length ? "Seleziona un roster in Assegnazione e registro per vedere studenti e target." : "Nessun roster locale disponibile.");
     els.rosterSummary.innerHTML = '<p class="status">Nessun roster selezionato.</p>';
     els.rosterBody.innerHTML = '<tr><td colspan="4">Seleziona un roster per vedere gli studenti.</td></tr>';
     return;
@@ -2257,7 +2257,7 @@ async function previewAssignmentPlan() {
 
 async function generateReport() {
   els.generateReportBtn.disabled = true;
-  setStatus("Generazione registro consegne...");
+  setStatus("Creazione registro consegne...");
   try {
     const payload = await api("/api/assignment-reports/generate", {
       method: "POST",
@@ -2284,9 +2284,9 @@ async function generateReport() {
     renderOverview();
     clearReview();
     renderDashboard();
-    setStatus(`Registro generato e caricato: ${payload.saved?.path || payload.saved?.name}.`);
+    setStatus(`Registro consegne creato e caricato: ${payload.saved?.path || payload.saved?.name}.`);
   } catch (error) {
-    setStatus(`Registro non generato: ${error.message}`);
+    setStatus(`Registro consegne non creato: ${error.message}`);
   } finally {
     els.generateReportBtn.disabled = false;
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -218,6 +218,8 @@ const els = {
   dueAt: document.querySelector("#dueAt"),
   nowAt: document.querySelector("#nowAt"),
   targetsText: document.querySelector("#targetsText"),
+  previewAssignmentBtn: document.querySelector("#previewAssignmentBtn"),
+  assignmentPlanPreview: document.querySelector("#assignmentPlanPreview"),
   generateReportBtn: document.querySelector("#generateReportBtn"),
   panels: document.querySelectorAll("main.layout .panel"),
 };
@@ -2141,6 +2143,109 @@ function renderOverview() {
   setupResizableTables();
 }
 
+function assignmentPlanPayload() {
+  return {
+    activity_path: els.activityPath.value,
+    targets_text: els.targetsText.value,
+    language: "",
+    source_name: "",
+    thebitlab_ref: "",
+    overwrite: false,
+  };
+}
+
+function renderAssignmentAssetList(assets, emptyLabel) {
+  const items = Array.isArray(assets) ? assets : [];
+  if (!items.length) return `<p class="status">${escapeHtml(emptyLabel)}</p>`;
+  return `
+    <ul class="assignmentPlanList">
+      ${items.map((asset) => `
+        <li>
+          <strong>${escapeHtml(asset.target_path || asset.path || "-")}</strong>
+          ${badge(asset.type || "-", asset.visibility === "student" ? "ok" : "muted")}
+          <small>${escapeHtml(asset.description || asset.path || "")}</small>
+        </li>
+      `).join("")}
+    </ul>
+  `;
+}
+
+function renderAssignmentTargetList(targets) {
+  const rows = Array.isArray(targets) ? targets : [];
+  if (!rows.length) return '<p class="status">Nessun target indicato.</p>';
+  return `
+    <ul class="assignmentPlanList">
+      ${rows.map((target) => `
+        <li>
+          <strong>${escapeHtml(target.target || "-")}</strong>
+          ${badge(target.exists ? "gia presente" : "pronto", target.exists ? "warn" : "ok")}
+          <small>${escapeHtml(target.assignment_dir || "")}</small>
+        </li>
+      `).join("")}
+    </ul>
+  `;
+}
+
+function renderAssignmentPlan(plan) {
+  if (!els.assignmentPlanPreview) return;
+  if (!plan) {
+    els.assignmentPlanPreview.innerHTML = `<p class="status">Usa l'anteprima per verificare target e asset prima di assegnare una activity.</p>`;
+    return;
+  }
+  const status = plan.can_assign
+    ? badge("pronta", "ok")
+    : badge("target bloccati", "warn");
+  els.assignmentPlanPreview.innerHTML = `
+    <div class="assignmentPlanHeader">
+      <div>
+        <strong>${escapeHtml(plan.title || plan.activity_id || "-")}</strong>
+        <small>${escapeHtml(plan.activity_id || "-")} - ${escapeHtml(plan.language || "-")} - ${escapeHtml(plan.source_name || "-")}</small>
+      </div>
+      ${status}
+    </div>
+    <div class="assignmentPlanGrid">
+      <section>
+        <h3>Target</h3>
+        ${renderAssignmentTargetList(plan.targets)}
+      </section>
+      <section>
+        <h3>Asset studente</h3>
+        ${renderAssignmentAssetList(plan.student_assets, "Nessun asset studente dichiarato.")}
+      </section>
+      <section>
+        <h3>Riservati docente</h3>
+        ${renderAssignmentAssetList(plan.teacher_assets, "Nessun asset riservato dichiarato.")}
+      </section>
+    </div>
+  `;
+}
+
+async function previewAssignmentPlan() {
+  if (!els.previewAssignmentBtn) return;
+  els.previewAssignmentBtn.disabled = true;
+  setStatus("Calcolo anteprima assegnazione...");
+  if (els.assignmentPlanPreview) {
+    els.assignmentPlanPreview.innerHTML = '<p class="status">Calcolo anteprima assegnazione...</p>';
+  }
+  try {
+    const payload = await api("/api/activities/assignment-plan", {
+      method: "POST",
+      body: JSON.stringify(assignmentPlanPayload()),
+    });
+    renderAssignmentPlan(payload.plan);
+    setStatus(payload.plan?.can_assign
+      ? "Anteprima assegnazione pronta."
+      : "Anteprima pronta: alcuni target sono gia assegnati.");
+  } catch (error) {
+    if (els.assignmentPlanPreview) {
+      els.assignmentPlanPreview.innerHTML = `<p class="status">Anteprima non disponibile: ${escapeHtml(error.message)}</p>`;
+    }
+    setStatus(`Anteprima assegnazione non disponibile: ${error.message}`);
+  } finally {
+    els.previewAssignmentBtn.disabled = false;
+  }
+}
+
 async function generateReport() {
   els.generateReportBtn.disabled = true;
   setStatus("Generazione registro consegne...");
@@ -2919,6 +3024,7 @@ els.reloadBtn.addEventListener("click", async () => {
   await loadOverview();
 });
 els.resetPanelOrderBtn.addEventListener("click", resetPanelOrder);
+els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
 els.generateReportBtn.addEventListener("click", generateReport);
 els.reportSelect.addEventListener("change", loadSelectedReport);
 els.coverageOpenBtn.addEventListener("click", openCoverageDialog);


### PR DESCRIPTION
﻿## Cosa cambia
- Aggiunge nel pannello `Genera registro` il bottone `Anteprima assegnazione`.
- Mostra un riepilogo read-only del piano di assegnazione: target, asset visibili allo studente e asset riservati al docente.
- Evidenzia quando alcuni target risultano gia presenti, senza scrivere nei repository.

## Perche
Serve un passaggio intermedio prima dell'assegnazione reale: il docente puo controllare cosa verrebbe distribuito e a chi, riducendo il rischio di assegnare asset sbagliati o sovrascrivere consegne esistenti.

## Validazione
- `python -m pytest tests/test_assignment_dashboard_frontend.py`
