### PR TITLE
Trasforma assegnazione activity in wizard

### DIFF
--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -281,6 +281,84 @@ Regole dello scaffold:
 - lo scaffold studente copia solo asset con visibilita effettiva `student` e tipo `starter`, `example`, `fixture` o `visible_test`;
 - `hidden_test`, `runner` e `teacher_only` restano fuori dal repository studente.
 
+## Activity package e generazione AI
+
+La generazione AI/Codex non deve produrre solo testo libero. Deve produrre un **activity package** revisionabile dal docente, cioe un insieme coerente di metadati, consegna, file e policy.
+
+Un package generato o modificato dall'AI dovrebbe contenere:
+
+- metadati activity: titolo, tipo, difficolta, argomenti, percorso/UDA quando disponibili;
+- traccia o README per lo studente;
+- file studente: starter code, esempi, fixture e test pubblici;
+- file docente: test nascosti, runner, soluzione, note e rubrica;
+- policy di supporto studente: modalita AI, materiali ammessi, limiti di aiuto;
+- provenienza: prompt, provider, modello o adapter, timestamp e revisione docente.
+
+La GUI puo proporre scheletri diversi per tipo di activity, ma il docente deve sempre poter:
+
+- aggiungere file liberi;
+- rimuovere o rinominare file proposti;
+- cambiare ruolo e visibilita dei file;
+- modificare qualsiasi contenuto generato;
+- chiedere all'AI una nuova iterazione partendo dal package corrente;
+- scartare la bozza e proseguire manualmente.
+
+### Scheletri minimi consigliati
+
+Gli scheletri non sono vincoli rigidi: servono a dare una forma iniziale coerente al docente, all'AI e al backend.
+
+| Tipo | Elementi fondamentali | Elementi consigliati |
+|---|---|---|
+| `studio-guidato` | traccia, obiettivi, paragrafi collegati, domande guida | micro-esercizi, criteri di autovalutazione |
+| `esercizio-classe` | traccia, file attesi, criteri minimi | starter code, test pubblici, soluzione docente |
+| `compito-casa` | traccia, consegna attesa, scadenza, rubrica | starter code, esempi, test pubblici |
+| `laboratorio` | traccia, starter code, fixture, test pubblici | test nascosti, runner, note docente |
+| `verifica-pratica` | traccia, vincoli, test riservati, rubrica | soluzione docente, runner, materiali ammessi |
+| `verifica-scritta` | domande, criteri, materiali ammessi | griglia correzione, soluzione attesa |
+| `debug-didattico` | codice con bug, descrizione comportamento, criteri | indizi progressivi, soluzione, test che espongono il bug |
+
+### Bundle di contesto per provider AI/Codex
+
+Prima di chiamare un provider AI, TheBitLab dovrebbe costruire un bundle esplicito e ispezionabile:
+
+```json
+{
+  "task": "generate_activity",
+  "provider": "codex",
+  "prompt": "Rendi l'esercizio piu guidato e aggiungi test sui casi limite.",
+  "activity": {
+    "id": "python-base-somma-001",
+    "tipo": "laboratorio",
+    "difficolta": "B"
+  },
+  "course_context": {
+    "percorso": "terzo-anno",
+    "uda": "input-output",
+    "argomenti": ["variabili", "operatori"]
+  },
+  "files": [
+    {
+      "path": "README.md",
+      "role": "student_instructions",
+      "visibility": "student",
+      "content": "..."
+    },
+    {
+      "path": "tests/test_hidden.py",
+      "role": "hidden_test",
+      "visibility": "teacher",
+      "content": "..."
+    }
+  ],
+  "teacher_review": {
+    "status": "draft",
+    "required": true
+  }
+}
+```
+
+Lo stesso bundle deve poter essere usato da adapter diversi: API provider, Codex locale, workflow manuale copia/incolla o provider futuri.
+
 ## Correzione
 
 Il campo `correzione` indica quali controlli sono previsti.

--- a/doc/ASSIGNMENTS.md
+++ b/doc/ASSIGNMENTS.md
@@ -826,6 +826,66 @@ Feedback AI assisted:
 
 Questa separazione rende chiaro cosa e stato verificato automaticamente e cosa invece e una spiegazione didattica generata o supportata dall'AI.
 
