### PR TITLE
Guida il passo finale del wizard assegnazione

### DIFF
--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -71,8 +71,9 @@ Il pannello usa un percorso guidato. Puoi saltare tra le linguette, ma il flusso
    - controlla activity, linguaggio, file sorgente, destinatari, cartelle target, target gia esistenti, asset per studenti e asset riservati al docente/grading;
    - se ci sono target bloccati o file mancanti, correggi prima di distribuire.
 7. **Conferma**
+   - il bottone **Avanti** guida la sequenza: prima salva l'assegnazione, poi abilita la distribuzione;
    - **Salva assegnazione** registra l'assegnazione nel sistema docente senza necessariamente copiare asset nei repository;
-   - **Distribuisci ai target** copia traccia, README e asset studente nelle cartelle/repository target quando il piano e corretto.
+   - **Distribuisci ai target** si abilita solo dopo un salvataggio riuscito e copia traccia, README e asset studente nelle cartelle/repository target quando il piano e corretto.
 
 Regola pratica: prima genera o scegli l'activity, poi controlla destinatari e date, poi fai sempre anteprima prima di salvare o distribuire.
 
@@ -190,7 +191,7 @@ Passaggi:
 5. Nel passo **Destinatari**, scegli classe, gruppo o studenti.
 6. Nel passo **Date**, lascia **Assegnato il** se va bene la data corrente e compila **Scadenza**.
 7. Nel passo **Anteprima**, premi **Anteprima assegnazione** e controlla il piano.
-8. Nel passo **Conferma**, salva l'assegnazione o distribuisci ai target.
+8. Nel passo **Conferma**, usa **Avanti** per salvare l'assegnazione; dopo il salvataggio riuscito puoi usare ancora **Avanti** per distribuire ai target.
 
 Cosa controllare a schermo:
 
@@ -200,6 +201,7 @@ Cosa controllare a schermo:
 - la scadenza e compilata;
 - i target corrispondono agli studenti desiderati;
 - l'anteprima non segnala target bloccati o asset mancanti inattesi.
+- nel passo finale la distribuzione resta disabilitata finche l'assegnazione non e stata salvata.
 
 Screenshot previsti:
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -998,6 +998,53 @@ def test_assignment_confirm_next_ignores_concurrent_clicks_while_saving() -> Non
     )
 
 
+def test_assignment_confirm_busy_survives_field_reset_while_saving() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.setAssignmentWizardStep("confirm");
+          tested.state.activityReviewSaved = true;
+          tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.assignedAt.value = "2026-10-12T09:00";
+          tested.els.dueAt.value = "2026-10-19T23:59";
+          tested.els.activityAuthorLanguage.value = "python";
+          tested.els.activityAuthorSourceName.value = "main.py";
+
+          let resolveSave;
+          tested.fetchResponses["/api/assignments/save"] = new Promise((resolve) => {
+            resolveSave = resolve;
+          });
+
+          const saveClick = tested.moveAssignmentWizardStep(1);
+
+          assert.equal(tested.state.assignmentConfirmBusy, true);
+          tested.els.targetsText.value = "students/bianchi-luca";
+          tested.els.targetsText.dispatchEvent(new Event("input"));
+
+          assert.equal(tested.state.assignmentConfirmBusy, true);
+          assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
+
+          await tested.moveAssignmentWizardStep(1);
+          assert.equal(tested.fetchCalls.filter((entry) => entry.path === "/api/assignments/save").length, 1);
+
+          resolveSave({
+            ok: true,
+            assignment: { id: "assignment-python-base-somma-001-3a-tpsi", activity_id: "python-base-somma-001" },
+            assignments: [],
+            due_without_register: [],
+          });
+          await saveClick;
+
+          assert.equal(tested.state.assignmentConfirmBusy, false);
+          assert.equal(tested.state.assignmentRecordSaved, false);
+          assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Dati modificati dopo il salvataggio/);
+          assert.equal(tested.els.distributeAssignmentBtn.disabled, true);
+        })();
+        """
+    )
+
+
 def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
     assignment_section = html.split('data-panel-key="assignment"', 1)[1].split('data-panel-key="generate"', 1)[0]

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -967,6 +967,37 @@ def test_assignment_confirm_next_guides_save_then_distribute() -> None:
     )
 
 
+def test_assignment_confirm_next_ignores_concurrent_clicks_while_saving() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.setAssignmentWizardStep("confirm");
+          tested.state.activityReviewSaved = true;
+          tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.assignedAt.value = "2026-10-12T09:00";
+          tested.els.dueAt.value = "2026-10-19T23:59";
+          tested.els.activityAuthorLanguage.value = "python";
+          tested.els.activityAuthorSourceName.value = "main.py";
+
+          const firstClick = tested.moveAssignmentWizardStep(1);
+          const secondClick = tested.moveAssignmentWizardStep(1);
+
+          assert.equal(tested.state.assignmentConfirmBusy, true);
+          assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
+
+          await Promise.all([firstClick, secondClick]);
+
+          const saveCalls = tested.fetchCalls.filter((entry) => entry.path === "/api/assignments/save");
+          assert.equal(saveCalls.length, 1);
+          assert.equal(tested.state.assignmentConfirmBusy, false);
+          assert.equal(tested.state.assignmentRecordSaved, true);
+          assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Distribuisci ai target");
+        })();
+        """
+    )
+
+
 def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
     assignment_section = html.split('data-panel-key="assignment"', 1)[1].split('data-panel-key="generate"', 1)[0]

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -844,6 +844,9 @@ def test_save_assignment_record_posts_form_and_refreshes_due_assignments() -> No
           assert.match(tested.els.status.textContent, /Assegnazione salvata/);
           assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Assegnazione salvata/);
           assert.match(tested.els.assignmentConfirmStatus.innerHTML, /assignment-python-base-somma-001-3a-tpsi/);
