### PR TITLE
Collega runner locale alla TUI studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -37,6 +37,7 @@ Comandi disponibili nella TUI minima:
 - numero della riga: apre il dettaglio della consegna;
 - `r`: ricarica le consegne;
 - `q`: esce;
+- `e` dal dettaglio: esegue il runner locale e salva il report;
 - `o` dal dettaglio: apre la cartella workspace, se esiste.
 
 Il payload ha schema `student_lab.v1` e contiene:

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -12,7 +12,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import student_lab_service
+from scripts import student_lab_runner, student_lab_service
 
 
 InputFn = Callable[[str], str]
@@ -211,9 +211,25 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Stato:", runner.get("status")),
         detail_line("Backend:", runner.get("backend")),
         "",
-        "Comandi: o = apri workspace | invio = torna all'elenco",
+        "Comandi: e = esegui e salva report | o = apri workspace | invio = torna all'elenco",
     ]
     return "\n".join(lines)
+
+
+def runner_result_message(report: dict[str, Any], report_path: Path) -> str:
+    """Return a compact message after a runner execution."""
+
+    status = clean_text(report.get("status"))
+    summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
+    passed = summary.get("passed")
+    total = summary.get("total")
+    tests = f" ({passed}/{total} test)" if passed is not None and total is not None else ""
+    return "\n".join(
+        [
+            f"Runner completato: {status}{tests}",
+            f"Report salvato: {report_path}",
+        ]
+    )
 
 
 def clear_screen() -> None:
@@ -292,6 +308,15 @@ def run_tui(
             if not open_workspace(clean_text(workspace.get("path"), ""), root=root):
                 print_fn("Workspace non disponibile.")
                 input_fn("Premi invio per continuare...")
+        if action == "e":
+            try:
+                report = student_lab_runner.run_local_assignment(assignment, root=root)
+                report_path = student_lab_runner.write_student_report(root, assignment, report)
+                print_fn(runner_result_message(report, report_path))
+                payload = load_payload(root, student_id, now)
+            except ValueError as error:
+                print_fn(f"Runner non disponibile:\n{error}")
+            input_fn("Premi invio per continuare...")
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -113,6 +113,7 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "python" in rendered
     assert "not_graded" in rendered
     assert "not_run" in rendered
+    assert "e = esegui e salva report" in rendered
     assert "o = apri workspace" in rendered
 
 
@@ -144,6 +145,16 @@ def test_render_assignment_detail_summarizes_grading_tests() -> None:
     assert "8" in rendered
 
 
+def test_runner_result_message_shows_status_tests_and_report_path(tmp_path) -> None:
+    message = student_lab_cli.runner_result_message(
+        {"status": "passed", "summary": {"passed": 2, "total": 3}},
+        tmp_path / "reports" / "latest.json",
+    )
+
+    assert "Runner completato: passed (2/3 test)" in message
+    assert "Report salvato:" in message
+
+
 def test_run_tui_can_show_detail_and_exit(monkeypatch, tmp_path) -> None:
     payload = sample_payload()
     outputs = []
@@ -162,6 +173,45 @@ def test_run_tui_can_show_detail_and_exit(monkeypatch, tmp_path) -> None:
     assert result == 0
     assert any("TheBitLab - lab studente" in output for output in outputs)
     assert any("Dettaglio consegna" in output for output in outputs)
+
+
+def test_run_tui_can_execute_runner_save_report_and_reload(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "e", "", "q"])
+    load_calls = []
+    saved_reports = []
+
+    def fake_load_payload(root, student_id, now=None):
+        load_calls.append((root, student_id, now))
+        return payload
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", fake_load_payload)
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_runner,
+        "run_local_assignment",
+        lambda assignment, root: {"status": "passed", "summary": {"passed": 1, "total": 1}},
+    )
+
+    def fake_write_report(root, assignment, report):
+        saved_reports.append((root, assignment, report))
+        return tmp_path / "reports" / "latest.json"
+
+    monkeypatch.setattr(student_lab_cli.student_lab_runner, "write_student_report", fake_write_report)
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+    )
+
+    assert result == 0
+    assert len(load_calls) == 2
+    assert saved_reports
+    assert any("Runner completato: passed (1/1 test)" in output for output in outputs)
+    assert any("Report salvato:" in output for output in outputs)
 
 
 def test_open_workspace_rejects_missing_path(tmp_path) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Nel dettaglio consegna della TUI aggiunge il comando `e = esegui e salva report`.
- Il comando esegue il runner locale, salva il report standard e ricarica il payload.
- Mostra un messaggio sintetico con stato runner, conteggio test e path del report salvato.
- Aggiorna `doc/STUDENT_LAB.md` con il nuovo comando.

## Perche

Dopo runner locale e salvataggio report, lo studente deve poter completare il giro dalla TUI senza lanciare manualmente script separati.

## Fuori scope

- Docker.
- Storico tentativi.
- Layout tmux/SSH.
- GUI web.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py tests/test_student_lab_runner.py tests/test_student_lab_service.py
python -m py_compile scripts/student_lab_cli.py scripts/student_lab_runner.py
```

Risultato locale: 30 test passati.

## Issue

Closes #379