+### Budget, token e audit AI
+
+TheBitLab deve poter limitare l'uso dell'AI per evitare consumo incontrollato di crediti o saturazione dell'abbonamento della scuola.
+
+I budget dovrebbero esistere a piu livelli:
+
+| Livello | Esempio di limite |
+|---|---|
+| Organizzazione/scuola | tetto mensile globale di richieste, token o costo stimato |
+| Classe/team | quota massima condivisa dal gruppo |
+| Studente | numero richieste giornaliere, settimanali o per activity |
+| Activity/assegnazione | massimo tentativi AI consentiti per quella consegna |
+| Modalita AI | output breve, solo hint, feedback tecnico, tutor completo |
+
+Ogni richiesta AI dovrebbe produrre un record di audit separato dal voto:
+
+```json
+{
+  "student_id": "student-042",
+  "assignment_id": "assignment-python-base-somma-001-3a",
+  "provider": "openai",
+  "model": "provider-model",
+  "purpose": "student_hint",
+  "tokens_input": 1200,
+  "tokens_output": 350,
+  "estimated_cost": 0.003,
+  "created_at": "2026-10-14T10:12:00+02:00"
+}
+```
+
+La GUI studente dovrebbe mostrare un'indicazione semplice, per esempio richieste rimaste o modalita AI attiva. La GUI docente dovrebbe mostrare consumi aggregati per classe, studente e activity.
+
+Quando il budget e esaurito, la piattaforma dovrebbe poter degradare il supporto:
+
+- da `ai-assisted` a feedback tecnico;
+- da risposta lunga a hint breve;
+- da chat libera a richiami teorici precompilati;
+- oppure bloccare temporaneamente nuove richieste.
+
+### Integrita prove e copia/incolla
+
+Per le verifiche o le attivita controllate, TheBitLab puo prevedere una modalita di integrita limitata alla propria GUI.
+
+Controlli ragionevoli in una normale pagina web:
+
+- bloccare o intercettare `copy`, `paste` e `cut` dentro la GUI;
+- registrare tentativi di copia/incolla;
+- registrare cambio tab, perdita focus o uscita dal fullscreen;
+- disabilitare upload o drag/drop non autorizzati;
+- mostrare avvisi chiari allo studente;
+- salvare gli eventi in un audit log della consegna.
+
+Limite importante: una pagina web non puo monitorare tutto lo schermo o altre applicazioni dello studente. Per controlli piu forti servono strumenti dedicati, come browser kiosk, postazioni gestite, estensioni autorizzate o integrazioni di proctoring.
+
+Questa modalita deve essere trasparente:
+
+- lo studente deve sapere quali eventi vengono registrati;
+- non vanno raccolti dati non necessari;
+- i log devono aiutare il docente a valutare il contesto, non produrre automaticamente un voto o una sanzione.
+
 ## TheBitLab
 
 Il laboratorio interattivo del progetto prende il nome di **TheBitLab**.

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -562,9 +562,13 @@ Ordine consigliato:
 5. Asset activity e scaffold:
    - allegare o selezionare file di esempio, scheletri, fixture, test e runner;
    - distinguere asset pubblici per lo studente, asset riservati al grading e asset solo docente;
+   - definire un `activity package` composto da metadati, traccia, file studente, file docente, test, soluzione, rubrica e provenienza;
+   - prevedere scheletri minimi per tipo di activity, lasciando sempre al docente la possibilita di aggiungere file liberi;
    - copiare gli asset corretti nello scaffold consegna durante l'assegnazione.
 6. Generazione AI/Codex di activity e asset:
    - proporre traccia, esempi, starter code, bug da correggere, soluzione, test e rubrica;
+   - inviare ai provider un bundle esplicito con prompt, metadati, contesto didattico e file selezionati;
+   - supportare iterazioni docente-AI sul package corrente: modifica, richiesta aggiustamenti, confronto, nuova bozza;
    - lasciare al docente controllo completo: accetta, modifica, scarta, rigenera o crea manualmente;
    - registrare provenienza della generazione e policy AI usata.
 7. Pagina assegnazione activity a classe, gruppo o singolo studente e scaffold consegna.
@@ -588,7 +592,12 @@ Ordine consigliato:
 17. Catalogo fonti e import paragrafi da piu repository.
 18. Estensione layout pannelli alle altre pagine.
 19. Feedback assistito avanzato lato studente.
-20. Source provider API, indicizzazione frammenti e playground knowledge lab.
+20. Governance AI e integrita prove:
+   - budget token/richieste per scuola, classe, studente e activity;
+   - audit log separato dal voto per chiamate AI, costi stimati e policy applicata;
+   - modalita verifica controllata nella GUI con blocco/log copia-incolla, focus/tab e fullscreen;
+   - informativa chiara allo studente e minimizzazione dei dati raccolti.
+21. Source provider API, indicizzazione frammenti e playground knowledge lab.
 
 ## Criterio di priorita
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -164,6 +164,17 @@ def run_dashboard_js(assertions: str) -> None:
       button.dataset.legendTab = topic;
       return button;
     }});
