### PR TITLE
Registra richieste di aiuto del lab studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -87,6 +87,16 @@ Il payload lab aggiunge `support_policy`, cioe una descrizione leggibile per lo 
 
 In questa fase la policy e informativa: TUI e dashboard la mostrano chiaramente, mentre enforcement tecnico, log degli aiuti e limiti AI saranno introdotti nei passi successivi.
 
+## Log richieste di aiuto
+
+Il backend puo registrare richieste di aiuto dello studente in:
+
+`<repo-studente>/help/<activity-id>/events.json`
+
+Ogni evento indica tipo di aiuto richiesto, esito consentito/bloccato, motivazione e prompt dello studente.
+Il payload lab espone un riepilogo `help` con totale eventi, richieste consentite, richieste bloccate e ultimo esito.
+In questa fase il log non chiama provider AI e non applica ancora limiti token reali: prepara il contratto per enforcement, budget e audit successivi.
+
 ## Direzione
 
 Il report salvato usa lo schema `student_lab_run.v1` e mantiene separati:

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from json import JSONDecodeError
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -84,16 +85,24 @@ def help_log_path(repo_path: Path, activity_id: str) -> Path:
 
 
 def load_help_events(log_path: Path) -> list[dict[str, Any]]:
+    events, _ = read_help_log(log_path)
+    return events
+
+
+def read_help_log(log_path: Path) -> tuple[list[dict[str, Any]], str]:
     if not log_path.is_file():
-        return []
-    payload = json.loads(log_path.read_text(encoding="utf-8-sig"))
+        return [], ""
+    try:
+        payload = json.loads(log_path.read_text(encoding="utf-8-sig"))
+    except JSONDecodeError as error:
+        return [], f"JSON non valido: {error.msg}"
     if isinstance(payload, dict):
         events = payload.get("events")
         if isinstance(events, list):
-            return [event for event in events if isinstance(event, dict)]
+            return [event for event in events if isinstance(event, dict)], ""
     if isinstance(payload, list):
-        return [event for event in payload if isinstance(event, dict)]
-    return []
+        return [event for event in payload if isinstance(event, dict)], ""
+    return [], "Formato log aiuti non valido."
 
 
 def write_help_events(log_path: Path, events: list[dict[str, Any]]) -> None:
@@ -138,6 +147,8 @@ def help_summary(log_path: Path | None) -> dict[str, Any]:
         return {
             "path": "",
             "exists": False,
+            "status": "missing",
+            "error": "",
             "total": 0,
             "allowed": 0,
             "denied": 0,
@@ -145,7 +156,7 @@ def help_summary(log_path: Path | None) -> dict[str, Any]:
             "last_decision": "",
             "counts": {},
         }
-    events = load_help_events(log_path)
+    events, error = read_help_log(log_path)
     counts: dict[str, int] = {}
     for event in events:
         help_type = clean_text(event.get("help_type")) or "sconosciuto"
