### PR TITLE
Aggiunge anteprima pacchetto AI activity

### DIFF
--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -359,6 +359,8 @@ Prima di chiamare un provider AI, TheBitLab dovrebbe costruire un bundle esplici
 
 Lo stesso bundle deve poter essere usato da adapter diversi: API provider, Codex locale, workflow manuale copia/incolla o provider futuri.
 
+Nella dashboard docente il primo passo operativo e l'anteprima del pacchetto: il backend costruisce il JSON con prompt, contesto, target e contenuti dei file dichiarati negli asset, ma non chiama ancora provider reali e non consuma token. Questo permette di verificare quali dati uscirebbero dalla piattaforma prima di collegare adapter AI/Codex.
+
 ## Correzione
 
 Il campo `correzione` indica quali controlli sono previsti.

--- a/scripts/activity_ai_package.py
+++ b/scripts/activity_ai_package.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from scripts import assign_activity, create_submission_scaffold
+from scripts.thebitlab_contracts import normalize_activity
+
+MAX_AI_PACKAGE_FILE_BYTES = 128 * 1024
+
+
+def safe_asset_path(activity_path: Path, asset_path: str) -> Path:
+    """Return a safe path for an activity asset below the activity folder."""
+
+    clean_path = Path(str(asset_path).strip())
+    if not str(clean_path):
+        raise ValueError("Asset senza path.")
+    if clean_path.is_absolute() or ".." in clean_path.parts:
+        raise ValueError(f"Asset path non consentito: {asset_path}")
+    root = activity_path.resolve().parent
+    resolved = (root / clean_path).resolve()
+    resolved.relative_to(root)
+    return resolved
+
+
+def read_asset_content(activity_path: Path, asset: dict[str, Any]) -> dict[str, Any]:
+    """Return file metadata and content for one AI package asset."""
+
+    path = str(asset.get("path", "")).strip()
+    target_path = str(asset.get("target_path", path)).strip()
+    visibility = create_submission_scaffold.asset_visibility(asset)
+    item = {
+        "path": path,
+        "target_path": target_path,
+        "role": str(asset.get("type", "")).strip() or "material",
+        "visibility": visibility,
+        "description": str(asset.get("description", "")).strip(),
+        "included": False,
+        "content": "",
+        "size": 0,
+    }
+    if not path:
+        item["error"] = "asset senza path"
+        return item
+    try:
+        resolved = safe_asset_path(activity_path, path)
+    except ValueError as error:
+        item["error"] = str(error)
+        return item
+    if not resolved.is_file():
+        item["error"] = "file non trovato"
+        return item
+    size = resolved.stat().st_size
+    item["size"] = size
+    if size > MAX_AI_PACKAGE_FILE_BYTES:
+        item["error"] = f"file troppo grande per anteprima AI ({size} byte)"
+        return item
+    try:
+        item["content"] = resolved.read_text(encoding="utf-8-sig")
+    except UnicodeDecodeError:
+        item["error"] = "file non testuale"
+        return item
+    item["included"] = True
+    return item
+
+
+def activity_files_for_ai(activity_path: Path, activity: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the declared activity files that can be sent to an AI adapter."""
+
+    assets = activity.get("assets")
+    if not isinstance(assets, list):
+        return []
+    files = []
+    for asset in assets:
+        if isinstance(asset, dict):
+            files.append(read_asset_content(activity_path, asset))
+    return files
+
+
+def build_activity_ai_package(
+    *,
+    activity_path: Path,
+    targets: list[Path],
+    prompt: str,
+    provider: str,
+    student_budget: int | None = None,
+    integrity_mode: str = "normal",
+    source_name: str | None = None,
+    language: str | None = None,
+    thebitlab_ref: str = create_submission_scaffold.DEFAULT_THEBITLAB_REF,
+) -> dict[str, Any]:
+    """Build the write-free package that would be sent to an AI adapter."""
+
+    if not activity_path.is_file():
+        raise FileNotFoundError(f"Activity non trovata: {activity_path}")
+    activity = create_submission_scaffold.load_activity(activity_path)
+    normalized = normalize_activity(activity)
+    course_context = {}
+    if isinstance(activity.get("context"), dict):
+        course_context.update(activity["context"])
+    if isinstance(activity.get("contesto"), dict):
+        course_context.update(activity["contesto"])
+    plan = assign_activity.build_assignment_plan(
+        activity_path=activity_path,
+        targets=targets,
+        source_name=source_name,
+        language=language,
+        thebitlab_ref=thebitlab_ref,
+        overwrite=False,
+    )
+    return {
+        "schema_version": "activity_ai_package.v1",
+        "task": "generate_or_refine_activity",
+        "provider": provider or "codex",
+        "prompt": prompt.strip(),
+        "activity": {
+            "id": normalized.get("id", ""),
+            "title": normalized.get("title", ""),
+            "kind": normalized.get("kind", ""),
+            "difficulty": normalized.get("difficulty", ""),
+            "topics": normalized.get("topics", []),
+            "instructions": normalized.get("instructions", ""),
+            "student_support_mode": normalized.get("student_support_mode", ""),
+        },
+        "course_context": course_context,
+        "assignment": {
+            "targets": plan.targets,
+            "student_assets": plan.student_assets,
+            "teacher_assets": plan.teacher_assets,
+            "language": plan.language,
+            "source_name": plan.source_name,
+        },
+        "files": activity_files_for_ai(activity_path, activity),
+        "policy": {
+            "student_budget": max(0, int(student_budget or 0)),
+            "integrity_mode": integrity_mode or "normal",
+            "teacher_review_required": True,
+            "no_provider_call": True,
+        },
+        "teacher_review": {
+            "status": "draft",
+            "required": True,
+        },
+    }

--- a/scripts/activity_ai_package.py
+++ b/scripts/activity_ai_package.py
@@ -9,6 +9,28 @@ from scripts.thebitlab_contracts import normalize_activity
 MAX_AI_PACKAGE_FILE_BYTES = 128 * 1024
 
 
+def ai_target_id(index: int) -> str:
+    """Return a stable pseudonymous target id for AI package previews."""
+
+    return f"target-{index + 1:03d}"
+
+
+def minimize_assignment_targets(targets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return target metadata without local filesystem details."""
+
+    minimized = []
+    for index, target in enumerate(targets):
+        target_id = ai_target_id(index)
+        raw_target = str(target.get("target", "")).strip()
+        display_name = Path(raw_target).name if raw_target else target_id
+        minimized.append({
+            "target_id": target_id,
+            "display_name": display_name or target_id,
+            "exists": bool(target.get("exists", False)),
+        })
+    return minimized
+
+
 def safe_asset_path(activity_path: Path, asset_path: str) -> Path:
     """Return a safe path for an activity asset below the activity folder."""
 
@@ -124,7 +146,7 @@ def build_activity_ai_package(
         },
         "course_context": course_context,
         "assignment": {
-            "targets": plan.targets,
+            "targets": minimize_assignment_targets(plan.targets),
             "student_assets": plan.student_assets,
             "teacher_assets": plan.teacher_assets,
             "language": plan.language,

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -35,6 +35,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts import (
+    activity_ai_package,
     assignment_records,
     assign_activity,
     create_activity,
@@ -507,6 +508,27 @@ def preview_activity_assignment(payload: dict) -> dict:
         overwrite=bool(payload.get("overwrite", False)),
     )
     return {"ok": True, "plan": plan.to_dict()}
+
+
+def preview_activity_ai_package(payload: dict) -> dict:
+    """Return the write-free AI package for the selected activity and targets."""
+
+    activity_path = resolve_local_path(payload.get("activity_path", ""), "activity_path")
+    if not activity_path.is_file():
+        raise FileNotFoundError(f"Activity non trovata: {activity_path}")
+    targets = read_assignment_target_paths_from_text(str(payload.get("targets_text", "")))
+    package = activity_ai_package.build_activity_ai_package(
+        activity_path=activity_path,
+        targets=targets,
+        prompt=str(payload.get("prompt", "")),
+        provider=str(payload.get("provider", "codex")),
+        student_budget=int(payload.get("student_budget", 0) or 0),
+        integrity_mode=str(payload.get("integrity_mode", "normal")),
+        source_name=payload.get("source_name") or None,
+        language=payload.get("language") or None,
+        thebitlab_ref=payload.get("thebitlab_ref") or create_submission_scaffold.DEFAULT_THEBITLAB_REF,
+    )
+    return {"ok": True, "package": package}
 
 
 def distribute_activity_assignment(payload: dict) -> dict:
@@ -2028,6 +2050,20 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/activities/assignment-plan":
             try:
                 self.write_json(preview_activity_assignment(payload))
+            except FileNotFoundError as error:
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/activities/ai-package":
+            try:
+                self.write_json(preview_activity_ai_package(payload))
             except FileNotFoundError as error:
                 self.send_response(404)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -808,6 +808,7 @@ def test_preview_assignment_ai_package_posts_bundle_request_and_renders_json() -
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Somma in Python/);
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /nessuna chiamata AI/);
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /JSON pacchetto/);
+          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /starter/);
           assert.match(tested.els.assignmentAiDraftText.value, /activity_ai_package\\.v1/);
           assert.match(tested.els.status.textContent, /nessuna chiamata provider/);
         })();

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -809,7 +809,7 @@ def test_preview_assignment_ai_package_posts_bundle_request_and_renders_json() -
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /nessuna chiamata AI/);
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /JSON pacchetto/);
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /starter/);
-          assert.match(tested.els.assignmentAiDraftText.value, /activity_ai_package\\.v1/);
+          assert.equal(tested.els.assignmentAiDraftText.value, "");
           assert.match(tested.els.status.textContent, /nessuna chiamata provider/);
         })();
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -251,6 +251,37 @@ def run_dashboard_js(assertions: str) -> None:
               can_assign: false,
             }},
           }};
