### PR TITLE
Guida la conferma assegnazione dal wizard

### DIFF
--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -1303,10 +1303,11 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert "File aggiuntivi liberi" in assignment_section
     assert 'id="assignmentAiStudentBudget"' in assignment_section
     assert 'id="assignmentIntegrityMode"' in assignment_section
-    assert 'id="saveAssignmentBtn" type="button"' in assignment_section
-    assert 'id="distributeAssignmentBtn" type="button" disabled' in assignment_section
+    assert 'id="saveAssignmentBtn" type="button" hidden' in assignment_section
+    assert 'id="distributeAssignmentBtn" type="button" hidden disabled' in assignment_section
     assert "1 Salva assegnazione" in assignment_section
     assert "2 Distribuisci ai target" in assignment_section
+    assert "Usa il bottone Avanti" in assignment_section
 
 
 def test_assignment_wizard_uses_calendar_date_time_inputs() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -1307,7 +1307,7 @@ def test_assignment_wizard_contains_teacher_editable_ai_step() -> None:
     assert 'id="distributeAssignmentBtn" type="button" hidden disabled' in assignment_section
     assert "1 Salva assegnazione" in assignment_section
     assert "2 Distribuisci ai target" in assignment_section
-    assert "Usa il bottone Avanti" in assignment_section
+    assert "Usa il bottone principale in basso" in assignment_section
 
 
 def test_assignment_wizard_uses_calendar_date_time_inputs() -> None:

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -241,11 +241,11 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           </div>
           <div id="assignmentConfirmStatus" class="activityEditorStatus assignmentConfirmStatus" role="status" aria-live="polite">
             <strong>Pronto per la conferma</strong>
-            <span>Prima salva l'assegnazione, poi distribuisci ai target se vuoi copiare traccia e asset nei repository.</span>
+            <span>Usa il bottone Avanti: prima salva l'assegnazione, poi distribuisci ai target se vuoi copiare traccia e asset nei repository.</span>
           </div>
           <div class="generateActions">
-            <button id="saveAssignmentBtn" type="button" title="Salva l'assegnazione per classe, team o studenti senza distribuire ancora asset nei repository.">1 Salva assegnazione</button>
-            <button id="distributeAssignmentBtn" type="button" disabled title="Copia traccia, README e asset studente nelle cartelle dei repository target dopo il salvataggio.">2 Distribuisci ai target</button>
+            <button id="saveAssignmentBtn" type="button" hidden title="Salva l'assegnazione per classe, team o studenti senza distribuire ancora asset nei repository.">1 Salva assegnazione</button>
+            <button id="distributeAssignmentBtn" type="button" hidden disabled title="Copia traccia, README e asset studente nelle cartelle dei repository target dopo il salvataggio.">2 Distribuisci ai target</button>
           </div>
         </section>
         <nav class="assignmentWizardNav" aria-label="Navigazione wizard assegnazione">

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -241,7 +241,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
           </div>
           <div id="assignmentConfirmStatus" class="activityEditorStatus assignmentConfirmStatus" role="status" aria-live="polite">
             <strong>Pronto per la conferma</strong>
-            <span>Usa il bottone Avanti: prima salva l'assegnazione, poi distribuisci ai target se vuoi copiare traccia e asset nei repository.</span>
+            <span>Usa il bottone principale in basso: prima salva l'assegnazione, poi distribuisci ai target se vuoi copiare traccia e asset nei repository.</span>
           </div>
           <div class="generateActions">
             <button id="saveAssignmentBtn" type="button" hidden title="Salva l'assegnazione per classe, team o studenti senza distribuire ancora asset nei repository.">1 Salva assegnazione</button>


### PR DESCRIPTION
## Cosa cambia
- Nel passo 7 del wizard l'utente non vede piu due bottoni operativi separati.
- Il messaggio di conferma indica esplicitamente di usare il bottone `Avanti`.
- I bottoni tecnici restano nel DOM ma nascosti, cosi la logica esistente continua a usare le stesse funzioni.
- Aggiorna il test frontend che verifica la struttura del wizard.

## Test
- `python -m pytest tests/test_assignment_dashboard_frontend.py -q`
- `git diff --check`