### PR TITLE
Aggiungi backend Docker al runner studente

### DIFF
--- a/.github/workflows/assignment-runner-docker.yml
+++ b/.github/workflows/assignment-runner-docker.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - "docker/assignment-runner/**"
       - "scripts/grade_activity.py"
+      - "scripts/student_lab_runner.py"
+      - "tests/test_student_lab_runner.py"
       - ".github/workflows/assignment-runner-docker.yml"
   push:
     branches:
@@ -16,6 +18,8 @@ on:
     paths:
       - "docker/assignment-runner/**"
       - "scripts/grade_activity.py"
+      - "scripts/student_lab_runner.py"
+      - "tests/test_student_lab_runner.py"
       - ".github/workflows/assignment-runner-docker.yml"
 
 jobs:
@@ -70,4 +74,110 @@ jobs:
           report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "report.json").read_text(encoding="utf-8"))
           assert report["passed"] is True
           assert report["status"] == "passed"
+          PY
+
+      - name: Smoke test student lab Docker backend
+        run: |
+          mkdir -p "$RUNNER_TEMP/student-root"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts import assignment_records
+
+          root = Path(os.environ["RUNNER_TEMP"]) / "student-root"
+          activity_dir = root / "activities"
+          activity_dir.mkdir(parents=True, exist_ok=True)
+          activity_path = activity_dir / "c-base-somma-001.json"
+          activity_path.write_text(
+              json.dumps(
+                  {
+                      "schema_version": "1.0",
+                      "id": "c-base-somma-001",
+                      "title": "Somma C",
+                      "kind": "laboratorio",
+                      "difficulty": "B",
+                      "topics": ["variabili"],
+                      "language": "c",
+                      "source_name": "main.c",
+                      "instructions": "Somma due interi.",
+                      "grading_policy": {
+                          "compila": True,
+                          "test": True,
+                          "sandbox": True,
+                          "ai_feedback": False,
+                      },
+                      "test_cases": [
+                          {
+                              "name": "somma minima",
+                              "stdin": "2 3\n",
+                              "expected_stdout": "5\n",
+                          }
+                      ],
+                  }
+              ),
+              encoding="utf-8",
+          )
+          assignment = assignment_records.build_assignment_record(
+              activity_id="c-base-somma-001",
+              activity_path="activities/c-base-somma-001.json",
+              target_type="student",
+              assigned_at="2026-10-12T09:00:00+02:00",
+              due_at="2026-10-19T23:59:00+02:00",
+              targets=[
+                  {
+                      "student_id": "rossi-mario",
+                      "display_name": "Rossi Mario",
+                      "path": "examples/assignment_tracking/student_repos/rossi-mario",
+                  }
+              ],
+          )
+          assignment_records.JsonAssignmentRecordStorage(root).write_assignment(assignment)
+          workspace = root / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / "c-base-somma-001"
+          workspace.mkdir(parents=True, exist_ok=True)
+          (workspace / "main.c").write_text(
+              """#include <stdio.h>
+
+          int main(void) {
+            int a;
+            int b;
+            if (scanf("%d %d", &a, &b) != 2) {
+              return 1;
+            }
+            printf("%d\\n", a + b);
+            return 0;
+          }
+          """,
+              encoding="utf-8",
+          )
+          PY
+          python scripts/student_lab_runner.py \
+            --root "$RUNNER_TEMP/student-root" \
+            --student-id rossi-mario \
+            --activity-id c-base-somma-001 \
+            --backend docker \
+            --write-report
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(
+              (
+                  Path(os.environ["RUNNER_TEMP"])
+                  / "student-root"
+                  / "examples"
+                  / "assignment_tracking"
+                  / "student_repos"
+                  / "rossi-mario"
+                  / "reports"
+                  / "c-base-somma-001"
+                  / "latest.json"
+              ).read_text(encoding="utf-8")
+          )
+          assert report["backend"] == "docker"
+          assert report["passed"] is True
+          assert report["status"] == "passed"
+          assert report["summary"] == {"passed": 1, "total": 1}
           PY

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -26,6 +26,14 @@ Per salvare il risultato nel path standard dello studente:
 python scripts/student_lab_runner.py --student-id rossi-mario --activity-id python-base-somma-001 --write-report
 ```
 
+Per usare la sandbox Docker minima, per ora sulle consegne C:
+
+```powershell
+python scripts/student_lab_runner.py --student-id rossi-mario --activity-id c-base-somma-001 --backend docker --write-report
+```
+
+Il backend Docker usa l'immagine `thebitlab-assignment-runner`. Se Docker non e installato o non e avviato, il runner produce un report `docker-not-found` invece di interrompere la TUI con uno stack trace.
+
 La TUI usa colori ANSI quando il terminale li supporta. Per disattivarli:
 
 ```powershell
