### PR TITLE
Aggiungi cancellazione assegnazioni docente

### DIFF
--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -88,6 +88,7 @@ Usalo quando devi:
 - controllare o modificare il nome del registro JSON;
 - creare il registro in `teacher-reports`;
 - aggiornare il tracking dopo consegne, grading o feedback.
+- cancellare un'assegnazione salvata in `teacher-assignments` quando e stata creata per errore: questa azione non rimuove eventuali file gia distribuiti nei repository studenti.
 
 Screenshot previsto: `doc/images/dashboard-guides/docente-registro-consegne.png`.
 

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -318,6 +318,17 @@ class JsonAssignmentRecordStorage:
             raise FileNotFoundError(f"Assegnazione non trovata: {assignment_id}")
         return validate_assignment_record(self.read_json(path))
 
+    def delete_assignment(self, assignment_id: str) -> dict[str, Any]:
+        """Delete one assignment record by id."""
+
+        path = self.safe_assignment_path(assignment_id)
+        if not path.is_file():
+            raise FileNotFoundError(f"Assegnazione non trovata: {assignment_id}")
+        assignment = validate_assignment_record(self.read_json(path))
+        deleted = {**assignment, "name": path.name, "path": self.relative_path(path)}
+        path.unlink()
+        return deleted
+
     def list_assignments(self) -> list[dict[str, Any]]:
         """List assignment records stored in teacher-assignments."""
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -275,6 +275,17 @@ def list_assignment_records(now: str | None = None) -> dict:
     }
 
 
+def delete_assignment_record(payload: dict) -> dict:
+    """Delete one explicit assignment record and return the updated list."""
+
+    assignment_id = str(payload.get("assignment_id", "")).strip()
+    if not assignment_id:
+        raise ValueError("assignment_id obbligatorio.")
+    deleted = assignment_record_storage().delete_assignment(assignment_id)
+    updated = list_assignment_records(str(payload.get("now", "")).strip() or None)
+    return {"ok": True, "deleted": deleted, **updated}
+
+
 def list_class_rosters() -> list[dict]:
     """List local class rosters stored in doc/classes."""
 
@@ -2110,6 +2121,20 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/assignments/save":
             try:
                 self.write_json(save_assignment_record(payload))
+            except FileNotFoundError as error:
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/assignments/delete":
+            try:
+                self.write_json(delete_assignment_record(payload))
             except FileNotFoundError as error:
                 self.send_response(404)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -267,9 +267,14 @@ def list_assignment_records(now: str | None = None) -> dict:
             continue
     current_time = now or datetime_now_iso()
     assignments = record_storage.list_assignments()
