### PR TITLE
Collega assegnazioni scadute al registro consegne

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
+from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, unquote, urlparse
@@ -34,6 +35,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts import (
+    assignment_records,
     assign_activity,
     create_activity,
     create_submission_scaffold,
@@ -47,6 +49,7 @@ DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
 SCHOOL_CALENDARS_DIR = ROOT / "doc" / "calendars"
 TEACHER_REPORTS_DIR = ROOT / "teacher-reports"
+TEACHER_ASSIGNMENTS_DIR = ROOT / "teacher-assignments"
 ACTIVITY_DIRS = [ROOT / "activities", ROOT / "examples" / "assignment_tracking"]
 COURSE_PLAN_MD_PATH = ROOT / "doc" / "PERCORSO_DIDATTICO.md"
 README_PATH = ROOT / "README.md"
@@ -102,6 +105,12 @@ def assignment_service() -> thebitlab_services.AssignmentService:
     """Return the application service for assignment dashboard data."""
 
     return thebitlab_services.AssignmentService(assignment_storage())
+
+
+def assignment_record_storage() -> assignment_records.JsonAssignmentRecordStorage:
+    """Return the JSON storage adapter for explicit assignment records."""
+
+    return assignment_records.JsonAssignmentRecordStorage(ROOT, TEACHER_ASSIGNMENTS_DIR)
 
 
 def class_roster_storage() -> thebitlab_storage.JsonClassRosterStorage:
@@ -194,6 +203,12 @@ def school_calendar_path(name: str) -> Path:
     return course_service().school_calendar_path(name)
 
 
+def datetime_now_iso() -> str:
+    """Return the current local datetime with timezone for assignment status checks."""
+
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
 def safe_teacher_report_path(name: str) -> Path:
     """Return a safe teacher-report path below teacher-reports."""
 
@@ -234,6 +249,27 @@ def list_assignment_reports() -> list[dict]:
     """List assignment tracking reports stored in teacher-reports."""
 
     return assignment_service().list_assignment_reports()
+
+
+def list_assignment_records(now: str | None = None) -> dict:
+    """Return explicit assignment records and those due without register."""
+
+    storage = assignment_storage()
+    record_storage = assignment_record_storage()
+    registers = []
+    for report in storage.list_assignment_reports():
+        try:
+            registers.append(storage.read_assignment_report(str(report.get("name", ""))))
+        except Exception:  # noqa: BLE001
+            continue
+    current_time = now or datetime_now_iso()
+    assignments = record_storage.list_assignments()
+    due_without_register = record_storage.assignments_due_without_register(registers, current_time)
+    return {
+        "assignments": assignments,
+        "due_without_register": due_without_register,
+        "now": current_time,
+    }
 
 
 def list_class_rosters() -> list[dict]:
@@ -427,6 +463,9 @@ def generate_assignment_report(payload: dict) -> dict:
         class_label=payload.get("class_label") or None,
         github_team=payload.get("github_team") or None,
     )
+    assignment_id = str(payload.get("assignment_id", "")).strip()
+    if assignment_id:
+        index["assignment_id"] = assignment_id
     track_assignments.write_tracking_index(index, output_path)
     return {
         "ok": True,
@@ -1748,6 +1787,10 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/api/assignment-reports":
             self.write_json({"reports": list_assignment_reports()})
+            return
+        if parsed.path == "/api/assignments":
+            query = parse_qs(parsed.query)
+            self.write_json(list_assignment_records(query.get("now", [""])[0] or None))
             return
         if parsed.path == "/api/assignment-overview":
             self.write_json({"rows": assignment_overview()})

--- a/teacher-assignments/assignment-demo-python-base-somma-001-demo-3a-scaduta.json
+++ b/teacher-assignments/assignment-demo-python-base-somma-001-demo-3a-scaduta.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0",
+  "id": "assignment-demo-python-base-somma-001-demo-3a-scaduta",
+  "activity_id": "python-base-somma-001",
+  "activity_path": "examples/assignment_tracking/demo_activity.json",
+  "target_type": "class",
+  "class_id": "demo-3a",
+  "class_label": "Classe demo 3A",
+  "github_team": "",
+  "assigned_at": "2026-10-10T09:00:00+02:00",
+  "due_at": "2026-10-18T23:59:00+02:00",
+  "targets": [
+    {
+      "student_id": "bianchi-luca",
+      "display_name": "Bianchi Luca",
+      "path": "examples/assignment_tracking/student_repos/bianchi-luca"
+    },
+    {
+      "student_id": "rossi-mario",
+      "display_name": "Rossi Mario",
+      "path": "examples/assignment_tracking/student_repos/rossi-mario"
+    },
+    {
+      "student_id": "verdi-anna",
+      "display_name": "Verdi Anna",
+      "path": "examples/assignment_tracking/student_repos/verdi-anna"
+    }
+  ]
+}

