### PR TITLE
Distribuisci activity ai target locali

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -509,6 +509,43 @@ def preview_activity_assignment(payload: dict) -> dict:
     return {"ok": True, "plan": plan.to_dict()}
 
 
+def distribute_activity_assignment(payload: dict) -> dict:
+    """Create activity scaffolds in the selected local target repositories."""
+
+    activity_path = resolve_local_path(payload.get("activity_path", ""), "activity_path")
+    if not activity_path.is_file():
+        raise FileNotFoundError(f"Activity non trovata: {activity_path}")
+    targets = read_assignment_target_paths_from_text(str(payload.get("targets_text", "")))
+    results = assign_activity.assign_activity_to_targets(
+        activity_path=activity_path,
+        targets=targets,
+        source_name=payload.get("source_name") or None,
+        language=payload.get("language") or None,
+        thebitlab_ref=payload.get("thebitlab_ref") or create_submission_scaffold.DEFAULT_THEBITLAB_REF,
+        overwrite=bool(payload.get("overwrite", False)),
+        overwrite_source=bool(payload.get("overwrite_source", False)),
+    )
+    plan = assign_activity.build_assignment_plan(
+        activity_path=activity_path,
+        targets=targets,
+        source_name=payload.get("source_name") or None,
+        language=payload.get("language") or None,
+        thebitlab_ref=payload.get("thebitlab_ref") or create_submission_scaffold.DEFAULT_THEBITLAB_REF,
+        overwrite=bool(payload.get("overwrite", False)),
+    )
+    return {
+        "ok": True,
+        "results": [
+            {
+                "target": str(result.target),
+                "assignment_dir": str(result.assignment_dir),
+            }
+            for result in results
+        ],
+        "plan": plan.to_dict(),
+    }
+
+
 def generate_assignment_report(payload: dict) -> dict:
     """Generate and persist an assignment tracking report from the local GUI."""
 
@@ -2005,6 +2042,20 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/assignments/save":
             try:
                 self.write_json(save_assignment_record(payload))
+            except FileNotFoundError as error:
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/assignments/distribute":
+            try:
+                self.write_json(distribute_activity_assignment(payload))
             except FileNotFoundError as error:
                 self.send_response(404)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -218,6 +218,26 @@ def run_dashboard_js(assertions: str) -> None:
             assignments: [],
             due_without_register: [],
           }};
+          if (path === "/api/assignments/distribute") return {{
+            ok: true,
+            results: [{{ target: "students/rossi-mario", assignment_dir: "students/rossi-mario/assignments/python-base-somma-001" }}],
+            plan: {{
+              activity_id: "python-base-somma-001",
+              title: "Somma in Python",
+              language: "python",
+              source_name: "main.py",
+              student_assets: [],
+              teacher_assets: [],
+              targets: [{{
+                target: "students/rossi-mario",
+                assignment_dir: "students/rossi-mario/assignments/python-base-somma-001",
+                exists: true,
+              }}],
+              blocked_targets: ["students/rossi-mario"],
+              overwrite: false,
+              can_assign: false,
+            }},
+          }};
           if (path === "/api/activities") return {{ activities: [] }};
           if (path === "/api/activities/save") return {{
             ok: true,
@@ -312,6 +332,7 @@ def run_dashboard_js(assertions: str) -> None:
         assignmentPlanErrorMessage,
         previewAssignmentPlan,
         saveAssignmentRecord,
+        distributeAssignment,
         generateReport,
         loadAssignments,
         renderAssignmentSelect,
@@ -589,6 +610,51 @@ def test_save_assignment_record_posts_form_and_refreshes_due_assignments() -> No
           assert.equal(tested.state.dueAssignments.length, 1);
           assert.match(tested.els.assignmentStatus.textContent, /1 assegnazioni scadute senza registro/);
           assert.match(tested.els.status.textContent, /Assegnazione salvata/);
+        })();
+        """
+    )
+
+
+def test_distribute_assignment_posts_plan_and_renders_written_targets() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.els.targetsText.value = "students/rossi-mario";
+          tested.fetchResponses["/api/assignments/distribute"] = {
+            ok: true,
+            results: [
+              { target: "students/rossi-mario", assignment_dir: "students/rossi-mario/assignments/python-base-somma-001" },
+            ],
+            plan: {
+              activity_id: "python-base-somma-001",
+              title: "Somma in Python",
+              language: "python",
+              source_name: "main.py",
+              student_assets: [],
+              teacher_assets: [],
+              targets: [{
+                target: "students/rossi-mario",
+                assignment_dir: "students/rossi-mario/assignments/python-base-somma-001",
+                exists: true,
+              }],
+              blocked_targets: ["students/rossi-mario"],
+              overwrite: false,
+              can_assign: false,
+            },
+          };
+
+          await tested.distributeAssignment();
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/assignments/distribute");
+          assert.ok(call);
+          assert.equal(call.options.method, "POST");
+          const body = JSON.parse(call.options.body);
+          assert.equal(body.activity_path, "activities/python-base-somma-001.json");
+          assert.equal(body.targets_text, "students/rossi-mario");
+          assert.match(tested.els.assignmentPlanPreview.innerHTML, /Somma in Python/);
+          assert.match(tested.els.assignmentPlanPreview.innerHTML, /gia presente/);
+          assert.match(tested.els.status.textContent, /distribuita a 1 target/);
         })();
         """
     )