+    const assignmentStepNames = ["activity", "ai", "targets", "dates", "preview", "confirm"];
+    const assignmentStepTabs = assignmentStepNames.map((step) => {{
+      const button = new FakeElement(`[data-assignment-step-tab="${{step}}"]`);
+      button.dataset.assignmentStepTab = step;
+      return button;
+    }});
+    const assignmentSteps = assignmentStepNames.map((step) => {{
+      const section = new FakeElement(`[data-assignment-step="${{step}}"]`);
+      section.dataset.assignmentStep = step;
+      return section;
+    }});
 
     const fetchCalls = [];
     const fetchResponses = {{}};
@@ -190,6 +201,8 @@ def run_dashboard_js(assertions: str) -> None:
         querySelector: elementFor,
         querySelectorAll: (selector) => {{
           if (selector === "[data-legend-tab]") return legendTabs;
+          if (selector === "[data-assignment-step-tab]") return assignmentStepTabs;
+          if (selector === "[data-assignment-step]") return assignmentSteps;
           if (selector === "main.layout .panel") return collectPanels(layout);
           if (selector === "main.layout > .panelRow") return collectRows(layout);
           return [];
@@ -329,6 +342,7 @@ def run_dashboard_js(assertions: str) -> None:
         renderAssignmentAssetList,
         renderAssignmentTargetList,
         renderAssignmentPlan,
+        setAssignmentWizardStep,
         assignmentPlanErrorMessage,
         previewAssignmentPlan,
         saveAssignmentRecord,
@@ -656,6 +670,39 @@ def test_distribute_assignment_posts_plan_and_renders_written_targets() -> None:
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /gia presente/);
           assert.match(tested.els.status.textContent, /distribuita a 1 target/);
         })();
+        """
+    )
+
+
+def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
+    assignment_section = html.split('data-panel-key="assignment"', 1)[1].split('data-panel-key="generate"', 1)[0]
+
+    assert 'data-assignment-step-tab="activity"' in assignment_section
+    assert 'data-assignment-step-tab="ai"' in assignment_section
+    assert 'data-assignment-step-tab="confirm"' in assignment_section
+    assert 'data-assignment-step="ai"' in assignment_section
+    assert "Generazione AI assistita" in assignment_section
+    assert "provider AI o Codex" in assignment_section
+    assert "modificarla" in assignment_section
+
+
+def test_assignment_wizard_switches_visible_step() -> None:
+    run_dashboard_js(
+        """
+        tested.setAssignmentWizardStep("ai");
+
+        const aiTab = tested.els.assignmentStepTabs.find((button) => button.dataset.assignmentStepTab === "ai");
+        const activityTab = tested.els.assignmentStepTabs.find((button) => button.dataset.assignmentStepTab === "activity");
+        const aiStep = tested.els.assignmentSteps.find((section) => section.dataset.assignmentStep === "ai");
+        const activityStep = tested.els.assignmentSteps.find((section) => section.dataset.assignmentStep === "activity");
+
+        assert.equal(aiTab.classList.contains("isActive"), true);
+        assert.equal(aiTab["aria-selected"], "true");
+        assert.equal(activityTab.classList.contains("isActive"), false);
+        assert.equal(activityTab["aria-selected"], "false");
+        assert.equal(aiStep.hidden, false);
+        assert.equal(activityStep.hidden, true);
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -707,6 +707,14 @@ def test_assignment_wizard_uses_calendar_date_time_inputs() -> None:
     assert 'id="nowAt" type="datetime-local"' in assignment_section
 
 
+def test_assignment_ai_context_checkboxes_use_fixed_alignment() -> None:
+    css = open("tools/assignment_dashboard.css", encoding="utf-8").read()
+
+    assert ".assignmentAiContext label" in css
+    assert "grid-template-columns: 1rem minmax(0, 1fr);" in css
+    assert '.assignmentAiContext input[type="checkbox"]' in css
+
+
 def test_assignment_date_time_inputs_are_serialized_as_iso() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -692,6 +692,10 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert 'id="assignmentAiDraftText"' in assignment_section
     assert "Contesto da inviare" in assignment_section
     assert "Asset, starter file, test e soluzione" in assignment_section
+    assert "Pacchetto file activity" in assignment_section
+    assert "File aggiuntivi liberi" in assignment_section
+    assert 'id="assignmentAiStudentBudget"' in assignment_section
+    assert 'id="assignmentIntegrityMode"' in assignment_section
 
 
 def test_assignment_wizard_uses_calendar_date_time_inputs() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -315,6 +315,8 @@ def run_dashboard_js(assertions: str) -> None:
         aiFeedbackReviewDetails,
         aiFeedbackTeacherAction,
         reviewAiFeedback,
+        dateTimeInputToIso,
+        isoToDateTimeInput,
         compactStudentsSummaryItems,
         detailedStudentsSummaryItems,
         applyPanelOrder,
@@ -685,6 +687,36 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert "Generazione AI assistita" in assignment_section
     assert "provider AI o Codex" in assignment_section
     assert "modificarla" in assignment_section