--- a/teacher-assignments/assignment-demo-python-base-somma-001-demo-3a-scaduta.json
+++ b/teacher-assignments/assignment-demo-python-base-somma-001-demo-3a-scaduta.json
@@ -7,8 +7,8 @@
   "class_id": "demo-3a",
   "class_label": "Classe demo 3A",
   "github_team": "",
-  "assigned_at": "2026-10-10T09:00:00+02:00",
-  "due_at": "2026-10-18T23:59:00+02:00",
+  "assigned_at": "2026-07-01T09:00:00+02:00",
+  "due_at": "2026-07-10T23:59:00+02:00",
   "targets": [
     {
       "student_id": "bianchi-luca",

--- a/teacher-assignments/assignment-demo-python-sconto-classe-001-demo-3a-scaduta.json
+++ b/teacher-assignments/assignment-demo-python-sconto-classe-001-demo-3a-scaduta.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0",
-  "id": "assignment-demo-python-base-somma-001-demo-3a-scaduta",
-  "activity_id": "python-base-somma-001",
-  "activity_path": "examples/assignment_tracking/demo_activity.json",
+  "id": "assignment-demo-python-sconto-classe-001-demo-3a-scaduta",
+  "activity_id": "python-sconto-classe-001",
+  "activity_path": "examples/assignment_tracking/class_discount_activity.json",
   "target_type": "class",
   "class_id": "demo-3a",
   "class_label": "Classe demo 3A",

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -1299,6 +1299,68 @@ def test_manual_report_edit_clears_selected_assignment_id() -> None:
     )
 
 
+def test_roster_application_clears_selected_assignment_id() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.fetchResponses["/api/assignments"] = {
+            assignments: [{
+              id: "assignment-python-base-somma-001-3a",
+              activity_id: "python-base-somma-001",
+              activity_path: "activities/python-base-somma-001.json",
+              target_type: "class",
+              class_id: "3A-TPSI",
+              class_label: "3A TPSI",
+              assigned_at: "2026-10-12T09:00:00+02:00",
+              due_at: "2026-10-19T23:59:00+02:00",
+              targets: [{ student_id: "rossi-mario", path: "studenti/rossi-mario" }],
+            }],
+            due_without_register: [{
+              assignment: {
+                id: "assignment-python-base-somma-001-3a",
+                activity_id: "python-base-somma-001",
+                activity_path: "activities/python-base-somma-001.json",
+                target_type: "class",
+                class_id: "3A-TPSI",
+                class_label: "3A TPSI",
+                assigned_at: "2026-10-12T09:00:00+02:00",
+                due_at: "2026-10-19T23:59:00+02:00",
+                targets: [{ student_id: "rossi-mario", path: "studenti/rossi-mario" }],
+              },
+            }],
+          };
+          tested.fetchResponses["/api/assignment-reports/generate"] = {
+            report: { students: [] },
+            saved: { name: "roster/report.json", path: "teacher-reports/roster/report.json" },
+            reports: [],
+          };
+
+          await tested.loadAssignments();
+          tested.applyAssignmentToGenerateForm("assignment-python-base-somma-001-3a");
+          assert.equal(tested.state.selectedAssignmentId, "assignment-python-base-somma-001-3a");
+
+          tested.applyRosterToGenerateForm({
+            id: "4A-TPSI",
+            label: "4A TPSI",
+            github_team: "team-4a-tpsi",
+            students: [
+              { id: "verdi-anna", display_name: "Verdi Anna", local_path: "studenti/verdi-anna" },
+            ],
+          });
+          assert.equal(tested.state.selectedAssignmentId, "");
+
+          await tested.generateReport();
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/assignment-reports/generate");
+          assert.ok(call);
+          const body = JSON.parse(call.options.body);
+          assert.equal(body.assignment_id, "");
+          assert.equal(body.class_id, "4A-TPSI");
+          assert.equal(body.targets_text, "studenti/verdi-anna");
+        })();
+        """
+    )
+
+
 def test_class_roster_panel_is_available_on_assignment_dashboard() -> None:
     html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
     roster_section = html.split('data-panel-key="class-roster"', 1)[1].split('data-panel-key="selected-report"', 1)[0]

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -208,6 +208,7 @@ def run_dashboard_js(assertions: str) -> None:
           if (fakeResponse?.json) return fakeResponse.json;
           if (fakeResponse) return fakeResponse;
           if (path === "/api/assignment-reports") return {{ reports: [] }};
+          if (path === "/api/assignments") return {{ assignments: [], due_without_register: [] }};
           if (path === "/api/activities") return {{ activities: [] }};
           if (path === "/api/activities/save") return {{
             ok: true,
@@ -300,6 +301,10 @@ def run_dashboard_js(assertions: str) -> None:
         renderAssignmentPlan,
         assignmentPlanErrorMessage,
         previewAssignmentPlan,
+        generateReport,
+        loadAssignments,
+        renderAssignmentSelect,
+        applyAssignmentToGenerateForm,
         rosterOptionLabel,
         localTargetFromStudent,
         rosterTargets,
@@ -1173,6 +1178,71 @@ def test_assignment_and_report_panels_are_separated() -> None:
     assert 'id="generateReportBtn"' in report_section
     assert 'id="activitySelect"' not in report_section
     assert 'id="targetsText"' not in report_section
+
+
+def test_assignment_records_fill_generate_form_and_payload() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.fetchResponses["/api/assignments"] = {
+            assignments: [{
+              id: "assignment-python-base-somma-001-3a",
+              activity_id: "python-base-somma-001",
+              activity_path: "activities/python-base-somma-001.json",
+              target_type: "class",
+              class_id: "3A-TPSI",
+              class_label: "3A TPSI",
+              github_team: "team-3a-tpsi",
+              assigned_at: "2026-10-12T09:00:00+02:00",
+              due_at: "2026-10-19T23:59:00+02:00",
+              targets: [
+                { student_id: "rossi-mario", path: "studenti/rossi-mario" },
+                { student_id: "bianchi-luca", path: "studenti/bianchi-luca" },
+              ],
+            }],
+            due_without_register: [{
+              assignment: {
+                id: "assignment-python-base-somma-001-3a",
+                activity_id: "python-base-somma-001",
+                activity_path: "activities/python-base-somma-001.json",
+                target_type: "class",
+                class_id: "3A-TPSI",
+                class_label: "3A TPSI",
+                github_team: "team-3a-tpsi",
+                assigned_at: "2026-10-12T09:00:00+02:00",
+                due_at: "2026-10-19T23:59:00+02:00",
+                targets: [
+                  { student_id: "rossi-mario", path: "studenti/rossi-mario" },
+                  { student_id: "bianchi-luca", path: "studenti/bianchi-luca" },
+                ],
+              },
+            }],
+          };
+          tested.fetchResponses["/api/assignment-reports/generate"] = {
+            report: { students: [] },
+            saved: {
+              name: "3a-tpsi/python-base-somma-001.json",
+              path: "teacher-reports/3a-tpsi/python-base-somma-001.json",
+            },
+            reports: [],
+          };
+
+          await tested.loadAssignments();
+          tested.applyAssignmentToGenerateForm("assignment-python-base-somma-001-3a");
+
+          assert.equal(tested.els.activityPath.value, "activities/python-base-somma-001.json");
+          assert.equal(tested.els.classId.value, "3A-TPSI");
+          assert.equal(tested.els.githubTeam.value, "team-3a-tpsi");
+          assert.equal(tested.els.targetsText.value, "studenti/rossi-mario\\nstudenti/bianchi-luca");
+
+          await tested.generateReport();
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/assignment-reports/generate");
+          assert.ok(call);
+          const body = JSON.parse(call.options.body);
+          assert.equal(body.assignment_id, "assignment-python-base-somma-001-3a");
+        })();
+        """
+    )
 
 
 def test_class_roster_panel_is_available_on_assignment_dashboard() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -304,6 +304,7 @@ def run_dashboard_js(assertions: str) -> None:
         generateReport,
         loadAssignments,
         renderAssignmentSelect,
