### PR TITLE
Aggiungi budget richieste AI nel lab studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -87,7 +87,7 @@ Il payload lab aggiunge `support_policy`, cioe una descrizione leggibile per lo 
 | `studio-guidato` | Lo studente puo consultare richiami teorici, domande guida ed esempi approvati dal docente. |
 | `ai-assisted` | Lo studente puo usare aiuto AI nei limiti di budget e policy decisi dal docente. |
 
-La TUI mostra la policy e usa la stessa logica backend per consentire o bloccare le richieste di aiuto. I limiti AI reali e i budget token saranno introdotti nei passi successivi.
+La TUI mostra la policy e usa la stessa logica backend per consentire o bloccare le richieste di aiuto. Per l'MVP `ai-assisted` abilita un budget minimo di richieste AI per consegna; i limiti token reali saranno introdotti nei passi successivi.
 
 ## Log richieste di aiuto
 
@@ -96,7 +96,7 @@ Il backend puo registrare richieste di aiuto dello studente in:
 `<repo-studente>/help/<activity-id>/events.json`
 
 Ogni evento indica tipo di aiuto richiesto, esito consentito/bloccato, motivazione e prompt dello studente.
-Il payload lab espone un riepilogo `help` con totale eventi, richieste consentite, richieste bloccate e ultimo esito.
+Il payload lab espone un riepilogo `help` con totale eventi, richieste consentite, richieste bloccate, ultimo esito e budget AI usato/rimanente.
 La TUI puo registrare nuove richieste e mostrare lo storico salvato. In questa fase il log non chiama provider AI e non applica ancora limiti token reali: prepara il contratto per enforcement, budget e audit successivi.
 
 ## Direzione
@@ -122,7 +122,7 @@ In questo modo dashboard docente, dashboard studente e TUI leggono lo stesso ris
 
 Le prossime PR dovranno completare questo contratto con:
 
-1. budget AI e limiti di consumo per studente/consegna;
+1. budget AI a token/costo per scuola, classe, studente e consegna;
 2. chiamata reale a provider AI o adapter Codex quando la policy lo consente;
 3. demo end-to-end pulita con dati riproducibili;
 4. guida utente docente/studente aggiornata;

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -80,6 +80,44 @@ def evaluate_help_request(support_policy: dict[str, Any], help_type: Any) -> dic
     }
 
 