+          assert.equal(tested.state.assignmentRecordSaved, true);
+          assert.equal(tested.state.assignmentDistributed, false);
+          assert.equal(tested.els.distributeAssignmentBtn.disabled, false);
         })();
         """
     )
@@ -858,6 +861,7 @@ def test_distribute_assignment_posts_plan_and_renders_written_targets() -> None:
           tested.els.targetsText.value = "students/rossi-mario";
           tested.els.assignedAt.value = "2026-10-12T09:00";
           tested.els.dueAt.value = "2026-10-19T23:59";
+          tested.state.assignmentRecordSaved = true;
           tested.els.activityAuthorLanguage.value = "python";
           tested.els.activityAuthorSourceName.value = "main.py";
           tested.fetchResponses["/api/assignments/distribute"] = {
@@ -898,6 +902,66 @@ def test_distribute_assignment_posts_plan_and_renders_written_targets() -> None:
           assert.match(tested.els.status.textContent, /distribuita a 1 target/);
           assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Distribuzione completata/);
           assert.match(tested.els.assignmentConfirmStatus.innerHTML, /1 target aggiornati/);
+          assert.equal(tested.state.assignmentDistributed, true);
+          assert.equal(tested.els.distributeAssignmentBtn.disabled, true);
+        })();
+        """
+    )
+
+
+def test_distribute_assignment_requires_saved_record_before_posting() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.state.activityReviewSaved = true;
+          tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.assignedAt.value = "2026-10-12T09:00";
+          tested.els.dueAt.value = "2026-10-19T23:59";
+          tested.state.assignmentRecordSaved = false;
+
+          await tested.distributeAssignment();
+
+          assert.equal(tested.fetchCalls.some((entry) => entry.path === "/api/assignments/distribute"), false);
+          assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Salva prima l'assegnazione/);
+          assert.equal(tested.els.distributeAssignmentBtn.disabled, true);
+        })();
+        """
+    )
+
+
+def test_assignment_confirm_next_guides_save_then_distribute() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.setAssignmentWizardStep("confirm");
+          tested.state.activityReviewSaved = true;
+          tested.els.activityPath.value = "activities/python-base-somma-001.json";
+          tested.els.targetsText.value = "students/rossi-mario";
+          tested.els.assignedAt.value = "2026-10-12T09:00";
+          tested.els.dueAt.value = "2026-10-19T23:59";
+          tested.els.activityAuthorLanguage.value = "python";
+          tested.els.activityAuthorSourceName.value = "main.py";
+
+          assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
+          assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Salva assegnazione");
+          assert.equal(tested.els.distributeAssignmentBtn.disabled, true);
+
+          await tested.moveAssignmentWizardStep(1);
+
+          assert.equal(tested.state.assignmentRecordSaved, true);
+          assert.equal(tested.state.assignmentDistributed, false);
+          assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Distribuisci ai target");
+          assert.equal(tested.els.distributeAssignmentBtn.disabled, false);
+
+          await tested.moveAssignmentWizardStep(1);
+
+          assert.equal(tested.state.assignmentDistributed, true);
+          assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
+          assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Percorso completato");
+          assert.equal(tested.els.distributeAssignmentBtn.disabled, true);
+          assert.ok(tested.fetchCalls.find((entry) => entry.path === "/api/assignments/save"));
+          assert.ok(tested.fetchCalls.find((entry) => entry.path === "/api/assignments/distribute"));
         })();
         """
     )
