### PR TITLE
Aggiungi cancellazione protetta delle activity

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -291,6 +291,100 @@ def delete_assignment_record(payload: dict) -> dict:
     return {"ok": True, "deleted": deleted, **updated}
 
 
+def repository_relative_path(path: Path) -> str:
+    """Return a repository-relative path where possible."""
+
+    try:
+        return str(path.relative_to(ROOT)).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+def ensure_activity_draft_path(path: Path) -> None:
+    """Reject deletion targets outside activities/drafts."""
+
+    drafts_dir = (ROOT / "activities" / "drafts").resolve()
+    try:
+        path.resolve().relative_to(drafts_dir)
+    except ValueError as error:
+        raise ValueError("Puoi cancellare solo bozze activity dentro activities/drafts.") from error
+
+
+def activity_delete_dependencies(activity_path: Path, activity: dict) -> dict:
+    """Return assignments and registers that still reference an activity."""
+
+    activity_id = str(activity.get("id", "")).strip()
+    relative_activity_path = repository_relative_path(activity_path.resolve())
+    assignments = []
+    for assignment in assignment_record_storage().list_assignments():
+        assignment_activity_id = str(assignment.get("activity_id", "")).strip()
+        assignment_activity_path = str(assignment.get("activity_path", "")).strip().replace("\\", "/")
+        if (activity_id and assignment_activity_id == activity_id) or assignment_activity_path == relative_activity_path:
+            assignments.append(
+                {
+                    "id": assignment.get("id", ""),
+                    "activity_id": assignment_activity_id,
+                    "activity_path": assignment_activity_path,
+                    "target_type": assignment.get("target_type", ""),
+                    "class_id": assignment.get("class_id", ""),
+                    "github_team": assignment.get("github_team", ""),
+                    "due_at": assignment.get("due_at", ""),
+                }
+            )
+
+    storage = assignment_storage()
+    reports = []
+    for report_summary in storage.list_assignment_reports():
+        name = str(report_summary.get("name", "")).strip()
+        if not name:
+            continue
+        try:
+            report = storage.read_assignment_report(name)
+        except Exception:  # noqa: BLE001
+            continue
+        report_activity_id = str(report.get("activity_id", "")).strip()
+        report_activity_path = str(report.get("activity_path", "")).strip().replace("\\", "/")
+        if (activity_id and report_activity_id == activity_id) or report_activity_path == relative_activity_path:
+            reports.append(
+                {
+                    "name": name,
+                    "activity_id": report_activity_id,
+                    "assignment_id": report.get("assignment_id", ""),
+                    "class_id": report.get("class_id", ""),
+                    "github_team": report.get("github_team", ""),
+                    "due_at": report.get("due_at", ""),
+                }
+            )
+    return {"assignments": assignments, "reports": reports}
+
+
+def delete_activity_record(payload: dict) -> dict:
+    """Delete one unlinked teacher-authored activity draft."""
+
+    activity_path = resolve_local_path(str(payload.get("activity_path", "")), "activity_path")
+    if not activity_path.is_file():
+        raise FileNotFoundError(f"Activity non trovata: {activity_path}")
+    ensure_activity_draft_path(activity_path)
+    storage = assignment_storage()
+    activity = normalize_activity(storage.read_json(activity_path))
+    dependencies = activity_delete_dependencies(activity_path, activity)
+    if dependencies["assignments"] or dependencies["reports"]:
+        assignment_count = len(dependencies["assignments"])
+        report_count = len(dependencies["reports"])
+        raise ValueError(
+            "Activity collegata a "
+            f"{assignment_count} assegnazioni e {report_count} registri: cancellazione bloccata. "
+            "Cancella prima le assegnazioni o i registri collegati."
+        )
+    deleted = {
+        "id": activity.get("id", ""),
+        "title": activity.get("title", ""),
+        "path": repository_relative_path(activity_path),
+    }
+    activity_path.unlink()
+    return {"ok": True, "deleted": deleted, "dependencies": dependencies, "activities": list_activities()}
+
+
 def list_class_rosters() -> list[dict]:
     """List local class rosters stored in doc/classes."""
 
