### PR TITLE
Aggiungi TUI minima lab studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -37,7 +37,7 @@ Il payload ha schema `student_lab.v1` e contiene:
 - `grading`: riepilogo deterministico del report, se esiste;
 - `runner`: stato del runner lab.
 
-In questa prima PR il runner non esegue ancora codice: espone `not_run`.
+In questa prima fase il runner non esegue ancora codice: espone `not_run`.
 La TUI minima permette di consultare e aprire il workspace, ma non esegue ancora test.
 
 ## Stati minimi
@@ -53,8 +53,8 @@ La TUI minima permette di consultare e aprire il workspace, ma non esegue ancora
 
 Le prossime PR dovranno usare questo contratto per:
 
-1. aggiungere una CLI/TUI studente;
-2. introdurre un runner locale;
+1. introdurre un runner locale;
+2. salvare risultati strutturati prodotti dal lab;
 3. introdurre un runner Docker minimale;
-4. salvare risultati strutturati prodotti dal lab;
-5. far leggere gli stessi risultati alla dashboard studente e al registro docente.
+4. far leggere gli stessi risultati alla dashboard studente e al registro docente;
+5. valutare un adapter opzionale per layout terminale avanzato, per esempio tmux su ambienti compatibili.

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -8,6 +8,19 @@ Il primo contratto e prodotto da:
 python scripts/student_lab_service.py --student-id rossi-mario
 ```
 
+La prima interfaccia semigrafica e:
+
+```powershell
+python scripts/student_lab_cli.py --student-id rossi-mario
+```
+
+Comandi disponibili nella TUI minima:
+
+- numero della riga: apre il dettaglio della consegna;
+- `r`: ricarica le consegne;
+- `q`: esce;
+- `o` dal dettaglio: apre la cartella workspace, se esiste.
+
 Il payload ha schema `student_lab.v1` e contiene:
 
 - `student_id`: studente richiesto;
@@ -19,6 +32,7 @@ Il payload ha schema `student_lab.v1` e contiene:
 - `runner`: stato del runner lab.
 
 In questa prima PR il runner non esegue ancora codice: espone `not_run`.
+La TUI minima permette di consultare e aprire il workspace, ma non esegue ancora test.
 
 ## Stati minimi
 

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -14,6 +14,12 @@ La prima interfaccia semigrafica e:
 python scripts/student_lab_cli.py --student-id rossi-mario
 ```
 
+La TUI usa colori ANSI quando il terminale li supporta. Per disattivarli:
+
+```powershell
+python scripts/student_lab_cli.py --student-id rossi-mario --no-color
+```
+
 Comandi disponibili nella TUI minima:
 
 - numero della riga: apre il dettaglio della consegna;

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 
@@ -82,6 +83,18 @@ def truncate(text: str, width: int) -> str:
     return clean[: width - 3] + "..."
 
 
+def compact_datetime(value: Any) -> str:
+    """Return a compact date/time label for the terminal."""
+
+    text = clean_text(value, "")
+    if not text:
+        return "-"
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).strftime("%Y-%m-%d %H:%M")
+    except ValueError:
+        return text
+
+
 def render_header(student_id: str, assignments: list[dict[str, Any]]) -> str:
     """Render the static header for the student lab TUI."""
 