@@ -939,6 +1003,10 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert "File aggiuntivi liberi" in assignment_section
     assert 'id="assignmentAiStudentBudget"' in assignment_section
     assert 'id="assignmentIntegrityMode"' in assignment_section
+    assert 'id="saveAssignmentBtn" type="button"' in assignment_section
+    assert 'id="distributeAssignmentBtn" type="button" disabled' in assignment_section
+    assert "1 Salva assegnazione" in assignment_section
+    assert "2 Distribuisci ai target" in assignment_section
 
 
 def test_assignment_wizard_uses_calendar_date_time_inputs() -> None:
@@ -1049,11 +1117,15 @@ def test_assignment_confirm_status_resets_when_assignment_data_changes() -> None
 
         assert.equal(tested.validateAssignmentBeforeConfirm("salvare l'assegnazione"), true);
         tested.els.assignmentConfirmStatus.innerHTML = "<strong>Assegnazione salvata</strong><span>ID: demo</span>";
+        tested.state.assignmentRecordSaved = true;
+        tested.state.assignmentDistributed = false;
         tested.els.targetsText.value = "students/bianchi-luca";
         tested.els.targetsText.dispatchEvent(new Event("input"));
 
         assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Dati modificati/);
         assert.match(tested.els.assignmentConfirmStatus.innerHTML, /destinatari sono cambiati/);
