### PR TITLE
Aggiunge revisione activity al wizard

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -530,9 +530,9 @@ Nel riquadro `Assegna activity` compila i dati che identificano activity, destin
 | Classe | Identificativo classe dell'assegnazione, per esempio `3A-TPSI` |
 | Etichetta classe | Nome leggibile mostrato in dashboard, per esempio `3A TPSI` |
 | Team GitHub | Team GitHub della classe, se disponibile |
-| Assegnato il | Data ISO di assegnazione |
-| Scadenza | Data ISO di scadenza |
-| Ora simulata opzionale | Data ISO usata per simulare il momento attuale |
+| Assegnato il | Data/ora di assegnazione; nel wizard viene proposta automaticamente la data corrente |
+| Scadenza | Data/ora di scadenza; nel wizard e obbligatoria e va scelta dal docente |
+| Ora simulata opzionale | Data/ora usata solo per anteprime e test, per simulare il momento attuale senza cambiare l'orologio reale |
 | Repository studenti locali | Un path per riga verso i repository/cartelle studente |
 
 Nel riquadro `Registro consegne` compila:

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -678,4 +678,8 @@ Per il flusso consegne restano aperti soprattutto:
 6. archiviazione e cancellazione sicura di registri, activity e assegnazioni;
 7. valutazione dello stesso pattern di layout pannelli anche per calendario, course board e altre pagine GUI.
 
+Nota operativa per i prossimi step: la GUI dovra distinguere tra **archiviare**, **annullare** ed **eliminare definitivamente**.
+Per le activity conviene introdurre prima archiviazione e cancellazione solo se non esistono assegnazioni o registri collegati.
+Per le consegne/assegnazioni gia pubblicate l'azione principale dovrebbe essere **Annulla assegnazione/consegna**, mantenendo traccia e motivazione; l'eliminazione definitiva dovrebbe restare limitata a bozze, dati demo o assegnazioni non ancora distribuite.
+
 Il primo template repository studente e documentato in `STUDENT_REPOSITORY_TEMPLATE.md`.

--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -22,18 +22,59 @@ http://localhost:8765/tools/assignment_dashboard.html
 
 ### Assegna activity
 
-Serve a preparare l'associazione tra una activity, i destinatari e le date.
+Serve a creare o scegliere una activity, preparare destinatari e date, controllare l'anteprima e poi salvare o distribuire l'assegnazione.
 
-Nota di nomenclatura: l'assegnazione e la pubblicazione della activity verso classe, team o studenti. In questa fase MVP la distribuzione reale degli asset agli studenti non e ancora attiva dalla GUI: il pannello mostra l'anteprima e prepara i dati usati dal registro.
+Nota di nomenclatura: l'activity e la definizione didattica del lavoro; l'assegnazione collega quella activity a classe, team, gruppo o singolo studente con date e destinatari. Il registro consegne, invece, serve a monitorare stato, consegne, grading e feedback dopo l'assegnazione.
 
 Usalo quando devi:
 
-- scegliere una activity;
+- scegliere o creare una activity;
+- generare una proposta AI/Codex e revisionarla;
 - scegliere la classe tramite roster;
-- impostare classe, team, assegnazione e scadenza;
+- scegliere destinatari, gruppo o singoli studenti;
+- impostare data di assegnazione e scadenza;
 - verificare destinatari e asset con **Anteprima assegnazione**.
 
 Screenshot previsto: `doc/images/dashboard-guides/docente-genera-registro.png`.
+
+#### Wizard Assegna activity
+
+Il pannello usa un percorso guidato. Puoi saltare tra le linguette, ma il flusso consigliato e andare avanti in ordine.
+
+1. **Activity**
+   - scegli una activity gia salvata con **Scegli activity**;
+   - oppure entra nella revisione activity per crearne una nuova;
+   - controlla che `Activity JSON`, linguaggio e file sorgente siano coerenti.
+2. **AI**
+   - scrivi il prompt nel campo **Prompt docente**;
+   - usa **Invia prompt e genera proposta** per chiedere a Codex/provider una bozza;
+   - dopo l'invio il bottone resta disabilitato finche non rientri nel prompt per modificarlo;
+   - la vista **Proposta AI** mostra la bozza generata, i file proposti e le note docente;
+   - la vista **Dati inviati all'AI** mostra prompt, metadati, destinatari, policy e file di contesto che verrebbero inviati al provider;
+   - i **file di contesto inviati all'AI** sono input gia disponibili per aiutare la generazione;
+   - i **file proposti dall'AI** sono output generati dalla bozza e si aprono con **Apri file** in un modal stile revisione consegna;
+   - il JSON tecnico resta disponibile solo per debug.
+3. **Revisione**
+   - controlla e modifica la bozza activity;
+   - salva l'activity prima di proseguire;
+   - il docente resta sempre responsabile della versione finale, anche quando la proposta nasce dall'AI.
+4. **Destinatari**
+   - scegli il roster classe;
+   - seleziona classe intera, gruppo o singoli studenti;
+   - verifica il testo dei repository/target generato sotto.
+5. **Date**
+   - **Assegnato il** viene valorizzato automaticamente con data e ora correnti;
+   - **Scadenza** e obbligatoria, parte vuota e viene evidenziata in rosso se non la compili;
+   - **Ora simulata opzionale** serve per anteprime e test: simula il momento corrente senza cambiare l'orologio reale. Se e vuota, la dashboard usa l'ora reale.
+6. **Anteprima**
+   - usa **Anteprima assegnazione** per vedere cosa succederebbe senza scrivere nei repository;
+   - controlla activity, linguaggio, file sorgente, destinatari, cartelle target, target gia esistenti, asset per studenti e asset riservati al docente/grading;
+   - se ci sono target bloccati o file mancanti, correggi prima di distribuire.
+7. **Conferma**
+   - **Salva assegnazione** registra l'assegnazione nel sistema docente senza necessariamente copiare asset nei repository;
+   - **Distribuisci ai target** copia traccia, README e asset studente nelle cartelle/repository target quando il piano e corretto.
+
+Regola pratica: prima genera o scegli l'activity, poi controlla destinatari e date, poi fai sempre anteprima prima di salvare o distribuire.
 
 ### Registro consegne
 
@@ -126,7 +167,47 @@ Usalo quando:
 
 Screenshot previsto: `doc/images/dashboard-guides/docente-revisione-consegna.png`.
 
-## Scenario 1 - Creare un registro per activity e classe
+## Scenario 1 - Creare o scegliere una activity e preparare l'assegnazione
+
+Obiettivo: arrivare a una activity revisionata, con destinatari e date pronti per anteprima, salvataggio o distribuzione.
+
+Prerequisiti:
+
+- il server locale e avviato;
+- esiste almeno un roster classe oppure inserisci manualmente i target;
+- se usi Codex, il provider locale deve essere disponibile sulla macchina docente.
+
+Passaggi:
+
+1. Apri il pannello **Assegna activity**.
+2. Nel passo **Activity**, scegli una activity esistente oppure prepara una nuova bozza.
+3. Nel passo **AI**, se vuoi assistenza:
+   - scrivi il prompt;
+   - premi **Invia prompt e genera proposta**;
+   - apri i file proposti con **Apri file**;
+   - confronta **Proposta AI** e **Dati inviati all'AI** se vuoi controllare contesto e metadati.
+4. Nel passo **Revisione**, modifica la bozza e salva l'activity.
+5. Nel passo **Destinatari**, scegli classe, gruppo o studenti.
+6. Nel passo **Date**, lascia **Assegnato il** se va bene la data corrente e compila **Scadenza**.
+7. Nel passo **Anteprima**, premi **Anteprima assegnazione** e controlla il piano.
+8. Nel passo **Conferma**, salva l'assegnazione o distribuisci ai target.
+
+Cosa controllare a schermo:
+
+- la proposta AI non sostituisce automaticamente il lavoro docente;
+- i file proposti dall'AI sono leggibili nel modal;
+- i dati inviati all'AI sono separati dalla proposta generata;
+- la scadenza e compilata;
+- i target corrispondono agli studenti desiderati;
+- l'anteprima non segnala target bloccati o asset mancanti inattesi.
+
+Screenshot previsti:
+
+- `doc/images/dashboard-guides/scenario-assegna-activity-ai.png`;
+- `doc/images/dashboard-guides/scenario-assegna-activity-date.png`;
+- `doc/images/dashboard-guides/scenario-assegna-activity-anteprima.png`.
+
+## Scenario 2 - Creare un registro per activity e classe
 
 Obiettivo: creare un registro consegne per una activity assegnata a una classe.
 
@@ -169,7 +250,7 @@ Screenshot previsti:
 - `doc/images/dashboard-guides/scenario-genera-registro-02.png`;
 - `doc/images/dashboard-guides/scenario-genera-registro-03.png`.
 
-## Scenario 2 - Caricare un registro esistente
+## Scenario 3 - Caricare un registro esistente
 
 Obiettivo: aprire un registro gia salvato in `teacher-reports`.
 
@@ -191,7 +272,7 @@ Cosa controllare a schermo:
 
 Screenshot previsto: `doc/images/dashboard-guides/scenario-carica-registro.png`.
 
-## Scenario 3 - Controllare il quadro classe
+## Scenario 4 - Controllare il quadro classe
 
 Obiettivo: avere una vista aggregata di tutte le consegne disponibili.
 
@@ -218,7 +299,7 @@ Cosa controllare a schermo:
 
 Screenshot previsto: `doc/images/dashboard-guides/scenario-quadro-classe.png`.
 
-## Scenario 4 - Revisionare una consegna studente
+## Scenario 5 - Revisionare una consegna studente
 
 Obiettivo: aprire i file consegnati da uno studente e leggerli.
 
@@ -242,7 +323,7 @@ Cosa controllare a schermo:
 
 Screenshot previsto: `doc/images/dashboard-guides/scenario-revisione-consegna.png`.
 
-## Scenario 5 - Leggere e approvare feedback AI
+## Scenario 6 - Leggere e approvare feedback AI
 
 Obiettivo: distinguere feedback non generato, bozza AI, feedback approvato e respinto.
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -300,6 +300,18 @@ Le operazioni distruttive vanno progettate con attenzione.
 
 Regola consigliata: introdurre prima `archivia`, poi `elimina definitivamente`.
 
+Prossimi step GUI da progettare:
+
+- aggiungere nel pannello activity una azione **Archivia activity** per nascondere una activity senza perdere lo storico;
+- aggiungere una azione **Elimina activity** solo per activity non assegnate o dopo conferma forte quando esistono assegnazioni, consegne o registri collegati;
+- aggiungere una azione **Annulla assegnazione/consegna** come comportamento principale quando il docente vuole ritirare una consegna gia pubblicata;
+- distinguere chiaramente **annulla** da **elimina definitivamente**:
+  - `annulla` mantiene traccia, date, destinatari e motivazione;
+  - `elimina definitivamente` rimuove il record e va limitato a bozze, demo o assegnazioni non distribuite;
+- decidere se l'annullamento deve lasciare intatti i file gia copiati nei repository studenti o creare una nuova operazione esplicita di pulizia;
+- mostrare nella dashboard quando una activity o una assegnazione e archiviata/annullata, evitando che entri nei flussi normali di registro e grading;
+- registrare audit minimo: chi ha archiviato, annullato o eliminato, quando e con quale motivazione.
+
 ## Priorita 3 - Vista studente e feedback assistito
 
 Questa e la fase che chiude il ciclo docente-studente.

--- a/scripts/codex_activity_adapter.py
+++ b/scripts/codex_activity_adapter.py
@@ -104,13 +104,46 @@ def activity_patch_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
     patch_json = payload.get("activity_patch_json")
     if not isinstance(patch_json, str) or not patch_json.strip():
         raise ValueError("La risposta Codex non contiene `activity_patch_json` valido.")
-    try:
-        patch = json.loads(patch_json)
-    except json.JSONDecodeError as error:
-        raise ValueError(f"`activity_patch_json` non e JSON valido: {error}") from error
+    patch = load_activity_patch_json(patch_json)
     if not isinstance(patch, dict):
         raise ValueError("`activity_patch_json` deve contenere un oggetto JSON.")
     return patch
+
+
+def load_activity_patch_json(patch_json: str) -> Any:
+    """Decode Codex activity patch JSON, repairing invalid backslash escapes when safe."""
+
+    try:
+        return json.loads(patch_json)
+    except json.JSONDecodeError as original_error:
+        repaired = escape_invalid_json_backslashes(patch_json)
+        if repaired == patch_json:
+            raise ValueError(f"`activity_patch_json` non e JSON valido: {original_error}") from original_error
+        try:
+            return json.loads(repaired)
+        except json.JSONDecodeError as repaired_error:
+            raise ValueError(f"`activity_patch_json` non e JSON valido: {repaired_error}") from repaired_error
+
+
+def escape_invalid_json_backslashes(text: str) -> str:
+    """Return text with JSON-invalid backslashes escaped as literal backslashes."""
+
+    result: list[str] = []
+    index = 0
+    valid_escapes = {'"', "\\", "/", "b", "f", "n", "r", "t", "u"}
+    while index < len(text):
+        char = text[index]
+        if char != "\\":
+            result.append(char)
+            index += 1
+            continue
+        next_char = text[index + 1] if index + 1 < len(text) else ""
+        if next_char in valid_escapes:
+            result.append(char)
+        else:
+            result.append("\\\\")
+        index += 1
+    return "".join(result)
 
 
 def validate_codex_activity_draft(payload: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -334,6 +334,8 @@ def save_activity(payload: dict) -> dict:
         topics=topics,
         prompt=str(payload.get("prompt", "")).strip(),
         estimated_minutes=create_activity.positive_int(str(payload.get("estimated_minutes", "30"))),
+        language=create_submission_scaffold.validate_language(str(payload.get("language", "c") or "c")),
+        source_name=create_submission_scaffold.validate_source_name(str(payload.get("source_name", "main.c") or "main.c")),
         context={
             "classe": str(payload.get("class_id", "")).strip(),
             "team_github": str(payload.get("github_team", "")).strip(),

--- a/scripts/create_activity.py
+++ b/scripts/create_activity.py
@@ -56,6 +56,8 @@ def build_activity(
     topics: list[str],
     prompt: str,
     estimated_minutes: int,
+    language: str = "c",
+    source_name: str = "",
     context: dict[str, str] | None = None,
 ) -> dict:
     """Build a minimal activity dictionary compatible with validate_activity."""
@@ -69,6 +71,8 @@ def build_activity(
         "titolo": title,
         "tipo": activity_type,
         "difficolta": difficulty,
+        "linguaggio": language,
+        "language": language,
         "argomenti": topics,
         "consegna": prompt,
         "correzione": dict(DEFAULT_CORRECTION),
@@ -79,6 +83,8 @@ def build_activity(
     }
 
     clean_context = {key: value for key, value in (context or {}).items() if value}
+    if source_name:
+        clean_context["source_name"] = source_name
     if clean_context:
         activity["contesto"] = clean_context
 

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -84,6 +84,7 @@ def normalize_activity(payload: dict[str, Any]) -> dict[str, Any]:
     normalized["assets"] = first_list(payload, "assets")
     normalized["class_id"] = first_text(payload, "class_id") or first_text(context, "classe")
     normalized["github_team"] = first_text(payload, "github_team") or first_text(context, "team_github")
+    normalized["source_name"] = first_text(payload, "source_name") or first_text(context, "source_name")
     return normalized
 
 

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -231,6 +231,7 @@ class JsonAssignmentStorage:
             "class_label": activity.get("class_id", ""),
             "github_team": activity.get("github_team", ""),
             "language": activity.get("language", ""),
+            "source_name": activity.get("source_name", ""),
             "topics": activity.get("topics", []),
             "path": self.relative_path(path),
         }
@@ -317,6 +318,7 @@ class JsonAssignmentStorage:
                         "class_label": activity.get("class_id", ""),
                         "github_team": activity.get("github_team", ""),
                         "language": activity.get("language", ""),
+                        "source_name": activity.get("source_name", ""),
                         "topics": activity.get("topics", []),
                         "path": self.relative_path(path),
                     }

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -164,7 +164,7 @@ def run_dashboard_js(assertions: str) -> None:
       button.dataset.legendTab = topic;
       return button;
     }});
-    const assignmentStepNames = ["activity", "ai", "targets", "dates", "preview", "confirm"];
+const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "preview", "confirm"];
     const assignmentStepTabs = assignmentStepNames.map((step) => {{
       const button = new FakeElement(`[data-assignment-step-tab="${{step}}"]`);
       button.dataset.assignmentStepTab = step;
@@ -386,6 +386,9 @@ def run_dashboard_js(assertions: str) -> None:
         saveActivityDraft,
         openActivityEditor,
         closeActivityEditor,
+        openActivityReviewStep,
+        mountActivityEditorInWizard,
+        mountActivityEditorInDialog,
         renderActivityPanelSummary,
         activityAuthorTopicValue,
         activityAuthorTopicOptions,
@@ -561,14 +564,33 @@ def test_activity_editor_modal_is_shared_by_panel_and_wizard() -> None:
 def test_activity_editor_modal_opens_and_closes() -> None:
     run_dashboard_js(
         """
-        tested.openActivityEditor("wizard");
+        tested.openActivityEditor("panel");
 
         assert.equal(tested.els.activityEditorDialog.open, true);
-        assert.match(tested.els.activityPanelStatus.textContent, /wizard assegnazione/);
+        assert.equal(tested.els.activityEditorBody.parentElement, tested.els.activityEditorDialog);
+        assert.match(tested.els.activityPanelStatus.textContent, /libreria/);
 
         tested.closeActivityEditor();
 
         assert.equal(tested.els.activityEditorDialog.open, false);
+      """
+    )
+
+
+def test_activity_review_step_mounts_shared_editor_inside_wizard() -> None:
+    run_dashboard_js(
+        """
+        tested.openActivityEditor("panel");
+        assert.equal(tested.els.activityEditorDialog.open, true);
+        assert.equal(tested.els.activityEditorBody.parentElement, tested.els.activityEditorDialog);
+
+        tested.openActivityReviewStep();
+
+        const reviewStep = tested.els.assignmentSteps.find((section) => section.dataset.assignmentStep === "review");
+        assert.equal(tested.els.activityEditorDialog.open, false);
+        assert.equal(tested.els.activityEditorBody.parentElement, tested.els.activityWizardEditorMount);
+        assert.equal(reviewStep.hidden, false);
+        assert.match(tested.els.assignmentWizardHint.textContent, /Step 3 di 7/);
       """
     )
 
@@ -769,9 +791,12 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
 
     assert 'data-assignment-step-tab="activity"' in assignment_section
     assert 'data-assignment-step-tab="ai"' in assignment_section
+    assert 'data-assignment-step-tab="review"' in assignment_section
     assert 'data-assignment-step-tab="confirm"' in assignment_section
     assert 'data-assignment-step="ai"' in assignment_section
+    assert 'data-assignment-step="review"' in assignment_section
     assert "Generazione AI assistita" in assignment_section
+    assert "Revisione activity" in assignment_section
     assert "provider AI o Codex" in assignment_section
     assert "modificarla" in assignment_section
     assert 'id="assignmentAiProvider"' in assignment_section
@@ -781,7 +806,7 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert 'id="assignmentAiApplyDraftBtn"' in assignment_section
     assert 'id="assignmentAiApplyDraftBtn" type="button" disabled' in assignment_section
     assert "Genera proposta AI" in assignment_section
-    assert "Usa questa proposta" in assignment_section
+    assert "Prepara revisione" in assignment_section
     assert "Dettagli tecnici del pacchetto AI" in assignment_section
     assert "Mostra pacchetto tecnico" in assignment_section
     assert 'id="assignmentWizardPrevBtn"' in assignment_section
@@ -991,8 +1016,11 @@ def test_apply_assignment_ai_draft_to_activity_form_keeps_teacher_in_control() -
         assert.equal(tested.els.activityAuthorMinutes.value, "35");
         assert.match(tested.els.activityAuthorStatus.textContent, /Bozza AI applicata/);
         assert.match(tested.els.activityAuthorStatus.textContent, /Gli asset non vengono ancora salvati automaticamente/);
-        assert.match(tested.els.status.textContent, /docente puo ancora modificare tutto/);
-        assert.equal(tested.els.activityEditorDialog.open, true);
+        assert.match(tested.els.status.textContent, /Revisione activity/);
+        assert.equal(tested.els.activityEditorDialog.open, false);
+        assert.equal(tested.els.activityEditorBody.parentElement, tested.els.activityWizardEditorMount);
+        const reviewStep = tested.els.assignmentSteps.find((section) => section.dataset.assignmentStep === "review");
+        assert.equal(reviewStep.hidden, false);
       """
     )
 
@@ -1044,7 +1072,7 @@ def test_assignment_wizard_switches_visible_step() -> None:
         assert.equal(activityTab["aria-selected"], "false");
         assert.equal(aiStep.hidden, false);
         assert.equal(activityStep.hidden, true);
-        assert.match(tested.els.assignmentWizardHint.textContent, /Step 2 di 6/);
+        assert.match(tested.els.assignmentWizardHint.textContent, /Step 2 di 7/);
         assert.equal(tested.els.assignmentWizardPrevBtn.disabled, false);
         assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
         """
@@ -1057,18 +1085,22 @@ def test_assignment_wizard_prev_next_guides_the_flow() -> None:
         tested.setAssignmentWizardStep("activity");
 
         assert.equal(tested.els.assignmentWizardPrevBtn.disabled, true);
-        assert.match(tested.els.assignmentWizardHint.textContent, /Step 1 di 6/);
+        assert.match(tested.els.assignmentWizardHint.textContent, /Step 1 di 7/);
 
         tested.moveAssignmentWizardStep(1);
-        assert.match(tested.els.assignmentWizardHint.textContent, /Step 2 di 6/);
+        assert.match(tested.els.assignmentWizardHint.textContent, /Step 2 di 7/);
+
+        tested.moveAssignmentWizardStep(1);
+        assert.match(tested.els.assignmentWizardHint.textContent, /Step 3 di 7/);
+        assert.equal(tested.els.activityEditorBody.parentElement, tested.els.activityWizardEditorMount);
 
         tested.moveAssignmentWizardStep(10);
-        assert.match(tested.els.assignmentWizardHint.textContent, /Step 6 di 6/);
+        assert.match(tested.els.assignmentWizardHint.textContent, /Step 7 di 7/);
         assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
         assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Fine percorso");
 
         tested.moveAssignmentWizardStep(-1);
-        assert.match(tested.els.assignmentWizardHint.textContent, /Step 5 di 6/);
+        assert.match(tested.els.assignmentWizardHint.textContent, /Step 6 di 7/);
         assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
         assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Avanti");
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -1055,6 +1055,46 @@ def test_assignment_confirm_status_resets_when_assignment_data_changes() -> None
     )
 
 
+def test_assignment_confirm_status_resets_when_activity_is_selected() -> None:
+    run_dashboard_js(
+        """
+        tested.state.activities = [{
+          id: "python-base-somma-001",
+          title: "Somma in Python",
+          path: "activities/python-base-somma-001.json",
+          language: "python",
+          source_name: "main.py",
+        }];
+        tested.els.assignmentConfirmStatus.innerHTML = "<strong>Assegnazione salvata</strong><span>ID: demo</span>";
+
+        tested.selectActivity("activities/python-base-somma-001.json");
+
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Dati modificati/);
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /activity e cambiata/);
+        """
+    )
+
+
+def test_assignment_confirm_status_resets_when_roster_is_applied() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignmentConfirmStatus.innerHTML = "<strong>Distribuzione completata</strong><span>3 target aggiornati</span>";
+
+        tested.applyRosterToGenerateForm({
+          id: "3A",
+          label: "3A TPSI",
+          github_team: "team-3a",
+          students: [
+            { id: "rossi-mario", display_name: "Mario Rossi", local_path: "students/rossi-mario" },
+          ],
+        });
+
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Dati modificati/);
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /roster e i destinatari sono cambiati/);
+        """
+    )
+
+
 def test_assignment_ai_package_payload_includes_prompt_policy_and_targets() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -368,6 +368,9 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         reviewAiFeedback,
         dateTimeInputToIso,
         isoToDateTimeInput,
+        currentDateTimeInput,
+        initializeAssignmentDateFields,
+        validateAssignmentDateFields,
         compactStudentsSummaryItems,
         detailedStudentsSummaryItems,
         applyPanelOrder,
@@ -922,6 +925,35 @@ def test_assignment_wizard_uses_calendar_date_time_inputs() -> None:
     assert 'id="assignedAt" type="datetime-local"' in assignment_section
     assert 'id="dueAt" type="datetime-local"' in assignment_section
     assert 'id="nowAt" type="datetime-local"' in assignment_section
+    assert 'id="assignedAt" type="datetime-local" value=' not in assignment_section
+    assert 'id="dueAt" type="datetime-local" value=' not in assignment_section
+    assert 'id="assignedAt" type="datetime-local" required' in assignment_section
+    assert 'id="dueAt" type="datetime-local" required' in assignment_section
+    assert "simula il momento corrente" in assignment_section
+
+
+def test_assignment_dates_require_due_date_and_default_assigned_date() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignedAt.value = "";
+        tested.els.dueAt.value = "";
+
+        tested.setAssignmentWizardStep("dates");
+
+        assert.match(tested.els.assignedAt.value, /^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}$/);
+        assert.equal(tested.els.dueAt["aria-invalid"], "true");
+        assert.equal(tested.assignmentWizardStepComplete("dates"), false);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
+
+        tested.els.dueAt.value = "2026-10-19T23:59";
+        assert.equal(tested.validateAssignmentDateFields(), true);
+        tested.setAssignmentWizardStep("dates");
+
+        assert.equal(tested.els.dueAt["aria-invalid"], "false");
+        assert.equal(tested.assignmentWizardStepComplete("dates"), true);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
+        """
+    )
 
 
 def test_assignment_ai_context_uses_informative_status_rows() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -401,6 +401,9 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         assignmentRecordPayload,
         renderAssignmentAssetList,
         renderAssignmentTargetList,
+        renderAssignmentTargetPicker,
+        syncTargetsFromRosterSelection,
+        syncRosterSelectionFromTargetsText,
         renderAssignmentPlan,
         renderAssignmentAiPackage,
         renderAssignmentCodexDraft,
@@ -1417,6 +1420,40 @@ def test_class_roster_targets_fill_generate_form_with_demo_fallbacks() -> None:
     )
 
 
