### PR TITLE
Mostra storico aiuti nella TUI studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -48,6 +48,7 @@ Comandi disponibili nella TUI minima:
 - `r`: ricarica le consegne;
 - `q`: esce;
 - `a` dal dettaglio: registra una richiesta di aiuto secondo la policy della consegna;
+- `h` dal dettaglio: mostra lo storico delle richieste di aiuto registrate per quella consegna;
 - `e` dal dettaglio: esegue il runner locale e salva il report;
 - `o` dal dettaglio: apre la cartella workspace, se esiste.
 
@@ -86,7 +87,7 @@ Il payload lab aggiunge `support_policy`, cioe una descrizione leggibile per lo 
 | `studio-guidato` | Lo studente puo consultare richiami teorici, domande guida ed esempi approvati dal docente. |
 | `ai-assisted` | Lo studente puo usare aiuto AI nei limiti di budget e policy decisi dal docente. |
 
-In questa fase la policy e informativa: TUI e dashboard la mostrano chiaramente, mentre enforcement tecnico, log degli aiuti e limiti AI saranno introdotti nei passi successivi.
+La TUI mostra la policy e usa la stessa logica backend per consentire o bloccare le richieste di aiuto. I limiti AI reali e i budget token saranno introdotti nei passi successivi.
 
 ## Log richieste di aiuto
 
@@ -96,7 +97,7 @@ Il backend puo registrare richieste di aiuto dello studente in:
 
 Ogni evento indica tipo di aiuto richiesto, esito consentito/bloccato, motivazione e prompt dello studente.
 Il payload lab espone un riepilogo `help` con totale eventi, richieste consentite, richieste bloccate e ultimo esito.
-In questa fase il log non chiama provider AI e non applica ancora limiti token reali: prepara il contratto per enforcement, budget e audit successivi.
+La TUI puo registrare nuove richieste e mostrare lo storico salvato. In questa fase il log non chiama provider AI e non applica ancora limiti token reali: prepara il contratto per enforcement, budget e audit successivi.
 
 ## Direzione
 
@@ -119,10 +120,10 @@ La dashboard docente puo cosi mostrare numero di richieste, richieste AI, richie
 
 In questo modo dashboard docente, dashboard studente e TUI leggono lo stesso risultato senza ricalcolare grading o stato in modi divergenti.
 
-Le prossime PR dovranno usare questo contratto per:
+Le prossime PR dovranno completare questo contratto con:
 
-1. collegare il comando di esecuzione alla TUI;
-2. mostrare nella TUI l'esito appena salvato;
-3. introdurre un runner Docker minimale;
-4. far leggere gli stessi risultati alla dashboard studente e al registro docente;
+1. budget AI e limiti di consumo per studente/consegna;
+2. chiamata reale a provider AI o adapter Codex quando la policy lo consente;
+3. demo end-to-end pulita con dati riproducibili;
+4. guida utente docente/studente aggiornata;
 5. valutare un adapter opzionale per layout terminale avanzato, per esempio tmux su ambienti compatibili.

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -236,7 +236,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Stato:", runner.get("status")),
         detail_line("Backend:", runner.get("backend")),
         "",
-        "Comandi: a = chiedi aiuto | e = esegui e salva report | o = apri workspace | invio = torna all'elenco",
+        "Comandi: a = chiedi aiuto | h = storico aiuti | e = esegui e salva report | o = apri workspace | invio = torna all'elenco",
     ]
     return "\n".join(lines)
 
@@ -294,6 +294,50 @@ def assignment_repo_path(assignment: dict[str, Any], root: Path = PROJECT_ROOT) 
         resolved = raw_path if raw_path.is_absolute() else (root / raw_path).resolve(strict=False)
         return resolved.parents[1] if len(resolved.parents) >= 2 else None
     return None