+        clearSelectedAssignment,
         applyAssignmentToGenerateForm,
         rosterOptionLabel,
         localTargetFromStudent,
@@ -1240,6 +1241,59 @@ def test_assignment_records_fill_generate_form_and_payload() -> None:
           assert.ok(call);
           const body = JSON.parse(call.options.body);
           assert.equal(body.assignment_id, "assignment-python-base-somma-001-3a");
+        })();
+        """
+    )
+
+
+def test_manual_report_edit_clears_selected_assignment_id() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.fetchResponses["/api/assignments"] = {
+            assignments: [{
+              id: "assignment-python-base-somma-001-3a",
+              activity_id: "python-base-somma-001",
+              activity_path: "activities/python-base-somma-001.json",
+              target_type: "class",
+              class_id: "3A-TPSI",
+              class_label: "3A TPSI",
+              assigned_at: "2026-10-12T09:00:00+02:00",
+              due_at: "2026-10-19T23:59:00+02:00",
+              targets: [{ student_id: "rossi-mario", path: "studenti/rossi-mario" }],
+            }],
+            due_without_register: [{
+              assignment: {
+                id: "assignment-python-base-somma-001-3a",
+                activity_id: "python-base-somma-001",
+                activity_path: "activities/python-base-somma-001.json",
+                target_type: "class",
+                class_id: "3A-TPSI",
+                class_label: "3A TPSI",
+                assigned_at: "2026-10-12T09:00:00+02:00",
+                due_at: "2026-10-19T23:59:00+02:00",
+                targets: [{ student_id: "rossi-mario", path: "studenti/rossi-mario" }],
+              },
+            }],
+          };
+          tested.fetchResponses["/api/assignment-reports/generate"] = {
+            report: { students: [] },
+            saved: { name: "manuale/report.json", path: "teacher-reports/manuale/report.json" },
+            reports: [],
+          };
+
+          await tested.loadAssignments();
+          tested.applyAssignmentToGenerateForm("assignment-python-base-somma-001-3a");
+          assert.equal(tested.state.selectedAssignmentId, "assignment-python-base-somma-001-3a");
+
+          tested.clearSelectedAssignment();
+          assert.equal(tested.state.selectedAssignmentId, "");
+
+          await tested.generateReport();
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/assignment-reports/generate");
+          assert.ok(call);
+          const body = JSON.parse(call.options.body);
+          assert.equal(body.assignment_id, "");
         })();
         """
     )

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from scripts import course_board_server
+from scripts import assignment_records, course_board_server
 
 
 def test_assignment_overview_lists_students_across_saved_reports(tmp_path, monkeypatch) -> None:
