### PR TITLE
Salva report del runner studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -14,10 +14,16 @@ La prima interfaccia semigrafica e:
 python scripts/student_lab_cli.py --student-id rossi-mario
 ```
 
-Il primo runner locale, senza Docker e senza salvataggio automatico del report, e:
+Il primo runner locale, senza Docker, e:
 
 ```powershell
 python scripts/student_lab_runner.py --student-id rossi-mario --activity-id python-base-somma-001
+```
+
+Per salvare il risultato nel path standard dello studente:
+
+```powershell
+python scripts/student_lab_runner.py --student-id rossi-mario --activity-id python-base-somma-001 --write-report
 ```
 
 La TUI usa colori ANSI quando il terminale li supporta. Per disattivarli:
@@ -44,7 +50,8 @@ Il payload ha schema `student_lab.v1` e contiene:
 - `runner`: stato del runner lab nel payload di consultazione.
 
 Nel payload di consultazione la TUI espone ancora `not_run`, perche l'esecuzione e un comando separato.
-Il runner locale produce un report JSON su stdout, ma non lo salva ancora in `reports/<activity_id>/latest.json`.
+Il runner locale produce un report JSON su stdout e, con `--write-report`, lo salva in `reports/<activity_id>/latest.json`.
+Quando il report e salvato, il servizio lab lo rilegge e aggiorna stato consegna e riepilogo grading.
 
 ## Stati minimi
 
@@ -57,10 +64,16 @@ Il runner locale produce un report JSON su stdout, ma non lo salva ancora in `re
 
 ## Direzione
 
+Il report salvato usa lo schema `student_lab_run.v1` e mantiene separati:
+
+- risultato deterministico: `passed`, `status`, `summary`, `tests`, `stdout`, `stderr`;
+- metadati di collegamento: `assignment_id`, `activity_id`, `student_id`, `language`, `source`, `submitted_at`;
+- feedback AI: non presente in questo report, per evitare di mescolare esecuzione deterministica e suggerimenti generativi.
+
 Le prossime PR dovranno usare questo contratto per:
 
-1. salvare risultati strutturati prodotti dal lab;
-2. collegare il comando di esecuzione alla TUI;
+1. collegare il comando di esecuzione alla TUI;
+2. mostrare nella TUI l'esito appena salvato;
 3. introdurre un runner Docker minimale;
 4. far leggere gli stessi risultati alla dashboard studente e al registro docente;
 5. valutare un adapter opzionale per layout terminale avanzato, per esempio tmux su ambienti compatibili.

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -122,6 +122,19 @@ def parse_pytest_summary(output: str) -> dict[str, int | None]:
     return {"passed": counts["passed"], "total": total}
 
 