@@ -118,11 +131,11 @@ def render_assignment_row(index: int, assignment: dict[str, Any], use_color: boo
 
     title = truncate(clean_text(assignment.get("title") or assignment.get("activity_id")), 34)
     status = truncate(colored_status(clean_text(assignment.get("status")), use_color), 31 if use_color else 22)
-    due_at = truncate(clean_text(assignment.get("due_at")), 25)
+    due_at = truncate(compact_datetime(assignment.get("due_at")), 16)
     workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
     workspace_mark = colorize("workspace", WORKSPACE_COLOR, use_color) if workspace.get("exists") else "no workspace"
     status_width = 31 if use_color else 22
-    return f"{index:>2}. {title:<34} | {status:<{status_width}} | {due_at:<25} | {workspace_mark}"
+    return f"{index:>2}. {title:<34} | {status:<{status_width}} | {due_at:<16} | {workspace_mark}"
 
 
 def render_assignment_list(payload: dict[str, Any], use_color: bool = False) -> str:
@@ -140,8 +153,8 @@ def render_assignment_list(payload: dict[str, Any], use_color: bool = False) -> 
     if not assignments:
         lines.append("Nessuna consegna disponibile per questo studente.")
         return "\n".join(lines)
-    lines.append(" #  Titolo                             | Stato                  | Scadenza                  | Workspace")
-    lines.append("-" * 104)
+    lines.append(" #  Titolo                             | Stato                  | Scadenza         | Workspace")
+    lines.append("-" * 95)
     for index, assignment in enumerate(assignments, start=1):
         lines.append(render_assignment_row(index, assignment, use_color))
     return "\n".join(lines)
@@ -169,8 +182,8 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Activity:", assignment.get("activity_id")),
         detail_line("Assegnazione:", assignment.get("assignment_id")),
         detail_line("Classe:", assignment.get("class_label") or assignment.get("class_id")),
-        detail_line("Assegnata:", assignment.get("assigned_at")),
-        detail_line("Scadenza:", assignment.get("due_at")),
+        detail_line("Assegnata:", compact_datetime(assignment.get("assigned_at"))),
+        detail_line("Scadenza:", compact_datetime(assignment.get("due_at"))),
         detail_line("Stato:", colored_status(clean_text(assignment.get("status")), use_color)),
         "",
         "Workspace",
@@ -187,7 +200,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         "Report",
         detail_line("Path:", report.get("path")),
         detail_line("Esiste:", "si" if report.get("exists") else "no"),
-        detail_line("Consegnata:", report.get("submitted_at")),
+        detail_line("Consegnata:", compact_datetime(report.get("submitted_at"))),
         detail_line("Commit:", report.get("commit")),
         "",
         "Grading",

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -24,6 +24,14 @@ STATUS_LABELS = {
     "submitted": "Consegnata",
     "submitted_late": "Consegnata in ritardo",
 }
+STATUS_COLORS = {
+    "pending": "\033[33m",
+    "missing": "\033[31m",
+    "submitted": "\033[32m",
+    "submitted_late": "\033[35m",
+}
+WORKSPACE_COLOR = "\033[36m"
+RESET_COLOR = "\033[0m"
 
 
 def clean_text(value: Any, fallback: str = "-") -> str:
@@ -37,6 +45,19 @@ def status_label(status: str) -> str:
     """Return the human label for a lab assignment status."""
 
     return STATUS_LABELS.get(status, clean_text(status))
+
+
+def colorize(text: str, color: str, use_color: bool) -> str:
+    """Wrap text in ANSI color codes when color output is enabled."""
+
+    return f"{color}{text}{RESET_COLOR}" if use_color and color else text
+
+
+def colored_status(status: str, use_color: bool) -> str:
+    """Return the status label, optionally colorized for terminal output."""
+
+    clean_status = clean_text(status, "")
+    return colorize(status_label(clean_status), STATUS_COLORS.get(clean_status, ""), use_color)
 
 
 def grading_label(grading: dict[str, Any]) -> str:
@@ -76,18 +97,35 @@ def render_header(student_id: str, assignments: list[dict[str, Any]]) -> str:
     )
 
 
-def render_assignment_row(index: int, assignment: dict[str, Any]) -> str:
+def render_legend(use_color: bool = False) -> str:
+    """Render a compact legend for status and workspace labels."""
+
+    return "\n".join(
+        [
+            "Legenda:",
+            f"- {colored_status('pending', use_color)}: consegna assegnata, scadenza futura, nessun report ancora salvato.",
+            f"- {colored_status('missing', use_color)}: scadenza superata senza report/consegna.",
+            f"- {colored_status('submitted', use_color)}: esiste un report coerente con la consegna.",
+            f"- {colored_status('submitted_late', use_color)}: report presente ma consegnato dopo la scadenza.",
+            f"- {colorize('workspace', WORKSPACE_COLOR, use_color)}: cartella locale della consegna presente.",
+            "- no workspace: cartella locale non ancora presente o non trovata.",
+        ]
+    )
+
+
+def render_assignment_row(index: int, assignment: dict[str, Any], use_color: bool = False) -> str:
     """Render one compact assignment row."""
 
     title = truncate(clean_text(assignment.get("title") or assignment.get("activity_id")), 34)