@@ -111,6 +111,90 @@ def test_list_assignment_reports_counts_late_only_for_submitted_students(tmp_pat
     assert reports[0]["submitted"] == 2
     assert reports[0]["not_submitted"] == 1
     assert reports[0]["late"] == 1
+
+
+def test_list_assignment_records_marks_due_without_register(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+    monkeypatch.setattr(course_board_server, "TEACHER_ASSIGNMENTS_DIR", tmp_path / "teacher-assignments")
+
+    storage = assignment_records.JsonAssignmentRecordStorage(tmp_path, tmp_path / "teacher-assignments")
+    assignment = storage.write_assignment(
+        assignment_records.build_assignment_record(
+            activity_id="python-base-somma-001",
+            activity_path="activities/python-base-somma-001.json",
+            target_type="class",
+            class_id="3A-TPSI",
+            class_label="3A TPSI",
+            github_team="team-3a-tpsi",
+            assigned_at="2026-10-12T09:00:00+02:00",
+            due_at="2026-10-19T23:59:00+02:00",
+            targets=[
+                {"student_id": "rossi-mario", "path": "studenti/rossi-mario"},
+                {"student_id": "bianchi-luca", "path": "studenti/bianchi-luca"},
+            ],
+        ),
+    )
+
+    payload = course_board_server.list_assignment_records("2026-10-20T08:00:00+02:00")
+
+    assert payload["assignments"][0]["id"] == assignment["id"]
+    assert payload["due_without_register"][0]["assignment"]["id"] == assignment["id"]
+    assert payload["due_without_register"][0]["needs_register"] is True
+
+
+def test_generate_assignment_report_preserves_assignment_id(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+
+    activity_path = tmp_path / "activity.json"
+    activity_path.write_text(
+        json.dumps({
+            "schema_version": "1.0",
+            "id": "python-base-somma-001",
+            "titolo": "Somma in Python",
+            "linguaggio": "python",
+            "tipo": "compito-casa",
+            "difficolta": "B",
+            "argomenti": ["variabili"],
+            "consegna": "Somma due numeri.",
+            "correzione": {
+                "compila": True,
+                "test": True,
+                "sandbox": True,
+                "ai_feedback": False,
+            },
+            "metriche": {
+                "tempo_stimato_minuti": 20,
+                "traccia_tempo_dichiarato": True,
+                "traccia_sessioni_thebitlab": True,
+                "traccia_eventi_didattici": True,
+                "traccia_errori_compilazione": True,
+            },
+            "student_support_mode": "senza-aiuto",
+        }),
+        encoding="utf-8",
+    )
+    student_repo = tmp_path / "studenti" / "rossi-mario"
+    (student_repo / "assignments" / "python-base-somma-001").mkdir(parents=True)
+    (student_repo / "assignments" / "python-base-somma-001" / "main.py").write_text("print(3)\n", encoding="utf-8")
+
+    result = course_board_server.generate_assignment_report({
+        "activity_path": str(activity_path),
+        "output_name": "demo/report.json",
+        "class_id": "3A-TPSI",
+        "class_label": "3A TPSI",
+        "github_team": "team-3a-tpsi",
+        "assigned_at": "2026-10-12T09:00:00+02:00",
+        "due_at": "2026-10-19T23:59:00+02:00",
+        "now": "2026-10-20T08:00:00+02:00",
+        "targets_text": str(student_repo),
+        "assignment_id": "assignment-python-base-somma-001-3a",
+    })
+
+    assert result["report"]["assignment_id"] == "assignment-python-base-somma-001-3a"
+    saved_payload = json.loads((tmp_path / "teacher-reports" / "demo" / "report.json").read_text(encoding="utf-8"))
+    assert saved_payload["assignment_id"] == "assignment-python-base-somma-001-3a"
 
 
 def test_preview_activity_assignment_returns_plan_without_writing(tmp_path, monkeypatch) -> None:

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -196,6 +196,13 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       </div>
       <div class="generateGrid">
         <label class="wideField">
+          <span>Assegnazione da tracciare</span>
+          <select id="assignmentSelect" aria-label="Assegnazioni scadute senza registro">
+            <option value="">Caricamento assegnazioni...</option>
+          </select>
+        </label>
+        <p id="assignmentStatus" class="status wideField" aria-live="polite"></p>
+        <label class="wideField">
           <span>Output registro</span>
           <input id="outputName" type="text" value="demo/demo_assignment.json">
         </label>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1514,6 +1514,13 @@ function renderAssignmentSelect() {
   }
 }
 
+function clearSelectedAssignment() {
+  if (!state.selectedAssignmentId && !els.assignmentSelect?.value) return;
+  state.selectedAssignmentId = "";
+  if (els.assignmentSelect) els.assignmentSelect.value = "";
+  renderReportAssignmentSummary();
+}
+
 function applyAssignmentToGenerateForm(assignmentId) {
   const assignment = state.dueAssignments.find((candidate) => candidate.id === assignmentId)
     || state.assignments.find((candidate) => candidate.id === assignmentId);
@@ -3168,7 +3175,10 @@ els.reviewPrevBtn.addEventListener("click", () => openAdjacentSubmission(-1));
 els.reviewNextBtn.addEventListener("click", () => openAdjacentSubmission(1));
 els.reviewCloseBtn.addEventListener("click", closeReviewDialog);
 els.activitySelect.addEventListener("change", () => {
-  if (els.activitySelect.value) selectActivity(els.activitySelect.value);
+  if (els.activitySelect.value) {
+    clearSelectedAssignment();
+    selectActivity(els.activitySelect.value);
+  }
 });
 els.assignmentSelect?.addEventListener("change", () => {
   const assignment = applyAssignmentToGenerateForm(els.assignmentSelect.value);
@@ -3201,17 +3211,36 @@ els.activityAuthorClass?.addEventListener("change", () => {
 });
 els.classRosterSelect?.addEventListener("change", loadSelectedClassRoster);
 els.activityPath.addEventListener("input", () => {
+  clearSelectedAssignment();
   renderActivitySelect();
   renderAssignmentContext();
 });
 els.outputName.addEventListener("input", renderAssignmentContext);
-els.classId.addEventListener("input", renderReportAssignmentSummary);
-els.classLabel.addEventListener("input", renderAssignmentContext);
-els.githubTeam.addEventListener("input", renderAssignmentContext);
-els.assignedAt.addEventListener("input", renderReportAssignmentSummary);
-els.dueAt.addEventListener("input", renderReportAssignmentSummary);
+els.classId.addEventListener("input", () => {
+  clearSelectedAssignment();
+  renderReportAssignmentSummary();
+});
+els.classLabel.addEventListener("input", () => {
+  clearSelectedAssignment();
+  renderAssignmentContext();
+});
+els.githubTeam.addEventListener("input", () => {
+  clearSelectedAssignment();
+  renderAssignmentContext();
+});
+els.assignedAt.addEventListener("input", () => {
+  clearSelectedAssignment();
+  renderReportAssignmentSummary();
+});
+els.dueAt.addEventListener("input", () => {
+  clearSelectedAssignment();
+  renderReportAssignmentSummary();
+});
 els.nowAt.addEventListener("change", () => loadAssignments().catch((error) => setStatus(`Assegnazioni non aggiornate: ${error.message}`)));
-els.targetsText.addEventListener("input", renderAssignmentContext);
+els.targetsText.addEventListener("input", () => {
+  clearSelectedAssignment();
+  renderAssignmentContext();
+});
 els.classId.addEventListener("change", updateOutputNameForCurrentActivity);
 els.coverageBody.addEventListener("click", async (event) => {
   const toggleButton = event.target.closest("[data-coverage-toggle]");

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -90,6 +90,8 @@ const LEGEND_SECTIONS = {
 
 const state = {
   activities: [],
+  assignments: [],
+  dueAssignments: [],
   reports: [],
   classRosters: [],
   courseDesign: null,
@@ -120,6 +122,7 @@ const state = {
   reviewSplit: readReviewSplit(),
   draggedPanelKey: "",
   activityAuthorLastSuggestedId: "",
+  selectedAssignmentId: "",
 };
 
 const els = {
@@ -205,6 +208,8 @@ const els = {
   saveActivityBtn: document.querySelector("#saveActivityBtn"),
   activitySelect: document.querySelector("#activitySelect"),
   activityPath: document.querySelector("#activityPath"),
+  assignmentSelect: document.querySelector("#assignmentSelect"),
+  assignmentStatus: document.querySelector("#assignmentStatus"),
   classRosterSelect: document.querySelector("#classRosterSelect"),
   rosterStatus: document.querySelector("#rosterStatus"),
   rosterPanelStatus: document.querySelector("#rosterPanelStatus"),
@@ -795,7 +800,10 @@ function targetLineCount() {
 }
 
 function reportAssignmentSummaryItems() {
+  const assignment = state.assignments.find((candidate) => candidate.id === state.selectedAssignmentId)
+    || state.dueAssignments.find((candidate) => candidate.id === state.selectedAssignmentId);
   return [
+    ["Assegnazione", assignment?.id || "-"],
     ["Activity", currentActivityLabel()],
     ["Classe", els.classId.value.trim() || "-"],
     ["Team", els.githubTeam.value.trim() || "-"],
@@ -1461,6 +1469,77 @@ async function loadActivities() {
   renderActivitySelect();
   renderActivityAuthorMetadataSelects();
   renderCoverage();
+}
+
+async function loadAssignments() {
+  const query = els.nowAt?.value.trim() ? `?now=${encodeURIComponent(els.nowAt.value.trim())}` : "";
+  const payload = await api(`/api/assignments${query}`);
+  state.assignments = payload.assignments || [];
+  state.dueAssignments = (payload.due_without_register || []).map((item) => item.assignment || item);
+  renderAssignmentSelect();
+}
+
+function assignmentLabel(assignment) {
+  const target = assignment.class_label || assignment.class_id || assignment.github_team || assignment.target_type || "target";
+  const activity = assignment.activity_id || assignment.activity_path || "activity";
+  return `${target} - ${activity} - ${formatDate(assignment.due_at)}`;
+}
+
+function assignmentTargetLine(target) {
+  return String(target?.path || target?.target || target?.repo_ref || target?.student_id || "").trim().replaceAll("\\", "/");
+}
+
+function assignmentOutputName(assignment) {
+  const classPart = assignment.class_id || assignment.github_team || assignment.class_label || assignment.target_type || "target";
+  return `${slugPathSegment(classPart)}/${slugPathSegment(assignment.activity_id || assignment.id || "registro")}.json`;
+}
+
+function renderAssignmentSelect() {
+  if (!els.assignmentSelect) return;
+  const selected = state.selectedAssignmentId || els.assignmentSelect.value;
+  els.assignmentSelect.innerHTML = '<option value="">Nessuna assegnazione selezionata</option>';
+  for (const assignment of state.dueAssignments) {
+    const option = document.createElement("option");
+    option.value = assignment.id || "";
+    option.textContent = assignmentLabel(assignment);
+    option.title = assignment.id || "";
+    els.assignmentSelect.append(option);
+  }
+  els.assignmentSelect.value = state.dueAssignments.some((assignment) => assignment.id === selected) ? selected : "";
+  state.selectedAssignmentId = els.assignmentSelect.value;
+  if (els.assignmentStatus) {
+    els.assignmentStatus.textContent = state.dueAssignments.length
+      ? `${state.dueAssignments.length} assegnazioni scadute senza registro.`
+      : "Nessuna assegnazione scaduta senza registro.";
+  }
+}
+
+function applyAssignmentToGenerateForm(assignmentId) {
+  const assignment = state.dueAssignments.find((candidate) => candidate.id === assignmentId)
+    || state.assignments.find((candidate) => candidate.id === assignmentId);
+  state.selectedAssignmentId = assignment?.id || "";
+  if (!assignment) {
+    renderAssignmentSelect();
+    renderReportAssignmentSummary();
+    return null;
+  }
+  els.activityPath.value = assignment.activity_path || "";
+  els.classId.value = assignment.class_id || "";
+  els.classLabel.value = assignment.class_label || assignment.class_id || "";
+  els.githubTeam.value = assignment.github_team || "";
+  els.assignedAt.value = assignment.assigned_at || "";
+  els.dueAt.value = assignment.due_at || "";
+  els.outputName.value = assignmentOutputName(assignment);
+  const targetLines = (Array.isArray(assignment.targets) ? assignment.targets : [])
+    .map(assignmentTargetLine)
+    .filter(Boolean);
+  if (targetLines.length) {
+    els.targetsText.value = targetLines.join("\n");
+  }
+  renderActivitySelect();
+  renderAssignmentContext();
+  renderAssignmentSelect();
+  return assignment;
 }
 
 async function saveActivityDraft() {
@@ -2299,6 +2378,7 @@ async function generateReport() {
         due_at: els.dueAt.value,
         now: els.nowAt.value,
         targets_text: els.targetsText.value,
+        assignment_id: state.selectedAssignmentId,
       }),
     });
     state.report = payload.report;
@@ -2306,6 +2386,7 @@ async function generateReport() {
     state.reports = payload.reports || [];
     renderReportSelect();
     els.reportSelect.value = payload.saved?.name || "";
+    await loadAssignments();
     renderCoverage();
     await loadOverview();
     focusOverviewClassFromReport(state.report);
@@ -3060,6 +3141,7 @@ function closeStudentsDialog() {
 els.loadReportBtn.addEventListener("click", loadSelectedReport);
 els.reloadBtn.addEventListener("click", async () => {
   await loadReports();
+  await loadAssignments();
   await loadOverview();
 });
 els.resetPanelOrderBtn.addEventListener("click", resetPanelOrder);
@@ -3087,6 +3169,10 @@ els.reviewNextBtn.addEventListener("click", () => openAdjacentSubmission(1));
 els.reviewCloseBtn.addEventListener("click", closeReviewDialog);
 els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) selectActivity(els.activitySelect.value);
+});
+els.assignmentSelect?.addEventListener("change", () => {
+  const assignment = applyAssignmentToGenerateForm(els.assignmentSelect.value);
+  setStatus(assignment ? `Assegnazione selezionata: ${assignment.id}.` : "Nessuna assegnazione selezionata.");
 });
 els.saveActivityBtn?.addEventListener("click", saveActivityDraft);
 els.activityAuthorTitle?.addEventListener("input", syncActivityAuthorIdSuggestion);
@@ -3124,6 +3210,7 @@ els.classLabel.addEventListener("input", renderAssignmentContext);
 els.githubTeam.addEventListener("input", renderAssignmentContext);
 els.assignedAt.addEventListener("input", renderReportAssignmentSummary);
 els.dueAt.addEventListener("input", renderReportAssignmentSummary);
+els.nowAt.addEventListener("change", () => loadAssignments().catch((error) => setStatus(`Assegnazioni non aggiornate: ${error.message}`)));
 els.targetsText.addEventListener("input", renderAssignmentContext);
 els.classId.addEventListener("change", updateOutputNameForCurrentActivity);
 els.coverageBody.addEventListener("click", async (event) => {
@@ -3275,6 +3362,7 @@ setupResizableTables();
 Promise.all([
   loadReports(),
   loadActivities(),
+  loadAssignments(),
   loadOverview(),
   loadClassRosters(),
   loadCourseDesignForActivityAuthoring(),

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1679,6 +1679,7 @@ function rosterTargets(roster) {
 
 function applyRosterToGenerateForm(roster) {
   if (!roster) return { targets: [], warnings: ["Roster non valido."] };
+  clearSelectedAssignment();
   state.selectedClassRoster = roster;
   els.classId.value = roster.id || "";
   els.classLabel.value = roster.label || roster.id || "";


### PR DESCRIPTION
﻿## Cosa cambia
- aggiunge l'endpoint `/api/assignments` per esporre le assegnazioni esplicite e quelle scadute senza registro
- aggiunge nel pannello `Registro consegne` una select `Assegnazione da tracciare`
- quando il docente sceglie un'assegnazione, il form del registro viene compilato con activity, classe, team, scadenze, target e nome output
- quando viene generato il registro, viene salvato anche `assignment_id`, così la consegna risulta coperta dal registro

## Perché
Il flusso corretto diventa esplicito: si crea/assegna una activity, quella assegnazione diventa una consegna da tracciare, e solo dopo la scadenza il docente genera il registro relativo a quella consegna.

## Impatto UI
Nel pannello `Registro consegne` comparirà una lista di assegnazioni scadute senza registro. Se non ci sono assegnazioni esplicite salvate, la select mostrerà che non ci sono elementi da tracciare.

## Verifiche
- `python -m pytest tests/test_course_board_server.py tests/test_assignment_records.py tests/test_assignment_dashboard_frontend.py`
- `python -m py_compile scripts/course_board_server.py scripts/assignment_records.py`
- `git diff --check`