+    assert 'id="assignmentAiProvider"' in assignment_section
+    assert 'id="assignmentAiPrompt"' in assignment_section
+    assert 'id="assignmentAiDraftText"' in assignment_section
+    assert "Contesto da inviare" in assignment_section
+    assert "Asset, starter file, test e soluzione" in assignment_section
+
+
+def test_assignment_wizard_uses_calendar_date_time_inputs() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
+    assignment_section = html.split('data-panel-key="assignment"', 1)[1].split('data-panel-key="generate"', 1)[0]
+
+    assert 'id="assignedAt" type="datetime-local"' in assignment_section
+    assert 'id="dueAt" type="datetime-local"' in assignment_section
+    assert 'id="nowAt" type="datetime-local"' in assignment_section
+
+
+def test_assignment_date_time_inputs_are_serialized_as_iso() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignedAt.value = "2026-10-12T09:00";
+        tested.els.dueAt.value = "2026-10-19T23:59";
+        tested.els.nowAt.value = "2026-10-20T08:00";
+
+        const payload = tested.assignmentRecordPayload();
+        assert.match(payload.assigned_at, /^2026-10-12T09:00:00[+-]\\d{2}:\\d{2}$/);
+        assert.match(payload.due_at, /^2026-10-19T23:59:00[+-]\\d{2}:\\d{2}$/);
+        assert.match(payload.now, /^2026-10-20T08:00:00[+-]\\d{2}:\\d{2}$/);
+        assert.equal(tested.dateTimeInputToIso("2026-10-12T09:00:00+02:00"), "2026-10-12T09:00:00+02:00");
+        """
+    )
 
 
 def test_assignment_wizard_switches_visible_step() -> None:

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -244,6 +244,12 @@ select {
   font-size: .82rem;
 }
 
+.assignmentAiPolicy {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .8rem;
+}
+
 .overviewFilters {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -216,6 +216,34 @@ select {
   line-height: 1.55;
 }
 
+.assignmentAiChat {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .8rem;
+  margin-top: 1rem;
+}
+
+.assignmentAiContext {
+  display: grid;
+  gap: .45rem;
+  padding: .8rem;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.assignmentAiContext strong {
+  margin-bottom: .15rem;
+}
+
+.assignmentAiContext label {
+  display: flex;
+  align-items: center;
+  gap: .45rem;
+  color: var(--muted);
+  font-size: .82rem;
+}
+
 .overviewFilters {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -237,11 +237,24 @@ select {
 }
 
 .assignmentAiContext label {
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 1rem minmax(0, 1fr);
+  align-items: start;
   gap: .45rem;
   color: var(--muted);
   font-size: .82rem;
+  line-height: 1.35;
+}
+
+.assignmentAiContext input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  margin: .08rem 0 0;
+  accent-color: #111111;
+}
+
+.assignmentAiContext input[type="checkbox"]:disabled {
+  opacity: .7;
 }
 
 .assignmentAiPolicy {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -169,6 +169,53 @@ select {
   padding: 1.1rem;
 }
 
+.assignmentWizard {
+  border-top: 1px solid rgba(17, 17, 17, .08);
+}
+
+.assignmentWizardSteps {
+  display: flex;
+  gap: .45rem;
+  flex-wrap: wrap;
+  padding: 1rem 1.1rem 0;
+}
+
+.assignmentWizardSteps button {
+  box-shadow: none;
+  padding: .5rem .75rem;
+  color: var(--muted);
+}
+
+.assignmentWizardSteps button.isActive {
+  background: #111111;
+  border-color: #111111;
+  color: #ffffff;
+}
+
+.assignmentWizardStep {
+  min-height: 8rem;
+}
+
+.assignmentAiDraft {
+  margin: 1.1rem;
+  padding: 1rem;
+  border: 1px solid rgba(17, 17, 17, .12);
+  border-radius: 8px;
+  background: #fbfbfb;
+}
+
+.assignmentAiDraft strong {
+  display: block;
+  margin-bottom: .45rem;
+}
+
+.assignmentAiDraft p {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: .82rem;
+  line-height: 1.55;
+}
+
 .overviewFilters {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -158,6 +158,34 @@
           <div class="assignmentAiDraft">
             <strong>Generazione AI assistita</strong>
             <p>In arrivo: genera traccia, starter code, test, soluzione e rubric tramite provider AI o Codex. La proposta resta una bozza: il docente potra modificarla, rigenerare sezioni o scartarla prima di salvare e distribuire.</p>
+            <div class="assignmentAiChat">
+              <label>
+                <span>Provider</span>
+                <select id="assignmentAiProvider" aria-label="Provider AI per la bozza activity">
+                  <option value="codex">Codex</option>
+                  <option value="openai">OpenAI API provider</option>
+                  <option value="manual">Solo bozza manuale</option>
+                </select>
+              </label>
+              <label class="wideField">
+                <span>Prompt docente</span>
+                <textarea id="assignmentAiPrompt" rows="4" placeholder="Chiedi una traccia, una variante piu semplice, test aggiuntivi, codice da debuggare o una rubric diversa."></textarea>
+              </label>
+              <div class="assignmentAiContext wideField" aria-label="Contesto che verra inviato all'AI">
+                <strong>Contesto da inviare</strong>
+                <label><input type="checkbox" checked disabled> Activity selezionata e metadati</label>
+                <label><input type="checkbox" checked disabled> Percorso, UDA e argomenti collegati</label>
+                <label><input type="checkbox" checked disabled> Destinatari, classe/team e scadenze</label>
+                <label><input type="checkbox" checked disabled> Asset, starter file, test e soluzione quando disponibili</label>
+              </div>
+              <div class="generateActions wideField">
+                <button id="assignmentAiAskBtn" type="button" disabled title="Inviera prompt e contesto al provider AI selezionato quando l'adapter sara collegato.">Chiedi modifica</button>
+              </div>
+              <label class="wideField">
+                <span>Bozza AI modificabile dal docente</span>
+                <textarea id="assignmentAiDraftText" rows="6" placeholder="Qui comparira la proposta AI. Il docente potra modificarla prima di salvare l'activity o distribuirla."></textarea>
+              </label>
+            </div>
           </div>
         </section>
 
@@ -195,15 +223,15 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           <div class="generateGrid">
             <label>
               <span>Assegnato il</span>
-              <input id="assignedAt" type="text" value="2026-10-12T09:00:00+02:00">
+              <input id="assignedAt" type="datetime-local" value="2026-10-12T09:00">
             </label>
             <label>
               <span>Scadenza</span>
-              <input id="dueAt" type="text" value="2026-10-19T23:59:00+02:00">
+              <input id="dueAt" type="datetime-local" value="2026-10-19T23:59">
             </label>
             <label>
               <span>Ora simulata opzionale</span>
-              <input id="nowAt" type="text" placeholder="2026-10-18T12:00:00+02:00">
+              <input id="nowAt" type="datetime-local">
             </label>
           </div>
         </section>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -178,6 +178,28 @@
                 <label><input type="checkbox" checked disabled> Destinatari, classe/team e scadenze</label>
                 <label><input type="checkbox" checked disabled> Asset, starter file, test e soluzione quando disponibili</label>
               </div>
+              <div class="assignmentAiContext wideField" aria-label="Pacchetto file previsto per la generazione AI">
+                <strong>Pacchetto file activity</strong>
+                <label><input type="checkbox" checked disabled> Traccia e README studente</label>
+                <label><input type="checkbox" checked disabled> Starter code, esempi e fixture modificabili dal docente</label>
+                <label><input type="checkbox" checked disabled> Test pubblici per lo studente</label>
+                <label><input type="checkbox" checked disabled> Test riservati, runner e soluzione solo docente</label>
+                <label><input type="checkbox" disabled> File aggiuntivi liberi scelti da repository o caricati dal docente</label>
+              </div>
+              <div class="assignmentAiPolicy wideField">
+                <label>
+                  <span>Budget AI per studente</span>
+                  <input id="assignmentAiStudentBudget" type="number" min="0" step="1" value="5" disabled>
+                </label>
+                <label>
+                  <span>Modalita verifica</span>
+                  <select id="assignmentIntegrityMode" disabled aria-label="Modalita verifica e integrita">
+                    <option value="normal">Normale</option>
+                    <option value="controlled">Controllata: log focus e blocco copia/incolla nella GUI</option>
+                    <option value="kiosk">Kiosk/lab gestito futuro</option>
+                  </select>
+                </label>
+              </div>
               <div class="generateActions wideField">
                 <button id="assignmentAiAskBtn" type="button" disabled title="Inviera prompt e contesto al provider AI selezionato quando l'adapter sara collegato.">Chiedi modifica</button>
               </div>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -126,65 +126,107 @@
       <div class="panelHead">
         <div>
           <h2>Assegna activity</h2>
-          <p class="status">Prepara activity, destinatari e scadenza. Per ora l'assegnazione reale e' solo in anteprima e non scrive nei repository studenti.</p>
+          <p class="status">Segui gli step per scegliere activity, destinatari, date, anteprima e conferma. Le proposte AI saranno sempre modificabili dal docente prima della pubblicazione.</p>
         </div>
       </div>
-      <div class="generateGrid">
-        <label>
-          <span>Scegli activity</span>
-          <select id="activitySelect" aria-label="Scegli activity">
-            <option value="">Caricamento activity...</option>
-          </select>
-        </label>
-        <label>
-          <span>Activity JSON</span>
-          <input id="activityPath" type="text" value="examples/assignment_tracking/demo_activity.json">
-        </label>
-        <label>
-          <span>Classe da roster</span>
-          <select id="classRosterSelect" aria-label="Roster classi locali">
-            <option value="">Caricamento roster...</option>
-          </select>
-        </label>
-        <label>
-          <span>Classe</span>
-          <input id="classId" type="text" value="demo" placeholder="3A-TPSI">
-        </label>
-        <label>
-          <span>Etichetta classe</span>
-          <input id="classLabel" type="text" value="Classe demo" placeholder="3A TPSI">
-        </label>
-        <label>
-          <span>Team GitHub</span>
-          <input id="githubTeam" type="text" placeholder="3A-TPSI">
-        </label>
-        <label>
-          <span>Assegnato il</span>
-          <input id="assignedAt" type="text" value="2026-10-12T09:00:00+02:00">
-        </label>
-        <label>
-          <span>Scadenza</span>
-          <input id="dueAt" type="text" value="2026-10-19T23:59:00+02:00">
-        </label>
-        <label>
-          <span>Ora simulata opzionale</span>
-          <input id="nowAt" type="text" placeholder="2026-10-18T12:00:00+02:00">
-        </label>
-        <label class="wideField">
-          <span>Repository studenti locali, uno per riga</span>
-          <textarea id="targetsText" rows="4">examples/assignment_tracking/student_repos/rossi-mario
+      <div class="assignmentWizard" data-assignment-wizard>
+        <div class="assignmentWizardSteps" role="tablist" aria-label="Step assegnazione activity">
+          <button type="button" class="isActive" data-assignment-step-tab="activity" aria-selected="true">1 Activity</button>
+          <button type="button" data-assignment-step-tab="ai" aria-selected="false">2 AI</button>
+          <button type="button" data-assignment-step-tab="targets" aria-selected="false">3 Destinatari</button>
+          <button type="button" data-assignment-step-tab="dates" aria-selected="false">4 Date</button>
+          <button type="button" data-assignment-step-tab="preview" aria-selected="false">5 Anteprima</button>
+          <button type="button" data-assignment-step-tab="confirm" aria-selected="false">6 Conferma</button>
+        </div>
+
+        <section class="assignmentWizardStep isActive" data-assignment-step="activity">
+          <div class="generateGrid">
+            <label>
+              <span>Scegli activity</span>
+              <select id="activitySelect" aria-label="Scegli activity">
+                <option value="">Caricamento activity...</option>
+              </select>
+            </label>
+            <label class="wideField">
+              <span>Activity JSON</span>
+              <input id="activityPath" type="text" value="examples/assignment_tracking/demo_activity.json">
+            </label>
+          </div>
+        </section>
+
+        <section class="assignmentWizardStep" data-assignment-step="ai" hidden>
+          <div class="assignmentAiDraft">
+            <strong>Generazione AI assistita</strong>
+            <p>In arrivo: genera traccia, starter code, test, soluzione e rubric tramite provider AI o Codex. La proposta resta una bozza: il docente potra modificarla, rigenerare sezioni o scartarla prima di salvare e distribuire.</p>
+          </div>
+        </section>
+
+        <section class="assignmentWizardStep" data-assignment-step="targets" hidden>
+          <div class="generateGrid">
+            <label>
+              <span>Classe da roster</span>
+              <select id="classRosterSelect" aria-label="Roster classi locali">
+                <option value="">Caricamento roster...</option>
+              </select>
+            </label>
+            <label>
+              <span>Classe</span>
+              <input id="classId" type="text" value="demo" placeholder="3A-TPSI">
+            </label>
+            <label>
+              <span>Etichetta classe</span>
+              <input id="classLabel" type="text" value="Classe demo" placeholder="3A TPSI">
+            </label>
+            <label>
+              <span>Team GitHub</span>
+              <input id="githubTeam" type="text" placeholder="3A-TPSI">
+            </label>
+            <label class="wideField">
+              <span>Repository studenti locali, uno per riga</span>
+              <textarea id="targetsText" rows="4">examples/assignment_tracking/student_repos/rossi-mario
 examples/assignment_tracking/student_repos/bianchi-luca
 examples/assignment_tracking/student_repos/verdi-anna</textarea>
-        </label>
-        <p id="rosterStatus" class="status wideField" aria-live="polite"></p>
-      </div>
-      <div class="generateActions">
-        <button id="previewAssignmentBtn" type="button" title="Mostra cosa verrebbe assegnato agli studenti senza scrivere nei repository.">Anteprima assegnazione</button>
-        <button id="saveAssignmentBtn" type="button" class="primary" title="Salva la consegna per classe, team o studenti senza distribuire ancora asset nei repository.">Salva assegnazione</button>
-        <button id="distributeAssignmentBtn" type="button" title="Copia traccia, README e asset studente nelle cartelle dei repository target.">Distribuisci ai target</button>
-      </div>
-      <div id="assignmentPlanPreview" class="assignmentPlanPreview" aria-live="polite">
-        <p class="status">Usa l'anteprima per verificare target e asset prima di assegnare una activity.</p>
+            </label>
+            <p id="rosterStatus" class="status wideField" aria-live="polite"></p>
+          </div>
+        </section>
+
+        <section class="assignmentWizardStep" data-assignment-step="dates" hidden>
+          <div class="generateGrid">
+            <label>
+              <span>Assegnato il</span>
+              <input id="assignedAt" type="text" value="2026-10-12T09:00:00+02:00">
+            </label>
+            <label>
+              <span>Scadenza</span>
+              <input id="dueAt" type="text" value="2026-10-19T23:59:00+02:00">
+            </label>
+            <label>
+              <span>Ora simulata opzionale</span>
+              <input id="nowAt" type="text" placeholder="2026-10-18T12:00:00+02:00">
+            </label>
+          </div>
+        </section>
+
+        <section class="assignmentWizardStep" data-assignment-step="preview" hidden>
+          <div class="generateActions">
+            <button id="previewAssignmentBtn" type="button" class="primary" title="Mostra cosa verrebbe assegnato agli studenti senza scrivere nei repository.">Anteprima assegnazione</button>
+          </div>
+          <div id="assignmentPlanPreview" class="assignmentPlanPreview" aria-live="polite">
+            <p class="status">Usa l'anteprima per verificare target e asset prima di assegnare una activity.</p>
+          </div>
+        </section>
+
+        <section class="assignmentWizardStep" data-assignment-step="confirm" hidden>
+          <div class="assignmentAiDraft">
+            <strong>Conferma docente</strong>
+            <p>Salva la consegna nel registro docente e distribuisci gli asset solo dopo aver controllato activity, destinatari, date e anteprima.</p>
+          </div>
+          <div class="generateActions">
+            <button id="saveAssignmentBtn" type="button" class="primary" title="Salva la consegna per classe, team o studenti senza distribuire ancora asset nei repository.">Salva assegnazione</button>
+            <button id="distributeAssignmentBtn" type="button" title="Copia traccia, README e asset studente nelle cartelle dei repository target.">Distribuisci ai target</button>
+          </div>
+        </section>
       </div>
     </section>
 

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -228,6 +228,8 @@ const els = {
   saveAssignmentBtn: document.querySelector("#saveAssignmentBtn"),
   distributeAssignmentBtn: document.querySelector("#distributeAssignmentBtn"),
   assignmentPlanPreview: document.querySelector("#assignmentPlanPreview"),
+  assignmentStepTabs: document.querySelectorAll("[data-assignment-step-tab]"),
+  assignmentSteps: document.querySelectorAll("[data-assignment-step]"),
   generateReportBtn: document.querySelector("#generateReportBtn"),
   panels: document.querySelectorAll("main.layout .panel"),
 };
@@ -2271,6 +2273,19 @@ function assignmentPlanPayload() {
   };
 }
 
+function setAssignmentWizardStep(step) {
+  const selectedStep = step || "activity";
+  els.assignmentStepTabs.forEach((button) => {
+    const isActive = button.dataset.assignmentStepTab === selectedStep;
+    button.classList.toggle("isActive", isActive);
+    button.setAttribute("aria-selected", isActive ? "true" : "false");
+  });
+  els.assignmentSteps.forEach((section) => {
+    section.hidden = section.dataset.assignmentStep !== selectedStep;
+    section.classList.toggle("isActive", section.dataset.assignmentStep === selectedStep);
+  });
+}
+
 function assignmentRecordPayload() {
   return {
     activity_path: els.activityPath.value,
@@ -3215,6 +3230,9 @@ els.reloadBtn.addEventListener("click", async () => {
   await loadOverview();
 });
 els.resetPanelOrderBtn.addEventListener("click", resetPanelOrder);
+els.assignmentStepTabs.forEach((button) => {
+  button.addEventListener("click", () => setAssignmentWizardStep(button.dataset.assignmentStepTab));
+});
 els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
 els.saveAssignmentBtn?.addEventListener("click", saveAssignmentRecord);
 els.distributeAssignmentBtn?.addEventListener("click", distributeAssignment);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -410,6 +410,36 @@ function formatDate(value) {
   });
 }
 
+function timezoneOffset(date) {
+  const offset = -date.getTimezoneOffset();
+  const sign = offset >= 0 ? "+" : "-";
+  const absolute = Math.abs(offset);
+  const hours = String(Math.floor(absolute / 60)).padStart(2, "0");
+  const minutes = String(absolute % 60).padStart(2, "0");
+  return `${sign}${hours}:${minutes}`;
+}
+
+function dateTimeInputToIso(value) {
+  const trimmed = String(value || "").trim();
+  if (!trimmed) return "";
+  if (/[zZ]|[+-]\d{2}:\d{2}$/.test(trimmed)) return trimmed;
+  const withSeconds = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(trimmed) ? `${trimmed}:00` : trimmed;
+  const date = new Date(withSeconds);
+  if (Number.isNaN(date.getTime())) return trimmed;
+  return `${withSeconds}${timezoneOffset(date)}`;
+}
+
+function isoToDateTimeInput(value) {
+  const date = new Date(value || "");
+  if (Number.isNaN(date.getTime())) return "";
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
 function classValue(entity) {
   return entity?.class_label || entity?.class_id || entity?.github_team || "classe non indicata";
 }
@@ -811,7 +841,7 @@ function reportAssignmentSummaryItems() {
     ["Activity", currentActivityLabel()],
     ["Classe", els.classId.value.trim() || "-"],
     ["Team", els.githubTeam.value.trim() || "-"],
-    ["Scadenza", els.dueAt.value.trim() ? formatDate(els.dueAt.value) : "-"],
+    ["Scadenza", els.dueAt.value.trim() ? formatDate(dateTimeInputToIso(els.dueAt.value)) : "-"],
     ["Target", targetLineCount()],
     ["Output registro", els.outputName.value.trim() || "-"],
   ];
@@ -1476,7 +1506,8 @@ async function loadActivities() {
 }
 
 async function loadAssignments() {
-  const query = els.nowAt?.value.trim() ? `?now=${encodeURIComponent(els.nowAt.value.trim())}` : "";
+  const now = dateTimeInputToIso(els.nowAt?.value);
+  const query = now ? `?now=${encodeURIComponent(now)}` : "";
   const payload = await api(`/api/assignments${query}`);
   state.assignments = payload.assignments || [];
   state.dueAssignments = (payload.due_without_register || []).map((item) => item.assignment || item);
@@ -1538,8 +1569,8 @@ function applyAssignmentToGenerateForm(assignmentId) {
   els.classId.value = assignment.class_id || "";
   els.classLabel.value = assignment.class_label || assignment.class_id || "";
   els.githubTeam.value = assignment.github_team || "";
-  els.assignedAt.value = assignment.assigned_at || "";
-  els.dueAt.value = assignment.due_at || "";
+  els.assignedAt.value = isoToDateTimeInput(assignment.assigned_at);
+  els.dueAt.value = isoToDateTimeInput(assignment.due_at);
   els.outputName.value = assignmentOutputName(assignment);
   const targetLines = (Array.isArray(assignment.targets) ? assignment.targets : [])
     .map(assignmentTargetLine)
@@ -2292,9 +2323,9 @@ function assignmentRecordPayload() {
     class_id: els.classId.value,
     class_label: els.classLabel.value,
     github_team: els.githubTeam.value,
-    assigned_at: els.assignedAt.value,
-    due_at: els.dueAt.value,
-    now: els.nowAt.value,
+    assigned_at: dateTimeInputToIso(els.assignedAt.value),
+    due_at: dateTimeInputToIso(els.dueAt.value),
+    now: dateTimeInputToIso(els.nowAt.value),
     targets_text: els.targetsText.value,
     overwrite: false,
   };
@@ -2459,9 +2490,9 @@ async function generateReport() {
         class_id: els.classId.value,
         class_label: els.classLabel.value,
         github_team: els.githubTeam.value,
-        assigned_at: els.assignedAt.value,
-        due_at: els.dueAt.value,
-        now: els.nowAt.value,
+        assigned_at: dateTimeInputToIso(els.assignedAt.value),
+        due_at: dateTimeInputToIso(els.dueAt.value),
+        now: dateTimeInputToIso(els.nowAt.value),
         targets_text: els.targetsText.value,
         assignment_id: state.selectedAssignmentId,
       }),


### PR DESCRIPTION
﻿## Cosa cambia
- Trasforma il pannello `Assegna activity` in un wizard guidato a step.
- Mantiene i campi e le azioni esistenti, ma li distribuisce in: Activity, AI, Destinatari, Date, Anteprima e Conferma.
- Introduce uno step AI placeholder per esplicitare il flusso futuro: provider AI o Codex possono generare una bozza, ma il docente puo' sempre modificarla, rigenerarla o scartarla prima della pubblicazione.

## Impatto
- Nessuna modifica backend in questa PR.
- Il flusso esistente di anteprima, salvataggio assegnazione e distribuzione resta collegato agli stessi `id` HTML.
- Il docente ha un percorso piu' guidato e meno denso per creare/assegnare activity.

## Verifiche
- `python -m pytest tests/test_assignment_dashboard_frontend.py tests/test_course_board_server.py tests/test_assignment_records.py tests/test_assign_activity.py`
- `git diff --check`