+
+
+def assignment_help_log_path(assignment: dict[str, Any], root: Path = PROJECT_ROOT) -> Path | None:
+    """Return the local help log path for one assignment, when available."""
+
+    help_data = assignment.get("help") if isinstance(assignment.get("help"), dict) else {}
+    help_path = clean_text(help_data.get("path"), "")
+    if help_path:
+        raw_path = Path(help_path)
+        return raw_path if raw_path.is_absolute() else (root / raw_path).resolve(strict=False)
+    repo_path = assignment_repo_path(assignment, root=root)
+    activity_id = clean_text(assignment.get("activity_id"), "")
+    if repo_path is None or not activity_id:
+        return None
+    return student_help_service.help_log_path(repo_path, activity_id)
+
+
+def render_help_history(assignment: dict[str, Any], root: Path = PROJECT_ROOT) -> str:
+    """Render the help request history for one assignment."""
+
+    log_path = assignment_help_log_path(assignment, root=root)
+    lines = ["Storico richieste aiuto", ""]
+    if log_path is None:
+        lines.append("Log aiuti non disponibile per questa consegna.")
+        return "\n".join(lines)
+    events, error = student_help_service.read_help_log(log_path)
+    if error:
+        lines.append(f"Log aiuti non leggibile: {error}")
+        lines.append(f"Path: {log_path}")
+        return "\n".join(lines)
+    if not events:
+        lines.append("Nessuna richiesta di aiuto registrata.")
+        lines.append(f"Path: {log_path}")
+        return "\n".join(lines)
+    for index, event in enumerate(events, start=1):
+        decision = "consentita" if event.get("allowed") is True else "bloccata"
+        lines.extend(
+            [
+                f"{index}. {compact_datetime(event.get('requested_at'))} | {clean_text(event.get('label'))} | {decision}",
+                f"   Motivo: {clean_text(event.get('reason'))}",
+                f"   Prompt: {truncate(clean_text(event.get('prompt')), 100)}",
+            ]
+        )
+    return "\n".join(lines)
 
 
 def record_help_from_tui(
@@ -428,6 +472,9 @@ def run_tui(
                     payload = load_payload(root, student_id, now)
                 except ValueError as error:
                     print_fn(f"Richiesta aiuto non salvata:\n{error}")
+            input_fn("Premi invio per continuare...")
+        if action == "h":
+            print_fn(render_help_history(assignment, root=root))
             input_fn("Premi invio per continuare...")
         if action == "e":
             try:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from scripts import student_lab_cli
@@ -140,6 +141,7 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "not_graded" in rendered
     assert "not_run" in rendered
     assert "e = esegui e salva report" in rendered
+    assert "h = storico aiuti" in rendered
     assert "o = apri workspace" in rendered
 
 
@@ -192,6 +194,64 @@ def test_assignment_repo_path_uses_help_or_workspace_path(tmp_path) -> None:
     assignment_without_help = sample_assignment(help={}, workspace={"path": "student/assignments/python-base-somma-001", "exists": True})
 
     assert student_lab_cli.assignment_repo_path(assignment_without_help, root=tmp_path) == tmp_path / "student"
+
+
+def test_assignment_help_log_path_uses_payload_or_repo_path(tmp_path) -> None:
+    assignment = sample_assignment(help={"path": "student/help/python-base-somma-001/events.json"})
+
+    assert student_lab_cli.assignment_help_log_path(assignment, root=tmp_path) == tmp_path / "student" / "help" / "python-base-somma-001" / "events.json"
+
+    assignment_without_help_path = sample_assignment(help={}, workspace={"path": "student/assignments/python-base-somma-001", "exists": True})
+
+    assert (
+        student_lab_cli.assignment_help_log_path(assignment_without_help_path, root=tmp_path)
+        == tmp_path / "student" / "help" / "python-base-somma-001" / "events.json"
+    )
+
+
+def test_render_help_history_shows_events(tmp_path) -> None:
+    log_path = tmp_path / "student" / "help" / "python-base-somma-001" / "events.json"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text(
+        json.dumps(
+            {
+                "events": [
+                    {
+                        "requested_at": "2026-10-18T17:20:00+02:00",
+                        "label": "Aiuto AI",
+                        "allowed": False,
+                        "reason": "La modalita scelta dal docente non consente aiuto AI.",
+                        "prompt": "Mi scrivi la soluzione completa?",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assignment = sample_assignment(help={"path": "student/help/python-base-somma-001/events.json"})
+
+    rendered = student_lab_cli.render_help_history(assignment, root=tmp_path)
+
+    assert "Storico richieste aiuto" in rendered
+    assert "2026-10-18 17:20 | Aiuto AI | bloccata" in rendered
+    assert "non consente aiuto AI" in rendered
+    assert "Mi scrivi la soluzione completa?" in rendered
+
+
+def test_render_help_history_handles_empty_or_invalid_log(tmp_path) -> None:
+    assignment = sample_assignment(help={"path": "student/help/python-base-somma-001/events.json"})
+
+    empty_rendered = student_lab_cli.render_help_history(assignment, root=tmp_path)
+
+    assert "Nessuna richiesta di aiuto registrata" in empty_rendered
+
+    log_path = tmp_path / "student" / "help" / "python-base-somma-001" / "events.json"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("{non-json", encoding="utf-8")
+
+    invalid_rendered = student_lab_cli.render_help_history(assignment, root=tmp_path)
+
+    assert "Log aiuti non leggibile" in invalid_rendered
 
 
 def test_help_result_message_shows_policy_decision() -> None:
@@ -254,6 +314,44 @@ def test_run_tui_can_record_help_request_and_reload(monkeypatch, tmp_path) -> No
     assert log_path.exists()
     assert "Mi scrivi la soluzione?" in log_path.read_text(encoding="utf-8")
     assert any("Richiesta aiuto bloccata: Aiuto AI" in output for output in outputs)
+
+
+def test_run_tui_can_show_help_history(monkeypatch, tmp_path) -> None:
+    log_path = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "help" / "python-base-somma-001" / "events.json"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text(
+        json.dumps(
+            {
+                "events": [
+                    {
+                        "requested_at": "2026-10-18T17:20:00+02:00",
+                        "label": "Richiamo teorico",
+                        "allowed": True,
+                        "reason": "La modalita consente richiami teorici e materiali guida.",
+                        "prompt": "Mi ricordi la differenza tra input e output?",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "h", "", "q"])
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", lambda root, student_id, now=None: payload)
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+    )
+
+    assert result == 0
+    assert any("Storico richieste aiuto" in output for output in outputs)
+    assert any("Mi ricordi la differenza" in output for output in outputs)
 
 
 def test_run_tui_can_execute_runner_save_report_and_reload(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge il comando `h = storico aiuti` nel dettaglio della TUI studente.
- Legge il file `help/<activity-id>/events.json` usando il path gia presente nel payload oppure ricavandolo dal workspace.
- Mostra data, tipo di aiuto, esito, motivo e prompt per ogni richiesta.
- Gestisce log assente, vuoto o JSON non valido senza interrompere la TUI.
- Aggiorna la documentazione del lab studente e rimuove note ormai superate sul log aiuti.

## Perche

Dopo aver registrato le richieste di aiuto dalla TUI, lo studente deve poter vedere cosa e stato salvato e con quale esito, senza passare da file JSON o dashboard docente.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py tests/test_student_help_service.py tests/test_student_lab_service.py
python -m py_compile scripts/student_lab_cli.py scripts/student_help_service.py scripts/student_lab_service.py
git diff --check
```

Closes #393
