### PR TITLE
Mostra modalita di aiuto nel lab studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -73,6 +73,20 @@ Quando il report e salvato, il servizio lab lo rilegge e aggiorna stato consegna
 | `submitted` | Esiste un report coerente con la activity |
 | `submitted_late` | Esiste un report coerente, ma consegnato dopo la scadenza |
 
+## Modalita di aiuto
+
+Ogni consegna puo esporre `student_support_mode`.
+Il payload lab aggiunge `support_policy`, cioe una descrizione leggibile per lo studente:
+
+| Modalita | Significato MVP |
+|---|---|
+| `senza-aiuto` | Lo studente lavora in autonomia e vede solo consegna, workspace e risultati deterministici. |
+| `feedback-tecnico` | Lo studente puo usare errori, output e test falliti per correggere il lavoro. |
+| `studio-guidato` | Lo studente puo consultare richiami teorici, domande guida ed esempi approvati dal docente. |
+| `ai-assisted` | Lo studente puo usare aiuto AI nei limiti di budget e policy decisi dal docente. |
+
+In questa fase la policy e informativa: TUI e dashboard la mostrano chiaramente, mentre enforcement tecnico, log degli aiuti e limiti AI saranno introdotti nei passi successivi.
+
 ## Direzione
 
 Il report salvato usa lo schema `student_lab_run.v1` e mantiene separati:

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -72,6 +72,14 @@ def grading_label(grading: dict[str, Any]) -> str:
     return status
 
 
+def policy_list(values: Any) -> str:
+    """Return a compact comma-separated list for support policy details."""
+
+    if not isinstance(values, list) or not values:
+        return "-"
+    return ", ".join(clean_text(value) for value in values)
+
+
 def truncate(text: str, width: int) -> str:
     """Return text clipped to width with a suffix."""
 
@@ -174,6 +182,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
     report = assignment.get("report") if isinstance(assignment.get("report"), dict) else {}
     grading = assignment.get("grading") if isinstance(assignment.get("grading"), dict) else {}
     runner = assignment.get("runner") if isinstance(assignment.get("runner"), dict) else {}
