### PR TITLE
Salva assegnazioni activity dalla dashboard

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -44,6 +44,7 @@ from scripts import (
     thebitlab_storage,
     track_assignments,
 )
+from scripts.thebitlab_contracts import normalize_activity
 
 DESIGN_PATH = ROOT / "doc" / "course_design.json"
 COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
@@ -425,6 +426,69 @@ def read_assignment_target_paths_from_text(targets_text: str) -> list[Path]:
     if not targets:
         raise ValueError("Inserisci almeno un repository studente nei target.")
     return targets
+
+
+def assignment_record_targets_from_text(targets_text: str) -> list[dict]:
+    """Build explicit assignment targets from one local repository path per line."""
+
+    targets = []
+    for target_path in read_assignment_target_paths_from_text(targets_text):
+        try:
+            clean_path = str(target_path.relative_to(ROOT)).replace("\\", "/")
+        except ValueError:
+            clean_path = str(target_path)
+        targets.append({
+            "student_id": target_path.name,
+            "display_name": target_path.name,
+            "path": clean_path,
+        })
+    return targets
+
+
+def infer_assignment_target_type(class_id: str, github_team: str, targets: list[dict]) -> str:
+    """Infer the assignment target type from the current dashboard fields."""
+
+    if class_id:
+        return "class"
+    if github_team:
+        return "team"
+    if len(targets) == 1:
+        return "student"
+    return "group"
+
+
+def save_assignment_record(payload: dict) -> dict:
+    """Persist an explicit assignment record from the teacher dashboard."""
+
+    activity_path_value = str(payload.get("activity_path", "")).strip()
+    activity_path = resolve_local_path(activity_path_value, "activity_path")
+    if not activity_path.is_file():
+        raise FileNotFoundError(f"Activity non trovata: {activity_path}")
+    activity = normalize_activity(assignment_storage().read_json(activity_path))
+    activity_id = str(activity.get("id", "")).strip()
+    if not activity_id:
+        raise ValueError("Activity senza id.")
+    targets = assignment_record_targets_from_text(str(payload.get("targets_text", "")))
+    class_id = str(payload.get("class_id", "")).strip()
+    github_team = str(payload.get("github_team", "")).strip()
+    assignment = assignment_records.build_assignment_record(
+        activity_id=activity_id,
+        activity_path=activity_path_value.replace("\\", "/"),
+        target_type=str(payload.get("target_type", "")).strip() or infer_assignment_target_type(class_id, github_team, targets),
+        class_id=class_id,
+        class_label=str(payload.get("class_label", "")).strip(),
+        github_team=github_team,
+        assigned_at=str(payload.get("assigned_at", "")).strip(),
+        due_at=str(payload.get("due_at", "")).strip(),
+        targets=targets,
+    )
+    saved = assignment_record_storage().write_assignment(assignment, bool(payload.get("overwrite", False)))
+    records = list_assignment_records(str(payload.get("now", "")).strip() or None)
+    return {
+        "ok": True,
+        "assignment": saved,
+        **records,
+    }
 
 
 def preview_activity_assignment(payload: dict) -> dict:
@@ -1927,6 +1991,20 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/activities/assignment-plan":
             try:
                 self.write_json(preview_activity_assignment(payload))
+            except FileNotFoundError as error:
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/assignments/save":
+            try:
+                self.write_json(save_assignment_record(payload))
             except FileNotFoundError as error:
                 self.send_response(404)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -209,6 +209,15 @@ def run_dashboard_js(assertions: str) -> None:
           if (fakeResponse) return fakeResponse;
           if (path === "/api/assignment-reports") return {{ reports: [] }};
           if (path === "/api/assignments") return {{ assignments: [], due_without_register: [] }};
+          if (path === "/api/assignments/save") return {{
+            ok: true,
+            assignment: {{
+              id: "assignment-python-base-somma-001-3a-tpsi-2026-10-12t09-00-00-02-00",
+              activity_id: "python-base-somma-001",
+            }},
+            assignments: [],
+            due_without_register: [],
+          }};
           if (path === "/api/activities") return {{ activities: [] }};
           if (path === "/api/activities/save") return {{
             ok: true,
@@ -296,11 +305,13 @@ def run_dashboard_js(assertions: str) -> None:
         syncActivityAuthorIdSuggestion,
         renderActivityAuthorMetadataSelects,
         assignmentPlanPayload,
+        assignmentRecordPayload,
         renderAssignmentAssetList,
         renderAssignmentTargetList,
         renderAssignmentPlan,
         assignmentPlanErrorMessage,
         previewAssignmentPlan,
+        saveAssignmentRecord,
         generateReport,
         loadAssignments,
         renderAssignmentSelect,
@@ -520,6 +531,64 @@ def test_assignment_preview_explains_missing_server_endpoint() -> None:
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /endpoint non trovato/);
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /course_board_server.py/);
           assert.match(tested.els.status.textContent, /endpoint non trovato/);
