### PR TITLE
Aggiungi richiesta aiuto nella TUI studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -47,6 +47,7 @@ Comandi disponibili nella TUI minima:
 - numero della riga: apre il dettaglio della consegna;
 - `r`: ricarica le consegne;
 - `q`: esce;
+- `a` dal dettaglio: registra una richiesta di aiuto secondo la policy della consegna;
 - `e` dal dettaglio: esegue il runner locale e salva il report;
 - `o` dal dettaglio: apre la cartella workspace, se esiste.
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -12,7 +12,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import student_lab_runner, student_lab_service
+from scripts import student_help_service, student_lab_runner, student_lab_service
 
 
 InputFn = Callable[[str], str]
@@ -236,7 +236,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Stato:", runner.get("status")),
         detail_line("Backend:", runner.get("backend")),
         "",
-        "Comandi: e = esegui e salva report | o = apri workspace | invio = torna all'elenco",
+        "Comandi: a = chiedi aiuto | e = esegui e salva report | o = apri workspace | invio = torna all'elenco",
     ]
     return "\n".join(lines)
 
@@ -253,6 +253,81 @@ def runner_result_message(report: dict[str, Any], report_path: Path) -> str:
         [
             f"Runner completato: {status}{tests}",
             f"Report salvato: {report_path}",
+        ]
+    )
+
+
+HELP_MENU = {
+    "1": "feedback-tecnico",
+    "f": "feedback-tecnico",
+    "feedback": "feedback-tecnico",
+    "2": "teoria",
+    "t": "teoria",
+    "teoria": "teoria",
+    "3": "ai",
+    "a": "ai",
+    "ai": "ai",
+}
+
+
+def help_choice_label() -> str:
+    """Return a compact help-type menu label."""
+
+    return "1 feedback tecnico | 2 teoria | 3 AI"
+
+
+def assignment_repo_path(assignment: dict[str, Any], root: Path = PROJECT_ROOT) -> Path | None:
+    """Infer the local student repo path from assignment paths."""
+
+    help_data = assignment.get("help") if isinstance(assignment.get("help"), dict) else {}
+    help_path = clean_text(help_data.get("path"), "")
+    normalized_help_path = help_path.replace("\\", "/")
+    if help_path and "/help/" in normalized_help_path:
+        raw_path = Path(help_path)
+        resolved = raw_path if raw_path.is_absolute() else (root / raw_path).resolve(strict=False)
+        return resolved.parents[2] if len(resolved.parents) >= 3 else None
+    workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+    workspace_path = clean_text(workspace.get("path"), "")
+    normalized_workspace_path = workspace_path.replace("\\", "/")
+    if workspace_path and "/assignments/" in normalized_workspace_path:
+        raw_path = Path(workspace_path)
+        resolved = raw_path if raw_path.is_absolute() else (root / raw_path).resolve(strict=False)
+        return resolved.parents[1] if len(resolved.parents) >= 2 else None
+    return None
+
+
+def record_help_from_tui(
+    *,
+    assignment: dict[str, Any],
+    root: Path,
+    help_type: str,
+    prompt: str,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Record one student help request from the TUI."""
+
+    repo_path = assignment_repo_path(assignment, root=root)
+    if repo_path is None:
+        raise ValueError("Repository studente non disponibile per salvare la richiesta di aiuto.")
+    support_policy = assignment.get("support_policy") if isinstance(assignment.get("support_policy"), dict) else {}
+    return student_help_service.record_help_request(
+        repo_path=repo_path,
+        activity_id=clean_text(assignment.get("activity_id"), ""),
+        support_policy=support_policy,
+        help_type=help_type,
+        prompt=prompt,
+        now=now,
+    )
+
+
+def help_result_message(event: dict[str, Any]) -> str:
+    """Return a compact message after recording a help request."""
+
+    status = "consentita" if event.get("allowed") else "bloccata"
+    return "\n".join(
+        [
+            f"Richiesta aiuto {status}: {clean_text(event.get('label'))}",
+            clean_text(event.get("reason")),
         ]
     )
 
@@ -333,6 +408,27 @@ def run_tui(
             if not open_workspace(clean_text(workspace.get("path"), ""), root=root):
                 print_fn("Workspace non disponibile.")
                 input_fn("Premi invio per continuare...")
+        if action == "a":
+            print_fn(f"Tipo aiuto: {help_choice_label()}")
+            help_choice = input_fn("Tipo: ").strip().lower()
+            help_type = HELP_MENU.get(help_choice, help_choice)
+            prompt = input_fn("Scrivi la richiesta: ").strip()
+            if not prompt:
+                print_fn("Richiesta non salvata: prompt vuoto.")
+            else:
+                try:
+                    event = record_help_from_tui(
+                        assignment=assignment,
+                        root=root,
+                        help_type=help_type,
+                        prompt=prompt,
+                        now=now,
+                    )
+                    print_fn(help_result_message(event))
+                    payload = load_payload(root, student_id, now)
+                except ValueError as error:
+                    print_fn(f"Richiesta aiuto non salvata:\n{error}")
+            input_fn("Premi invio per continuare...")
         if action == "e":
             try:
                 report = student_lab_runner.run_local_assignment(assignment, root=root)

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -181,6 +181,32 @@ def test_runner_result_message_shows_status_tests_and_report_path(tmp_path) -> N
     assert "Report salvato:" in message
 
 
+def test_assignment_repo_path_uses_help_or_workspace_path(tmp_path) -> None:
+    assignment = sample_assignment(
+        help={"path": "student/help/python-base-somma-001/events.json"},
+        workspace={"path": "student/assignments/python-base-somma-001", "exists": True},
+    )
+
+    assert student_lab_cli.assignment_repo_path(assignment, root=tmp_path) == tmp_path / "student"
+
+    assignment_without_help = sample_assignment(help={}, workspace={"path": "student/assignments/python-base-somma-001", "exists": True})
+
+    assert student_lab_cli.assignment_repo_path(assignment_without_help, root=tmp_path) == tmp_path / "student"
+
+
+def test_help_result_message_shows_policy_decision() -> None:
+    message = student_lab_cli.help_result_message(
+        {
+            "allowed": False,
+            "label": "Aiuto AI",
+            "reason": "La modalita scelta dal docente non consente aiuto AI.",
+        }
+    )
+
+    assert "Richiesta aiuto bloccata: Aiuto AI" in message
+    assert "non consente aiuto AI" in message
+
+
 def test_run_tui_can_show_detail_and_exit(monkeypatch, tmp_path) -> None:
     payload = sample_payload()
     outputs = []
@@ -199,6 +225,35 @@ def test_run_tui_can_show_detail_and_exit(monkeypatch, tmp_path) -> None:
     assert result == 0
     assert any("TheBitLab - lab studente" in output for output in outputs)
     assert any("Dettaglio consegna" in output for output in outputs)
+
+
+def test_run_tui_can_record_help_request_and_reload(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "a", "3", "Mi scrivi la soluzione?", "", "q"])
+    load_calls = []
+
+    def fake_load_payload(root, student_id, now=None):
+        load_calls.append((root, student_id, now))
+        return payload
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", fake_load_payload)
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+    )
+
+    log_path = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "help" / "python-base-somma-001" / "events.json"
+
+    assert result == 0
+    assert len(load_calls) == 2
+    assert log_path.exists()
+    assert "Mi scrivi la soluzione?" in log_path.read_text(encoding="utf-8")
+    assert any("Richiesta aiuto bloccata: Aiuto AI" in output for output in outputs)
 
 
 def test_run_tui_can_execute_runner_save_report_and_reload(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge il comando `a = chiedi aiuto` nel dettaglio della TUI studente.
- Lo studente sceglie il tipo di aiuto: feedback tecnico, teoria o AI.
- La TUI chiede un prompt libero, valuta la richiesta con la policy della consegna e salva l'evento in `help/<activity-id>/events.json`.
- Mostra subito se la richiesta e consentita o bloccata e ricarica il payload.
- Aggiorna la documentazione dei comandi TUI.

## Perche

Dopo aver tracciato e mostrato le richieste di aiuto lato studente e docente, serve un modo operativo per produrle dal flusso TUI.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py tests/test_student_help_service.py tests/test_student_lab_service.py
python -m py_compile scripts/student_lab_cli.py scripts/student_help_service.py scripts/student_lab_service.py
git diff --check
```

Closes #391