+    support_policy = assignment.get("support_policy") if isinstance(assignment.get("support_policy"), dict) else {}
     topics = activity.get("topics") if isinstance(activity.get("topics"), list) else []
     lines = [
         "Dettaglio consegna",
@@ -196,6 +205,12 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Linguaggio:", activity.get("language")),
         detail_line("Sorgente:", activity.get("source_name")),
         detail_line("Argomenti:", ", ".join(str(topic) for topic in topics) if topics else "-"),
+        "",
+        "Aiuto consentito",
+        detail_line("Modalita:", support_policy.get("label") or assignment.get("student_support_mode")),
+        detail_line("Sintesi:", support_policy.get("summary")),
+        detail_line("Permesso:", policy_list(support_policy.get("allowed"))),
+        detail_line("Non permesso:", policy_list(support_policy.get("not_allowed"))),
         "",
         "Report",
         detail_line("Path:", report.get("path")),

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -11,7 +11,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import assignment_records, track_assignments
+from scripts import assignment_records, student_support_policy, track_assignments
 from scripts.thebitlab_contracts import normalize_activity
 
 
@@ -106,6 +106,7 @@ def load_activity_summary(root: Path, activity_path_value: str) -> dict[str, Any
             "language": "",
             "source_name": "",
             "topics": [],
+            "student_support_mode": "",
         }
     payload = json.loads(activity_path.read_text(encoding="utf-8-sig"))
     if not isinstance(payload, dict):
@@ -119,6 +120,7 @@ def load_activity_summary(root: Path, activity_path_value: str) -> dict[str, Any
         "language": clean_text(activity.get("language")),
         "source_name": clean_text(activity.get("source_name")),
         "topics": activity.get("topics") if isinstance(activity.get("topics"), list) else [],
+        "student_support_mode": clean_text(activity.get("student_support_mode")),
     }
 
 
@@ -184,6 +186,8 @@ def build_lab_assignment(
         "assignment_id": normalized["id"],
         "activity_id": activity_id,
         "title": activity["title"] or activity_id,
+        "student_support_mode": activity.get("student_support_mode", ""),
+        "support_policy": student_support_policy.support_policy(activity.get("student_support_mode", "")),
         "student_id": student_id,
         "target_type": normalized["target_type"],
         "class_id": normalized["class_id"],

--- a/scripts/student_support_policy.py
+++ b/scripts/student_support_policy.py
@@ -1,0 +1,68 @@
+"""Student-facing support policy labels for activity support modes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+DEFAULT_SUPPORT_MODE = "feedback-tecnico"
+
+SUPPORT_POLICIES: dict[str, dict[str, Any]] = {
+    "senza-aiuto": {
+        "mode": "senza-aiuto",
+        "label": "Senza aiuto",
+        "summary": "Lavora in autonomia: il sistema mostra consegna, workspace e risultati dei test.",
+        "allowed": ["consultare consegna e file assegnati", "eseguire test se previsti", "vedere esito deterministico"],
+        "not_allowed": ["aiuto AI", "suggerimenti sugli errori", "richiami teorici generati"],
+        "ai_allowed": False,
+        "theory_allowed": False,
+        "debug_allowed": False,
+    },
+    "feedback-tecnico": {
+        "mode": "feedback-tecnico",
+        "label": "Feedback tecnico",
+        "summary": "Puoi usare errori, output e risultati dei test per capire cosa correggere.",
+        "allowed": ["messaggi di compilazione", "errori runtime", "test falliti", "stdout e stderr"],
+        "not_allowed": ["soluzioni complete", "aiuto AI generativo se non autorizzato"],
+        "ai_allowed": False,
+        "theory_allowed": False,
+        "debug_allowed": True,
+    },
+    "studio-guidato": {
+        "mode": "studio-guidato",
+        "label": "Studio guidato",
+        "summary": "Puoi consultare materiali, richiami teorici e domande guida collegate all'attivita.",
+        "allowed": ["riferimenti alla teoria", "domande guida", "esempi approvati dal docente", "feedback tecnico"],
+        "not_allowed": ["soluzioni complete non approvate", "AI generativa libera"],
+        "ai_allowed": False,
+        "theory_allowed": True,
+        "debug_allowed": True,
+    },
+    "ai-assisted": {
+        "mode": "ai-assisted",
+        "label": "AI assisted",
+        "summary": "Puoi usare aiuto AI nei limiti decisi dal docente e tracciati dalla piattaforma.",
+        "allowed": ["feedback tecnico", "richiami teorici", "suggerimenti AI controllati", "domande di chiarimento"],
+        "not_allowed": ["sostituire la consegna con una soluzione non rivista", "superare i limiti di budget o policy"],
+        "ai_allowed": True,
+        "theory_allowed": True,
+        "debug_allowed": True,
+    },
+}
+
+
+def normalize_support_mode(value: Any) -> str:
+    """Return a known support mode, or the default policy for empty/unknown values."""
+
+    mode = str(value or "").strip()
+    return mode if mode in SUPPORT_POLICIES else DEFAULT_SUPPORT_MODE
+
+
+def support_policy(value: Any) -> dict[str, Any]:
+    """Return a copy of the student-facing policy for a support mode."""
+
+    mode = normalize_support_mode(value)
+    policy = dict(SUPPORT_POLICIES[mode])
+    policy["source_mode"] = str(value or "").strip()
+    policy["is_defaulted"] = policy["source_mode"] != mode
+    return policy

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -160,6 +160,13 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
               due_at: "2026-10-19T23:59:00+02:00",
               status: "submitted",
               submitted: true,
+              student_support_mode: "studio-guidato",
+              support_policy: {
+                label: "Studio guidato",
+                summary: "Puoi consultare materiali e domande guida.",
+                allowed: ["riferimenti alla teoria", "feedback tecnico"],
+                not_allowed: ["soluzioni complete"],
+              },
               activity: { language: "python" },
               workspace: { path: "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001", exists: true },
               report: { path: "examples/assignment_tracking/student_repos/rossi-mario/reports/python-base-somma-001/latest.json", exists: true, submitted_at: "2026-10-18T18:22:10+02:00" },
@@ -188,6 +195,9 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
         assert.match(tested.els.studentLab.innerHTML, /Workspace pronto/);
         assert.match(tested.els.studentLab.innerHTML, /Report salvato/);
         assert.match(tested.els.studentLab.innerHTML, /Test: 2\\/2/);
+        assert.match(tested.els.studentLab.innerHTML, /Studio guidato/);
+        assert.match(tested.els.studentLab.innerHTML, /riferimenti alla teoria, feedback tecnico/);
+        assert.match(tested.els.studentLab.innerHTML, /soluzioni complete/);
         assert.match(tested.els.studentLabStatus.textContent, /1 consegne lab · 1 report salvati/);
         """
     )

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -21,6 +21,14 @@ def sample_assignment(**overrides):
         "due_at": "2026-10-19T23:59:00+02:00",
         "status": "pending",
         "submitted": False,
+        "student_support_mode": "studio-guidato",
+        "support_policy": {
+            "mode": "studio-guidato",
+            "label": "Studio guidato",
+            "summary": "Puoi consultare materiali e domande guida.",
+            "allowed": ["riferimenti alla teoria", "feedback tecnico"],
+            "not_allowed": ["soluzioni complete"],
+        },
         "workspace": {
             "path": "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001",
             "exists": True,
@@ -111,6 +119,10 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001" in rendered
     assert "Linguaggio:" in rendered
     assert "python" in rendered
+    assert "Aiuto consentito" in rendered
+    assert "Studio guidato" in rendered
+    assert "riferimenti alla teoria, feedback tecnico" in rendered
+    assert "soluzioni complete" in rendered
     assert "not_graded" in rendered
     assert "not_run" in rendered
     assert "e = esegui e salva report" in rendered

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -5,11 +5,11 @@ import json
 from scripts import assignment_records, student_lab_service
 
 
-def write_activity(root, activity_id: str = "python-base-somma-001") -> str:
+def write_activity(root, activity_id: str = "python-base-somma-001", student_support_mode: str = "") -> str:
     """Write a minimal activity and return its repository-relative path."""
 
     path = root / "activities" / f"{activity_id}.json"
-    path.parent.mkdir(parents=True)
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(
             {
@@ -22,6 +22,7 @@ def write_activity(root, activity_id: str = "python-base-somma-001") -> str:
                 "language": "python",
                 "source_name": "main.py",
                 "instructions": "Scrivi un programma che stampa una somma.",
+                "student_support_mode": student_support_mode,
                 "grading_policy": {
                     "compila": True,
                     "test": True,
@@ -32,15 +33,16 @@ def write_activity(root, activity_id: str = "python-base-somma-001") -> str:
         ),
         encoding="utf-8",
     )
-    return "activities/python-base-somma-001.json"
+    return f"activities/{activity_id}.json"
 
 
 def sample_assignment(root, **overrides):
     """Return a valid assignment record for lab tests."""
 
+    activity_path = overrides.get("activity_path") or write_activity(root)
     payload = {
         "activity_id": "python-base-somma-001",
-        "activity_path": write_activity(root),
+        "activity_path": activity_path,
         "target_type": "group",
         "assigned_at": "2026-10-12T09:00:00+02:00",
         "due_at": "2026-10-19T23:59:00+02:00",
@@ -96,8 +98,28 @@ def test_student_lab_lists_only_requested_student_assignments(tmp_path) -> None:
     }
     assert assignment["activity"]["exists"] is True
     assert assignment["activity"]["language"] == "python"
+    assert assignment["support_policy"]["label"] == "Feedback tecnico"
+    assert assignment["support_policy"]["debug_allowed"] is True
     assert assignment["report"]["exists"] is False
     assert assignment["runner"]["status"] == "not_run"
+
+
+def test_student_lab_exposes_explicit_support_policy(tmp_path) -> None:
+    activity_id = "python-ai-assisted-001"
+    activity_path = write_activity(tmp_path, activity_id=activity_id, student_support_mode="ai-assisted")
+    write_assignment(tmp_path, sample_assignment(tmp_path, activity_id=activity_id, activity_path=activity_path))
+
+    assignment = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-18T12:00:00+02:00",
+    )[0]
+
+    assert assignment["activity_id"] == activity_id
+    assert assignment["student_support_mode"] == "ai-assisted"
+    assert assignment["support_policy"]["label"] == "AI assisted"
+    assert assignment["support_policy"]["ai_allowed"] is True
+    assert "suggerimenti AI controllati" in assignment["support_policy"]["allowed"]
 
 
 def test_student_lab_marks_missing_after_due_date_without_report(tmp_path) -> None:

--- a/tests/test_student_support_policy.py
+++ b/tests/test_student_support_policy.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from scripts import student_support_policy
+
+
+def test_support_policy_exposes_known_ai_assisted_mode() -> None:
+    policy = student_support_policy.support_policy("ai-assisted")
+
+    assert policy["mode"] == "ai-assisted"
+    assert policy["label"] == "AI assisted"
+    assert policy["ai_allowed"] is True
+    assert policy["theory_allowed"] is True
+    assert policy["debug_allowed"] is True
+    assert "suggerimenti AI controllati" in policy["allowed"]
+
+
+def test_support_policy_defaults_unknown_mode_to_technical_feedback() -> None:
+    policy = student_support_policy.support_policy("modalita-sconosciuta")
+
+    assert policy["mode"] == "feedback-tecnico"
+    assert policy["source_mode"] == "modalita-sconosciuta"
+    assert policy["is_defaulted"] is True
+    assert policy["ai_allowed"] is False
+    assert policy["debug_allowed"] is True

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -892,6 +892,24 @@ button:hover { transform: translateY(-1px); }
   text-align: justify;
 }
 
+.supportPolicy {
+  min-width: 0;
+  max-width: 70rem;
+  border-left: 4px solid #164a9f;
+  border-radius: 0 8px 8px 0;
+  padding: .75rem .85rem;
+  background: #f5f8ff;
+}
+
+.supportPolicy h4 {
+  margin: 0 0 .35rem;
+}
+
+.supportPolicy p {
+  margin-bottom: .45rem;
+  text-align: justify;
+}
+
 .emptyFeedback {
   color: var(--muted);
 }

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -280,6 +280,30 @@ function labReportBadge(report) {
   return badge("Report assente");
 }
 
+function supportPolicyLabel(assignment) {
+  return assignment.support_policy?.label || assignment.student_support_mode || "Modalita non indicata";
+}
+
+function renderSupportPolicy(assignment) {
+  const policy = assignment.support_policy || {};
+  const allowed = Array.isArray(policy.allowed) && policy.allowed.length
+    ? policy.allowed.join(", ")
+    : "-";
+  const notAllowed = Array.isArray(policy.not_allowed) && policy.not_allowed.length
+    ? policy.not_allowed.join(", ")
+    : "-";
+  return `
+    <section class="supportPolicy">
+      <h4>${escapeHtml(supportPolicyLabel(assignment))}</h4>
+      <p>${escapeHtml(policy.summary || "Modalita di supporto non indicata dal docente.")}</p>
+      <p class="details">
+        <span>Permesso: ${escapeHtml(allowed)}</span>
+        <span>Non permesso: ${escapeHtml(notAllowed)}</span>
+      </p>
+    </section>
+  `;
+}
+
 function renderLabAssignment(assignment) {
   const grading = assignment.grading || {};
   const workspace = assignment.workspace || {};
@@ -311,6 +335,7 @@ function renderLabAssignment(assignment) {
         <span>Report: ${escapeHtml(report.path || "-")}</span>
         <span>Backend: ${escapeHtml(assignment.runner?.backend || "-")}</span>
       </p>
+      ${renderSupportPolicy(assignment)}
       ${grading.detail ? `<p class="details">${escapeHtml(grading.detail)}</p>` : ""}
       ${failedTests.length ? `<p class="details">Test falliti: ${failedTests.map(escapeHtml).join(", ")}</p>` : ""}
     </article>
@@ -1225,10 +1250,11 @@ function renderAssignmentDetail(assignment) {
         ${detailItem("Titolo", assignment.title || assignment.activity_id)}
         ${detailItem("Classe", assignment.class_label || assignment.class_id || currentClassLabel)}
         ${detailItem("Tipo", assignment.kind || "tipo non indicato")}
-        ${detailItem("Modalita", assignment.student_support_mode || "modalita non indicata")}
+        ${detailItem("Modalita", supportPolicyLabel(assignment))}
         ${detailItem("Assegnata", formatDate(assignment.assigned_at))}
         ${detailItem("Scadenza", formatDate(assignment.due_at))}
       </div>
+      ${renderSupportPolicy(assignment)}
     </section>
     <section class="detailSection">
       <h3>Consegna</h3>


### PR DESCRIPTION
## Cosa cambia

- Aggiunge un contratto centralizzato per le modalita di aiuto dello studente.
- Il payload lab espone `support_policy` per ogni consegna.
- La TUI mostra la sezione "Aiuto consentito" nel dettaglio consegna.
- La dashboard studente mostra la policy nel pannello Lab e nel dettaglio consegna.
- La documentazione spiega le quattro modalita MVP.

## Perche

#288 richiede una prima interfaccia studente che renda esplicito quale aiuto e consentito. Questa PR non introduce ancora enforcement, chat AI o budget: stabilizza il contratto e lo rende visibile.

## Verifiche

```powershell
python -m pytest tests/test_student_support_policy.py tests/test_student_lab_service.py tests/test_student_lab_cli.py tests/test_student_dashboard_frontend.py
python -m py_compile scripts/student_support_policy.py scripts/student_lab_service.py scripts/student_lab_cli.py
git diff --check
```

Closes #385