+def test_assignment_targets_can_select_subset_of_roster_students() -> None:
+    run_dashboard_js(
+        """
+        tested.applyRosterToGenerateForm({
+          id: "demo-3a",
+          label: "Classe demo 3A",
+          github_team: "team-demo-3a",
+          students: [
+            { id: "rossi-mario", display_name: "Rossi Mario", local_path: "local/rossi-mario", active: true },
+            { id: "bianchi-luca", display_name: "Bianchi Luca", local_path: "local/bianchi-luca", active: true },
+            { id: "verdi-anna", display_name: "Verdi Anna", local_path: "local/verdi-anna", active: true },
+          ],
+        });
+
+        assert.match(tested.els.assignmentTargetPicker.innerHTML, /Rossi Mario/);
+        assert.match(tested.els.assignmentTargetPicker.innerHTML, /Bianchi Luca/);
+        assert.equal(tested.state.selectedRosterTargetIds.size, 3);
+
+        tested.state.selectedRosterTargetIds = new Set(["rossi-mario", "verdi-anna"]);
+        tested.syncTargetsFromRosterSelection();
+
+        assert.equal(tested.els.targetsText.value, ["local/rossi-mario", "local/verdi-anna"].join("\\n"));
+        assert.match(tested.els.rosterStatus.textContent, /2 target studenti/);
+        assert.match(tested.els.assignmentTargetPicker.innerHTML, /data-roster-target-student="rossi-mario" checked/);
+        assert.doesNotMatch(tested.els.assignmentTargetPicker.innerHTML, /data-roster-target-student="bianchi-luca" checked/);
+
+        tested.els.targetsText.value = "local/bianchi-luca";
+        tested.syncRosterSelectionFromTargetsText();
+
+        assert.deepEqual(Array.from(tested.state.selectedRosterTargetIds), ["bianchi-luca"]);
+      """
+    )
+
+
 def test_class_roster_option_label_includes_year_and_students() -> None:
     run_dashboard_js(
         """
@@ -1850,6 +1887,11 @@ def test_assignment_and_report_panels_are_separated() -> None:
     assert "Assegna activity" in assignment_section
     assert 'id="activitySelect"' in assignment_section
     assert 'id="classRosterSelect"' in assignment_section
+    assert 'id="assignmentTargetPicker"' in assignment_section
+    assert 'id="selectAllRosterTargetsBtn"' in assignment_section
+    assert 'id="clearRosterTargetsBtn"' in assignment_section
+    assert "Studenti dal roster" in assignment_section
+    assert "gruppo di studenti o un singolo studente" in assignment_section
     assert 'id="targetsText"' in assignment_section
     assert 'id="previewAssignmentBtn"' in assignment_section
     assert 'id="saveAssignmentBtn"' in assignment_section

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -385,6 +385,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         renderLegend,
         saveActivityDraft,
         validateActivityAuthorRequiredFields,
+        setActivityAuthorStatus,
         openActivityEditor,
         closeActivityEditor,
         openActivityReviewStep,
@@ -552,7 +553,8 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           assert.equal(body.class_id, "3A-TPSI");
           assert.equal(tested.state.activities.length, 1);
           assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
-          assert.match(tested.els.activityAuthorStatus.textContent, /Activity salvata/);
+          assert.equal(tested.els.activityAuthorStatus.classList.contains("isSuccess"), true);
+          assert.match(tested.els.activityAuthorStatus.innerHTML, /Activity salvata/);
           assert.match(tested.els.activityPanelStatus.textContent, /Activity salvata/);
         })();
         """
@@ -623,7 +625,9 @@ def test_save_activity_from_review_enables_wizard_next() -> None:
 
           assert.equal(tested.state.activityReviewSaved, true);
           assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
-          assert.match(tested.els.activityAuthorStatus.textContent, /Activity salvata/);
+          assert.equal(tested.els.activityAuthorStatus.classList.contains("isSuccess"), true);
+          assert.match(tested.els.activityAuthorStatus.innerHTML, /Activity salvata/);
+          assert.match(tested.els.activityAuthorStatus.innerHTML, /punto 4 Destinatari/);
           assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
         })();
         """
@@ -1109,8 +1113,8 @@ def test_apply_assignment_ai_draft_to_activity_form_keeps_teacher_in_control() -
         assert.equal(tested.els.activityAuthorTopics.value, "variabili, input");
         assert.equal(tested.els.activityAuthorPrompt.value, "Scrivi un programma che somma due interi anche negativi.");
         assert.equal(tested.els.activityAuthorMinutes.value, "35");
-        assert.match(tested.els.activityAuthorStatus.textContent, /Bozza AI applicata/);
-        assert.match(tested.els.activityAuthorStatus.textContent, /Gli asset non vengono ancora salvati automaticamente/);
+        assert.match(tested.els.activityAuthorStatus.innerHTML, /Bozza AI applicata/);
+        assert.match(tested.els.activityAuthorStatus.innerHTML, /Gli asset non vengono ancora salvati automaticamente/);
         assert.match(tested.els.status.textContent, /Revisione activity/);
         assert.equal(tested.els.activityEditorDialog.open, false);
         assert.equal(tested.els.activityEditorBody.parentElement, tested.els.activityWizardEditorMount);
@@ -1157,9 +1161,40 @@ def test_save_activity_draft_requires_prompt_before_posting() -> None:
 
           const call = tested.fetchCalls.find((entry) => entry.path === "/api/activities/save");
           assert.equal(call, undefined);
-          assert.match(tested.els.activityAuthorStatus.textContent, /Completa i campi obbligatori: Consegna/);
+          assert.equal(tested.els.activityAuthorStatus.classList.contains("isError"), true);
+          assert.match(tested.els.activityAuthorStatus.innerHTML, /Completa i campi obbligatori: Consegna/);
           assert.match(tested.els.status.textContent, /Completa i campi obbligatori: Consegna/);
           assert.equal(tested.els.activityAuthorPrompt["aria-invalid"], "true");
+        })();
+      """
+    )
+
+
+def test_save_activity_draft_shows_backend_errors_in_review_status() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.fetchResponses["/api/activities/save"] = {
+            ok: false,
+            status: 400,
+            statusText: "Bad Request",
+            text: JSON.stringify({ error: "File gia esistente: activities/drafts/array-c.json." }),
+          };
+          tested.els.activityAuthorTitle.value = "Array in C";
+          tested.els.activityAuthorId.value = "array-c";
+          tested.els.activityAuthorKind.value = "laboratorio";
+          tested.els.activityAuthorDifficulty.value = "B";
+          tested.els.activityAuthorTopics.value = "array";
+          tested.els.activityAuthorMinutes.value = "30";
+          tested.els.activityAuthorPrompt.value = "Completa il programma.";
+
+          await tested.saveActivityDraft();
+
+          assert.equal(tested.state.activityReviewSaved, false);
+          assert.equal(tested.els.activityAuthorStatus.classList.contains("isError"), true);
+          assert.match(tested.els.activityAuthorStatus.innerHTML, /Activity non salvata/);
+          assert.match(tested.els.activityAuthorStatus.innerHTML, /File gia esistente/);
+          assert.match(tested.els.status.textContent, /Errore salvataggio activity/);
         })();
       """
     )
@@ -1184,7 +1219,8 @@ def test_activity_author_required_fields_show_and_clear_invalid_state() -> None:
         assert.equal(tested.els.activityAuthorTopics["aria-invalid"], "true");
         assert.equal(tested.els.activityAuthorMinutes["aria-invalid"], "true");
         assert.equal(tested.els.activityAuthorPrompt["aria-invalid"], "true");
-        assert.match(tested.els.activityAuthorStatus.textContent, /Titolo, Tipo, Argomenti, Tempo stimato, Consegna/);
+        assert.equal(tested.els.activityAuthorStatus.classList.contains("isError"), true);
+        assert.match(tested.els.activityAuthorStatus.innerHTML, /Titolo, Tipo, Argomenti, Tempo stimato, Consegna/);
 
         tested.els.activityAuthorTitle.value = "Array in C";
         tested.els.activityAuthorKind.value = "laboratorio";
@@ -1212,7 +1248,8 @@ def test_apply_assignment_ai_draft_reports_invalid_json() -> None:
         const applied = tested.applyAssignmentAiDraftToActivityForm();
 
         assert.equal(applied, false);
-        assert.match(tested.els.activityAuthorStatus.textContent, /Bozza AI non applicata/);
+        assert.equal(tested.els.activityAuthorStatus.classList.contains("isError"), true);
+        assert.match(tested.els.activityAuthorStatus.innerHTML, /Bozza AI non applicata/);
         assert.match(tested.els.status.textContent, /Bozza AI non valida/);
       """
     )

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -421,6 +421,8 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         updateAssignmentAiApplyState,
         setAssignmentAiProgress,
         setAssignmentAiProgressError,
+        setAssignmentAiPromptLocked,
+        unlockAssignmentAiPrompt,
         assignmentWizardStepComplete,
         setAssignmentWizardStep,
         moveAssignmentWizardStep,
@@ -892,7 +894,7 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert 'id="assignmentAiDraftText"' in assignment_section
     assert 'id="assignmentAiGenerateBtn"' in assignment_section
     assert 'id="assignmentAiProgress"' in assignment_section
-    assert "Genera proposta AI" in assignment_section
+    assert "Invia prompt e genera proposta" in assignment_section
     assert "Generazione proposta AI in corso" in assignment_section
     assert "Dettagli tecnici del pacchetto AI" in assignment_section
     assert "Mostra pacchetto tecnico" in assignment_section
@@ -902,6 +904,7 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert "Contesto da inviare" in assignment_section
     assert "Asset, starter file, test e soluzione" in assignment_section
     assert "Pacchetto file activity" in assignment_section
+    assert '<details class="assignmentAiContext wideField"' in assignment_section
     assert "File aggiuntivi liberi" in assignment_section
     assert 'id="assignmentAiStudentBudget"' in assignment_section
     assert 'id="assignmentIntegrityMode"' in assignment_section
@@ -1065,7 +1068,26 @@ def test_generate_assignment_ai_draft_with_codex_posts_request_and_fills_teacher
           assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
           assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Avanti: 3 Prepara revisione");
           assert.match(tested.els.status.textContent, /Bozza Codex pronta/);
+          assert.equal(tested.els.assignmentAiGenerateBtn.disabled, true);
+          assert.match(tested.els.assignmentAiGenerateBtn.title, /Hai gia inviato questo prompt/);
         })();
+        """
+    )
+
+
+def test_assignment_ai_prompt_unlocks_generate_button_for_next_request() -> None:
+    run_dashboard_js(
+        """
+        tested.state.assignmentAiGenerating = false;
+
+        tested.setAssignmentAiPromptLocked(true);
+
+        assert.equal(tested.els.assignmentAiGenerateBtn.disabled, true);
+
+        tested.unlockAssignmentAiPrompt();
+
+        assert.equal(tested.els.assignmentAiGenerateBtn.disabled, false);
+        assert.match(tested.els.assignmentAiGenerateBtn.title, /Invia il prompt/);
         """
     )
 
@@ -1139,7 +1161,7 @@ def test_assignment_ai_generation_error_is_visible_outside_details() -> None:
           assert.equal(tested.els.assignmentAiProgress.classList.contains("isError"), true);
           assert.match(tested.els.assignmentAiProgress.innerHTML, /Generazione proposta AI interrotta/);
           assert.match(tested.els.assignmentAiProgress.innerHTML, /Provider non ancora collegato/);
-          assert.equal(tested.els.assignmentAiGenerateBtn.disabled, false);
+          assert.equal(tested.els.assignmentAiGenerateBtn.disabled, true);
           assert.match(tested.els.status.textContent, /Provider non ancora collegato/);
         })();
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -47,9 +47,20 @@ def run_dashboard_js(assertions: str) -> None:
         this.clientWidth = 960;
         this.testWidth = 240;
         this.tHead = {{ rows: [{{ cells: [] }}] }};
+        this.listeners = {{}};
       }}
-      addEventListener() {{}}
-      removeEventListener() {{}}
+      addEventListener(type, handler) {{
+        this.listeners[type] = this.listeners[type] || [];
+        this.listeners[type].push(handler);
+      }}
+      removeEventListener(type, handler) {{
+        this.listeners[type] = (this.listeners[type] || []).filter((candidate) => candidate !== handler);
+      }}
+      dispatchEvent(event) {{
+        const nextEvent = {{ type: event?.type || "", target: this }};
+        (this.listeners[nextEvent.type] || []).forEach((handler) => handler(nextEvent));
+        return true;
+      }}
       setAttribute(name, value) {{ this[name] = value; }}
       toggleAttribute(name, force) {{
         const enabled = force === undefined ? !Boolean(this[name]) : Boolean(force);
@@ -429,6 +440,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         setAssignmentAiPromptLocked,
         unlockAssignmentAiPrompt,
         assignmentWizardStepComplete,
+        validateAssignmentBeforeConfirm,
         setAssignmentWizardStep,
         moveAssignmentWizardStep,
         assignmentPlanErrorMessage,
@@ -778,6 +790,7 @@ def test_save_assignment_record_posts_form_and_refreshes_due_assignments() -> No
         """
         (async () => {
           tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.state.activityReviewSaved = true;
           tested.els.classId.value = "3A-TPSI";
           tested.els.classLabel.value = "3A TPSI";
           tested.els.githubTeam.value = "team-3a-tpsi";
@@ -838,7 +851,10 @@ def test_distribute_assignment_posts_plan_and_renders_written_targets() -> None:
         """
         (async () => {
           tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.state.activityReviewSaved = true;
           tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.assignedAt.value = "2026-10-12T09:00";
+          tested.els.dueAt.value = "2026-10-19T23:59";
           tested.els.activityAuthorLanguage.value = "python";
           tested.els.activityAuthorSourceName.value = "main.py";
           tested.fetchResponses["/api/assignments/distribute"] = {
@@ -994,6 +1010,47 @@ def test_assignment_date_time_inputs_are_serialized_as_iso() -> None:
         assert.match(payload.due_at, /^2026-10-19T23:59:00[+-]\\d{2}:\\d{2}$/);
         assert.match(payload.now, /^2026-10-20T08:00:00[+-]\\d{2}:\\d{2}$/);
         assert.equal(tested.dateTimeInputToIso("2026-10-12T09:00:00+02:00"), "2026-10-12T09:00:00+02:00");
+        """
+    )
+
+
+def test_save_assignment_requires_complete_wizard_data_before_posting() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.state.activityReviewSaved = true;
+          tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.assignedAt.value = "2026-10-12T09:00";
+          tested.els.dueAt.value = "";
+
+          await tested.saveAssignmentRecord();
+
+          assert.equal(tested.fetchCalls.some((entry) => entry.path === "/api/assignments/save"), false);
+          assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Date incomplete/);
+          assert.equal(tested.els.dueAt["aria-invalid"], "true");
+          assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
+        })();
+        """
+    )
+
+
+def test_assignment_confirm_status_resets_when_assignment_data_changes() -> None:
+    run_dashboard_js(
+        """
+        tested.els.activityPath.value = "activities/python-base-somma-001.json";
+        tested.state.activityReviewSaved = true;
+        tested.els.targetsText.value = "students/rossi-mario";
+        tested.els.assignedAt.value = "2026-10-12T09:00";
+        tested.els.dueAt.value = "2026-10-19T23:59";
+
+        assert.equal(tested.validateAssignmentBeforeConfirm("salvare l'assegnazione"), true);
+        tested.els.assignmentConfirmStatus.innerHTML = "<strong>Assegnazione salvata</strong><span>ID: demo</span>";
+        tested.els.targetsText.value = "students/bianchi-luca";
+        tested.els.targetsText.dispatchEvent(new Event("input"));
+
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Dati modificati/);
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /destinatari sono cambiati/);
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -596,6 +596,30 @@ def test_activity_review_step_mounts_shared_editor_inside_wizard() -> None:
     )
 
 
+def test_save_activity_from_review_enables_wizard_next() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.openActivityReviewStep();
+          tested.els.activityAuthorTitle.value = "Somma in Python";
+          tested.els.activityAuthorId.value = "somma-in-python";
+          tested.els.activityAuthorPrompt.value = "Scrivi un programma che somma due numeri.";
+          tested.state.activityReviewSaved = false;
+          tested.setAssignmentWizardStep("review");
+
+          assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
+
+          await tested.saveActivityDraft();
+
+          assert.equal(tested.state.activityReviewSaved, true);
+          assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
+          assert.match(tested.els.activityAuthorStatus.textContent, /Activity salvata/);
+          assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
+        })();
+        """
+    )
+
+
 def test_assignment_preview_posts_plan_and_renders_assets() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -406,6 +406,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         renderAssignmentCodexDraft,
         applyAssignmentAiDraftToActivityForm,
         updateAssignmentAiApplyState,
+        setAssignmentAiProgress,
         assignmentWizardStepComplete,
         setAssignmentWizardStep,
         moveAssignmentWizardStep,
@@ -828,7 +829,9 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert 'id="assignmentAiPrompt"' in assignment_section
     assert 'id="assignmentAiDraftText"' in assignment_section
     assert 'id="assignmentAiGenerateBtn"' in assignment_section
+    assert 'id="assignmentAiProgress"' in assignment_section
     assert "Genera proposta AI" in assignment_section
+    assert "Generazione proposta AI in corso" in assignment_section
     assert "Dettagli tecnici del pacchetto AI" in assignment_section
     assert "Mostra pacchetto tecnico" in assignment_section
     assert 'id="assignmentWizardPrevBtn"' in assignment_section
@@ -857,6 +860,14 @@ def test_assignment_ai_context_checkboxes_use_fixed_alignment() -> None:
     assert ".assignmentAiContext label" in css
     assert "grid-template-columns: 1rem minmax(0, 1fr);" in css
     assert '.assignmentAiContext input[type="checkbox"]' in css
+
+
+def test_assignment_ai_progress_has_visible_indeterminate_bar() -> None:
+    css = open("tools/assignment_dashboard.css", encoding="utf-8").read()
+
+    assert ".assignmentAiProgress" in css
+    assert ".assignmentAiProgressTrack" in css
+    assert "@keyframes assignmentAiProgressSweep" in css
 
 
 def test_assignment_date_time_inputs_are_serialized_as_iso() -> None:
@@ -980,12 +991,40 @@ def test_generate_assignment_ai_draft_with_codex_posts_request_and_fills_teacher
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Bozza Codex pronta/);
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /File proposti/);
           assert.match(tested.els.assignmentAiDraftText.value, /Somma con negativi/);
+          assert.equal(tested.els.assignmentAiProgress.hidden, true);
           tested.setAssignmentWizardStep("ai");
           assert.equal(tested.assignmentWizardStepComplete("ai"), true);
           assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
           assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Avanti: 3 Prepara revisione");
           assert.match(tested.els.status.textContent, /Bozza Codex pronta/);
         })();
+        """
+    )
+
+
+def test_assignment_ai_progress_blocks_next_until_generation_finishes() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignmentAiDraftText.value = JSON.stringify({ activity_patch: { titolo: "Somma" }, files: [] });
+        tested.setAssignmentWizardStep("ai");
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
+
+        tested.state.assignmentAiGenerating = true;
+        tested.setAssignmentAiProgress(true, "Generazione proposta AI in corso", "Provider: codex.");
+        tested.updateAssignmentAiApplyState();
+
+        assert.equal(tested.els.assignmentAiProgress.hidden, false);
+        assert.match(tested.els.assignmentAiProgress.innerHTML, /Provider: codex/);
+        assert.equal(tested.assignmentWizardStepComplete("ai"), false);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
+
+        tested.state.assignmentAiGenerating = false;
+        tested.setAssignmentAiProgress(false);
+        tested.updateAssignmentAiApplyState();
+
+        assert.equal(tested.els.assignmentAiProgress.hidden, true);
+        assert.equal(tested.assignmentWizardStepComplete("ai"), true);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -414,6 +414,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         renderAssignmentAiPackage,
         renderAssignmentCodexDraft,
         setAssignmentAiPreviewView,
+        selectAssignmentAiPreviewView,
         assignmentAiDraftFiles,
         renderAssignmentAiFilesReview,
         openAssignmentAiFilesDialog,
@@ -898,7 +899,8 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert "Invia prompt e genera proposta" in assignment_section
     assert "Generazione proposta AI in corso" in assignment_section
     assert "Controllo dati inviati all'AI" in assignment_section
-    assert "Aggiorna controllo dati" in assignment_section
+    assert "Aggiorna controllo dati" not in assignment_section
+    assert 'id="assignmentAiAskBtn"' not in assignment_section
     assert 'data-ai-preview-view="draft"' in assignment_section
     assert 'data-ai-preview-view="context"' in assignment_section
     assert 'id="assignmentWizardPrevBtn"' in assignment_section
@@ -1025,6 +1027,24 @@ def test_preview_assignment_ai_package_posts_bundle_request_and_renders_json() -
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /starter/);
           assert.equal(tested.els.assignmentAiDraftText.value, "");
           assert.match(tested.els.status.textContent, /Controllo dati AI pronto/);
+        })();
+        """
+    )
+
+
+def test_assignment_ai_context_tab_updates_context_preview() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.assignmentAiPrompt.value = "Aggiungi test sui negativi";
+
+          await tested.selectAssignmentAiPreviewView("context");
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/activities/ai-package");
+          assert.ok(call);
+          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /File di contesto inviati all'AI/);
         })();
         """
     )

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -392,11 +392,15 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         mountActivityEditorInWizard,
         mountActivityEditorInDialog,
         renderActivityPanelSummary,
+        selectActivity,
         activityAuthorTopicValue,
         activityAuthorTopicOptions,
         renderTopicSearch,
         suggestedActivityId,
         syncActivityAuthorIdSuggestion,
+        defaultSourceNameForLanguage,
+        languageFromSourceName,
+        syncSourceNameForLanguage,
         renderActivityAuthorMetadataSelects,
         assignmentPlanPayload,
         assignmentAiPackagePayload,
@@ -537,6 +541,8 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           topicOption.dataset.topicValue = "variabili";
           tested.els.activityAuthorTopicsList.append(topicOption);
           tested.els.activityAuthorMinutes.value = "25";
+          tested.els.activityAuthorLanguage.value = "python";
+          tested.els.activityAuthorSourceName.value = "main.py";
           tested.els.activityAuthorClass.value = "3A-TPSI";
           tested.els.activityAuthorTeam.value = "team-3a";
           tested.els.activityAuthorPath.value = "base";
@@ -550,6 +556,8 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           assert.equal(call.options.method, "POST");
           assert.equal(body.title, "Somma in Python");
           assert.equal(body.topics, "variabili");
+          assert.equal(body.language, "python");
+          assert.equal(body.source_name, "main.py");
           assert.equal(body.class_id, "3A-TPSI");
           assert.equal(tested.state.activities.length, 1);
           assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