+          if (path === "/api/activities/ai-package") return {{
+            ok: true,
+            package: {{
+              schema_version: "activity_ai_package.v1",
+              provider: "codex",
+              prompt: "Aggiungi test sui negativi",
+              activity: {{
+                id: "python-base-somma-001",
+                title: "Somma in Python",
+                kind: "compito-casa",
+              }},
+              files: [
+                {{
+                  path: "starter/main.py",
+                  target_path: "main.py",
+                  role: "starter",
+                  visibility: "student",
+                  included: true,
+                  content: "print('starter')\\n",
+                  size: 17,
+                }},
+              ],
+              policy: {{
+                student_budget: 5,
+                integrity_mode: "normal",
+                teacher_review_required: true,
+                no_provider_call: true,
+              }},
+              teacher_review: {{ status: "draft", required: true }},
+            }},
+          }};
           if (path === "/api/activities") return {{ activities: [] }};
           if (path === "/api/activities/save") return {{
             ok: true,
@@ -340,13 +371,16 @@ def run_dashboard_js(assertions: str) -> None:
         syncActivityAuthorIdSuggestion,
         renderActivityAuthorMetadataSelects,
         assignmentPlanPayload,
+        assignmentAiPackagePayload,
         assignmentRecordPayload,
         renderAssignmentAssetList,
         renderAssignmentTargetList,
         renderAssignmentPlan,
+        renderAssignmentAiPackage,
         setAssignmentWizardStep,
         assignmentPlanErrorMessage,
         previewAssignmentPlan,
+        previewAssignmentAiPackage,
         saveAssignmentRecord,
         distributeAssignment,
         generateReport,
@@ -727,6 +761,56 @@ def test_assignment_date_time_inputs_are_serialized_as_iso() -> None:
         assert.match(payload.due_at, /^2026-10-19T23:59:00[+-]\\d{2}:\\d{2}$/);
         assert.match(payload.now, /^2026-10-20T08:00:00[+-]\\d{2}:\\d{2}$/);
         assert.equal(tested.dateTimeInputToIso("2026-10-12T09:00:00+02:00"), "2026-10-12T09:00:00+02:00");
+        """
+    )
+
+
+def test_assignment_ai_package_payload_includes_prompt_policy_and_targets() -> None:
+    run_dashboard_js(
+        """
+        tested.els.activityPath.value = "activities/python-base-somma-001.json";
+        tested.els.targetsText.value = "students/rossi-mario";
+        tested.els.assignmentAiProvider.value = "codex";
+        tested.els.assignmentAiPrompt.value = "Aggiungi test sui negativi";
+        tested.els.assignmentAiStudentBudget.value = "7";
+        tested.els.assignmentIntegrityMode.value = "controlled";
+
+        const payload = tested.assignmentAiPackagePayload();
+
+        assert.equal(payload.activity_path, "activities/python-base-somma-001.json");
+        assert.equal(payload.targets_text, "students/rossi-mario");
+        assert.equal(payload.provider, "codex");
+        assert.equal(payload.prompt, "Aggiungi test sui negativi");
+        assert.equal(payload.student_budget, 7);
+        assert.equal(payload.integrity_mode, "controlled");
+        """
+    )
+
+
+def test_preview_assignment_ai_package_posts_bundle_request_and_renders_json() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.assignmentAiProvider.value = "codex";
+          tested.els.assignmentAiPrompt.value = "Aggiungi test sui negativi";
+          tested.els.assignmentAiStudentBudget.value = "5";
+          tested.els.assignmentIntegrityMode.value = "normal";
+
+          await tested.previewAssignmentAiPackage();
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/activities/ai-package");
+          assert.ok(call);
+          assert.equal(call.options.method, "POST");
+          const body = JSON.parse(call.options.body);
+          assert.equal(body.prompt, "Aggiungi test sui negativi");
+          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Somma in Python/);
+          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /nessuna chiamata AI/);
+          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /JSON pacchetto/);
+          assert.match(tested.els.assignmentAiDraftText.value, /activity_ai_package\\.v1/);
+          assert.match(tested.els.status.textContent, /nessuna chiamata provider/);
+        })();
         """
     )
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -249,6 +249,79 @@ def test_preview_activity_assignment_returns_plan_without_writing(tmp_path, monk
     assert not (target / "assignments").exists()
 
 
+def test_preview_activity_ai_package_returns_context_files_and_policy(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    activities_dir = tmp_path / "activities"
+    activities_dir.mkdir()
+    (activities_dir / "starter").mkdir()
+    (activities_dir / "tests").mkdir()
+    (activities_dir / "starter" / "main.py").write_text("print('starter')\n", encoding="utf-8")
+    (activities_dir / "tests" / "hidden.py").write_text("assert True\n", encoding="utf-8")
+    activity_path = activities_dir / "activity.json"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": "python-base-somma-001",
+                "titolo": "Somma in Python",
+                "tipo": "laboratorio",
+                "difficolta": "B",
+                "argomenti": ["variabili", "operatori"],
+                "linguaggio": "python",
+                "consegna": "Completa main.py.",
+                "contesto": {"percorso": "terzo-anno", "uda": "uda-input"},
+                "assets": [
+                    {"type": "starter", "path": "starter/main.py", "target_path": "main.py", "visibility": "student"},
+                    {"type": "hidden_test", "path": "tests/hidden.py", "visibility": "teacher"},
+                ],
+                "correzione": {
+                    "compila": True,
+                    "test": True,
+                    "sandbox": True,
+                    "ai_feedback": False,
+                },
+                "metriche": {
+                    "tempo_stimato_minuti": 20,
+                    "traccia_tempo_dichiarato": True,
+                    "traccia_sessioni_thebitlab": True,
+                    "traccia_eventi_didattici": True,
+                    "traccia_errori_compilazione": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    target = tmp_path / "students" / "rossi-mario"
+
+    response = course_board_server.preview_activity_ai_package(
+        {
+            "activity_path": "activities/activity.json",
+            "targets_text": "students/rossi-mario",
+            "prompt": "Aggiungi test sui negativi",
+            "provider": "codex",
+            "student_budget": 5,
+            "integrity_mode": "controlled",
+        }
+    )
+
+    package = response["package"]
+    assert response["ok"] is True
+    assert package["schema_version"] == "activity_ai_package.v1"
+    assert package["provider"] == "codex"
+    assert package["prompt"] == "Aggiungi test sui negativi"
+    assert package["activity"]["id"] == "python-base-somma-001"
+    assert package["course_context"]["uda"] == "uda-input"
+    assert package["assignment"]["targets"][0]["target"] == str(target.resolve())
+    assert package["files"][0]["path"] == "starter/main.py"
+    assert package["files"][0]["included"] is True
+    assert "starter" in package["files"][0]["content"]
+    assert package["files"][1]["visibility"] == "teacher"
+    assert package["policy"]["student_budget"] == 5
+    assert package["policy"]["integrity_mode"] == "controlled"
+    assert package["policy"]["no_provider_call"] is True
+    assert not (target / "assignments").exists()
+
+
 def test_save_assignment_record_persists_dashboard_assignment(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "TEACHER_ASSIGNMENTS_DIR", tmp_path / "teacher-assignments")

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -311,7 +311,15 @@ def test_preview_activity_ai_package_returns_context_files_and_policy(tmp_path, 
     assert package["prompt"] == "Aggiungi test sui negativi"
     assert package["activity"]["id"] == "python-base-somma-001"
     assert package["course_context"]["uda"] == "uda-input"
-    assert package["assignment"]["targets"][0]["target"] == str(target.resolve())
+    target_entry = package["assignment"]["targets"][0]
+    assert target_entry == {
+        "target_id": "target-001",
+        "display_name": "rossi-mario",
+        "exists": False,
+    }
+    assert "target" not in target_entry
+    assert "assignment_dir" not in target_entry
+    assert str(tmp_path) not in json.dumps(package["assignment"]["targets"])
     assert package["files"][0]["path"] == "starter/main.py"
     assert package["files"][0]["included"] is True
     assert "starter" in package["files"][0]["content"]

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -263,6 +263,26 @@ select {
   gap: .8rem;
 }
 
+.assignmentPackageJson {
+  margin-top: .9rem;
+}
+
+.assignmentPackageJson summary {
+  cursor: pointer;
+  color: var(--muted);
+  font-size: .84rem;
+}
+
+.assignmentPackageJson pre {
+  max-height: 18rem;
+  overflow: auto;
+  padding: .85rem;
+  border-radius: 8px;
+  background: #111111;
+  color: #f7f7f7;
+  font-size: .78rem;
+}
+
 .overviewFilters {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -189,11 +189,11 @@
               <div class="assignmentAiPolicy wideField">
                 <label>
                   <span>Budget AI per studente</span>
-                  <input id="assignmentAiStudentBudget" type="number" min="0" step="1" value="5" disabled>
+                  <input id="assignmentAiStudentBudget" type="number" min="0" step="1" value="5">
                 </label>
                 <label>
                   <span>Modalita verifica</span>
-                  <select id="assignmentIntegrityMode" disabled aria-label="Modalita verifica e integrita">
+                  <select id="assignmentIntegrityMode" aria-label="Modalita verifica e integrita">
                     <option value="normal">Normale</option>
                     <option value="controlled">Controllata: log focus e blocco copia/incolla nella GUI</option>
                     <option value="kiosk">Kiosk/lab gestito futuro</option>
@@ -201,12 +201,15 @@
                 </label>
               </div>
               <div class="generateActions wideField">
-                <button id="assignmentAiAskBtn" type="button" disabled title="Inviera prompt e contesto al provider AI selezionato quando l'adapter sara collegato.">Chiedi modifica</button>
+                <button id="assignmentAiAskBtn" type="button" title="Prepara il pacchetto JSON con prompt, contesto e file che verra inviato al provider AI quando l'adapter sara collegato.">Prepara pacchetto AI</button>
               </div>
               <label class="wideField">
                 <span>Bozza AI modificabile dal docente</span>
                 <textarea id="assignmentAiDraftText" rows="6" placeholder="Qui comparira la proposta AI. Il docente potra modificarla prima di salvare l'activity o distribuirla."></textarea>
               </label>
+              <div id="assignmentAiPackagePreview" class="assignmentPlanPreview wideField" aria-live="polite">
+                <p class="status">Prepara il pacchetto AI per controllare prompt, contesto e file prima di chiamare provider o Codex.</p>
+              </div>
             </div>
           </div>
         </section>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2362,9 +2362,6 @@ function renderAssignmentAiPackage(aiPackage) {
       <pre>${escapeHtml(JSON.stringify(aiPackage, null, 2))}</pre>
     </details>
   `;
-  if (els.assignmentAiDraftText) {
-    els.assignmentAiDraftText.value = JSON.stringify(aiPackage, null, 2);
-  }
 }
 
 function setAssignmentWizardStep(step) {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -230,6 +230,13 @@ const els = {
   assignmentPlanPreview: document.querySelector("#assignmentPlanPreview"),
   assignmentStepTabs: document.querySelectorAll("[data-assignment-step-tab]"),
   assignmentSteps: document.querySelectorAll("[data-assignment-step]"),
+  assignmentAiProvider: document.querySelector("#assignmentAiProvider"),
+  assignmentAiPrompt: document.querySelector("#assignmentAiPrompt"),
+  assignmentAiStudentBudget: document.querySelector("#assignmentAiStudentBudget"),
+  assignmentIntegrityMode: document.querySelector("#assignmentIntegrityMode"),
+  assignmentAiAskBtn: document.querySelector("#assignmentAiAskBtn"),
+  assignmentAiDraftText: document.querySelector("#assignmentAiDraftText"),
+  assignmentAiPackagePreview: document.querySelector("#assignmentAiPackagePreview"),
   generateReportBtn: document.querySelector("#generateReportBtn"),
   panels: document.querySelectorAll("main.layout .panel"),
 };
@@ -2304,6 +2311,62 @@ function assignmentPlanPayload() {
   };
 }
 
+function assignmentAiPackagePayload() {
+  return {
+    ...assignmentPlanPayload(),
+    provider: els.assignmentAiProvider?.value || "codex",
+    prompt: els.assignmentAiPrompt?.value || "",
+    student_budget: Number(els.assignmentAiStudentBudget?.value || 0),
+    integrity_mode: els.assignmentIntegrityMode?.value || "normal",
+  };
+}
+
+function renderAssignmentAiPackage(aiPackage) {
+  if (!els.assignmentAiPackagePreview) return;
+  if (!aiPackage) {
+    els.assignmentAiPackagePreview.innerHTML = '<p class="status">Prepara il pacchetto AI per controllare prompt, contesto e file prima di chiamare provider o Codex.</p>';
+    return;
+  }
+  const files = Array.isArray(aiPackage.files) ? aiPackage.files : [];
+  const includedFiles = files.filter((file) => file.included);
+  const skippedFiles = files.filter((file) => !file.included);
+  const promptStatus = aiPackage.prompt?.trim() ? "prompt incluso" : "prompt vuoto";
+  els.assignmentAiPackagePreview.innerHTML = `
+    <div class="assignmentPlanHeader">
+      <div>
+        <strong>${escapeHtml(aiPackage.activity?.title || aiPackage.activity?.id || "Pacchetto AI")}</strong>
+        <small>${escapeHtml(aiPackage.provider || "-")} - ${escapeHtml(aiPackage.schema_version || "-")} - ${escapeHtml(promptStatus)}</small>
+      </div>
+      ${badge("nessuna chiamata AI", "muted")}
+    </div>
+    <div class="assignmentPlanGrid">
+      <section>
+        <h3>File inclusi</h3>
+        ${renderAssignmentAssetList(includedFiles, "Nessun file incluso nel pacchetto.")}
+      </section>
+      <section>
+        <h3>File esclusi o mancanti</h3>
+        ${renderAssignmentAssetList(skippedFiles.map((file) => ({ ...file, description: file.error || file.description })), "Nessun file escluso.")}
+      </section>
+      <section>
+        <h3>Policy</h3>
+        <ul class="assignmentPlanList">
+          <li><strong>Budget studente</strong><small>${escapeHtml(aiPackage.policy?.student_budget ?? 0)} richieste</small></li>
+          <li><strong>Modalita verifica</strong><small>${escapeHtml(aiPackage.policy?.integrity_mode || "normal")}</small></li>
+          <li><strong>Revisione docente</strong><small>${aiPackage.teacher_review?.required ? "obbligatoria" : "non richiesta"}</small></li>
+        </ul>
+      </section>
+    </div>
+    <details class="assignmentPackageJson">
+      <summary>JSON pacchetto</summary>
+      <pre>${escapeHtml(JSON.stringify(aiPackage, null, 2))}</pre>
+    </details>
+  `;
+  if (els.assignmentAiDraftText) {
+    els.assignmentAiDraftText.value = JSON.stringify(aiPackage, null, 2);
+  }
+}
+
 function setAssignmentWizardStep(step) {
   const selectedStep = step || "activity";
   els.assignmentStepTabs.forEach((button) => {
@@ -2429,6 +2492,31 @@ async function previewAssignmentPlan() {
     setStatus(`Anteprima assegnazione non disponibile: ${message}`);
   } finally {
     els.previewAssignmentBtn.disabled = false;
+  }
+}
+
+async function previewAssignmentAiPackage() {
+  if (!els.assignmentAiAskBtn) return;
+  els.assignmentAiAskBtn.disabled = true;
+  setStatus("Preparazione pacchetto AI...");
+  if (els.assignmentAiPackagePreview) {
+    els.assignmentAiPackagePreview.innerHTML = '<p class="status">Preparazione pacchetto AI...</p>';
+  }
+  try {
+    const payload = await api("/api/activities/ai-package", {
+      method: "POST",
+      body: JSON.stringify(assignmentAiPackagePayload()),
+    });
+    renderAssignmentAiPackage(payload.package);
+    setStatus("Pacchetto AI pronto: nessuna chiamata provider eseguita.");
+  } catch (error) {
+    const message = assignmentPlanErrorMessage(error);
+    if (els.assignmentAiPackagePreview) {
+      els.assignmentAiPackagePreview.innerHTML = `<p class="status">Pacchetto AI non disponibile: ${escapeHtml(message)}</p>`;
+    }
+    setStatus(`Pacchetto AI non disponibile: ${message}`);
+  } finally {
+    els.assignmentAiAskBtn.disabled = false;
   }
 }
 
@@ -3265,6 +3353,7 @@ els.assignmentStepTabs.forEach((button) => {
   button.addEventListener("click", () => setAssignmentWizardStep(button.dataset.assignmentStepTab));
 });
 els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
+els.assignmentAiAskBtn?.addEventListener("click", previewAssignmentAiPackage);
 els.saveAssignmentBtn?.addEventListener("click", saveAssignmentRecord);
 els.distributeAssignmentBtn?.addEventListener("click", distributeAssignment);
 els.generateReportBtn.addEventListener("click", generateReport);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2402,7 +2402,7 @@ function renderAssignmentAssetList(assets, emptyLabel) {
       ${items.map((asset) => `
         <li>
           <strong>${escapeHtml(asset.target_path || asset.path || "-")}</strong>
-          ${badge(asset.type || "-", asset.visibility === "student" ? "ok" : "muted")}
+          ${badge(asset.type || asset.role || "-", asset.visibility === "student" ? "ok" : "muted")}
           <small>${escapeHtml(asset.description || asset.path || "")}</small>
         </li>
       `).join("")}


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `scripts/activity_ai_package.py`, un builder testabile per il pacchetto AI dell'activity.
- Espone `POST /api/activities/ai-package` nel server locale.
- Aggiunge nella dashboard docente il bottone **Prepara pacchetto AI** nello step AI.
- Mostra una preview del bundle: file inclusi, file esclusi/mancanti, policy, budget, modalita verifica e JSON completo.
- Non chiama provider AI reali e non consuma token.

## Perché

Prima di collegare Codex/OpenAI/provider reali dobbiamo stabilizzare il contratto dei dati: prompt, contesto didattico, target, asset studente, file riservati docente e policy. Questa PR permette di ispezionare cosa uscirebbe dalla piattaforma prima di attivare un adapter AI.

## Verifiche

- `python -m pytest tests/test_course_board_server.py tests/test_assignment_dashboard_frontend.py tests/test_assign_activity.py tests/test_assignment_records.py`
- `python -m py_compile scripts/activity_ai_package.py scripts/course_board_server.py`
- `git diff --check`
