### PR TITLE
Apply AI activity drafts to authoring form

### DIFF
--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -363,6 +363,8 @@ Nella dashboard docente il primo passo operativo e l'anteprima del pacchetto: il
 
 L'adapter Codex locale usa lo stesso pacchetto sul backend della macchina docente: la dashboard invia la richiesta al server locale, il server esegue `codex exec` in modalita non interattiva e restituisce una bozza JSON modificabile dal docente. Le credenziali Codex non devono essere esposte nel browser o alle postazioni studente; l'output resta una bozza da rivedere, non una activity approvata automaticamente.
 
+Nel wizard docente la bozza AI/Codex puo essere applicata ai campi editabili della activity: titolo, id, tipo, difficolta, argomenti, consegna, tempo stimato e contesto quando presenti nel patch. Il docente deve controllare e salvare esplicitamente. I file e gli asset proposti dalla bozza restano visibili come proposta: il salvataggio automatico dei file generati, il caricamento da repository e l'upload verso GitHub/GitLab sono step successivi separati.
+
 ## Correzione
 
 Il campo `correzione` indica quali controlli sono previsti.

--- a/doc/ACTIVITIES_SCHEMA.md
+++ b/doc/ACTIVITIES_SCHEMA.md
@@ -365,6 +365,8 @@ L'adapter Codex locale usa lo stesso pacchetto sul backend della macchina docent
 
 Nel wizard docente la bozza AI/Codex puo essere applicata ai campi editabili della activity: titolo, id, tipo, difficolta, argomenti, consegna, tempo stimato e contesto quando presenti nel patch. Il docente deve controllare e salvare esplicitamente. I file e gli asset proposti dalla bozza restano visibili come proposta: il salvataggio automatico dei file generati, il caricamento da repository e l'upload verso GitHub/GitLab sono step successivi separati.
 
+Le iterazioni successive con AI/Codex non dipendono da una memoria implicita del provider. Se la textarea contiene una bozza JSON valida, la dashboard la invia nel campo `current_draft` insieme al nuovo prompt docente. L'adapter deve quindi rifinire la bozza corrente, conservando le parti non coinvolte dalla richiesta e modificando solo cio che il docente chiede.
+
 ## Correzione
 
 Il campo `correzione` indica quali controlli sono previsti.

--- a/scripts/activity_ai_package.py
+++ b/scripts/activity_ai_package.py
@@ -99,6 +99,18 @@ def activity_files_for_ai(activity_path: Path, activity: dict[str, Any]) -> list
     return files
 
 