@@ -558,6 +566,31 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           assert.match(tested.els.activityPanelStatus.textContent, /Activity salvata/);
         })();
         """
+    )
+
+
+def test_select_activity_restores_language_and_source_name() -> None:
+    run_dashboard_js(
+        """
+        tested.state.activities = [{
+          id: "python-base-somma-001",
+          title: "Somma in Python",
+          path: "activities/drafts/python-base-somma-001.json",
+          class_id: "3A-TPSI",
+          github_team: "team-3a",
+          language: "python",
+          source_name: "main.py",
+        }];
+        tested.els.activityAuthorLanguage.value = "c";
+        tested.els.activityAuthorSourceName.value = "main.c";
+
+        tested.selectActivity("activities/drafts/python-base-somma-001.json");
+
+        assert.equal(tested.els.activityPath.value, "activities/drafts/python-base-somma-001.json");
+        assert.equal(tested.els.activityAuthorLanguage.value, "python");
+        assert.equal(tested.els.activityAuthorSourceName.value, "main.py");
+        assert.equal(tested.els.classId.value, "3A-TPSI");
+      """
     )
 
 
@@ -615,6 +648,8 @@ def test_save_activity_from_review_enables_wizard_next() -> None:
           tested.els.activityAuthorDifficulty.value = "B";
           tested.els.activityAuthorTopics.value = "variabili";
           tested.els.activityAuthorMinutes.value = "30";
+          tested.els.activityAuthorLanguage.value = "python";
+          tested.els.activityAuthorSourceName.value = "main.py";
           tested.els.activityAuthorPrompt.value = "Scrivi un programma che somma due numeri.";
           tested.state.activityReviewSaved = false;
           tested.setAssignmentWizardStep("review");
@@ -640,6 +675,8 @@ def test_assignment_preview_posts_plan_and_renders_assets() -> None:
         (async () => {
           tested.els.activityPath.value = "activities/examples/python_assets_scaffold/activity.json";
           tested.els.targetsText.value = "students/rossi-mario\\nstudents/bianchi-luca";
+          tested.els.activityAuthorLanguage.value = "python";
+          tested.els.activityAuthorSourceName.value = "main.py";
           tested.fetchResponses["/api/activities/assignment-plan"] = {
             ok: true,
             plan: {
@@ -688,6 +725,8 @@ def test_assignment_preview_posts_plan_and_renders_assets() -> None:
           assert.equal(call.options.method, "POST");
           assert.equal(body.activity_path, "activities/examples/python_assets_scaffold/activity.json");
           assert.equal(body.targets_text, "students/rossi-mario\\nstudents/bianchi-luca");
+          assert.equal(body.language, "python");
+          assert.equal(body.source_name, "main.py");
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /Somma con scaffold Python/);
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /main.py/);
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /tests\\/test_hidden.py/);
@@ -704,6 +743,8 @@ def test_assignment_preview_explains_missing_server_endpoint() -> None:
         (async () => {
           tested.els.activityPath.value = "activities/examples/python_assets_scaffold/activity.json";
           tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.activityAuthorLanguage.value = "python";
+          tested.els.activityAuthorSourceName.value = "main.py";
           tested.fetchResponses["/api/activities/assignment-plan"] = {
             ok: false,
             status: 404,
@@ -785,6 +826,8 @@ def test_distribute_assignment_posts_plan_and_renders_written_targets() -> None:
         (async () => {
           tested.els.activityPath.value = "activities/python-base-somma-001.json";
           tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.activityAuthorLanguage.value = "python";
+          tested.els.activityAuthorSourceName.value = "main.py";
           tested.fetchResponses["/api/assignments/distribute"] = {
             ok: true,
             results: [
@@ -816,6 +859,8 @@ def test_distribute_assignment_posts_plan_and_renders_written_targets() -> None:
           const body = JSON.parse(call.options.body);
           assert.equal(body.activity_path, "activities/python-base-somma-001.json");
           assert.equal(body.targets_text, "students/rossi-mario");
+          assert.equal(body.language, "python");
+          assert.equal(body.source_name, "main.py");
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /Somma in Python/);
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /gia presente/);
           assert.match(tested.els.status.textContent, /distribuita a 1 target/);
@@ -1094,6 +1139,8 @@ def test_apply_assignment_ai_draft_to_activity_form_keeps_teacher_in_control() -
             titolo: "Somma con numeri negativi",
             tipo: "laboratorio",
             difficolta: "C",
+            linguaggio: "python",
+            source_name: "main.py",
             argomenti: ["variabili", "input"],
             consegna: "Scrivi un programma che somma due interi anche negativi.",
             metriche: { tempo_stimato_minuti: 35 },
@@ -1113,6 +1160,8 @@ def test_apply_assignment_ai_draft_to_activity_form_keeps_teacher_in_control() -
         assert.equal(tested.els.activityAuthorTopics.value, "variabili, input");
         assert.equal(tested.els.activityAuthorPrompt.value, "Scrivi un programma che somma due interi anche negativi.");
         assert.equal(tested.els.activityAuthorMinutes.value, "35");
+        assert.equal(tested.els.activityAuthorLanguage.value, "python");
+        assert.equal(tested.els.activityAuthorSourceName.value, "main.py");
         assert.match(tested.els.activityAuthorStatus.innerHTML, /Bozza AI applicata/);
         assert.match(tested.els.activityAuthorStatus.innerHTML, /Gli asset non vengono ancora salvati automaticamente/);
         assert.match(tested.els.status.textContent, /Revisione activity/);
@@ -1120,6 +1169,50 @@ def test_apply_assignment_ai_draft_to_activity_form_keeps_teacher_in_control() -
         assert.equal(tested.els.activityEditorBody.parentElement, tested.els.activityWizardEditorMount);
         const reviewStep = tested.els.assignmentSteps.find((section) => section.dataset.assignmentStep === "review");
         assert.equal(reviewStep.hidden, false);
+      """
+    )
+
+
+def test_apply_assignment_ai_draft_infers_language_from_proposed_file() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignmentAiDraftText.value = JSON.stringify({
+          summary: "Bozza Codex pronta",
+          activity_patch: {
+            titolo: "Somma in Python",
+            tipo: "laboratorio",
+            difficolta: "B",
+            argomenti: ["liste"],
+            consegna: "Completa il programma Python.",
+          },
+          files: [{ path: "starter/main.py", role: "starter", content: "print(0)\\n" }],
+        });
+
+        const applied = tested.applyAssignmentAiDraftToActivityForm();
+
+        assert.equal(applied, true);
+        assert.equal(tested.els.activityAuthorLanguage.value, "python");
+        assert.equal(tested.els.activityAuthorSourceName.value, "main.py");
+      """
+    )
+
+
+def test_activity_author_language_updates_default_source_name_only_when_safe() -> None:
+    run_dashboard_js(
+        """
+        tested.els.activityAuthorLanguage.value = "python";
+        tested.els.activityAuthorSourceName.value = "main.c";
+
+        tested.syncSourceNameForLanguage();
+
+        assert.equal(tested.els.activityAuthorSourceName.value, "main.py");
+
+        tested.els.activityAuthorSourceName.value = "soluzione_personale.py";
+        tested.els.activityAuthorLanguage.value = "c";
+
+        tested.syncSourceNameForLanguage();
+
+        assert.equal(tested.els.activityAuthorSourceName.value, "soluzione_personale.py");
       """
     )
 
@@ -1155,6 +1248,8 @@ def test_save_activity_draft_requires_prompt_before_posting() -> None:
           tested.els.activityAuthorDifficulty.value = "B";
           tested.els.activityAuthorTopics.value = "array";
           tested.els.activityAuthorMinutes.value = "30";
+          tested.els.activityAuthorLanguage.value = "c";
+          tested.els.activityAuthorSourceName.value = "main.c";
           tested.els.activityAuthorPrompt.value = "";
 
           await tested.saveActivityDraft();
@@ -1186,6 +1281,8 @@ def test_save_activity_draft_shows_backend_errors_in_review_status() -> None:
           tested.els.activityAuthorDifficulty.value = "B";
           tested.els.activityAuthorTopics.value = "array";
           tested.els.activityAuthorMinutes.value = "30";
+          tested.els.activityAuthorLanguage.value = "c";
+          tested.els.activityAuthorSourceName.value = "main.c";
           tested.els.activityAuthorPrompt.value = "Completa il programma.";
 
           await tested.saveActivityDraft();
@@ -1208,24 +1305,30 @@ def test_activity_author_required_fields_show_and_clear_invalid_state() -> None:
         tested.els.activityAuthorDifficulty.value = "B";
         tested.els.activityAuthorTopics.value = "";
         tested.els.activityAuthorMinutes.value = "0";
+        tested.els.activityAuthorLanguage.value = "";
+        tested.els.activityAuthorSourceName.value = "";
         tested.els.activityAuthorPrompt.value = "";
 
         let missing = tested.validateActivityAuthorRequiredFields({ showMessage: true });
 
-        assert.equal(JSON.stringify(missing), JSON.stringify(["Titolo", "Tipo", "Argomenti", "Tempo stimato", "Consegna"]));
+        assert.equal(JSON.stringify(missing), JSON.stringify(["Titolo", "Tipo", "Argomenti", "Tempo stimato", "Linguaggio", "File sorgente", "Consegna"]));
         assert.equal(tested.els.activityAuthorTitle["aria-invalid"], "true");
         assert.equal(tested.els.activityAuthorKind["aria-invalid"], "true");
         assert.equal(tested.els.activityAuthorDifficulty["aria-invalid"], "false");
         assert.equal(tested.els.activityAuthorTopics["aria-invalid"], "true");
         assert.equal(tested.els.activityAuthorMinutes["aria-invalid"], "true");
+        assert.equal(tested.els.activityAuthorLanguage["aria-invalid"], "true");
+        assert.equal(tested.els.activityAuthorSourceName["aria-invalid"], "true");
         assert.equal(tested.els.activityAuthorPrompt["aria-invalid"], "true");
         assert.equal(tested.els.activityAuthorStatus.classList.contains("isError"), true);
-        assert.match(tested.els.activityAuthorStatus.innerHTML, /Titolo, Tipo, Argomenti, Tempo stimato, Consegna/);
+        assert.match(tested.els.activityAuthorStatus.innerHTML, /Titolo, Tipo, Argomenti, Tempo stimato, Linguaggio, File sorgente, Consegna/);
 
         tested.els.activityAuthorTitle.value = "Array in C";
         tested.els.activityAuthorKind.value = "laboratorio";
         tested.els.activityAuthorTopics.value = "array";
         tested.els.activityAuthorMinutes.value = "30";
+        tested.els.activityAuthorLanguage.value = "c";
+        tested.els.activityAuthorSourceName.value = "main.c";
         tested.els.activityAuthorPrompt.value = "Completa il programma.";
 
         missing = tested.validateActivityAuthorRequiredFields({ showMessage: true });
@@ -1235,6 +1338,8 @@ def test_activity_author_required_fields_show_and_clear_invalid_state() -> None:
         assert.equal(tested.els.activityAuthorKind["aria-invalid"], "false");
         assert.equal(tested.els.activityAuthorTopics["aria-invalid"], "false");
         assert.equal(tested.els.activityAuthorMinutes["aria-invalid"], "false");
+        assert.equal(tested.els.activityAuthorLanguage["aria-invalid"], "false");
+        assert.equal(tested.els.activityAuthorSourceName["aria-invalid"], "false");
         assert.equal(tested.els.activityAuthorPrompt["aria-invalid"], "false");
       """
     )
@@ -1498,6 +1603,8 @@ def test_activity_authoring_required_fields_are_marked_in_markup_and_css() -> No
         "activityAuthorDifficulty",
         "activityAuthorTopics",
         "activityAuthorMinutes",
+        "activityAuthorLanguage",
+        "activityAuthorSourceName",
         "activityAuthorPrompt",
     ]:
         field_markup = html.split(f'id="{field_id}"', 1)[1].split(">", 1)[0]

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -1115,6 +1115,46 @@ def test_apply_assignment_ai_draft_to_activity_form_keeps_teacher_in_control() -
     )
 
 
+def test_apply_assignment_ai_draft_accepts_instruction_aliases_for_prompt() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignmentAiDraftText.value = JSON.stringify({
+          summary: "Bozza proposta",
+          activity_patch: {
+            titolo: "Array in C",
+            istruzioni: "Completa il programma C che somma gli elementi di un array.",
+          },
+          files: [],
+        });
+
+        const applied = tested.applyAssignmentAiDraftToActivityForm();
+
+        assert.equal(applied, true);
+        assert.equal(tested.els.activityAuthorTitle.value, "Array in C");
+        assert.equal(tested.els.activityAuthorPrompt.value, "Completa il programma C che somma gli elementi di un array.");
+      """
+    )
+
+
+def test_save_activity_draft_requires_prompt_before_posting() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityAuthorTitle.value = "Array in C";
+          tested.els.activityAuthorId.value = "array-c";
+          tested.els.activityAuthorPrompt.value = "";
+
+          await tested.saveActivityDraft();
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/activities/save");
+          assert.equal(call, undefined);
+          assert.match(tested.els.activityAuthorStatus.textContent, /Completa il campo Consegna/);
+          assert.match(tested.els.status.textContent, /Completa il campo Consegna/);
+        })();
+      """
+    )
+
+
 def test_apply_assignment_ai_draft_reports_invalid_json() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -413,6 +413,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         renderAssignmentPlan,
         renderAssignmentAiPackage,
         renderAssignmentCodexDraft,
+        setAssignmentAiPreviewView,
         assignmentAiDraftFiles,
         renderAssignmentAiFilesReview,
         openAssignmentAiFilesDialog,
@@ -898,6 +899,8 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert "Generazione proposta AI in corso" in assignment_section
     assert "Controllo dati inviati all'AI" in assignment_section
     assert "Aggiorna controllo dati" in assignment_section
+    assert 'data-ai-preview-view="draft"' in assignment_section
+    assert 'data-ai-preview-view="context"' in assignment_section
     assert 'id="assignmentWizardPrevBtn"' in assignment_section
     assert 'id="assignmentWizardNextBtn"' in assignment_section
     assert 'id="assignmentWizardHint"' in assignment_section
@@ -1093,6 +1096,41 @@ def test_generate_assignment_ai_draft_with_codex_posts_request_and_fills_teacher
           assert.match(tested.els.assignmentAiGenerateBtn.title, /Hai gia inviato questo prompt/);
         })();
         """
+    )
+
+
+def test_assignment_ai_preview_switches_between_draft_and_context_without_losing_content() -> None:
+    run_dashboard_js(
+        """
+        tested.renderAssignmentCodexDraft({
+          draft: {
+            summary: "Bozza pronta da mantenere",
+            activity_patch: { titolo: "Somma" },
+            files: [{ path: "starter/main.py", role: "starter", content: "print(1)\\n" }],
+          },
+        });
+        assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Bozza Codex pronta/);
+        assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /starter\\/main.py/);
+
+        tested.renderAssignmentAiPackage({
+          schema_version: "activity_ai_package.v1",
+          provider: "codex",
+          prompt: "Crea una traccia",
+          activity: { id: "demo", title: "Demo" },
+          files: [],
+          policy: { student_budget: 5, integrity_mode: "normal" },
+          teacher_review: { required: true },
+        });
+        assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /File di contesto inviati all'AI/);
+        assert.doesNotMatch(tested.els.assignmentAiPackagePreview.innerHTML, /Bozza Codex pronta/);
+
+        tested.setAssignmentAiPreviewView("draft");
+        assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Bozza Codex pronta/);
+        assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /starter\\/main.py/);
+
+        tested.setAssignmentAiPreviewView("context");
+        assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /File di contesto inviati all'AI/);
+      """
     )
 
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -826,6 +826,8 @@ def test_save_assignment_record_posts_form_and_refreshes_due_assignments() -> No
           assert.equal(tested.state.dueAssignments.length, 1);
           assert.match(tested.els.assignmentStatus.textContent, /1 assegnazioni scadute senza registro/);
           assert.match(tested.els.status.textContent, /Assegnazione salvata/);
+          assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Assegnazione salvata/);
+          assert.match(tested.els.assignmentConfirmStatus.innerHTML, /assignment-python-base-somma-001-3a-tpsi/);
         })();
         """
     )
@@ -875,6 +877,8 @@ def test_distribute_assignment_posts_plan_and_renders_written_targets() -> None:
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /Somma in Python/);
           assert.match(tested.els.assignmentPlanPreview.innerHTML, /gia presente/);
           assert.match(tested.els.status.textContent, /distribuita a 1 target/);
+          assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Distribuzione completata/);
+          assert.match(tested.els.assignmentConfirmStatus.innerHTML, /1 target aggiornati/);
         })();
         """
     )

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -384,6 +384,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         setupPanelDragAndDrop,
         renderLegend,
         saveActivityDraft,
+        validateActivityAuthorRequiredFields,
         openActivityEditor,
         closeActivityEditor,
         openActivityReviewStep,
@@ -608,6 +609,10 @@ def test_save_activity_from_review_enables_wizard_next() -> None:
           tested.openActivityReviewStep();
           tested.els.activityAuthorTitle.value = "Somma in Python";
           tested.els.activityAuthorId.value = "somma-in-python";
+          tested.els.activityAuthorKind.value = "compito-casa";
+          tested.els.activityAuthorDifficulty.value = "B";
+          tested.els.activityAuthorTopics.value = "variabili";
+          tested.els.activityAuthorMinutes.value = "30";
           tested.els.activityAuthorPrompt.value = "Scrivi un programma che somma due numeri.";
           tested.state.activityReviewSaved = false;
           tested.setAssignmentWizardStep("review");
@@ -1142,15 +1147,59 @@ def test_save_activity_draft_requires_prompt_before_posting() -> None:
         (async () => {
           tested.els.activityAuthorTitle.value = "Array in C";
           tested.els.activityAuthorId.value = "array-c";
+          tested.els.activityAuthorKind.value = "laboratorio";
+          tested.els.activityAuthorDifficulty.value = "B";
+          tested.els.activityAuthorTopics.value = "array";
+          tested.els.activityAuthorMinutes.value = "30";
           tested.els.activityAuthorPrompt.value = "";
 
           await tested.saveActivityDraft();
 
           const call = tested.fetchCalls.find((entry) => entry.path === "/api/activities/save");
           assert.equal(call, undefined);
-          assert.match(tested.els.activityAuthorStatus.textContent, /Completa il campo Consegna/);
-          assert.match(tested.els.status.textContent, /Completa il campo Consegna/);
+          assert.match(tested.els.activityAuthorStatus.textContent, /Completa i campi obbligatori: Consegna/);
+          assert.match(tested.els.status.textContent, /Completa i campi obbligatori: Consegna/);
+          assert.equal(tested.els.activityAuthorPrompt["aria-invalid"], "true");
         })();
+      """
+    )
+
+
+def test_activity_author_required_fields_show_and_clear_invalid_state() -> None:
+    run_dashboard_js(
+        """
+        tested.els.activityAuthorTitle.value = "";
+        tested.els.activityAuthorKind.value = "";
+        tested.els.activityAuthorDifficulty.value = "B";
+        tested.els.activityAuthorTopics.value = "";
+        tested.els.activityAuthorMinutes.value = "0";
+        tested.els.activityAuthorPrompt.value = "";
+
+        let missing = tested.validateActivityAuthorRequiredFields({ showMessage: true });
+
+        assert.equal(JSON.stringify(missing), JSON.stringify(["Titolo", "Tipo", "Argomenti", "Tempo stimato", "Consegna"]));
+        assert.equal(tested.els.activityAuthorTitle["aria-invalid"], "true");
+        assert.equal(tested.els.activityAuthorKind["aria-invalid"], "true");
+        assert.equal(tested.els.activityAuthorDifficulty["aria-invalid"], "false");
+        assert.equal(tested.els.activityAuthorTopics["aria-invalid"], "true");
+        assert.equal(tested.els.activityAuthorMinutes["aria-invalid"], "true");
+        assert.equal(tested.els.activityAuthorPrompt["aria-invalid"], "true");
+        assert.match(tested.els.activityAuthorStatus.textContent, /Titolo, Tipo, Argomenti, Tempo stimato, Consegna/);
+
+        tested.els.activityAuthorTitle.value = "Array in C";
+        tested.els.activityAuthorKind.value = "laboratorio";
+        tested.els.activityAuthorTopics.value = "array";
+        tested.els.activityAuthorMinutes.value = "30";
+        tested.els.activityAuthorPrompt.value = "Completa il programma.";
+
+        missing = tested.validateActivityAuthorRequiredFields({ showMessage: true });
+
+        assert.equal(JSON.stringify(missing), JSON.stringify([]));
+        assert.equal(tested.els.activityAuthorTitle["aria-invalid"], "false");
+        assert.equal(tested.els.activityAuthorKind["aria-invalid"], "false");
+        assert.equal(tested.els.activityAuthorTopics["aria-invalid"], "false");
+        assert.equal(tested.els.activityAuthorMinutes["aria-invalid"], "false");
+        assert.equal(tested.els.activityAuthorPrompt["aria-invalid"], "false");
       """
     )
 
@@ -1400,6 +1449,25 @@ def test_activity_authoring_difficulty_options_include_readable_labels() -> None
 
     assert '<option value="B" selected>B - facile: modifica piccola</option>' in difficulty_section
     assert '<option value="F">F - ninja: produzione</option>' in difficulty_section
+
+
+def test_activity_authoring_required_fields_are_marked_in_markup_and_css() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
+    css = open("tools/assignment_dashboard.css", encoding="utf-8").read()
+
+    for field_id in [
+        "activityAuthorTitle",
+        "activityAuthorKind",
+        "activityAuthorDifficulty",
+        "activityAuthorTopics",
+        "activityAuthorMinutes",
+        "activityAuthorPrompt",
+    ]:
+        field_markup = html.split(f'id="{field_id}"', 1)[1].split(">", 1)[0]
+        assert "required" in field_markup
+
+    assert '[aria-invalid="true"]' in css
+    assert "#b91c1c" in css
 
 
 def test_legend_renders_static_marks_but_escapes_descriptions() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -144,6 +144,8 @@ def run_dashboard_js(assertions: str) -> None:
       }}
       closest() {{ return {{ clientWidth: 960 }}; }}
       getBoundingClientRect() {{ return {{ top: 0, bottom: 120, left: 0, right: this.testWidth, width: this.testWidth, height: 120 }}; }}
+      scrollIntoView() {{}}
+      focus() {{}}
       showModal() {{ this.open = true; }}
       close() {{ this.open = false; }}
       setPointerCapture() {{}}
@@ -454,6 +456,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         renderAssignmentSelect,
         clearSelectedAssignment,
         applyAssignmentToGenerateForm,
+        selectCoverageActivity,
         rosterOptionLabel,
         localTargetFromStudent,
         rosterTargets,
@@ -1091,6 +1094,43 @@ def test_assignment_confirm_status_resets_when_roster_is_applied() -> None:
 
         assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Dati modificati/);
         assert.match(tested.els.assignmentConfirmStatus.innerHTML, /roster e i destinatari sono cambiati/);
+        """
+    )
+
+
+def test_assignment_confirm_status_resets_when_existing_assignment_is_loaded() -> None:
+    run_dashboard_js(
+        """
+        tested.state.dueAssignments = [{
+          id: "assignment-python-base-somma-001-3a",
+          activity_id: "python-base-somma-001",
+          activity_path: "activities/python-base-somma-001.json",
+          class_id: "3A",
+          class_label: "3A TPSI",
+          github_team: "team-3a",
+          assigned_at: "2026-10-12T09:00:00+02:00",
+          due_at: "2026-10-19T23:59:00+02:00",
+          targets: [{ path: "students/rossi-mario" }],
+        }];
+        tested.els.assignmentConfirmStatus.innerHTML = "<strong>Assegnazione salvata</strong><span>ID: demo</span>";
+
+        tested.applyAssignmentToGenerateForm("assignment-python-base-somma-001-3a");
+
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Dati modificati/);
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Assegnazione caricata/);
+        """
+    )
+
+
+def test_assignment_confirm_status_resets_when_coverage_activity_is_selected() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignmentConfirmStatus.innerHTML = "<strong>Distribuzione completata</strong><span>3 target aggiornati</span>";
+
+        tested.selectCoverageActivity("activities/python-base-somma-001.json", "demo/python-base-somma-001.json");
+
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Dati modificati/);
+        assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Activity selezionata dalla copertura/);
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -896,8 +896,8 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert 'id="assignmentAiProgress"' in assignment_section
     assert "Invia prompt e genera proposta" in assignment_section
     assert "Generazione proposta AI in corso" in assignment_section
-    assert "Dettagli tecnici del pacchetto AI" in assignment_section
-    assert "Mostra pacchetto tecnico" in assignment_section
+    assert "Controllo dati inviati all'AI" in assignment_section
+    assert "Aggiorna controllo dati" in assignment_section
     assert 'id="assignmentWizardPrevBtn"' in assignment_section
     assert 'id="assignmentWizardNextBtn"' in assignment_section
     assert 'id="assignmentWizardHint"' in assignment_section
@@ -1016,11 +1016,32 @@ def test_preview_assignment_ai_package_posts_bundle_request_and_renders_json() -
           assert.equal(body.prompt, "Aggiungi test sui negativi");
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Somma in Python/);
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /nessuna chiamata AI/);
-          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /JSON pacchetto/);
+          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /File di contesto inviati all'AI/);
+          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /File di contesto non inviati/);
+          assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /JSON tecnico per debug/);
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /starter/);
           assert.equal(tested.els.assignmentAiDraftText.value, "");
-          assert.match(tested.els.status.textContent, /nessuna chiamata provider/);
+          assert.match(tested.els.status.textContent, /Controllo dati AI pronto/);
         })();
+        """
+    )
+
+
+def test_assignment_ai_package_empty_context_files_are_explained() -> None:
+    run_dashboard_js(
+        """
+        tested.renderAssignmentAiPackage({
+          schema_version: "activity_ai_package.v1",
+          provider: "codex",
+          prompt: "Crea una traccia",
+          activity: { id: "demo", title: "Demo" },
+          files: [],
+          policy: { student_budget: 5, integrity_mode: "normal" },
+          teacher_review: { required: true },
+        });
+
+        assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Nessun file di contesto collegato all'activity/);
+        assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Verranno inviati prompt e metadati/);
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -404,8 +404,9 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         renderAssignmentPlan,
         renderAssignmentAiPackage,
         renderAssignmentCodexDraft,
-        updateAssignmentAiApplyState,
         applyAssignmentAiDraftToActivityForm,
+        updateAssignmentAiApplyState,
+        assignmentWizardStepComplete,
         setAssignmentWizardStep,
         moveAssignmentWizardStep,
         assignmentPlanErrorMessage,
@@ -803,10 +804,7 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert 'id="assignmentAiPrompt"' in assignment_section
     assert 'id="assignmentAiDraftText"' in assignment_section
     assert 'id="assignmentAiGenerateBtn"' in assignment_section
-    assert 'id="assignmentAiApplyDraftBtn"' in assignment_section
-    assert 'id="assignmentAiApplyDraftBtn" type="button" disabled' in assignment_section
     assert "Genera proposta AI" in assignment_section
-    assert "Prepara revisione" in assignment_section
     assert "Dettagli tecnici del pacchetto AI" in assignment_section
     assert "Mostra pacchetto tecnico" in assignment_section
     assert 'id="assignmentWizardPrevBtn"' in assignment_section
@@ -958,29 +956,34 @@ def test_generate_assignment_ai_draft_with_codex_posts_request_and_fills_teacher
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Bozza Codex pronta/);
           assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /File proposti/);
           assert.match(tested.els.assignmentAiDraftText.value, /Somma con negativi/);
-          assert.equal(tested.els.assignmentAiApplyDraftBtn.disabled, false);
+          tested.setAssignmentWizardStep("ai");
+          assert.equal(tested.assignmentWizardStepComplete("ai"), true);
+          assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
+          assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Avanti: 3 Prepara revisione");
           assert.match(tested.els.status.textContent, /Bozza Codex pronta/);
         })();
         """
     )
 
 
-def test_assignment_ai_apply_button_tracks_valid_draft_text() -> None:
+def test_assignment_ai_next_button_tracks_valid_draft_text() -> None:
     run_dashboard_js(
         """
-        assert.equal(tested.els.assignmentAiApplyDraftBtn.disabled, false);
+        tested.setAssignmentWizardStep("ai");
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
 
         tested.els.assignmentAiDraftText.value = "";
         tested.updateAssignmentAiApplyState();
-        assert.equal(tested.els.assignmentAiApplyDraftBtn.disabled, true);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
 
         tested.els.assignmentAiDraftText.value = "{";
         tested.updateAssignmentAiApplyState();
-        assert.equal(tested.els.assignmentAiApplyDraftBtn.disabled, true);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
 
         tested.els.assignmentAiDraftText.value = JSON.stringify({ activity_patch: { titolo: "Somma" }, files: [] });
         tested.updateAssignmentAiApplyState();
-        assert.equal(tested.els.assignmentAiApplyDraftBtn.disabled, false);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
+        assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Avanti: 3 Prepara revisione");
         """
     )
 
@@ -1074,7 +1077,7 @@ def test_assignment_wizard_switches_visible_step() -> None:
         assert.equal(activityStep.hidden, true);
         assert.match(tested.els.assignmentWizardHint.textContent, /Step 2 di 7/);
         assert.equal(tested.els.assignmentWizardPrevBtn.disabled, false);
-        assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
         """
     )
 
@@ -1083,16 +1086,30 @@ def test_assignment_wizard_prev_next_guides_the_flow() -> None:
     run_dashboard_js(
         """
         tested.setAssignmentWizardStep("activity");
+        tested.els.activityPath.value = "activities/python-base-somma-001.json";
+        tested.setAssignmentWizardStep("activity");
 
         assert.equal(tested.els.assignmentWizardPrevBtn.disabled, true);
         assert.match(tested.els.assignmentWizardHint.textContent, /Step 1 di 7/);
 
         tested.moveAssignmentWizardStep(1);
         assert.match(tested.els.assignmentWizardHint.textContent, /Step 2 di 7/);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
 
+        tested.moveAssignmentWizardStep(1);
+        assert.match(tested.els.assignmentWizardHint.textContent, /Step 2 di 7/);
+
+        tested.els.assignmentAiDraftText.value = JSON.stringify({ activity_patch: { titolo: "Somma" }, files: [] });
+        tested.updateAssignmentAiApplyState();
         tested.moveAssignmentWizardStep(1);
         assert.match(tested.els.assignmentWizardHint.textContent, /Step 3 di 7/);
         assert.equal(tested.els.activityEditorBody.parentElement, tested.els.activityWizardEditorMount);
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
+
+        tested.state.activityReviewSaved = true;
+        tested.els.activityPath.value = "activities/drafts/somma.json";
+        tested.setAssignmentWizardStep("review");
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
 
         tested.moveAssignmentWizardStep(10);
         assert.match(tested.els.assignmentWizardHint.textContent, /Step 7 di 7/);
@@ -1102,7 +1119,7 @@ def test_assignment_wizard_prev_next_guides_the_flow() -> None:
         tested.moveAssignmentWizardStep(-1);
         assert.match(tested.els.assignmentWizardHint.textContent, /Step 6 di 7/);
         assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
-        assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Avanti");
+        assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Avanti: 7 Conferma");
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -413,6 +413,10 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         renderAssignmentPlan,
         renderAssignmentAiPackage,
         renderAssignmentCodexDraft,
