### PR TITLE
Separa assegnazione activity e registro consegne

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -522,12 +522,11 @@ La GUI usa questi campi in creazione registro consegne, selettore registri, riep
 
 La pagina `Consegne` puo anche creare un registro consegne senza usare direttamente la CLI.
 
-Nel riquadro `Assegnazione e registro` compila:
+Nel riquadro `Assegna activity` compila i dati che identificano activity, destinatari e date:
 
 | Campo | Significato |
 |---|---|
 | Activity JSON | Scheda activity da tracciare |
-| Output registro | Path relativo dentro `teacher-reports`, per esempio `3A/somma.json` |
 | Classe | Identificativo classe dell'assegnazione, per esempio `3A-TPSI` |
 | Etichetta classe | Nome leggibile mostrato in dashboard, per esempio `3A TPSI` |
 | Team GitHub | Team GitHub della classe, se disponibile |
@@ -535,6 +534,12 @@ Nel riquadro `Assegnazione e registro` compila:
 | Scadenza | Data ISO di scadenza |
 | Ora simulata opzionale | Data ISO usata per simulare il momento attuale |
 | Repository studenti locali | Un path per riga verso i repository/cartelle studente |
+
+Nel riquadro `Registro consegne` compila:
+
+| Campo | Significato |
+|---|---|
+| Output registro | Path relativo dentro `teacher-reports`, per esempio `3A/somma.json` |
 
 Nota: questa azione crea o aggiorna il registro consegne per tracciare stato, ritardi e grading. Non distribuisce ancora gli asset agli studenti; l'assegnazione reale dell'activity avra un flusso dedicato.
 

--- a/doc/CLASS_ROSTERS.md
+++ b/doc/CLASS_ROSTERS.md
@@ -68,7 +68,7 @@ POST /api/class-rosters/load
 
 La vista studente usa il roster come fonte primaria della lista studenti.
 
-La dashboard consegne usa il roster nel pannello `Assegnazione e registro`:
+La dashboard consegne usa il roster nel pannello `Assegna activity`:
 
 - compila `Classe`, `Etichetta classe` e `Team GitHub`;
 - genera la textarea dei target dagli studenti attivi;

--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -20,21 +20,34 @@ http://localhost:8765/tools/assignment_dashboard.html
 
 ## Pannelli
 
-### Assegnazione e registro
+### Assegna activity
 
-Serve a preparare l'associazione tra una activity, i destinatari e le date, poi creare o aggiornare il registro consegne.
+Serve a preparare l'associazione tra una activity, i destinatari e le date.
 
-Nota di nomenclatura: il registro non e l'assegnazione completa dell'activity e non assegna voti. Il registro e il documento di tracciamento che permette di vedere consegne attese, mancanti, in ritardo, grading, voti e feedback per una activity associata a una classe, un team o uno studente. La distribuzione reale degli asset agli studenti avra un flusso dedicato.
+Nota di nomenclatura: l'assegnazione e la pubblicazione della activity verso classe, team o studenti. In questa fase MVP la distribuzione reale degli asset agli studenti non e ancora attiva dalla GUI: il pannello mostra l'anteprima e prepara i dati usati dal registro.
 
 Usalo quando devi:
 
 - scegliere una activity;
 - scegliere la classe tramite roster;
-- controllare o modificare il nome del registro JSON;
 - impostare classe, team, assegnazione e scadenza;
-- creare il registro in `teacher-reports`.
+- verificare destinatari e asset con **Anteprima assegnazione**.
 
 Screenshot previsto: `doc/images/dashboard-guides/docente-genera-registro.png`.
+
+### Registro consegne
+
+Serve a creare o aggiornare il registro che traccia consegne attese, mancanti, in ritardo, grading, voti e feedback per l'activity selezionata.
+
+Il registro non assegna voti da solo e non distribuisce asset agli studenti: e il documento di monitoraggio che alimenta dashboard docente, studenti, quadro classe e copertura registri.
+
+Usalo quando devi:
+
+- controllare o modificare il nome del registro JSON;
+- creare il registro in `teacher-reports`;
+- aggiornare il tracking dopo consegne, grading o feedback.
+
+Screenshot previsto: `doc/images/dashboard-guides/docente-registro-consegne.png`.
 
 ### Roster classe
 