+def pytest_report_tests(*, passed: bool, status: str, stdout: str, stderr: str) -> list[dict[str, Any]]:
+    """Return an aggregate pytest test entry for dashboard grading."""
+
+    return [
+        {
+            "name": "pytest",
+            "passed": passed,
+            "status": status,
+            "message": stderr or stdout,
+        }
+    ]
+
+
 def run_python_pytest(
     assignment: dict[str, Any],
     *,
@@ -182,7 +195,12 @@ def run_python_pytest(
         "command": command,
         "returncode": result.returncode,
         "summary": parse_pytest_summary(output),
-        "tests": [],
+        "tests": pytest_report_tests(
+            passed=result.returncode == 0,
+            status=status,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        ),
         "stdout": result.stdout,
         "stderr": result.stderr,
     }
@@ -296,6 +314,74 @@ def run_student_assignment(
     return run_local_assignment(assignment, root=root, timeout_seconds=timeout_seconds)
 
 
+def load_student_assignment(
+    *,
+    root: Path = PROJECT_ROOT,
+    student_id: str,
+    assignment_id: str | None = None,
+    activity_id: str | None = None,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Load one normalized assignment for a student."""
+
+    payload = student_lab_service.student_lab_payload(root=root, student_id=student_id, now=now)
+    assignments = payload.get("assignments") if isinstance(payload.get("assignments"), list) else []
+    return select_assignment(assignments, assignment_id=assignment_id, activity_id=activity_id)
+
+
+def assignment_report_path(root: Path, assignment: dict[str, Any]) -> Path:
+    """Return the default report path for an assignment."""
+
+    report = assignment.get("report") if isinstance(assignment.get("report"), dict) else {}
+    report_path_value = clean_text(report.get("path"))
+    if not report_path_value:
+        raise ValueError("report.path mancante nella consegna.")
+    return student_lab_service.resolve_local_path(root, report_path_value)
+
+
+def student_repo_path(root: Path, assignment: dict[str, Any]) -> Path | None:
+    """Infer the student repository path from the assignment workspace."""
+
+    workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+    workspace_path_value = clean_text(workspace.get("path"))
+    if not workspace_path_value:
+        return None
+    workspace_path = student_lab_service.resolve_local_path(root, workspace_path_value)
+    if workspace_path.parent.name != "assignments":
+        return None
+    return workspace_path.parent.parent
+
+
+def storage_report(root: Path, assignment: dict[str, Any], report: dict[str, Any]) -> dict[str, Any]:
+    """Return a report normalized for storage in the student repository."""
+
+    stored = dict(report)
+    stored.setdefault("submitted_at", clean_text(report.get("generated_at")) or datetime.now().astimezone().isoformat(timespec="seconds"))
+    repo_path = student_repo_path(root, assignment)
+    source_value = clean_text(stored.get("source"))
+    if repo_path is not None and source_value:
+        source_path = Path(source_value)
+        resolved_source = source_path.resolve(strict=False) if source_path.is_absolute() else (root / source_path).resolve(strict=False)
+        try:
+            stored["source"] = str(resolved_source.relative_to(repo_path.resolve())).replace("\\", "/")
+        except ValueError:
+            stored["source"] = source_value
+    return stored
+
+
+def write_student_report(root: Path, assignment: dict[str, Any], report: dict[str, Any], report_path: Path | None = None) -> Path:
+    """Persist a student lab report as JSON."""
+
+    output = report_path or assignment_report_path(root, assignment)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(storage_report(root, assignment, report), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return output
+
+
 def positive_int(value: str) -> int:
     """Parse a positive integer CLI argument."""
 
@@ -318,6 +404,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--root", type=Path, default=PROJECT_ROOT, help="Root del repository TheBitLab.")
     parser.add_argument("--now", help="Data ISO da usare per calcolare lo stato della consegna.")
     parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout del runner locale.")
+    parser.add_argument("--write-report", action="store_true", help="Scrive il report nel path standard dello studente.")
+    parser.add_argument("--report", type=Path, help="Path alternativo del report JSON da scrivere.")
     return parser.parse_args()
 
 
@@ -326,14 +414,17 @@ def main() -> int:
 
     args = parse_args()
     try:
-        report = run_student_assignment(
-            root=args.root.resolve(strict=False),
+        root = args.root.resolve(strict=False)
+        assignment = load_student_assignment(
+            root=root,
             student_id=args.student_id,
             assignment_id=args.assignment_id,
             activity_id=args.activity_id,
             now=args.now,
-            timeout_seconds=args.timeout,
         )
+        report = run_local_assignment(assignment, root=root, timeout_seconds=args.timeout)
+        if args.write_report or args.report:
+            write_student_report(root, assignment, report, args.report.resolve(strict=False) if args.report else None)
     except ValueError as error:
         print(f"Runner lab non disponibile:\n{error}", file=sys.stderr)
         return 1

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 
-from scripts import assignment_records, student_lab_runner
+from scripts import assignment_records, student_lab_runner, student_lab_service
 
 
 def write_activity(root, activity_id: str = "python-base-somma-001", **overrides) -> str:
@@ -85,6 +85,44 @@ def test_run_student_assignment_passes_python_pytest(tmp_path) -> None:
     assert report["status"] == "passed"
     assert report["passed"] is True
     assert report["summary"] == {"passed": 1, "total": 1}
+
+
+def test_write_student_report_persists_latest_json_and_service_reads_it(tmp_path) -> None:
+    write_assignment(tmp_path, write_activity(tmp_path))
+    write_python_workspace(
+        tmp_path,
+        source="def somma(a, b):\n    return a + b\n",
+        test_source="from main import somma\n\ndef test_somma():\n    assert somma(2, 3) == 5\n",
+    )
+
+    assignment = student_lab_runner.load_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        now="2026-10-18T12:00:00+02:00",
+    )
+    report = student_lab_runner.run_local_assignment(assignment, root=tmp_path)
+    report_path = student_lab_runner.write_student_report(tmp_path, assignment, report)
+
+    stored = json.loads(report_path.read_text(encoding="utf-8"))
+    assert stored["activity_id"] == "python-base-somma-001"
+    assert stored["submitted_at"] == report["generated_at"]
+    assert stored["source"] == "assignments/python-base-somma-001/main.py"
+
+    payload = student_lab_service.student_lab_payload(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-20T12:00:00+02:00",
+    )
+
+    assignment_payload = payload["assignments"][0]
+    assert assignment_payload["status"] == "submitted"
+    assert assignment_payload["submitted"] is True
+    assert assignment_payload["report"]["exists"] is True
+    assert assignment_payload["report"]["submitted_at"] == report["generated_at"]
+    assert assignment_payload["grading"]["status"] == "graded_passed"
+    assert assignment_payload["grading"]["tests_passed"] == 1
+    assert assignment_payload["grading"]["tests_total"] == 1
 
 
 def test_run_student_assignment_reports_python_pytest_failure(tmp_path) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge salvataggio opzionale del report prodotto dal runner studente con `--write-report`.
- Scrive il JSON nel path standard `reports/<activity_id>/latest.json` gia esposto dal contratto `student_lab.v1`.
- Normalizza `source` come path relativo al repository studente quando possibile.
- Aggiunge `submitted_at` al report salvato.
- Aggiorna la documentazione del lab studente.

## Perche

Il runner locale produceva gia un report JSON su stdout, ma la TUI e il servizio lab non potevano ancora rileggerlo. Questo passo collega il risultato del runner al contratto usato da dashboard e registro.

## Fuori scope

- Storico tentativi multipli.
- Integrazione del comando direttamente nella TUI.
- Runner Docker.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_service.py tests/test_student_lab_cli.py tests/test_student_lab_runner.py
python -m py_compile scripts/student_lab_runner.py
```

Risultato locale: 28 test passati.

## Issue

Closes #371