+        assignmentAiDraftFiles,
+        renderAssignmentAiFilesReview,
+        openAssignmentAiFilesDialog,
+        closeAssignmentAiFilesDialog,
         applyAssignmentAiDraftToActivityForm,
         updateAssignmentAiApplyState,
         setAssignmentAiProgress,
@@ -912,12 +916,17 @@ def test_assignment_wizard_uses_calendar_date_time_inputs() -> None:
     assert 'id="nowAt" type="datetime-local"' in assignment_section
 
 
-def test_assignment_ai_context_checkboxes_use_fixed_alignment() -> None:
+def test_assignment_ai_context_uses_informative_status_rows() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
     css = open("tools/assignment_dashboard.css", encoding="utf-8").read()
+    assignment_section = html.split('data-assignment-step="ai"', 1)[1].split('data-assignment-step="review"', 1)[0]
 
-    assert ".assignmentAiContext label" in css
-    assert "grid-template-columns: 1rem minmax(0, 1fr);" in css
-    assert '.assignmentAiContext input[type="checkbox"]' in css
+    assert 'type="checkbox"' not in assignment_section
+    assert "contextState isIncluded" in assignment_section
+    assert "contextState isPlanned" in assignment_section
+    assert ".assignmentAiContextItem" in css
+    assert ".contextState.isIncluded" in css
+    assert ".contextState.isPlanned" in css
 
 
 def test_assignment_ai_progress_has_visible_indeterminate_bar() -> None:
@@ -1057,6 +1066,36 @@ def test_generate_assignment_ai_draft_with_codex_posts_request_and_fills_teacher
           assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Avanti: 3 Prepara revisione");
           assert.match(tested.els.status.textContent, /Bozza Codex pronta/);
         })();
+        """
+    )
+
+
+def test_generated_ai_files_open_in_review_style_modal() -> None:
+    run_dashboard_js(
+        """
+        tested.renderAssignmentCodexDraft({
+          draft: {
+            summary: "Bozza pronta",
+            activity_patch: { titolo: "Somma" },
+            files: [
+              { path: "starter/main.py", role: "starter", content: "print(1)\\n" },
+              { path: "tests/test_main.py", role: "test", content: "def test_ok():\\n    assert True\\n" },
+            ],
+          },
+        });
+
+        assert.match(tested.els.assignmentAiPackagePreview.innerHTML, /Apri file/);
+
+        tested.openAssignmentAiFilesDialog(1);
+
+        assert.equal(tested.els.assignmentAiFilesDialog.open, true);
+        assert.match(tested.els.assignmentAiFilesStatus.textContent, /tests\\/test_main.py/);
+        assert.match(tested.els.assignmentAiFilesReview.innerHTML, /starter\\/main.py/);
+        assert.match(tested.els.assignmentAiFilesReview.innerHTML, /test_ok/);
+
+        tested.closeAssignmentAiFilesDialog();
+
+        assert.equal(tested.els.assignmentAiFilesDialog.open, false);
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -407,6 +407,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         applyAssignmentAiDraftToActivityForm,
         updateAssignmentAiApplyState,
         setAssignmentAiProgress,
+        setAssignmentAiProgressError,
         assignmentWizardStepComplete,
         setAssignmentWizardStep,
         moveAssignmentWizardStep,
@@ -867,6 +868,7 @@ def test_assignment_ai_progress_has_visible_indeterminate_bar() -> None:
 
     assert ".assignmentAiProgress" in css
     assert ".assignmentAiProgressTrack" in css
+    assert ".assignmentAiProgress.isError" in css
     assert "@keyframes assignmentAiProgressSweep" in css
 
 
@@ -1025,6 +1027,25 @@ def test_assignment_ai_progress_blocks_next_until_generation_finishes() -> None:
         assert.equal(tested.els.assignmentAiProgress.hidden, true);
         assert.equal(tested.assignmentWizardStepComplete("ai"), true);
         assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
+        """
+    )
+
+
+def test_assignment_ai_generation_error_is_visible_outside_details() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.assignmentAiProvider.value = "openai";
+
+          await tested.generateAssignmentAiDraft();
+
+          assert.equal(tested.els.assignmentAiProgress.hidden, false);
+          assert.equal(tested.els.assignmentAiProgress.classList.contains("isError"), true);
+          assert.match(tested.els.assignmentAiProgress.innerHTML, /Generazione proposta AI interrotta/);
+          assert.match(tested.els.assignmentAiProgress.innerHTML, /Provider non ancora collegato/);
+          assert.equal(tested.els.assignmentAiGenerateBtn.disabled, false);
+          assert.match(tested.els.status.textContent, /Provider non ancora collegato/);
+        })();
         """
     )
 

--- a/tests/test_codex_activity_adapter.py
+++ b/tests/test_codex_activity_adapter.py
@@ -132,6 +132,21 @@ def test_validate_codex_activity_draft_decodes_activity_patch_json() -> None:
     assert draft["activity_patch"]["argomenti"] == ["array"]
 
 