-    due_without_register = record_storage.assignments_due_without_register(registers, current_time)
+    assignment_statuses = [
+        assignment_records.assignment_status(assignment, registers, current_time).to_dict()
+        for assignment in assignments
+    ]
+    due_without_register = [status for status in assignment_statuses if status["needs_register"]]
     return {
         "assignments": assignments,
+        "assignment_statuses": assignment_statuses,
         "due_without_register": due_without_register,
         "now": current_time,
     }

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -204,6 +204,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
       }},
       window: {{
         addEventListener() {{}},
+        confirm() {{ return true; }},
         location: {{
           reloaded: false,
           reload() {{ this.reloaded = true; }},
@@ -451,6 +452,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         generateAssignmentAiDraft,
         saveAssignmentRecord,
         distributeAssignment,
+        deleteSelectedAssignment,
         generateReport,
         loadAssignments,
         renderAssignmentSelect,
@@ -925,6 +927,71 @@ def test_distribute_assignment_requires_saved_record_before_posting() -> None:
           assert.equal(tested.fetchCalls.some((entry) => entry.path === "/api/assignments/distribute"), false);
           assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Salva prima l'assegnazione/);
           assert.equal(tested.els.distributeAssignmentBtn.disabled, true);
+        })();
+        """
+    )
+
+
+def test_delete_selected_assignment_posts_confirmation_and_refreshes_list() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.state.dueAssignments = [{
+            id: "assignment-python-base-somma-001-3a",
+            activity_id: "python-base-somma-001",
+            activity_path: "activities/python-base-somma-001.json",
+            class_id: "3A",
+            class_label: "3A TPSI",
+            due_at: "2026-10-19T23:59:00+02:00",
+          }];
+          tested.renderAssignmentSelect();
+          tested.els.assignmentSelect.value = "assignment-python-base-somma-001-3a";
+          tested.state.selectedAssignmentId = "assignment-python-base-somma-001-3a";
+          tested.renderAssignmentSelect();
+          tested.els.nowAt.value = "2026-10-20T08:00";
+          tested.fetchResponses["/api/assignments/delete"] = {
+            ok: true,
+            deleted: { id: "assignment-python-base-somma-001-3a" },
+            assignments: [],
+            due_without_register: [],
+          };
+
+          await tested.deleteSelectedAssignment();
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/assignments/delete");
+          assert.ok(call);
+          assert.equal(call.options.method, "POST");
+          assert.deepEqual(JSON.parse(call.options.body), {
+            assignment_id: "assignment-python-base-somma-001-3a",
+            now: "2026-10-20T08:00:00+02:00",
+          });
+          assert.equal(tested.state.dueAssignments.length, 0);
+          assert.equal(tested.state.selectedAssignmentId, "");
+          assert.equal(tested.els.deleteAssignmentBtn.disabled, true);
+          assert.match(tested.els.status.textContent, /Assegnazione cancellata/);
+        })();
+        """
+    )
+
+
+def test_delete_selected_assignment_stops_when_confirmation_is_cancelled() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.window.confirm = () => false;
+          tested.state.dueAssignments = [{
+            id: "assignment-python-base-somma-001-3a",
+            activity_id: "python-base-somma-001",
+            class_label: "3A TPSI",
+            due_at: "2026-10-19T23:59:00+02:00",
+          }];
+          tested.state.selectedAssignmentId = "assignment-python-base-somma-001-3a";
+          tested.renderAssignmentSelect();
+
+          await tested.deleteSelectedAssignment();
+
+          assert.equal(tested.fetchCalls.some((entry) => entry.path === "/api/assignments/delete"), false);
+          assert.equal(tested.state.selectedAssignmentId, "assignment-python-base-somma-001-3a");
         })();
         """
     )
@@ -2619,6 +2686,8 @@ def test_assignment_and_report_panels_are_separated() -> None:
     assert 'id="outputName"' in report_section
     assert 'id="reportAssignmentSummary"' in report_section
     assert 'id="generateReportBtn"' in report_section
+    assert 'id="deleteAssignmentBtn"' in report_section
+    assert "Cancella assegnazione" in report_section
     assert 'id="saveAssignmentBtn"' not in report_section
     assert 'id="distributeAssignmentBtn"' not in report_section
     assert 'id="activitySelect"' not in report_section

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -842,7 +842,7 @@ def test_save_assignment_record_posts_form_and_refreshes_due_assignments() -> No
           });
           assert.equal(tested.state.assignments.length, 1);
           assert.equal(tested.state.dueAssignments.length, 1);
-          assert.match(tested.els.assignmentStatus.textContent, /1 assegnazioni scadute senza registro/);
+          assert.match(tested.els.assignmentStatus.textContent, /1 da tracciare/);
           assert.match(tested.els.status.textContent, /Assegnazione salvata/);
           assert.match(tested.els.assignmentConfirmStatus.innerHTML, /Assegnazione salvata/);
           assert.match(tested.els.assignmentConfirmStatus.innerHTML, /assignment-python-base-somma-001-3a-tpsi/);
@@ -979,32 +979,58 @@ def test_assignment_select_lists_all_saved_assignments_with_tracking_status() ->
         """
         tested.state.assignments = [
           {
-            id: "assignment-future-3a",
-            activity_id: "python-base-lista-001",
+            id: "assignment-due-with-register",
+            activity_id: "demo-scaduta-con-registro",
+            class_label: "3A TPSI",
+            due_at: "2026-10-19T23:59:00+02:00",
+          },
+          {
+            id: "assignment-due-without-register",
+            activity_id: "demo-scaduta-senza-registro",
+            class_label: "3A TPSI",
+            due_at: "2026-10-19T23:59:00+02:00",
+          },
+          {
+            id: "assignment-future-with-register",
+            activity_id: "demo-non-scaduta-con-registro",
             class_label: "3A TPSI",
             due_at: "2026-11-02T23:59:00+01:00",
           },
           {
-            id: "assignment-due-3a",
-            activity_id: "python-base-somma-001",
+            id: "assignment-future-without-register",
+            activity_id: "demo-non-scaduta-senza-registro",
             class_label: "3A TPSI",
-            due_at: "2026-10-19T23:59:00+02:00",
+            due_at: "2026-11-03T23:59:00+01:00",
           },
         ];
