### PR TITLE
Mostra richieste aiuto nel registro docente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -113,6 +113,9 @@ Quando il report esiste, il registro salva nella `submission` anche:
 - `report_schema_version`: versione dello schema del report;
 - `report_status`: stato tecnico del report originale.
 
+Il registro docente legge anche `help/<activity_id>/events.json`, quando presente, e aggiunge a ogni studente il riepilogo `help`.
+La dashboard docente puo cosi mostrare numero di richieste, richieste AI, richieste bloccate e prompt inviati dallo studente per quella consegna.
+
 In questo modo dashboard docente, dashboard studente e TUI leggono lo stesso risultato senza ricalcolare grading o stato in modi divergenti.
 
 Le prossime PR dovranno usare questo contratto per:

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -174,3 +174,30 @@ def help_summary(log_path: Path | None) -> dict[str, Any]:
         "last_decision": "consentita" if last.get("allowed") is True else ("bloccata" if last.get("allowed") is False else ""),
         "counts": counts,
     }
+
+
+def teacher_help_summary(log_path: Path | None) -> dict[str, Any]:
+    """Return a teacher-facing help summary with sanitized event prompts."""
+
+    summary = help_summary(log_path)
+    if log_path is None:
+        summary["events"] = []
+        summary["ai_total"] = 0
+        return summary
+    events, error = read_help_log(log_path)
+    teacher_events = [
+        {
+            "requested_at": clean_text(event.get("requested_at")),
+            "help_type": clean_text(event.get("help_type")),
+            "label": clean_text(event.get("label")),
+            "allowed": event.get("allowed") is True,
+            "reason": clean_text(event.get("reason")),
+            "prompt": clean_text(event.get("prompt")),
+        }
+        for event in events
+    ]
+    summary["events"] = teacher_events
+    summary["ai_total"] = sum(1 for event in teacher_events if event["help_type"] == "ai")
+    if error:
+        summary["events"] = []
+    return summary

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from scripts import assign_activity, create_submission_scaffold
+from scripts import assign_activity, create_submission_scaffold, student_help_service
 from scripts.thebitlab_contracts import (
     legacy_activity_validation_payload,
     normalize_activity,
@@ -369,10 +369,13 @@ def track_assignments(
     for target in targets:
         repo_url = github_repo_url(target)
         report_path = default_report_path(target, activity_id)
+        help_log_path = student_help_service.help_log_path(target.path, activity_id)
         report = load_report(report_path)
         if report is not None:
             validate_report_activity(report, activity_id, report_path)
         relative_report_path = relative_to_root_or_repo(report_path, target.path) if report_path.exists() else None
+        help = student_help_service.teacher_help_summary(help_log_path)
+        help["path"] = relative_to_root_or_repo(help_log_path, target.path)
         source_path = report.get("source") if report else None
         submitted = report is not None
         submitted_at = report.get("submitted_at") if report else None
@@ -405,6 +408,7 @@ def track_assignments(
                     "report_status": report.get("status") if report else None,
                 },
                 "grading": grading_summary(report),
+                "help": help,
                 "ai_feedback": ai_feedback_placeholder(),
                 "report_path": relative_report_path,
             }

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -376,6 +376,7 @@ def track_assignments(
         relative_report_path = relative_to_root_or_repo(report_path, target.path) if report_path.exists() else None
         help = student_help_service.teacher_help_summary(help_log_path)
         help["path"] = relative_to_root_or_repo(help_log_path, target.path)
+        help["activity_id"] = activity_id
         source_path = report.get("source") if report else None
         submitted = report is not None
         submitted_at = report.get("submitted_at") if report else None

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -2807,6 +2807,7 @@ def test_student_help_details_render_counts_and_prompts() -> None:
     run_dashboard_js(
         """
         const html = tested.studentHelpDetails({
+          activity_id: "python-base-somma-001",
           total: 3,
           ai_total: 2,
           denied: 1,
@@ -2831,6 +2832,7 @@ def test_student_help_details_render_counts_and_prompts() -> None:
         });
 
         assert.match(html, /Aiuti 3/);
+        assert.match(html, /Consegna: python-base-somma-001/);
         assert.match(html, /AI: 2/);
         assert.match(html, /Bloccate: 1/);
         assert.match(html, /Prompt aiuti/);

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -389,6 +389,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         aiFeedbackDetails,
         aiFeedbackReviewDetails,
         aiFeedbackTeacherAction,
+        studentHelpDetails,
         reviewAiFeedback,
         dateTimeInputToIso,
         isoToDateTimeInput,
@@ -2690,6 +2691,9 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           late: 1,
           passed: 2,
           failed: 1,
+          helpRequests: 0,
+          helpAiRequests: 0,
+          helpDenied: 0,
           averageGrade: 6.5,
           missingGrades: 3,
         }));
@@ -2718,6 +2722,9 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           ["Grading KO", 1],
           ["Media voto", "6.5"],
           ["Voti mancanti", 3],
+          ["Aiuti", 0],
+          ["Aiuti AI", 0],
+          ["Aiuti bloccati", 0],
         ]));
         tested.state.filter = "all";
         assert.equal(tested.activeStudentFilterLabel(), "nessuno");
@@ -2796,6 +2803,63 @@ def test_ai_feedback_helpers_render_teacher_review_states() -> None:
     )
 
 
+def test_student_help_details_render_counts_and_prompts() -> None:
+    run_dashboard_js(
+        """
+        const html = tested.studentHelpDetails({
+          total: 3,
+          ai_total: 2,
+          denied: 1,
+          events: [
+            {
+              requested_at: "2026-10-20T08:10:00+02:00",
+              help_type: "teoria",
+              label: "Richiamo teorico",
+              allowed: true,
+              reason: "Consentito dalla policy.",
+              prompt: "Puoi ricordarmi come funziona input()?",
+            },
+            {
+              requested_at: "2026-10-20T08:15:00+02:00",
+              help_type: "ai",
+              label: "Aiuto AI",
+              allowed: false,
+              reason: "AI non consentita.",
+              prompt: "Scrivimi la soluzione completa.",
+            },
+          ],
+        });
+
+        assert.match(html, /Aiuti 3/);
+        assert.match(html, /AI: 2/);
+        assert.match(html, /Bloccate: 1/);
+        assert.match(html, /Prompt aiuti/);
+        assert.match(html, /Puoi ricordarmi come funziona input\\(\\)\\?/);
+        assert.match(html, /Scrivimi la soluzione completa\\./);
+        assert.match(html, /Bloccata/);
+
+        const empty = tested.studentHelpDetails({ total: 0, events: [] });
+        assert.match(empty, /Nessuna richiesta registrata/);
+        """
+    )
+
+
+def test_summary_counts_include_student_help_requests() -> None:
+    run_dashboard_js(
+        """
+        const counts = tested.summaryCounts([
+          { help: { total: 3, ai_total: 2, denied: 1 }, grading: {}, status: "pending" },
+          { help: { total: 1, counts: { ai: 1 }, denied: 0 }, grading: {}, status: "pending" },
+        ]);
+
+        assert.equal(counts.helpRequests, 4);
+        assert.equal(counts.helpAiRequests, 3);
+        assert.equal(counts.helpDenied, 1);
+        assert.equal(tested.summaryTooltip("Aiuti AI"), "Numero di richieste di aiuto AI registrate dagli studenti per questa consegna.");
+        """
+    )
+
+
 def test_ai_feedback_details_css_limits_expanded_content_height() -> None:
     css = open("tools/assignment_dashboard.css", encoding="utf-8").read()
 
@@ -2804,6 +2868,7 @@ def test_ai_feedback_details_css_limits_expanded_content_height() -> None:
     assert "overflow-y: auto;" in css
     assert "text-align: justify;" in css
     assert ".aiFeedbackActions" in css
+    assert ".studentHelpDetails dl" in css
 
 
 def test_report_loader_controls_live_in_selected_report_panel() -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -581,6 +581,7 @@ def test_track_assignments_exposes_student_help_requests(tmp_path) -> None:
     help_summary = index["students"][0]["help"]
 
     assert help_summary["path"] == "help/python-base-somma-001/events.json"
+    assert help_summary["activity_id"] == "python-base-somma-001"
     assert help_summary["total"] == 2
     assert help_summary["ai_total"] == 1
     assert help_summary["allowed"] == 1

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from scripts import track_assignments
+from scripts import student_help_service, student_support_policy, track_assignments
 from scripts.thebitlab_repository_providers import LocalRepositoryProvider, StudentRepository
 
 
@@ -548,6 +548,46 @@ def test_track_assignments_exposes_student_lab_report_metadata(tmp_path) -> None
     assert row["submission"]["report_schema_version"] == "student_lab_run.v1"
     assert row["submission"]["report_status"] == "passed"
     assert row["grading"]["status"] == "graded_passed"
+
+
+def test_track_assignments_exposes_student_help_requests(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    policy = student_support_policy.support_policy("studio-guidato")
+    student_help_service.record_help_request(
+        repo_path=student.path,
+        activity_id="python-base-somma-001",
+        support_policy=policy,
+        help_type="teoria",
+        prompt="Puoi ricordarmi come funziona input()?",
+        now="2026-10-20T08:10:00+02:00",
+    )
+    student_help_service.record_help_request(
+        repo_path=student.path,
+        activity_id="python-base-somma-001",
+        support_policy=policy,
+        help_type="ai",
+        prompt="Scrivimi la soluzione completa.",
+        now="2026-10-20T08:15:00+02:00",
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+    )
+
+    help_summary = index["students"][0]["help"]
+
+    assert help_summary["path"] == "help/python-base-somma-001/events.json"
+    assert help_summary["total"] == 2
+    assert help_summary["ai_total"] == 1
+    assert help_summary["allowed"] == 1
+    assert help_summary["denied"] == 1
+    assert help_summary["events"][0]["prompt"] == "Puoi ricordarmi come funziona input()?"
+    assert help_summary["events"][1]["prompt"] == "Scrivimi la soluzione completa."
+    assert help_summary["events"][1]["allowed"] is False
 
 
 def test_track_assignments_rejects_report_for_different_activity(tmp_path) -> None:

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1665,12 +1665,30 @@ label > textarea {
   min-width: 0;
 }
 
+.studentHelpCell {
+  min-width: 0;
+  margin-top: .55rem;
+  padding-top: .55rem;
+  border-top: 1px solid rgba(17, 17, 17, .1);
+}
+
 .aiFeedbackDetails {
   margin-top: .45rem;
   font-size: .78rem;
 }
 
+.studentHelpDetails {
+  margin-top: .45rem;
+  font-size: .78rem;
+}
+
 .aiFeedbackDetails summary {
+  cursor: pointer;
+  color: #111111;
+  font-weight: 800;
+}
+
+.studentHelpDetails summary {
   cursor: pointer;
   color: #111111;
   font-weight: 800;
@@ -1689,7 +1707,24 @@ label > textarea {
   scrollbar-gutter: stable;
 }
 
+.studentHelpDetails dl {
+  display: grid;
+  gap: .45rem;
+  margin: .45rem 0 0;
+  max-height: 14rem;
+  overflow-y: auto;
+  padding: .55rem;
+  border: 1px solid rgba(17, 17, 17, .12);
+  border-radius: 8px;
+  background: #fafafa;
+  scrollbar-gutter: stable;
+}
+
 .aiFeedbackDetails div {
+  min-width: 0;
+}
+
+.studentHelpDetails div {
   min-width: 0;
 }
 
@@ -1700,10 +1735,27 @@ label > textarea {
   text-transform: uppercase;
 }
 
+.studentHelpDetails dt {
+  color: var(--muted);
+  font-size: .68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
 .aiFeedbackDetails dd {
   margin: .12rem 0 0;
   overflow-wrap: anywhere;
   text-align: justify;
+}
+
+.studentHelpDetails dd {
+  margin: .12rem 0 0;
+  overflow-wrap: anywhere;
+  text-align: justify;
+}
+
+.studentHelpDetails p {
+  margin: .35rem 0;
 }
 
 .aiFeedbackActions {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -3879,6 +3879,37 @@ function aiFeedbackReviewDetails(ai) {
   `;
 }
 
+function studentHelpDetails(help) {
+  const data = help || {};
+  const total = Number(data.total || 0);
+  const aiTotal = Number(data.ai_total || data.counts?.ai || 0);
+  const denied = Number(data.denied || 0);
+  const kind = denied > 0 ? "bad" : aiTotal > 0 ? "warn" : total > 0 ? "ok" : "muted";
+  const events = Array.isArray(data.events) ? data.events : [];
+  const rows = events.length
+    ? events.map((event) => `
+        <div>
+          <dt>${escapeHtml(formatDate(event.requested_at))} · ${escapeHtml(event.label || event.help_type || "aiuto")}</dt>
+          <dd>
+            ${badge(event.allowed ? "Consentita" : "Bloccata", event.allowed ? "ok" : "bad")}
+            ${event.prompt ? `<p>${escapeHtml(event.prompt)}</p>` : "<p>Prompt non disponibile.</p>"}
+            ${event.reason ? `<small>${escapeHtml(event.reason)}</small>` : ""}
+          </dd>
+        </div>
+      `).join("")
+    : `<div><dt>Prompt</dt><dd>${escapeHtml(data.error || "Nessuna richiesta registrata.")}</dd></div>`;
+  return `
+    <div class="studentHelpCell">
+      ${badge(`Aiuti ${total}`, kind)}<br>
+      <small>AI: ${escapeHtml(aiTotal)} · Bloccate: ${escapeHtml(denied)}</small>
+      <details class="studentHelpDetails">
+        <summary>Prompt aiuti</summary>
+        <dl>${rows}</dl>
+      </details>
+    </div>
+  `;
+}
+
 function gradingDetails(grading) {
   const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
   const tests = Array.isArray(grading.tests) ? grading.tests : [];
@@ -3934,6 +3965,9 @@ const SUMMARY_TOOLTIPS = {
   "Grading KO": "Numero di studenti con grading completato ma fallito.",
   "Media voto": "Media dei voti numerici disponibili nel registro selezionato.",
   "Voti mancanti": "Numero di studenti senza voto numerico disponibile.",
+  Aiuti: "Numero totale di richieste di aiuto registrate dagli studenti per questa consegna.",
+  "Aiuti AI": "Numero di richieste di aiuto AI registrate dagli studenti per questa consegna.",
+  "Aiuti bloccati": "Numero di richieste di aiuto non consentite dalla policy della consegna.",
 };
 
 function summaryTooltip(label) {
@@ -3958,6 +3992,9 @@ function summaryCounts(students) {
     late: students.filter((student) => student.submitted && student.late).length,
     passed: students.filter((student) => student.grading?.status === "graded_passed").length,
     failed: students.filter((student) => student.grading?.status === "graded_failed").length,
+    helpRequests: students.reduce((total, student) => total + Number(student.help?.total || 0), 0),
+    helpAiRequests: students.reduce((total, student) => total + Number(student.help?.ai_total || student.help?.counts?.ai || 0), 0),
+    helpDenied: students.reduce((total, student) => total + Number(student.help?.denied || 0), 0),
     averageGrade: grades.length ? grades.reduce((sum, grade) => sum + grade, 0) / grades.length : null,
     missingGrades: students.length - grades.length,
   };
@@ -4005,6 +4042,9 @@ function detailedStudentsSummaryItems(counts) {
     ["Grading KO", counts.failed],
     ["Media voto", counts.averageGrade == null ? "-" : counts.averageGrade.toFixed(1)],
     ["Voti mancanti", counts.missingGrades],
+    ["Aiuti", counts.helpRequests],
+    ["Aiuti AI", counts.helpAiRequests],
+    ["Aiuti bloccati", counts.helpDenied],
   ];
 }
 
@@ -4075,6 +4115,7 @@ function renderStudents(students) {
   for (const student of visible) {
     const grading = student.grading || {};
     const ai = student.ai_feedback || {};
+    const help = student.help || {};
     const submission = student.submission || {};
     const files = submissionFiles(student);
     const canReview = student.submitted && files.length > 0;
@@ -4106,6 +4147,7 @@ function renderStudents(students) {
       <td>
         <div data-ai-feedback-student="${escapeHtml(student.student_id || student.student)}">
           ${aiFeedbackDetails(ai)}
+          ${studentHelpDetails(help)}
         </div>
       </td>
       <td>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -3901,6 +3901,7 @@ function studentHelpDetails(help) {
   return `
     <div class="studentHelpCell">
       ${badge(`Aiuti ${total}`, kind)}<br>
+      <small>Consegna: ${escapeHtml(data.activity_id || "-")}</small><br>
       <small>AI: ${escapeHtml(aiTotal)} · Bloccate: ${escapeHtml(denied)}</small>
       <details class="studentHelpDetails">
         <summary>Prompt aiuti</summary>


### PR DESCRIPTION
## Cosa cambia

- Il registro docente legge anche `help/<activity-id>/events.json` dai repository degli studenti.
- Ogni riga studente del registro espone `help`: totale richieste, richieste AI, consentite, bloccate, ultimo esito ed eventi con prompt.
- La dashboard docente mostra nella tabella studenti un blocco "Aiuti" accanto al feedback AI.
- Il dettaglio espandibile mostra i prompt inviati dallo studente, divisi per richiesta e con esito consentita/bloccata.
- Il riepilogo studenti del modal aggiunge contatori: Aiuti, Aiuti AI, Aiuti bloccati.
- Aggiorna la documentazione del contratto lab/registro.

## Perche

Il docente deve poter capire in quale consegna lo studente ha chiesto aiuto, quanto usa l'AI e quali richieste sono state bloccate dalla policy.

## Verifiche

```powershell
python -m pytest tests/test_track_assignments.py tests/test_student_help_service.py tests/test_assignment_dashboard_frontend.py
python -m py_compile scripts/track_assignments.py scripts/student_help_service.py
git diff --check
```

Closes #389