@@ -127,7 +140,7 @@ Prerequisiti:
 Passaggi:
 
 1. Apri la dashboard consegne.
-2. Nel pannello **Assegnazione e registro**, scegli una activity da **Scegli activity**.
+2. Nel pannello **Assegna activity**, scegli una activity da **Scegli activity**.
 3. Scegli una classe da **Classe da roster**.
 4. Controlla il pannello **Roster classe**:
    - classe;
@@ -136,8 +149,8 @@ Passaggi:
    - studenti attivi;
    - target locali;
    - fallback demo.
-5. Se serve, modifica **Output registro**.
-6. Controlla scadenza e data di assegnazione.
+5. Controlla scadenza e data di assegnazione.
+6. Nel pannello **Registro consegne**, se serve, modifica **Output registro**.
 7. Premi **Crea registro consegne**.
 8. Verifica il pannello **Registro selezionato**.
 9. Apri **Studenti** o **Quadro classe** per controllare il risultato.

--- a/doc/images/dashboard-guides/README.md
+++ b/doc/images/dashboard-guides/README.md
@@ -44,7 +44,8 @@ Pagina studente:
 
 | File | Stato | Pagina | Cosa deve mostrare |
 |---|---|---|---|
-| `docente-genera-registro.png` | da fare | Dashboard docente | Pannello **Assegnazione e registro** con activity, roster, output registro, scadenza e target studenti visibili |
+| `docente-genera-registro.png` | da fare | Dashboard docente | Pannello **Assegna activity** con activity, roster, scadenza, target studenti e anteprima assegnazione visibili |
+| `docente-registro-consegne.png` | da fare | Dashboard docente | Pannello **Registro consegne** con output registro e bottone di creazione visibili |
 | `docente-roster-classe.png` | da fare | Dashboard docente | Pannello **Roster classe** con classe, activity, output registro, studenti attivi, target locali e fallback demo |
 | `docente-registro-selezionato.png` | da fare | Dashboard docente | Pannello **Registro selezionato** con registro caricato e riepilogo compilato |
 | `docente-quadro-classe.png` | da fare | Dashboard docente | Pannello **Quadro classe** con riepilogo e bottone per aprire il modal |

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -1122,6 +1122,26 @@ def test_report_loader_controls_live_in_selected_report_panel() -> None:
     assert 'id="reportSelect"' not in hero_section
 
 
+def test_assignment_and_report_panels_are_separated() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
+    assignment_section = html.split('data-panel-key="assignment"', 1)[1].split('data-panel-key="generate"', 1)[0]
+    report_section = html.split('data-panel-key="generate"', 1)[1].split('data-panel-key="coverage-registers"', 1)[0]
+
+    assert "Assegna activity" in assignment_section
+    assert 'id="activitySelect"' in assignment_section
+    assert 'id="classRosterSelect"' in assignment_section
+    assert 'id="targetsText"' in assignment_section
+    assert 'id="previewAssignmentBtn"' in assignment_section
+    assert 'id="outputName"' not in assignment_section
+    assert 'id="generateReportBtn"' not in assignment_section
+
+    assert "Registro consegne" in report_section
+    assert 'id="outputName"' in report_section
+    assert 'id="generateReportBtn"' in report_section
+    assert 'id="activitySelect"' not in report_section
+    assert 'id="targetsText"' not in report_section
+
+
 def test_class_roster_panel_is_available_on_assignment_dashboard() -> None:
     html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
     roster_section = html.split('data-panel-key="class-roster"', 1)[1].split('data-panel-key="selected-report"', 1)[0]

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -304,6 +304,8 @@ def run_dashboard_js(assertions: str) -> None:
         localTargetFromStudent,
         rosterTargets,
         rosterSummaryItems,
+        reportAssignmentSummaryItems,
+        renderReportAssignmentSummary,
         renderRosterPanel,
         applyRosterToGenerateForm,
         els,
@@ -777,6 +779,35 @@ def test_class_roster_panel_renders_selected_roster_students_and_targets() -> No
     )
 
 