@@ -154,6 +165,8 @@ def help_summary(log_path: Path | None) -> dict[str, Any]:
     return {
         "path": str(log_path).replace("\\", "/"),
         "exists": bool(events),
+        "status": "invalid" if error else "ok",
+        "error": error,
         "total": len(events),
         "allowed": sum(1 for event in events if event.get("allowed") is True),
         "denied": sum(1 for event in events if event.get("allowed") is False),

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+HELP_LOG_SCHEMA_VERSION = "student_help_log.v1"
+HELP_EVENT_SCHEMA_VERSION = "student_help_event.v1"
+
+HELP_TYPES: dict[str, dict[str, str]] = {
+    "feedback-tecnico": {
+        "label": "Feedback tecnico",
+        "policy_key": "debug_allowed",
+        "allowed_reason": "La modalita consente feedback tecnico, errori e risultati dei test.",
+        "denied_reason": "La modalita scelta dal docente non consente feedback tecnico aggiuntivo.",
+    },
+    "teoria": {
+        "label": "Richiamo teorico",
+        "policy_key": "theory_allowed",
+        "allowed_reason": "La modalita consente richiami teorici e materiali guida.",
+        "denied_reason": "La modalita scelta dal docente non consente richiami teorici aggiuntivi.",
+    },
+    "ai": {
+        "label": "Aiuto AI",
+        "policy_key": "ai_allowed",
+        "allowed_reason": "La modalita consente aiuto AI nei limiti decisi dal docente.",
+        "denied_reason": "La modalita scelta dal docente non consente aiuto AI.",
+    },
+}
+
+HELP_TYPE_ALIASES = {
+    "debug": "feedback-tecnico",
+    "feedback": "feedback-tecnico",
+    "technical": "feedback-tecnico",
+    "theory": "teoria",
+    "richiamo-teorico": "teoria",
+    "ia": "ai",
+    "ai-assisted": "ai",
+}
+
+
+def clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def parse_now(now: str | None = None) -> str:
+    return clean_text(now) or datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+def normalize_help_type(value: Any) -> str:
+    help_type = clean_text(value).lower()
+    return HELP_TYPE_ALIASES.get(help_type, help_type)
+
+
+def help_type_definition(help_type: Any) -> dict[str, str] | None:
+    return HELP_TYPES.get(normalize_help_type(help_type))
+
+
+def evaluate_help_request(support_policy: dict[str, Any], help_type: Any) -> dict[str, Any]:
+    normalized_type = normalize_help_type(help_type)
+    definition = help_type_definition(normalized_type)
+    if definition is None:
+        return {
+            "schema_version": "student_help_decision.v1",
+            "help_type": normalized_type,
+            "label": clean_text(help_type) or "Aiuto non indicato",
+            "allowed": False,
+            "reason": "Tipo di aiuto non riconosciuto.",
+        }
+    allowed = bool(support_policy.get(definition["policy_key"]))
+    return {
+        "schema_version": "student_help_decision.v1",
+        "help_type": normalized_type,
+        "label": definition["label"],
+        "allowed": allowed,
+        "reason": definition["allowed_reason"] if allowed else definition["denied_reason"],
+    }
+
+
+def help_log_path(repo_path: Path, activity_id: str) -> Path:
+    return repo_path / "help" / clean_text(activity_id) / "events.json"
+
+
+def load_help_events(log_path: Path) -> list[dict[str, Any]]:
+    if not log_path.is_file():
+        return []
+    payload = json.loads(log_path.read_text(encoding="utf-8-sig"))
+    if isinstance(payload, dict):
+        events = payload.get("events")
+        if isinstance(events, list):
+            return [event for event in events if isinstance(event, dict)]
+    if isinstance(payload, list):
+        return [event for event in payload if isinstance(event, dict)]
+    return []
+
+
+def write_help_events(log_path: Path, events: list[dict[str, Any]]) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": HELP_LOG_SCHEMA_VERSION,
+        "events": events,
+    }
+    log_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def record_help_request(
+    *,
+    repo_path: Path,
+    activity_id: str,
+    support_policy: dict[str, Any],
+    help_type: Any,
+    prompt: str = "",
+    now: str | None = None,
+) -> dict[str, Any]:
+    decision = evaluate_help_request(support_policy, help_type)
+    requested_at = parse_now(now)
+    event = {
+        "schema_version": HELP_EVENT_SCHEMA_VERSION,
+        "requested_at": requested_at,
+        "activity_id": clean_text(activity_id),
+        "help_type": decision["help_type"],
+        "label": decision["label"],
+        "allowed": decision["allowed"],
+        "reason": decision["reason"],
+        "prompt": clean_text(prompt),
+    }
+    path = help_log_path(repo_path, activity_id)
+    events = load_help_events(path)
+    events.append(event)
+    write_help_events(path, events)
+    return event
+
+
+def help_summary(log_path: Path | None) -> dict[str, Any]:
+    if log_path is None:
+        return {
+            "path": "",
+            "exists": False,
+            "total": 0,
+            "allowed": 0,
+            "denied": 0,
+            "last_requested_at": "",
+            "last_decision": "",
+            "counts": {},
+        }
+    events = load_help_events(log_path)
+    counts: dict[str, int] = {}
+    for event in events:
+        help_type = clean_text(event.get("help_type")) or "sconosciuto"
+        counts[help_type] = counts.get(help_type, 0) + 1
+    last = events[-1] if events else {}
+    return {
+        "path": str(log_path).replace("\\", "/"),
+        "exists": bool(events),
+        "total": len(events),
+        "allowed": sum(1 for event in events if event.get("allowed") is True),
+        "denied": sum(1 for event in events if event.get("allowed") is False),
+        "last_requested_at": clean_text(last.get("requested_at")),
+        "last_decision": "consentita" if last.get("allowed") is True else ("bloccata" if last.get("allowed") is False else ""),
+        "counts": counts,
+    }

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -214,6 +214,8 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Non permesso:", policy_list(support_policy.get("not_allowed"))),
         "",
         "Richieste aiuto",