+        tested.state.assignmentStatuses = [
+          { assignment: tested.state.assignments[0], due: true, has_register: true, needs_register: false },
+          { assignment: tested.state.assignments[1], due: true, has_register: false, needs_register: true },
+          { assignment: tested.state.assignments[2], due: false, has_register: true, needs_register: false },
+          { assignment: tested.state.assignments[3], due: false, has_register: false, needs_register: false },
+        ];
         tested.state.dueAssignments = [tested.state.assignments[1]];
-        tested.state.selectedAssignmentId = "assignment-future-3a";
+        tested.state.selectedAssignmentId = "assignment-future-with-register";
 
         tested.renderAssignmentSelect();
 
         const labels = tested.els.assignmentSelect.children.map((option) => option.textContent);
-        assert.equal(labels.length, 2);
-        assert.match(labels[0], /python-base-lista-001/);
-        assert.match(labels[0], /gia tracciata o non scaduta/);
-        assert.match(labels[1], /python-base-somma-001/);
-        assert.match(labels[1], /da tracciare/);
-        assert.equal(tested.els.assignmentSelect.value, "assignment-future-3a");
+        assert.equal(labels.length, 4);
+        assert.match(labels[0], /demo-scaduta-con-registro/);
+        assert.match(labels[0], /scaduta - con registro/);
+        assert.match(labels[1], /demo-scaduta-senza-registro/);
+        assert.match(labels[1], /scaduta - senza registro - da tracciare/);
+        assert.match(labels[2], /demo-non-scaduta-con-registro/);
+        assert.match(labels[2], /non scaduta - con registro/);
+        assert.match(labels[3], /demo-non-scaduta-senza-registro/);
+        assert.match(labels[3], /non scaduta - senza registro/);
+        assert.equal(tested.els.assignmentSelect.value, "assignment-future-with-register");
         assert.equal(tested.els.deleteAssignmentBtn.disabled, false);
-        assert.match(tested.els.assignmentStatus.textContent, /1 assegnazioni scadute senza registro su 2 assegnazioni salvate/);
+        assert.match(tested.els.assignmentStatus.textContent, /1 da tracciare/);
+        assert.match(tested.els.assignmentStatus.textContent, /1 scadute con registro/);
+        assert.match(tested.els.assignmentStatus.textContent, /1 non scadute senza registro/);
+        assert.match(tested.els.assignmentStatus.textContent, /1 non scadute con registro/);
+        assert.match(tested.els.assignmentStatus.textContent, /4 assegnazioni salvate/);
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -974,6 +974,41 @@ def test_delete_selected_assignment_posts_confirmation_and_refreshes_list() -> N
     )
 
 