+def ai_package_language(activity: dict[str, Any], explicit_language: str | None = None) -> str:
+    """Return a supported language for AI packaging, tolerating empty draft metadata."""
+
+    if explicit_language and str(explicit_language).strip():
+        return create_submission_scaffold.validate_language(explicit_language)
+    for key in ("linguaggio", "language"):
+        value = activity.get(key)
+        if value is not None and str(value).strip():
+            return create_submission_scaffold.validate_language(value)
+    return create_submission_scaffold.validate_language("c")
+
+
 def build_activity_ai_package(
     *,
     activity_path: Path,
@@ -126,7 +138,7 @@ def build_activity_ai_package(
         activity_path=activity_path,
         targets=targets,
         source_name=source_name,
-        language=language,
+        language=ai_package_language(activity, language),
         thebitlab_ref=thebitlab_ref,
         overwrite=False,
     )

--- a/scripts/codex_activity_adapter.py
+++ b/scripts/codex_activity_adapter.py
@@ -15,7 +15,7 @@ CODEX_ACTIVITY_DRAFT_SCHEMA: dict[str, Any] = {
     "properties": {
         "summary": {"type": "string"},
         "teacher_notes": {"type": "string"},
-        "activity_patch": {"type": "object"},
+        "activity_patch_json": {"type": "string"},
         "files": {
             "type": "array",
             "items": {
@@ -28,7 +28,7 @@ CODEX_ACTIVITY_DRAFT_SCHEMA: dict[str, Any] = {
                     "description": {"type": "string"},
                 },
                 "required": ["path", "role", "content"],
-                "additionalProperties": True,
+                "additionalProperties": False,
             },
         },
         "questions": {
@@ -40,8 +40,8 @@ CODEX_ACTIVITY_DRAFT_SCHEMA: dict[str, Any] = {
             "items": {"type": "string"},
         },
     },
-    "required": ["summary", "activity_patch", "files", "teacher_notes"],
-    "additionalProperties": True,
+    "required": ["summary", "activity_patch_json", "files", "teacher_notes", "questions", "warnings"],
+    "additionalProperties": False,
 }
 
 
@@ -53,7 +53,8 @@ def codex_activity_prompt() -> str:
         "Riceverai su stdin un JSON `activity_ai_package.v1` con prompt docente, contesto, policy e file. "
         "Non modificare file sul filesystem. Restituisci solo una bozza JSON conforme allo schema richiesto. "
         "La bozza deve essere modificabile dal docente e non deve dare per approvata nessuna decisione. "
-        "Quando proponi file, includi path relativo, ruolo, visibilita, descrizione e contenuto."
+        "Quando proponi file, includi path relativo, ruolo, visibilita, descrizione e contenuto. "
+        "Il campo activity_patch_json deve contenere una stringa JSON valida con le modifiche proposte alla activity."
     )
 
 
@@ -93,14 +94,29 @@ def normalize_activity_patch(activity_patch: dict[str, Any]) -> dict[str, Any]:
     return patch
 
 
+def activity_patch_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the activity patch from structured Codex output."""
+
+    if isinstance(payload.get("activity_patch"), dict):
+        return payload["activity_patch"]
+    patch_json = payload.get("activity_patch_json")
+    if not isinstance(patch_json, str) or not patch_json.strip():
+        raise ValueError("La risposta Codex non contiene `activity_patch_json` valido.")
+    try:
+        patch = json.loads(patch_json)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"`activity_patch_json` non e JSON valido: {error}") from error
+    if not isinstance(patch, dict):
+        raise ValueError("`activity_patch_json` deve contenere un oggetto JSON.")
+    return patch
+
+
 def validate_codex_activity_draft(payload: dict[str, Any]) -> dict[str, Any]:
     """Return a normalized Codex activity draft or raise ValueError."""
 
     if not isinstance(payload, dict):
         raise ValueError("La risposta Codex non e un oggetto JSON.")
-    if not isinstance(payload.get("activity_patch"), dict):
-        raise ValueError("La risposta Codex non contiene `activity_patch` valido.")
-    activity_patch = normalize_activity_patch(payload["activity_patch"])
+    activity_patch = normalize_activity_patch(activity_patch_from_payload(payload))
     files = payload.get("files", [])
     if files is None:
         files = []

--- a/scripts/codex_activity_adapter.py
+++ b/scripts/codex_activity_adapter.py
@@ -27,7 +27,7 @@ CODEX_ACTIVITY_DRAFT_SCHEMA: dict[str, Any] = {
                     "visibility": {"type": "string"},
                     "description": {"type": "string"},
                 },
-                "required": ["path", "role", "content"],
+                "required": ["path", "role", "content", "visibility", "description"],
                 "additionalProperties": False,
             },
         },

--- a/scripts/codex_activity_adapter.py
+++ b/scripts/codex_activity_adapter.py
@@ -53,6 +53,8 @@ def codex_activity_prompt() -> str:
         "Riceverai su stdin un JSON `activity_ai_package.v1` con prompt docente, contesto, policy e file. "
         "Non modificare file sul filesystem. Restituisci solo una bozza JSON conforme allo schema richiesto. "
         "La bozza deve essere modificabile dal docente e non deve dare per approvata nessuna decisione. "
+        "Se il pacchetto contiene current_draft, usalo come bozza corrente da rifinire: applica la nuova richiesta "
+        "del docente e conserva metadati e file non coinvolti dalla modifica. "
         "Quando proponi file, includi path relativo, ruolo, visibilita, descrizione e contenuto. "
         "Il campo activity_patch_json deve contenere una stringa JSON valida con le modifiche proposte alla activity."
     )

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -529,6 +529,9 @@ def preview_activity_ai_package(payload: dict) -> dict:
         language=payload.get("language") or None,
         thebitlab_ref=payload.get("thebitlab_ref") or create_submission_scaffold.DEFAULT_THEBITLAB_REF,
     )
+    current_draft = payload.get("current_draft")
+    if isinstance(current_draft, dict):
+        package["current_draft"] = current_draft
     return {"ok": True, "package": package}
 
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -813,6 +813,23 @@ def test_assignment_ai_package_payload_includes_prompt_policy_and_targets() -> N
     )
 
 
+def test_assignment_ai_package_payload_includes_current_teacher_draft() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignmentAiDraftText.value = JSON.stringify({
+          summary: "Prima bozza",
+          activity_patch: { titolo: "Somma guidata" },
+          files: [],
+        });
+
+        const payload = tested.assignmentAiPackagePayload();
+
+        assert.equal(payload.current_draft.summary, "Prima bozza");
+        assert.equal(payload.current_draft.activity_patch.titolo, "Somma guidata");
+        """
+    )
+
+
 def test_preview_assignment_ai_package_posts_bundle_request_and_renders_json() -> None:
     run_dashboard_js(
         """
@@ -837,6 +854,24 @@ def test_preview_assignment_ai_package_posts_bundle_request_and_renders_json() -
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /starter/);
           assert.equal(tested.els.assignmentAiDraftText.value, "");
           assert.match(tested.els.status.textContent, /nessuna chiamata provider/);
+        })();
+        """
+    )
+
+
+def test_generate_assignment_ai_draft_blocks_invalid_current_draft_json() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.assignmentAiProvider.value = "codex";
+          tested.els.assignmentAiDraftText.value = "{";
+
+          await tested.generateAssignmentAiDraft();
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/activities/ai-codex-draft");
+          assert.equal(call, undefined);
+          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Bozza AI non valida/);
+          assert.match(tested.els.status.textContent, /Bozza AI non valida/);
         })();
         """
     )

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -398,6 +398,7 @@ def run_dashboard_js(assertions: str) -> None:
         renderAssignmentPlan,
         renderAssignmentAiPackage,
         renderAssignmentCodexDraft,
+        applyAssignmentAiDraftToActivityForm,
         setAssignmentWizardStep,
         assignmentPlanErrorMessage,
         previewAssignmentPlan,
@@ -747,6 +748,7 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert 'id="assignmentAiPrompt"' in assignment_section
     assert 'id="assignmentAiDraftText"' in assignment_section
     assert 'id="assignmentAiGenerateBtn"' in assignment_section
+    assert 'id="assignmentAiApplyDraftBtn"' in assignment_section
     assert "Genera bozza" in assignment_section
     assert "Contesto da inviare" in assignment_section
     assert "Asset, starter file, test e soluzione" in assignment_section
@@ -862,6 +864,56 @@ def test_generate_assignment_ai_draft_with_codex_posts_request_and_fills_teacher
           assert.match(tested.els.status.textContent, /Bozza Codex pronta/);
         })();
         """