-    status = truncate(status_label(clean_text(assignment.get("status"))), 22)
+    status = truncate(colored_status(clean_text(assignment.get("status")), use_color), 31 if use_color else 22)
     due_at = truncate(clean_text(assignment.get("due_at")), 25)
     workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
-    workspace_mark = "workspace" if workspace.get("exists") else "no workspace"
-    return f"{index:>2}. {title:<34} | {status:<22} | {due_at:<25} | {workspace_mark}"
+    workspace_mark = colorize("workspace", WORKSPACE_COLOR, use_color) if workspace.get("exists") else "no workspace"
+    status_width = 31 if use_color else 22
+    return f"{index:>2}. {title:<34} | {status:<{status_width}} | {due_at:<25} | {workspace_mark}"
 
 
-def render_assignment_list(payload: dict[str, Any]) -> str:
+def render_assignment_list(payload: dict[str, Any], use_color: bool = False) -> str:
     """Render the main assignment list."""
 
     assignments = payload.get("assignments") if isinstance(payload.get("assignments"), list) else []
@@ -96,6 +134,8 @@ def render_assignment_list(payload: dict[str, Any]) -> str:
         "",
         "Comandi: numero = dettaglio | r = ricarica | q = esci",
         "",
+        render_legend(use_color),
+        "",
     ]
     if not assignments:
         lines.append("Nessuna consegna disponibile per questo studente.")
@@ -103,7 +143,7 @@ def render_assignment_list(payload: dict[str, Any]) -> str:
     lines.append(" #  Titolo                             | Stato                  | Scadenza                  | Workspace")
     lines.append("-" * 104)
     for index, assignment in enumerate(assignments, start=1):
-        lines.append(render_assignment_row(index, assignment))
+        lines.append(render_assignment_row(index, assignment, use_color))
     return "\n".join(lines)
 
 
@@ -113,7 +153,7 @@ def detail_line(label: str, value: Any) -> str:
     return f"{label:<18} {clean_text(value)}"
 
 
-def render_assignment_detail(assignment: dict[str, Any]) -> str:
+def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False) -> str:
     """Render the detail page for one lab assignment."""
 
     workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
@@ -131,7 +171,7 @@ def render_assignment_detail(assignment: dict[str, Any]) -> str:
         detail_line("Classe:", assignment.get("class_label") or assignment.get("class_id")),
         detail_line("Assegnata:", assignment.get("assigned_at")),
         detail_line("Scadenza:", assignment.get("due_at")),
-        detail_line("Stato:", status_label(clean_text(assignment.get("status")))),
+        detail_line("Stato:", colored_status(clean_text(assignment.get("status")), use_color)),
         "",
         "Workspace",
         detail_line("Path:", workspace.get("path")),
@@ -169,6 +209,16 @@ def clear_screen() -> None:
     os.system("cls" if os.name == "nt" else "clear")
 
 
+def supports_color(no_color: bool = False) -> bool:
+    """Return whether ANSI colors should be emitted."""
+
+    if no_color:
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    return sys.stdout.isatty()
+
+
 def open_workspace(path_value: str, root: Path = PROJECT_ROOT) -> bool:
     """Open a workspace folder with the platform file manager."""
 
@@ -198,6 +248,7 @@ def run_tui(
     input_fn: InputFn = input,
     print_fn: PrintFn = print,
     clear: bool = True,
+    use_color: bool = False,
 ) -> int:
     """Run the interactive student lab loop."""
 