+def test_assignment_select_lists_all_saved_assignments_with_tracking_status() -> None:
+    run_dashboard_js(
+        """
+        tested.state.assignments = [
+          {
+            id: "assignment-future-3a",
+            activity_id: "python-base-lista-001",
+            class_label: "3A TPSI",
+            due_at: "2026-11-02T23:59:00+01:00",
+          },
+          {
+            id: "assignment-due-3a",
+            activity_id: "python-base-somma-001",
+            class_label: "3A TPSI",
+            due_at: "2026-10-19T23:59:00+02:00",
+          },
+        ];
+        tested.state.dueAssignments = [tested.state.assignments[1]];
+        tested.state.selectedAssignmentId = "assignment-future-3a";
+
+        tested.renderAssignmentSelect();
+
+        const labels = tested.els.assignmentSelect.children.map((option) => option.textContent);
+        assert.equal(labels.length, 2);
+        assert.match(labels[0], /python-base-lista-001/);
+        assert.match(labels[0], /gia tracciata o non scaduta/);
+        assert.match(labels[1], /python-base-somma-001/);
+        assert.match(labels[1], /da tracciare/);
+        assert.equal(tested.els.assignmentSelect.value, "assignment-future-3a");
+        assert.equal(tested.els.deleteAssignmentBtn.disabled, false);
+        assert.match(tested.els.assignmentStatus.textContent, /1 assegnazioni scadute senza registro su 2 assegnazioni salvate/);
+        """
+    )
+
+
 def test_delete_selected_assignment_stops_when_confirmation_is_cancelled() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -1014,7 +1014,9 @@ def test_assignment_select_lists_all_saved_assignments_with_tracking_status() ->
 
         tested.renderAssignmentSelect();
 