+    )
+
+
+def test_apply_assignment_ai_draft_to_activity_form_keeps_teacher_in_control() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignmentAiDraftText.value = JSON.stringify({
+          summary: "Bozza Codex pronta",
+          activity_patch: {
+            id: "somma-negativi-python",
+            titolo: "Somma con numeri negativi",
+            tipo: "laboratorio",
+            difficolta: "C",
+            argomenti: ["variabili", "input"],
+            consegna: "Scrivi un programma che somma due interi anche negativi.",
+            metriche: { tempo_stimato_minuti: 35 },
+            assets: [{ type: "starter", path: "starter/main.py", target_path: "main.py" }],
+          },
+          files: [{ path: "starter/main.py", role: "starter", content: "print(0)\\n" }],
+          teacher_notes: "Controllare la rubric.",
+        });
+
+        const applied = tested.applyAssignmentAiDraftToActivityForm();
+
+        assert.equal(applied, true);
+        assert.equal(tested.els.activityAuthorTitle.value, "Somma con numeri negativi");
+        assert.equal(tested.els.activityAuthorId.value, "somma-negativi-python");
+        assert.equal(tested.els.activityAuthorKind.value, "laboratorio");
+        assert.equal(tested.els.activityAuthorDifficulty.value, "C");
+        assert.equal(tested.els.activityAuthorTopics.value, "variabili, input");
+        assert.equal(tested.els.activityAuthorPrompt.value, "Scrivi un programma che somma due interi anche negativi.");
+        assert.equal(tested.els.activityAuthorMinutes.value, "35");
+        assert.match(tested.els.activityAuthorStatus.textContent, /Bozza AI applicata/);
+        assert.match(tested.els.activityAuthorStatus.textContent, /Gli asset non vengono ancora salvati automaticamente/);
+        assert.match(tested.els.status.textContent, /docente puo ancora modificare tutto/);
+      """
+    )
+
+
+def test_apply_assignment_ai_draft_reports_invalid_json() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignmentAiDraftText.value = "{";
+
+        const applied = tested.applyAssignmentAiDraftToActivityForm();
+
+        assert.equal(applied, false);
+        assert.match(tested.els.activityAuthorStatus.textContent, /Bozza AI non applicata/);
+        assert.match(tested.els.status.textContent, /Bozza AI non valida/);
+      """
     )
 
 

