### PR TITLE
Aggiungi runner locale lab studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -14,6 +14,12 @@ La prima interfaccia semigrafica e:
 python scripts/student_lab_cli.py --student-id rossi-mario
 ```
 
+Il primo runner locale, senza Docker e senza salvataggio automatico del report, e:
+
+```powershell
+python scripts/student_lab_runner.py --student-id rossi-mario --activity-id python-base-somma-001
+```
+
 La TUI usa colori ANSI quando il terminale li supporta. Per disattivarli:
 
 ```powershell
@@ -35,10 +41,10 @@ Il payload ha schema `student_lab.v1` e contiene:
 - `activity`: metadati minimi della activity collegata;
 - `report`: report locale `reports/<activity_id>/latest.json`, se esiste;
 - `grading`: riepilogo deterministico del report, se esiste;
-- `runner`: stato del runner lab.
+- `runner`: stato del runner lab nel payload di consultazione.
 
-In questa prima fase il runner non esegue ancora codice: espone `not_run`.
-La TUI minima permette di consultare e aprire il workspace, ma non esegue ancora test.
+Nel payload di consultazione la TUI espone ancora `not_run`, perche l'esecuzione e un comando separato.
+Il runner locale produce un report JSON su stdout, ma non lo salva ancora in `reports/<activity_id>/latest.json`.
 
 ## Stati minimi
 
@@ -53,8 +59,8 @@ La TUI minima permette di consultare e aprire il workspace, ma non esegue ancora
 
 Le prossime PR dovranno usare questo contratto per:
 
-1. introdurre un runner locale;
-2. salvare risultati strutturati prodotti dal lab;
+1. salvare risultati strutturati prodotti dal lab;
+2. collegare il comando di esecuzione alla TUI;
 3. introdurre un runner Docker minimale;
 4. far leggere gli stessi risultati alla dashboard studente e al registro docente;
 5. valutare un adapter opzionale per layout terminale avanzato, per esempio tmux su ambienti compatibili.

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -245,11 +245,20 @@ def select_assignment(
 ) -> dict[str, Any]:
     """Return the requested assignment from a student lab payload."""
 
-    for assignment in assignments:
-        if assignment_id and assignment.get("assignment_id") == assignment_id:
-            return assignment
-        if activity_id and assignment.get("activity_id") == activity_id:
-            return assignment
+    if assignment_id:
+        for assignment in assignments:
+            if assignment.get("assignment_id") == assignment_id:
+                return assignment
+        raise ValueError(f"Consegna non trovata: {assignment_id}")
+    if activity_id:
+        matches = [assignment for assignment in assignments if assignment.get("activity_id") == activity_id]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise ValueError(
+                f"Activity {activity_id} presente in piu consegne. Usa --assignment-id per scegliere quella corretta."
+            )
+        raise ValueError(f"Activity non trovata: {activity_id}")
     if not assignment_id and not activity_id and len(assignments) == 1:
         return assignments[0]
     raise ValueError("Nessuna consegna selezionata. Usa --assignment-id o --activity-id.")

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -53,6 +53,13 @@ def source_name_for(activity: dict[str, Any], language: str) -> str:
     return clean_text(normalized.get("source_name")) or DEFAULT_SOURCE_NAMES.get(language, "")
 
 
+def is_safe_source_name(source_name: str) -> bool:
+    """Return whether source_name is a simple file name inside the workspace."""
+
+    path = Path(source_name)
+    return bool(source_name) and not path.is_absolute() and len(path.parts) == 1 and ".." not in path.parts
+
+
 def report_base(assignment: dict[str, Any], *, language: str, source: Path, backend: str = "local") -> dict[str, Any]:
     """Return common fields for local runner reports."""
 