+        assert.equal(tested.state.assignmentRecordSaved, false);
+        assert.equal(tested.els.distributeAssignmentBtn.disabled, true);
         """
     )
 
@@ -1744,8 +1816,8 @@ def test_assignment_wizard_prev_next_guides_the_flow() -> None:
 
         tested.moveAssignmentWizardStep(10);
         assert.match(tested.els.assignmentWizardHint.textContent, /Step 7 di 7/);
-        assert.equal(tested.els.assignmentWizardNextBtn.disabled, true);
-        assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Fine percorso");
+        assert.equal(tested.els.assignmentWizardNextBtn.disabled, false);
+        assert.equal(tested.els.assignmentWizardNextBtn.textContent, "Salva assegnazione");
 
         tested.moveAssignmentWizardStep(-1);
         assert.match(tested.els.assignmentWizardHint.textContent, /Step 6 di 7/);

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -244,8 +244,8 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
             <span>Prima salva l'assegnazione, poi distribuisci ai target se vuoi copiare traccia e asset nei repository.</span>
           </div>
           <div class="generateActions">
-            <button id="saveAssignmentBtn" type="button" class="primary" title="Salva l'assegnazione per classe, team o studenti senza distribuire ancora asset nei repository.">Salva assegnazione</button>
-            <button id="distributeAssignmentBtn" type="button" title="Copia traccia, README e asset studente nelle cartelle dei repository target.">Distribuisci ai target</button>
+            <button id="saveAssignmentBtn" type="button" title="Salva l'assegnazione per classe, team o studenti senza distribuire ancora asset nei repository.">1 Salva assegnazione</button>
+            <button id="distributeAssignmentBtn" type="button" disabled title="Copia traccia, README e asset studente nelle cartelle dei repository target dopo il salvataggio.">2 Distribuisci ai target</button>
           </div>
         </section>
         <nav class="assignmentWizardNav" aria-label="Navigazione wizard assegnazione">

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -155,6 +155,7 @@ const state = {
   activityReviewSaved: false,
   assignmentRecordSaved: false,
   assignmentDistributed: false,
+  assignmentConfirmBusy: false,
   assignmentAiGenerating: false,
   assignmentAiPromptLocked: false,
   assignmentAiDraftFilePath: "",
@@ -1875,19 +1876,20 @@ function setAssignmentConfirmStatus(type, title, message) {
 
 function updateAssignmentConfirmActions() {
   if (els.distributeAssignmentBtn) {
-    els.distributeAssignmentBtn.disabled = !state.assignmentRecordSaved || state.assignmentDistributed;
+    els.distributeAssignmentBtn.disabled = state.assignmentConfirmBusy || !state.assignmentRecordSaved || state.assignmentDistributed;
     els.distributeAssignmentBtn.title = state.assignmentRecordSaved
       ? "Copia traccia, README e asset studente nelle cartelle dei repository target."
       : "Salva prima l'assegnazione, poi potrai distribuire ai target.";
   }
   if (els.saveAssignmentBtn) {
-    els.saveAssignmentBtn.disabled = state.assignmentDistributed;
+    els.saveAssignmentBtn.disabled = state.assignmentConfirmBusy || state.assignmentDistributed;
   }
 }
 
 function resetAssignmentConfirmStatus(message = "I dati dell'assegnazione sono cambiati: ricontrolla anteprima e conferma prima di salvare o distribuire.") {
   state.assignmentRecordSaved = false;
   state.assignmentDistributed = false;
+  state.assignmentConfirmBusy = false;
   setAssignmentConfirmStatus("info", "Dati modificati", message);
   updateAssignmentConfirmActions();
 }
@@ -3182,7 +3184,7 @@ function setAssignmentWizardStep(step) {
   if (els.assignmentWizardNextBtn) {
     const isLast = index >= ASSIGNMENT_WIZARD_STEPS.length - 1;
     const isComplete = assignmentWizardStepComplete(selectedStep);
-    els.assignmentWizardNextBtn.disabled = isLast ? isComplete : !isComplete;
+    els.assignmentWizardNextBtn.disabled = state.assignmentConfirmBusy || (isLast ? isComplete : !isComplete);
     els.assignmentWizardNextBtn.textContent = assignmentWizardNextLabel(selectedStep);
   }
   if (selectedStep === "confirm") updateAssignmentConfirmActions();
@@ -3190,6 +3192,7 @@ function setAssignmentWizardStep(step) {
 
 async function moveAssignmentWizardStep(offset) {
   const current = currentAssignmentWizardStep();
+  if (state.assignmentConfirmBusy) return;
   if (offset > 0) {
     if (current === "ai") {
       applyAssignmentAiDraftToActivityForm();
@@ -3402,10 +3405,13 @@ async function generateAssignmentAiDraft() {
 
 async function saveAssignmentRecord() {
   if (!els.saveAssignmentBtn) return;
+  if (state.assignmentConfirmBusy) return;
   if (!validateAssignmentBeforeConfirm("salvare l'assegnazione")) return;
+  state.assignmentConfirmBusy = true;
   state.assignmentRecordSaved = false;
   state.assignmentDistributed = false;
   updateAssignmentConfirmActions();
+  setAssignmentWizardStep(currentAssignmentWizardStep());
   els.saveAssignmentBtn.disabled = true;
   setStatus("Salvataggio assegnazione...");
   setAssignmentConfirmStatus("saving", "Salvataggio assegnazione", "Sto salvando dati, destinatari e date dell'assegnazione.");
@@ -3432,19 +3438,24 @@ async function saveAssignmentRecord() {
     setStatus(`Assegnazione non salvata: ${message}`);
     setAssignmentConfirmStatus("error", "Assegnazione non salvata", message);
   } finally {
-    els.saveAssignmentBtn.disabled = false;
+    state.assignmentConfirmBusy = false;
     updateAssignmentConfirmActions();
+    setAssignmentWizardStep(currentAssignmentWizardStep());
   }
 }
 
 async function distributeAssignment() {
   if (!els.distributeAssignmentBtn) return;
+  if (state.assignmentConfirmBusy) return;
   if (!validateAssignmentBeforeConfirm("distribuire ai target")) return;
   if (!state.assignmentRecordSaved) {
     setAssignmentConfirmStatus("error", "Salva prima l'assegnazione", "La distribuzione e disponibile solo dopo un salvataggio riuscito.");
     setAssignmentWizardStep("confirm");
     return;
   }
+  state.assignmentConfirmBusy = true;
+  updateAssignmentConfirmActions();
+  setAssignmentWizardStep(currentAssignmentWizardStep());
   els.distributeAssignmentBtn.disabled = true;
   setStatus("Distribuzione assegnazione ai target...");
   setAssignmentConfirmStatus("saving", "Distribuzione ai target", "Sto copiando traccia e asset nelle cartelle dei target selezionati.");
@@ -3473,8 +3484,9 @@ async function distributeAssignment() {
     setStatus(`Distribuzione non completata: ${message}`);
     setAssignmentConfirmStatus("error", "Distribuzione non completata", message);
   } finally {
-    els.distributeAssignmentBtn.disabled = false;
+    state.assignmentConfirmBusy = false;
     updateAssignmentConfirmActions();
+    setAssignmentWizardStep(currentAssignmentWizardStep());
   }
 }
 

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -153,6 +153,8 @@ const state = {
   draggedPanelKey: "",
   activityAuthorLastSuggestedId: "",
   activityReviewSaved: false,
+  assignmentRecordSaved: false,
+  assignmentDistributed: false,
   assignmentAiGenerating: false,
   assignmentAiPromptLocked: false,
   assignmentAiDraftFilePath: "",
@@ -1871,8 +1873,23 @@ function setAssignmentConfirmStatus(type, title, message) {
   els.assignmentConfirmStatus.innerHTML = `<strong>${escapeHtml(title)}</strong><span>${escapeHtml(message)}</span>`;
 }
 
+function updateAssignmentConfirmActions() {
+  if (els.distributeAssignmentBtn) {
+    els.distributeAssignmentBtn.disabled = !state.assignmentRecordSaved || state.assignmentDistributed;
+    els.distributeAssignmentBtn.title = state.assignmentRecordSaved
+      ? "Copia traccia, README e asset studente nelle cartelle dei repository target."
+      : "Salva prima l'assegnazione, poi potrai distribuire ai target.";
+  }
+  if (els.saveAssignmentBtn) {
+    els.saveAssignmentBtn.disabled = state.assignmentDistributed;
+  }
+}
+
 function resetAssignmentConfirmStatus(message = "I dati dell'assegnazione sono cambiati: ricontrolla anteprima e conferma prima di salvare o distribuire.") {
+  state.assignmentRecordSaved = false;
+  state.assignmentDistributed = false;
   setAssignmentConfirmStatus("info", "Dati modificati", message);
+  updateAssignmentConfirmActions();
 }
 
 function activityAuthorRequiredFields() {
@@ -3090,6 +3107,7 @@ function assignmentWizardStepComplete(step) {
   if (step === "ai") return updateAssignmentAiApplyState();
   if (step === "review") return Boolean(state.activityReviewSaved && String(els.activityPath?.value || "").trim());
   if (step === "dates") return validateAssignmentDateFields();
+  if (step === "confirm") return state.assignmentDistributed;
   return true;
 }
 
@@ -3120,6 +3138,11 @@ function validateAssignmentBeforeConfirm(actionLabel) {
 }
 
 function assignmentWizardNextLabel(step) {
+  if (step === "confirm") {
+    if (!state.assignmentRecordSaved) return "Salva assegnazione";
+    if (!state.assignmentDistributed) return "Distribuisci ai target";
+    return "Percorso completato";
+  }
   const next = nextAssignmentWizardStep(step);
   if (!next || next.id === step) return "Fine percorso";
   if (step === "ai") return "Avanti: 3 Prepara revisione";
@@ -3158,16 +3181,27 @@ function setAssignmentWizardStep(step) {
   if (els.assignmentWizardPrevBtn) els.assignmentWizardPrevBtn.disabled = index <= 0;
   if (els.assignmentWizardNextBtn) {
     const isLast = index >= ASSIGNMENT_WIZARD_STEPS.length - 1;
-    els.assignmentWizardNextBtn.disabled = isLast || !assignmentWizardStepComplete(selectedStep);
-    els.assignmentWizardNextBtn.textContent = isLast ? "Fine percorso" : assignmentWizardNextLabel(selectedStep);
+    const isComplete = assignmentWizardStepComplete(selectedStep);
+    els.assignmentWizardNextBtn.disabled = isLast ? isComplete : !isComplete;
+    els.assignmentWizardNextBtn.textContent = assignmentWizardNextLabel(selectedStep);
   }
+  if (selectedStep === "confirm") updateAssignmentConfirmActions();
 }
 
-function moveAssignmentWizardStep(offset) {
+async function moveAssignmentWizardStep(offset) {
   const current = currentAssignmentWizardStep();
   if (offset > 0) {
     if (current === "ai") {
       applyAssignmentAiDraftToActivityForm();
+      return;
+    }
+    if (current === "confirm") {
+      if (!state.assignmentRecordSaved) {
+        await saveAssignmentRecord();
+      } else if (!state.assignmentDistributed) {
+        await distributeAssignment();
+      }
+      setAssignmentWizardStep("confirm");
       return;
     }
     if (!assignmentWizardStepComplete(current)) {
@@ -3369,6 +3403,9 @@ async function generateAssignmentAiDraft() {
 async function saveAssignmentRecord() {
   if (!els.saveAssignmentBtn) return;
   if (!validateAssignmentBeforeConfirm("salvare l'assegnazione")) return;
+  state.assignmentRecordSaved = false;
+  state.assignmentDistributed = false;
+  updateAssignmentConfirmActions();
   els.saveAssignmentBtn.disabled = true;
   setStatus("Salvataggio assegnazione...");
   setAssignmentConfirmStatus("saving", "Salvataggio assegnazione", "Sto salvando dati, destinatari e date dell'assegnazione.");
@@ -3382,6 +3419,8 @@ async function saveAssignmentRecord() {
     state.selectedAssignmentId = "";
     renderAssignmentSelect();
     const assignmentId = payload.assignment?.id || "-";
+    state.assignmentRecordSaved = true;
+    state.assignmentDistributed = false;
     setStatus(`Assegnazione salvata: ${assignmentId}.`);
     setAssignmentConfirmStatus(
       "success",
@@ -3394,12 +3433,18 @@ async function saveAssignmentRecord() {
     setAssignmentConfirmStatus("error", "Assegnazione non salvata", message);
   } finally {
     els.saveAssignmentBtn.disabled = false;
+    updateAssignmentConfirmActions();
   }
 }
 
 async function distributeAssignment() {
   if (!els.distributeAssignmentBtn) return;
   if (!validateAssignmentBeforeConfirm("distribuire ai target")) return;
+  if (!state.assignmentRecordSaved) {
+    setAssignmentConfirmStatus("error", "Salva prima l'assegnazione", "La distribuzione e disponibile solo dopo un salvataggio riuscito.");
+    setAssignmentWizardStep("confirm");
+    return;
+  }
   els.distributeAssignmentBtn.disabled = true;
   setStatus("Distribuzione assegnazione ai target...");
   setAssignmentConfirmStatus("saving", "Distribuzione ai target", "Sto copiando traccia e asset nelle cartelle dei target selezionati.");
@@ -3413,6 +3458,7 @@ async function distributeAssignment() {
     });
     renderAssignmentPlan(payload.plan);
     const targetCount = payload.results?.length || 0;
+    state.assignmentDistributed = true;
     setStatus(`Assegnazione distribuita a ${targetCount} target.`);
     setAssignmentConfirmStatus(
       "success",
@@ -3428,6 +3474,7 @@ async function distributeAssignment() {
     setAssignmentConfirmStatus("error", "Distribuzione non completata", message);
   } finally {
     els.distributeAssignmentBtn.disabled = false;
+    updateAssignmentConfirmActions();
   }
 }
 

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -156,6 +156,7 @@ const state = {
   assignmentRecordSaved: false,
   assignmentDistributed: false,
   assignmentConfirmBusy: false,
+  assignmentConfirmRevision: 0,
   assignmentAiGenerating: false,
   assignmentAiPromptLocked: false,
   assignmentAiDraftFilePath: "",
@@ -1889,7 +1890,7 @@ function updateAssignmentConfirmActions() {
 function resetAssignmentConfirmStatus(message = "I dati dell'assegnazione sono cambiati: ricontrolla anteprima e conferma prima di salvare o distribuire.") {
   state.assignmentRecordSaved = false;
   state.assignmentDistributed = false;
-  state.assignmentConfirmBusy = false;
+  state.assignmentConfirmRevision += 1;
   setAssignmentConfirmStatus("info", "Dati modificati", message);
   updateAssignmentConfirmActions();
 }
@@ -3410,6 +3411,7 @@ async function saveAssignmentRecord() {
   state.assignmentConfirmBusy = true;
   state.assignmentRecordSaved = false;
   state.assignmentDistributed = false;
+  const confirmRevision = state.assignmentConfirmRevision;
   updateAssignmentConfirmActions();
   setAssignmentWizardStep(currentAssignmentWizardStep());
   els.saveAssignmentBtn.disabled = true;
@@ -3425,14 +3427,23 @@ async function saveAssignmentRecord() {
     state.selectedAssignmentId = "";
     renderAssignmentSelect();
     const assignmentId = payload.assignment?.id || "-";
-    state.assignmentRecordSaved = true;
-    state.assignmentDistributed = false;
-    setStatus(`Assegnazione salvata: ${assignmentId}.`);
-    setAssignmentConfirmStatus(
-      "success",
-      "Assegnazione salvata",
-      `ID: ${assignmentId}. Ora puoi distribuire ai target oppure tornare agli step precedenti per modificare i dati.`
-    );
+    if (confirmRevision === state.assignmentConfirmRevision) {
+      state.assignmentRecordSaved = true;
+      state.assignmentDistributed = false;
+      setStatus(`Assegnazione salvata: ${assignmentId}.`);
+      setAssignmentConfirmStatus(
+        "success",
+        "Assegnazione salvata",
+        `ID: ${assignmentId}. Ora puoi distribuire ai target oppure tornare agli step precedenti per modificare i dati.`
+      );
+    } else {
+      setStatus(`Assegnazione salvata: ${assignmentId}, ma i dati correnti sono cambiati.`);
+      setAssignmentConfirmStatus(
+        "info",
+        "Dati modificati dopo il salvataggio",
+        "Il salvataggio precedente e completato, ma i dati visibili ora sono cambiati: ricontrolla e salva di nuovo prima di distribuire."
+      );
+    }
   } catch (error) {
     const message = assignmentPlanErrorMessage(error);
     setStatus(`Assegnazione non salvata: ${message}`);
@@ -3454,6 +3465,7 @@ async function distributeAssignment() {
     return;
   }
   state.assignmentConfirmBusy = true;
+  const confirmRevision = state.assignmentConfirmRevision;
   updateAssignmentConfirmActions();
   setAssignmentWizardStep(currentAssignmentWizardStep());
   els.distributeAssignmentBtn.disabled = true;
@@ -3469,13 +3481,22 @@ async function distributeAssignment() {
     });
     renderAssignmentPlan(payload.plan);
     const targetCount = payload.results?.length || 0;
-    state.assignmentDistributed = true;
-    setStatus(`Assegnazione distribuita a ${targetCount} target.`);
-    setAssignmentConfirmStatus(
-      "success",
-      "Distribuzione completata",
-      `${targetCount} target aggiornati. Controlla l'anteprima per eventuali target gia presenti o bloccati.`
-    );
+    if (confirmRevision === state.assignmentConfirmRevision) {
+      state.assignmentDistributed = true;
+      setStatus(`Assegnazione distribuita a ${targetCount} target.`);
+      setAssignmentConfirmStatus(
+        "success",
+        "Distribuzione completata",
+        `${targetCount} target aggiornati. Controlla l'anteprima per eventuali target gia presenti o bloccati.`
+      );
+    } else {
+      setStatus(`Distribuzione completata per ${targetCount} target, ma i dati correnti sono cambiati.`);
+      setAssignmentConfirmStatus(
+        "info",
+        "Dati modificati dopo la distribuzione",
+        "La distribuzione precedente e completata, ma i dati visibili ora sono cambiati: ricontrolla prima di procedere."
+      );
+    }
   } catch (error) {
     const message = assignmentPlanErrorMessage(error);
     if (els.assignmentPlanPreview) {


### PR DESCRIPTION
## Cosa cambia
- rende guidato il passo finale del wizard: il bottone Avanti salva prima l'assegnazione e poi distribuisce ai target
- disabilita la distribuzione finche il salvataggio non e riuscito
- aggiorna stati, tooltip, test frontend e guida docente per rendere chiaro il flusso

## Perche
Nel passo finale c'erano azioni separate e poco sequenziali: era facile provare a distribuire prima di aver salvato. Ora il percorso e piu lineare e reversibile.

## Test
- `python -m pytest tests/test_assignment_dashboard_frontend.py`
- `python -m pytest tests/test_course_board_server.py tests/test_codex_activity_adapter.py tests/test_thebitlab_storage.py`
- `git diff --check`