@@ -68,7 +76,7 @@ Quando il report e salvato, il servizio lab lo rilegge e aggiorna stato consegna
 Il report salvato usa lo schema `student_lab_run.v1` e mantiene separati:
 
 - risultato deterministico: `passed`, `status`, `summary`, `tests`, `stdout`, `stderr`;
-- metadati di collegamento: `assignment_id`, `activity_id`, `student_id`, `language`, `source`, `submitted_at`;
+- metadati di collegamento: `assignment_id`, `activity_id`, `student_id`, `language`, `source`, `backend`, `submitted_at`;
 - feedback AI: non presente in questo report, per evitare di mescolare esecuzione deterministica e suggerimenti generativi.
 
 Le prossime PR dovranno usare questo contratto per:

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -5,6 +5,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,8 @@ from scripts.thebitlab_contracts import normalize_activity
 
 
 DEFAULT_TIMEOUT_SECONDS = 5
+DEFAULT_DOCKER_IMAGE = grade_activity.DEFAULT_DOCKER_IMAGE
+RUNNER_BACKENDS = {"local", "docker"}
 DEFAULT_SOURCE_NAMES = {
     "c": "main.c",
     "python": "main.py",
@@ -221,6 +224,101 @@ def wrap_c_report(assignment: dict[str, Any], source: Path, report: dict[str, An
     }
 
 
+def run_c_docker(
+    assignment: dict[str, Any],
+    *,
+    activity_path: Path,
+    source: Path,
+    timeout_seconds: int,
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
+) -> dict[str, Any]:
+    """Run a C assignment through the existing Docker grading sandbox."""
+
+    if not source.is_file():
+        return error_report(
+            assignment,
+            language="c",
+            source=source,
+            status="source-not-found",
+            error=f"Sorgente non trovato: {source}",
+            backend="docker",
+        )
+    with tempfile.TemporaryDirectory(prefix="thebitlab-student-docker-") as temp_dir:
+        temp_root = Path(temp_dir)
+        try:
+            workspace, copied_activity, copied_source = grade_activity.prepare_docker_workspace(activity_path, source, temp_root)
+            docker_timeout = grade_activity.docker_timeout_seconds(grade_activity.load_activity(copied_activity), timeout_seconds)
+            command = grade_activity.docker_command(
+                activity=copied_activity,
+                source=copied_source,
+                language="c",
+                timeout_seconds=timeout_seconds,
+                image=docker_image,
+                workspace=workspace,
+            )
+        except (OSError, ValueError) as error:
+            return error_report(
+                assignment,
+                language="c",
+                source=source,
+                status="docker-setup-error",
+                error=str(error),
+                backend="docker",
+            )
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, timeout=docker_timeout, check=False)
+        except subprocess.TimeoutExpired:
+            return error_report(
+                assignment,
+                language="c",
+                source=source,
+                status="docker-timeout",
+                error=f"Timeout Docker dopo {docker_timeout} secondi.",
+                backend="docker",
+            )
+        except FileNotFoundError:
+            return error_report(
+                assignment,
+                language="c",
+                source=source,
+                status="docker-not-found",
+                error="Docker non trovato. Installa Docker oppure usa --backend local.",
+                backend="docker",
+            )
+    try:
+        report = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return error_report(
+            assignment,
+            language="c",
+            source=source,
+            status="docker-invalid-output",
+            error=result.stderr or result.stdout or "Il container non ha prodotto JSON valido.",
+            backend="docker",
+        )
+    if not grade_activity.has_minimal_report_shape(report):
+        return error_report(
+            assignment,
+            language="c",
+            source=source,
+            status="docker-invalid-report",
+            error=result.stderr or "Il container non ha prodotto un report di grading valido.",
+            backend="docker",
+        )
+    if result.returncode != 0 and report.get("passed") is True:
+        return error_report(
+            assignment,
+            language="c",
+            source=source,
+            status="docker-inconsistent-report",
+            error=result.stderr or "Il container ha fallito ma ha prodotto un report di successo.",
+            backend="docker",
+        )
+    wrapped = wrap_c_report(assignment, source, report)
+    wrapped["backend"] = "docker"
+    return wrapped
+
+
 def run_local_assignment(
     assignment: dict[str, Any],
     *,
@@ -270,6 +368,84 @@ def run_local_assignment(
     )
 
 
+def run_docker_assignment(
+    assignment: dict[str, Any],
+    *,
+    root: Path = PROJECT_ROOT,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
+) -> dict[str, Any]:
+    """Run one student lab assignment with Docker when supported."""
+
+    activity_summary = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
+    activity_path_value = clean_text(activity_summary.get("path"))
+    activity_path = student_lab_service.resolve_local_path(root, activity_path_value) if activity_path_value else root
+    activity = load_activity(root, assignment)
+    normalized = normalize_activity(activity)
+    language = clean_text(normalized.get("language")).lower()
+    workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+    workspace_path_value = clean_text(workspace.get("path"))
+    workspace_path = student_lab_service.resolve_local_path(root, workspace_path_value) if workspace_path_value else root
+    source_name = source_name_for(activity, language)
+    source = workspace_path / source_name if source_name else workspace_path
+    if not is_safe_source_name(source_name):
+        return error_report(
+            assignment,
+            language=language,
+            source=source,
+            status="invalid-source-name",
+            error="source_name deve essere un nome file semplice dentro il workspace.",
+            backend="docker",
+        )
+    if not workspace_path.is_dir():
+        return error_report(
+            assignment,
+            language=language,
+            source=source,
+            status="workspace-not-found",
+            error=f"Workspace non trovato: {workspace_path_value}",
+            backend="docker",
+        )
+    if language == "c":
+        return run_c_docker(
+            assignment,
+            activity_path=activity_path,
+            source=source,
+            timeout_seconds=timeout_seconds,
+            docker_image=docker_image,
+        )
+    return error_report(
+        assignment,
+        language=language,
+        source=source,
+        status="unsupported-docker-language",
+        error=f"Runner Docker non supportato per il linguaggio: {language or '-'}",
+        backend="docker",
+    )
+
+
+def run_assignment(
+    assignment: dict[str, Any],
+    *,
+    root: Path = PROJECT_ROOT,
+    backend: str = "local",
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
+) -> dict[str, Any]:
+    """Run one assignment with the requested backend."""
+
+    if backend == "local":
+        return run_local_assignment(assignment, root=root, timeout_seconds=timeout_seconds)
+    if backend == "docker":
+        return run_docker_assignment(
+            assignment,
+            root=root,
+            timeout_seconds=timeout_seconds,
+            docker_image=docker_image,
+        )
+    raise ValueError(f"Backend runner non supportato: {backend}")
+
+
 def select_assignment(
     assignments: list[dict[str, Any]],
     *,
@@ -304,14 +480,22 @@ def run_student_assignment(
     assignment_id: str | None = None,
     activity_id: str | None = None,
     now: str | None = None,
+    backend: str = "local",
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
 ) -> dict[str, Any]:
     """Load and run one assignment for a student."""
 
     payload = student_lab_service.student_lab_payload(root=root, student_id=student_id, now=now)
     assignments = payload.get("assignments") if isinstance(payload.get("assignments"), list) else []
     assignment = select_assignment(assignments, assignment_id=assignment_id, activity_id=activity_id)
-    return run_local_assignment(assignment, root=root, timeout_seconds=timeout_seconds)
+    return run_assignment(
+        assignment,
+        root=root,
+        backend=backend,
+        timeout_seconds=timeout_seconds,
+        docker_image=docker_image,
+    )
 
 
 def load_student_assignment(
@@ -403,6 +587,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--activity-id", help="ID activity da eseguire se l'assegnazione e univoca.")
     parser.add_argument("--root", type=Path, default=PROJECT_ROOT, help="Root del repository TheBitLab.")
     parser.add_argument("--now", help="Data ISO da usare per calcolare lo stato della consegna.")
+    parser.add_argument("--backend", choices=sorted(RUNNER_BACKENDS), default="local", help="Backend runner da usare.")
+    parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE, help="Immagine Docker da usare con --backend docker.")
     parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout del runner locale.")
     parser.add_argument("--write-report", action="store_true", help="Scrive il report nel path standard dello studente.")
     parser.add_argument("--report", type=Path, help="Path alternativo del report JSON da scrivere.")
@@ -422,7 +608,13 @@ def main() -> int:
             activity_id=args.activity_id,
             now=args.now,
         )
-        report = run_local_assignment(assignment, root=root, timeout_seconds=args.timeout)
+        report = run_assignment(
+            assignment,
+            root=root,
+            backend=args.backend,
+            timeout_seconds=args.timeout,
+            docker_image=args.docker_image,
+        )
         if args.write_report or args.report:
             write_student_report(root, assignment, report, args.report.resolve(strict=False) if args.report else None)
     except ValueError as error:

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -252,6 +252,115 @@ def test_run_local_assignment_wraps_c_compile_error(monkeypatch, tmp_path) -> No
     assert report["summary"] == {"passed": 0, "total": 0}
 
 
+def test_run_docker_assignment_wraps_container_report(monkeypatch, tmp_path) -> None:
+    activity_id = "c-base-somma-001"
+    activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")
+    write_assignment(tmp_path, activity_path, activity_id=activity_id)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / activity_id
+    workspace.mkdir(parents=True)
+    (workspace / "main.c").write_text("int main(void){ return 0; }\n", encoding="utf-8")
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                "passed": True,
+                "status": "passed",
+                "activity_id": activity_id,
+                "language": "c",
+                "source": "/workspace/source/main.c",
+                "tests": [{"name": "smoke", "passed": True, "status": "passed"}],
+                "summary": {"passed": 1, "total": 1},
+            }
+        )
+        stderr = ""
+
+    monkeypatch.setattr(student_lab_runner.subprocess, "run", lambda *args, **kwargs: Result())
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+        backend="docker",
+    )
+
+    assert report["backend"] == "docker"
+    assert report["status"] == "passed"
+    assert report["passed"] is True
+    assert report["summary"] == {"passed": 1, "total": 1}
+
+
+def test_run_docker_assignment_reports_missing_docker(monkeypatch, tmp_path) -> None:
+    activity_id = "c-base-somma-001"
+    activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")
+    write_assignment(tmp_path, activity_path, activity_id=activity_id)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / activity_id
+    workspace.mkdir(parents=True)
+    (workspace / "main.c").write_text("int main(void){ return 0; }\n", encoding="utf-8")
+
+    def missing_docker(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(student_lab_runner.subprocess, "run", missing_docker)
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+        backend="docker",
+    )
+
+    assert report["backend"] == "docker"
+    assert report["status"] == "docker-not-found"
+    assert "Docker non trovato" in report["error"]
+
+
+def test_run_docker_assignment_rejects_success_report_on_container_error(monkeypatch, tmp_path) -> None:
+    activity_id = "c-base-somma-001"
+    activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")
+    write_assignment(tmp_path, activity_path, activity_id=activity_id)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / activity_id
+    workspace.mkdir(parents=True)
+    (workspace / "main.c").write_text("int main(void){ return 0; }\n", encoding="utf-8")
+
+    class Result:
+        returncode = 1
+        stdout = json.dumps({"passed": True, "status": "passed"})
+        stderr = "errore container"
+
+    monkeypatch.setattr(student_lab_runner.subprocess, "run", lambda *args, **kwargs: Result())
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+        backend="docker",
+    )
+
+    assert report["backend"] == "docker"
+    assert report["status"] == "docker-inconsistent-report"
+    assert report["passed"] is False
+
+
+def test_run_docker_assignment_reports_unsupported_language(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, language="python", source_name="main.py")
+    write_assignment(tmp_path, activity_path)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / "python-base-somma-001"
+    workspace.mkdir(parents=True)
+    (workspace / "main.py").write_text("print(1)\n", encoding="utf-8")
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        backend="docker",
+    )
+
+    assert report["backend"] == "docker"
+    assert report["status"] == "unsupported-docker-language"
+    assert report["language"] == "python"
+
+
 def test_select_assignment_requires_disambiguation() -> None:
     try:
         student_lab_runner.select_assignment(


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `--backend docker` al runner studente.
- Per ora supporta consegne C usando la sandbox Docker gia esistente del grader deterministico.
- Mantiene `local` come backend predefinito.
- Restituisce report espliciti per Docker mancante, timeout Docker, output non valido e linguaggi Docker non supportati.
- Estende la workflow Docker con uno smoke end-to-end tramite `scripts/student_lab_runner.py --backend docker --write-report`.
- Aggiorna `doc/STUDENT_LAB.md`.

## Perche

Serve portare il lab studente verso l'esecuzione isolata senza rendere Docker obbligatorio per la TUI o per chi sta solo provando il flusso locale.

## Fuori scope

- Docker per Python o altri linguaggi.
- Sandbox multiutente completa.
- Configurazione quote/limiti per classe o studente.
- Terminale web/tmux.

## Verifiche locali

```powershell
python -m pytest tests/test_student_lab_cli.py tests/test_student_lab_runner.py tests/test_student_lab_service.py
python -m py_compile scripts/student_lab_runner.py scripts/student_lab_cli.py
```

Risultato locale: 34 test passati.

La build reale dell'immagine e lo smoke Docker girano in GitHub Actions.

## Issue

Closes #372