@@ -212,6 +219,14 @@ def run_local_assignment(
     workspace_path = student_lab_service.resolve_local_path(root, workspace_path_value) if workspace_path_value else root
     source_name = source_name_for(activity, language)
     source = workspace_path / source_name if source_name else workspace_path
+    if not is_safe_source_name(source_name):
+        return error_report(
+            assignment,
+            language=language,
+            source=source,
+            status="invalid-source-name",
+            error="source_name deve essere un nome file semplice dentro il workspace.",
+        )
     if not workspace_path.is_dir():
         return error_report(
             assignment,

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import grade_activity, student_lab_service
+from scripts.thebitlab_contracts import normalize_activity
+
+
+DEFAULT_TIMEOUT_SECONDS = 5
+DEFAULT_SOURCE_NAMES = {
+    "c": "main.c",
+    "python": "main.py",
+}
+
+
+def clean_text(value: Any) -> str:
+    """Return a stripped string value."""
+
+    return str(value or "").strip()
+
+
+def load_activity(root: Path, assignment: dict[str, Any]) -> dict[str, Any]:
+    """Load the full activity JSON for a lab assignment."""
+
+    activity_summary = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
+    activity_path_value = clean_text(activity_summary.get("path"))
+    if not activity_path_value:
+        raise ValueError("activity.path mancante nella consegna.")
+    activity_path = student_lab_service.resolve_local_path(root, activity_path_value)
+    if not activity_path.is_file():
+        raise ValueError(f"Activity non trovata: {activity_path_value}")
+    payload = json.loads(activity_path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Activity non valida: {activity_path_value}")
+    return payload
+
+
+def source_name_for(activity: dict[str, Any], language: str) -> str:
+    """Return the source filename expected in the student workspace."""
+
+    normalized = normalize_activity(activity)
+    return clean_text(normalized.get("source_name")) or DEFAULT_SOURCE_NAMES.get(language, "")
+
+
+def report_base(assignment: dict[str, Any], *, language: str, source: Path, backend: str = "local") -> dict[str, Any]:
+    """Return common fields for local runner reports."""
+
+    return {
+        "schema_version": "student_lab_run.v1",
+        "backend": backend,
+        "assignment_id": clean_text(assignment.get("assignment_id")),
+        "activity_id": clean_text(assignment.get("activity_id")),
+        "student_id": clean_text(assignment.get("student_id")),
+        "language": language,
+        "source": str(source),
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+    }
+
+
+def error_report(
+    assignment: dict[str, Any],
+    *,
+    language: str,
+    source: Path,
+    status: str,
+    error: str,
+    backend: str = "local",
+) -> dict[str, Any]:
+    """Return a deterministic error report."""
+
+    return {
+        **report_base(assignment, language=language, source=source, backend=backend),
+        "passed": False,
+        "status": status,
+        "summary": {"passed": 0, "total": 0},
+        "tests": [],
+        "stdout": "",
+        "stderr": error,
+        "error": error,
+    }
+
+
+def pytest_targets(workspace: Path) -> list[str]:
+    """Return pytest targets discoverable in a student workspace."""
+
+    tests_dir = workspace / "tests"
+    if tests_dir.is_dir():
+        return ["tests"]
+    root_tests = sorted(path.name for path in workspace.glob("test_*.py") if path.is_file())
+    return root_tests
+
+
+def parse_pytest_summary(output: str) -> dict[str, int | None]:
+    """Extract a small test count summary from pytest output."""
+
+    counts = {"passed": 0, "failed": 0, "errors": 0, "skipped": 0}
+    for key in counts:
+        match = re.search(rf"(\d+)\s+{key}", output)
+        if match:
+            counts[key] = int(match.group(1))
+    total = sum(counts.values())
+    if total == 0:
+        return {"passed": None, "total": None}
+    return {"passed": counts["passed"], "total": total}
+
+
+def run_python_pytest(
+    assignment: dict[str, Any],
+    *,
+    workspace: Path,
+    source: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    """Run pytest in the student workspace and return a report."""
+
+    if not source.is_file():
+        return error_report(
+            assignment,
+            language="python",
+            source=source,
+            status="source-not-found",
+            error=f"Sorgente non trovato: {source}",
+        )
+    targets = pytest_targets(workspace)
+    if not targets:
+        return error_report(
+            assignment,
+            language="python",
+            source=source,
+            status="no-tests",
+            error="Nessun test pytest rilevato nel workspace.",
+        )
+    command = [sys.executable, "-m", "pytest", "-q", *targets]
+    try:
+        result = subprocess.run(
+            command,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout or ""
+        stderr = error.stderr or ""
+        return {
+            **report_base(assignment, language="python", source=source),
+            "passed": False,
+            "status": "timeout",
+            "command": command,
+            "returncode": None,
+            "summary": parse_pytest_summary(f"{stdout}\n{stderr}"),
+            "tests": [],
+            "stdout": stdout,
+            "stderr": stderr,
+            "error": f"Timeout dopo {timeout_seconds} secondi.",
+        }
+    status = "passed" if result.returncode == 0 else "failed"
+    output = f"{result.stdout}\n{result.stderr}"
+    return {
+        **report_base(assignment, language="python", source=source),
+        "passed": result.returncode == 0,
+        "status": status,
+        "command": command,
+        "returncode": result.returncode,
+        "summary": parse_pytest_summary(output),
+        "tests": [],
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def wrap_c_report(assignment: dict[str, Any], source: Path, report: dict[str, Any]) -> dict[str, Any]:
+    """Wrap the existing C grader output in the student lab runner contract."""
+
+    summary = report.get("summary") if isinstance(report.get("summary"), dict) else {"passed": 0, "total": 0}
+    return {
+        **report_base(assignment, language="c", source=source),
+        **report,
+        "schema_version": "student_lab_run.v1",
+        "backend": "local",
+        "assignment_id": clean_text(assignment.get("assignment_id")),
+        "student_id": clean_text(assignment.get("student_id")),
+        "summary": summary,
+    }
+
+
+def run_local_assignment(
+    assignment: dict[str, Any],
+    *,
+    root: Path = PROJECT_ROOT,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Run one student lab assignment locally without Docker."""
+
+    activity = load_activity(root, assignment)
+    normalized = normalize_activity(activity)
+    language = clean_text(normalized.get("language")).lower()
+    workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+    workspace_path_value = clean_text(workspace.get("path"))
+    workspace_path = student_lab_service.resolve_local_path(root, workspace_path_value) if workspace_path_value else root
+    source_name = source_name_for(activity, language)
+    source = workspace_path / source_name if source_name else workspace_path
+    if not workspace_path.is_dir():
+        return error_report(
+            assignment,
+            language=language,
+            source=source,
+            status="workspace-not-found",
+            error=f"Workspace non trovato: {workspace_path_value}",
+        )
+    if language == "python":
+        return run_python_pytest(assignment, workspace=workspace_path, source=source, timeout_seconds=timeout_seconds)
+    if language == "c":
+        return wrap_c_report(
+            assignment,
+            source,
+            grade_activity.grade_activity(activity, source, timeout_seconds=timeout_seconds, language="c"),
+        )
+    return error_report(
+        assignment,
+        language=language,
+        source=source,
+        status="unsupported-language",
+        error=f"Runner locale non supportato per il linguaggio: {language or '-'}",
+    )
+
+
+def select_assignment(
+    assignments: list[dict[str, Any]],
+    *,
+    assignment_id: str | None = None,
+    activity_id: str | None = None,
+) -> dict[str, Any]:
+    """Return the requested assignment from a student lab payload."""
+
+    for assignment in assignments:
+        if assignment_id and assignment.get("assignment_id") == assignment_id:
+            return assignment
+        if activity_id and assignment.get("activity_id") == activity_id:
+            return assignment
+    if not assignment_id and not activity_id and len(assignments) == 1:
+        return assignments[0]
+    raise ValueError("Nessuna consegna selezionata. Usa --assignment-id o --activity-id.")
+
+
+def run_student_assignment(
+    *,
+    root: Path = PROJECT_ROOT,
+    student_id: str,
+    assignment_id: str | None = None,
+    activity_id: str | None = None,
+    now: str | None = None,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Load and run one assignment for a student."""
+
+    payload = student_lab_service.student_lab_payload(root=root, student_id=student_id, now=now)
+    assignments = payload.get("assignments") if isinstance(payload.get("assignments"), list) else []
+    assignment = select_assignment(assignments, assignment_id=assignment_id, activity_id=activity_id)
+    return run_local_assignment(assignment, root=root, timeout_seconds=timeout_seconds)
+
+
+def positive_int(value: str) -> int:
+    """Parse a positive integer CLI argument."""
+
+    try:
+        number = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("deve essere un numero intero") from error
+    if number <= 0:
+        raise argparse.ArgumentTypeError("deve essere un numero positivo")
+    return number
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the local student lab runner."""
+
+    parser = argparse.ArgumentParser(description="Esegue localmente una consegna del lab studente.")
+    parser.add_argument("--student-id", required=True, help="Identificativo studente, per esempio rossi-mario.")
+    parser.add_argument("--assignment-id", help="ID della consegna da eseguire.")
+    parser.add_argument("--activity-id", help="ID activity da eseguire se l'assegnazione e univoca.")
+    parser.add_argument("--root", type=Path, default=PROJECT_ROOT, help="Root del repository TheBitLab.")
+    parser.add_argument("--now", help="Data ISO da usare per calcolare lo stato della consegna.")
+    parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout del runner locale.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the local student lab runner from the command line."""
+
+    args = parse_args()
+    try:
+        report = run_student_assignment(
+            root=args.root.resolve(strict=False),
+            student_id=args.student_id,
+            assignment_id=args.assignment_id,
+            activity_id=args.activity_id,
+            now=args.now,
+            timeout_seconds=args.timeout,
+        )
+    except ValueError as error:
+        print(f"Runner lab non disponibile:\n{error}", file=sys.stderr)
+        return 1
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if report.get("passed") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -165,6 +165,22 @@ def test_run_local_assignment_reports_unsupported_language(tmp_path) -> None:
     assert report["language"] == "sql"
 
 
+def test_run_local_assignment_rejects_source_name_outside_workspace(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, source_name="../main.py")
+    write_assignment(tmp_path, activity_path)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / "python-base-somma-001"
+    workspace.mkdir(parents=True)
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+    )
+
+    assert report["status"] == "invalid-source-name"
+    assert report["passed"] is False
+
+
 def test_run_local_assignment_wraps_c_compile_error(monkeypatch, tmp_path) -> None:
     activity_id = "c-base-somma-001"
     activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from scripts import assignment_records, student_lab_runner
+
+
+def write_activity(root, activity_id: str = "python-base-somma-001", **overrides) -> str:
+    """Write a minimal activity used by runner tests."""
+
+    payload = {
+        "schema_version": "1.0",
+        "id": activity_id,
+        "title": "Somma in Python",
+        "kind": "laboratorio",
+        "difficulty": "B",
+        "topics": ["variabili", "input-output"],
+        "language": "python",
+        "source_name": "main.py",
+        "instructions": "Scrivi una funzione somma.",
+        "grading_policy": {
+            "compila": True,
+            "test": True,
+            "sandbox": False,
+            "ai_feedback": False,
+        },
+    }
+    payload.update(overrides)
+    path = root / "activities" / f"{activity_id}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return f"activities/{activity_id}.json"
+
+
+def write_assignment(root, activity_path: str, activity_id: str = "python-base-somma-001") -> dict:
+    """Write an assignment visible to rossi-mario."""
+
+    assignment = assignment_records.build_assignment_record(
+        activity_id=activity_id,
+        activity_path=activity_path,
+        target_type="student",
+        assigned_at="2026-10-12T09:00:00+02:00",
+        due_at="2026-10-19T23:59:00+02:00",
+        targets=[
+            {
+                "student_id": "rossi-mario",
+                "display_name": "Rossi Mario",
+                "path": "examples/assignment_tracking/student_repos/rossi-mario",
+            }
+        ],
+    )
+    storage = assignment_records.JsonAssignmentRecordStorage(root)
+    storage.write_assignment(assignment)
+    return assignment
+
+
+def write_python_workspace(root, *, source: str, test_source: str) -> None:
+    """Write a Python student workspace with pytest tests."""
+
+    workspace = root / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / "python-base-somma-001"
+    tests = workspace / "tests"
+    tests.mkdir(parents=True)
+    (workspace / "main.py").write_text(source, encoding="utf-8")
+    (tests / "test_main.py").write_text(test_source, encoding="utf-8")
+
+
+def test_run_student_assignment_passes_python_pytest(tmp_path) -> None:
+    write_assignment(tmp_path, write_activity(tmp_path))
+    write_python_workspace(
+        tmp_path,
+        source="def somma(a, b):\n    return a + b\n",
+        test_source="from main import somma\n\ndef test_somma():\n    assert somma(2, 3) == 5\n",
+    )
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        now="2026-10-18T12:00:00+02:00",
+    )
+
+    assert report["schema_version"] == "student_lab_run.v1"
+    assert report["backend"] == "local"
+    assert report["status"] == "passed"
+    assert report["passed"] is True
+    assert report["summary"] == {"passed": 1, "total": 1}
+
+
+def test_run_student_assignment_reports_python_pytest_failure(tmp_path) -> None:
+    write_assignment(tmp_path, write_activity(tmp_path))
+    write_python_workspace(
+        tmp_path,
+        source="def somma(a, b):\n    return a - b\n",
+        test_source="from main import somma\n\ndef test_somma():\n    assert somma(2, 3) == 5\n",
+    )
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        now="2026-10-18T12:00:00+02:00",
+    )
+
+    assert report["status"] == "failed"
+    assert report["passed"] is False
+    assert report["summary"]["total"] == 1
+    assert "FAILED" in report["stdout"]
+
+
+def test_run_student_assignment_reports_timeout(monkeypatch, tmp_path) -> None:
+    write_assignment(tmp_path, write_activity(tmp_path))
+    write_python_workspace(
+        tmp_path,
+        source="def somma(a, b):\n    return a + b\n",
+        test_source="from main import somma\n\ndef test_somma():\n    assert somma(2, 3) == 5\n",
+    )
+
+    def timeout_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(student_lab_runner.subprocess, "run", timeout_run)
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        timeout_seconds=1,
+    )
+
+    assert report["status"] == "timeout"
+    assert report["passed"] is False
+    assert report["returncode"] is None
+
+
+def test_run_local_assignment_reports_missing_source(tmp_path) -> None:
+    write_assignment(tmp_path, write_activity(tmp_path))
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / "python-base-somma-001"
+    (workspace / "tests").mkdir(parents=True)
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+    )
+
+    assert report["status"] == "source-not-found"
+    assert report["passed"] is False
+
+
+def test_run_local_assignment_reports_unsupported_language(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, language="sql", source_name="query.sql")
+    write_assignment(tmp_path, activity_path)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / "python-base-somma-001"
+    workspace.mkdir(parents=True)
+    (workspace / "query.sql").write_text("select 1;", encoding="utf-8")
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+    )
+
+    assert report["status"] == "unsupported-language"
+    assert report["language"] == "sql"
+
+
+def test_run_local_assignment_wraps_c_compile_error(monkeypatch, tmp_path) -> None:
+    activity_id = "c-base-somma-001"
+    activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")
+    write_assignment(tmp_path, activity_path, activity_id=activity_id)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / activity_id
+    workspace.mkdir(parents=True)
+    (workspace / "main.c").write_text("int main(void){ return }\n", encoding="utf-8")
+
+    def compile_error(activity, source, **kwargs):
+        return {
+            "passed": False,
+            "status": "compile-error",
+            "activity_id": activity["id"],
+            "language": "c",
+            "source": str(source),
+            "compile": {"stderr": "errore compilazione"},
+            "tests": [],
+        }
+
+    monkeypatch.setattr(student_lab_runner.grade_activity, "grade_activity", compile_error)
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+    )
+
+    assert report["schema_version"] == "student_lab_run.v1"
+    assert report["status"] == "compile-error"
+    assert report["passed"] is False
+    assert report["summary"] == {"passed": 0, "total": 0}
+
+
+def test_select_assignment_requires_disambiguation() -> None:
+    try:
+        student_lab_runner.select_assignment(
+            [
+                {"assignment_id": "a", "activity_id": "x"},
+                {"assignment_id": "b", "activity_id": "y"},
+            ]
+        )
+    except ValueError as error:
+        assert "--assignment-id" in str(error)
+    else:
+        raise AssertionError("select_assignment should require explicit selection")

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -210,3 +210,19 @@ def test_select_assignment_requires_disambiguation() -> None:
         assert "--assignment-id" in str(error)
     else:
         raise AssertionError("select_assignment should require explicit selection")