+        detail_line("Stato log:", help_summary.get("status")),
+        detail_line("Errore log:", help_summary.get("error")),
         detail_line("Eventi:", help_summary.get("total")),
         detail_line("Consentite:", help_summary.get("allowed")),
         detail_line("Bloccate:", help_summary.get("denied")),

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -183,6 +183,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
     grading = assignment.get("grading") if isinstance(assignment.get("grading"), dict) else {}
     runner = assignment.get("runner") if isinstance(assignment.get("runner"), dict) else {}
     support_policy = assignment.get("support_policy") if isinstance(assignment.get("support_policy"), dict) else {}
+    help_summary = assignment.get("help") if isinstance(assignment.get("help"), dict) else {}
     topics = activity.get("topics") if isinstance(activity.get("topics"), list) else []
     lines = [
         "Dettaglio consegna",
@@ -211,6 +212,13 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Sintesi:", support_policy.get("summary")),
         detail_line("Permesso:", policy_list(support_policy.get("allowed"))),
         detail_line("Non permesso:", policy_list(support_policy.get("not_allowed"))),
+        "",
+        "Richieste aiuto",
+        detail_line("Eventi:", help_summary.get("total")),
+        detail_line("Consentite:", help_summary.get("allowed")),
+        detail_line("Bloccate:", help_summary.get("denied")),
+        detail_line("Ultima:", compact_datetime(help_summary.get("last_requested_at"))),
+        detail_line("Esito ultima:", help_summary.get("last_decision")),
         "",
         "Report",
         detail_line("Path:", report.get("path")),

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -11,7 +11,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import assignment_records, student_support_policy, track_assignments
+from scripts import assignment_records, student_help_service, student_support_policy, track_assignments
 from scripts.thebitlab_contracts import normalize_activity
 
 
@@ -177,17 +177,22 @@ def build_lab_assignment(
     repo_path = target_repo_path(root, target, student_id)
     workspace_path = repo_path / "assignments" / activity_id if repo_path is not None else None
     report_path = repo_path / "reports" / activity_id / "latest.json" if repo_path is not None else None
+    help_log_path = student_help_service.help_log_path(repo_path, activity_id) if repo_path is not None else None
     report = load_report(report_path, activity_id) if report_path is not None else None
     submitted_at = clean_text(report.get("submitted_at")) if report else ""
     status = status_with_report(report, normalized["due_at"], now) if report else status_without_report(normalized["due_at"], now)
     activity = load_activity_summary(root, normalized["activity_path"])
+    support_policy = student_support_policy.support_policy(activity.get("student_support_mode", ""))
+    help_log = student_help_service.help_summary(help_log_path)
+    if help_log_path is not None:
+        help_log["path"] = relative_to_root(root, help_log_path)
     grading = track_assignments.grading_summary(report)
     return {
         "assignment_id": normalized["id"],
         "activity_id": activity_id,
         "title": activity["title"] or activity_id,
         "student_support_mode": activity.get("student_support_mode", ""),
-        "support_policy": student_support_policy.support_policy(activity.get("student_support_mode", "")),
+        "support_policy": support_policy,
         "student_id": student_id,
         "target_type": normalized["target_type"],
         "class_id": normalized["class_id"],
@@ -209,6 +214,7 @@ def build_lab_assignment(
             "commit": report.get("commit") if report else None,
         },
         "grading": grading,
+        "help": help_log,
         "runner": {
             "status": "not_run",
             "backend": "student_lab_service",

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -167,6 +167,11 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
                 allowed: ["riferimenti alla teoria", "feedback tecnico"],
                 not_allowed: ["soluzioni complete"],
               },
+              help: {
+                total: 2,
+                allowed: 1,
+                denied: 1,
+              },
               activity: { language: "python" },
               workspace: { path: "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001", exists: true },
               report: { path: "examples/assignment_tracking/student_repos/rossi-mario/reports/python-base-somma-001/latest.json", exists: true, submitted_at: "2026-10-18T18:22:10+02:00" },
@@ -198,6 +203,8 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
         assert.match(tested.els.studentLab.innerHTML, /Studio guidato/);
         assert.match(tested.els.studentLab.innerHTML, /riferimenti alla teoria, feedback tecnico/);
         assert.match(tested.els.studentLab.innerHTML, /soluzioni complete/);
+        assert.match(tested.els.studentLab.innerHTML, /Aiuti tracciati: 2/);
+        assert.match(tested.els.studentLab.innerHTML, /Bloccati: 1/);
         assert.match(tested.els.studentLabStatus.textContent, /1 consegne lab · 1 report salvati/);
         """
     )

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -50,3 +50,16 @@ def test_record_help_request_appends_event_and_summary(tmp_path) -> None:
     assert summary["allowed"] == 1
     assert summary["denied"] == 0
     assert summary["last_decision"] == "consentita"
+
+
+def test_help_summary_marks_invalid_json_without_raising(tmp_path) -> None:
+    log_path = tmp_path / "student-repo" / "help" / "activity" / "events.json"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("{non-json", encoding="utf-8")
+
+    summary = student_help_service.help_summary(log_path)
+
+    assert summary["status"] == "invalid"
+    assert summary["error"].startswith("JSON non valido")
+    assert summary["total"] == 0
+    assert summary["allowed"] == 0

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+
+from scripts import student_help_service, student_support_policy
+
+
+def test_evaluate_help_request_denies_ai_when_policy_does_not_allow_it() -> None:
+    policy = student_support_policy.support_policy("feedback-tecnico")
+
+    decision = student_help_service.evaluate_help_request(policy, "ai")
+
+    assert decision["help_type"] == "ai"
+    assert decision["label"] == "Aiuto AI"
+    assert decision["allowed"] is False
+    assert "non consente aiuto AI" in decision["reason"]
+
+
+def test_evaluate_help_request_allows_theory_for_guided_study() -> None:
+    policy = student_support_policy.support_policy("studio-guidato")
+
+    decision = student_help_service.evaluate_help_request(policy, "teoria")
+
+    assert decision["help_type"] == "teoria"
+    assert decision["allowed"] is True
+    assert "richiami teorici" in decision["reason"]
+
+
+def test_record_help_request_appends_event_and_summary(tmp_path) -> None:
+    repo = tmp_path / "student-repo"
+    policy = student_support_policy.support_policy("ai-assisted")
+
+    event = student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=policy,
+        help_type="ai",
+        prompt="Dammi un suggerimento, non la soluzione.",
+        now="2026-10-18T10:30:00+02:00",
+    )
+
+    log_path = repo / "help" / "python-base-somma-001" / "events.json"
+    payload = json.loads(log_path.read_text(encoding="utf-8"))
+    summary = student_help_service.help_summary(log_path)
+
+    assert event["allowed"] is True
+    assert payload["schema_version"] == "student_help_log.v1"
+    assert payload["events"][0]["prompt"] == "Dammi un suggerimento, non la soluzione."
+    assert summary["total"] == 1
+    assert summary["allowed"] == 1
+    assert summary["denied"] == 0
+    assert summary["last_decision"] == "consentita"

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -29,6 +29,16 @@ def sample_assignment(**overrides):
             "allowed": ["riferimenti alla teoria", "feedback tecnico"],
             "not_allowed": ["soluzioni complete"],
         },
+        "help": {
+            "path": "examples/assignment_tracking/student_repos/rossi-mario/help/python-base-somma-001/events.json",
+            "exists": True,
+            "total": 2,
+            "allowed": 1,
+            "denied": 1,
+            "last_requested_at": "2026-10-18T17:20:00+02:00",
+            "last_decision": "bloccata",
+            "counts": {"teoria": 1, "ai": 1},
+        },
         "workspace": {
             "path": "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001",
             "exists": True,
@@ -123,6 +133,10 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "Studio guidato" in rendered
     assert "riferimenti alla teoria, feedback tecnico" in rendered
     assert "soluzioni complete" in rendered
+    assert "Richieste aiuto" in rendered
+    assert "Bloccate:" in rendered
+    assert "2026-10-18 17:20" in rendered
+    assert "bloccata" in rendered
     assert "not_graded" in rendered
     assert "not_run" in rendered
     assert "e = esegui e salva report" in rendered

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from scripts import assignment_records, student_lab_service
+from scripts import assignment_records, student_help_service, student_lab_service, student_support_policy
 
 
 def write_activity(root, activity_id: str = "python-base-somma-001", student_support_mode: str = "") -> str:
@@ -179,6 +179,42 @@ def test_student_lab_uses_existing_report_and_grading_summary(tmp_path) -> None:
     assert assignment["grading"]["status"] == "graded_passed"
     assert assignment["grading"]["tests_passed"] == 2
     assert assignment["grading"]["tests_total"] == 2
+
+
+def test_student_lab_exposes_help_summary(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, student_support_mode="studio-guidato")
+    write_assignment(tmp_path, sample_assignment(tmp_path, activity_path=activity_path))
+    repo = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario"
+    policy = student_support_policy.support_policy("studio-guidato")
+    student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=policy,
+        help_type="teoria",
+        prompt="Ripassami gli array.",
+        now="2026-10-18T17:15:00+02:00",
+    )
+    student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=policy,
+        help_type="ai",
+        prompt="Scrivi la soluzione.",
+        now="2026-10-18T17:20:00+02:00",
+    )
+
+    assignment = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-18T18:00:00+02:00",
+    )[0]
+
+    assert assignment["help"]["path"] == "examples/assignment_tracking/student_repos/rossi-mario/help/python-base-somma-001/events.json"
+    assert assignment["help"]["total"] == 2
+    assert assignment["help"]["allowed"] == 1
+    assert assignment["help"]["denied"] == 1
+    assert assignment["help"]["last_decision"] == "bloccata"
+    assert assignment["help"]["counts"] == {"teoria": 1, "ai": 1}
 
 
 def test_student_lab_keeps_assignment_when_local_repo_path_is_only_inferred(tmp_path) -> None:

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -286,6 +286,7 @@ function supportPolicyLabel(assignment) {
 
 function renderSupportPolicy(assignment) {
   const policy = assignment.support_policy || {};
+  const help = assignment.help || {};
   const allowed = Array.isArray(policy.allowed) && policy.allowed.length
     ? policy.allowed.join(", ")
     : "-";
@@ -299,6 +300,11 @@ function renderSupportPolicy(assignment) {
       <p class="details">
         <span>Permesso: ${escapeHtml(allowed)}</span>
         <span>Non permesso: ${escapeHtml(notAllowed)}</span>
+      </p>
+      <p class="details">
+        <span>Aiuti tracciati: ${escapeHtml(help.total ?? 0)}</span>
+        <span>Consentiti: ${escapeHtml(help.allowed ?? 0)}</span>
+        <span>Bloccati: ${escapeHtml(help.denied ?? 0)}</span>
       </p>
     </section>
   `;

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -306,6 +306,7 @@ function renderSupportPolicy(assignment) {
         <span>Consentiti: ${escapeHtml(help.allowed ?? 0)}</span>
         <span>Bloccati: ${escapeHtml(help.denied ?? 0)}</span>
       </p>
+      ${help.error ? `<p class="details">Log aiuti: ${escapeHtml(help.error)}</p>` : ""}
     </section>
   `;
 }


### PR DESCRIPTION
## Cosa cambia

- Aggiunge `student_help_service`, che valuta richieste di aiuto rispetto alla `support_policy` della consegna.
- Registra eventi JSON locali in `<repo-studente>/help/<activity-id>/events.json`.
- Il payload lab espone un riepilogo `help` con totale, richieste consentite, richieste bloccate e ultimo esito.
- La TUI e la dashboard studente mostrano il riepilogo delle richieste di aiuto tracciate.
- Aggiorna la documentazione del lab studente.

## Perche

Dopo aver mostrato le modalita di aiuto consentite, serve un primo contratto backend per tracciare cosa lo studente chiede e se la policy lo consente. Questa PR non chiama ancora provider AI e non applica budget token reali.

## Verifiche

```powershell
python -m pytest tests/test_student_help_service.py tests/test_student_support_policy.py tests/test_student_lab_service.py tests/test_student_lab_cli.py tests/test_student_dashboard_frontend.py
python -m py_compile scripts/student_help_service.py scripts/student_support_policy.py scripts/student_lab_service.py scripts/student_lab_cli.py
git diff --check
```

Closes #387
