### PR TITLE
Espone metadati report lab nel registro docente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -79,6 +79,16 @@ Il report salvato usa lo schema `student_lab_run.v1` e mantiene separati:
 - metadati di collegamento: `assignment_id`, `activity_id`, `student_id`, `language`, `source`, `backend`, `submitted_at`;
 - feedback AI: non presente in questo report, per evitare di mescolare esecuzione deterministica e suggerimenti generativi.
 
+Il registro docente legge lo stesso `reports/<activity_id>/latest.json` usato dal lab studente.
+Quando il report esiste, il registro salva nella `submission` anche:
+
+- `report_path`: path relativo del report letto;
+- `report_backend`: backend che ha prodotto il report, per esempio `local` o `docker`;
+- `report_schema_version`: versione dello schema del report;
+- `report_status`: stato tecnico del report originale.
+
+In questo modo dashboard docente, dashboard studente e TUI leggono lo stesso risultato senza ricalcolare grading o stato in modi divergenti.
+
 Le prossime PR dovranno usare questo contratto per:
 
 1. collegare il comando di esecuzione alla TUI;

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -372,6 +372,7 @@ def track_assignments(
         report = load_report(report_path)
         if report is not None:
             validate_report_activity(report, activity_id, report_path)
+        relative_report_path = relative_to_root_or_repo(report_path, target.path) if report_path.exists() else None
         source_path = report.get("source") if report else None
         submitted = report is not None
         submitted_at = report.get("submitted_at") if report else None
@@ -398,10 +399,14 @@ def track_assignments(
                     "files": submission_files(target, activity_id, report, repo_url),
                     "submitted_at": submitted_at,
                     "commit": report.get("commit") if report else None,
+                    "report_path": relative_report_path,
+                    "report_backend": report.get("backend") if report else None,
+                    "report_schema_version": report.get("schema_version") if report else None,
+                    "report_status": report.get("status") if report else None,
                 },
                 "grading": grading_summary(report),
                 "ai_feedback": ai_feedback_placeholder(),
-                "report_path": str(report_path) if report_path.exists() else None,
+                "report_path": relative_report_path,
             }
         )
 

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -523,6 +523,33 @@ def test_track_assignments_uses_technical_grading_adapter_for_infrastructure_err
     assert grading["report_status"] == "unsupported-language"
 
 
+def test_track_assignments_exposes_student_lab_report_metadata(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    write_report(student.path, "2026-10-20T08:00:00+02:00", passed=True)
+    report_path = student.path / "reports" / "python-base-somma-001" / "latest.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report["schema_version"] = "student_lab_run.v1"
+    report["backend"] = "docker"
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+    )
+
+    row = index["students"][0]
+
+    assert row["report_path"] == "reports/python-base-somma-001/latest.json"
+    assert row["submission"]["report_path"] == "reports/python-base-somma-001/latest.json"
+    assert row["submission"]["report_backend"] == "docker"
+    assert row["submission"]["report_schema_version"] == "student_lab_run.v1"
+    assert row["submission"]["report_status"] == "passed"
+    assert row["grading"]["status"] == "graded_passed"
+
+
 def test_track_assignments_rejects_report_for_different_activity(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "verdi-anna")

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -4093,6 +4093,8 @@ function renderStudents(students) {
         ${escapeHtml(formatDate(submission.submitted_at))}<br>
         <small>${submission.commit ? `commit ${escapeHtml(submission.commit)}` : "commit non disponibile"}</small><br>
         <small>${submission.source_path ? escapeHtml(submission.source_path) : "sorgente non indicato"}</small>
+        ${submission.report_path ? `<br><small>report ${escapeHtml(submission.report_path)}</small>` : ""}
+        ${submission.report_backend ? `<br><small>backend ${escapeHtml(submission.report_backend)}</small>` : ""}
         ${submission.source_github_url ? `<br>${externalLink(submission.source_github_url, "Apri su GitHub")}` : ""}
       </td>
       <td>


### PR DESCRIPTION
﻿## Cosa cambia

- Il registro docente conserva nella `submission` i metadati del report prodotto dal lab studente: path, backend, schema e stato tecnico.
- Il path del report viene normalizzato in forma relativa, stabile tra macchina locale e dashboard.
- La tabella studenti del registro mostra path report e backend quando disponibili.
- La documentazione chiarisce il contratto condiviso tra TUI, dashboard studente e registro docente.

## Perche

Il lab studente produce gia `reports/<activity_id>/latest.json`; il registro docente deve leggere lo stesso risultato senza ricalcolare grading o stato in modo divergente.

## Verifiche

```powershell
python -m pytest tests/test_track_assignments.py tests/test_assignment_dashboard_frontend.py
python -m py_compile scripts/track_assignments.py
git diff --check
```

Closes #374