@@ -2140,6 +2234,20 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/assignments/delete":
             try:
                 self.write_json(delete_assignment_record(payload))
+            except FileNotFoundError as error:
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            except Exception as error:  # noqa: BLE001
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
+            return
+        if parsed.path == "/api/activities/delete":
+            try:
+                self.write_json(delete_activity_record(payload))
             except FileNotFoundError as error:
                 self.send_response(404)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -332,6 +332,16 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
               path: "activities/drafts/somma-in-python.json",
             }}],
           }};
+          if (path === "/api/activities/delete") return {{
+            ok: true,
+            deleted: {{
+              id: "somma-in-python",
+              title: "Somma in Python",
+              path: "activities/drafts/somma-in-python.json",
+            }},
+            dependencies: {{ assignments: [], reports: [] }},
+            activities: [],
+          }};
           if (path === "/api/assignment-overview") return {{ rows: [] }};
           if (path === "/api/assignment-reports/ai-feedback/review") {{
             return {{
@@ -401,6 +411,9 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         setupPanelDragAndDrop,
         renderLegend,
         saveActivityDraft,
+        deleteSelectedActivity,
+        updateDeleteActivityButton,
+        renderActivitySelect,
         validateActivityAuthorRequiredFields,
         setActivityAuthorStatus,
         openActivityEditor,
@@ -598,6 +611,80 @@ def test_save_activity_draft_posts_form_and_selects_saved_activity() -> None:
           assert.equal(tested.els.activityAuthorStatus.classList.contains("isSuccess"), true);
           assert.match(tested.els.activityAuthorStatus.innerHTML, /Activity salvata/);
           assert.match(tested.els.activityPanelStatus.textContent, /Activity salvata/);
+        })();
+        """
+    )
+
+
+def test_delete_selected_activity_posts_confirmation_and_refreshes_list() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.state.activities = [{
+            id: "somma-in-python",
+            title: "Somma in Python",
+            kind: "compito-casa",
+            path: "activities/drafts/somma-in-python.json",
+          }];
+          tested.els.activityPath.value = "activities/drafts/somma-in-python.json";
+          tested.renderActivitySelect();
+          assert.equal(tested.els.deleteActivityBtn.disabled, false);
+
+          await tested.deleteSelectedActivity();
+
+          const call = tested.fetchCalls.find((entry) => entry.path === "/api/activities/delete");
+          assert.ok(call);
+          assert.equal(call.options.method, "POST");
+          assert.equal(JSON.parse(call.options.body).activity_path, "activities/drafts/somma-in-python.json");
+          assert.deepEqual(tested.state.activities, []);
+          assert.equal(tested.els.activityPath.value, "");
+          assert.equal(tested.els.deleteActivityBtn.disabled, true);
+          assert.match(tested.els.activityAuthorStatus.innerHTML, /Activity cancellata/);
+        })();
+        """
+    )
+
+
+def test_delete_selected_activity_stops_for_non_draft_activity() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.state.activities = [{
+            id: "demo",
+            title: "Demo",
+            kind: "laboratorio",
+            path: "examples/assignment_tracking/demo_activity.json",
+          }];
+          tested.els.activityPath.value = "examples/assignment_tracking/demo_activity.json";
+          tested.renderActivitySelect();
+          assert.equal(tested.els.deleteActivityBtn.disabled, true);
+
+          await tested.deleteSelectedActivity();
+
+          assert.equal(tested.fetchCalls.some((entry) => entry.path === "/api/activities/delete"), false);
+          assert.match(tested.els.activityAuthorStatus.innerHTML, /solo bozze activity/);
+        })();
+        """
+    )
+
+
+def test_delete_selected_activity_stops_when_confirmation_is_cancelled() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.window.confirm = () => false;
+          tested.state.activities = [{
+            id: "somma-in-python",
+            title: "Somma in Python",
+            kind: "compito-casa",
+            path: "activities/drafts/somma-in-python.json",
+          }];
+          tested.els.activityPath.value = "activities/drafts/somma-in-python.json";
+
+          await tested.deleteSelectedActivity();
+
+          assert.equal(tested.fetchCalls.some((entry) => entry.path === "/api/activities/delete"), false);
+          assert.equal(tested.els.activityPath.value, "activities/drafts/somma-in-python.json");
         })();
         """
     )

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -2,7 +2,48 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from scripts import assignment_records, course_board_server
+
+
+def patch_assignment_paths(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+    monkeypatch.setattr(course_board_server, "TEACHER_ASSIGNMENTS_DIR", tmp_path / "teacher-assignments")
+    monkeypatch.setattr(course_board_server, "ACTIVITY_DIRS", [tmp_path / "activities"])
+
+
+def write_demo_activity(path, activity_id: str = "python-base-somma-001") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": activity_id,
+                "titolo": "Somma in Python",
+                "tipo": "laboratorio",
+                "difficolta": "B",
+                "argomenti": ["variabili"],
+                "linguaggio": "python",
+                "consegna": "Somma due numeri.",
+                "correzione": {
+                    "compila": True,
+                    "test": True,
+                    "sandbox": True,
+                    "ai_feedback": False,
+                },
+                "metriche": {
+                    "tempo_stimato_minuti": 20,
+                    "traccia_tempo_dichiarato": True,
+                    "traccia_sessioni_thebitlab": True,
+                    "traccia_eventi_didattici": True,
+                    "traccia_errori_compilazione": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 def test_assignment_overview_lists_students_across_saved_reports(tmp_path, monkeypatch) -> None:
@@ -176,6 +217,88 @@ def test_delete_assignment_record_removes_saved_record(tmp_path, monkeypatch) ->
     assert payload["assignments"] == []
     assert payload["due_without_register"] == []
     assert not (tmp_path / assignment["path"]).exists()
+
+
+def test_delete_activity_record_removes_unlinked_draft(tmp_path, monkeypatch) -> None:
+    patch_assignment_paths(tmp_path, monkeypatch)
+    activity_path = tmp_path / "activities" / "drafts" / "python-base-somma-001.json"
+    write_demo_activity(activity_path)
+
+    payload = course_board_server.delete_activity_record({
+        "activity_path": "activities/drafts/python-base-somma-001.json",
+    })
+
+    assert payload["ok"] is True
+    assert payload["deleted"]["id"] == "python-base-somma-001"
+    assert payload["dependencies"] == {"assignments": [], "reports": []}
+    assert payload["activities"] == []
+    assert not activity_path.exists()
+
+
+def test_delete_activity_record_blocks_when_assignment_exists(tmp_path, monkeypatch) -> None:
+    patch_assignment_paths(tmp_path, monkeypatch)
+    activity_path = tmp_path / "activities" / "drafts" / "python-base-somma-001.json"
+    write_demo_activity(activity_path)
+    storage = assignment_records.JsonAssignmentRecordStorage(tmp_path, tmp_path / "teacher-assignments")
+    storage.write_assignment(
+        assignment_records.build_assignment_record(
+            activity_id="python-base-somma-001",
+            activity_path="activities/drafts/python-base-somma-001.json",
+            target_type="class",
+            class_id="3A-TPSI",
+            class_label="3A TPSI",
+            github_team="team-3a-tpsi",
+            assigned_at="2026-10-12T09:00:00+02:00",
+            due_at="2026-10-19T23:59:00+02:00",
+            targets=[{"student_id": "rossi-mario", "path": "studenti/rossi-mario"}],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="assegnazioni"):
+        course_board_server.delete_activity_record({
+            "activity_path": "activities/drafts/python-base-somma-001.json",
+        })
+
+    assert activity_path.exists()
+
+
+def test_delete_activity_record_blocks_when_register_exists(tmp_path, monkeypatch) -> None:
+    patch_assignment_paths(tmp_path, monkeypatch)
+    activity_path = tmp_path / "activities" / "drafts" / "python-base-somma-001.json"
+    write_demo_activity(activity_path)
+    report_path = tmp_path / "teacher-reports" / "demo" / "python-base-somma-001.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "activity_id": "python-base-somma-001",
+                "title": "Somma in Python",
+                "students": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="registri"):
+        course_board_server.delete_activity_record({
+            "activity_path": "activities/drafts/python-base-somma-001.json",
+        })
+
+    assert activity_path.exists()
+
+
+def test_delete_activity_record_rejects_non_draft_activity(tmp_path, monkeypatch) -> None:
+    patch_assignment_paths(tmp_path, monkeypatch)
+    activity_path = tmp_path / "activities" / "python-base-somma-001.json"
+    write_demo_activity(activity_path)
+
+    with pytest.raises(ValueError, match="activities/drafts"):
+        course_board_server.delete_activity_record({
+            "activity_path": "activities/python-base-somma-001.json",
+        })
+
+    assert activity_path.exists()
 
 
 def test_generate_assignment_report_preserves_assignment_id(tmp_path, monkeypatch) -> None:

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -489,6 +489,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           <input id="activityAuthorOverwrite" type="checkbox">
           <span>Sovrascrivi bozza esistente</span>
         </label>
+        <button id="deleteActivityBtn" type="button" class="danger" disabled title="Cancella solo bozze activity in activities/drafts non collegate a consegne o registri.">Cancella activity</button>
         <button id="saveActivityBtn" type="button" class="primary" title="Valida e salva la bozza activity in activities/drafts.">Salva activity</button>
       </div>
     </div>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -273,6 +273,7 @@ const els = {
   activityAuthorPrompt: document.querySelector("#activityAuthorPrompt"),
   activityAuthorOverwrite: document.querySelector("#activityAuthorOverwrite"),
   saveActivityBtn: document.querySelector("#saveActivityBtn"),
+  deleteActivityBtn: document.querySelector("#deleteActivityBtn"),
   activitySelect: document.querySelector("#activitySelect"),
   activityPath: document.querySelector("#activityPath"),
   assignmentSelect: document.querySelector("#assignmentSelect"),
@@ -2065,6 +2066,31 @@ async function saveActivityDraft() {
   }
 }
 
+function normalizedActivityPathValue() {
+  return String(els.activityPath?.value || "").trim().replaceAll("\\", "/");
+}
+
+function isDraftActivityPath(path) {
+  return String(path || "").trim().replaceAll("\\", "/").startsWith("activities/drafts/");
+}
+
+function updateDeleteActivityButton() {
+  if (!els.deleteActivityBtn) return;
+  const path = normalizedActivityPathValue();
+  const activity = currentActivity();
+  const canDelete = Boolean(activity && isDraftActivityPath(path));
+  els.deleteActivityBtn.disabled = !canDelete;
+  if (!path) {
+    els.deleteActivityBtn.title = "Seleziona una bozza activity da cancellare.";
+  } else if (!activity) {
+    els.deleteActivityBtn.title = "Seleziona una activity salvata dall'elenco prima di cancellarla.";
+  } else if (!isDraftActivityPath(path)) {
+    els.deleteActivityBtn.title = "Puoi cancellare solo bozze activity dentro activities/drafts.";
+  } else {
+    els.deleteActivityBtn.title = "Cancella questa bozza activity se non ha consegne o registri collegati.";
+  }
+}
+
 function renderActivitySelect() {
   els.activitySelect.innerHTML = '<option value="">Scegli activity</option>';
   for (const activity of state.activities) {
@@ -2076,6 +2102,48 @@ function renderActivitySelect() {
   }
   const current = els.activityPath.value.trim().replaceAll("\\", "/");
   els.activitySelect.value = state.activities.some((activity) => activity.path === current) ? current : "";
+  updateDeleteActivityButton();
+}
+
+async function deleteSelectedActivity() {
+  const activity = currentActivity();
+  const activityPath = normalizedActivityPathValue();
+  if (!activity || !activityPath) {
+    setActivityAuthorStatus("error", "Activity non cancellata", "Seleziona prima una activity salvata dall'elenco.");
+    return;
+  }
+  if (!isDraftActivityPath(activityPath)) {
+    setActivityAuthorStatus("error", "Activity non cancellata", "Puoi cancellare solo bozze activity dentro activities/drafts.");
+    return;
+  }
+  const label = activity.title || activity.id || activityPath;
+  const confirmed = window.confirm(
+    `Cancellare l'activity "${label}"?\n\n` +
+      "Viene rimosso solo il file della bozza. Se esistono consegne o registri collegati, il server blocca la cancellazione.",
+  );
+  if (!confirmed) return;
+  els.deleteActivityBtn.disabled = true;
+  setActivityAuthorStatus("saving", "Cancellazione activity", "Controllo collegamenti e rimozione della bozza in corso...");
+  try {
+    const payload = await api("/api/activities/delete", {
+      method: "POST",
+      body: JSON.stringify({ activity_path: activityPath }),
+    });
+    state.activities = payload.activities || [];
+    els.activityPath.value = "";
+    els.activitySelect.value = "";
+    state.activityReviewSaved = false;
+    renderActivitySelect();
+    renderCoverage();
+    renderActivityPanelSummary();
+    resetAssignmentConfirmStatus("Activity cancellata: scegli o crea una nuova activity prima di continuare.");
+    setActivityAuthorStatus("success", "Activity cancellata", `Bozza rimossa: ${payload.deleted?.path || activityPath}.`);
+    setStatus(`Activity cancellata: ${label}.`);
+  } catch (error) {
+    setActivityAuthorStatus("error", "Activity non cancellata", error.message);
+    setStatus(`Errore cancellazione activity: ${error.message}`);
+    updateDeleteActivityButton();
+  }
 }
 
 function activityCoverageKey(activity) {
@@ -4280,6 +4348,7 @@ function selectActivity(path) {
   els.activityPath.value = path;
   const activity = state.activities.find((candidate) => candidate.path === path);
   if (activity) state.activityReviewSaved = true;
+  renderActivitySelect();
   if (activity?.id) {
     const language = activity.language || activity.linguaggio || "";
     if (language) setSelectValueIfAvailable(els.activityAuthorLanguage, language);
@@ -4465,6 +4534,7 @@ els.assignmentSelect?.addEventListener("change", () => {
   setStatus(assignment ? `Assegnazione selezionata: ${assignment.id}.` : "Nessuna assegnazione selezionata.");
 });
 els.saveActivityBtn?.addEventListener("click", saveActivityDraft);
+els.deleteActivityBtn?.addEventListener("click", deleteSelectedActivity);
 els.activityAuthorTitle?.addEventListener("input", () => {
   syncActivityAuthorIdSuggestion();
   markActivityReviewDirty();


### PR DESCRIPTION
## Cosa cambia
- Aggiunge l'endpoint `POST /api/activities/delete` per cancellare solo bozze activity in `activities/drafts`.
- Blocca la cancellazione se l'activity e ancora collegata ad assegnazioni o registri.
- Aggiunge il bottone `Cancella activity` nella dashboard, abilitato solo per bozze cancellabili.
- Aggiorna i test backend e frontend per casi positivi, blocchi e conferma utente.

## Test
- `python -m pytest tests/test_course_board_server.py tests/test_assignment_dashboard_frontend.py -q`
- `git diff --check`