+def positive_int(value: Any, default: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def ai_events_used(events: list[dict[str, Any]]) -> int:
+    return sum(1 for event in events if normalize_help_type(event.get("help_type")) == "ai" and event.get("allowed") is True)
+
+
+def ai_budget_status(support_policy: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+    limit = positive_int(support_policy.get("ai_request_limit"))
+    used = ai_events_used(events)
+    remaining = max(limit - used, 0) if limit else 0
+    return {
+        "limit": limit,
+        "used": used,
+        "remaining": remaining,
+        "exhausted": bool(limit and used >= limit),
+    }
+
+
+def apply_budget_limit(decision: dict[str, Any], support_policy: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+    if decision.get("help_type") != "ai" or decision.get("allowed") is not True:
+        return decision
+    budget = ai_budget_status(support_policy, events)
+    if not budget["exhausted"]:
+        decision["budget"] = budget
+        return decision
+    blocked = dict(decision)
+    blocked["allowed"] = False
+    blocked["reason"] = "Budget richieste AI esaurito per questa consegna."
+    blocked["budget"] = budget
+    return blocked
+
+
 def help_log_path(repo_path: Path, activity_id: str) -> Path:
     return repo_path / "help" / clean_text(activity_id) / "events.json"
 
@@ -123,7 +161,9 @@ def record_help_request(
     prompt: str = "",
     now: str | None = None,
 ) -> dict[str, Any]:
-    decision = evaluate_help_request(support_policy, help_type)
+    path = help_log_path(repo_path, activity_id)
+    events = load_help_events(path)
+    decision = apply_budget_limit(evaluate_help_request(support_policy, help_type), support_policy, events)
     requested_at = parse_now(now)
     event = {
         "schema_version": HELP_EVENT_SCHEMA_VERSION,
@@ -135,8 +175,8 @@ def record_help_request(
         "reason": decision["reason"],
         "prompt": clean_text(prompt),
     }
-    path = help_log_path(repo_path, activity_id)
-    events = load_help_events(path)
+    if "budget" in decision:
+        event["budget"] = decision["budget"]
     events.append(event)
     write_help_events(path, events)
     return event
@@ -201,3 +241,8 @@ def teacher_help_summary(log_path: Path | None) -> dict[str, Any]:
     if error:
         summary["events"] = []
     return summary
+
+
+def help_budget_summary(log_path: Path | None, support_policy: dict[str, Any]) -> dict[str, Any]:
+    events = load_help_events(log_path) if log_path is not None else []
+    return ai_budget_status(support_policy, events)

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -80,6 +80,20 @@ def policy_list(values: Any) -> str:
     return ", ".join(clean_text(value) for value in values)
 
 
+def ai_budget_label(value: Any) -> str:
+    """Return a compact AI budget summary."""
+
+    if not isinstance(value, dict):
+        return "-"
+    limit = value.get("limit")
+    used = value.get("used")
+    remaining = value.get("remaining")
+    if not limit:
+        return "non disponibile"
+    label = f"{used or 0}/{limit} usate, {remaining or 0} rimanenti"
+    return f"{label} (esaurito)" if value.get("exhausted") else label
+
+
 def truncate(text: str, width: int) -> str:
     """Return text clipped to width with a suffix."""
 
@@ -219,6 +233,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Eventi:", help_summary.get("total")),
         detail_line("Consentite:", help_summary.get("allowed")),
         detail_line("Bloccate:", help_summary.get("denied")),
+        detail_line("AI budget:", ai_budget_label(help_summary.get("ai_budget"))),
         detail_line("Ultima:", compact_datetime(help_summary.get("last_requested_at"))),
         detail_line("Esito ultima:", help_summary.get("last_decision")),
         "",

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -186,6 +186,7 @@ def build_lab_assignment(
     help_log = student_help_service.help_summary(help_log_path)
     if help_log_path is not None:
         help_log["path"] = relative_to_root(root, help_log_path)
+    help_log["ai_budget"] = student_help_service.help_budget_summary(help_log_path, support_policy)
     grading = track_assignments.grading_summary(report)
     return {
         "assignment_id": normalized["id"],

--- a/scripts/student_support_policy.py
+++ b/scripts/student_support_policy.py
@@ -17,6 +17,7 @@ SUPPORT_POLICIES: dict[str, dict[str, Any]] = {
         "ai_allowed": False,
         "theory_allowed": False,
         "debug_allowed": False,
+        "ai_request_limit": 0,
     },
     "feedback-tecnico": {
         "mode": "feedback-tecnico",
@@ -27,6 +28,7 @@ SUPPORT_POLICIES: dict[str, dict[str, Any]] = {
         "ai_allowed": False,
         "theory_allowed": False,
         "debug_allowed": True,
+        "ai_request_limit": 0,
     },
     "studio-guidato": {
         "mode": "studio-guidato",
@@ -37,6 +39,7 @@ SUPPORT_POLICIES: dict[str, dict[str, Any]] = {
         "ai_allowed": False,
         "theory_allowed": True,
         "debug_allowed": True,
+        "ai_request_limit": 0,
     },
     "ai-assisted": {
         "mode": "ai-assisted",
@@ -47,6 +50,7 @@ SUPPORT_POLICIES: dict[str, dict[str, Any]] = {
         "ai_allowed": True,
         "theory_allowed": True,
         "debug_allowed": True,
+        "ai_request_limit": 5,
     },
 }
 

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -52,6 +52,41 @@ def test_record_help_request_appends_event_and_summary(tmp_path) -> None:
     assert summary["last_decision"] == "consentita"
 
 
+def test_record_help_request_blocks_ai_when_budget_is_exhausted(tmp_path) -> None:
+    repo = tmp_path / "student-repo"
+    policy = dict(student_support_policy.support_policy("ai-assisted"))
+    policy["ai_request_limit"] = 1
+
+    first = student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=policy,
+        help_type="ai",
+        prompt="Dammi un suggerimento.",
+        now="2026-10-18T10:30:00+02:00",
+    )
+    second = student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=policy,
+        help_type="ai",
+        prompt="Altro suggerimento.",
+        now="2026-10-18T10:35:00+02:00",
+    )
+
+    log_path = repo / "help" / "python-base-somma-001" / "events.json"
+    budget = student_help_service.help_budget_summary(log_path, policy)
+    summary = student_help_service.help_summary(log_path)
+
+    assert first["allowed"] is True
+    assert second["allowed"] is False
+    assert second["reason"] == "Budget richieste AI esaurito per questa consegna."
+    assert second["budget"]["exhausted"] is True
+    assert budget == {"limit": 1, "used": 1, "remaining": 0, "exhausted": True}
+    assert summary["allowed"] == 1
+    assert summary["denied"] == 1
+
+
 def test_help_summary_marks_invalid_json_without_raising(tmp_path) -> None:
     log_path = tmp_path / "student-repo" / "help" / "activity" / "events.json"
     log_path.parent.mkdir(parents=True)

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -39,6 +39,7 @@ def sample_assignment(**overrides):
             "last_requested_at": "2026-10-18T17:20:00+02:00",
             "last_decision": "bloccata",
             "counts": {"teoria": 1, "ai": 1},
+            "ai_budget": {"limit": 5, "used": 1, "remaining": 4, "exhausted": False},
         },
         "workspace": {
             "path": "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001",
@@ -136,6 +137,7 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "soluzioni complete" in rendered
     assert "Richieste aiuto" in rendered
     assert "Bloccate:" in rendered
+    assert "1/5 usate, 4 rimanenti" in rendered
     assert "2026-10-18 17:20" in rendered
     assert "bloccata" in rendered
     assert "not_graded" in rendered
@@ -265,6 +267,11 @@ def test_help_result_message_shows_policy_decision() -> None:
 
     assert "Richiesta aiuto bloccata: Aiuto AI" in message
     assert "non consente aiuto AI" in message
+
+
+def test_ai_budget_label_handles_missing_and_exhausted_budget() -> None:
+    assert student_lab_cli.ai_budget_label({}) == "non disponibile"
+    assert student_lab_cli.ai_budget_label({"limit": 2, "used": 2, "remaining": 0, "exhausted": True}) == "2/2 usate, 0 rimanenti (esaurito)"
 
 
 def test_run_tui_can_show_detail_and_exit(monkeypatch, tmp_path) -> None:

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -119,6 +119,7 @@ def test_student_lab_exposes_explicit_support_policy(tmp_path) -> None:
     assert assignment["student_support_mode"] == "ai-assisted"
     assert assignment["support_policy"]["label"] == "AI assisted"
     assert assignment["support_policy"]["ai_allowed"] is True
+    assert assignment["support_policy"]["ai_request_limit"] == 5
     assert "suggerimenti AI controllati" in assignment["support_policy"]["allowed"]
 
 
@@ -215,6 +216,30 @@ def test_student_lab_exposes_help_summary(tmp_path) -> None:
     assert assignment["help"]["denied"] == 1
     assert assignment["help"]["last_decision"] == "bloccata"
     assert assignment["help"]["counts"] == {"teoria": 1, "ai": 1}
+    assert assignment["help"]["ai_budget"] == {"limit": 0, "used": 0, "remaining": 0, "exhausted": False}
+
+
+def test_student_lab_exposes_ai_budget_summary(tmp_path) -> None:
+    activity_path = write_activity(tmp_path, student_support_mode="ai-assisted")
+    write_assignment(tmp_path, sample_assignment(tmp_path, activity_path=activity_path))
+    repo = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario"
+    policy = student_support_policy.support_policy("ai-assisted")
+    student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=policy,
+        help_type="ai",
+        prompt="Dammi un suggerimento.",
+        now="2026-10-18T17:15:00+02:00",
+    )
+
+    assignment = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-18T18:00:00+02:00",
+    )[0]
+
+    assert assignment["help"]["ai_budget"] == {"limit": 5, "used": 1, "remaining": 4, "exhausted": False}
 
 
 def test_student_lab_keeps_assignment_when_local_repo_path_is_only_inferred(tmp_path) -> None:

--- a/tests/test_student_support_policy.py
+++ b/tests/test_student_support_policy.py
@@ -11,6 +11,7 @@ def test_support_policy_exposes_known_ai_assisted_mode() -> None:
     assert policy["ai_allowed"] is True
     assert policy["theory_allowed"] is True
     assert policy["debug_allowed"] is True
+    assert policy["ai_request_limit"] == 5
     assert "suggerimenti AI controllati" in policy["allowed"]
 
 
@@ -21,4 +22,5 @@ def test_support_policy_defaults_unknown_mode_to_technical_feedback() -> None:
     assert policy["source_mode"] == "modalita-sconosciuta"
     assert policy["is_defaulted"] is True
     assert policy["ai_allowed"] is False
+    assert policy["ai_request_limit"] == 0
     assert policy["debug_allowed"] is True


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `ai_request_limit` alle policy di supporto studente.
- Per l'MVP `ai-assisted` consente 5 richieste AI per consegna; le altre modalita restano a 0 e continuano a bloccare AI via policy.
- Blocca nuove richieste AI quando il budget e esaurito, salvando comunque l'evento come richiesta bloccata.
- Espone nel payload lab `help.ai_budget` con limite, usate, rimanenti ed esaurito.
- Mostra il budget AI nel dettaglio della TUI studente.
- Aggiorna test e documentazione del lab studente.

## Perche

Prima di collegare provider AI o Codex serve un primo enforcement di consumo: anche se per ora contiamo richieste e non token, il contratto permette gia audit e limite per consegna.

## Verifiche

```powershell
python -m pytest tests/test_student_support_policy.py tests/test_student_help_service.py tests/test_student_lab_service.py tests/test_student_lab_cli.py
python -m py_compile scripts/student_support_policy.py scripts/student_help_service.py scripts/student_lab_service.py scripts/student_lab_cli.py
git diff --check
```

Closes #395
