### PR TITLE
Aggiungi contratto lab studente MVP

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -1,0 +1,40 @@
+# Lab studente MVP
+
+Il lab studente nasce come backend riusabile prima della TUI e prima della GUI web completa.
+
+Il primo contratto e prodotto da:
+
+```powershell
+python scripts/student_lab_service.py --student-id rossi-mario
+```
+
+Il payload ha schema `student_lab.v1` e contiene:
+
+- `student_id`: studente richiesto;
+- `assignments`: consegne operative visibili allo studente;
+- `workspace`: cartella locale `assignments/<activity_id>` in cui lo studente lavora;
+- `activity`: metadati minimi della activity collegata;
+- `report`: report locale `reports/<activity_id>/latest.json`, se esiste;
+- `grading`: riepilogo deterministico del report, se esiste;
+- `runner`: stato del runner lab.
+
+In questa prima PR il runner non esegue ancora codice: espone `not_run`.
+
+## Stati minimi
+
+| Stato | Significato |
+|---|---|
+| `pending` | La consegna non ha report ed e prima della scadenza |
+| `missing` | La consegna non ha report ed e oltre la scadenza |
+| `submitted` | Esiste un report coerente con la activity |
+| `submitted_late` | Esiste un report coerente, ma consegnato dopo la scadenza |
+
+## Direzione
+
+Le prossime PR dovranno usare questo contratto per:
+
+1. aggiungere una CLI/TUI studente;
+2. introdurre un runner locale;
+3. introdurre un runner Docker minimale;
+4. salvare risultati strutturati prodotti dal lab;
+5. far leggere gli stessi risultati alla dashboard studente e al registro docente.

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import assignment_records, track_assignments
+from scripts.thebitlab_contracts import normalize_activity
+
+
+DEFAULT_STUDENT_REPOS_DIR = Path("examples/assignment_tracking/student_repos")
+
+
+def clean_text(value: Any) -> str:
+    """Return a stripped text value for optional record fields."""
+
+    return str(value or "").strip()
+
+
+def url_path(path: Path) -> str:
+    """Return a path with URL-style separators."""
+
+    return str(path).replace("\\", "/")
+
+
+def relative_to_root(root: Path, path: Path) -> str:
+    """Return a repository-relative path when possible."""
+
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    try:
+        return url_path(resolved_path.relative_to(resolved_root))
+    except ValueError:
+        return url_path(resolved_path)
+
+
+def resolve_local_path(root: Path, path_value: str) -> Path:
+    """Resolve a local path from the project root without requiring it to exist."""
+
+    path = Path(path_value)
+    return path.resolve(strict=False) if path.is_absolute() else (root / path).resolve(strict=False)
+
+
+def target_student_id(target: dict[str, Any]) -> str:
+    """Return the best student identifier exposed by an assignment target."""
+
+    for key in ("student_id", "target", "display_name"):
+        value = clean_text(target.get(key))
+        if value:
+            return Path(value).name if key in {"target"} else value
+    path_value = clean_text(target.get("path"))
+    if path_value:
+        return Path(path_value).name
+    repo_ref = clean_text(target.get("repo_ref"))
+    if repo_ref:
+        return repo_ref.rstrip("/").split("/")[-1]
+    return ""
+
+
+def target_matches_student(target: dict[str, Any], student_id: str) -> bool:
+    """Return whether an assignment target belongs to the requested student."""
+
+    clean_student_id = clean_text(student_id)
+    candidates = {
+        clean_text(target.get("student_id")),
+        clean_text(target.get("display_name")),
+        target_student_id(target),
+    }
+    for key in ("path", "target", "repo_ref"):
+        value = clean_text(target.get(key))
+        if value:
+            candidates.add(Path(value).name)
+            candidates.add(value.rstrip("/").split("/")[-1])
+    return clean_student_id in {candidate for candidate in candidates if candidate}
+
+
+def target_repo_path(root: Path, target: dict[str, Any], student_id: str) -> Path | None:
+    """Return the local repository path declared by a target, if available."""
+
+    for key in ("path", "target"):
+        value = clean_text(target.get(key))
+        if value:
+            return resolve_local_path(root, value)
+    if clean_text(student_id):
+        return (root / DEFAULT_STUDENT_REPOS_DIR / student_id).resolve(strict=False)
+    return None
+
+
+def load_activity_summary(root: Path, activity_path_value: str) -> dict[str, Any]:
+    """Load a compact activity summary for a lab assignment."""
+
+    activity_path = resolve_local_path(root, activity_path_value)
+    if not activity_path.is_file():
+        return {
+            "path": url_path(activity_path_value),
+            "exists": False,
+            "title": "",
+            "kind": "",
+            "language": "",
+            "source_name": "",
+            "topics": [],
+        }
+    payload = json.loads(activity_path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Activity non valida: {activity_path}")
+    activity = normalize_activity(payload)
+    return {
+        "path": relative_to_root(root, activity_path),
+        "exists": True,
+        "title": clean_text(activity.get("title")),
+        "kind": clean_text(activity.get("kind")),
+        "language": clean_text(activity.get("language")),
+        "source_name": clean_text(activity.get("source_name")),
+        "topics": activity.get("topics") if isinstance(activity.get("topics"), list) else [],
+    }
+
+
+def parse_now(now: str | None = None) -> str:
+    """Return an ISO datetime for status computation."""
+
+    return clean_text(now) or datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+def status_without_report(due_at: str, now: str) -> str:
+    """Return the lab status for an assignment without a report."""
+
+    due = assignment_records.parse_iso_datetime(due_at, "due_at")
+    current_time = assignment_records.parse_iso_datetime(now, "now")
+    assignment_records.require_same_timezone_kind(current_time, due, "now", "due_at")
+    return "missing" if current_time >= due else "pending"
+
+
+def status_with_report(report: dict[str, Any], due_at: str, now: str) -> str:
+    """Return the lab status for an assignment with a valid report."""
+
+    submitted_at = clean_text(report.get("submitted_at")) or None
+    _, late = track_assignments.submission_status(
+        submitted=True,
+        submitted_at=submitted_at,
+        due_at=due_at,
+        now=now,
+    )
+    return "submitted_late" if late else "submitted"
+
+
+def load_report(report_path: Path, activity_id: str) -> dict[str, Any] | None:
+    """Load and validate the latest student report, if present."""
+
+    report = track_assignments.load_report(report_path)
+    if report is None:
+        return None
+    track_assignments.validate_report_activity(report, activity_id, report_path)
+    return report
+
+
+def build_lab_assignment(
+    *,
+    root: Path,
+    assignment: dict[str, Any],
+    target: dict[str, Any],
+    student_id: str,
+    now: str,
+) -> dict[str, Any]:
+    """Build the student-lab contract for one assignment target."""
+
+    normalized = assignment_records.validate_assignment_record(assignment)
+    activity_id = normalized["activity_id"]
+    repo_path = target_repo_path(root, target, student_id)
+    workspace_path = repo_path / "assignments" / activity_id if repo_path is not None else None
+    report_path = repo_path / "reports" / activity_id / "latest.json" if repo_path is not None else None
+    report = load_report(report_path, activity_id) if report_path is not None else None
+    submitted_at = clean_text(report.get("submitted_at")) if report else ""
+    status = status_with_report(report, normalized["due_at"], now) if report else status_without_report(normalized["due_at"], now)
+    activity = load_activity_summary(root, normalized["activity_path"])
+    grading = track_assignments.grading_summary(report)
+    return {
+        "assignment_id": normalized["id"],
+        "activity_id": activity_id,
+        "title": activity["title"] or activity_id,
+        "student_id": student_id,
+        "target_type": normalized["target_type"],
+        "class_id": normalized["class_id"],
+        "class_label": normalized["class_label"],
+        "github_team": normalized["github_team"],
+        "assigned_at": normalized["assigned_at"],
+        "due_at": normalized["due_at"],
+        "status": status,
+        "submitted": report is not None,
+        "workspace": {
+            "path": relative_to_root(root, workspace_path) if workspace_path is not None else "",
+            "exists": bool(workspace_path and workspace_path.is_dir()),
+        },
+        "activity": activity,
+        "report": {
+            "path": relative_to_root(root, report_path) if report_path is not None else "",
+            "exists": report is not None,
+            "submitted_at": submitted_at,
+            "commit": report.get("commit") if report else None,
+        },
+        "grading": grading,
+        "runner": {
+            "status": "not_run",
+            "backend": "student_lab_service",
+        },
+    }
+
+
+def list_student_lab_assignments(
+    *,
+    root: Path = PROJECT_ROOT,
+    student_id: str,
+    assignments_dir: Path | None = None,
+    now: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return normalized lab assignments visible to one student."""
+
+    clean_student_id = clean_text(student_id)
+    if not clean_student_id:
+        raise ValueError("student_id obbligatorio.")
+    current_time = parse_now(now)
+    storage = assignment_records.JsonAssignmentRecordStorage(root, assignments_dir)
+    lab_assignments = []
+    for assignment in storage.list_assignments():
+        targets = assignment.get("targets") if isinstance(assignment.get("targets"), list) else []
+        for target in targets:
+            if isinstance(target, dict) and target_matches_student(target, clean_student_id):
+                lab_assignments.append(
+                    build_lab_assignment(
+                        root=root,
+                        assignment=assignment,
+                        target=target,
+                        student_id=clean_student_id,
+                        now=current_time,
+                    )
+                )
+    lab_assignments.sort(key=lambda item: (item.get("due_at") or "", item.get("activity_id") or ""))
+    return lab_assignments
+
+
+def student_lab_payload(
+    *,
+    root: Path = PROJECT_ROOT,
+    student_id: str,
+    assignments_dir: Path | None = None,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Return the complete student-lab payload for frontend or CLI consumers."""
+
+    return {
+        "schema_version": "student_lab.v1",
+        "student_id": clean_text(student_id),
+        "generated_at": parse_now(now),
+        "assignments": list_student_lab_assignments(
+            root=root,
+            student_id=student_id,
+            assignments_dir=assignments_dir,
+            now=now,
+        ),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the student lab service preview."""
+
+    parser = argparse.ArgumentParser(description="Mostra le consegne operative del lab studente.")
+    parser.add_argument("--student-id", required=True, help="Identificativo studente, per esempio rossi-mario.")
+    parser.add_argument("--root", type=Path, default=PROJECT_ROOT, help="Root del repository TheBitLab.")
+    parser.add_argument("--assignments-dir", type=Path, help="Cartella teacher-assignments alternativa.")
+    parser.add_argument("--now", help="Data ISO da usare per calcolare scadenze e mancanti.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the student lab service preview CLI."""
+
+    args = parse_args()
+    try:
+        payload = student_lab_payload(
+            root=args.root.resolve(strict=False),
+            student_id=args.student_id,
+            assignments_dir=args.assignments_dir,
+            now=args.now,
+        )
+    except ValueError as error:
+        print(f"Lab studente non disponibile:\n{error}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+
+from scripts import assignment_records, student_lab_service
+
+
+def write_activity(root, activity_id: str = "python-base-somma-001") -> str:
+    """Write a minimal activity and return its repository-relative path."""
+
+    path = root / "activities" / f"{activity_id}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": activity_id,
+                "title": "Somma in Python",
+                "kind": "laboratorio",
+                "difficulty": "B",
+                "topics": ["variabili", "input-output"],
+                "language": "python",
+                "source_name": "main.py",
+                "instructions": "Scrivi un programma che stampa una somma.",
+                "grading_policy": {
+                    "compila": True,
+                    "test": True,
+                    "sandbox": True,
+                    "ai_feedback": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return "activities/python-base-somma-001.json"
+
+
+def sample_assignment(root, **overrides):
+    """Return a valid assignment record for lab tests."""
+
+    payload = {
+        "activity_id": "python-base-somma-001",
+        "activity_path": write_activity(root),
+        "target_type": "group",
+        "assigned_at": "2026-10-12T09:00:00+02:00",
+        "due_at": "2026-10-19T23:59:00+02:00",
+        "targets": [
+            {
+                "student_id": "rossi-mario",
+                "display_name": "Rossi Mario",
+                "repo_ref": "TheBitPoets/rossi-mario",
+                "path": "examples/assignment_tracking/student_repos/rossi-mario",
+            },
+            {
+                "student_id": "bianchi-luca",
+                "display_name": "Bianchi Luca",
+                "repo_ref": "TheBitPoets/bianchi-luca",
+                "path": "examples/assignment_tracking/student_repos/bianchi-luca",
+            },
+        ],
+    }
+    payload.update(overrides)
+    return assignment_records.build_assignment_record(**payload)
+
+
+def write_assignment(root, assignment):
+    """Persist one assignment record in the temporary root."""
+
+    storage = assignment_records.JsonAssignmentRecordStorage(root)
+    return storage.write_assignment(assignment)
+
+
+def test_student_lab_lists_only_requested_student_assignments(tmp_path) -> None:
+    write_assignment(tmp_path, sample_assignment(tmp_path))
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / "python-base-somma-001"
+    workspace.mkdir(parents=True)
+
+    payload = student_lab_service.student_lab_payload(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-18T12:00:00+02:00",
+    )
+
+    assert payload["schema_version"] == "student_lab.v1"
+    assert payload["student_id"] == "rossi-mario"
+    assert len(payload["assignments"]) == 1
+    assignment = payload["assignments"][0]
+    assert assignment["assignment_id"].startswith("assignment-python-base-somma-001-group-")
+    assert assignment["activity_id"] == "python-base-somma-001"
+    assert assignment["title"] == "Somma in Python"
+    assert assignment["status"] == "pending"
+    assert assignment["submitted"] is False
+    assert assignment["workspace"] == {
+        "path": "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001",
+        "exists": True,
+    }
+    assert assignment["activity"]["exists"] is True
+    assert assignment["activity"]["language"] == "python"
+    assert assignment["report"]["exists"] is False
+    assert assignment["runner"]["status"] == "not_run"
+
+
+def test_student_lab_marks_missing_after_due_date_without_report(tmp_path) -> None:
+    write_assignment(tmp_path, sample_assignment(tmp_path))
+
+    assignments = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="bianchi-luca",
+        now="2026-10-20T12:00:00+02:00",
+    )
+
+    assert len(assignments) == 1
+    assert assignments[0]["status"] == "missing"
+    assert assignments[0]["workspace"]["exists"] is False
+    assert assignments[0]["grading"]["status"] == "not_graded"
+
+
+def test_student_lab_uses_existing_report_and_grading_summary(tmp_path) -> None:
+    write_assignment(tmp_path, sample_assignment(tmp_path))
+    repo = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario"
+    workspace = repo / "assignments" / "python-base-somma-001"
+    report_path = repo / "reports" / "python-base-somma-001" / "latest.json"
+    workspace.mkdir(parents=True)
+    report_path.parent.mkdir(parents=True)
+    (workspace / "main.py").write_text("print(3)\n", encoding="utf-8")
+    report_path.write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "status": "passed",
+                "passed": True,
+                "source": "assignments/python-base-somma-001/main.py",
+                "submitted_at": "2026-10-18T18:00:00+02:00",
+                "commit": "abc1234",
+                "summary": {"passed": 2, "total": 2},
+                "tests": [
+                    {"name": "somma positiva", "status": "passed", "passed": True},
+                    {"name": "somma negativa", "status": "passed", "passed": True},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assignments = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-20T12:00:00+02:00",
+    )
+
+    assignment = assignments[0]
+    assert assignment["status"] == "submitted"
+    assert assignment["submitted"] is True
+    assert assignment["report"]["path"] == "examples/assignment_tracking/student_repos/rossi-mario/reports/python-base-somma-001/latest.json"
+    assert assignment["report"]["submitted_at"] == "2026-10-18T18:00:00+02:00"
+    assert assignment["report"]["commit"] == "abc1234"
+    assert assignment["grading"]["status"] == "graded_passed"
+    assert assignment["grading"]["tests_passed"] == 2
+    assert assignment["grading"]["tests_total"] == 2
+
+
+def test_student_lab_keeps_assignment_when_local_repo_path_is_only_inferred(tmp_path) -> None:
+    write_assignment(
+        tmp_path,
+        sample_assignment(
+            tmp_path,
+            target_type="student",
+            targets=[{"student_id": "neri-giulia", "repo_ref": "TheBitPoets/neri-giulia"}],
+        ),
+    )
+
+    assignments = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="neri-giulia",
+        now="2026-10-18T12:00:00+02:00",
+    )
+
+    assert len(assignments) == 1
+    assert assignments[0]["workspace"]["path"] == "examples/assignment_tracking/student_repos/neri-giulia/assignments/python-base-somma-001"
+    assert assignments[0]["workspace"]["exists"] is False
+
+
+def test_student_lab_rejects_missing_student_id(tmp_path) -> None:
+    try:
+        student_lab_service.list_student_lab_assignments(root=tmp_path, student_id="")
+    except ValueError as error:
+        assert "student_id obbligatorio" in str(error)
+    else:
+        raise AssertionError("student lab should require a student id")


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `scripts/student_lab_service.py`, primo backend MVP per il lab studente.
- Espone il contratto `student_lab.v1` con consegne dello studente, workspace, activity, report, grading e stato runner.
- Aggiunge test unitari per filtro studente, workspace, report, stato mancante/pending e target senza path locale esplicito.
- Documenta il payload in `doc/STUDENT_LAB.md`.

## Perche

Serve un motore riusabile prima di costruire CLI/TUI e GUI: dashboard studente, registro docente e futuro lab devono leggere lo stesso contratto invece di duplicare logica.

## Limiti intenzionali

- Il runner non esegue ancora codice: espone `not_run`.
- Docker e salvataggio risultati lab arrivano nelle prossime PR.

## Verifica

- `python -m pytest tests/test_student_lab_service.py tests/test_assignment_records.py tests/test_track_assignments.py`
- `git diff --check -- scripts/student_lab_service.py tests/test_student_lab_service.py doc/STUDENT_LAB.md`
