### PR TITLE
Aggiunge modello JSON esplicito per assegnazioni

### DIFF
--- a/doc/DATA_MODEL_MVP.md
+++ b/doc/DATA_MODEL_MVP.md
@@ -384,7 +384,7 @@ Fase di transizione:
 
 ### Assignment
 
-Rappresenta l'assegnazione di una activity a una classe.
+Rappresenta l'assegnazione di una activity a una classe, team, gruppo o singolo studente.
 
 Campi minimi:
 
@@ -392,18 +392,31 @@ Campi minimi:
 schema_version
 id
 activity_id
-class_id
+activity_path
+target_type
 assigned_at
 due_at
-student_support_mode
-provider
-provider_ref
-status
+targets
 ```
 
-Questa entita oggi e implicita dentro il registro docente e nei parametri di `track_assignments.py`.
+Campi opzionali MVP:
 
-Va resa esplicita prima della GUI di creazione/assegnazione activity.
+```text
+class_id
+class_label
+github_team
+```
+
+`target_type` deve distinguere almeno `class`, `team`, `group`, `student`.
+
+Questa entita oggi e implicita dentro il registro docente e nei parametri di `track_assignments.py`. Il primo storage JSON esplicito usa `teacher-assignments/*.json`, con un helper dedicato per:
+
+- creare un id stabile dell'assegnazione;
+- validare i campi minimi;
+- salvare e leggere record JSON;
+- individuare assegnazioni scadute senza registro.
+
+La GUI successiva dovra usare questa entita per scegliere una vera `Assegnazione da tracciare`, invece di ricostruire il registro partendo da campi sparsi.
 
 ### Submission
 

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -119,6 +119,25 @@ def assignment_target_ref(
     return target_type or "target"
 
 
+def validate_target_shape(
+    *,
+    target_type: str,
+    class_id: str,
+    github_team: str,
+    targets: list[dict[str, str]],
+) -> None:
+    """Validate target fields against the declared target type."""
+
+    if target_type == "class" and not class_id:
+        raise ValueError("class_id obbligatorio per target_type class.")
+    if target_type == "team" and not github_team:
+        raise ValueError("github_team obbligatorio per target_type team.")
+    if target_type == "student" and len(targets) != 1:
+        raise ValueError("target_type student richiede esattamente un target.")
+    if target_type == "group" and len(targets) < 2:
+        raise ValueError("target_type group richiede almeno due target.")
+
+
 def build_assignment_id(activity_id: str, target_ref: str, assigned_at: str) -> str:
     """Build a stable filesystem-friendly assignment id."""
 
@@ -154,12 +173,20 @@ def build_assignment_record(
     normalized_targets = [normalize_target(target) for target in targets]
     if not normalized_targets:
         raise ValueError("targets obbligatorio.")
+    clean_class_id = str(class_id or "").strip()
+    clean_github_team = str(github_team or "").strip()
+    validate_target_shape(
+        target_type=clean_target_type,
+        class_id=clean_class_id,
+        github_team=clean_github_team,
+        targets=normalized_targets,
+    )
     parse_iso_datetime(assigned_at, "assigned_at")
     parse_iso_datetime(due_at, "due_at")
     target_ref = assignment_target_ref(
         target_type=clean_target_type,
-        class_id=str(class_id or "").strip(),
-        github_team=str(github_team or "").strip(),
+        class_id=clean_class_id,
+        github_team=clean_github_team,
         targets=normalized_targets,
     )
     clean_assignment_id = str(assignment_id or "").strip() or build_assignment_id(
@@ -173,9 +200,9 @@ def build_assignment_record(
         "activity_id": clean_activity_id,
         "activity_path": clean_activity_path,
         "target_type": clean_target_type,
-        "class_id": str(class_id or "").strip(),
+        "class_id": clean_class_id,
         "class_label": str(class_label or "").strip(),
-        "github_team": str(github_team or "").strip(),
+        "github_team": clean_github_team,
         "assigned_at": str(assigned_at).strip(),
         "due_at": str(due_at).strip(),
         "targets": normalized_targets,

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -170,6 +170,9 @@ def validate_assignment_record(payload: dict[str, Any]) -> dict[str, Any]:
 
     if not isinstance(payload, dict):
         raise ValueError("Assegnazione non valida.")
+    schema_version = str(payload.get("schema_version", "")).strip()
+    if schema_version != ASSIGNMENT_SCHEMA_VERSION:
+        raise ValueError(f"schema_version non supportata: {schema_version or 'mancante'}")
     return build_assignment_record(
         assignment_id=str(payload.get("id", "")).strip(),
         activity_id=str(payload.get("activity_id", "")).strip(),

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -1,0 +1,284 @@
+"""Helpers for explicit MVP activity assignment records."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from scripts import create_activity
+
+
+ASSIGNMENT_SCHEMA_VERSION = "1.0"
+DEFAULT_ASSIGNMENTS_DIR = Path("teacher-assignments")
+
+
+@dataclass(frozen=True)
+class AssignmentStatus:
+    """Computed status for one assignment record."""
+
+    assignment: dict[str, Any]
+    due: bool
+    has_register: bool
+
+    @property
+    def needs_register(self) -> bool:
+        """Return whether the assignment is due and lacks a register."""
+
+        return self.due and not self.has_register
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serializable status summary."""
+
+        return {
+            "assignment": self.assignment,
+            "due": self.due,
+            "has_register": self.has_register,
+            "needs_register": self.needs_register,
+        }
+
+
+def parse_iso_datetime(value: str, field_name: str) -> datetime:
+    """Parse an ISO datetime, accepting a trailing Z for UTC."""
+
+    clean = str(value or "").strip()
+    if not clean:
+        raise ValueError(f"{field_name} obbligatorio.")
+    try:
+        return datetime.fromisoformat(clean.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{field_name} non valido: {clean}") from error
+
+
+def normalize_target(target: dict[str, Any] | str) -> dict[str, str]:
+    """Normalize a target entry into the assignment target shape."""
+
+    if isinstance(target, str):
+        clean = target.strip()
+        if not clean:
+            raise ValueError("Target vuoto.")
+        return {"target": clean}
+    if not isinstance(target, dict):
+        raise ValueError("Target non valido.")
+    normalized = {
+        key: str(target.get(key, "")).strip()
+        for key in ("student_id", "display_name", "repo_ref", "path", "target")
+        if str(target.get(key, "")).strip()
+    }
+    if not normalized:
+        raise ValueError("Target vuoto.")
+    return normalized
+
+
+def assignment_target_ref(
+    *,
+    target_type: str,
+    class_id: str = "",
+    github_team: str = "",
+    targets: list[dict[str, str]] | None = None,
+) -> str:
+    """Return the human/stable target reference used in generated ids."""
+
+    if target_type == "class" and class_id:
+        return class_id
+    if target_type == "team" and github_team:
+        return github_team
+    targets = targets or []
+    if target_type == "student" and len(targets) == 1:
+        return targets[0].get("student_id") or targets[0].get("target") or targets[0].get("path") or "student"
+    if target_type == "group" and targets:
+        return f"group-{len(targets)}"
+    return target_type or "target"
+
+
+def build_assignment_id(activity_id: str, target_ref: str, assigned_at: str) -> str:
+    """Build a stable filesystem-friendly assignment id."""
+
+    date_part = parse_iso_datetime(assigned_at, "assigned_at").date().isoformat()
+    slug = create_activity.slugify(f"{activity_id}-{target_ref}-{date_part}")
+    return f"assignment-{slug}"
+
+
+def build_assignment_record(
+    *,
+    activity_id: str,
+    activity_path: str,
+    target_type: str,
+    assigned_at: str,
+    due_at: str,
+    targets: list[dict[str, Any] | str],
+    class_id: str = "",
+    class_label: str = "",
+    github_team: str = "",
+    assignment_id: str = "",
+) -> dict[str, Any]:
+    """Build and validate an explicit assignment record."""
+
+    clean_activity_id = str(activity_id or "").strip()
+    clean_activity_path = str(activity_path or "").strip().replace("\\", "/")
+    clean_target_type = str(target_type or "").strip() or "group"
+    if not clean_activity_id:
+        raise ValueError("activity_id obbligatorio.")
+    if not clean_activity_path:
+        raise ValueError("activity_path obbligatorio.")
+    if clean_target_type not in {"class", "team", "group", "student"}:
+        raise ValueError("target_type deve essere class, team, group o student.")
+    normalized_targets = [normalize_target(target) for target in targets]
+    if not normalized_targets:
+        raise ValueError("targets obbligatorio.")
+    parse_iso_datetime(assigned_at, "assigned_at")
+    parse_iso_datetime(due_at, "due_at")
+    target_ref = assignment_target_ref(
+        target_type=clean_target_type,
+        class_id=str(class_id or "").strip(),
+        github_team=str(github_team or "").strip(),
+        targets=normalized_targets,
+    )
+    clean_assignment_id = str(assignment_id or "").strip() or build_assignment_id(
+        clean_activity_id,
+        target_ref,
+        assigned_at,
+    )
+    return {
+        "schema_version": ASSIGNMENT_SCHEMA_VERSION,
+        "id": clean_assignment_id,
+        "activity_id": clean_activity_id,
+        "activity_path": clean_activity_path,
+        "target_type": clean_target_type,
+        "class_id": str(class_id or "").strip(),
+        "class_label": str(class_label or "").strip(),
+        "github_team": str(github_team or "").strip(),
+        "assigned_at": str(assigned_at).strip(),
+        "due_at": str(due_at).strip(),
+        "targets": normalized_targets,
+    }
+
+
+def validate_assignment_record(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate and normalize an assignment record payload."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("Assegnazione non valida.")
+    return build_assignment_record(
+        assignment_id=str(payload.get("id", "")).strip(),
+        activity_id=str(payload.get("activity_id", "")).strip(),
+        activity_path=str(payload.get("activity_path", "")).strip(),
+        target_type=str(payload.get("target_type", "")).strip(),
+        class_id=str(payload.get("class_id", "")).strip(),
+        class_label=str(payload.get("class_label", "")).strip(),
+        github_team=str(payload.get("github_team", "")).strip(),
+        assigned_at=str(payload.get("assigned_at", "")).strip(),
+        due_at=str(payload.get("due_at", "")).strip(),
+        targets=payload.get("targets") if isinstance(payload.get("targets"), list) else [],
+    )
+
+
+def assignment_matches_register(assignment: dict[str, Any], register: dict[str, Any]) -> bool:
+    """Return whether a register already covers an assignment."""
+
+    if not isinstance(register, dict):
+        return False
+    assignment_id = str(assignment.get("id", "")).strip()
+    register_assignment_id = str(register.get("assignment_id", "")).strip()
+    if assignment_id and register_assignment_id:
+        return assignment_id == register_assignment_id
+    return (
+        str(assignment.get("activity_id", "")).strip() == str(register.get("activity_id", "")).strip()
+        and str(assignment.get("class_id", "")).strip() == str(register.get("class_id", "")).strip()
+        and str(assignment.get("due_at", "")).strip() == str(register.get("due_at", "")).strip()
+    )
+
+
+def assignment_status(
+    assignment: dict[str, Any],
+    registers: list[dict[str, Any]],
+    now: str | datetime,
+) -> AssignmentStatus:
+    """Return due/register status for one assignment."""
+
+    normalized = validate_assignment_record(assignment)
+    current_time = now if isinstance(now, datetime) else parse_iso_datetime(str(now), "now")
+    due_at = parse_iso_datetime(normalized["due_at"], "due_at")
+    has_register = any(assignment_matches_register(normalized, register) for register in registers)
+    return AssignmentStatus(assignment=normalized, due=current_time >= due_at, has_register=has_register)
+
+
+class JsonAssignmentRecordStorage:
+    """JSON storage adapter for explicit assignment records."""
+
+    def __init__(self, root: Path, assignments_dir: Path | None = None) -> None:
+        self.root = root
+        self.assignments_dir = assignments_dir or root / DEFAULT_ASSIGNMENTS_DIR
+
+    def relative_path(self, path: Path) -> str:
+        """Return a repository-relative path with URL-style separators."""
+
+        return str(path.relative_to(self.root)).replace("\\", "/")
+
+    def safe_assignment_path(self, assignment_id: str) -> Path:
+        """Return a safe assignment JSON path below teacher-assignments."""
+
+        filename = f"{create_activity.slugify(assignment_id)}.json"
+        path = (self.assignments_dir / filename).resolve()
+        path.relative_to(self.assignments_dir.resolve())
+        return path
+
+    def read_json(self, path: Path) -> dict[str, Any]:
+        """Read a JSON object from path."""
+
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"JSON non valido: {path}")
+        return payload
+
+    def write_json(self, path: Path, payload: dict[str, Any]) -> None:
+        """Write a JSON object with stable formatting."""
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def write_assignment(self, payload: dict[str, Any], overwrite: bool = False) -> dict[str, Any]:
+        """Persist one assignment record."""
+
+        assignment = validate_assignment_record(payload)
+        path = self.safe_assignment_path(assignment["id"])
+        if path.exists() and not overwrite:
+            raise ValueError(f"Assegnazione gia esistente: {self.relative_path(path)}")
+        self.write_json(path, assignment)
+        return {**assignment, "name": path.name, "path": self.relative_path(path)}
+
+    def read_assignment(self, assignment_id: str) -> dict[str, Any]:
+        """Read one assignment record by id."""
+
+        path = self.safe_assignment_path(assignment_id)
+        if not path.is_file():
+            raise FileNotFoundError(f"Assegnazione non trovata: {assignment_id}")
+        return validate_assignment_record(self.read_json(path))
+
+    def list_assignments(self) -> list[dict[str, Any]]:
+        """List assignment records stored in teacher-assignments."""
+
+        self.assignments_dir.mkdir(parents=True, exist_ok=True)
+        assignments = []
+        for path in sorted(self.assignments_dir.glob("*.json")):
+            try:
+                assignment = validate_assignment_record(self.read_json(path))
+            except Exception:  # noqa: BLE001
+                continue
+            assignments.append({**assignment, "name": path.name, "path": self.relative_path(path)})
+        return assignments
+
+    def assignments_due_without_register(
+        self,
+        registers: list[dict[str, Any]],
+        now: str | datetime,
+    ) -> list[dict[str, Any]]:
+        """Return stored assignments that are due and not covered by a register."""
+
+        return [
+            status.to_dict()
+            for status in (assignment_status(assignment, registers, now) for assignment in self.list_assignments())
+            if status.needs_register
+        ]

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -62,6 +62,19 @@ def require_same_timezone_kind(left: datetime, right: datetime, left_name: str, 
         raise ValueError(f"{left_name} e {right_name} devono usare timezone coerenti.")
 
 
+def target_sort_key(target: dict[str, str]) -> tuple[str, str, str, str, str]:
+    """Return a stable sort key for assignment targets."""
+
+    serialized = json.dumps(target, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return (
+        target.get("student_id", ""),
+        target.get("target", ""),
+        target.get("repo_ref", ""),
+        target.get("path", ""),
+        serialized,
+    )
+
+
 def normalize_target(target: dict[str, Any] | str) -> dict[str, str]:
     """Normalize a target entry into the assignment target shape."""
 
@@ -99,7 +112,8 @@ def assignment_target_ref(
     if target_type == "student" and len(targets) == 1:
         return targets[0].get("student_id") or targets[0].get("target") or targets[0].get("path") or "student"
     if target_type == "group" and targets:
-        target_fingerprint = json.dumps(targets, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        canonical_targets = sorted(targets, key=target_sort_key)
+        target_fingerprint = json.dumps(canonical_targets, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
         digest = hashlib.sha1(target_fingerprint.encode("utf-8")).hexdigest()[:10]
         return f"group-{digest}"
     return target_type or "target"

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from datetime import datetime
@@ -98,15 +99,17 @@ def assignment_target_ref(
     if target_type == "student" and len(targets) == 1:
         return targets[0].get("student_id") or targets[0].get("target") or targets[0].get("path") or "student"
     if target_type == "group" and targets:
-        return f"group-{len(targets)}"
+        target_fingerprint = json.dumps(targets, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha1(target_fingerprint.encode("utf-8")).hexdigest()[:10]
+        return f"group-{digest}"
     return target_type or "target"
 
 
 def build_assignment_id(activity_id: str, target_ref: str, assigned_at: str) -> str:
     """Build a stable filesystem-friendly assignment id."""
 
-    date_part = parse_iso_datetime(assigned_at, "assigned_at").date().isoformat()
-    slug = create_activity.slugify(f"{activity_id}-{target_ref}-{date_part}")
+    assigned_timestamp = parse_iso_datetime(assigned_at, "assigned_at").isoformat()
+    slug = create_activity.slugify(f"{activity_id}-{target_ref}-{assigned_timestamp}")
     return f"assignment-{slug}"
 
 

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -52,6 +52,15 @@ def parse_iso_datetime(value: str, field_name: str) -> datetime:
         raise ValueError(f"{field_name} non valido: {clean}") from error
 
 
+def require_same_timezone_kind(left: datetime, right: datetime, left_name: str, right_name: str) -> None:
+    """Reject comparisons between offset-aware and naive datetimes."""
+
+    left_has_timezone = left.tzinfo is not None and left.utcoffset() is not None
+    right_has_timezone = right.tzinfo is not None and right.utcoffset() is not None
+    if left_has_timezone != right_has_timezone:
+        raise ValueError(f"{left_name} e {right_name} devono usare timezone coerenti.")
+
+
 def normalize_target(target: dict[str, Any] | str) -> dict[str, str]:
     """Normalize a target entry into the assignment target shape."""
 
@@ -201,6 +210,7 @@ def assignment_status(
     normalized = validate_assignment_record(assignment)
     current_time = now if isinstance(now, datetime) else parse_iso_datetime(str(now), "now")
     due_at = parse_iso_datetime(normalized["due_at"], "due_at")
+    require_same_timezone_kind(current_time, due_at, "now", "due_at")
     has_register = any(assignment_matches_register(normalized, register) for register in registers)
     return AssignmentStatus(assignment=normalized, due=current_time >= due_at, has_register=has_register)
 

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -240,6 +240,10 @@ def assignment_matches_register(assignment: dict[str, Any], register: dict[str, 
     register_assignment_id = str(register.get("assignment_id", "")).strip()
     if assignment_id and register_assignment_id:
         return assignment_id == register_assignment_id
+    if str(assignment.get("target_type", "")).strip() != "class":
+        return False
+    if not str(assignment.get("class_id", "")).strip():
+        return False
     return (
         str(assignment.get("activity_id", "")).strip() == str(register.get("activity_id", "")).strip()
         and str(assignment.get("class_id", "")).strip() == str(register.get("class_id", "")).strip()

--- a/tests/fixtures/contracts/assignment.json
+++ b/tests/fixtures/contracts/assignment.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "1.0",
+  "id": "assignment-python-base-somma-001-3a-tpsi-2026-10-12",
+  "activity_id": "python-base-somma-001",
+  "activity_path": "activities/python-base-somma-001.json",
+  "target_type": "class",
+  "class_id": "3A-TPSI",
+  "class_label": "3A TPSI",
+  "github_team": "team-3a-tpsi",
+  "assigned_at": "2026-10-12T09:00:00+02:00",
+  "due_at": "2026-10-19T23:59:00+02:00",
+  "targets": [
+    {
+      "student_id": "rossi-mario",
+      "display_name": "Rossi Mario",
+      "repo_ref": "TheBitPoets/rossi-mario"
+    },
+    {
+      "student_id": "bianchi-luca",
+      "display_name": "Bianchi Luca",
+      "path": "studenti/bianchi-luca"
+    }
+  ]
+}

--- a/tests/fixtures/contracts/assignment.json
+++ b/tests/fixtures/contracts/assignment.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "id": "assignment-python-base-somma-001-3a-tpsi-2026-10-12",
+  "id": "assignment-python-base-somma-001-3a-tpsi-2026-10-12t09-00-00-02-00",
   "activity_id": "python-base-somma-001",
   "activity_path": "activities/python-base-somma-001.json",
   "target_type": "class",

--- a/tests/test_assignment_records.py
+++ b/tests/test_assignment_records.py
@@ -80,6 +80,13 @@ def test_assignment_status_matches_legacy_register_without_assignment_id() -> No
     assert covered.needs_register is False
 
 
+def test_assignment_status_rejects_mixed_timezone_awareness() -> None:
+    assignment = assignment_records.build_assignment_record(**sample_assignment(due_at="2026-10-19T23:59:00"))
+
+    with pytest.raises(ValueError, match="timezone"):
+        assignment_records.assignment_status(assignment, [], "2026-10-20T08:00:00+02:00")
+
+
 def test_assignment_record_storage_writes_lists_and_filters_due_without_register(tmp_path) -> None:
     storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
     saved = storage.write_assignment(sample_assignment())

--- a/tests/test_assignment_records.py
+++ b/tests/test_assignment_records.py
@@ -194,6 +194,34 @@ def test_assignment_status_matches_legacy_register_without_assignment_id() -> No
     assert covered.needs_register is False
 
 
+def test_assignment_status_does_not_match_legacy_register_for_non_class_assignment() -> None:
+    assignment = assignment_records.build_assignment_record(
+        **sample_assignment(
+            target_type="group",
+            class_id="",
+            class_label="",
+            github_team="",
+            targets=[
+                {"student_id": "rossi-mario"},
+                {"student_id": "bianchi-luca"},
+            ],
+        ),
+    )
+
+    status = assignment_records.assignment_status(
+        assignment,
+        [{
+            "activity_id": "python-base-somma-001",
+            "class_id": "",
+            "due_at": "2026-10-19T23:59:00+02:00",
+        }],
+        "2026-10-20T08:00:00+02:00",
+    )
+
+    assert status.has_register is False
+    assert status.needs_register is True
+
+
 def test_assignment_status_rejects_mixed_timezone_awareness() -> None:
     assignment = assignment_records.build_assignment_record(**sample_assignment(due_at="2026-10-19T23:59:00"))
 

--- a/tests/test_assignment_records.py
+++ b/tests/test_assignment_records.py
@@ -1,0 +1,107 @@
+import pytest
+
+from scripts import assignment_records
+
+
+def sample_assignment(**overrides):
+    payload = {
+        "activity_id": "python-base-somma-001",
+        "activity_path": "activities/python-base-somma-001.json",
+        "target_type": "class",
+        "class_id": "3A-TPSI",
+        "class_label": "3A TPSI",
+        "github_team": "team-3a-tpsi",
+        "assigned_at": "2026-10-12T09:00:00+02:00",
+        "due_at": "2026-10-19T23:59:00+02:00",
+        "targets": [
+            {"student_id": "rossi-mario", "repo_ref": "TheBitPoets/rossi-mario"},
+            {"student_id": "bianchi-luca", "path": "studenti/bianchi-luca"},
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_build_assignment_record_generates_stable_id_and_targets() -> None:
+    assignment = assignment_records.build_assignment_record(**sample_assignment())
+
+    assert assignment["schema_version"] == "1.0"
+    assert assignment["id"] == "assignment-python-base-somma-001-3a-tpsi-2026-10-12"
+    assert assignment["activity_id"] == "python-base-somma-001"
+    assert assignment["target_type"] == "class"
+    assert assignment["targets"] == [
+        {"student_id": "rossi-mario", "repo_ref": "TheBitPoets/rossi-mario"},
+        {"student_id": "bianchi-luca", "path": "studenti/bianchi-luca"},
+    ]
+
+
+def test_assignment_record_validation_rejects_missing_or_bad_fields() -> None:
+    with pytest.raises(ValueError, match="activity_id"):
+        assignment_records.build_assignment_record(**sample_assignment(activity_id=""))
+    with pytest.raises(ValueError, match="target_type"):
+        assignment_records.build_assignment_record(**sample_assignment(target_type="school"))
+    with pytest.raises(ValueError, match="due_at"):
+        assignment_records.build_assignment_record(**sample_assignment(due_at="not-a-date"))
+    with pytest.raises(ValueError, match="targets"):
+        assignment_records.build_assignment_record(**sample_assignment(targets=[]))
+
+
+def test_assignment_status_detects_due_without_register_and_existing_register() -> None:
+    assignment = assignment_records.build_assignment_record(**sample_assignment())
+
+    missing = assignment_records.assignment_status(assignment, [], "2026-10-20T08:00:00+02:00")
+    assert missing.due is True
+    assert missing.has_register is False
+    assert missing.needs_register is True
+
+    covered = assignment_records.assignment_status(
+        assignment,
+        [{"assignment_id": assignment["id"]}],
+        "2026-10-20T08:00:00+02:00",
+    )
+    assert covered.has_register is True
+    assert covered.needs_register is False
+
+
+def test_assignment_status_matches_legacy_register_without_assignment_id() -> None:
+    assignment = assignment_records.build_assignment_record(**sample_assignment())
+
+    covered = assignment_records.assignment_status(
+        assignment,
+        [{
+            "activity_id": "python-base-somma-001",
+            "class_id": "3A-TPSI",
+            "due_at": "2026-10-19T23:59:00+02:00",
+        }],
+        "2026-10-20T08:00:00+02:00",
+    )
+
+    assert covered.has_register is True
+    assert covered.needs_register is False
+
+
+def test_assignment_record_storage_writes_lists_and_filters_due_without_register(tmp_path) -> None:
+    storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
+    saved = storage.write_assignment(sample_assignment())
+
+    assert saved["name"] == "assignment-python-base-somma-001-3a-tpsi-2026-10-12.json"
+    assert saved["path"] == "teacher-assignments/assignment-python-base-somma-001-3a-tpsi-2026-10-12.json"
+    assert storage.read_assignment(saved["id"])["id"] == saved["id"]
+    assert [assignment["id"] for assignment in storage.list_assignments()] == [saved["id"]]
+
+    due = storage.assignments_due_without_register([], "2026-10-20T08:00:00+02:00")
+    assert len(due) == 1
+    assert due[0]["assignment"]["id"] == saved["id"]
+    assert due[0]["needs_register"] is True
+    assert storage.assignments_due_without_register([{"assignment_id": saved["id"]}], "2026-10-20T08:00:00+02:00") == []
+
+
+def test_assignment_record_storage_rejects_duplicate_without_overwrite(tmp_path) -> None:
+    storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
+    storage.write_assignment(sample_assignment())
+
+    with pytest.raises(ValueError, match="gia esistente"):
+        storage.write_assignment(sample_assignment())
+
+    overwritten = storage.write_assignment(sample_assignment(class_label="3A TPSI aggiornata"), overwrite=True)
+    assert overwritten["class_label"] == "3A TPSI aggiornata"

--- a/tests/test_assignment_records.py
+++ b/tests/test_assignment_records.py
@@ -46,6 +46,22 @@ def test_assignment_record_validation_rejects_missing_or_bad_fields() -> None:
         assignment_records.build_assignment_record(**sample_assignment(targets=[]))
 
 
+def test_validate_assignment_record_rejects_unsupported_schema_version() -> None:
+    payload = assignment_records.build_assignment_record(**sample_assignment())
+    payload["schema_version"] = "2.0"
+
+    with pytest.raises(ValueError, match="schema_version"):
+        assignment_records.validate_assignment_record(payload)
+
+
+def test_validate_assignment_record_rejects_missing_schema_version() -> None:
+    payload = assignment_records.build_assignment_record(**sample_assignment())
+    del payload["schema_version"]
+
+    with pytest.raises(ValueError, match="schema_version"):
+        assignment_records.validate_assignment_record(payload)
+
+
 def test_assignment_status_detects_due_without_register_and_existing_register() -> None:
     assignment = assignment_records.build_assignment_record(**sample_assignment())
 
@@ -89,7 +105,7 @@ def test_assignment_status_rejects_mixed_timezone_awareness() -> None:
 
 def test_assignment_record_storage_writes_lists_and_filters_due_without_register(tmp_path) -> None:
     storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
-    saved = storage.write_assignment(sample_assignment())
+    saved = storage.write_assignment(assignment_records.build_assignment_record(**sample_assignment()))
 
     assert saved["name"] == "assignment-python-base-somma-001-3a-tpsi-2026-10-12.json"
     assert saved["path"] == "teacher-assignments/assignment-python-base-somma-001-3a-tpsi-2026-10-12.json"
@@ -105,10 +121,13 @@ def test_assignment_record_storage_writes_lists_and_filters_due_without_register
 
 def test_assignment_record_storage_rejects_duplicate_without_overwrite(tmp_path) -> None:
     storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
-    storage.write_assignment(sample_assignment())
+    storage.write_assignment(assignment_records.build_assignment_record(**sample_assignment()))
 
     with pytest.raises(ValueError, match="gia esistente"):
-        storage.write_assignment(sample_assignment())
+        storage.write_assignment(assignment_records.build_assignment_record(**sample_assignment()))
 
-    overwritten = storage.write_assignment(sample_assignment(class_label="3A TPSI aggiornata"), overwrite=True)
+    overwritten = storage.write_assignment(
+        assignment_records.build_assignment_record(**sample_assignment(class_label="3A TPSI aggiornata")),
+        overwrite=True,
+    )
     assert overwritten["class_label"] == "3A TPSI aggiornata"

--- a/tests/test_assignment_records.py
+++ b/tests/test_assignment_records.py
@@ -114,6 +114,36 @@ def test_assignment_record_validation_rejects_missing_or_bad_fields() -> None:
         assignment_records.build_assignment_record(**sample_assignment(targets=[]))
 
 
+def test_assignment_record_validation_rejects_incoherent_target_shape() -> None:
+    with pytest.raises(ValueError, match="class_id"):
+        assignment_records.build_assignment_record(**sample_assignment(class_id=""))
+    with pytest.raises(ValueError, match="github_team"):
+        assignment_records.build_assignment_record(**sample_assignment(target_type="team", github_team=""))
+    with pytest.raises(ValueError, match="esattamente un target"):
+        assignment_records.build_assignment_record(
+            **sample_assignment(
+                target_type="student",
+                class_id="",
+                class_label="",
+                github_team="",
+                targets=[
+                    {"student_id": "rossi-mario"},
+                    {"student_id": "bianchi-luca"},
+                ],
+            ),
+        )
+    with pytest.raises(ValueError, match="almeno due target"):
+        assignment_records.build_assignment_record(
+            **sample_assignment(
+                target_type="group",
+                class_id="",
+                class_label="",
+                github_team="",
+                targets=[{"student_id": "rossi-mario"}],
+            ),
+        )
+
+
 def test_validate_assignment_record_rejects_unsupported_schema_version() -> None:
     payload = assignment_records.build_assignment_record(**sample_assignment())
     payload["schema_version"] = "2.0"

--- a/tests/test_assignment_records.py
+++ b/tests/test_assignment_records.py
@@ -74,6 +74,35 @@ def test_build_assignment_record_uses_group_members_to_avoid_count_collisions() 
     assert "group-2" not in second_group["id"]
 
 
+def test_build_assignment_record_keeps_group_id_stable_when_targets_are_reordered() -> None:
+    first_order = assignment_records.build_assignment_record(
+        **sample_assignment(
+            target_type="group",
+            class_id="",
+            class_label="",
+            github_team="",
+            targets=[
+                {"student_id": "rossi-mario"},
+                {"student_id": "bianchi-luca"},
+            ],
+        ),
+    )
+    reversed_order = assignment_records.build_assignment_record(
+        **sample_assignment(
+            target_type="group",
+            class_id="",
+            class_label="",
+            github_team="",
+            targets=[
+                {"student_id": "bianchi-luca"},
+                {"student_id": "rossi-mario"},
+            ],
+        ),
+    )
+
+    assert first_order["id"] == reversed_order["id"]
+
+
 def test_assignment_record_validation_rejects_missing_or_bad_fields() -> None:
     with pytest.raises(ValueError, match="activity_id"):
         assignment_records.build_assignment_record(**sample_assignment(activity_id=""))

--- a/tests/test_assignment_records.py
+++ b/tests/test_assignment_records.py
@@ -26,13 +26,52 @@ def test_build_assignment_record_generates_stable_id_and_targets() -> None:
     assignment = assignment_records.build_assignment_record(**sample_assignment())
 
     assert assignment["schema_version"] == "1.0"
-    assert assignment["id"] == "assignment-python-base-somma-001-3a-tpsi-2026-10-12"
+    assert assignment["id"] == "assignment-python-base-somma-001-3a-tpsi-2026-10-12t09-00-00-02-00"
     assert assignment["activity_id"] == "python-base-somma-001"
     assert assignment["target_type"] == "class"
     assert assignment["targets"] == [
         {"student_id": "rossi-mario", "repo_ref": "TheBitPoets/rossi-mario"},
         {"student_id": "bianchi-luca", "path": "studenti/bianchi-luca"},
     ]
+
+
+def test_build_assignment_record_uses_time_to_avoid_same_day_collisions() -> None:
+    morning = assignment_records.build_assignment_record(**sample_assignment(assigned_at="2026-10-12T09:00:00+02:00"))
+    afternoon = assignment_records.build_assignment_record(**sample_assignment(assigned_at="2026-10-12T15:30:00+02:00"))
+
+    assert morning["id"] != afternoon["id"]
+    assert afternoon["id"] == "assignment-python-base-somma-001-3a-tpsi-2026-10-12t15-30-00-02-00"
+
+
+def test_build_assignment_record_uses_group_members_to_avoid_count_collisions() -> None:
+    first_group = assignment_records.build_assignment_record(
+        **sample_assignment(
+            target_type="group",
+            class_id="",
+            class_label="",
+            github_team="",
+            targets=[
+                {"student_id": "rossi-mario"},
+                {"student_id": "bianchi-luca"},
+            ],
+        ),
+    )
+    second_group = assignment_records.build_assignment_record(
+        **sample_assignment(
+            target_type="group",
+            class_id="",
+            class_label="",
+            github_team="",
+            targets=[
+                {"student_id": "verdi-anna"},
+                {"student_id": "neri-paolo"},
+            ],
+        ),
+    )
+
+    assert first_group["id"] != second_group["id"]
+    assert "group-2" not in first_group["id"]
+    assert "group-2" not in second_group["id"]
 
 
 def test_assignment_record_validation_rejects_missing_or_bad_fields() -> None:
@@ -107,8 +146,8 @@ def test_assignment_record_storage_writes_lists_and_filters_due_without_register
     storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
     saved = storage.write_assignment(assignment_records.build_assignment_record(**sample_assignment()))
 
-    assert saved["name"] == "assignment-python-base-somma-001-3a-tpsi-2026-10-12.json"
-    assert saved["path"] == "teacher-assignments/assignment-python-base-somma-001-3a-tpsi-2026-10-12.json"
+    assert saved["name"] == "assignment-python-base-somma-001-3a-tpsi-2026-10-12t09-00-00-02-00.json"
+    assert saved["path"] == "teacher-assignments/assignment-python-base-somma-001-3a-tpsi-2026-10-12t09-00-00-02-00.json"
     assert storage.read_assignment(saved["id"])["id"] == saved["id"]
     assert [assignment["id"] for assignment in storage.list_assignments()] == [saved["id"]]
 

--- a/tests/test_data_contract_fixtures.py
+++ b/tests/test_data_contract_fixtures.py
@@ -91,3 +91,24 @@ def test_assignment_register_contract_fixture() -> None:
     assert student["submission"]["files"][0]["path"] == "assignments/python-base-somma-001/main.py"
     assert student["grading"]["failed_tests"] == []
     assert student["ai_feedback"]["status"] == "not_generated"
+
+
+def test_assignment_contract_fixture() -> None:
+    payload = load_fixture("assignment.json")
+
+    assert_required(
+        payload,
+        {
+            "schema_version",
+            "id",
+            "activity_id",
+            "activity_path",
+            "target_type",
+            "assigned_at",
+            "due_at",
+            "targets",
+        },
+    )
+    assert payload["target_type"] == "class"
+    assert payload["targets"][0]["student_id"] == "rossi-mario"
+    assert payload["targets"][0]["repo_ref"] == "TheBitPoets/rossi-mario"


### PR DESCRIPTION
﻿## Cosa cambia
- Introduce `scripts/assignment_records.py`, helper MVP per record espliciti di assegnazione activity.
- Definisce il salvataggio JSON provvisorio in `teacher-assignments/*.json`.
- Aggiunge validazione, id stabile, lettura/scrittura/lista e calcolo delle assegnazioni scadute senza registro.
- Supporta il match futuro via `assignment_id` e un fallback MVP con activity/classe/scadenza per i registri attuali.
- Aggiunge fixture contrattuale `assignment.json` e aggiorna `doc/DATA_MODEL_MVP.md`.

## Perche
La GUI ha separato `Assegna activity` da `Registro consegne`, ma manca ancora l'oggetto dati intermedio. Questa PR mette a terra il modello `activity -> assignment -> submission -> register`, cosi il prossimo step potra introdurre una vera select `Assegnazione da tracciare`.

## Non incluso
- Nessuna GUI nuova.
- Nessuna distribuzione asset nei repository studenti.
- Nessuna integrazione automatica con `track_assignments.py`.

## Validazione
- `python -m pytest tests/test_assignment_records.py tests/test_data_contract_fixtures.py`
- `python -m pytest tests/test_thebitlab_storage.py tests/test_assignment_dashboard_frontend.py`
- `python -m py_compile scripts/assignment_records.py`