+def test_report_assignment_summary_shows_current_assignment_context() -> None:
+    run_dashboard_js(
+        """
+        tested.state.activities = [
+          { id: "somma", title: "Somma in Python", path: "activities/somma.json" },
+        ];
+        tested.els.activityPath.value = "activities/somma.json";
+        tested.els.classId.value = "3A-TPSI";
+        tested.els.githubTeam.value = "team-3a";
+        tested.els.dueAt.value = "2026-10-19T23:59:00+02:00";
+        tested.els.outputName.value = "3a-tpsi/somma.json";
+        tested.els.targetsText.value = [
+          "studenti/rossi-mario",
+          "# commento",
+          "studenti/bianchi-luca",
+        ].join("\\n");
+
+        tested.renderReportAssignmentSummary();
+
+        const html = tested.els.reportAssignmentSummary.innerHTML;
+        assert.match(html, /<strong>Activity<\\/strong>\\s*<span>Somma in Python<\\/span>/);
+        assert.match(html, /<strong>Classe<\\/strong>\\s*<span>3A-TPSI<\\/span>/);
+        assert.match(html, /<strong>Team<\\/strong>\\s*<span>team-3a<\\/span>/);
+        assert.match(html, /<strong>Target<\\/strong>\\s*<span>2<\\/span>/);
+        assert.match(html, /<strong>Output registro<\\/strong>\\s*<span>3a-tpsi\\/somma.json<\\/span>/);
+      """
+    )
+
+
 def test_panel_order_is_applied_and_persisted() -> None:
     run_dashboard_js(
         """
@@ -1133,10 +1164,12 @@ def test_assignment_and_report_panels_are_separated() -> None:
     assert 'id="targetsText"' in assignment_section
     assert 'id="previewAssignmentBtn"' in assignment_section
     assert 'id="outputName"' not in assignment_section
+    assert 'id="reportAssignmentSummary"' not in assignment_section
     assert 'id="generateReportBtn"' not in assignment_section
 
     assert "Registro consegne" in report_section
     assert 'id="outputName"' in report_section
+    assert 'id="reportAssignmentSummary"' in report_section
     assert 'id="generateReportBtn"' in report_section
     assert 'id="activitySelect"' not in report_section
     assert 'id="targetsText"' not in report_section

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -200,6 +200,9 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           <input id="outputName" type="text" value="demo/demo_assignment.json">
         </label>
       </div>
+      <div id="reportAssignmentSummary" class="summaryGrid">
+        <p class="status">Seleziona activity e destinatari per vedere cosa verra tracciato nel registro.</p>
+      </div>
       <div class="generateActions">
         <button id="generateReportBtn" type="button" class="primary" title="Crea il registro consegne, lo salva in teacher-reports e lo carica nella dashboard. Non distribuisce ancora gli asset agli studenti.">Crea registro consegne</button>
       </div>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -122,11 +122,11 @@
       </div>
     </section>
 
-    <section class="panel" data-panel-key="generate">
+    <section class="panel" data-panel-key="assignment">
       <div class="panelHead">
         <div>
-          <h2>Assegnazione e registro</h2>
-          <p class="status">Prepara l'associazione tra activity, destinatari e scadenza, poi crea il registro consegne per tracciarne lo stato.</p>
+          <h2>Assegna activity</h2>
+          <p class="status">Prepara activity, destinatari e scadenza. Per ora l'assegnazione reale e' solo in anteprima e non scrive nei repository studenti.</p>
         </div>
       </div>
       <div class="generateGrid">
@@ -145,10 +145,6 @@
           <select id="classRosterSelect" aria-label="Roster classi locali">
             <option value="">Caricamento roster...</option>
           </select>
-        </label>
-        <label>
-          <span>Output registro</span>
-          <input id="outputName" type="text" value="demo/demo_assignment.json">
         </label>
         <label>
           <span>Classe</span>
@@ -184,10 +180,28 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       </div>
       <div class="generateActions">
         <button id="previewAssignmentBtn" type="button" title="Mostra cosa verrebbe assegnato agli studenti senza scrivere nei repository.">Anteprima assegnazione</button>
-        <button id="generateReportBtn" type="button" class="primary" title="Crea il registro consegne, lo salva in teacher-reports e lo carica nella dashboard. Non distribuisce ancora gli asset agli studenti.">Crea registro consegne</button>
+        <button type="button" disabled title="In arrivo: distribuira gli asset della activity nei repository degli studenti.">Assegna activity</button>
       </div>
       <div id="assignmentPlanPreview" class="assignmentPlanPreview" aria-live="polite">
         <p class="status">Usa l'anteprima per verificare target e asset prima di assegnare una activity.</p>
+      </div>
+    </section>
+
+    <section class="panel" data-panel-key="generate">
+      <div class="panelHead">
+        <div>
+          <h2>Registro consegne</h2>
+          <p class="status">Crea o aggiorna il registro che traccia consegne, ritardi, grading, voti e feedback per l'activity selezionata.</p>
+        </div>
+      </div>
+      <div class="generateGrid">
+        <label class="wideField">
+          <span>Output registro</span>
+          <input id="outputName" type="text" value="demo/demo_assignment.json">
+        </label>
+      </div>
+      <div class="generateActions">
+        <button id="generateReportBtn" type="button" class="primary" title="Crea il registro consegne, lo salva in teacher-reports e lo carica nella dashboard. Non distribuisce ancora gli asset agli studenti.">Crea registro consegne</button>
       </div>
       <div class="coverageBlock" data-panel-key="coverage-registers">
         <div class="coverageHead">
@@ -206,7 +220,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       <div class="panelHead">
         <div>
           <h2>Roster classe</h2>
-          <p id="rosterPanelStatus" class="status">Seleziona un roster in Assegnazione e registro per vedere studenti e target.</p>
+          <p id="rosterPanelStatus" class="status">Seleziona un roster in Assegna activity per vedere studenti e target.</p>
         </div>
       </div>
       <div id="rosterSummary" class="summaryGrid">

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -210,6 +210,7 @@ const els = {
   rosterPanelStatus: document.querySelector("#rosterPanelStatus"),
   rosterSummary: document.querySelector("#rosterSummary"),
   rosterBody: document.querySelector("#rosterBody"),
+  reportAssignmentSummary: document.querySelector("#reportAssignmentSummary"),
   outputName: document.querySelector("#outputName"),
   classId: document.querySelector("#classId"),
   classLabel: document.querySelector("#classLabel"),
@@ -789,6 +790,21 @@ function rosterSummaryItems(roster) {
   ];
 }
 
+function targetLineCount() {
+  return els.targetsText.value.split(/\r?\n/).filter((line) => line.trim() && !line.trim().startsWith("#")).length;
+}
+
+function reportAssignmentSummaryItems() {
+  return [
+    ["Activity", currentActivityLabel()],
+    ["Classe", els.classId.value.trim() || "-"],
+    ["Team", els.githubTeam.value.trim() || "-"],
+    ["Scadenza", els.dueAt.value.trim() ? formatDate(els.dueAt.value) : "-"],
+    ["Target", targetLineCount()],
+    ["Output registro", els.outputName.value.trim() || "-"],
+  ];
+}
+
 function renderRosterSummaryCards(items) {
   return items.map(([label, value]) => `
     <article class="summaryCard" title="${escapeHtml(summaryTooltip(label))}">
@@ -796,6 +812,16 @@ function renderRosterSummaryCards(items) {
       <span>${escapeHtml(value)}</span>
     </article>
   `).join("");
+}
+
+function renderReportAssignmentSummary() {
+  if (!els.reportAssignmentSummary) return;
+  els.reportAssignmentSummary.innerHTML = renderRosterSummaryCards(reportAssignmentSummaryItems());
+}
+
+function renderAssignmentContext() {
+  renderRosterPanel();
+  renderReportAssignmentSummary();
 }
 
 function studentAccountLabel(student) {
@@ -818,11 +844,13 @@ function renderRosterPanel() {
     setRosterPanelStatus(state.classRosters.length ? "Seleziona un roster in Assegna activity per vedere studenti e target." : "Nessun roster locale disponibile.");
     els.rosterSummary.innerHTML = '<p class="status">Nessun roster selezionato.</p>';
     els.rosterBody.innerHTML = '<tr><td colspan="4">Seleziona un roster per vedere gli studenti.</td></tr>';
+    renderReportAssignmentSummary();
     return;
   }
   const students = Array.isArray(roster.students) ? roster.students : [];
   setRosterPanelStatus(`${rosterClassValue(roster)} - ${currentActivityLabel()} - ${students.length} studenti nel roster.`);
   els.rosterSummary.innerHTML = renderRosterSummaryCards(rosterSummaryItems(roster));
+  renderReportAssignmentSummary();
   if (!students.length) {
     els.rosterBody.innerHTML = '<tr><td colspan="4">Roster senza studenti.</td></tr>';
     return;
@@ -2496,6 +2524,8 @@ const SUMMARY_TOOLTIPS = {
   Righe: "Righe activity-studente mostrate rispetto al totale disponibile.",
   Filtri: "Filtri attivi nella vista corrente.",
   Classe: "Classe associata al registro consegne selezionato.",
+  Team: "Team GitHub o gruppo associato ai destinatari correnti.",
+  Target: "Numero di repository o cartelle studente indicati come destinatari correnti.",
   Attivi: "Numero di studenti attivi nel roster e inclusi nella generazione del registro.",
   "Output registro": "Nome del file JSON che verra generato per l'activity e la classe selezionate.",
   "Target locali": "Numero di studenti attivi con un target locale o repo path gia disponibile.",
@@ -3086,9 +3116,15 @@ els.activityAuthorClass?.addEventListener("change", () => {
 els.classRosterSelect?.addEventListener("change", loadSelectedClassRoster);
 els.activityPath.addEventListener("input", () => {
   renderActivitySelect();
-  renderRosterPanel();
+  renderAssignmentContext();
 });
-els.outputName.addEventListener("input", renderRosterPanel);
+els.outputName.addEventListener("input", renderAssignmentContext);
+els.classId.addEventListener("input", renderReportAssignmentSummary);
+els.classLabel.addEventListener("input", renderAssignmentContext);
+els.githubTeam.addEventListener("input", renderAssignmentContext);
+els.assignedAt.addEventListener("input", renderReportAssignmentSummary);
+els.dueAt.addEventListener("input", renderReportAssignmentSummary);
+els.targetsText.addEventListener("input", renderAssignmentContext);
 els.classId.addEventListener("change", updateOutputNameForCurrentActivity);
 els.coverageBody.addEventListener("click", async (event) => {
   const toggleButton = event.target.closest("[data-coverage-toggle]");

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -815,7 +815,7 @@ function renderRosterPanel() {
   const roster = state.selectedClassRoster;
   if (!els.rosterSummary || !els.rosterBody) return;
   if (!roster) {
-    setRosterPanelStatus(state.classRosters.length ? "Seleziona un roster in Assegnazione e registro per vedere studenti e target." : "Nessun roster locale disponibile.");
+    setRosterPanelStatus(state.classRosters.length ? "Seleziona un roster in Assegna activity per vedere studenti e target." : "Nessun roster locale disponibile.");
     els.rosterSummary.innerHTML = '<p class="status">Nessun roster selezionato.</p>';
     els.rosterBody.innerHTML = '<tr><td colspan="4">Seleziona un roster per vedere gli studenti.</td></tr>';
     return;


### PR DESCRIPTION
﻿## Cosa cambia
- Separa il vecchio pannello unico in `Assegna activity` e `Registro consegne`.
- Mantiene l'assegnazione reale in stato esplicitamente disabilitato/in arrivo.
- Lascia `Crea registro consegne` nel pannello dedicato al tracking.
- Aggiorna guida docente, guida consegne, roster e lista screenshot.
- Aggiunge un test frontend che protegge la separazione dei due pannelli.

## Perche
La GUI deve rendere chiara la differenza tra assegnare una activity, creare il registro consegne e valutare le consegne. Questa PR corregge la struttura UX senza introdurre ancora scritture nei repository studenti.

## Validazione
- `python -m pytest tests/test_assignment_dashboard_frontend.py tests/test_assign_activity.py`