-        const labels = tested.els.assignmentSelect.children.map((option) => option.textContent);
+        const labels = tested.els.assignmentSelect.children
+          .filter((option) => option.value)
+          .map((option) => option.textContent);
         assert.equal(labels.length, 4);
         assert.match(labels[0], /demo-scaduta-con-registro/);
         assert.match(labels[0], /scaduta - con registro/);

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -480,7 +480,13 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
     const tested = context.__dashboardTest;
     {assertions}
     """
-    subprocess.run(["node", "-e", textwrap.dedent(script)], check=True)
+    result = subprocess.run(["node", "-e", textwrap.dedent(script)], capture_output=True, text=True)
+    if result.returncode:
+        raise AssertionError(
+            f"Node dashboard test failed with exit code {result.returncode}\n"
+            f"STDOUT:\n{result.stdout}\n"
+            f"STDERR:\n{result.stderr}"
+        )
 
 
 def test_reports_for_activity_isolates_explicit_classes() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -967,10 +967,9 @@ def test_delete_selected_assignment_posts_confirmation_and_refreshes_list() -> N
           const call = tested.fetchCalls.find((entry) => entry.path === "/api/assignments/delete");
           assert.ok(call);
           assert.equal(call.options.method, "POST");
-          assert.deepEqual(JSON.parse(call.options.body), {
-            assignment_id: "assignment-python-base-somma-001-3a",
-            now: "2026-10-20T08:00:00+02:00",
-          });
+          const body = JSON.parse(call.options.body);
+          assert.equal(body.assignment_id, "assignment-python-base-somma-001-3a");
+          assert.match(body.now, /^2026-10-20T08:00:00[+-]\\d{2}:\\d{2}$/);
           assert.equal(tested.state.dueAssignments.length, 0);
           assert.equal(tested.state.selectedAssignmentId, "");
           assert.equal(tested.els.deleteAssignmentBtn.disabled, true);

--- a/tests/test_assignment_records.py
+++ b/tests/test_assignment_records.py
@@ -245,6 +245,19 @@ def test_assignment_record_storage_writes_lists_and_filters_due_without_register
     assert storage.assignments_due_without_register([{"assignment_id": saved["id"]}], "2026-10-20T08:00:00+02:00") == []
 
 
+def test_assignment_record_storage_deletes_assignment(tmp_path) -> None:
+    storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
+    saved = storage.write_assignment(assignment_records.build_assignment_record(**sample_assignment()))
+
+    deleted = storage.delete_assignment(saved["id"])
+
+    assert deleted["id"] == saved["id"]
+    assert deleted["path"] == saved["path"]
+    assert storage.list_assignments() == []
+    with pytest.raises(FileNotFoundError, match="Assegnazione non trovata"):
+        storage.read_assignment(saved["id"])
+
+
 def test_assignment_record_storage_rejects_duplicate_without_overwrite(tmp_path) -> None:
     storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
     storage.write_assignment(assignment_records.build_assignment_record(**sample_assignment()))

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -139,6 +139,9 @@ def test_list_assignment_records_marks_due_without_register(tmp_path, monkeypatc
     payload = course_board_server.list_assignment_records("2026-10-20T08:00:00+02:00")
 
     assert payload["assignments"][0]["id"] == assignment["id"]
+    assert payload["assignment_statuses"][0]["assignment"]["id"] == assignment["id"]
+    assert payload["assignment_statuses"][0]["due"] is True
+    assert payload["assignment_statuses"][0]["has_register"] is False
     assert payload["due_without_register"][0]["assignment"]["id"] == assignment["id"]
     assert payload["due_without_register"][0]["needs_register"] is True
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -143,6 +143,38 @@ def test_list_assignment_records_marks_due_without_register(tmp_path, monkeypatc
     assert payload["due_without_register"][0]["needs_register"] is True
 
 
+def test_delete_assignment_record_removes_saved_record(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+    monkeypatch.setattr(course_board_server, "TEACHER_ASSIGNMENTS_DIR", tmp_path / "teacher-assignments")
+
+    storage = assignment_records.JsonAssignmentRecordStorage(tmp_path, tmp_path / "teacher-assignments")
+    assignment = storage.write_assignment(
+        assignment_records.build_assignment_record(
+            activity_id="python-base-somma-001",
+            activity_path="activities/python-base-somma-001.json",
+            target_type="class",
+            class_id="3A-TPSI",
+            class_label="3A TPSI",
+            github_team="team-3a-tpsi",
+            assigned_at="2026-10-12T09:00:00+02:00",
+            due_at="2026-10-19T23:59:00+02:00",
+            targets=[{"student_id": "rossi-mario", "path": "studenti/rossi-mario"}],
+        ),
+    )
+
+    payload = course_board_server.delete_assignment_record({
+        "assignment_id": assignment["id"],
+        "now": "2026-10-20T08:00:00+02:00",
+    })
+
+    assert payload["ok"] is True
+    assert payload["deleted"]["id"] == assignment["id"]
+    assert payload["assignments"] == []
+    assert payload["due_without_register"] == []
+    assert not (tmp_path / assignment["path"]).exists()
+
+
 def test_generate_assignment_report_preserves_assignment_id(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -265,8 +265,8 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       </div>
       <div class="generateGrid">
         <label class="wideField">
-          <span>Assegnazione da tracciare</span>
-          <select id="assignmentSelect" aria-label="Assegnazioni scadute senza registro">
+          <span>Assegnazione salvata</span>
+          <select id="assignmentSelect" aria-label="Assegnazioni salvate">
             <option value="">Caricamento assegnazioni...</option>
           </select>
         </label>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -271,6 +271,9 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           </select>
         </label>
         <p id="assignmentStatus" class="status wideField" aria-live="polite"></p>
+        <div class="generateActions wideField">
+          <button id="deleteAssignmentBtn" type="button" class="danger" disabled title="Cancella solo il record docente dell'assegnazione selezionata. Non rimuove eventuali file gia distribuiti nei repository studenti.">Cancella assegnazione</button>
+        </div>
         <label class="wideField">
           <span>Output registro</span>
           <input id="outputName" type="text" value="demo/demo_assignment.json">

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1755,7 +1755,10 @@ function renderAssignmentSelect() {
   const dueIds = dueAssignmentIds();
   const statusesById = assignmentStatusMap();
   const displayedAssignments = state.assignments.length ? state.assignments : state.dueAssignments;
-  els.assignmentSelect.innerHTML = '<option value="">Nessuna assegnazione selezionata</option>';
+  const emptyOption = document.createElement("option");
+  emptyOption.value = "";
+  emptyOption.textContent = "Nessuna assegnazione selezionata";
+  els.assignmentSelect.replaceChildren(emptyOption);
   for (const assignment of displayedAssignments) {
     const option = document.createElement("option");
     option.value = assignment.id || "";

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1717,6 +1717,10 @@ function assignmentLabel(assignment) {
   return `${target} - ${activity} - ${formatDate(assignment.due_at)}`;
 }
 
+function dueAssignmentIds() {
+  return new Set(state.dueAssignments.map((assignment) => assignment.id).filter(Boolean));
+}
+
 function assignmentTargetLine(target) {
   return String(target?.path || target?.target || target?.repo_ref || target?.student_id || "").trim().replaceAll("\\", "/");
 }
@@ -1729,15 +1733,18 @@ function assignmentOutputName(assignment) {
 function renderAssignmentSelect() {
   if (!els.assignmentSelect) return;
   const selected = state.selectedAssignmentId || els.assignmentSelect.value;
+  const dueIds = dueAssignmentIds();
+  const displayedAssignments = state.assignments.length ? state.assignments : state.dueAssignments;
   els.assignmentSelect.innerHTML = '<option value="">Nessuna assegnazione selezionata</option>';
-  for (const assignment of state.dueAssignments) {
+  for (const assignment of displayedAssignments) {
     const option = document.createElement("option");
     option.value = assignment.id || "";
-    option.textContent = assignmentLabel(assignment);
+    const status = dueIds.has(assignment.id) ? "da tracciare" : "gia tracciata o non scaduta";
+    option.textContent = `${assignmentLabel(assignment)} - ${status}`;
     option.title = assignment.id || "";
     els.assignmentSelect.append(option);
   }
-  els.assignmentSelect.value = state.dueAssignments.some((assignment) => assignment.id === selected) ? selected : "";
+  els.assignmentSelect.value = displayedAssignments.some((assignment) => assignment.id === selected) ? selected : "";
   state.selectedAssignmentId = els.assignmentSelect.value;
   if (els.deleteAssignmentBtn) {
     els.deleteAssignmentBtn.disabled = !state.selectedAssignmentId;
@@ -1746,9 +1753,11 @@ function renderAssignmentSelect() {
       : "Seleziona un'assegnazione da tracciare prima di cancellarla.";
   }
   if (els.assignmentStatus) {
-    els.assignmentStatus.textContent = state.dueAssignments.length
-      ? `${state.dueAssignments.length} assegnazioni scadute senza registro.`
-      : "Nessuna assegnazione scaduta senza registro.";
+    if (displayedAssignments.length) {
+      els.assignmentStatus.textContent = `${state.dueAssignments.length} assegnazioni scadute senza registro su ${displayedAssignments.length} assegnazioni salvate.`;
+    } else {
+      els.assignmentStatus.textContent = "Nessuna assegnazione salvata.";
+    }
   }
 }
 

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -121,6 +121,7 @@ const LEGEND_SECTIONS = {
 const state = {
   activities: [],
   assignments: [],
+  assignmentStatuses: [],
   dueAssignments: [],
   reports: [],
   classRosters: [],
@@ -1707,6 +1708,7 @@ async function loadAssignments() {
   const query = now ? `?now=${encodeURIComponent(now)}` : "";
   const payload = await api(`/api/assignments${query}`);
   state.assignments = payload.assignments || [];
+  state.assignmentStatuses = payload.assignment_statuses || [];
   state.dueAssignments = (payload.due_without_register || []).map((item) => item.assignment || item);
   renderAssignmentSelect();
 }
@@ -1719,6 +1721,23 @@ function assignmentLabel(assignment) {
 
 function dueAssignmentIds() {
   return new Set(state.dueAssignments.map((assignment) => assignment.id).filter(Boolean));
+}
+
+function assignmentStatusMap() {
+  return new Map(
+    state.assignmentStatuses
+      .filter((status) => status?.assignment?.id)
+      .map((status) => [status.assignment.id, status]),
+  );
+}
+
+function assignmentSelectStatusLabel(assignment, status, dueIds) {
+  const due = status?.due === true || dueIds.has(assignment.id);
+  const hasRegister = status?.has_register === true;
+  if (due && !hasRegister) return "scaduta - senza registro - da tracciare";
+  if (due && hasRegister) return "scaduta - con registro";
+  if (!due && hasRegister) return "non scaduta - con registro";
+  return "non scaduta - senza registro";
 }
 
 function assignmentTargetLine(target) {
@@ -1734,12 +1753,13 @@ function renderAssignmentSelect() {
   if (!els.assignmentSelect) return;
   const selected = state.selectedAssignmentId || els.assignmentSelect.value;
   const dueIds = dueAssignmentIds();
+  const statusesById = assignmentStatusMap();
   const displayedAssignments = state.assignments.length ? state.assignments : state.dueAssignments;
   els.assignmentSelect.innerHTML = '<option value="">Nessuna assegnazione selezionata</option>';
   for (const assignment of displayedAssignments) {
     const option = document.createElement("option");
     option.value = assignment.id || "";
-    const status = dueIds.has(assignment.id) ? "da tracciare" : "gia tracciata o non scaduta";
+    const status = assignmentSelectStatusLabel(assignment, statusesById.get(assignment.id), dueIds);
     option.textContent = `${assignmentLabel(assignment)} - ${status}`;
     option.title = assignment.id || "";
     els.assignmentSelect.append(option);
@@ -1754,7 +1774,18 @@ function renderAssignmentSelect() {
   }
   if (els.assignmentStatus) {
     if (displayedAssignments.length) {
-      els.assignmentStatus.textContent = `${state.dueAssignments.length} assegnazioni scadute senza registro su ${displayedAssignments.length} assegnazioni salvate.`;
+      const statusCounters = displayedAssignments.reduce((counters, assignment) => {
+        const label = assignmentSelectStatusLabel(assignment, statusesById.get(assignment.id), dueIds);
+        counters[label] = (counters[label] || 0) + 1;
+        return counters;
+      }, {});
+      els.assignmentStatus.textContent = [
+        `${state.dueAssignments.length} da tracciare`,
+        `${statusCounters["scaduta - con registro"] || 0} scadute con registro`,
+        `${statusCounters["non scaduta - senza registro"] || 0} non scadute senza registro`,
+        `${statusCounters["non scaduta - con registro"] || 0} non scadute con registro`,
+        `${displayedAssignments.length} assegnazioni salvate`,
+      ].join(", ") + ".";
     } else {
       els.assignmentStatus.textContent = "Nessuna assegnazione salvata.";
     }
@@ -3440,6 +3471,7 @@ async function saveAssignmentRecord() {
       body: JSON.stringify(assignmentRecordPayload()),
     });
     state.assignments = payload.assignments || [];
+    state.assignmentStatuses = payload.assignment_statuses || [];
     state.dueAssignments = (payload.due_without_register || []).map((item) => item.assignment || item);
     state.selectedAssignmentId = "";
     renderAssignmentSelect();
@@ -3555,6 +3587,7 @@ async function deleteSelectedAssignment() {
       }),
     });
     state.assignments = payload.assignments || [];
+    state.assignmentStatuses = payload.assignment_statuses || [];
     state.dueAssignments = (payload.due_without_register || []).map((item) => item.assignment || item);
     state.selectedAssignmentId = "";
     if (els.assignmentSelect) els.assignmentSelect.value = "";

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -276,6 +276,7 @@ const els = {
   activityPath: document.querySelector("#activityPath"),
   assignmentSelect: document.querySelector("#assignmentSelect"),
   assignmentStatus: document.querySelector("#assignmentStatus"),
+  deleteAssignmentBtn: document.querySelector("#deleteAssignmentBtn"),
   assignmentConfirmStatus: document.querySelector("#assignmentConfirmStatus"),
   classRosterSelect: document.querySelector("#classRosterSelect"),
   rosterStatus: document.querySelector("#rosterStatus"),
@@ -1738,6 +1739,12 @@ function renderAssignmentSelect() {
   }
   els.assignmentSelect.value = state.dueAssignments.some((assignment) => assignment.id === selected) ? selected : "";
   state.selectedAssignmentId = els.assignmentSelect.value;
+  if (els.deleteAssignmentBtn) {
+    els.deleteAssignmentBtn.disabled = !state.selectedAssignmentId;
+    els.deleteAssignmentBtn.title = state.selectedAssignmentId
+      ? "Cancella solo il record docente dell'assegnazione selezionata. Non rimuove eventuali file gia distribuiti nei repository studenti."
+      : "Seleziona un'assegnazione da tracciare prima di cancellarla.";
+  }
   if (els.assignmentStatus) {
     els.assignmentStatus.textContent = state.dueAssignments.length
       ? `${state.dueAssignments.length} assegnazioni scadute senza registro.`
@@ -1749,6 +1756,7 @@ function clearSelectedAssignment() {
   if (!state.selectedAssignmentId && !els.assignmentSelect?.value) return;
   state.selectedAssignmentId = "";
   if (els.assignmentSelect) els.assignmentSelect.value = "";
+  if (els.deleteAssignmentBtn) els.deleteAssignmentBtn.disabled = true;
   renderReportAssignmentSummary();
 }
 
@@ -3511,6 +3519,48 @@ async function distributeAssignment() {
   }
 }
 
+async function deleteSelectedAssignment() {
+  if (!els.deleteAssignmentBtn) return;
+  const assignmentId = state.selectedAssignmentId || els.assignmentSelect?.value || "";
+  if (!assignmentId) {
+    setStatus("Seleziona un'assegnazione da cancellare.");
+    return;
+  }
+  const assignment = state.dueAssignments.find((candidate) => candidate.id === assignmentId)
+    || state.assignments.find((candidate) => candidate.id === assignmentId);
+  const label = assignment ? assignmentLabel(assignment) : assignmentId;
+  const confirmed = window.confirm?.(
+    `Cancellare l'assegnazione "${label}"?\n\n` +
+    "Verrà eliminato solo il record docente in teacher-assignments. " +
+    "Eventuali file già distribuiti nei repository studenti non verranno rimossi."
+  );
+  if (!confirmed) return;
+  els.deleteAssignmentBtn.disabled = true;
+  setStatus("Cancellazione assegnazione...");
+  try {
+    const payload = await api("/api/assignments/delete", {
+      method: "POST",
+      body: JSON.stringify({
+        assignment_id: assignmentId,
+        now: dateTimeInputToIso(els.nowAt?.value),
+      }),
+    });
+    state.assignments = payload.assignments || [];
+    state.dueAssignments = (payload.due_without_register || []).map((item) => item.assignment || item);
+    state.selectedAssignmentId = "";
+    if (els.assignmentSelect) els.assignmentSelect.value = "";
+    renderAssignmentSelect();
+    clearSelectedAssignment();
+    renderReportAssignmentSummary();
+    resetAssignmentConfirmStatus("Assegnazione cancellata: seleziona o crea un'altra consegna prima di salvare o distribuire.");
+    setStatus(`Assegnazione cancellata: ${payload.deleted?.id || assignmentId}.`);
+  } catch (error) {
+    const message = assignmentPlanErrorMessage(error);
+    setStatus(`Assegnazione non cancellata: ${message}`);
+    renderAssignmentSelect();
+  }
+}
+
 async function generateReport() {
   els.generateReportBtn.disabled = true;
   setStatus("Creazione registro consegne...");
@@ -4337,6 +4387,7 @@ els.wizardOpenActivityEditorBtn?.addEventListener("click", openActivityReviewSte
 els.activityEditorCloseBtn?.addEventListener("click", closeActivityEditor);
 els.saveAssignmentBtn?.addEventListener("click", saveAssignmentRecord);
 els.distributeAssignmentBtn?.addEventListener("click", distributeAssignment);
+els.deleteAssignmentBtn?.addEventListener("click", deleteSelectedAssignment);
 els.generateReportBtn.addEventListener("click", generateReport);
 els.reportSelect.addEventListener("change", loadSelectedReport);
 els.coverageOpenBtn.addEventListener("click", openCoverageDialog);


### PR DESCRIPTION
﻿## Cosa cambia
- aggiunge la cancellazione dei record assegnazione salvati in `teacher-assignments`
- espone l'endpoint locale `/api/assignments/delete`
- aggiunge il bottone **Cancella assegnazione** nel pannello Registro consegne, con conferma esplicita
- aggiorna la guida docente chiarendo che non vengono rimossi i file gia distribuiti nei repository studenti

## Perche
Dopo il flusso guidato di creazione/assegnazione serve poter rimuovere una consegna creata per errore senza toccare i repository degli studenti. Questo prepara anche le future protezioni per cancellare activity collegate.

## Test
- `python -m pytest tests/test_assignment_records.py tests/test_course_board_server.py tests/test_assignment_dashboard_frontend.py`
- `git diff --check`