@@ -205,7 +256,7 @@ def run_tui(
     while True:
         if clear:
             clear_screen()
-        print_fn(render_assignment_list(payload))
+        print_fn(render_assignment_list(payload, use_color=use_color))
         choice = input_fn("\nScelta: ").strip().lower()
         if choice in {"q", "quit", "esci"}:
             return 0
@@ -221,7 +272,7 @@ def run_tui(
         assignment = assignments[index]
         if clear:
             clear_screen()
-        print_fn(render_assignment_detail(assignment))
+        print_fn(render_assignment_detail(assignment, use_color=use_color))
         action = input_fn("\nDettaglio: ").strip().lower()
         if action == "o":
             workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
@@ -238,6 +289,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--root", type=Path, default=PROJECT_ROOT, help="Root del repository TheBitLab.")
     parser.add_argument("--now", help="Data ISO da usare per calcolare scadenze e mancanti.")
     parser.add_argument("--no-clear", action="store_true", help="Non pulire lo schermo tra una vista e l'altra.")
+    parser.add_argument("--no-color", action="store_true", help="Disabilita colori ANSI.")
     return parser.parse_args()
 
 
@@ -251,6 +303,7 @@ def main() -> int:
             root=args.root.resolve(strict=False),
             now=args.now,
             clear=not args.no_clear,
+            use_color=supports_color(args.no_color),
         )
     except ValueError as error:
         print(f"Lab studente non disponibile:\n{error}", file=sys.stderr)

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -51,14 +51,14 @@ def grading_label(grading: dict[str, Any]) -> str:
 
 
 def truncate(text: str, width: int) -> str:
-    """Return text clipped to width with an ellipsis-like suffix."""
+    """Return text clipped to width with a suffix."""
 
     clean = clean_text(text)
-    if width <= 1:
+    if width <= 3:
         return clean[:width]
     if len(clean) <= width:
         return clean
-    return clean[: width - 1] + "…"
+    return clean[: width - 3] + "..."
 
 
 def render_header(student_id: str, assignments: list[dict[str, Any]]) -> str:
@@ -169,10 +169,11 @@ def clear_screen() -> None:
     os.system("cls" if os.name == "nt" else "clear")
 
 
-def open_workspace(path_value: str) -> bool:
+def open_workspace(path_value: str, root: Path = PROJECT_ROOT) -> bool:
     """Open a workspace folder with the platform file manager."""
 
-    path = Path(path_value)
+    raw_path = Path(path_value)
+    path = raw_path if raw_path.is_absolute() else (root / raw_path).resolve(strict=False)
     if not path.is_dir():
         return False
     if os.name == "nt":
@@ -224,7 +225,7 @@ def run_tui(
         action = input_fn("\nDettaglio: ").strip().lower()
         if action == "o":
             workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
-            if not open_workspace(clean_text(workspace.get("path"), "")):
+            if not open_workspace(clean_text(workspace.get("path"), ""), root=root):
                 print_fn("Workspace non disponibile.")
                 input_fn("Premi invio per continuare...")
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import student_lab_service
+
+
+InputFn = Callable[[str], str]
+PrintFn = Callable[[str], None]
+
+
+STATUS_LABELS = {
+    "pending": "Da fare",
+    "missing": "Mancante",
+    "submitted": "Consegnata",
+    "submitted_late": "Consegnata in ritardo",
+}
+
+
+def clean_text(value: Any, fallback: str = "-") -> str:
+    """Return a compact label for terminal output."""
+
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def status_label(status: str) -> str:
+    """Return the human label for a lab assignment status."""
+
+    return STATUS_LABELS.get(status, clean_text(status))
+
+
+def grading_label(grading: dict[str, Any]) -> str:
+    """Return a short grading summary for list and detail views."""
+
+    status = clean_text(grading.get("status"), "non valutata")
+    passed = grading.get("tests_passed")
+    total = grading.get("tests_total")
+    if passed is not None and total is not None:
+        return f"{status} ({passed}/{total} test)"
+    return status
+
+
+def truncate(text: str, width: int) -> str:
+    """Return text clipped to width with an ellipsis-like suffix."""
+
+    clean = clean_text(text)
+    if width <= 1:
+        return clean[:width]
+    if len(clean) <= width:
+        return clean
+    return clean[: width - 1] + "…"
+
+
+def render_header(student_id: str, assignments: list[dict[str, Any]]) -> str:
+    """Render the static header for the student lab TUI."""
+
+    submitted = sum(1 for item in assignments if item.get("submitted"))
+    missing = sum(1 for item in assignments if item.get("status") == "missing")
+    pending = sum(1 for item in assignments if item.get("status") == "pending")
+    return "\n".join(
+        [
+            "TheBitLab - lab studente",
+            f"Studente: {clean_text(student_id)}",
+            f"Consegne: {len(assignments)} | Da fare: {pending} | Mancanti: {missing} | Consegnate: {submitted}",
+        ]
+    )
+
+
+def render_assignment_row(index: int, assignment: dict[str, Any]) -> str:
+    """Render one compact assignment row."""
+
+    title = truncate(clean_text(assignment.get("title") or assignment.get("activity_id")), 34)
+    status = truncate(status_label(clean_text(assignment.get("status"))), 22)
+    due_at = truncate(clean_text(assignment.get("due_at")), 25)
+    workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+    workspace_mark = "workspace" if workspace.get("exists") else "no workspace"
+    return f"{index:>2}. {title:<34} | {status:<22} | {due_at:<25} | {workspace_mark}"
+
+
+def render_assignment_list(payload: dict[str, Any]) -> str:
+    """Render the main assignment list."""
+
+    assignments = payload.get("assignments") if isinstance(payload.get("assignments"), list) else []
+    lines = [
+        render_header(clean_text(payload.get("student_id")), assignments),
+        "",
+        "Comandi: numero = dettaglio | r = ricarica | q = esci",
+        "",
+    ]
+    if not assignments:
+        lines.append("Nessuna consegna disponibile per questo studente.")
+        return "\n".join(lines)
+    lines.append(" #  Titolo                             | Stato                  | Scadenza                  | Workspace")
+    lines.append("-" * 104)
+    for index, assignment in enumerate(assignments, start=1):
+        lines.append(render_assignment_row(index, assignment))
+    return "\n".join(lines)
+
+
+def detail_line(label: str, value: Any) -> str:
+    """Render one label/value line for the detail view."""
+
+    return f"{label:<18} {clean_text(value)}"
+
+
+def render_assignment_detail(assignment: dict[str, Any]) -> str:
+    """Render the detail page for one lab assignment."""
+
+    workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+    activity = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
+    report = assignment.get("report") if isinstance(assignment.get("report"), dict) else {}
+    grading = assignment.get("grading") if isinstance(assignment.get("grading"), dict) else {}
+    runner = assignment.get("runner") if isinstance(assignment.get("runner"), dict) else {}
+    topics = activity.get("topics") if isinstance(activity.get("topics"), list) else []
+    lines = [
+        "Dettaglio consegna",
+        "",
+        detail_line("Titolo:", assignment.get("title") or assignment.get("activity_id")),
+        detail_line("Activity:", assignment.get("activity_id")),
+        detail_line("Assegnazione:", assignment.get("assignment_id")),
+        detail_line("Classe:", assignment.get("class_label") or assignment.get("class_id")),
+        detail_line("Assegnata:", assignment.get("assigned_at")),
+        detail_line("Scadenza:", assignment.get("due_at")),
+        detail_line("Stato:", status_label(clean_text(assignment.get("status")))),
+        "",
+        "Workspace",
+        detail_line("Path:", workspace.get("path")),
+        detail_line("Esiste:", "si" if workspace.get("exists") else "no"),
+        "",
+        "Activity",
+        detail_line("Path:", activity.get("path")),
+        detail_line("Tipo:", activity.get("kind")),
+        detail_line("Linguaggio:", activity.get("language")),
+        detail_line("Sorgente:", activity.get("source_name")),
+        detail_line("Argomenti:", ", ".join(str(topic) for topic in topics) if topics else "-"),
+        "",
+        "Report",
+        detail_line("Path:", report.get("path")),
+        detail_line("Esiste:", "si" if report.get("exists") else "no"),
+        detail_line("Consegnata:", report.get("submitted_at")),
+        detail_line("Commit:", report.get("commit")),
+        "",
+        "Grading",
+        detail_line("Stato:", grading_label(grading)),
+        detail_line("Voto:", grading.get("teacher_grade") if grading.get("teacher_grade") is not None else grading.get("score")),
+        "",
+        "Runner",
+        detail_line("Stato:", runner.get("status")),
+        detail_line("Backend:", runner.get("backend")),
+        "",
+        "Comandi: o = apri workspace | invio = torna all'elenco",
+    ]
+    return "\n".join(lines)
+
+
+def clear_screen() -> None:
+    """Clear the terminal screen when possible."""
+
+    os.system("cls" if os.name == "nt" else "clear")
+
+
+def open_workspace(path_value: str) -> bool:
+    """Open a workspace folder with the platform file manager."""
+
+    path = Path(path_value)
+    if not path.is_dir():
+        return False
+    if os.name == "nt":
+        os.startfile(path)  # type: ignore[attr-defined]
+        return True
+    opener = "open" if sys.platform == "darwin" else "xdg-open"
+    subprocess.Popen([opener, str(path)])
+    return True
+
+
+def load_payload(root: Path, student_id: str, now: str | None = None) -> dict[str, Any]:
+    """Load the current student lab payload."""
+
+    return student_lab_service.student_lab_payload(root=root, student_id=student_id, now=now)
+
+
+def run_tui(
+    *,
+    student_id: str,
+    root: Path = PROJECT_ROOT,
+    now: str | None = None,
+    input_fn: InputFn = input,
+    print_fn: PrintFn = print,
+    clear: bool = True,
+) -> int:
+    """Run the interactive student lab loop."""
+
+    payload = load_payload(root, student_id, now)
+    while True:
+        if clear:
+            clear_screen()
+        print_fn(render_assignment_list(payload))
+        choice = input_fn("\nScelta: ").strip().lower()
+        if choice in {"q", "quit", "esci"}:
+            return 0
+        if choice in {"r", "reload", "ricarica"}:
+            payload = load_payload(root, student_id, now)
+            continue
+        if not choice.isdigit():
+            continue
+        index = int(choice) - 1
+        assignments = payload.get("assignments") if isinstance(payload.get("assignments"), list) else []
+        if index < 0 or index >= len(assignments):
+            continue
+        assignment = assignments[index]
+        if clear:
+            clear_screen()
+        print_fn(render_assignment_detail(assignment))
+        action = input_fn("\nDettaglio: ").strip().lower()
+        if action == "o":
+            workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+            if not open_workspace(clean_text(workspace.get("path"), "")):
+                print_fn("Workspace non disponibile.")
+                input_fn("Premi invio per continuare...")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the student lab TUI."""
+
+    parser = argparse.ArgumentParser(description="Apri la TUI minima del lab studente.")
+    parser.add_argument("--student-id", required=True, help="Identificativo studente, per esempio rossi-mario.")
+    parser.add_argument("--root", type=Path, default=PROJECT_ROOT, help="Root del repository TheBitLab.")
+    parser.add_argument("--now", help="Data ISO da usare per calcolare scadenze e mancanti.")
+    parser.add_argument("--no-clear", action="store_true", help="Non pulire lo schermo tra una vista e l'altra.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the student lab TUI from the command line."""
+
+    args = parse_args()
+    try:
+        return run_tui(
+            student_id=args.student_id,
+            root=args.root.resolve(strict=False),
+            now=args.now,
+            clear=not args.no_clear,
+        )
+    except ValueError as error:
+        print(f"Lab studente non disponibile:\n{error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -148,9 +148,21 @@ def test_open_workspace_rejects_missing_path(tmp_path) -> None:
     assert student_lab_cli.open_workspace(str(tmp_path / "missing")) is False
 
 
+def test_open_workspace_resolves_relative_path_from_root(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "student" / "assignments" / "python-base-somma-001"
+    workspace.mkdir(parents=True)
+    opened = []
+
+    monkeypatch.setattr(student_lab_cli.os, "startfile", opened.append, raising=False)
+    monkeypatch.setattr(student_lab_cli.os, "name", "nt")
+
+    assert student_lab_cli.open_workspace("student/assignments/python-base-somma-001", root=tmp_path) is True
+    assert opened == [workspace.resolve()]
+
+
 def test_truncate_keeps_short_text_and_clips_long_text() -> None:
     assert student_lab_cli.truncate("abc", 5) == "abc"
-    assert student_lab_cli.truncate("abcdef", 4) == "abc…"
+    assert student_lab_cli.truncate("abcdef", 5) == "ab..."
 
 
 def test_status_label_uses_human_labels() -> None:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -86,6 +86,9 @@ def test_render_assignment_list_summarizes_statuses() -> None:
     assert "Array in C" in rendered
     assert "workspace" in rendered
     assert "numero = dettaglio" in rendered
+    assert "Legenda:" in rendered
+    assert "Mancante: scadenza superata" in rendered
+    assert "no workspace: cartella locale" in rendered
 
 
 def test_render_assignment_list_handles_empty_payload() -> None:
@@ -107,6 +110,19 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "not_graded" in rendered
     assert "not_run" in rendered
     assert "o = apri workspace" in rendered
+
+
+def test_render_assignment_list_can_color_statuses() -> None:
+    rendered = student_lab_cli.render_assignment_list(sample_payload(), use_color=True)
+
+    assert "\033[33mDa fare\033[0m" in rendered
+    assert "\033[36mworkspace\033[0m" in rendered
+
+
+def test_render_assignment_detail_can_color_status() -> None:
+    rendered = student_lab_cli.render_assignment_detail(sample_assignment(status="missing"), use_color=True)
+
+    assert "\033[31mMancante\033[0m" in rendered
 
 
 def test_render_assignment_detail_summarizes_grading_tests() -> None:
@@ -168,3 +184,9 @@ def test_truncate_keeps_short_text_and_clips_long_text() -> None:
 def test_status_label_uses_human_labels() -> None:
     assert student_lab_cli.status_label("missing") == "Mancante"
     assert student_lab_cli.status_label("custom") == "custom"
+
+
+def test_supports_color_respects_no_color(monkeypatch) -> None:
+    assert student_lab_cli.supports_color(no_color=True) is False
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert student_lab_cli.supports_color() is False

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import student_lab_cli
+
+
+def sample_assignment(**overrides):
+    """Return a lab assignment payload for TUI rendering tests."""
+
+    payload = {
+        "assignment_id": "assignment-python-base-somma-001-demo",
+        "activity_id": "python-base-somma-001",
+        "title": "Somma in Python",
+        "student_id": "rossi-mario",
+        "target_type": "class",
+        "class_id": "demo-3a",
+        "class_label": "Classe demo 3A",
+        "github_team": "demo-3a",
+        "assigned_at": "2026-10-12T09:00:00+02:00",
+        "due_at": "2026-10-19T23:59:00+02:00",
+        "status": "pending",
+        "submitted": False,
+        "workspace": {
+            "path": "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001",
+            "exists": True,
+        },
+        "activity": {
+            "path": "activities/python-base-somma-001.json",
+            "exists": True,
+            "title": "Somma in Python",
+            "kind": "laboratorio",
+            "language": "python",
+            "source_name": "main.py",
+            "topics": ["variabili", "input-output"],
+        },
+        "report": {
+            "path": "examples/assignment_tracking/student_repos/rossi-mario/reports/python-base-somma-001/latest.json",
+            "exists": False,
+            "submitted_at": "",
+            "commit": None,
+        },
+        "grading": {
+            "status": "not_graded",
+            "tests_passed": None,
+            "tests_total": None,
+            "teacher_grade": None,
+            "score": None,
+        },
+        "runner": {
+            "status": "not_run",
+            "backend": "student_lab_service",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def sample_payload(assignments=None):
+    """Return a full student lab payload."""
+
+    return {
+        "schema_version": "student_lab.v1",
+        "student_id": "rossi-mario",
+        "generated_at": "2026-10-20T12:00:00+02:00",
+        "assignments": assignments if assignments is not None else [sample_assignment()],
+    }
+
+
+def test_render_assignment_list_summarizes_statuses() -> None:
+    payload = sample_payload(
+        [
+            sample_assignment(status="pending", submitted=False),
+            sample_assignment(title="Debug puntatori", status="missing", submitted=False),
+            sample_assignment(title="Array in C", status="submitted", submitted=True),
+        ]
+    )
+
+    rendered = student_lab_cli.render_assignment_list(payload)
+
+    assert "TheBitLab - lab studente" in rendered
+    assert "Studente: rossi-mario" in rendered
+    assert "Consegne: 3 | Da fare: 1 | Mancanti: 1 | Consegnate: 1" in rendered
+    assert "Somma in Python" in rendered
+    assert "Debug puntatori" in rendered
+    assert "Array in C" in rendered
+    assert "workspace" in rendered
+    assert "numero = dettaglio" in rendered
+
+
+def test_render_assignment_list_handles_empty_payload() -> None:
+    rendered = student_lab_cli.render_assignment_list(sample_payload([]))
+
+    assert "Nessuna consegna disponibile" in rendered
+
+
+def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
+    rendered = student_lab_cli.render_assignment_detail(sample_assignment())
+
+    assert "Dettaglio consegna" in rendered
+    assert "Somma in Python" in rendered
+    assert "Classe demo 3A" in rendered
+    assert "Path:" in rendered
+    assert "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001" in rendered
+    assert "Linguaggio:" in rendered
+    assert "python" in rendered
+    assert "not_graded" in rendered
+    assert "not_run" in rendered
+    assert "o = apri workspace" in rendered
+
+
+def test_render_assignment_detail_summarizes_grading_tests() -> None:
+    assignment = sample_assignment(
+        status="submitted",
+        submitted=True,
+        grading={"status": "graded_passed", "tests_passed": 2, "tests_total": 3, "teacher_grade": 8, "score": None},
+        report={"path": "reports/latest.json", "exists": True, "submitted_at": "2026-10-18T18:00:00+02:00", "commit": "abc1234"},
+    )
+
+    rendered = student_lab_cli.render_assignment_detail(assignment)
+
+    assert "graded_passed (2/3 test)" in rendered
+    assert "abc1234" in rendered
+    assert "8" in rendered
+
+
+def test_run_tui_can_show_detail_and_exit(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "", "q"])
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", lambda root, student_id, now=None: payload)
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+    )
+
+    assert result == 0
+    assert any("TheBitLab - lab studente" in output for output in outputs)
+    assert any("Dettaglio consegna" in output for output in outputs)
+
+
+def test_open_workspace_rejects_missing_path(tmp_path) -> None:
+    assert student_lab_cli.open_workspace(str(tmp_path / "missing")) is False
+
+
+def test_truncate_keeps_short_text_and_clips_long_text() -> None:
+    assert student_lab_cli.truncate("abc", 5) == "abc"
+    assert student_lab_cli.truncate("abcdef", 4) == "abc…"
+
+
+def test_status_label_uses_human_labels() -> None:
+    assert student_lab_cli.status_label("missing") == "Mancante"
+    assert student_lab_cli.status_label("custom") == "custom"

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -86,6 +86,8 @@ def test_render_assignment_list_summarizes_statuses() -> None:
     assert "Array in C" in rendered
     assert "workspace" in rendered
     assert "numero = dettaglio" in rendered
+    assert "2026-10-19 23:59" in rendered
+    assert "2026-10-19T23:59:00+02:00" not in rendered
     assert "Legenda:" in rendered
     assert "Mancante: scadenza superata" in rendered
     assert "no workspace: cartella locale" in rendered
@@ -103,6 +105,8 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "Dettaglio consegna" in rendered
     assert "Somma in Python" in rendered
     assert "Classe demo 3A" in rendered
+    assert "2026-10-12 09:00" in rendered
+    assert "2026-10-19 23:59" in rendered
     assert "Path:" in rendered
     assert "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001" in rendered
     assert "Linguaggio:" in rendered
@@ -179,6 +183,12 @@ def test_open_workspace_resolves_relative_path_from_root(monkeypatch, tmp_path) 
 def test_truncate_keeps_short_text_and_clips_long_text() -> None:
     assert student_lab_cli.truncate("abc", 5) == "abc"
     assert student_lab_cli.truncate("abcdef", 5) == "ab..."
+
+
+def test_compact_datetime_hides_seconds_and_timezone() -> None:
+    assert student_lab_cli.compact_datetime("2026-10-19T23:59:00+02:00") == "2026-10-19 23:59"
+    assert student_lab_cli.compact_datetime("") == "-"
+    assert student_lab_cli.compact_datetime("non-data") == "non-data"
 
 
 def test_status_label_uses_human_labels() -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `scripts/student_lab_cli.py`, prima TUI/CLI semigrafica sopra `student_lab.v1`.
- Mostra elenco consegne, riepilogo stati, dettaglio consegna, workspace, activity, report, grading e runner.
- Permette di ricaricare, uscire e aprire il workspace quando la cartella esiste.
- Aggiunge test di rendering e loop interattivo simulato.
- Aggiorna `doc/STUDENT_LAB.md` con comando e comandi disponibili.

## Decisione UI

La prima interfaccia e testuale, lineare e standard library. Non usa curses/Textual/Rich per restare robusta su Windows/PowerShell e arrivare rapidamente a una prova reale.

## Limiti intenzionali

- Non esegue ancora test.
- Non salva risultati.
- Non usa Docker.

## Issue

Closes #369

## Verifica

- `python -m pytest tests/test_student_lab_cli.py tests/test_student_lab_service.py`
- `python scripts/student_lab_cli.py --student-id rossi-mario --now 2026-10-20T12:00:00+02:00 --no-clear`
- `git diff --check`