+def test_validate_codex_activity_draft_repairs_invalid_backslash_escape() -> None:
+    draft = codex_activity_adapter.validate_codex_activity_draft(
+        {
+            "summary": "Bozza",
+            "teacher_notes": "Note",
+            "activity_patch_json": '{"titolo": "Array C", "consegna": "Completa funzione somma\\_array"}',
+            "files": [],
+            "questions": [],
+            "warnings": [],
+        }
+    )
+
+    assert draft["activity_patch"]["consegna"] == "Completa funzione somma\\_array"
+
+
 def test_validate_codex_activity_draft_normalizes_activity_patch_asset_paths() -> None:
     draft = codex_activity_adapter.validate_codex_activity_draft(
         {

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -741,6 +741,8 @@ def test_save_activity_builds_valid_draft_from_gui_payload(tmp_path, monkeypatch
         "topics": "variabili, operatori",
         "prompt": "Scrivi un programma che somma due numeri.",
         "estimated_minutes": "25",
+        "language": "python",
+        "source_name": "main.py",
         "class_id": "3A-TPSI",
         "github_team": "team-3a",
         "uda_id": "uda-1",
@@ -754,9 +756,16 @@ def test_save_activity_builds_valid_draft_from_gui_payload(tmp_path, monkeypatch
     assert saved_payload["id"] == "somma-in-python"
     assert saved_payload["titolo"] == "Somma in Python"
     assert saved_payload["tipo"] == "compito-casa"
+    assert saved_payload["linguaggio"] == "python"
+    assert saved_payload["language"] == "python"
     assert saved_payload["argomenti"] == ["variabili", "operatori"]
     assert saved_payload["metriche"]["tempo_stimato_minuti"] == 25
-    assert saved_payload["contesto"] == {"classe": "3A-TPSI", "team_github": "team-3a", "uda": "uda-1"}
+    assert saved_payload["contesto"] == {
+        "classe": "3A-TPSI",
+        "team_github": "team-3a",
+        "uda": "uda-1",
+        "source_name": "main.py",
+    }
 
 
 def test_ai_secret_status_reports_paths_and_configured_keys_without_values(tmp_path, monkeypatch) -> None:

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -219,7 +219,7 @@ def test_list_activities_skips_invalid_json_and_deduplicates_paths(tmp_path) -> 
                 "titolo": "Somma in Python",
                 "tipo": "compito-casa",
                 "linguaggio": "python",
-                "contesto": {"classe": "3A-TPSI", "team_github": "team-3a-tpsi"},
+                "contesto": {"classe": "3A-TPSI", "team_github": "team-3a-tpsi", "source_name": "main.py"},
             }
         ),
         encoding="utf-8",
@@ -237,6 +237,7 @@ def test_list_activities_skips_invalid_json_and_deduplicates_paths(tmp_path) -> 
             "class_label": "3A-TPSI",
             "github_team": "team-3a-tpsi",
             "language": "python",
+            "source_name": "main.py",
             "topics": [],
             "path": "activities/activity.json",
         }
@@ -273,6 +274,7 @@ def test_save_activity_persists_valid_draft_and_lists_it(tmp_path) -> None:
 
     assert saved["path"] == "activities/drafts/python-base-somma-001.json"
     assert saved["topics"] == ["variabili", "operatori"]
+    assert saved["source_name"] == ""
     assert (tmp_path / "activities" / "drafts" / "python-base-somma-001.json").is_file()
     assert storage.list_activities() == [saved]
     with pytest.raises(ValueError, match="gia esistente"):

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -169,6 +169,71 @@ select {
   padding: 1.1rem;
 }
 
+.assignmentTargetPicker {
+  display: grid;
+  gap: .75rem;
+  padding: .85rem;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.assignmentTargetPickerHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.assignmentTargetPickerHead strong {
+  display: block;
+  margin-bottom: .2rem;
+}
+
+.assignmentTargetPickerHead p {
+  max-width: 48rem;
+  margin: 0;
+  color: var(--muted);
+  font-size: .82rem;
+  line-height: 1.45;
+}
+
+.assignmentTargetPickerList {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: .55rem;
+}
+
+.assignmentTargetOption {
+  display: grid;
+  grid-template-columns: 1rem minmax(0, 1fr);
+  align-items: start;
+  gap: .55rem;
+  padding: .65rem;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-radius: 8px;
+  background: #fbfbfb;
+}
+
+.assignmentTargetOption input {
+  width: 1rem;
+  height: 1rem;
+  margin: .12rem 0 0;
+  accent-color: #111111;
+}
+
+.assignmentTargetOption strong,
+.assignmentTargetOption small {
+  display: block;
+}
+
+.assignmentTargetOption small {
+  margin-top: .15rem;
+  color: var(--muted);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
 .assignmentWizard {
   border-top: 1px solid rgba(17, 17, 17, .08);
 }
@@ -2189,6 +2254,10 @@ code {
 
   .generateGrid {
     grid-template-columns: 1fr;
+  }
+
+  .assignmentTargetPickerHead {
+    flex-direction: column;
   }
 
   .assignmentPlanGrid {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -225,6 +225,10 @@ select {
   overflow: visible;
 }
 
+.activityEditorStatus {
+  margin: 1rem 1.1rem 0;
+}
+
 .assignmentAiDraft {
   margin: 1.1rem;
   padding: 1rem;

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -388,25 +388,41 @@ textarea[aria-invalid="true"]:focus {
   margin-bottom: .15rem;
 }
 
-.assignmentAiContext label {
+.assignmentAiContextItem {
   display: grid;
-  grid-template-columns: 1rem minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: start;
-  gap: .45rem;
+  gap: .55rem;
   color: var(--muted);
   font-size: .82rem;
   line-height: 1.35;
 }
 
-.assignmentAiContext input[type="checkbox"] {
-  width: 1rem;
-  height: 1rem;
-  margin: .08rem 0 0;
-  accent-color: #111111;
+.contextState {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.1rem;
+  border-radius: 999px;
+  padding: .1rem .42rem;
+  border: 1px solid rgba(17, 17, 17, .14);
+  background: #f3f4f6;
+  color: #374151;
+  font-size: .7rem;
+  font-weight: 800;
+  text-transform: uppercase;
 }
 
-.assignmentAiContext input[type="checkbox"]:disabled {
-  opacity: .7;
+.contextState.isIncluded {
+  border-color: rgba(22, 101, 52, .24);
+  background: #ecfdf3;
+  color: #166534;
+}
+
+.contextState.isPlanned {
+  border-color: rgba(146, 64, 14, .24);
+  background: #fff7ed;
+  color: #92400e;
 }
 
 .assignmentAiPolicy {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -213,6 +213,18 @@ select {
   text-align: center;
 }
 
+.activityWizardEditorMount {
+  margin: 0 1.1rem 1.1rem;
+  border: 1px solid rgba(17, 17, 17, .1);
+  border-radius: 8px;
+  background: #ffffff;
+  overflow: hidden;
+}
+
+.activityWizardEditorMount .activityEditorBody {
+  overflow: visible;
+}
+
 .assignmentAiDraft {
   margin: 1.1rem;
   padding: 1rem;

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -296,6 +296,68 @@ select {
   gap: .8rem;
 }
 
+.assignmentAiProgress {
+  display: grid;
+  gap: .65rem;
+  padding: .85rem;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.assignmentAiProgress[hidden] {
+  display: none;
+}
+
+.assignmentAiProgressHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: .8rem;
+}
+
+.assignmentAiProgressHeader strong {
+  margin: 0;
+}
+
+.assignmentAiProgressHeader span,
+.assignmentAiProgress p {
+  color: var(--muted);
+  font-size: .82rem;
+  line-height: 1.45;
+}
+
+.assignmentAiProgress p {
+  margin: 0;
+}
+
+.assignmentAiProgressTrack {
+  height: .55rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(17, 17, 17, .08);
+}
+
+.assignmentAiProgressTrack span {
+  display: block;
+  width: 45%;
+  height: 100%;
+  border-radius: inherit;
+  background:
+    linear-gradient(90deg, rgba(17, 17, 17, .15), rgba(17, 17, 17, .78), rgba(17, 17, 17, .15));
+  animation: assignmentAiProgressSweep 1.35s ease-in-out infinite;
+}
+
+@keyframes assignmentAiProgressSweep {
+  0% {
+    transform: translateX(-110%);
+  }
+
+  100% {
+    transform: translateX(230%);
+  }
+}
+
 .assignmentPackageJson {
   margin-top: .9rem;
 }

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -306,6 +306,46 @@ textarea[aria-invalid="true"]:focus {
 
 .activityEditorStatus {
   margin: 1rem 1.1rem 0;
+  padding: .85rem;
+  border: 1px solid rgba(17, 17, 17, .12);
+  border-radius: 8px;
+  background: #fbfbfb;
+  color: var(--muted);
+}
+
+.activityEditorStatus strong,
+.activityEditorStatus span {
+  display: block;
+}
+
+.activityEditorStatus strong {
+  margin-bottom: .2rem;
+  color: var(--text);
+}
+
+.activityEditorStatus.isSaving {
+  border-color: rgba(17, 17, 17, .22);
+  background: #ffffff;
+}
+
+.activityEditorStatus.isSuccess {
+  border-color: rgba(21, 128, 61, .35);
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.activityEditorStatus.isError {
+  border-color: rgba(185, 28, 28, .35);
+  background: #fff7f7;
+  color: #7f1d1d;
+}
+
+.activityEditorStatus.isSuccess strong {
+  color: #166534;
+}
+
+.activityEditorStatus.isError strong {
+  color: #991b1b;
 }
 
 .assignmentAiDraft {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -348,6 +348,19 @@ select {
   animation: assignmentAiProgressSweep 1.35s ease-in-out infinite;
 }
 
+.assignmentAiProgress.isError {
+  border-color: rgba(185, 28, 28, .35);
+  background: #fff7f7;
+}
+
+.assignmentAiProgress.isError .assignmentAiProgressHeader strong {
+  color: #991b1b;
+}
+
+.assignmentAiProgress.isError p {
+  color: #7f1d1d;
+}
+
 @keyframes assignmentAiProgressSweep {
   0% {
     transform: translateX(-110%);

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -375,6 +375,22 @@ textarea[aria-invalid="true"]:focus {
   margin-top: 1rem;
 }
 
+.assignmentAiPromptField {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: .55rem;
+}
+
+.assignmentAiPromptField span,
+.assignmentAiPromptField textarea {
+  grid-column: 1 / -1;
+}
+
+.assignmentAiPromptField button {
+  justify-self: end;
+}
+
 .assignmentAiContext {
   display: grid;
   gap: .45rem;
@@ -384,8 +400,14 @@ textarea[aria-invalid="true"]:focus {
   background: #ffffff;
 }
 
-.assignmentAiContext strong {
+.assignmentAiContext summary {
+  cursor: pointer;
+  font-weight: 800;
   margin-bottom: .15rem;
+}
+
+.assignmentAiContext summary::marker {
+  color: var(--muted);
 }
 
 .assignmentAiContextItem {

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -162,6 +162,20 @@ select {
   padding: .72rem .9rem;
 }
 
+input[aria-invalid="true"],
+select[aria-invalid="true"],
+textarea[aria-invalid="true"] {
+  border-color: #b91c1c;
+  background: #fff7f7;
+  box-shadow: 0 0 0 3px rgba(185, 28, 28, .12);
+}
+
+input[aria-invalid="true"]:focus,
+select[aria-invalid="true"]:focus,
+textarea[aria-invalid="true"]:focus {
+  outline-color: #b91c1c;
+}
+
 .generateGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -271,6 +271,25 @@ textarea[aria-invalid="true"]:focus {
   color: #ffffff;
 }
 
+.segmentedTabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem;
+  margin: .65rem 0;
+}
+
+.segmentedTabs button {
+  box-shadow: none;
+  padding: .42rem .7rem;
+  color: var(--muted);
+}
+
+.segmentedTabs button.isActive {
+  background: #111111;
+  border-color: #111111;
+  color: #ffffff;
+}
+
 .assignmentWizardStep {
   min-height: 8rem;
 }

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -211,15 +211,16 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           <div class="generateGrid">
             <label>
               <span>Assegnato il</span>
-              <input id="assignedAt" type="datetime-local" value="2026-10-12T09:00">
+              <input id="assignedAt" type="datetime-local" required>
             </label>
             <label>
               <span>Scadenza</span>
-              <input id="dueAt" type="datetime-local" value="2026-10-19T23:59">
+              <input id="dueAt" type="datetime-local" required>
             </label>
             <label>
               <span>Ora simulata opzionale</span>
               <input id="nowAt" type="datetime-local">
+              <small>Serve solo per anteprime e test: simula il momento corrente senza cambiare l'orologio reale.</small>
             </label>
           </div>
         </section>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -140,12 +140,13 @@
                 <textarea id="assignmentAiDraftText" rows="6" placeholder="Qui comparira la proposta AI. Il docente potra modificarla prima di salvare l'activity o distribuirla."></textarea>
               </label>
               <details class="assignmentPackageJson wideField">
-                <summary>Dettagli tecnici del pacchetto AI</summary>
+                <summary>Controllo dati inviati all'AI</summary>
+                <p class="status">Questa sezione mostra il contesto che verra inviato all'AI. Non genera una proposta: per quello usa il prompt sopra.</p>
                 <div class="generateActions">
-                  <button id="assignmentAiAskBtn" type="button" class="smallButton" title="Prepara il pacchetto JSON con prompt, contesto e file senza chiamare il provider AI.">Mostra pacchetto tecnico</button>
+                  <button id="assignmentAiAskBtn" type="button" class="smallButton" title="Aggiorna la preview di prompt, metadati e file di contesto senza chiamare il provider AI.">Aggiorna controllo dati</button>
                 </div>
                 <div id="assignmentAiPackagePreview" class="assignmentPlanPreview" aria-live="polite">
-                  <p class="status">Dettaglio avanzato: qui puoi controllare prompt, contesto e file inviati al provider o a Codex.</p>
+                  <p class="status">Qui vedrai prompt, metadati e file di contesto che saranno inviati al provider o a Codex.</p>
                 </div>
               </details>
             </div>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -142,9 +142,6 @@
               <details class="assignmentPackageJson wideField">
                 <summary>Controllo dati inviati all'AI</summary>
                 <p class="status">Questa sezione mostra il contesto che verra inviato all'AI. Non genera una proposta: per quello usa il prompt sopra.</p>
-                <div class="generateActions">
-                  <button id="assignmentAiAskBtn" type="button" class="smallButton" title="Aggiorna la preview di prompt, metadati e file di contesto senza chiamare il provider AI.">Aggiorna controllo dati</button>
-                </div>
                 <div class="segmentedTabs" role="tablist" aria-label="Vista risultati AI">
                   <button type="button" data-ai-preview-view="draft" aria-selected="true">Proposta AI</button>
                   <button type="button" data-ai-preview-view="context" aria-selected="false">Dati inviati all'AI</button>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -145,6 +145,10 @@
                 <div class="generateActions">
                   <button id="assignmentAiAskBtn" type="button" class="smallButton" title="Aggiorna la preview di prompt, metadati e file di contesto senza chiamare il provider AI.">Aggiorna controllo dati</button>
                 </div>
+                <div class="segmentedTabs" role="tablist" aria-label="Vista risultati AI">
+                  <button type="button" data-ai-preview-view="draft" aria-selected="true">Proposta AI</button>
+                  <button type="button" data-ai-preview-view="context" aria-selected="false">Dati inviati all'AI</button>
+                </div>
                 <div id="assignmentAiPackagePreview" class="assignmentPlanPreview" aria-live="polite">
                   <p class="status">Qui vedrai prompt, metadati e file di contesto che saranno inviati al provider o a Codex.</p>
                 </div>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -93,25 +93,26 @@
                   <option value="manual">Solo bozza manuale</option>
                 </select>
               </label>
-              <label class="wideField">
+              <label class="wideField assignmentAiPromptField">
                 <span>Prompt docente</span>
                 <textarea id="assignmentAiPrompt" rows="4" placeholder="Chiedi una traccia, una variante piu semplice, test aggiuntivi, codice da debuggare o una rubric diversa."></textarea>
+                <button id="assignmentAiGenerateBtn" type="button" class="primary" title="Invia il prompt al provider selezionato e genera una proposta modificabile. Per ora e attivo Codex locale.">Invia prompt e genera proposta</button>
               </label>
-              <div class="assignmentAiContext wideField" aria-label="Contesto che verra inviato all'AI">
-                <strong>Contesto da inviare</strong>
+              <details class="assignmentAiContext wideField" aria-label="Contesto che verra inviato all'AI" open>
+                <summary>Contesto da inviare</summary>
                 <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Activity selezionata e metadati</span></div>
                 <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Percorso, UDA e argomenti collegati</span></div>
                 <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Destinatari, classe/team e scadenze</span></div>
                 <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Asset, starter file, test e soluzione quando disponibili</span></div>
-              </div>
-              <div class="assignmentAiContext wideField" aria-label="Pacchetto file previsto per la generazione AI">
-                <strong>Pacchetto file activity</strong>
+              </details>
+              <details class="assignmentAiContext wideField" aria-label="Pacchetto file previsto per la generazione AI">
+                <summary>Pacchetto file activity</summary>
                 <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Traccia e README studente</span></div>
                 <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Starter code, esempi e fixture modificabili dal docente</span></div>
                 <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Test pubblici per lo studente</span></div>
                 <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Test riservati, runner e soluzione solo docente</span></div>
                 <div class="assignmentAiContextItem"><span class="contextState isPlanned">futuro</span><span>File aggiuntivi liberi scelti da repository o caricati dal docente</span></div>
-              </div>
+              </details>
               <div class="assignmentAiPolicy wideField">
                 <label>
                   <span>Budget AI per studente</span>
@@ -125,9 +126,6 @@
                     <option value="kiosk">Kiosk/lab gestito futuro</option>
                   </select>
                 </label>
-              </div>
-              <div class="generateActions wideField">
-                <button id="assignmentAiGenerateBtn" type="button" class="primary" title="Genera una proposta modificabile usando il provider selezionato. Per ora e attivo Codex locale.">Genera proposta AI</button>
               </div>
               <div id="assignmentAiProgress" class="assignmentAiProgress wideField" role="status" aria-live="polite" hidden>
                 <div class="assignmentAiProgressHeader">

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -424,6 +424,26 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           <input id="activityAuthorMinutes" type="number" min="1" step="1" value="30" required>
         </label>
         <label>
+          <span>Linguaggio</span>
+          <select id="activityAuthorLanguage" required>
+            <option value="c" selected>C</option>
+            <option value="cpp">C++</option>
+            <option value="python">Python</option>
+            <option value="java">Java</option>
+            <option value="javascript">JavaScript</option>
+            <option value="nodejs">Node.js</option>
+            <option value="go">Go</option>
+            <option value="html">HTML</option>
+            <option value="php">PHP</option>
+            <option value="sql">SQL</option>
+            <option value="assembly">Assembly</option>
+          </select>
+        </label>
+        <label>
+          <span>File sorgente</span>
+          <input id="activityAuthorSourceName" type="text" value="main.c" placeholder="main.c" required>
+        </label>
+        <label>
           <span>Classe opzionale</span>
           <span class="selectWithCount">
             <select id="activityAuthorClass" aria-label="Classe opzionale"></select>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -349,13 +349,13 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
     <div class="activityEditorDialogHead">
       <div>
         <h2 id="activityEditorTitle">Editor activity</h2>
-        <p id="activityAuthorStatus" class="status">Crea una bozza activity locale da validare e poi assegnare.</p>
       </div>
       <div class="dialogActions">
         <button id="activityEditorCloseBtn" type="button" class="smallButton" title="Chiudi l'editor activity e torna alla dashboard.">Chiudi</button>
       </div>
     </div>
     <div id="activityEditorBody" class="activityEditorBody">
+      <p id="activityAuthorStatus" class="status activityEditorStatus">Crea una bozza activity locale da validare e poi assegnare.</p>
       <div class="generateGrid">
         <label>
           <span>Titolo</span>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -55,10 +55,11 @@
         <div class="assignmentWizardSteps" role="tablist" aria-label="Step assegnazione activity">
           <button type="button" class="isActive" data-assignment-step-tab="activity" aria-selected="true">1 Activity</button>
           <button type="button" data-assignment-step-tab="ai" aria-selected="false">2 AI</button>
-          <button type="button" data-assignment-step-tab="targets" aria-selected="false">3 Destinatari</button>
-          <button type="button" data-assignment-step-tab="dates" aria-selected="false">4 Date</button>
-          <button type="button" data-assignment-step-tab="preview" aria-selected="false">5 Anteprima</button>
-          <button type="button" data-assignment-step-tab="confirm" aria-selected="false">6 Conferma</button>
+          <button type="button" data-assignment-step-tab="review" aria-selected="false">3 Revisione</button>
+          <button type="button" data-assignment-step-tab="targets" aria-selected="false">4 Destinatari</button>
+          <button type="button" data-assignment-step-tab="dates" aria-selected="false">5 Date</button>
+          <button type="button" data-assignment-step-tab="preview" aria-selected="false">6 Anteprima</button>
+          <button type="button" data-assignment-step-tab="confirm" aria-selected="false">7 Conferma</button>
         </div>
 
         <section class="assignmentWizardStep isActive" data-assignment-step="activity">
@@ -75,7 +76,7 @@
             </label>
           </div>
           <div class="generateActions">
-            <button id="wizardOpenActivityEditorBtn" type="button" title="Apri lo stesso editor activity usato dalla libreria, senza uscire dal wizard.">Apri editor activity</button>
+            <button id="wizardOpenActivityEditorBtn" type="button" title="Vai allo step Revisione activity per controllare e salvare la bozza.">Vai a revisione activity</button>
           </div>
         </section>
 
@@ -127,7 +128,7 @@
               </div>
               <div class="generateActions wideField">
                 <button id="assignmentAiGenerateBtn" type="button" class="primary" title="Genera una proposta modificabile usando il provider selezionato. Per ora e attivo Codex locale.">Genera proposta AI</button>
-                <button id="assignmentAiApplyDraftBtn" type="button" disabled title="Usa la proposta AI nell'editor activity. Il docente puo modificarla prima di salvare.">Usa questa proposta</button>
+                <button id="assignmentAiApplyDraftBtn" type="button" disabled title="Porta la proposta AI nello step Revisione activity. Il docente puo modificarla prima di salvare.">Prepara revisione</button>
               </div>
               <label class="wideField">
                 <span>Bozza AI modificabile dal docente</span>
@@ -144,6 +145,14 @@
               </details>
             </div>
           </div>
+        </section>
+
+        <section class="assignmentWizardStep" data-assignment-step="review" hidden>
+          <div class="assignmentAiDraft">
+            <strong>Revisione activity</strong>
+            <p>Controlla la bozza, modifica i campi e salva l'activity prima di scegliere destinatari, date e distribuzione.</p>
+          </div>
+          <div id="activityWizardEditorMount" class="activityWizardEditorMount"></div>
         </section>
 
         <section class="assignmentWizardStep" data-assignment-step="targets" hidden>
@@ -214,7 +223,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         </section>
         <nav class="assignmentWizardNav" aria-label="Navigazione wizard assegnazione">
           <button id="assignmentWizardPrevBtn" type="button" title="Torna allo step precedente del wizard.">Indietro</button>
-          <p id="assignmentWizardHint" class="status">Step 1 di 6: scegli o crea la activity.</p>
+          <p id="assignmentWizardHint" class="status">Step 1 di 7: scegli o crea la activity.</p>
           <button id="assignmentWizardNextBtn" type="button" class="primary" title="Vai allo step successivo del wizard.">Avanti</button>
         </nav>
       </div>
@@ -347,7 +356,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         <button id="activityEditorCloseBtn" type="button" class="smallButton" title="Chiudi l'editor activity e torna alla dashboard.">Chiudi</button>
       </div>
     </div>
-    <div class="activityEditorBody">
+    <div id="activityEditorBody" class="activityEditorBody">
       <div class="generateGrid">
         <label>
           <span>Titolo</span>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -129,6 +129,14 @@
               <div class="generateActions wideField">
                 <button id="assignmentAiGenerateBtn" type="button" class="primary" title="Genera una proposta modificabile usando il provider selezionato. Per ora e attivo Codex locale.">Genera proposta AI</button>
               </div>
+              <div id="assignmentAiProgress" class="assignmentAiProgress wideField" role="status" aria-live="polite" hidden>
+                <div class="assignmentAiProgressHeader">
+                  <strong>Generazione proposta AI in corso</strong>
+                  <span>Codex sta lavorando sulla macchina docente.</span>
+                </div>
+                <div class="assignmentAiProgressTrack" aria-hidden="true"><span></span></div>
+                <p>La durata dipende dal provider e dai file inviati. Se qualcosa si blocca, qui comparira un errore chiaro.</p>
+              </div>
               <label class="wideField">
                 <span>Bozza AI modificabile dal docente</span>
                 <textarea id="assignmentAiDraftText" rows="6" placeholder="Qui comparira la proposta AI. Il docente potra modificarla prima di salvare l'activity o distribuirla."></textarea>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -382,7 +382,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       <div class="generateGrid">
         <label>
           <span>Titolo</span>
-          <input id="activityAuthorTitle" type="text" placeholder="Somma in Python">
+          <input id="activityAuthorTitle" type="text" placeholder="Somma in Python" required>
         </label>
         <label>
           <span>ID opzionale</span>
@@ -390,7 +390,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         </label>
         <label>
           <span>Tipo</span>
-          <select id="activityAuthorKind">
+          <select id="activityAuthorKind" required>
             <option value="compito-casa">compito-casa</option>
             <option value="laboratorio">laboratorio</option>
             <option value="esercizio-classe">esercizio-classe</option>
@@ -402,7 +402,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         </label>
         <label>
           <span>Difficolta</span>
-          <select id="activityAuthorDifficulty">
+          <select id="activityAuthorDifficulty" required>
             <option value="A">A - base: copia e osserva</option>
             <option value="B" selected>B - facile: modifica piccola</option>
             <option value="C">C - medio: scrivi da zero</option>
@@ -414,14 +414,14 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         <label>
           <span>Argomenti</span>
           <span class="selectWithCount">
-            <input id="activityAuthorTopics" type="search" list="activityAuthorTopicsList" placeholder="Cerca argomento" autocomplete="off" aria-label="Argomenti">
+            <input id="activityAuthorTopics" type="search" list="activityAuthorTopicsList" placeholder="Cerca argomento" autocomplete="off" aria-label="Argomenti" required>
             <datalist id="activityAuthorTopicsList"></datalist>
             <span id="activityAuthorTopicsCount" class="selectCountBadge" title="Numero di argomenti disponibili con i filtri correnti.">0</span>
           </span>
         </label>
         <label>
           <span>Tempo stimato</span>
-          <input id="activityAuthorMinutes" type="number" min="1" step="1" value="30">
+          <input id="activityAuthorMinutes" type="number" min="1" step="1" value="30" required>
         </label>
         <label>
           <span>Classe opzionale</span>
@@ -453,7 +453,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         </label>
         <label class="wideField">
           <span>Consegna</span>
-          <textarea id="activityAuthorPrompt" rows="4" placeholder="Scrivi la traccia che vedra lo studente."></textarea>
+          <textarea id="activityAuthorPrompt" rows="4" placeholder="Scrivi la traccia che vedra lo studente." required></textarea>
         </label>
       </div>
       <div class="generateActions">

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -182,6 +182,21 @@
               <span>Team GitHub</span>
               <input id="githubTeam" type="text" placeholder="3A-TPSI">
             </label>
+            <div class="assignmentTargetPicker wideField" aria-label="Studenti e gruppi da assegnare">
+              <div class="assignmentTargetPickerHead">
+                <div>
+                  <strong>Studenti dal roster</strong>
+                  <p>Seleziona tutta la classe, un gruppo di studenti o un singolo studente. I repository target sotto vengono aggiornati automaticamente.</p>
+                </div>
+                <div class="generateActions">
+                  <button id="selectAllRosterTargetsBtn" type="button" class="smallButton" title="Seleziona tutti gli studenti attivi del roster.">Tutti</button>
+                  <button id="clearRosterTargetsBtn" type="button" class="smallButton" title="Rimuovi tutti gli studenti dalla consegna.">Nessuno</button>
+                </div>
+              </div>
+              <div id="assignmentTargetPicker" class="assignmentTargetPickerList">
+                <p class="status">Seleziona un roster per scegliere classe intera, gruppo o singolo studente.</p>
+              </div>
+            </div>
             <label class="wideField">
               <span>Repository studenti locali, uno per riga</span>
               <textarea id="targetsText" rows="4">examples/assignment_tracking/student_repos/rossi-mario

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -128,7 +128,6 @@
               </div>
               <div class="generateActions wideField">
                 <button id="assignmentAiGenerateBtn" type="button" class="primary" title="Genera una proposta modificabile usando il provider selezionato. Per ora e attivo Codex locale.">Genera proposta AI</button>
-                <button id="assignmentAiApplyDraftBtn" type="button" disabled title="Porta la proposta AI nello step Revisione activity. Il docente puo modificarla prima di salvare.">Prepara revisione</button>
               </div>
               <label class="wideField">
                 <span>Bozza AI modificabile dal docente</span>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -99,18 +99,18 @@
               </label>
               <div class="assignmentAiContext wideField" aria-label="Contesto che verra inviato all'AI">
                 <strong>Contesto da inviare</strong>
-                <label><input type="checkbox" checked disabled> Activity selezionata e metadati</label>
-                <label><input type="checkbox" checked disabled> Percorso, UDA e argomenti collegati</label>
-                <label><input type="checkbox" checked disabled> Destinatari, classe/team e scadenze</label>
-                <label><input type="checkbox" checked disabled> Asset, starter file, test e soluzione quando disponibili</label>
+                <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Activity selezionata e metadati</span></div>
+                <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Percorso, UDA e argomenti collegati</span></div>
+                <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Destinatari, classe/team e scadenze</span></div>
+                <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Asset, starter file, test e soluzione quando disponibili</span></div>
               </div>
               <div class="assignmentAiContext wideField" aria-label="Pacchetto file previsto per la generazione AI">
                 <strong>Pacchetto file activity</strong>
-                <label><input type="checkbox" checked disabled> Traccia e README studente</label>
-                <label><input type="checkbox" checked disabled> Starter code, esempi e fixture modificabili dal docente</label>
-                <label><input type="checkbox" checked disabled> Test pubblici per lo studente</label>
-                <label><input type="checkbox" checked disabled> Test riservati, runner e soluzione solo docente</label>
-                <label><input type="checkbox" disabled> File aggiuntivi liberi scelti da repository o caricati dal docente</label>
+                <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Traccia e README studente</span></div>
+                <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Starter code, esempi e fixture modificabili dal docente</span></div>
+                <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Test pubblici per lo studente</span></div>
+                <div class="assignmentAiContextItem"><span class="contextState isIncluded">incluso</span><span>Test riservati, runner e soluzione solo docente</span></div>
+                <div class="assignmentAiContextItem"><span class="contextState isPlanned">futuro</span><span>File aggiuntivi liberi scelti da repository o caricati dal docente</span></div>
               </div>
               <div class="assignmentAiPolicy wideField">
                 <label>
@@ -586,6 +586,22 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
     </div>
     <div id="submissionReview" class="reviewEmpty">
       Nessuna consegna selezionata.
+    </div>
+  </dialog>
+
+  <dialog id="assignmentAiFilesDialog" class="reviewDialog" aria-labelledby="assignmentAiFilesDialogTitle">
+    <div class="reviewDialogHead">
+      <div>
+        <p class="modalBreadcrumb" aria-label="Percorso modal">Dashboard &gt; Assegna activity &gt; File AI</p>
+        <h2 id="assignmentAiFilesDialogTitle">File proposti dall'AI</h2>
+        <p id="assignmentAiFilesStatus" class="status">Seleziona un file generato dalla bozza AI.</p>
+      </div>
+      <div class="reviewDialogActions">
+        <button id="assignmentAiFilesCloseBtn" type="button" class="smallButton" title="Chiudi la preview dei file proposti dall'AI.">Chiudi</button>
+      </div>
+    </div>
+    <div id="assignmentAiFilesReview" class="reviewEmpty">
+      Nessun file AI selezionato.
     </div>
   </dialog>
 

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -237,10 +237,14 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
         <section class="assignmentWizardStep" data-assignment-step="confirm" hidden>
           <div class="assignmentAiDraft">
             <strong>Conferma docente</strong>
-            <p>Salva la consegna nel registro docente e distribuisci gli asset solo dopo aver controllato activity, destinatari, date e anteprima.</p>
+            <p>Salva l'assegnazione e distribuisci gli asset solo dopo aver controllato activity, destinatari, date e anteprima.</p>
+          </div>
+          <div id="assignmentConfirmStatus" class="activityEditorStatus assignmentConfirmStatus" role="status" aria-live="polite">
+            <strong>Pronto per la conferma</strong>
+            <span>Prima salva l'assegnazione, poi distribuisci ai target se vuoi copiare traccia e asset nei repository.</span>
           </div>
           <div class="generateActions">
-            <button id="saveAssignmentBtn" type="button" class="primary" title="Salva la consegna per classe, team o studenti senza distribuire ancora asset nei repository.">Salva assegnazione</button>
+            <button id="saveAssignmentBtn" type="button" class="primary" title="Salva l'assegnazione per classe, team o studenti senza distribuire ancora asset nei repository.">Salva assegnazione</button>
             <button id="distributeAssignmentBtn" type="button" title="Copia traccia, README e asset studente nelle cartelle dei repository target.">Distribuisci ai target</button>
           </div>
         </section>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -153,6 +153,7 @@ const state = {
   draggedPanelKey: "",
   activityAuthorLastSuggestedId: "",
   activityReviewSaved: false,
+  assignmentAiGenerating: false,
   selectedAssignmentId: "",
 };
 
@@ -280,6 +281,7 @@ const els = {
   assignmentAiGenerateBtn: document.querySelector("#assignmentAiGenerateBtn"),
   assignmentAiApplyDraftBtn: document.querySelector("#assignmentAiApplyDraftBtn"),
   assignmentAiDraftText: document.querySelector("#assignmentAiDraftText"),
+  assignmentAiProgress: document.querySelector("#assignmentAiProgress"),
   assignmentAiPackagePreview: document.querySelector("#assignmentAiPackagePreview"),
   generateReportBtn: document.querySelector("#generateReportBtn"),
   panels: document.querySelectorAll("main.layout .panel"),
@@ -2541,7 +2543,7 @@ function updateAssignmentAiApplyState() {
     isValid = false;
   }
   if (els.assignmentAiApplyDraftBtn) {
-    els.assignmentAiApplyDraftBtn.disabled = !isValid;
+    els.assignmentAiApplyDraftBtn.disabled = !isValid || state.assignmentAiGenerating;
     els.assignmentAiApplyDraftBtn.title = isValid
       ? "Porta la proposta AI nello step Revisione activity. Il docente puo modificarla prima di salvare."
       : "Genera una proposta AI valida prima di preparare la revisione activity.";
@@ -2550,11 +2552,25 @@ function updateAssignmentAiApplyState() {
     const current = currentAssignmentWizardStep();
     const index = assignmentWizardStepIndex(current);
     if (els.assignmentWizardNextBtn && index >= 0 && index < ASSIGNMENT_WIZARD_STEPS.length - 1) {
-      els.assignmentWizardNextBtn.disabled = !isValid;
+      els.assignmentWizardNextBtn.disabled = !isValid || state.assignmentAiGenerating;
       els.assignmentWizardNextBtn.textContent = assignmentWizardNextLabel(current);
     }
   }
   return isValid;
+}
+
+function setAssignmentAiProgress(active, title = "Generazione proposta AI in corso", detail = "Codex sta lavorando sulla macchina docente.") {
+  if (!els.assignmentAiProgress) return;
+  els.assignmentAiProgress.hidden = !active;
+  if (!active) return;
+  els.assignmentAiProgress.innerHTML = `
+    <div class="assignmentAiProgressHeader">
+      <strong>${escapeHtml(title)}</strong>
+      <span>${escapeHtml(detail)}</span>
+    </div>
+    <div class="assignmentAiProgressTrack" aria-hidden="true"><span></span></div>
+    <p>La durata dipende dal provider e dai file inviati. Se qualcosa si blocca, qui comparira un errore chiaro.</p>
+  `;
 }
 
 function markActivityReviewDirty() {
@@ -2678,6 +2694,7 @@ function nextAssignmentWizardStep(step) {
 
 function assignmentWizardStepComplete(step) {
   if (step === "activity") return Boolean(String(els.activityPath?.value || "").trim());
+  if (step === "ai" && state.assignmentAiGenerating) return false;
   if (step === "ai") return updateAssignmentAiApplyState();
   if (step === "review") return Boolean(state.activityReviewSaved && String(els.activityPath?.value || "").trim());
   return true;
@@ -2884,9 +2901,14 @@ async function previewAssignmentAiPackage() {
 async function generateAssignmentAiDraft() {
   if (!els.assignmentAiGenerateBtn) return;
   const provider = els.assignmentAiProvider?.value || "codex";
+  state.assignmentAiGenerating = true;
   els.assignmentAiGenerateBtn.disabled = true;
   if (els.assignmentAiApplyDraftBtn) els.assignmentAiApplyDraftBtn.disabled = true;
+  if (els.assignmentWizardNextBtn && currentAssignmentWizardStep() === "ai") {
+    els.assignmentWizardNextBtn.disabled = true;
+  }
   setStatus(`Generazione bozza con provider ${provider}...`);
+  setAssignmentAiProgress(true, "Generazione proposta AI in corso", `Provider: ${provider}. Attendi il completamento prima di avanzare.`);
   if (els.assignmentAiPackagePreview) {
     els.assignmentAiPackagePreview.innerHTML = '<p class="status">Generazione bozza in corso...</p>';
   }
@@ -2911,7 +2933,10 @@ async function generateAssignmentAiDraft() {
     updateAssignmentAiApplyState();
     setStatus(`Bozza AI non disponibile: ${message}`);
   } finally {
+    state.assignmentAiGenerating = false;
+    setAssignmentAiProgress(false);
     els.assignmentAiGenerateBtn.disabled = false;
+    updateAssignmentAiApplyState();
   }
 }
 

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2563,6 +2563,7 @@ function setAssignmentAiProgress(active, title = "Generazione proposta AI in cor
   if (!els.assignmentAiProgress) return;
   els.assignmentAiProgress.hidden = !active;
   if (!active) return;
+  els.assignmentAiProgress.classList.remove("isError");
   els.assignmentAiProgress.innerHTML = `
     <div class="assignmentAiProgressHeader">
       <strong>${escapeHtml(title)}</strong>
@@ -2570,6 +2571,19 @@ function setAssignmentAiProgress(active, title = "Generazione proposta AI in cor
     </div>
     <div class="assignmentAiProgressTrack" aria-hidden="true"><span></span></div>
     <p>La durata dipende dal provider e dai file inviati. Se qualcosa si blocca, qui comparira un errore chiaro.</p>
+  `;
+}
+
+function setAssignmentAiProgressError(message) {
+  if (!els.assignmentAiProgress) return;
+  els.assignmentAiProgress.hidden = false;
+  els.assignmentAiProgress.classList.add("isError");
+  els.assignmentAiProgress.innerHTML = `
+    <div class="assignmentAiProgressHeader">
+      <strong>Generazione proposta AI interrotta</strong>
+      <span>Controlla il messaggio e riprova dopo la correzione.</span>
+    </div>
+    <p>${escapeHtml(message)}</p>
   `;
 }
 
@@ -2901,6 +2915,7 @@ async function previewAssignmentAiPackage() {
 async function generateAssignmentAiDraft() {
   if (!els.assignmentAiGenerateBtn) return;
   const provider = els.assignmentAiProvider?.value || "codex";
+  let failedMessage = "";
   state.assignmentAiGenerating = true;
   els.assignmentAiGenerateBtn.disabled = true;
   if (els.assignmentAiApplyDraftBtn) els.assignmentAiApplyDraftBtn.disabled = true;
@@ -2927,6 +2942,7 @@ async function generateAssignmentAiDraft() {
     setStatus("Bozza Codex pronta: controlla e modifica prima di salvare.");
   } catch (error) {
     const message = assignmentPlanErrorMessage(error);
+    failedMessage = message;
     if (els.assignmentAiPackagePreview) {
       els.assignmentAiPackagePreview.innerHTML = `<p class="status">Bozza AI non disponibile: ${escapeHtml(message)}</p>`;
     }
@@ -2934,7 +2950,11 @@ async function generateAssignmentAiDraft() {
     setStatus(`Bozza AI non disponibile: ${message}`);
   } finally {
     state.assignmentAiGenerating = false;
-    setAssignmentAiProgress(false);
+    if (failedMessage) {
+      setAssignmentAiProgressError(`Bozza AI non disponibile: ${failedMessage}`);
+    } else {
+      setAssignmentAiProgress(false);
+    }
     els.assignmentAiGenerateBtn.disabled = false;
     updateAssignmentAiApplyState();
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -21,27 +21,31 @@ const OVERVIEW_SUPPORT_ORDER = ["senza-aiuto", "feedback-tecnico", "studio-guida
 const ASSIGNMENT_WIZARD_STEPS = [
   {
     id: "activity",
-    hint: "Step 1 di 6: scegli una activity salvata oppure apri l'editor per crearla o modificarla.",
+    hint: "Step 1 di 7: scegli una activity salvata oppure apri la revisione per crearla o modificarla.",
   },
   {
     id: "ai",
-    hint: "Step 2 di 6: genera o rifinisci una proposta AI, poi usala nell'editor activity.",
+    hint: "Step 2 di 7: genera o rifinisci una proposta AI, poi prepara la revisione activity.",
+  },
+  {
+    id: "review",
+    hint: "Step 3 di 7: controlla, modifica e salva l'activity prima di assegnarla.",
   },
   {
     id: "targets",
-    hint: "Step 3 di 6: scegli classe, team o studenti destinatari della consegna.",
+    hint: "Step 4 di 7: scegli classe, team o studenti destinatari della consegna.",
   },
   {
     id: "dates",
-    hint: "Step 4 di 6: imposta data di assegnazione, scadenza e ora simulata se serve.",
+    hint: "Step 5 di 7: imposta data di assegnazione, scadenza e ora simulata se serve.",
   },
   {
     id: "preview",
-    hint: "Step 5 di 6: controlla anteprima, target e asset prima di salvare o distribuire.",
+    hint: "Step 6 di 7: controlla anteprima, target e asset prima di salvare o distribuire.",
   },
   {
     id: "confirm",
-    hint: "Step 6 di 6: salva la consegna e, quando sei pronto, distribuisci gli asset ai target.",
+    hint: "Step 7 di 7: salva la consegna e, quando sei pronto, distribuisci gli asset ai target.",
   },
 ];
 const OVERVIEW_STATUS_ORDER = [
@@ -214,6 +218,8 @@ const els = {
   filterButtons: document.querySelectorAll("[data-filter]"),
   activityEditorDialog: document.querySelector("#activityEditorDialog"),
   activityEditorCloseBtn: document.querySelector("#activityEditorCloseBtn"),
+  activityEditorBody: document.querySelector("#activityEditorBody"),
+  activityWizardEditorMount: document.querySelector("#activityWizardEditorMount"),
   openActivityEditorBtn: document.querySelector("#openActivityEditorBtn"),
   wizardOpenActivityEditorBtn: document.querySelector("#wizardOpenActivityEditorBtn"),
   activityPanelStatus: document.querySelector("#activityPanelStatus"),
@@ -1659,9 +1665,25 @@ function renderActivityPanelSummary() {
   `).join("");
 }
 
+function mountActivityEditorInDialog() {
+  if (!els.activityEditorDialog || !els.activityEditorBody) return;
+  if (els.activityEditorBody.parentElement !== els.activityEditorDialog) {
+    els.activityEditorDialog.append(els.activityEditorBody);
+  }
+}
+
+function mountActivityEditorInWizard() {
+  if (!els.activityWizardEditorMount || !els.activityEditorBody) return;
+  if (els.activityEditorDialog?.open) els.activityEditorDialog.close();
+  if (els.activityEditorBody.parentElement !== els.activityWizardEditorMount) {
+    els.activityWizardEditorMount.append(els.activityEditorBody);
+  }
+}
+
 function openActivityEditor(source = "panel") {
   renderActivityAuthorMetadataSelects(true);
   renderActivityPanelSummary();
+  mountActivityEditorInDialog();
   if (els.activityPanelStatus) {
     els.activityPanelStatus.textContent = source === "wizard"
       ? "Editor activity aperto dal wizard assegnazione."
@@ -1674,6 +1696,19 @@ function openActivityEditor(source = "panel") {
 
 function closeActivityEditor() {
   els.activityEditorDialog?.close?.();
+  const current = Array.from(els.assignmentSteps).find((section) => !section.hidden)?.dataset.assignmentStep || "";
+  if (current === "review") {
+    mountActivityEditorInWizard();
+  }
+  renderActivityPanelSummary();
+}
+
+function openActivityReviewStep(statusMessage = "Controlla la bozza activity, modifica se serve e salva prima di proseguire.") {
+  mountActivityEditorInWizard();
+  setAssignmentWizardStep("review");
+  if (els.activityAuthorStatus) {
+    els.activityAuthorStatus.textContent = statusMessage;
+  }
   renderActivityPanelSummary();
 }
 
@@ -2500,11 +2535,11 @@ function updateAssignmentAiApplyState() {
   try {
     parseAssignmentAiDraftText();
     els.assignmentAiApplyDraftBtn.disabled = false;
-    els.assignmentAiApplyDraftBtn.title = "Usa la proposta AI nell'editor activity. Il docente puo modificarla prima di salvare.";
+    els.assignmentAiApplyDraftBtn.title = "Porta la proposta AI nello step Revisione activity. Il docente puo modificarla prima di salvare.";
     return true;
   } catch (error) {
     els.assignmentAiApplyDraftBtn.disabled = true;
-    els.assignmentAiApplyDraftBtn.title = "Genera una proposta AI valida prima di usarla nell'editor activity.";
+    els.assignmentAiApplyDraftBtn.title = "Genera una proposta AI valida prima di preparare la revisione activity.";
     return false;
   }
 }
@@ -2590,12 +2625,8 @@ function applyAssignmentAiDraftToActivityForm() {
     const suffix = fileCount || assetCount
       ? ` File proposti: ${fileCount}; asset dichiarati: ${assetCount}. Gli asset non vengono ancora salvati automaticamente.`
       : "";
-    if (els.activityAuthorStatus) {
-      els.activityAuthorStatus.textContent = `Bozza AI applicata al form activity. Controlla e salva quando e pronta.${suffix}`;
-    }
-    setStatus("Bozza AI applicata al form activity: il docente puo ancora modificare tutto.");
-    setAssignmentWizardStep("activity");
-    openActivityEditor("wizard");
+    setStatus("Bozza AI pronta nello step Revisione activity: il docente puo ancora modificare tutto.");
+    openActivityReviewStep(`Bozza AI applicata alla revisione activity. Controlla e salva quando e pronta.${suffix}`);
     return true;
   } catch (error) {
     if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = `Bozza AI non applicata: ${error.message}`;
@@ -2606,6 +2637,9 @@ function applyAssignmentAiDraftToActivityForm() {
 
 function setAssignmentWizardStep(step) {
   const selectedStep = ASSIGNMENT_WIZARD_STEPS.some((candidate) => candidate.id === step) ? step : "activity";
+  if (selectedStep === "review") {
+    mountActivityEditorInWizard();
+  }
   els.assignmentStepTabs.forEach((button) => {
     const isActive = button.dataset.assignmentStepTab === selectedStep;
     button.classList.toggle("isActive", isActive);
@@ -3649,7 +3683,7 @@ els.assignmentAiGenerateBtn?.addEventListener("click", generateAssignmentAiDraft
 els.assignmentAiApplyDraftBtn?.addEventListener("click", applyAssignmentAiDraftToActivityForm);
 els.assignmentAiDraftText?.addEventListener("input", updateAssignmentAiApplyState);
 els.openActivityEditorBtn?.addEventListener("click", () => openActivityEditor("panel"));
-els.wizardOpenActivityEditorBtn?.addEventListener("click", () => openActivityEditor("wizard"));
+els.wizardOpenActivityEditorBtn?.addEventListener("click", openActivityReviewStep);
 els.activityEditorCloseBtn?.addEventListener("click", closeActivityEditor);
 els.saveAssignmentBtn?.addEventListener("click", saveAssignmentRecord);
 els.distributeAssignmentBtn?.addEventListener("click", distributeAssignment);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -156,6 +156,9 @@ const state = {
   assignmentAiGenerating: false,
   assignmentAiPromptLocked: false,
   assignmentAiDraftFilePath: "",
+  assignmentAiPreviewView: "draft",
+  assignmentAiDraftHtml: "",
+  assignmentAiContextHtml: "",
   selectedRosterTargetIds: new Set(),
   selectedAssignmentId: "",
 };
@@ -305,6 +308,7 @@ const els = {
   assignmentAiDraftText: document.querySelector("#assignmentAiDraftText"),
   assignmentAiProgress: document.querySelector("#assignmentAiProgress"),
   assignmentAiPackagePreview: document.querySelector("#assignmentAiPackagePreview"),
+  assignmentAiPreviewButtons: document.querySelectorAll("[data-ai-preview-view]"),
   assignmentAiFilesDialog: document.querySelector("#assignmentAiFilesDialog"),
   assignmentAiFilesCloseBtn: document.querySelector("#assignmentAiFilesCloseBtn"),
   assignmentAiFilesStatus: document.querySelector("#assignmentAiFilesStatus"),
@@ -2649,10 +2653,28 @@ function assignmentAiPackagePayload() {
   return payload;
 }
 
-function renderAssignmentAiPackage(aiPackage) {
+function setAssignmentAiPreviewView(view) {
+  state.assignmentAiPreviewView = view === "context" ? "context" : "draft";
+  els.assignmentAiPreviewButtons?.forEach((button) => {
+    const isActive = button.dataset.aiPreviewView === state.assignmentAiPreviewView;
+    button.classList.toggle("isActive", isActive);
+    button.setAttribute("aria-selected", isActive ? "true" : "false");
+  });
   if (!els.assignmentAiPackagePreview) return;
+  const html = state.assignmentAiPreviewView === "context"
+    ? state.assignmentAiContextHtml
+    : state.assignmentAiDraftHtml;
+  els.assignmentAiPackagePreview.innerHTML = html || (
+    state.assignmentAiPreviewView === "context"
+      ? '<p class="status">Clicca Aggiorna controllo dati per vedere prompt, metadati e file di contesto inviati all\'AI.</p>'
+      : '<p class="status">Qui comparira la proposta generata dall\'AI. I dati inviati all\'AI restano disponibili nella vista dedicata.</p>'
+  );
+}
+
+function renderAssignmentAiPackage(aiPackage) {
   if (!aiPackage) {
-    els.assignmentAiPackagePreview.innerHTML = '<p class="status">Prepara il pacchetto AI per controllare prompt, contesto e file prima di chiamare provider o Codex.</p>';
+    state.assignmentAiContextHtml = '<p class="status">Clicca Aggiorna controllo dati per vedere prompt, metadati e file di contesto inviati all\'AI.</p>';
+    setAssignmentAiPreviewView("context");
     return;
   }
   const files = Array.isArray(aiPackage.files) ? aiPackage.files : [];
@@ -2660,7 +2682,7 @@ function renderAssignmentAiPackage(aiPackage) {
   const skippedFiles = files.filter((file) => !file.included);
   const promptStatus = aiPackage.prompt?.trim() ? "prompt incluso" : "prompt vuoto";
   const draftStatus = aiPackage.current_draft ? "bozza corrente inclusa" : "nessuna bozza corrente";
-  els.assignmentAiPackagePreview.innerHTML = `
+  state.assignmentAiContextHtml = `
     <div class="assignmentPlanHeader">
       <div>
         <strong>${escapeHtml(aiPackage.activity?.title || aiPackage.activity?.id || "Controllo dati AI")}</strong>
@@ -2691,6 +2713,7 @@ function renderAssignmentAiPackage(aiPackage) {
       <pre>${escapeHtml(JSON.stringify(aiPackage, null, 2))}</pre>
     </details>
   `;
+  setAssignmentAiPreviewView("context");
 }
 
 function renderAssignmentCodexDraft(response) {
@@ -2699,11 +2722,10 @@ function renderAssignmentCodexDraft(response) {
     els.assignmentAiDraftText.value = JSON.stringify(response.draft, null, 2);
   }
   updateAssignmentAiApplyState();
-  if (!els.assignmentAiPackagePreview) return;
   const files = Array.isArray(response.draft.files) ? response.draft.files : [];
   const questions = Array.isArray(response.draft.questions) ? response.draft.questions : [];
   const warnings = Array.isArray(response.draft.warnings) ? response.draft.warnings : [];
-  els.assignmentAiPackagePreview.innerHTML = `
+  state.assignmentAiDraftHtml = `
     <div class="assignmentPlanHeader">
       <div>
         <strong>Bozza Codex pronta</strong>
@@ -2726,6 +2748,7 @@ function renderAssignmentCodexDraft(response) {
       </section>
     </div>
   `;
+  setAssignmentAiPreviewView("draft");
 }
 
 function updateAssignmentAiApplyState() {
@@ -3196,9 +3219,8 @@ async function previewAssignmentAiPackage() {
   if (!els.assignmentAiAskBtn) return;
   els.assignmentAiAskBtn.disabled = true;
   setStatus("Aggiornamento controllo dati inviati all'AI...");
-  if (els.assignmentAiPackagePreview) {
-    els.assignmentAiPackagePreview.innerHTML = '<p class="status">Aggiornamento controllo dati inviati all\'AI...</p>';
-  }
+  state.assignmentAiContextHtml = '<p class="status">Aggiornamento controllo dati inviati all\'AI...</p>';
+  setAssignmentAiPreviewView("context");
   try {
     const payload = await api("/api/activities/ai-package", {
       method: "POST",
@@ -3208,9 +3230,8 @@ async function previewAssignmentAiPackage() {
     setStatus("Controllo dati AI pronto: nessuna chiamata provider eseguita.");
   } catch (error) {
     const message = assignmentPlanErrorMessage(error);
-    if (els.assignmentAiPackagePreview) {
-      els.assignmentAiPackagePreview.innerHTML = `<p class="status">Controllo dati AI non disponibile: ${escapeHtml(message)}</p>`;
-    }
+    state.assignmentAiContextHtml = `<p class="status">Controllo dati AI non disponibile: ${escapeHtml(message)}</p>`;
+    setAssignmentAiPreviewView("context");
     setStatus(`Controllo dati AI non disponibile: ${message}`);
   } finally {
     els.assignmentAiAskBtn.disabled = false;
@@ -3230,9 +3251,8 @@ async function generateAssignmentAiDraft() {
   }
   setStatus(`Generazione bozza con provider ${provider}...`);
   setAssignmentAiProgress(true, "Generazione proposta AI in corso", `Provider: ${provider}. Attendi il completamento prima di avanzare.`);
-  if (els.assignmentAiPackagePreview) {
-    els.assignmentAiPackagePreview.innerHTML = '<p class="status">Generazione bozza in corso...</p>';
-  }
+  state.assignmentAiDraftHtml = '<p class="status">Generazione bozza in corso...</p>';
+  setAssignmentAiPreviewView("draft");
   try {
     if (provider === "manual") {
       throw new Error("Modalita manuale: scrivi direttamente la bozza nel campo dedicato.");
@@ -3249,9 +3269,8 @@ async function generateAssignmentAiDraft() {
   } catch (error) {
     const message = assignmentPlanErrorMessage(error);
     failedMessage = message;
-    if (els.assignmentAiPackagePreview) {
-      els.assignmentAiPackagePreview.innerHTML = `<p class="status">Bozza AI non disponibile: ${escapeHtml(message)}</p>`;
-    }
+    state.assignmentAiDraftHtml = `<p class="status">Bozza AI non disponibile: ${escapeHtml(message)}</p>`;
+    setAssignmentAiPreviewView("draft");
     updateAssignmentAiApplyState();
     setStatus(`Bozza AI non disponibile: ${message}`);
   } finally {
@@ -4111,6 +4130,9 @@ setAssignmentWizardStep("activity");
 els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
 els.assignmentAiAskBtn?.addEventListener("click", previewAssignmentAiPackage);
 els.assignmentAiGenerateBtn?.addEventListener("click", generateAssignmentAiDraft);
+els.assignmentAiPreviewButtons?.forEach((button) => {
+  button.addEventListener("click", () => setAssignmentAiPreviewView(button.dataset.aiPreviewView));
+});
 els.assignmentAiPrompt?.addEventListener("focus", unlockAssignmentAiPrompt);
 els.assignmentAiPrompt?.addEventListener("click", unlockAssignmentAiPrompt);
 els.assignmentAiPrompt?.addEventListener("input", unlockAssignmentAiPrompt);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -154,6 +154,7 @@ const state = {
   activityAuthorLastSuggestedId: "",
   activityReviewSaved: false,
   assignmentAiGenerating: false,
+  assignmentAiPromptLocked: false,
   assignmentAiDraftFilePath: "",
   selectedRosterTargetIds: new Set(),
   selectedAssignmentId: "",
@@ -2823,6 +2824,20 @@ function closeAssignmentAiFilesDialog() {
   }
 }
 
+function setAssignmentAiPromptLocked(locked) {
+  state.assignmentAiPromptLocked = Boolean(locked);
+  if (!els.assignmentAiGenerateBtn) return;
+  els.assignmentAiGenerateBtn.disabled = state.assignmentAiGenerating || state.assignmentAiPromptLocked;
+  els.assignmentAiGenerateBtn.title = state.assignmentAiPromptLocked
+    ? "Hai gia inviato questo prompt. Clicca nel prompt e modificalo per inviare una nuova richiesta."
+    : "Invia il prompt al provider selezionato e genera una proposta modificabile. Per ora e attivo Codex locale.";
+}
+
+function unlockAssignmentAiPrompt() {
+  if (!state.assignmentAiPromptLocked) return;
+  setAssignmentAiPromptLocked(false);
+}
+
 function setAssignmentAiProgress(active, title = "Generazione proposta AI in corso", detail = "Codex sta lavorando sulla macchina docente.") {
   if (!els.assignmentAiProgress) return;
   els.assignmentAiProgress.hidden = !active;
@@ -3207,6 +3222,7 @@ async function generateAssignmentAiDraft() {
   const provider = els.assignmentAiProvider?.value || "codex";
   let failedMessage = "";
   state.assignmentAiGenerating = true;
+  setAssignmentAiPromptLocked(true);
   els.assignmentAiGenerateBtn.disabled = true;
   if (els.assignmentAiApplyDraftBtn) els.assignmentAiApplyDraftBtn.disabled = true;
   if (els.assignmentWizardNextBtn && currentAssignmentWizardStep() === "ai") {
@@ -3245,7 +3261,7 @@ async function generateAssignmentAiDraft() {
     } else {
       setAssignmentAiProgress(false);
     }
-    els.assignmentAiGenerateBtn.disabled = false;
+    setAssignmentAiPromptLocked(true);
     updateAssignmentAiApplyState();
   }
 }
@@ -4095,6 +4111,9 @@ setAssignmentWizardStep("activity");
 els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
 els.assignmentAiAskBtn?.addEventListener("click", previewAssignmentAiPackage);
 els.assignmentAiGenerateBtn?.addEventListener("click", generateAssignmentAiDraft);
+els.assignmentAiPrompt?.addEventListener("focus", unlockAssignmentAiPrompt);
+els.assignmentAiPrompt?.addEventListener("click", unlockAssignmentAiPrompt);
+els.assignmentAiPrompt?.addEventListener("input", unlockAssignmentAiPrompt);
 els.assignmentAiDraftText?.addEventListener("input", updateAssignmentAiApplyState);
 els.assignmentAiPackagePreview?.addEventListener("click", (event) => {
   const button = event.target.closest("[data-ai-draft-file-index]");

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2663,19 +2663,19 @@ function renderAssignmentAiPackage(aiPackage) {
   els.assignmentAiPackagePreview.innerHTML = `
     <div class="assignmentPlanHeader">
       <div>
-        <strong>${escapeHtml(aiPackage.activity?.title || aiPackage.activity?.id || "Pacchetto AI")}</strong>
-        <small>${escapeHtml(aiPackage.provider || "-")} - ${escapeHtml(aiPackage.schema_version || "-")} - ${escapeHtml(promptStatus)} - ${escapeHtml(draftStatus)}</small>
+        <strong>${escapeHtml(aiPackage.activity?.title || aiPackage.activity?.id || "Controllo dati AI")}</strong>
+        <small>${escapeHtml(aiPackage.provider || "-")} - ${escapeHtml(aiPackage.schema_version || "-")} - ${escapeHtml(promptStatus)} - ${escapeHtml(draftStatus)}. Questa anteprima non chiama l'AI.</small>
       </div>
       ${badge("nessuna chiamata AI", "muted")}
     </div>
     <div class="assignmentPlanGrid">
       <section>
-        <h3>File inclusi</h3>
-        ${renderAssignmentAssetList(includedFiles, "Nessun file incluso nel pacchetto.")}
+        <h3>File di contesto inviati all'AI</h3>
+        ${renderAssignmentAssetList(includedFiles, "Nessun file di contesto collegato all'activity. Verranno inviati prompt e metadati.")}
       </section>
       <section>
-        <h3>File esclusi o mancanti</h3>
-        ${renderAssignmentAssetList(skippedFiles.map((file) => ({ ...file, description: file.error || file.description })), "Nessun file escluso.")}
+        <h3>File di contesto non inviati</h3>
+        ${renderAssignmentAssetList(skippedFiles.map((file) => ({ ...file, description: file.error || file.description })), "Nessun file escluso o mancante.")}
       </section>
       <section>
         <h3>Policy</h3>
@@ -2687,7 +2687,7 @@ function renderAssignmentAiPackage(aiPackage) {
       </section>
     </div>
     <details class="assignmentPackageJson">
-      <summary>JSON pacchetto</summary>
+      <summary>JSON tecnico per debug</summary>
       <pre>${escapeHtml(JSON.stringify(aiPackage, null, 2))}</pre>
     </details>
   `;
@@ -3195,9 +3195,9 @@ async function previewAssignmentPlan() {
 async function previewAssignmentAiPackage() {
   if (!els.assignmentAiAskBtn) return;
   els.assignmentAiAskBtn.disabled = true;
-  setStatus("Preparazione pacchetto AI...");
+  setStatus("Aggiornamento controllo dati inviati all'AI...");
   if (els.assignmentAiPackagePreview) {
-    els.assignmentAiPackagePreview.innerHTML = '<p class="status">Preparazione pacchetto AI...</p>';
+    els.assignmentAiPackagePreview.innerHTML = '<p class="status">Aggiornamento controllo dati inviati all\'AI...</p>';
   }
   try {
     const payload = await api("/api/activities/ai-package", {
@@ -3205,13 +3205,13 @@ async function previewAssignmentAiPackage() {
       body: JSON.stringify(assignmentAiPackagePayload()),
     });
     renderAssignmentAiPackage(payload.package);
-    setStatus("Pacchetto AI pronto: nessuna chiamata provider eseguita.");
+    setStatus("Controllo dati AI pronto: nessuna chiamata provider eseguita.");
   } catch (error) {
     const message = assignmentPlanErrorMessage(error);
     if (els.assignmentAiPackagePreview) {
-      els.assignmentAiPackagePreview.innerHTML = `<p class="status">Pacchetto AI non disponibile: ${escapeHtml(message)}</p>`;
+      els.assignmentAiPackagePreview.innerHTML = `<p class="status">Controllo dati AI non disponibile: ${escapeHtml(message)}</p>`;
     }
-    setStatus(`Pacchetto AI non disponibile: ${message}`);
+    setStatus(`Controllo dati AI non disponibile: ${message}`);
   } finally {
     els.assignmentAiAskBtn.disabled = false;
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -154,6 +154,7 @@ const state = {
   activityAuthorLastSuggestedId: "",
   activityReviewSaved: false,
   assignmentAiGenerating: false,
+  selectedRosterTargetIds: new Set(),
   selectedAssignmentId: "",
 };
 
@@ -264,6 +265,9 @@ const els = {
   dueAt: document.querySelector("#dueAt"),
   nowAt: document.querySelector("#nowAt"),
   targetsText: document.querySelector("#targetsText"),
+  assignmentTargetPicker: document.querySelector("#assignmentTargetPicker"),
+  selectAllRosterTargetsBtn: document.querySelector("#selectAllRosterTargetsBtn"),
+  clearRosterTargetsBtn: document.querySelector("#clearRosterTargetsBtn"),
   previewAssignmentBtn: document.querySelector("#previewAssignmentBtn"),
   saveAssignmentBtn: document.querySelector("#saveAssignmentBtn"),
   distributeAssignmentBtn: document.querySelector("#distributeAssignmentBtn"),
@@ -886,6 +890,87 @@ function targetLineCount() {
   return els.targetsText.value.split(/\r?\n/).filter((line) => line.trim() && !line.trim().startsWith("#")).length;
 }
 
+function targetTextLines() {
+  return new Set(els.targetsText.value.split(/\r?\n/).map((line) => line.trim()).filter((line) => line && !line.startsWith("#")));
+}
+
+function rosterStudentKey(student) {
+  return String(student?.id || student?.display_name || student?.local_path || student?.repo_path || student?.repo_ref || "").trim();
+}
+
+function activeRosterStudents(roster = state.selectedClassRoster) {
+  return (Array.isArray(roster?.students) ? roster.students : []).filter((student) => student?.active !== false);
+}
+
+function selectedRosterStudents() {
+  const roster = state.selectedClassRoster;
+  if (!roster) return [];
+  return activeRosterStudents(roster).filter((student) => state.selectedRosterTargetIds.has(rosterStudentKey(student)));
+}
+
+function syncTargetsFromRosterSelection() {
+  if (!state.selectedClassRoster || !els.assignmentTargetPicker) return;
+  const warnings = [];
+  const targets = [];
+  for (const student of selectedRosterStudents()) {
+    const result = localTargetFromStudent(student);
+    if (result.target) targets.push(result.target);
+    if (result.warning) warnings.push(result.warning);
+  }
+  els.targetsText.value = targets.join("\n");
+  clearSelectedAssignment();
+  renderAssignmentContext();
+  setRosterStatus(warnings.length
+    ? `Destinatari aggiornati con avvisi: ${warnings.join(" ")}`
+    : `Destinatari aggiornati: ${targets.length} target studenti.`);
+}
+
+function syncRosterSelectionFromTargetsText() {
+  if (!state.selectedClassRoster) return;
+  const lines = targetTextLines();
+  state.selectedRosterTargetIds = new Set(
+    activeRosterStudents().filter((student) => {
+      const target = localTargetFromStudent(student).target;
+      return target && lines.has(target);
+    }).map(rosterStudentKey),
+  );
+  renderAssignmentTargetPicker();
+}
+
+function renderAssignmentTargetPicker() {
+  if (!els.assignmentTargetPicker) return;
+  const roster = state.selectedClassRoster;
+  if (!roster) {
+    els.assignmentTargetPicker.innerHTML = '<p class="status">Seleziona un roster per scegliere classe intera, gruppo o singolo studente.</p>';
+    if (els.selectAllRosterTargetsBtn) els.selectAllRosterTargetsBtn.disabled = true;
+    if (els.clearRosterTargetsBtn) els.clearRosterTargetsBtn.disabled = true;
+    return;
+  }
+  const students = activeRosterStudents(roster);
+  if (els.selectAllRosterTargetsBtn) els.selectAllRosterTargetsBtn.disabled = students.length === 0;
+  if (els.clearRosterTargetsBtn) els.clearRosterTargetsBtn.disabled = students.length === 0;
+  if (!students.length) {
+    els.assignmentTargetPicker.innerHTML = '<p class="status">Il roster non contiene studenti attivi da assegnare.</p>';
+    return;
+  }
+  els.assignmentTargetPicker.innerHTML = students.map((student) => {
+    const key = rosterStudentKey(student);
+    const target = localTargetFromStudent(student);
+    const checked = state.selectedRosterTargetIds.has(key) ? " checked" : "";
+    const name = student.display_name || student.id || key || "-";
+    const hint = target.warning || target.target || "Target non disponibile";
+    return `
+      <label class="assignmentTargetOption">
+        <input type="checkbox" data-roster-target-student="${escapeHtml(key)}"${checked}>
+        <span>
+          <strong>${escapeHtml(name)}</strong>
+          <small>${escapeHtml(hint)}</small>
+        </span>
+      </label>
+    `;
+  }).join("");
+}
+
 function reportAssignmentSummaryItems() {
   const assignment = state.assignments.find((candidate) => candidate.id === state.selectedAssignmentId)
     || state.dueAssignments.find((candidate) => candidate.id === state.selectedAssignmentId);
@@ -915,6 +1000,7 @@ function renderReportAssignmentSummary() {
 }
 
 function renderAssignmentContext() {
+  renderAssignmentTargetPicker();
   renderRosterPanel();
   renderReportAssignmentSummary();
 }
@@ -1856,13 +1942,14 @@ function applyRosterToGenerateForm(roster) {
   els.classLabel.value = roster.label || roster.id || "";
   els.githubTeam.value = roster.github_team || "";
   const result = rosterTargets(roster);
+  state.selectedRosterTargetIds = new Set(activeRosterStudents(roster).map(rosterStudentKey));
   els.targetsText.value = result.targets.join("\n");
   const activity = currentActivity();
   if (activity?.id) els.outputName.value = defaultOutputName({ ...activity, class_id: roster.id, class_label: roster.label, github_team: roster.github_team });
   setRosterStatus(result.warnings.length
     ? `Roster applicato con avvisi: ${result.warnings.join(" ")}`
     : `Roster applicato: ${result.targets.length} target studenti.`);
-  renderRosterPanel();
+  renderAssignmentContext();
   return result;
 }
 
@@ -1870,7 +1957,9 @@ async function loadSelectedClassRoster() {
   const name = els.classRosterSelect?.value || "";
   if (!name) {
     state.selectedClassRoster = null;
+    state.selectedRosterTargetIds = new Set();
     renderRosterPanel();
+    renderAssignmentTargetPicker();
     setRosterStatus("Seleziona un roster per compilare classe e target.");
     return;
   }
@@ -3882,6 +3971,26 @@ els.activityAuthorClass?.addEventListener("change", () => {
   field?.addEventListener("change", markActivityReviewDirty);
 });
 els.classRosterSelect?.addEventListener("change", loadSelectedClassRoster);
+els.assignmentTargetPicker?.addEventListener("change", (event) => {
+  const input = event.target.closest("[data-roster-target-student]");
+  if (!input) return;
+  const key = input.dataset.rosterTargetStudent;
+  if (input.checked) {
+    state.selectedRosterTargetIds.add(key);
+  } else {
+    state.selectedRosterTargetIds.delete(key);
+  }
+  syncTargetsFromRosterSelection();
+});
+els.selectAllRosterTargetsBtn?.addEventListener("click", () => {
+  if (!state.selectedClassRoster) return;
+  state.selectedRosterTargetIds = new Set(activeRosterStudents().map(rosterStudentKey));
+  syncTargetsFromRosterSelection();
+});
+els.clearRosterTargetsBtn?.addEventListener("click", () => {
+  state.selectedRosterTargetIds = new Set();
+  syncTargetsFromRosterSelection();
+});
 els.activityPath.addEventListener("input", () => {
   clearSelectedAssignment();
   renderActivitySelect();
@@ -3911,6 +4020,7 @@ els.dueAt.addEventListener("input", () => {
 els.nowAt.addEventListener("change", () => loadAssignments().catch((error) => setStatus(`Assegnazioni non aggiornate: ${error.message}`)));
 els.targetsText.addEventListener("input", () => {
   clearSelectedAssignment();
+  syncRosterSelectionFromTargetsText();
   renderAssignmentContext();
 });
 els.classId.addEventListener("change", updateOutputNameForCurrentActivity);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1803,6 +1803,12 @@ function openActivityReviewStep(statusMessage = "Controlla la bozza activity, mo
 
 async function saveActivityDraft() {
   if (!els.saveActivityBtn) return;
+  if (!String(els.activityAuthorPrompt?.value || "").trim()) {
+    const message = "Completa il campo Consegna prima di salvare l'activity.";
+    if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = message;
+    setStatus(message);
+    return;
+  }
   els.saveActivityBtn.disabled = true;
   if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = "Salvataggio activity...";
   try {
@@ -2740,7 +2746,7 @@ function applyAssignmentAiDraftToActivityForm() {
     const metriche = patch.metriche && typeof patch.metriche === "object" ? patch.metriche : {};
     const contesto = patch.contesto && typeof patch.contesto === "object" ? patch.contesto : {};
 
-    const title = firstDraftValue(patch, ["titolo", "title"]) || firstDraftValue(draft, ["titolo", "title", "summary"]);
+    const title = firstDraftValue(patch, ["titolo", "title", "nome", "name"]) || firstDraftValue(draft, ["titolo", "title"]);
     if (title && els.activityAuthorTitle) {
       els.activityAuthorTitle.value = title;
       syncActivityAuthorIdSuggestion();
@@ -2754,7 +2760,18 @@ function applyAssignmentAiDraftToActivityForm() {
     setSelectValueIfAvailable(els.activityAuthorKind, kind);
     const difficulty = firstDraftValue(patch, ["difficolta", "difficulty"]);
     setSelectValueIfAvailable(els.activityAuthorDifficulty, difficulty);
-    const prompt = firstDraftValue(patch, ["consegna", "prompt", "description"]);
+    const prompt = firstDraftValue(patch, [
+      "consegna",
+      "istruzioni",
+      "instructions",
+      "prompt",
+      "description",
+      "descrizione",
+      "traccia",
+      "testo",
+      "student_prompt",
+      "student_instructions",
+    ]);
     if (prompt && els.activityAuthorPrompt) els.activityAuthorPrompt.value = prompt;
     const minutes = firstDraftValue(metriche, ["tempo_stimato_minuti"]) || firstDraftValue(patch, ["estimated_minutes"]);
     if (minutes && els.activityAuthorMinutes) els.activityAuthorMinutes.value = minutes;

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1801,12 +1801,47 @@ function openActivityReviewStep(statusMessage = "Controlla la bozza activity, mo
   renderActivityPanelSummary();
 }
 
-async function saveActivityDraft() {
-  if (!els.saveActivityBtn) return;
-  if (!String(els.activityAuthorPrompt?.value || "").trim()) {
-    const message = "Completa il campo Consegna prima di salvare l'activity.";
+function activityAuthorRequiredFields() {
+  return [
+    { field: els.activityAuthorTitle, label: "Titolo" },
+    { field: els.activityAuthorKind, label: "Tipo" },
+    { field: els.activityAuthorDifficulty, label: "Difficolta" },
+    { field: els.activityAuthorTopics, label: "Argomenti" },
+    {
+      field: els.activityAuthorMinutes,
+      label: "Tempo stimato",
+      isValid: (value) => Number(value) > 0,
+    },
+    { field: els.activityAuthorPrompt, label: "Consegna" },
+  ];
+}
+
+function markActivityAuthorFieldInvalid(field, invalid) {
+  if (!field) return;
+  field.classList.toggle("fieldInvalid", invalid);
+  field.setAttribute("aria-invalid", invalid ? "true" : "false");
+}
+
+function validateActivityAuthorRequiredFields({ showMessage = false } = {}) {
+  const missing = [];
+  for (const item of activityAuthorRequiredFields()) {
+    const value = String(item.field?.value || "").trim();
+    const invalid = item.isValid ? !item.isValid(value) : !value;
+    markActivityAuthorFieldInvalid(item.field, invalid);
+    if (invalid) missing.push(item.label);
+  }
+  if (showMessage && missing.length) {
+    const message = `Completa i campi obbligatori: ${missing.join(", ")}.`;
     if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = message;
     setStatus(message);
+  }
+  return missing;
+}
+
+async function saveActivityDraft() {
+  if (!els.saveActivityBtn) return;
+  const missingFields = validateActivityAuthorRequiredFields({ showMessage: true });
+  if (missingFields.length) {
     return;
   }
   els.saveActivityBtn.disabled = true;
@@ -2684,6 +2719,7 @@ function setAssignmentAiProgressError(message) {
 
 function markActivityReviewDirty() {
   state.activityReviewSaved = false;
+  validateActivityAuthorRequiredFields();
   if (currentAssignmentWizardStep() === "review") {
     setAssignmentWizardStep("review");
   }
@@ -2791,6 +2827,7 @@ function applyAssignmentAiDraftToActivityForm() {
     setStatus("Bozza AI pronta nello step Revisione activity: il docente puo ancora modificare tutto.");
     markActivityReviewDirty();
     openActivityReviewStep(`Bozza AI applicata alla revisione activity. Controlla e salva quando e pronta.${suffix}`);
+    validateActivityAuthorRequiredFields();
     return true;
   } catch (error) {
     if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = `Bozza AI non applicata: ${error.message}`;

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1773,6 +1773,7 @@ function applyAssignmentToGenerateForm(assignmentId) {
   renderActivitySelect();
   renderAssignmentContext();
   renderAssignmentSelect();
+  resetAssignmentConfirmStatus("Assegnazione caricata: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   return assignment;
 }
 
@@ -2129,6 +2130,7 @@ function selectCoverageActivity(activityPath, outputName = "") {
   els.activityPath.value = activityPath;
   renderActivitySelect();
   if (outputName) els.outputName.value = outputName;
+  resetAssignmentConfirmStatus("Activity selezionata dalla copertura: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   els.activityPath.scrollIntoView({ behavior: "smooth", block: "center" });
   els.activityPath.focus();
 }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -522,6 +522,32 @@ function isoToDateTimeInput(value) {
   return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
+function currentDateTimeInput() {
+  return isoToDateTimeInput(new Date().toISOString());
+}
+
+function initializeAssignmentDateFields() {
+  if (els.assignedAt && !String(els.assignedAt.value || "").trim()) {
+    els.assignedAt.value = currentDateTimeInput();
+  }
+  validateAssignmentDateFields();
+}
+
+function validateAssignmentDateFields({ showMessage = false } = {}) {
+  const missingAssigned = !String(els.assignedAt?.value || "").trim();
+  const missingDue = !String(els.dueAt?.value || "").trim();
+  markActivityAuthorFieldInvalid(els.assignedAt, missingAssigned);
+  markActivityAuthorFieldInvalid(els.dueAt, missingDue);
+  if (showMessage && (missingAssigned || missingDue)) {
+    const missing = [
+      missingAssigned ? "Assegnato il" : "",
+      missingDue ? "Scadenza" : "",
+    ].filter(Boolean).join(", ");
+    setStatus(`Completa i campi data obbligatori: ${missing}.`);
+  }
+  return !(missingAssigned || missingDue);
+}
+
 function classValue(entity) {
   return entity?.class_label || entity?.class_id || entity?.github_team || "classe non indicata";
 }
@@ -3045,6 +3071,7 @@ function assignmentWizardStepComplete(step) {
   if (step === "ai" && state.assignmentAiGenerating) return false;
   if (step === "ai") return updateAssignmentAiApplyState();
   if (step === "review") return Boolean(state.activityReviewSaved && String(els.activityPath?.value || "").trim());
+  if (step === "dates") return validateAssignmentDateFields();
   return true;
 }
 
@@ -3068,6 +3095,9 @@ function setAssignmentWizardStep(step) {
   const selectedStep = ASSIGNMENT_WIZARD_STEPS.some((candidate) => candidate.id === step) ? step : "activity";
   if (selectedStep === "review") {
     mountActivityEditorInWizard();
+  }
+  if (selectedStep === "dates") {
+    initializeAssignmentDateFields();
   }
   els.assignmentStepTabs.forEach((button) => {
     const isActive = button.dataset.assignmentStepTab === selectedStep;
@@ -4284,10 +4314,14 @@ els.githubTeam.addEventListener("input", () => {
 });
 els.assignedAt.addEventListener("input", () => {
   clearSelectedAssignment();
+  validateAssignmentDateFields();
+  setAssignmentWizardStep(currentAssignmentWizardStep());
   renderReportAssignmentSummary();
 });
 els.dueAt.addEventListener("input", () => {
   clearSelectedAssignment();
+  validateAssignmentDateFields();
+  setAssignmentWizardStep(currentAssignmentWizardStep());
   renderReportAssignmentSummary();
 });
 els.nowAt.addEventListener("change", () => loadAssignments().catch((error) => setStatus(`Assegnazioni non aggiornate: ${error.message}`)));

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2099,6 +2099,7 @@ function applyRosterToGenerateForm(roster) {
     ? `Roster applicato con avvisi: ${result.warnings.join(" ")}`
     : `Roster applicato: ${result.targets.length} target studenti.`);
   renderAssignmentContext();
+  resetAssignmentConfirmStatus("Il roster e i destinatari sono cambiati: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   return result;
 }
 
@@ -4115,6 +4116,7 @@ function selectActivity(path) {
     renderRosterPanel();
   }
   renderActivityPanelSummary();
+  resetAssignmentConfirmStatus("L'activity e cambiata: ricontrolla anteprima e conferma prima di salvare o distribuire.");
 }
 
 function updateOutputNameForCurrentActivity() {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -302,7 +302,6 @@ const els = {
   assignmentAiPrompt: document.querySelector("#assignmentAiPrompt"),
   assignmentAiStudentBudget: document.querySelector("#assignmentAiStudentBudget"),
   assignmentIntegrityMode: document.querySelector("#assignmentIntegrityMode"),
-  assignmentAiAskBtn: document.querySelector("#assignmentAiAskBtn"),
   assignmentAiGenerateBtn: document.querySelector("#assignmentAiGenerateBtn"),
   assignmentAiApplyDraftBtn: document.querySelector("#assignmentAiApplyDraftBtn"),
   assignmentAiDraftText: document.querySelector("#assignmentAiDraftText"),
@@ -2666,14 +2665,22 @@ function setAssignmentAiPreviewView(view) {
     : state.assignmentAiDraftHtml;
   els.assignmentAiPackagePreview.innerHTML = html || (
     state.assignmentAiPreviewView === "context"
-      ? '<p class="status">Clicca Aggiorna controllo dati per vedere prompt, metadati e file di contesto inviati all\'AI.</p>'
+      ? '<p class="status">Apri Dati inviati all\'AI per vedere prompt, metadati e file di contesto.</p>'
       : '<p class="status">Qui comparira la proposta generata dall\'AI. I dati inviati all\'AI restano disponibili nella vista dedicata.</p>'
   );
 }
 
+async function selectAssignmentAiPreviewView(view) {
+  if (view === "context") {
+    await previewAssignmentAiPackage();
+    return;
+  }
+  setAssignmentAiPreviewView(view);
+}
+
 function renderAssignmentAiPackage(aiPackage) {
   if (!aiPackage) {
-    state.assignmentAiContextHtml = '<p class="status">Clicca Aggiorna controllo dati per vedere prompt, metadati e file di contesto inviati all\'AI.</p>';
+    state.assignmentAiContextHtml = '<p class="status">Apri Dati inviati all\'AI per vedere prompt, metadati e file di contesto.</p>';
     setAssignmentAiPreviewView("context");
     return;
   }
@@ -3216,8 +3223,8 @@ async function previewAssignmentPlan() {
 }
 
 async function previewAssignmentAiPackage() {
-  if (!els.assignmentAiAskBtn) return;
-  els.assignmentAiAskBtn.disabled = true;
+  const contextButton = Array.from(els.assignmentAiPreviewButtons || []).find((button) => button.dataset.aiPreviewView === "context");
+  if (contextButton) contextButton.disabled = true;
   setStatus("Aggiornamento controllo dati inviati all'AI...");
   state.assignmentAiContextHtml = '<p class="status">Aggiornamento controllo dati inviati all\'AI...</p>';
   setAssignmentAiPreviewView("context");
@@ -3234,7 +3241,7 @@ async function previewAssignmentAiPackage() {
     setAssignmentAiPreviewView("context");
     setStatus(`Controllo dati AI non disponibile: ${message}`);
   } finally {
-    els.assignmentAiAskBtn.disabled = false;
+    if (contextButton) contextButton.disabled = false;
   }
 }
 
@@ -4128,10 +4135,12 @@ els.assignmentWizardPrevBtn?.addEventListener("click", () => moveAssignmentWizar
 els.assignmentWizardNextBtn?.addEventListener("click", () => moveAssignmentWizardStep(1));
 setAssignmentWizardStep("activity");
 els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
-els.assignmentAiAskBtn?.addEventListener("click", previewAssignmentAiPackage);
 els.assignmentAiGenerateBtn?.addEventListener("click", generateAssignmentAiDraft);
 els.assignmentAiPreviewButtons?.forEach((button) => {
-  button.addEventListener("click", () => setAssignmentAiPreviewView(button.dataset.aiPreviewView));
+  button.addEventListener("click", () => {
+    selectAssignmentAiPreviewView(button.dataset.aiPreviewView)
+      .catch((error) => setStatus(`Controllo dati AI non disponibile: ${error.message}`));
+  });
 });
 els.assignmentAiPrompt?.addEventListener("focus", unlockAssignmentAiPrompt);
 els.assignmentAiPrompt?.addEventListener("click", unlockAssignmentAiPrompt);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1795,10 +1795,17 @@ function closeActivityEditor() {
 function openActivityReviewStep(statusMessage = "Controlla la bozza activity, modifica se serve e salva prima di proseguire.") {
   mountActivityEditorInWizard();
   setAssignmentWizardStep("review");
-  if (els.activityAuthorStatus) {
-    els.activityAuthorStatus.textContent = statusMessage;
-  }
+  setActivityAuthorStatus("info", "Revisione activity", statusMessage);
   renderActivityPanelSummary();
+}
+
+function setActivityAuthorStatus(type, title, message) {
+  if (!els.activityAuthorStatus) return;
+  els.activityAuthorStatus.classList.remove("isSaving", "isSuccess", "isError");
+  if (type === "saving") els.activityAuthorStatus.classList.add("isSaving");
+  if (type === "success") els.activityAuthorStatus.classList.add("isSuccess");
+  if (type === "error") els.activityAuthorStatus.classList.add("isError");
+  els.activityAuthorStatus.innerHTML = `<strong>${escapeHtml(title)}</strong><span>${escapeHtml(message)}</span>`;
 }
 
 function activityAuthorRequiredFields() {
@@ -1832,7 +1839,7 @@ function validateActivityAuthorRequiredFields({ showMessage = false } = {}) {
   }
   if (showMessage && missing.length) {
     const message = `Completa i campi obbligatori: ${missing.join(", ")}.`;
-    if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = message;
+    setActivityAuthorStatus("error", "Activity non salvata", `${message} Correggi i campi evidenziati in rosso.`);
     setStatus(message);
   }
   return missing;
@@ -1845,7 +1852,7 @@ async function saveActivityDraft() {
     return;
   }
   els.saveActivityBtn.disabled = true;
-  if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = "Salvataggio activity...";
+  setActivityAuthorStatus("saving", "Salvataggio activity", "Validazione e scrittura della bozza in corso...");
   try {
     const payload = await api("/api/activities/save", {
       method: "POST",
@@ -1869,16 +1876,18 @@ async function saveActivityDraft() {
     renderCoverage();
     if (payload.activity?.path) selectActivity(payload.activity.path);
     markActivityReviewSaved();
-    if (els.activityAuthorStatus) {
-      els.activityAuthorStatus.textContent = `Activity salvata: ${payload.activity?.path || "-"}.`;
-    }
+    setActivityAuthorStatus(
+      "success",
+      "Activity salvata",
+      `Puoi passare al punto 4 Destinatari. File: ${payload.activity?.path || "-"}.`,
+    );
     if (els.activityPanelStatus) {
       els.activityPanelStatus.textContent = `Activity salvata: ${payload.activity?.title || payload.activity?.id || "-"}.`;
     }
     renderActivityPanelSummary();
     setStatus(`Activity salvata: ${payload.activity?.title || payload.activity?.id || "-"}.`);
   } catch (error) {
-    if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = `Errore: ${error.message}`;
+    setActivityAuthorStatus("error", "Activity non salvata", error.message);
     setStatus(`Errore salvataggio activity: ${error.message}`);
   } finally {
     els.saveActivityBtn.disabled = false;
@@ -2830,7 +2839,7 @@ function applyAssignmentAiDraftToActivityForm() {
     validateActivityAuthorRequiredFields();
     return true;
   } catch (error) {
-    if (els.activityAuthorStatus) els.activityAuthorStatus.textContent = `Bozza AI non applicata: ${error.message}`;
+    setActivityAuthorStatus("error", "Bozza AI non applicata", error.message);
     setStatus(`Bozza AI non applicata: ${error.message}`);
     return false;
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -154,6 +154,7 @@ const state = {
   activityAuthorLastSuggestedId: "",
   activityReviewSaved: false,
   assignmentAiGenerating: false,
+  assignmentAiDraftFilePath: "",
   selectedRosterTargetIds: new Set(),
   selectedAssignmentId: "",
 };
@@ -303,6 +304,10 @@ const els = {
   assignmentAiDraftText: document.querySelector("#assignmentAiDraftText"),
   assignmentAiProgress: document.querySelector("#assignmentAiProgress"),
   assignmentAiPackagePreview: document.querySelector("#assignmentAiPackagePreview"),
+  assignmentAiFilesDialog: document.querySelector("#assignmentAiFilesDialog"),
+  assignmentAiFilesCloseBtn: document.querySelector("#assignmentAiFilesCloseBtn"),
+  assignmentAiFilesStatus: document.querySelector("#assignmentAiFilesStatus"),
+  assignmentAiFilesReview: document.querySelector("#assignmentAiFilesReview"),
   generateReportBtn: document.querySelector("#generateReportBtn"),
   panels: document.querySelectorAll("main.layout .panel"),
 };
@@ -2708,7 +2713,7 @@ function renderAssignmentCodexDraft(response) {
     <div class="assignmentPlanGrid">
       <section>
         <h3>File proposti</h3>
-        ${renderAssignmentAssetList(files, "Nessun file proposto da Codex.")}
+        ${renderAssignmentAssetList(files, "Nessun file proposto da Codex.", { openDraftFiles: true })}
       </section>
       <section>
         <h3>Note docente</h3>
@@ -2745,6 +2750,77 @@ function updateAssignmentAiApplyState() {
     }
   }
   return isValid;
+}
+
+function assignmentAiDraftFiles() {
+  try {
+    const draft = parseAssignmentAiDraftText();
+    return Array.isArray(draft.files) ? draft.files.filter((file) => file && typeof file === "object") : [];
+  } catch (error) {
+    return [];
+  }
+}
+
+function renderAssignmentAiFilesReview() {
+  if (!els.assignmentAiFilesReview) return;
+  const files = assignmentAiDraftFiles();
+  if (!files.length) {
+    els.assignmentAiFilesReview.className = "reviewEmpty";
+    els.assignmentAiFilesReview.textContent = "La bozza AI non contiene file proposti.";
+    if (els.assignmentAiFilesStatus) els.assignmentAiFilesStatus.textContent = "Nessun file proposto dalla bozza AI.";
+    return;
+  }
+  const selected = files.find((file) => String(file.path || "") === state.assignmentAiDraftFilePath) || files[0];
+  state.assignmentAiDraftFilePath = String(selected.path || files.indexOf(selected));
+  const selectedPath = String(selected.path || "file-proposto.txt");
+  const selectedContent = selected.content === undefined || selected.content === null
+    ? "Contenuto non presente nella risposta AI. Il file e dichiarato come asset, ma non e stato generato inline."
+    : String(selected.content);
+  if (els.assignmentAiFilesStatus) {
+    els.assignmentAiFilesStatus.textContent = `File AI: ${selectedPath}.`;
+  }
+  els.assignmentAiFilesReview.className = "reviewGrid";
+  els.assignmentAiFilesReview.innerHTML = `
+    <aside class="fileList">
+      <h3>File proposti</h3>
+      ${files.map((file, index) => {
+        const path = String(file.path || `file-${index + 1}.txt`);
+        const active = path === state.assignmentAiDraftFilePath;
+        return `
+          <button type="button" class="${active ? "isActive" : ""}" data-ai-draft-preview-file="${escapeHtml(path)}" title="Mostra il contenuto del file ${escapeHtml(path)}.">
+            <span>${escapeHtml(path.split(/[\\/]/).pop() || path)}</span>
+            <small>${escapeHtml(file.role || file.type || file.visibility || "file")}</small>
+          </button>
+        `;
+      }).join("")}
+    </aside>
+    <div class="reviewSplitter" role="separator" aria-label="Separatore lista file AI" aria-orientation="vertical"></div>
+    <section class="filePreview">
+      <div class="filePreviewHead">
+        <div>
+          <strong>${escapeHtml(selectedPath)}</strong>
+        </div>
+        <span>${escapeHtml(languageFromPath(selectedPath))}</span>
+      </div>
+      <pre><code>${highlightCode(selectedContent, selectedPath)}</code></pre>
+    </section>
+  `;
+}
+
+function openAssignmentAiFilesDialog(index = 0) {
+  const files = assignmentAiDraftFiles();
+  const selected = files[index] || files[0];
+  state.assignmentAiDraftFilePath = selected ? String(selected.path || `file-${index + 1}.txt`) : "";
+  renderAssignmentAiFilesReview();
+  if (els.assignmentAiFilesDialog && !els.assignmentAiFilesDialog.open) {
+    els.assignmentAiFilesDialog.showModal();
+  }
+}
+
+function closeAssignmentAiFilesDialog() {
+  if (els.assignmentAiFilesDialog?.open) {
+    els.assignmentAiFilesDialog.close();
+  }
 }
 
 function setAssignmentAiProgress(active, title = "Generazione proposta AI in corso", detail = "Codex sta lavorando sulla macchina docente.") {
@@ -2999,16 +3075,17 @@ function assignmentRecordPayload() {
   };
 }
 
-function renderAssignmentAssetList(assets, emptyLabel) {
+function renderAssignmentAssetList(assets, emptyLabel, options = {}) {
   const items = Array.isArray(assets) ? assets : [];
   if (!items.length) return `<p class="status">${escapeHtml(emptyLabel)}</p>`;
   return `
     <ul class="assignmentPlanList">
-      ${items.map((asset) => `
+      ${items.map((asset, index) => `
         <li>
           <strong>${escapeHtml(asset.target_path || asset.path || "-")}</strong>
           ${badge(asset.type || asset.role || "-", asset.visibility === "student" ? "ok" : "muted")}
           <small>${escapeHtml(asset.description || asset.path || "")}</small>
+          ${options.openDraftFiles ? `<button type="button" class="smallButton" data-ai-draft-file-index="${index}" title="Apri il contenuto del file proposto ${escapeHtml(asset.path || asset.target_path || "")}.">Apri file</button>` : ""}
         </li>
       `).join("")}
     </ul>
@@ -4019,6 +4096,18 @@ els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
 els.assignmentAiAskBtn?.addEventListener("click", previewAssignmentAiPackage);
 els.assignmentAiGenerateBtn?.addEventListener("click", generateAssignmentAiDraft);
 els.assignmentAiDraftText?.addEventListener("input", updateAssignmentAiApplyState);
+els.assignmentAiPackagePreview?.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-ai-draft-file-index]");
+  if (!button) return;
+  openAssignmentAiFilesDialog(Number(button.dataset.aiDraftFileIndex || 0));
+});
+els.assignmentAiFilesReview?.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-ai-draft-preview-file]");
+  if (!button) return;
+  state.assignmentAiDraftFilePath = button.dataset.aiDraftPreviewFile || "";
+  renderAssignmentAiFilesReview();
+});
+els.assignmentAiFilesCloseBtn?.addEventListener("click", closeAssignmentAiFilesDialog);
 els.openActivityEditorBtn?.addEventListener("click", () => openActivityEditor("panel"));
 els.wizardOpenActivityEditorBtn?.addEventListener("click", openActivityReviewStep);
 els.activityEditorCloseBtn?.addEventListener("click", closeActivityEditor);

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -972,6 +972,7 @@ function syncTargetsFromRosterSelection() {
   els.targetsText.value = targets.join("\n");
   clearSelectedAssignment();
   renderAssignmentContext();
+  resetAssignmentConfirmStatus("I destinatari sono cambiati: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   setRosterStatus(warnings.length
     ? `Destinatari aggiornati con avvisi: ${warnings.join(" ")}`
     : `Destinatari aggiornati: ${targets.length} target studenti.`);
@@ -1867,6 +1868,10 @@ function setAssignmentConfirmStatus(type, title, message) {
   if (type === "success") els.assignmentConfirmStatus.classList.add("isSuccess");
   if (type === "error") els.assignmentConfirmStatus.classList.add("isError");
   els.assignmentConfirmStatus.innerHTML = `<strong>${escapeHtml(title)}</strong><span>${escapeHtml(message)}</span>`;
+}
+
+function resetAssignmentConfirmStatus(message = "I dati dell'assegnazione sono cambiati: ricontrolla anteprima e conferma prima di salvare o distribuire.") {
+  setAssignmentConfirmStatus("info", "Dati modificati", message);
 }
 
 function activityAuthorRequiredFields() {
@@ -3085,6 +3090,32 @@ function assignmentWizardStepComplete(step) {
   return true;
 }
 
+function validateAssignmentBeforeConfirm(actionLabel) {
+  if (!String(els.activityPath?.value || "").trim()) {
+    setAssignmentConfirmStatus("error", "Activity mancante", `Scegli o salva una activity prima di ${actionLabel}.`);
+    setAssignmentWizardStep("activity");
+    return false;
+  }
+  if (!state.activityReviewSaved) {
+    setAssignmentConfirmStatus("error", "Revisione activity da completare", `Salva l'activity nello step Revisione prima di ${actionLabel}.`);
+    setAssignmentWizardStep("review");
+    return false;
+  }
+  if (targetLineCount() <= 0) {
+    markActivityAuthorFieldInvalid(els.targetsText, true);
+    setAssignmentConfirmStatus("error", "Destinatari mancanti", `Scegli almeno un target nello step Destinatari prima di ${actionLabel}.`);
+    setAssignmentWizardStep("targets");
+    return false;
+  }
+  markActivityAuthorFieldInvalid(els.targetsText, false);
+  if (!validateAssignmentDateFields({ showMessage: true })) {
+    setAssignmentConfirmStatus("error", "Date incomplete", `Completa assegnazione e scadenza prima di ${actionLabel}.`);
+    setAssignmentWizardStep("dates");
+    return false;
+  }
+  return true;
+}
+
 function assignmentWizardNextLabel(step) {
   const next = nextAssignmentWizardStep(step);
   if (!next || next.id === step) return "Fine percorso";
@@ -3334,6 +3365,7 @@ async function generateAssignmentAiDraft() {
 
 async function saveAssignmentRecord() {
   if (!els.saveAssignmentBtn) return;
+  if (!validateAssignmentBeforeConfirm("salvare l'assegnazione")) return;
   els.saveAssignmentBtn.disabled = true;
   setStatus("Salvataggio assegnazione...");
   setAssignmentConfirmStatus("saving", "Salvataggio assegnazione", "Sto salvando dati, destinatari e date dell'assegnazione.");
@@ -3364,6 +3396,7 @@ async function saveAssignmentRecord() {
 
 async function distributeAssignment() {
   if (!els.distributeAssignmentBtn) return;
+  if (!validateAssignmentBeforeConfirm("distribuire ai target")) return;
   els.distributeAssignmentBtn.disabled = true;
   setStatus("Distribuzione assegnazione ai target...");
   setAssignmentConfirmStatus("saving", "Distribuzione ai target", "Sto copiando traccia e asset nelle cartelle dei target selezionati.");
@@ -4323,30 +4356,36 @@ els.clearRosterTargetsBtn?.addEventListener("click", () => {
 });
 els.activityPath.addEventListener("input", () => {
   clearSelectedAssignment();
+  resetAssignmentConfirmStatus("L'activity e cambiata: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   renderActivitySelect();
   renderAssignmentContext();
 });
 els.outputName.addEventListener("input", renderAssignmentContext);
 els.classId.addEventListener("input", () => {
   clearSelectedAssignment();
+  resetAssignmentConfirmStatus("La classe e cambiata: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   renderReportAssignmentSummary();
 });
 els.classLabel.addEventListener("input", () => {
   clearSelectedAssignment();
+  resetAssignmentConfirmStatus("L'etichetta classe e cambiata: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   renderAssignmentContext();
 });
 els.githubTeam.addEventListener("input", () => {
   clearSelectedAssignment();
+  resetAssignmentConfirmStatus("Il team GitHub e cambiato: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   renderAssignmentContext();
 });
 els.assignedAt.addEventListener("input", () => {
   clearSelectedAssignment();
+  resetAssignmentConfirmStatus("Le date sono cambiate: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   validateAssignmentDateFields();
   setAssignmentWizardStep(currentAssignmentWizardStep());
   renderReportAssignmentSummary();
 });
 els.dueAt.addEventListener("input", () => {
   clearSelectedAssignment();
+  resetAssignmentConfirmStatus("Le date sono cambiate: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   validateAssignmentDateFields();
   setAssignmentWizardStep(currentAssignmentWizardStep());
   renderReportAssignmentSummary();
@@ -4354,6 +4393,7 @@ els.dueAt.addEventListener("input", () => {
 els.nowAt.addEventListener("change", () => loadAssignments().catch((error) => setStatus(`Assegnazioni non aggiornate: ${error.message}`)));
 els.targetsText.addEventListener("input", () => {
   clearSelectedAssignment();
+  resetAssignmentConfirmStatus("I destinatari sono cambiati: ricontrolla anteprima e conferma prima di salvare o distribuire.");
   syncRosterSelectionFromTargetsText();
   renderAssignmentContext();
 });

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -272,6 +272,7 @@ const els = {
   activityPath: document.querySelector("#activityPath"),
   assignmentSelect: document.querySelector("#assignmentSelect"),
   assignmentStatus: document.querySelector("#assignmentStatus"),
+  assignmentConfirmStatus: document.querySelector("#assignmentConfirmStatus"),
   classRosterSelect: document.querySelector("#classRosterSelect"),
   rosterStatus: document.querySelector("#rosterStatus"),
   rosterPanelStatus: document.querySelector("#rosterPanelStatus"),
@@ -1859,6 +1860,15 @@ function setActivityAuthorStatus(type, title, message) {
   els.activityAuthorStatus.innerHTML = `<strong>${escapeHtml(title)}</strong><span>${escapeHtml(message)}</span>`;
 }
 
+function setAssignmentConfirmStatus(type, title, message) {
+  if (!els.assignmentConfirmStatus) return;
+  els.assignmentConfirmStatus.classList.remove("isSaving", "isSuccess", "isError");
+  if (type === "saving") els.assignmentConfirmStatus.classList.add("isSaving");
+  if (type === "success") els.assignmentConfirmStatus.classList.add("isSuccess");
+  if (type === "error") els.assignmentConfirmStatus.classList.add("isError");
+  els.assignmentConfirmStatus.innerHTML = `<strong>${escapeHtml(title)}</strong><span>${escapeHtml(message)}</span>`;
+}
+
 function activityAuthorRequiredFields() {
   return [
     { field: els.activityAuthorTitle, label: "Titolo" },
@@ -3326,6 +3336,7 @@ async function saveAssignmentRecord() {
   if (!els.saveAssignmentBtn) return;
   els.saveAssignmentBtn.disabled = true;
   setStatus("Salvataggio assegnazione...");
+  setAssignmentConfirmStatus("saving", "Salvataggio assegnazione", "Sto salvando dati, destinatari e date dell'assegnazione.");
   try {
     const payload = await api("/api/assignments/save", {
       method: "POST",
@@ -3335,9 +3346,17 @@ async function saveAssignmentRecord() {
     state.dueAssignments = (payload.due_without_register || []).map((item) => item.assignment || item);
     state.selectedAssignmentId = "";
     renderAssignmentSelect();
-    setStatus(`Assegnazione salvata: ${payload.assignment?.id || "-"}.`);
+    const assignmentId = payload.assignment?.id || "-";
+    setStatus(`Assegnazione salvata: ${assignmentId}.`);
+    setAssignmentConfirmStatus(
+      "success",
+      "Assegnazione salvata",
+      `ID: ${assignmentId}. Ora puoi distribuire ai target oppure tornare agli step precedenti per modificare i dati.`
+    );
   } catch (error) {
-    setStatus(`Assegnazione non salvata: ${assignmentPlanErrorMessage(error)}`);
+    const message = assignmentPlanErrorMessage(error);
+    setStatus(`Assegnazione non salvata: ${message}`);
+    setAssignmentConfirmStatus("error", "Assegnazione non salvata", message);
   } finally {
     els.saveAssignmentBtn.disabled = false;
   }
@@ -3347,6 +3366,7 @@ async function distributeAssignment() {
   if (!els.distributeAssignmentBtn) return;
   els.distributeAssignmentBtn.disabled = true;
   setStatus("Distribuzione assegnazione ai target...");
+  setAssignmentConfirmStatus("saving", "Distribuzione ai target", "Sto copiando traccia e asset nelle cartelle dei target selezionati.");
   if (els.assignmentPlanPreview) {
     els.assignmentPlanPreview.innerHTML = '<p class="status">Distribuzione assegnazione ai target...</p>';
   }
@@ -3356,13 +3376,20 @@ async function distributeAssignment() {
       body: JSON.stringify(assignmentPlanPayload()),
     });
     renderAssignmentPlan(payload.plan);
-    setStatus(`Assegnazione distribuita a ${payload.results?.length || 0} target.`);
+    const targetCount = payload.results?.length || 0;
+    setStatus(`Assegnazione distribuita a ${targetCount} target.`);
+    setAssignmentConfirmStatus(
+      "success",
+      "Distribuzione completata",
+      `${targetCount} target aggiornati. Controlla l'anteprima per eventuali target gia presenti o bloccati.`
+    );
   } catch (error) {
     const message = assignmentPlanErrorMessage(error);
     if (els.assignmentPlanPreview) {
       els.assignmentPlanPreview.innerHTML = `<p class="status">Distribuzione non completata: ${escapeHtml(message)}</p>`;
     }
     setStatus(`Distribuzione non completata: ${message}`);
+    setAssignmentConfirmStatus("error", "Distribuzione non completata", message);
   } finally {
     els.distributeAssignmentBtn.disabled = false;
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -152,6 +152,7 @@ const state = {
   reviewSplit: readReviewSplit(),
   draggedPanelKey: "",
   activityAuthorLastSuggestedId: "",
+  activityReviewSaved: false,
   selectedAssignmentId: "",
 };
 
@@ -1738,6 +1739,7 @@ async function saveActivityDraft() {
     renderActivitySelect();
     renderCoverage();
     if (payload.activity?.path) selectActivity(payload.activity.path);
+    markActivityReviewSaved();
     if (els.activityAuthorStatus) {
       els.activityAuthorStatus.textContent = `Activity salvata: ${payload.activity?.path || "-"}.`;
     }
@@ -2531,16 +2533,41 @@ function renderAssignmentCodexDraft(response) {
 }
 
 function updateAssignmentAiApplyState() {
-  if (!els.assignmentAiApplyDraftBtn) return false;
+  let isValid = false;
   try {
     parseAssignmentAiDraftText();
-    els.assignmentAiApplyDraftBtn.disabled = false;
-    els.assignmentAiApplyDraftBtn.title = "Porta la proposta AI nello step Revisione activity. Il docente puo modificarla prima di salvare.";
-    return true;
+    isValid = true;
   } catch (error) {
-    els.assignmentAiApplyDraftBtn.disabled = true;
-    els.assignmentAiApplyDraftBtn.title = "Genera una proposta AI valida prima di preparare la revisione activity.";
-    return false;
+    isValid = false;
+  }
+  if (els.assignmentAiApplyDraftBtn) {
+    els.assignmentAiApplyDraftBtn.disabled = !isValid;
+    els.assignmentAiApplyDraftBtn.title = isValid
+      ? "Porta la proposta AI nello step Revisione activity. Il docente puo modificarla prima di salvare."
+      : "Genera una proposta AI valida prima di preparare la revisione activity.";
+  }
+  if (currentAssignmentWizardStep() === "ai") {
+    const current = currentAssignmentWizardStep();
+    const index = assignmentWizardStepIndex(current);
+    if (els.assignmentWizardNextBtn && index >= 0 && index < ASSIGNMENT_WIZARD_STEPS.length - 1) {
+      els.assignmentWizardNextBtn.disabled = !isValid;
+      els.assignmentWizardNextBtn.textContent = assignmentWizardNextLabel(current);
+    }
+  }
+  return isValid;
+}
+
+function markActivityReviewDirty() {
+  state.activityReviewSaved = false;
+  if (currentAssignmentWizardStep() === "review") {
+    setAssignmentWizardStep("review");
+  }
+}
+
+function markActivityReviewSaved() {
+  state.activityReviewSaved = true;
+  if (currentAssignmentWizardStep() === "review") {
+    setAssignmentWizardStep("review");
   }
 }
 
@@ -2626,6 +2653,7 @@ function applyAssignmentAiDraftToActivityForm() {
       ? ` File proposti: ${fileCount}; asset dichiarati: ${assetCount}. Gli asset non vengono ancora salvati automaticamente.`
       : "";
     setStatus("Bozza AI pronta nello step Revisione activity: il docente puo ancora modificare tutto.");
+    markActivityReviewDirty();
     openActivityReviewStep(`Bozza AI applicata alla revisione activity. Controlla e salva quando e pronta.${suffix}`);
     return true;
   } catch (error) {
@@ -2633,6 +2661,42 @@ function applyAssignmentAiDraftToActivityForm() {
     setStatus(`Bozza AI non applicata: ${error.message}`);
     return false;
   }
+}
+
+function currentAssignmentWizardStep() {
+  return Array.from(els.assignmentSteps).find((section) => !section.hidden)?.dataset.assignmentStep || "activity";
+}
+
+function assignmentWizardStepIndex(step) {
+  return ASSIGNMENT_WIZARD_STEPS.findIndex((candidate) => candidate.id === step);
+}
+
+function nextAssignmentWizardStep(step) {
+  const index = assignmentWizardStepIndex(step);
+  return ASSIGNMENT_WIZARD_STEPS[Math.min(index + 1, ASSIGNMENT_WIZARD_STEPS.length - 1)] || null;
+}
+
+function assignmentWizardStepComplete(step) {
+  if (step === "activity") return Boolean(String(els.activityPath?.value || "").trim());
+  if (step === "ai") return updateAssignmentAiApplyState();
+  if (step === "review") return Boolean(state.activityReviewSaved && String(els.activityPath?.value || "").trim());
+  return true;
+}
+
+function assignmentWizardNextLabel(step) {
+  const next = nextAssignmentWizardStep(step);
+  if (!next || next.id === step) return "Fine percorso";
+  if (step === "ai") return "Avanti: 3 Prepara revisione";
+  const index = assignmentWizardStepIndex(next.id);
+  const label = {
+    ai: "AI",
+    review: "Revisione",
+    targets: "Destinatari",
+    dates: "Date",
+    preview: "Anteprima",
+    confirm: "Conferma",
+  }[next.id] || next.id;
+  return `Avanti: ${index + 1} ${label}`;
 }
 
 function setAssignmentWizardStep(step) {
@@ -2655,14 +2719,24 @@ function setAssignmentWizardStep(step) {
   if (els.assignmentWizardPrevBtn) els.assignmentWizardPrevBtn.disabled = index <= 0;
   if (els.assignmentWizardNextBtn) {
     const isLast = index >= ASSIGNMENT_WIZARD_STEPS.length - 1;
-    els.assignmentWizardNextBtn.disabled = isLast;
-    els.assignmentWizardNextBtn.textContent = isLast ? "Fine percorso" : "Avanti";
+    els.assignmentWizardNextBtn.disabled = isLast || !assignmentWizardStepComplete(selectedStep);
+    els.assignmentWizardNextBtn.textContent = isLast ? "Fine percorso" : assignmentWizardNextLabel(selectedStep);
   }
 }
 
 function moveAssignmentWizardStep(offset) {
-  const current = Array.from(els.assignmentSteps).find((section) => !section.hidden)?.dataset.assignmentStep || "activity";
-  const index = ASSIGNMENT_WIZARD_STEPS.findIndex((candidate) => candidate.id === current);
+  const current = currentAssignmentWizardStep();
+  if (offset > 0) {
+    if (current === "ai") {
+      applyAssignmentAiDraftToActivityForm();
+      return;
+    }
+    if (!assignmentWizardStepComplete(current)) {
+      setAssignmentWizardStep(current);
+      return;
+    }
+  }
+  const index = assignmentWizardStepIndex(current);
   const next = ASSIGNMENT_WIZARD_STEPS[Math.min(Math.max(index + offset, 0), ASSIGNMENT_WIZARD_STEPS.length - 1)];
   setAssignmentWizardStep(next?.id || "activity");
 }
@@ -3560,6 +3634,7 @@ function setFilter(filter) {
 function selectActivity(path) {
   els.activityPath.value = path;
   const activity = state.activities.find((candidate) => candidate.path === path);
+  if (activity) state.activityReviewSaved = true;
   if (activity?.id) {
     els.classId.value = activity.class_id || activity.github_team || "";
     els.classLabel.value = activity.class_label || activity.class_id || "";
@@ -3680,7 +3755,6 @@ setAssignmentWizardStep("activity");
 els.previewAssignmentBtn?.addEventListener("click", previewAssignmentPlan);
 els.assignmentAiAskBtn?.addEventListener("click", previewAssignmentAiPackage);
 els.assignmentAiGenerateBtn?.addEventListener("click", generateAssignmentAiDraft);
-els.assignmentAiApplyDraftBtn?.addEventListener("click", applyAssignmentAiDraftToActivityForm);
 els.assignmentAiDraftText?.addEventListener("input", updateAssignmentAiApplyState);
 els.openActivityEditorBtn?.addEventListener("click", () => openActivityEditor("panel"));
 els.wizardOpenActivityEditorBtn?.addEventListener("click", openActivityReviewStep);
@@ -3719,16 +3793,22 @@ els.assignmentSelect?.addEventListener("change", () => {
   setStatus(assignment ? `Assegnazione selezionata: ${assignment.id}.` : "Nessuna assegnazione selezionata.");
 });
 els.saveActivityBtn?.addEventListener("click", saveActivityDraft);
-els.activityAuthorTitle?.addEventListener("input", syncActivityAuthorIdSuggestion);
+els.activityAuthorTitle?.addEventListener("input", () => {
+  syncActivityAuthorIdSuggestion();
+  markActivityReviewDirty();
+});
 els.activityAuthorId?.addEventListener("input", () => {
   const current = els.activityAuthorId.value.trim();
   if (!current) state.activityAuthorLastSuggestedId = "";
+  markActivityReviewDirty();
 });
 els.activityAuthorPath?.addEventListener("change", () => {
   renderActivityAuthorMetadataSelects();
+  markActivityReviewDirty();
 });
 els.activityAuthorUda?.addEventListener("change", () => {
   renderTopicSearch(activityAuthorTopicOptions());
+  markActivityReviewDirty();
 });
 els.activityAuthorTopics?.addEventListener("input", () => {
   renderTopicSearch(
@@ -3736,12 +3816,25 @@ els.activityAuthorTopics?.addEventListener("input", () => {
     true,
   );
   renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA", els.activityAuthorUdaCount);
+  markActivityReviewDirty();
 });
 els.activityAuthorClass?.addEventListener("change", () => {
   const roster = state.classRosters.find((candidate) => (
     String(candidate.id || candidate.label || candidate.name || "").trim() === els.activityAuthorClass.value
   ));
   if (roster?.github_team && els.activityAuthorTeam) els.activityAuthorTeam.value = roster.github_team;
+  markActivityReviewDirty();
+});
+[
+  els.activityAuthorKind,
+  els.activityAuthorDifficulty,
+  els.activityAuthorTeam,
+  els.activityAuthorPrompt,
+  els.activityAuthorMinutes,
+  els.activityAuthorOverwrite,
+].forEach((field) => {
+  field?.addEventListener("input", markActivityReviewDirty);
+  field?.addEventListener("change", markActivityReviewDirty);
 });
 els.classRosterSelect?.addEventListener("change", loadSelectedClassRoster);
 els.activityPath.addEventListener("input", () => {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -158,6 +158,20 @@ const state = {
   selectedAssignmentId: "",
 };
 
+const DEFAULT_SOURCE_NAMES = {
+  assembly: "main.asm",
+  c: "main.c",
+  cpp: "main.cpp",
+  go: "main.go",
+  html: "index.html",
+  java: "Main.java",
+  javascript: "main.js",
+  nodejs: "main.js",
+  php: "main.php",
+  python: "main.py",
+  sql: "main.sql",
+};
+
 const els = {
   reportSelect: document.querySelector("#reportSelect"),
   loadReportBtn: document.querySelector("#loadReportBtn"),
@@ -236,6 +250,8 @@ const els = {
   activityAuthorTopicsList: document.querySelector("#activityAuthorTopicsList"),
   activityAuthorTopicsCount: document.querySelector("#activityAuthorTopicsCount"),
   activityAuthorMinutes: document.querySelector("#activityAuthorMinutes"),
+  activityAuthorLanguage: document.querySelector("#activityAuthorLanguage"),
+  activityAuthorSourceName: document.querySelector("#activityAuthorSourceName"),
   activityAuthorClass: document.querySelector("#activityAuthorClass"),
   activityAuthorClassCount: document.querySelector("#activityAuthorClassCount"),
   activityAuthorTeam: document.querySelector("#activityAuthorTeam"),
@@ -1819,8 +1835,39 @@ function activityAuthorRequiredFields() {
       label: "Tempo stimato",
       isValid: (value) => Number(value) > 0,
     },
+    { field: els.activityAuthorLanguage, label: "Linguaggio" },
+    { field: els.activityAuthorSourceName, label: "File sorgente" },
     { field: els.activityAuthorPrompt, label: "Consegna" },
   ];
+}
+
+function defaultSourceNameForLanguage(language) {
+  return DEFAULT_SOURCE_NAMES[String(language || "").trim().toLowerCase()] || "main.c";
+}
+
+function languageFromSourceName(sourceName) {
+  const value = String(sourceName || "").trim().toLowerCase();
+  if (value.endsWith(".py")) return "python";
+  if (value.endsWith(".cpp") || value.endsWith(".cc") || value.endsWith(".cxx")) return "cpp";
+  if (value.endsWith(".c")) return "c";
+  if (value.endsWith(".go")) return "go";
+  if (value.endsWith(".html") || value.endsWith(".htm")) return "html";
+  if (value.endsWith(".java")) return "java";
+  if (value.endsWith(".js")) return "javascript";
+  if (value.endsWith(".php")) return "php";
+  if (value.endsWith(".sql")) return "sql";
+  if (value.endsWith(".asm") || value.endsWith(".s")) return "assembly";
+  return "";
+}
+
+function syncSourceNameForLanguage(force = false) {
+  if (!els.activityAuthorLanguage || !els.activityAuthorSourceName) return;
+  const nextSource = defaultSourceNameForLanguage(els.activityAuthorLanguage.value);
+  const currentSource = String(els.activityAuthorSourceName.value || "").trim();
+  const defaultSources = new Set(Object.values(DEFAULT_SOURCE_NAMES));
+  if (force || !currentSource || defaultSources.has(currentSource)) {
+    els.activityAuthorSourceName.value = nextSource;
+  }
 }
 
 function markActivityAuthorFieldInvalid(field, invalid) {
@@ -1864,6 +1911,8 @@ async function saveActivityDraft() {
         topics: activityAuthorTopicValue(),
         prompt: els.activityAuthorPrompt?.value || "",
         estimated_minutes: els.activityAuthorMinutes?.value || "30",
+        language: els.activityAuthorLanguage?.value || "",
+        source_name: els.activityAuthorSourceName?.value || "",
         class_id: els.activityAuthorClass?.value || "",
         github_team: els.activityAuthorTeam?.value || "",
         path_id: els.activityAuthorPath?.value || "",
@@ -2572,8 +2621,8 @@ function assignmentPlanPayload() {
   return {
     activity_path: els.activityPath.value,
     targets_text: els.targetsText.value,
-    language: "",
-    source_name: "",
+    language: els.activityAuthorLanguage?.value || "",
+    source_name: els.activityAuthorSourceName?.value || "",
     thebitlab_ref: "",
     overwrite: false,
   };
@@ -2820,6 +2869,18 @@ function applyAssignmentAiDraftToActivityForm() {
     if (prompt && els.activityAuthorPrompt) els.activityAuthorPrompt.value = prompt;
     const minutes = firstDraftValue(metriche, ["tempo_stimato_minuti"]) || firstDraftValue(patch, ["estimated_minutes"]);
     if (minutes && els.activityAuthorMinutes) els.activityAuthorMinutes.value = minutes;
+    const files = Array.isArray(draft.files) ? draft.files : [];
+    const firstSourceFile = files.find((file) => file && typeof file === "object" && String(file.path || "").trim());
+    const sourceName = firstDraftValue(patch, ["source_name", "sourceName", "file_sorgente", "nome_file"])
+      || (firstSourceFile ? String(firstSourceFile.path || "").split(/[\\/]/).pop() : "");
+    const language = firstDraftValue(patch, ["linguaggio", "language", "lingua"])
+      || languageFromSourceName(sourceName);
+    setSelectValueIfAvailable(els.activityAuthorLanguage, language);
+    if (sourceName && els.activityAuthorSourceName) {
+      els.activityAuthorSourceName.value = sourceName;
+    } else {
+      syncSourceNameForLanguage();
+    }
     setSelectValueIfAvailable(els.activityAuthorPath, firstDraftValue(contesto, ["percorso", "path_id"]));
     renderActivityAuthorMetadataSelects();
     setSelectValueIfAvailable(els.activityAuthorUda, firstDraftValue(contesto, ["uda", "uda_id"]));
@@ -2828,7 +2889,7 @@ function applyAssignmentAiDraftToActivityForm() {
     const topics = firstDraftValue(patch, ["argomenti", "topics"]);
     if (topics && els.activityAuthorTopics) els.activityAuthorTopics.value = topics;
 
-    const fileCount = Array.isArray(draft.files) ? draft.files.length : 0;
+    const fileCount = files.length;
     const assetCount = Array.isArray(patch.assets) ? patch.assets.length : 0;
     const suffix = fileCount || assetCount
       ? ` File proposti: ${fileCount}; asset dichiarati: ${assetCount}. Gli asset non vengono ancora salvati automaticamente.`
@@ -3833,6 +3894,11 @@ function selectActivity(path) {
   const activity = state.activities.find((candidate) => candidate.path === path);
   if (activity) state.activityReviewSaved = true;
   if (activity?.id) {
+    const language = activity.language || activity.linguaggio || "";
+    if (language) setSelectValueIfAvailable(els.activityAuthorLanguage, language);
+    if (els.activityAuthorSourceName) {
+      els.activityAuthorSourceName.value = activity.source_name || activity.sourceName || defaultSourceNameForLanguage(language || els.activityAuthorLanguage?.value);
+    }
     els.classId.value = activity.class_id || activity.github_team || "";
     els.classLabel.value = activity.class_label || activity.class_id || "";
     els.githubTeam.value = activity.github_team || "";
@@ -4015,6 +4081,10 @@ els.activityAuthorTopics?.addEventListener("input", () => {
   renderCompactSelect(els.activityAuthorUda, activityAuthorUdaOptions(), "Nessuna UDA", els.activityAuthorUdaCount);
   markActivityReviewDirty();
 });
+els.activityAuthorLanguage?.addEventListener("change", () => {
+  syncSourceNameForLanguage();
+  markActivityReviewDirty();
+});
 els.activityAuthorClass?.addEventListener("change", () => {
   const roster = state.classRosters.find((candidate) => (
     String(candidate.id || candidate.label || candidate.name || "").trim() === els.activityAuthorClass.value
@@ -4026,6 +4096,7 @@ els.activityAuthorClass?.addEventListener("change", () => {
   els.activityAuthorKind,
   els.activityAuthorDifficulty,
   els.activityAuthorTeam,
+  els.activityAuthorSourceName,
   els.activityAuthorPrompt,
   els.activityAuthorMinutes,
   els.activityAuthorOverwrite,


### PR DESCRIPTION
## Cosa cambia

- Aggiunge lo step `3 Revisione` nel wizard di assegnazione activity.
- Il flusso diventa: Activity -> AI -> Revisione -> Destinatari -> Date -> Anteprima -> Conferma.
- Rimuove il bottone separato `Prepara revisione`: nello step AI il bottone `Avanti` diventa `Avanti: 3 Prepara revisione`.
- `Avanti` nello step AI resta disabilitato finche non esiste una bozza AI valida.
- Durante la generazione della proposta AI compare una barra di avanzamento indeterminata con messaggio di stato, cosi la pagina non sembra bloccata.
- Durante la generazione AI, `Avanti` resta disabilitato anche se era presente una bozza precedente valida.
- Se la generazione AI fallisce, l'errore resta visibile nel riquadro dello step AI, senza dover aprire i dettagli tecnici.
- L'adapter Codex ripara gli escape backslash non validi piu comuni dentro `activity_patch_json`, per esempio `\_`, prima di validare la bozza.
- La bozza AI puo valorizzare la consegna anche con alias come `istruzioni`, `instructions`, `traccia`, `testo`, oltre a `consegna`.
- Il salvataggio activity viene bloccato lato GUI se mancano campi obbligatori, con messaggio chiaro nello step Revisione.
- I campi obbligatori non validi vengono evidenziati con bordo rosso e `aria-invalid=true`.
- L'esito del salvataggio activity ora appare in un riquadro evidente: salvataggio in corso, successo verde o errore rosso.
- In caso di successo il riquadro dice esplicitamente che si puo passare al punto 4 Destinatari.
- In caso di errore backend il messaggio resta visibile nello step Revisione.
- `Avanti` nello step Revisione resta disabilitato finche l'activity non viene salvata con `Salva activity`.
- Lo stesso editor activity viene riusato: modal dal pannello Activity, contenuto inline nello step Revisione del wizard.
- `Vai a revisione activity` dallo step Activity porta direttamente allo step Revisione.
- Lo step Destinatari permette di selezionare dal roster tutta la classe, un gruppo di studenti o un singolo studente.
- La selezione studenti aggiorna automaticamente i repository target usati da anteprima, salvataggio e distribuzione.

## Test

- `python -m pytest tests/test_assignment_dashboard_frontend.py`
- `python -m pytest tests/test_course_board_server.py tests/test_codex_activity_adapter.py`
- `python -m py_compile scripts\course_board_server.py scripts\codex_activity_adapter.py scripts\activity_ai_package.py`
- `git diff --check`

## Verifica manuale suggerita

1. Apri la dashboard consegne e vai nel wizard `Assegna activity`.
2. Controlla che gli step siano 7 e che `3 Revisione` sia tra `AI` e `Destinatari`.
3. Nello step AI, prima di generare una bozza valida, `Avanti` deve essere disabilitato.
4. Clicca `Genera proposta AI`: deve comparire la barra `Generazione proposta AI in corso`.
5. Durante la generazione, `Genera proposta AI` e `Avanti` devono restare disabilitati.
6. A generazione completata, la barra deve sparire e `Avanti` deve diventare `Avanti: 3 Prepara revisione`.
7. Se Codex/provider fallisce, la barra deve diventare un riquadro di errore visibile nello step AI, anche con dettagli tecnici chiusi.
8. Clicca `Avanti`: il wizard deve passare allo step Revisione con i campi gia valorizzati.
9. Nello step Revisione, svuota un campo obbligatorio come `Consegna` o `Argomenti` e clicca `Salva activity`: il campo deve diventare rosso e non deve partire il salvataggio.
10. Correggi il campo obbligatorio: il bordo rosso deve sparire.
11. Clicca `Salva activity`: deve comparire un riquadro di salvataggio in corso.
12. Dopo un salvataggio riuscito, il riquadro deve diventare verde e indicare che puoi passare al punto 4 Destinatari.
13. Se il salvataggio fallisce, il riquadro deve diventare rosso e mostrare l'errore nello step Revisione.
14. Dopo `Salva activity`, `Avanti` deve portare a `4 Destinatari`.
15. Nello step Destinatari, scegli un roster: devono comparire gli studenti attivi selezionabili.
16. Clicca `Nessuno`, poi seleziona uno o due studenti: il campo repository target deve aggiornarsi solo con quei target.
17. Clicca `Tutti`: il campo repository target deve tornare a tutti gli studenti attivi del roster.
18. Dal pannello Activity clicca `Apri editor activity`: l'editor deve aprirsi ancora nel modal.