+
+
+def test_select_assignment_requires_assignment_id_for_duplicate_activity() -> None:
+    try:
+        student_lab_runner.select_assignment(
+            [
+                {"assignment_id": "a", "activity_id": "x"},
+                {"assignment_id": "b", "activity_id": "x"},
+            ],
+            activity_id="x",
+        )
+    except ValueError as error:
+        assert "piu consegne" in str(error)
+        assert "--assignment-id" in str(error)
+    else:
+        raise AssertionError("select_assignment should reject ambiguous activity_id")


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `scripts/student_lab_runner.py`, runner locale minimale per una consegna del lab studente.
- Supporta Python tramite `pytest` rilevando `tests/` o `test_*.py` nel workspace.
- Supporta C riusando il grader deterministico esistente in `scripts/grade_activity.py`.
- Produce un report JSON in memoria/stdout con schema `student_lab_run.v1`.
- Documenta il comando in `doc/STUDENT_LAB.md`.

## Perche

Questo e il passo successivo dopo la TUI minima: lo studente deve poter eseguire localmente una consegna e ottenere un esito tecnico chiaro, prima di salvare report, collegare TUI e introdurre Docker.

## Fuori scope

- Salvataggio automatico in `reports/<activity_id>/latest.json`.
- Integrazione diretta nella TUI.
- Docker/sandbox forte.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_service.py tests/test_student_lab_cli.py tests/test_student_lab_runner.py
```

Risultato locale: 25 test passati.

## Issue

Closes #370