--- a/tests/test_codex_activity_adapter.py
+++ b/tests/test_codex_activity_adapter.py
@@ -64,6 +64,9 @@ def test_codex_activity_draft_schema_is_closed_for_structured_outputs() -> None:
 
     assert schema["additionalProperties"] is False
     assert schema["properties"]["files"]["items"]["additionalProperties"] is False
+    assert set(schema["properties"]["files"]["items"]["required"]) == set(
+        schema["properties"]["files"]["items"]["properties"]
+    )
     assert "activity_patch_json" in schema["required"]
     assert "activity_patch" not in schema["properties"]
 

--- a/tests/test_codex_activity_adapter.py
+++ b/tests/test_codex_activity_adapter.py
@@ -28,7 +28,7 @@ def test_run_codex_activity_draft_invokes_codex_exec_with_schema(tmp_path, monke
                 {
                     "summary": "Bozza pronta",
                     "teacher_notes": "Controllare rubric.",
-                    "activity_patch": {"titolo": "Somma con negativi"},
+                    "activity_patch_json": json.dumps({"titolo": "Somma con negativi"}),
                     "files": [{"path": "main.py", "role": "starter", "content": "print(0)\n"}],
                     "questions": [],
                     "warnings": [],
@@ -57,6 +57,15 @@ def test_run_codex_activity_draft_invokes_codex_exec_with_schema(tmp_path, monke
     assert captured["args"][3:5] == ["--sandbox", "read-only"]
     assert "--output-schema" in captured["args"]
     assert "activity_ai_package.v1" in captured["input"]
+
+
+def test_codex_activity_draft_schema_is_closed_for_structured_outputs() -> None:
+    schema = codex_activity_adapter.CODEX_ACTIVITY_DRAFT_SCHEMA
+
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["files"]["items"]["additionalProperties"] is False
+    assert "activity_patch_json" in schema["required"]
+    assert "activity_patch" not in schema["properties"]
 
 
 def test_run_codex_activity_draft_reports_missing_cli(monkeypatch, tmp_path) -> None:
@@ -98,6 +107,22 @@ def test_validate_codex_activity_draft_normalizes_relative_file_paths() -> None:
     )
 
     assert draft["files"][0]["path"] == "starter/main.py"
+
+
+def test_validate_codex_activity_draft_decodes_activity_patch_json() -> None:
+    draft = codex_activity_adapter.validate_codex_activity_draft(
+        {
+            "summary": "Bozza",
+            "teacher_notes": "Note",
+            "activity_patch_json": json.dumps({"titolo": "Somma", "argomenti": ["array"]}),
+            "files": [],
+            "questions": [],
+            "warnings": [],
+        }
+    )
+
+    assert draft["activity_patch"]["titolo"] == "Somma"
+    assert draft["activity_patch"]["argomenti"] == ["array"]
 
 
 def test_validate_codex_activity_draft_normalizes_activity_patch_asset_paths() -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -437,6 +437,11 @@ def test_preview_activity_ai_codex_draft_uses_local_adapter(tmp_path, monkeypatc
             "targets_text": "students/rossi-mario",
             "prompt": "Aggiungi test sui negativi",
             "provider": "codex",
+            "current_draft": {
+                "summary": "Prima bozza",
+                "activity_patch": {"titolo": "Somma guidata"},
+                "files": [],
+            },
         }
     )
 
@@ -444,6 +449,7 @@ def test_preview_activity_ai_codex_draft_uses_local_adapter(tmp_path, monkeypatc
     assert response["adapter"] == "codex_exec"
     assert response["draft"]["activity_patch"]["titolo"] == "Somma con negativi"
     assert "raw" not in response
+    assert captured["package"]["current_draft"]["summary"] == "Prima bozza"
     assert captured["package"]["prompt"] == "Aggiungi test sui negativi"
     assert captured["cwd"] == tmp_path
     assert captured["codex_command"] == "codex-test"

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -330,6 +330,53 @@ def test_preview_activity_ai_package_returns_context_files_and_policy(tmp_path, 
     assert not (target / "assignments").exists()
 
 
+def test_preview_activity_ai_package_tolerates_empty_draft_language(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    activities_dir = tmp_path / "activities"
+    activities_dir.mkdir()
+    activity_path = activities_dir / "activity.json"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": "activity-senza-linguaggio",
+                "titolo": "Bozza senza linguaggio",
+                "tipo": "laboratorio",
+                "difficolta": "B",
+                "argomenti": ["variabili"],
+                "linguaggio": "",
+                "consegna": "Completa la bozza.",
+                "correzione": {
+                    "compila": True,
+                    "test": True,
+                    "sandbox": True,
+                    "ai_feedback": False,
+                },
+                "metriche": {
+                    "tempo_stimato_minuti": 20,
+                    "traccia_tempo_dichiarato": True,
+                    "traccia_sessioni_thebitlab": True,
+                    "traccia_eventi_didattici": True,
+                    "traccia_errori_compilazione": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    response = course_board_server.preview_activity_ai_package(
+        {
+            "activity_path": "activities/activity.json",
+            "targets_text": "students/rossi-mario",
+            "prompt": "Genera starter file",
+            "provider": "codex",
+        }
+    )
+
+    assert response["ok"] is True
+    assert response["package"]["assignment"]["language"] == "c"
+
+
 def test_preview_activity_ai_codex_draft_uses_local_adapter(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setenv("CODEX_COMMAND", "codex-test")

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -203,6 +203,7 @@
               <div class="generateActions wideField">
                 <button id="assignmentAiAskBtn" type="button" title="Prepara il pacchetto JSON con prompt, contesto e file che verra inviato al provider AI quando l'adapter sara collegato.">Prepara pacchetto AI</button>
                 <button id="assignmentAiGenerateBtn" type="button" title="Genera una bozza usando il provider selezionato. Per ora e attivo solo Codex locale.">Genera bozza</button>
+                <button id="assignmentAiApplyDraftBtn" type="button" title="Applica la bozza AI ai campi della activity. Il docente puo modificarli prima di salvare.">Applica al form activity</button>
               </div>
               <label class="wideField">
                 <span>Bozza AI modificabile dal docente</span>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -236,6 +236,7 @@ const els = {
   assignmentIntegrityMode: document.querySelector("#assignmentIntegrityMode"),
   assignmentAiAskBtn: document.querySelector("#assignmentAiAskBtn"),
   assignmentAiGenerateBtn: document.querySelector("#assignmentAiGenerateBtn"),
+  assignmentAiApplyDraftBtn: document.querySelector("#assignmentAiApplyDraftBtn"),
   assignmentAiDraftText: document.querySelector("#assignmentAiDraftText"),
   assignmentAiPackagePreview: document.querySelector("#assignmentAiPackagePreview"),
   generateReportBtn: document.querySelector("#generateReportBtn"),
@@ -2399,6 +2400,100 @@ function renderAssignmentCodexDraft(response) {
   `;
 }
 
+function parseAssignmentAiDraftText() {
+  const draftText = String(els.assignmentAiDraftText?.value || "").trim();
+  if (!draftText) throw new Error("Nessuna bozza AI da applicare.");
+  try {
+    const draft = JSON.parse(draftText);
+    if (!draft || typeof draft !== "object" || Array.isArray(draft)) {
+      throw new Error("La bozza AI deve essere un oggetto JSON.");
+    }
+    return draft;
+  } catch (error) {
+    if (error.message === "La bozza AI deve essere un oggetto JSON.") throw error;
+    throw new Error(`Bozza AI non valida: ${error.message}`);
+  }
+}
+
+function firstDraftValue(source, keys) {
+  if (!source || typeof source !== "object") return "";
+  for (const key of keys) {
+    const value = source[key];
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      const clean = value.map((item) => String(item).trim()).filter(Boolean);
+      if (clean.length) return clean.join(", ");
+      continue;
+    }
+    const text = String(value).trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+function setSelectValueIfAvailable(select, value) {
+  if (!select || !value) return false;
+  const options = Array.from(select.children || []);
+  if (!options.length) {
+    select.value = value;
+    return true;
+  }
+  if (!options.some((option) => option.value === value)) return false;
+  select.value = value;
+  return true;
+}
+
+function applyAssignmentAiDraftToActivityForm() {
+  try {
+    const draft = parseAssignmentAiDraftText();
+    const patch = draft.activity_patch && typeof draft.activity_patch === "object" ? draft.activity_patch : {};
+    const metriche = patch.metriche && typeof patch.metriche === "object" ? patch.metriche : {};
+    const contesto = patch.contesto && typeof patch.contesto === "object" ? patch.contesto : {};
+
+    const title = firstDraftValue(patch, ["titolo", "title"]) || firstDraftValue(draft, ["titolo", "title", "summary"]);
+    if (title && els.activityAuthorTitle) {
+      els.activityAuthorTitle.value = title;
+      syncActivityAuthorIdSuggestion();
+    }
+    const activityId = firstDraftValue(patch, ["id", "activity_id"]);
+    if (activityId && els.activityAuthorId) {
+      els.activityAuthorId.value = suggestedActivityId(activityId);
+      state.activityAuthorLastSuggestedId = els.activityAuthorId.value;
+    }
+    const kind = firstDraftValue(patch, ["tipo", "kind", "type"]);
+    setSelectValueIfAvailable(els.activityAuthorKind, kind);
+    const difficulty = firstDraftValue(patch, ["difficolta", "difficulty"]);
+    setSelectValueIfAvailable(els.activityAuthorDifficulty, difficulty);
+    const prompt = firstDraftValue(patch, ["consegna", "prompt", "description"]);
+    if (prompt && els.activityAuthorPrompt) els.activityAuthorPrompt.value = prompt;
+    const minutes = firstDraftValue(metriche, ["tempo_stimato_minuti"]) || firstDraftValue(patch, ["estimated_minutes"]);
+    if (minutes && els.activityAuthorMinutes) els.activityAuthorMinutes.value = minutes;
+    setSelectValueIfAvailable(els.activityAuthorPath, firstDraftValue(contesto, ["percorso", "path_id"]));
+    renderActivityAuthorMetadataSelects();
+    setSelectValueIfAvailable(els.activityAuthorUda, firstDraftValue(contesto, ["uda", "uda_id"]));
+    setSelectValueIfAvailable(els.activityAuthorClass, firstDraftValue(contesto, ["classe", "class_id"]));
+    setSelectValueIfAvailable(els.activityAuthorTeam, firstDraftValue(contesto, ["team_github", "github_team"]));
+    const topics = firstDraftValue(patch, ["argomenti", "topics"]);
+    if (topics && els.activityAuthorTopics) els.activityAuthorTopics.value = topics;
+
+    const fileCount = Array.isArray(draft.files) ? draft.files.length : 0;
+    const assetCount = Array.isArray(patch.assets) ? patch.assets.length : 0;
+    const suffix = fileCount || assetCount
+      ? ` File proposti: ${fileCount}; asset dichiarati: ${assetCount}. Gli asset non vengono ancora salvati automaticamente.`
+      : "";
+    if (els.activityAuthorStatus) {
+      els.activityAuthorStatus.textContent = `Bozza AI applicata al form activity. Controlla e salva quando e pronta.${suffix}`;
+    }
+    setStatus("Bozza AI applicata al form activity: il docente puo ancora modificare tutto.");
+    setAssignmentWizardStep("activity");
+    return true;
+  } catch (error) {
+    if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = `Bozza AI non applicata: ${error.message}`;
+    setStatus(`Bozza AI non applicata: ${error.message}`);
+    return false;
+  }
+}
+
 function setAssignmentWizardStep(step) {
   const selectedStep = step || "activity";
   els.assignmentStepTabs.forEach((button) => {
@@ -3419,6 +3514,7 @@ els.assignmentStepTabs.forEach((button) => {
 els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
 els.assignmentAiAskBtn?.addEventListener("click", previewAssignmentAiPackage);
 els.assignmentAiGenerateBtn?.addEventListener("click", generateAssignmentAiDraft);
+els.assignmentAiApplyDraftBtn?.addEventListener("click", applyAssignmentAiDraftToActivityForm);
 els.saveAssignmentBtn?.addEventListener("click", saveAssignmentRecord);
 els.distributeAssignmentBtn?.addEventListener("click", distributeAssignment);
 els.generateReportBtn.addEventListener("click", generateReport);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2314,13 +2314,18 @@ function assignmentPlanPayload() {
 }
 
 function assignmentAiPackagePayload() {
-  return {
+  const payload = {
     ...assignmentPlanPayload(),
     provider: els.assignmentAiProvider?.value || "codex",
     prompt: els.assignmentAiPrompt?.value || "",
     student_budget: Number(els.assignmentAiStudentBudget?.value || 0),
     integrity_mode: els.assignmentIntegrityMode?.value || "normal",
   };
+  const draftText = String(els.assignmentAiDraftText?.value || "").trim();
+  if (draftText) {
+    payload.current_draft = parseAssignmentAiDraftText();
+  }
+  return payload;
 }
 
 function renderAssignmentAiPackage(aiPackage) {
@@ -2333,11 +2338,12 @@ function renderAssignmentAiPackage(aiPackage) {
   const includedFiles = files.filter((file) => file.included);
   const skippedFiles = files.filter((file) => !file.included);
   const promptStatus = aiPackage.prompt?.trim() ? "prompt incluso" : "prompt vuoto";
+  const draftStatus = aiPackage.current_draft ? "bozza corrente inclusa" : "nessuna bozza corrente";
   els.assignmentAiPackagePreview.innerHTML = `
     <div class="assignmentPlanHeader">
       <div>
         <strong>${escapeHtml(aiPackage.activity?.title || aiPackage.activity?.id || "Pacchetto AI")}</strong>
-        <small>${escapeHtml(aiPackage.provider || "-")} - ${escapeHtml(aiPackage.schema_version || "-")} - ${escapeHtml(promptStatus)}</small>
+        <small>${escapeHtml(aiPackage.provider || "-")} - ${escapeHtml(aiPackage.schema_version || "-")} - ${escapeHtml(promptStatus)} - ${escapeHtml(draftStatus)}</small>
       </div>
       ${badge("nessuna chiamata AI", "muted")}
     </div>


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge il bottone `Applica al form activity` nel wizard AI.
- Permette al docente di applicare una bozza AI/Codex JSON ai campi editabili della activity: titolo, id, tipo, difficolta, argomenti, consegna, tempo stimato e contesto quando presente.
- Mantiene il docente in controllo: la bozza compila il form, ma non salva automaticamente e non distribuisce nulla.
- Documenta che file e asset generati restano proposta visibile: salvataggio automatico dei file, upload da locale e repository GitHub/GitLab saranno step successivi.

## Perche

Dopo la generazione Codex mancava il passaggio operativo per trasformare la proposta in una activity modificabile dal docente. Questo PR chiude quel primo giro senza anticipare il lavoro piu ampio sugli asset.

## Verifiche

- `python -m pytest tests/test_assignment_dashboard_frontend.py tests/test_codex_activity_adapter.py tests/test_course_board_server.py`
- `python -m py_compile scripts/codex_activity_adapter.py scripts/course_board_server.py`
- `git diff --check`