@@ -1239,6 +1305,7 @@ def test_assignment_and_report_panels_are_separated() -> None:
     assert 'id="targetsText"' in assignment_section
     assert 'id="previewAssignmentBtn"' in assignment_section
     assert 'id="saveAssignmentBtn"' in assignment_section
+    assert 'id="distributeAssignmentBtn"' in assignment_section
     assert 'id="outputName"' not in assignment_section
     assert 'id="reportAssignmentSummary"' not in assignment_section
     assert 'id="generateReportBtn"' not in assignment_section
@@ -1248,6 +1315,7 @@ def test_assignment_and_report_panels_are_separated() -> None:
     assert 'id="reportAssignmentSummary"' in report_section
     assert 'id="generateReportBtn"' in report_section
     assert 'id="saveAssignmentBtn"' not in report_section
+    assert 'id="distributeAssignmentBtn"' not in report_section
     assert 'id="activitySelect"' not in report_section
     assert 'id="targetsText"' not in report_section
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -307,6 +307,58 @@ def test_save_assignment_record_persists_dashboard_assignment(tmp_path, monkeypa
     assert saved_path.is_file()
 
 
+def test_distribute_activity_assignment_writes_scaffolds(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+
+    activities_dir = tmp_path / "activities"
+    activities_dir.mkdir()
+    (activities_dir / "starter").mkdir()
+    (activities_dir / "starter" / "main.py").write_text("print('starter')\n", encoding="utf-8")
+    activity_path = activities_dir / "activity.json"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": "python-base-somma-001",
+                "titolo": "Somma in Python",
+                "tipo": "compito-casa",
+                "difficolta": "B",
+                "argomenti": ["variabili"],
+                "linguaggio": "python",
+                "consegna": "Completa main.py.",
+                "assets": [{"type": "starter", "path": "starter/main.py", "target_path": "main.py"}],
+                "correzione": {
+                    "compila": True,
+                    "test": True,
+                    "sandbox": True,
+                    "ai_feedback": False,
+                },
+                "metriche": {
+                    "tempo_stimato_minuti": 20,
+                    "traccia_tempo_dichiarato": True,
+                    "traccia_sessioni_thebitlab": True,
+                    "traccia_eventi_didattici": True,
+                    "traccia_errori_compilazione": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    target = tmp_path / "students" / "rossi-mario"
+
+    response = course_board_server.distribute_activity_assignment({
+        "activity_path": "activities/activity.json",
+        "targets_text": "students/rossi-mario",
+    })
+
+    assignment_dir = target / "assignments" / "python-base-somma-001"
+    assert response["ok"] is True
+    assert response["results"][0]["assignment_dir"] == str(assignment_dir.resolve())
+    assert response["plan"]["targets"][0]["exists"] is True
+    assert (assignment_dir / "activity.json").is_file()
+    assert (assignment_dir / "main.py").read_text(encoding="utf-8") == "print('starter')\n"
+
+
 def test_review_assignment_ai_feedback_persists_teacher_decision(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -181,6 +181,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       <div class="generateActions">
         <button id="previewAssignmentBtn" type="button" title="Mostra cosa verrebbe assegnato agli studenti senza scrivere nei repository.">Anteprima assegnazione</button>
         <button id="saveAssignmentBtn" type="button" class="primary" title="Salva la consegna per classe, team o studenti senza distribuire ancora asset nei repository.">Salva assegnazione</button>
+        <button id="distributeAssignmentBtn" type="button" title="Copia traccia, README e asset studente nelle cartelle dei repository target.">Distribuisci ai target</button>
       </div>
       <div id="assignmentPlanPreview" class="assignmentPlanPreview" aria-live="polite">
         <p class="status">Usa l'anteprima per verificare target e asset prima di assegnare una activity.</p>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -226,6 +226,7 @@ const els = {
   targetsText: document.querySelector("#targetsText"),
   previewAssignmentBtn: document.querySelector("#previewAssignmentBtn"),
   saveAssignmentBtn: document.querySelector("#saveAssignmentBtn"),
+  distributeAssignmentBtn: document.querySelector("#distributeAssignmentBtn"),
   assignmentPlanPreview: document.querySelector("#assignmentPlanPreview"),
   generateReportBtn: document.querySelector("#generateReportBtn"),
   panels: document.querySelectorAll("main.layout .panel"),
@@ -2406,6 +2407,31 @@ async function saveAssignmentRecord() {
   }
 }
 
+async function distributeAssignment() {
+  if (!els.distributeAssignmentBtn) return;
+  els.distributeAssignmentBtn.disabled = true;
+  setStatus("Distribuzione assegnazione ai target...");
+  if (els.assignmentPlanPreview) {
+    els.assignmentPlanPreview.innerHTML = '<p class="status">Distribuzione assegnazione ai target...</p>';
+  }
+  try {
+    const payload = await api("/api/assignments/distribute", {
+      method: "POST",
+      body: JSON.stringify(assignmentPlanPayload()),
+    });
+    renderAssignmentPlan(payload.plan);
+    setStatus(`Assegnazione distribuita a ${payload.results?.length || 0} target.`);
+  } catch (error) {
+    const message = assignmentPlanErrorMessage(error);
+    if (els.assignmentPlanPreview) {
+      els.assignmentPlanPreview.innerHTML = `<p class="status">Distribuzione non completata: ${escapeHtml(message)}</p>`;
+    }
+    setStatus(`Distribuzione non completata: ${message}`);
+  } finally {
+    els.distributeAssignmentBtn.disabled = false;
+  }
+}
+
 async function generateReport() {
   els.generateReportBtn.disabled = true;
   setStatus("Creazione registro consegne...");
@@ -3191,6 +3217,7 @@ els.reloadBtn.addEventListener("click", async () => {
 els.resetPanelOrderBtn.addEventListener("click", resetPanelOrder);
 els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
 els.saveAssignmentBtn?.addEventListener("click", saveAssignmentRecord);
+els.distributeAssignmentBtn?.addEventListener("click", distributeAssignment);
 els.generateReportBtn.addEventListener("click", generateReport);
 els.reportSelect.addEventListener("change", loadSelectedReport);
 els.coverageOpenBtn.addEventListener("click", openCoverageDialog);


### PR DESCRIPTION
﻿## Cosa cambia
- aggiunge `POST /api/assignments/distribute` per creare scaffold e asset studente nei target locali
- aggiunge il bottone `Distribuisci ai target` nel pannello `Assegna activity`
- riusa `assign_activity.assign_activity_to_targets(...)` e il piano di assegnazione esistente
- dopo la distribuzione mostra il piano aggiornato con i target ormai presenti

## Limite intenzionale
La UI non espone ancora overwrite/force: se un target ha già quella consegna, la distribuzione viene bloccata e il docente vede l'errore. La gestione guidata dell'overwrite resta un passo successivo.

## Verifiche
- `python -m pytest tests/test_course_board_server.py tests/test_assign_activity.py tests/test_assignment_dashboard_frontend.py tests/test_assignment_records.py`
- `python -m py_compile scripts/course_board_server.py scripts/assign_activity.py`
- `git diff --check`