+        })();
+        """
+    )
+
+
+def test_save_assignment_record_posts_form_and_refreshes_due_assignments() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.els.classId.value = "3A-TPSI";
+          tested.els.classLabel.value = "3A TPSI";
+          tested.els.githubTeam.value = "team-3a-tpsi";
+          tested.els.assignedAt.value = "2026-10-12T09:00:00+02:00";
+          tested.els.dueAt.value = "2026-10-19T23:59:00+02:00";
+          tested.els.nowAt.value = "2026-10-20T08:00:00+02:00";
+          tested.els.targetsText.value = "students/rossi-mario\\nstudents/bianchi-luca";
+          tested.fetchResponses["/api/assignments/save"] = {
+            ok: true,
+            assignment: {
+              id: "assignment-python-base-somma-001-3a-tpsi-2026-10-12t09-00-00-02-00",
+              activity_id: "python-base-somma-001",
+            },
+            assignments: [{
+              id: "assignment-python-base-somma-001-3a-tpsi-2026-10-12t09-00-00-02-00",
+              activity_id: "python-base-somma-001",
+            }],
+            due_without_register: [{
+              assignment: {
+                id: "assignment-python-base-somma-001-3a-tpsi-2026-10-12t09-00-00-02-00",
+                activity_id: "python-base-somma-001",
+                class_label: "3A TPSI",
+                due_at: "2026-10-19T23:59:00+02:00",
+              },
+            }],
+          };
+
+          await tested.saveAssignmentRecord();
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/assignments/save");
+          assert.ok(call);
+          assert.equal(call.options.method, "POST");
+          const body = JSON.parse(call.options.body);
+          assert.deepEqual(body, {
+            activity_path: "activities/python-base-somma-001.json",
+            class_id: "3A-TPSI",
+            class_label: "3A TPSI",
+            github_team: "team-3a-tpsi",
+            assigned_at: "2026-10-12T09:00:00+02:00",
+            due_at: "2026-10-19T23:59:00+02:00",
+            now: "2026-10-20T08:00:00+02:00",
+            targets_text: "students/rossi-mario\\nstudents/bianchi-luca",
+            overwrite: false,
+          });
+          assert.equal(tested.state.assignments.length, 1);
+          assert.equal(tested.state.dueAssignments.length, 1);
+          assert.match(tested.els.assignmentStatus.textContent, /1 assegnazioni scadute senza registro/);
+          assert.match(tested.els.status.textContent, /Assegnazione salvata/);
         })();
         """
     )
@@ -1169,6 +1238,7 @@ def test_assignment_and_report_panels_are_separated() -> None:
     assert 'id="classRosterSelect"' in assignment_section
     assert 'id="targetsText"' in assignment_section
     assert 'id="previewAssignmentBtn"' in assignment_section
+    assert 'id="saveAssignmentBtn"' in assignment_section
     assert 'id="outputName"' not in assignment_section
     assert 'id="reportAssignmentSummary"' not in assignment_section
     assert 'id="generateReportBtn"' not in assignment_section
@@ -1177,6 +1247,7 @@ def test_assignment_and_report_panels_are_separated() -> None:
     assert 'id="outputName"' in report_section
     assert 'id="reportAssignmentSummary"' in report_section
     assert 'id="generateReportBtn"' in report_section
