### PR TITLE
Collega risultati lab alla dashboard studente

### DIFF
--- a/doc/STUDENT_DASHBOARD.md
+++ b/doc/STUDENT_DASHBOARD.md
@@ -49,6 +49,29 @@ Per ogni consegna dello studente mostra:
 - link repository o file consegna quando disponibili;
 - feedback AI/didattico solo se approvato dal docente.
 
+Il pannello `Lab` legge anche il payload operativo prodotto da `scripts/student_lab_service.py` e mostra:
+
+- workspace locale della consegna;
+- presenza dell'ultimo report `reports/<activity_id>/latest.json`;
+- stato ultimo tentativo;
+- test passati e totali;
+- backend usato dal runner, per esempio `local` o `docker`.
+
+Smoke test manuale:
+
+```bash
+python scripts/course_board_server.py
+```
+
+Apri `http://localhost:8765/tools/student_dashboard.html`, scegli uno studente con consegne assegnate e controlla il pannello `Lab`.
+Se prima esegui il runner con `--write-report`, per esempio:
+
+```bash
+python scripts/student_lab_runner.py --student-id rossi-mario --activity-id python-base-somma-001 --write-report
+```
+
+la dashboard deve mostrare il report salvato, il numero di test e il path del workspace.
+
 ## Relazione con il lab studente
 
 La dashboard studente web e la vista di consultazione: mostra consegne, calendario, percorso, stato, risultati e feedback approvato.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -42,6 +42,7 @@ from scripts import (
     create_activity,
     create_submission_scaffold,
     manual_ai_feedback,
+    student_lab_service,
     thebitlab_services,
     thebitlab_storage,
     track_assignments,
@@ -421,7 +422,17 @@ def assignment_overview() -> list[dict]:
 def student_dashboard(student_id: str) -> dict:
     """Return the minimal student-facing assignment dashboard."""
 
-    return assignment_service().student_dashboard(student_id)
+    dashboard = assignment_service().student_dashboard(student_id)
+    try:
+        dashboard["lab"] = student_lab_service.student_lab_payload(root=ROOT, student_id=student_id)
+    except Exception as error:  # noqa: BLE001
+        dashboard["lab"] = {
+            "schema_version": "student_lab.v1",
+            "student_id": str(student_id or "").strip(),
+            "assignments": [],
+            "error": str(error),
+        }
+    return dashboard
 
 
 def list_activities() -> list[dict]:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -855,6 +855,64 @@ def test_student_dashboard_endpoint_filters_to_requested_student(tmp_path, monke
     assert dashboard["assignments"][0]["approved_feedback"]["student_feedback"] == "Feedback visibile."
 
 
+def test_student_dashboard_endpoint_includes_student_lab_results(tmp_path, monkeypatch) -> None:
+    patch_assignment_paths(tmp_path, monkeypatch)
+    write_demo_activity(tmp_path / "activities" / "python-base-somma-001.json")
+    assignment_records.JsonAssignmentRecordStorage(tmp_path, tmp_path / "teacher-assignments").write_assignment(
+        assignment_records.build_assignment_record(
+            activity_id="python-base-somma-001",
+            activity_path="activities/python-base-somma-001.json",
+            target_type="class",
+            class_id="3A-TPSI",
+            class_label="3A TPSI",
+            github_team="team-3a-tpsi",
+            assigned_at="2026-10-12T09:00:00+02:00",
+            due_at="2026-10-19T23:59:00+02:00",
+            targets=[
+                {
+                    "student_id": "rossi-mario",
+                    "path": "examples/assignment_tracking/student_repos/rossi-mario",
+                }
+            ],
+        ),
+    )
+    repo = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario"
+    workspace = repo / "assignments" / "python-base-somma-001"
+    report_path = repo / "reports" / "python-base-somma-001" / "latest.json"
+    workspace.mkdir(parents=True)
+    report_path.parent.mkdir(parents=True)
+    (workspace / "main.py").write_text("print(3)\n", encoding="utf-8")
+    report_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "student_lab_run.v1",
+                "activity_id": "python-base-somma-001",
+                "student_id": "rossi-mario",
+                "status": "passed",
+                "passed": True,
+                "source": "assignments/python-base-somma-001/main.py",
+                "submitted_at": "2026-10-18T18:00:00+02:00",
+                "summary": {"passed": 2, "total": 2},
+                "tests": [
+                    {"name": "somma positiva", "status": "passed", "passed": True},
+                    {"name": "somma negativa", "status": "passed", "passed": True},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dashboard = course_board_server.student_dashboard("rossi-mario")
+
+    assert dashboard["lab"]["schema_version"] == "student_lab.v1"
+    assert len(dashboard["lab"]["assignments"]) == 1
+    lab_assignment = dashboard["lab"]["assignments"][0]
+    assert lab_assignment["workspace"]["exists"] is True
+    assert lab_assignment["report"]["exists"] is True
+    assert lab_assignment["grading"]["status"] == "graded_passed"
+    assert lab_assignment["grading"]["tests_passed"] == 2
+
+
 def test_class_roster_helpers_use_local_roster_storage(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     classes_dir = tmp_path / "doc" / "classes"

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -73,6 +73,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderStudentCalendar,
         renderCoursePath,
         renderFeedback,
+        renderStudentLab,
         renderAssignment,
         renderAssignmentDetail,
         openAssignmentDetail,
@@ -152,6 +153,20 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
 
         tested.renderDashboard({
           student_id: "rossi-mario",
+          lab: {
+            assignments: [{
+              activity_id: "python-base-somma-001",
+              title: "Somma in Python",
+              due_at: "2026-10-19T23:59:00+02:00",
+              status: "submitted",
+              submitted: true,
+              activity: { language: "python" },
+              workspace: { path: "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001", exists: true },
+              report: { path: "examples/assignment_tracking/student_repos/rossi-mario/reports/python-base-somma-001/latest.json", exists: true, submitted_at: "2026-10-18T18:22:10+02:00" },
+              grading: { status: "graded_passed", tests_passed: 2, tests_total: 2, failed_tests: [] },
+              runner: { backend: "local" },
+            }],
+          },
           assignments: [assignment, { activity_id: "python-loop-001", status: "missing", submitted: false, late: false }],
         });
 
@@ -170,6 +185,10 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
         assert.match(tested.els.assignments.innerHTML, /Dettaglio/);
         assert.match(tested.els.assignments.innerHTML, /data-detail-index="0"/);
         assert.match(tested.els.assignments.innerHTML, /href="https:\\/\\/github.com\\/TheBitPoets\\/rossi-mario\\/blob\\/main\\/assignments\\/python-base-somma-001\\/main.py"/);
+        assert.match(tested.els.studentLab.innerHTML, /Workspace pronto/);
+        assert.match(tested.els.studentLab.innerHTML, /Report salvato/);
+        assert.match(tested.els.studentLab.innerHTML, /Test: 2\\/2/);
+        assert.match(tested.els.studentLabStatus.textContent, /1 consegne lab · 1 report salvati/);
         """
     )
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -160,6 +160,7 @@ button {
 button:hover { transform: translateY(-1px); }
 
 .summary,
+.studentLab,
 .studentCalendar,
 .coursePath,
 .assignments {
@@ -240,6 +241,41 @@ button:hover { transform: translateY(-1px); }
   gap: .85rem;
   min-width: 0;
   padding: 1.1rem;
+}
+
+.studentLabBody {
+  display: grid;
+  gap: .85rem;
+  min-width: 0;
+  padding: 1.1rem;
+}
+
+.studentLabCard {
+  display: grid;
+  gap: .75rem;
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 18px;
+  background: #ffffff;
+  padding: 1rem;
+}
+
+.studentLabHead {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.studentLabHead > div {
+  min-width: 0;
+}
+
+.studentLabHead h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  overflow-wrap: anywhere;
 }
 
 .studentCalendarControls {

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -41,6 +41,16 @@
       <p class="status">Carica uno studente per vedere consegne, stato e feedback approvato.</p>
     </section>
 
+    <section class="studentLab">
+      <div class="sectionHead">
+        <h2>Lab</h2>
+        <p id="studentLabStatus" class="status" aria-live="polite"></p>
+      </div>
+      <div id="studentLab" class="studentLabBody">
+        <p class="status">Carica uno studente per vedere workspace e risultati del runner.</p>
+      </div>
+    </section>
+
     <section class="studentCalendar">
       <div class="sectionHead">
         <h2>Calendario</h2>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -5,6 +5,8 @@ const els = {
   assignmentFilter: document.querySelector("#assignmentFilter"),
   assignmentSort: document.querySelector("#assignmentSort"),
   summary: document.querySelector("#summary"),
+  studentLab: document.querySelector("#studentLab"),
+  studentLabStatus: document.querySelector("#studentLabStatus"),
   status: document.querySelector("#status"),
   assignments: document.querySelector("#assignments"),
   studentCalendar: document.querySelector("#studentCalendar"),
@@ -258,6 +260,80 @@ function gradingBadge(grading) {
 function gradeValue(grading) {
   const grade = grading?.teacher_grade ?? grading?.score;
   return grade == null || String(grade).trim() === "" ? "-" : grade;
+}
+
+function labStatusBadge(assignment) {
+  if (assignment.status === "missing") return badge("Mancante", "badgeBad");
+  if (assignment.status === "submitted_late") return badge("Report in ritardo", "badgeWarn");
+  if (assignment.submitted || assignment.status === "submitted") return badge("Report presente", "badgeOk");
+  if (assignment.status === "pending") return badge("Da fare");
+  return badge(assignment.status || "Stato non disponibile");
+}
+
+function labWorkspaceBadge(workspace) {
+  if (workspace?.exists) return badge("Workspace pronto", "badgeOk");
+  return badge("Workspace non trovato", "badgeWarn");
+}
+
+function labReportBadge(report) {
+  if (report?.exists) return badge("Report salvato", "badgeOk");
+  return badge("Report assente");
+}
+
+function renderLabAssignment(assignment) {
+  const grading = assignment.grading || {};
+  const workspace = assignment.workspace || {};
+  const report = assignment.report || {};
+  const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
+  return `
+    <article class="studentLabCard">
+      <div class="studentLabHead">
+        <div>
+          <h3>${escapeHtml(assignment.title || assignment.activity_id || "Activity")}</h3>
+          <p class="meta">
+            <span>${escapeHtml(assignment.activity?.language || "linguaggio non indicato")}</span>
+            <span>Scadenza: ${escapeHtml(formatDate(assignment.due_at))}</span>
+          </p>
+        </div>
+        <div class="assignmentBadges">
+          ${labStatusBadge(assignment)}
+          ${gradingBadge(grading)}
+        </div>
+      </div>
+      <p class="details">
+        <span>${labWorkspaceBadge(workspace)}</span>
+        <span>${labReportBadge(report)}</span>
+        <span>Test: ${escapeHtml(grading.tests_passed ?? "-")}/${escapeHtml(grading.tests_total ?? "-")}</span>
+        <span>Ultimo tentativo: ${escapeHtml(formatDate(report.submitted_at))}</span>
+      </p>
+      <p class="details">
+        <span>Workspace: ${escapeHtml(workspace.path || "-")}</span>
+        <span>Report: ${escapeHtml(report.path || "-")}</span>
+        <span>Backend: ${escapeHtml(assignment.runner?.backend || "-")}</span>
+      </p>
+      ${grading.detail ? `<p class="details">${escapeHtml(grading.detail)}</p>` : ""}
+      ${failedTests.length ? `<p class="details">Test falliti: ${failedTests.map(escapeHtml).join(", ")}</p>` : ""}
+    </article>
+  `;
+}
+
+function renderStudentLab(lab) {
+  if (!els.studentLab) return;
+  const assignments = Array.isArray(lab?.assignments) ? lab.assignments : [];
+  if (lab?.error) {
+    els.studentLab.innerHTML = `<p class="status">Lab non disponibile: ${escapeHtml(lab.error)}</p>`;
+    if (els.studentLabStatus) els.studentLabStatus.textContent = "Errore dati lab";
+    return;
+  }
+  if (els.studentLabStatus) {
+    const reports = assignments.filter((assignment) => assignment.report?.exists).length;
+    els.studentLabStatus.textContent = assignments.length
+      ? `${assignments.length} consegne lab · ${reports} report salvati`
+      : "Nessuna consegna lab";
+  }
+  els.studentLab.innerHTML = assignments.length
+    ? assignments.map(renderLabAssignment).join("")
+    : '<p class="status">Nessuna consegna lab operativa disponibile per questo studente.</p>';
 }
 
 function isOpenAssignment(assignment) {
@@ -1263,6 +1339,7 @@ function renderDashboard(payload) {
   const nextAssignment = nextOpenAssignment(assignments);
   const visibleAssignments = sortedAssignments(filteredAssignments(assignments, filterValue), sortValue);
   renderSummary(payload.student_id || "-", assignments);
+  renderStudentLab(payload.lab);
   renderStudentCalendar(assignments);
   renderCoursePath(currentCourseDesign, assignments, payload.student_id);
   renderStudentPathFilters(assignments, payload.student_id);


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge il payload `lab` alla risposta `/api/student-dashboard`, riusando `student_lab_service`.
- Mostra nella dashboard studente un pannello `Lab` con workspace, report salvato, stato ultimo tentativo, test e backend runner.
- Aggiorna test backend/frontend e documentazione dello smoke test manuale.

## Perche

La TUI e il runner studente producono gia report locali; la vista web studente deve poterli leggere per diventare la vista di consultazione unica di consegne, risultati e feedback.

## Verifiche

```powershell
python -m pytest tests/test_student_dashboard_frontend.py tests/test_course_board_server.py tests/test_student_lab_service.py
python -m py_compile scripts/course_board_server.py scripts/student_lab_service.py
git diff --check
```

Closes #373