+    assert 'id="saveAssignmentBtn"' not in report_section
     assert 'id="activitySelect"' not in report_section
     assert 'id="targetsText"' not in report_section
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -249,6 +249,64 @@ def test_preview_activity_assignment_returns_plan_without_writing(tmp_path, monk
     assert not (target / "assignments").exists()
 
 
+def test_save_assignment_record_persists_dashboard_assignment(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_ASSIGNMENTS_DIR", tmp_path / "teacher-assignments")
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+
+    activities_dir = tmp_path / "activities"
+    activities_dir.mkdir()
+    activity_path = activities_dir / "activity.json"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": "python-base-somma-001",
+                "titolo": "Somma in Python",
+                "tipo": "compito-casa",
+                "difficolta": "B",
+                "argomenti": ["variabili"],
+                "linguaggio": "python",
+                "consegna": "Completa main.py.",
+                "correzione": {
+                    "compila": True,
+                    "test": True,
+                    "sandbox": True,
+                    "ai_feedback": False,
+                },
+                "metriche": {
+                    "tempo_stimato_minuti": 20,
+                    "traccia_tempo_dichiarato": True,
+                    "traccia_sessioni_thebitlab": True,
+                    "traccia_eventi_didattici": True,
+                    "traccia_errori_compilazione": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "students" / "rossi-mario").mkdir(parents=True)
+    (tmp_path / "students" / "bianchi-luca").mkdir(parents=True)
+
+    response = course_board_server.save_assignment_record({
+        "activity_path": "activities/activity.json",
+        "class_id": "3A-TPSI",
+        "class_label": "3A TPSI",
+        "assigned_at": "2026-10-12T09:00:00+02:00",
+        "due_at": "2026-10-19T23:59:00+02:00",
+        "now": "2026-10-20T08:00:00+02:00",
+        "targets_text": "students/rossi-mario\nstudents/bianchi-luca",
+    })
+
+    assert response["ok"] is True
+    assert response["assignment"]["activity_id"] == "python-base-somma-001"
+    assert response["assignment"]["target_type"] == "class"
+    assert response["assignment"]["targets"][0]["path"] == "students/rossi-mario"
+    assert response["due_without_register"][0]["assignment"]["id"] == response["assignment"]["id"]
+    saved_path = tmp_path / response["assignment"]["path"]
+    assert saved_path.is_file()
+
+
 def test_review_assignment_ai_feedback_persists_teacher_decision(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -180,7 +180,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       </div>
       <div class="generateActions">
         <button id="previewAssignmentBtn" type="button" title="Mostra cosa verrebbe assegnato agli studenti senza scrivere nei repository.">Anteprima assegnazione</button>
-        <button type="button" disabled title="In arrivo: distribuira gli asset della activity nei repository degli studenti.">Assegna activity</button>
+        <button id="saveAssignmentBtn" type="button" class="primary" title="Salva la consegna per classe, team o studenti senza distribuire ancora asset nei repository.">Salva assegnazione</button>
       </div>
       <div id="assignmentPlanPreview" class="assignmentPlanPreview" aria-live="polite">
         <p class="status">Usa l'anteprima per verificare target e asset prima di assegnare una activity.</p>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -225,6 +225,7 @@ const els = {
   nowAt: document.querySelector("#nowAt"),
   targetsText: document.querySelector("#targetsText"),
   previewAssignmentBtn: document.querySelector("#previewAssignmentBtn"),
+  saveAssignmentBtn: document.querySelector("#saveAssignmentBtn"),
   assignmentPlanPreview: document.querySelector("#assignmentPlanPreview"),
   generateReportBtn: document.querySelector("#generateReportBtn"),
   panels: document.querySelectorAll("main.layout .panel"),
@@ -2269,6 +2270,20 @@ function assignmentPlanPayload() {
   };
 }
 
+function assignmentRecordPayload() {
+  return {
+    activity_path: els.activityPath.value,
+    class_id: els.classId.value,
+    class_label: els.classLabel.value,
+    github_team: els.githubTeam.value,
+    assigned_at: els.assignedAt.value,
+    due_at: els.dueAt.value,
+    now: els.nowAt.value,
+    targets_text: els.targetsText.value,
+    overwrite: false,
+  };
+}
+
 function renderAssignmentAssetList(assets, emptyLabel) {
   const items = Array.isArray(assets) ? assets : [];
   if (!items.length) return `<p class="status">${escapeHtml(emptyLabel)}</p>`;
@@ -2367,6 +2382,27 @@ async function previewAssignmentPlan() {
     setStatus(`Anteprima assegnazione non disponibile: ${message}`);
   } finally {
     els.previewAssignmentBtn.disabled = false;
+  }
+}
+
+async function saveAssignmentRecord() {
+  if (!els.saveAssignmentBtn) return;
+  els.saveAssignmentBtn.disabled = true;
+  setStatus("Salvataggio assegnazione...");
+  try {
+    const payload = await api("/api/assignments/save", {
+      method: "POST",
+      body: JSON.stringify(assignmentRecordPayload()),
+    });
+    state.assignments = payload.assignments || [];
+    state.dueAssignments = (payload.due_without_register || []).map((item) => item.assignment || item);
+    state.selectedAssignmentId = "";
+    renderAssignmentSelect();
+    setStatus(`Assegnazione salvata: ${payload.assignment?.id || "-"}.`);
+  } catch (error) {
+    setStatus(`Assegnazione non salvata: ${assignmentPlanErrorMessage(error)}`);
+  } finally {
+    els.saveAssignmentBtn.disabled = false;
   }
 }
 
@@ -3154,6 +3190,7 @@ els.reloadBtn.addEventListener("click", async () => {
 });
 els.resetPanelOrderBtn.addEventListener("click", resetPanelOrder);
 els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
+els.saveAssignmentBtn?.addEventListener("click", saveAssignmentRecord);
 els.generateReportBtn.addEventListener("click", generateReport);
 els.reportSelect.addEventListener("change", loadSelectedReport);
 els.coverageOpenBtn.addEventListener("click", openCoverageDialog);


### PR DESCRIPTION
﻿## Cosa cambia
- aggiunge `POST /api/assignments/save` per salvare una consegna/assegnazione esplicita in `teacher-assignments`
- trasforma il bottone disabilitato del pannello `Assegna activity` in `Salva assegnazione`
- salva activity, classe/team, date e target locali come record assegnazione
- aggiorna subito la lista `Assegnazione da tracciare`, così le assegnazioni già scadute diventano disponibili per generare il registro

## Limite intenzionale
Questa PR salva il record didattico della consegna, ma non distribuisce ancora asset o scaffold nei repository studenti. La distribuzione reale resta un passo successivo.

## Perché
Serve chiudere il flusso dati minimo: `crea activity -> assegna activity -> nasce consegna -> genera registro per la consegna` senza dipendere da JSON demo scritti a mano.

## Verifiche
- `python -m pytest tests/test_course_board_server.py tests/test_assignment_records.py tests/test_assignment_dashboard_frontend.py`
- `python -m py_compile scripts/course_board_server.py scripts/assignment_records.py`
- `git diff --check`
