### PR TITLE
Mantieni il dettaglio nella TUI studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -51,6 +51,9 @@ Comandi disponibili nella TUI minima:
 - `h` dal dettaglio: mostra lo storico delle richieste di aiuto registrate per quella consegna;
 - `e` dal dettaglio: esegue il runner locale e salva il report;
 - `o` dal dettaglio: apre la cartella workspace, se esiste.
+- invio dal dettaglio: torna alla lista delle consegne;
+
+Dopo un comando di dettaglio la TUI resta sulla stessa consegna e ricarica i dati quando il comando modifica lo stato, per esempio dopo una richiesta di aiuto o dopo l'esecuzione del runner.
 
 Il payload ha schema `student_lab.v1` e contiene:
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -251,7 +251,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Stato:", runner.get("status")),
         detail_line("Backend:", runner.get("backend")),
         "",
-        "Comandi: a = chiedi aiuto | h = storico aiuti | e = esegui e salva report | o = apri workspace | invio = torna all'elenco",
+        "Comandi: a = chiedi aiuto | h = storico aiuti | e = esegui e salva report | o = apri workspace | invio = lista | q = esci",
     ]
     return "\n".join(lines)
 
@@ -428,6 +428,28 @@ def load_payload(root: Path, student_id: str, now: str | None = None) -> dict[st
     return student_lab_service.student_lab_payload(root=root, student_id=student_id, now=now)
 
 
+def payload_assignments(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return assignment items from a student lab payload."""
+
+    assignments = payload.get("assignments")
+    return assignments if isinstance(assignments, list) else []
+
+
+def find_assignment(payload: dict[str, Any], assignment_id: str, fallback_index: int) -> dict[str, Any] | None:
+    """Return the selected assignment after a payload reload."""
+
+    assignments = payload_assignments(payload)
+    clean_assignment_id = clean_text(assignment_id, "")
+    if clean_assignment_id:
+        for assignment in assignments:
+            if isinstance(assignment, dict) and clean_text(assignment.get("assignment_id"), "") == clean_assignment_id:
+                return assignment
+    if 0 <= fallback_index < len(assignments):
+        assignment = assignments[fallback_index]
+        return assignment if isinstance(assignment, dict) else None
+    return None
+
+
 def run_tui(
     *,
     student_id: str,
@@ -454,52 +476,65 @@ def run_tui(
         if not choice.isdigit():
             continue
         index = int(choice) - 1
-        assignments = payload.get("assignments") if isinstance(payload.get("assignments"), list) else []
+        assignments = payload_assignments(payload)
         if index < 0 or index >= len(assignments):
             continue
-        assignment = assignments[index]
-        if clear:
-            clear_screen()
-        print_fn(render_assignment_detail(assignment, use_color=use_color))
-        action = input_fn("\nDettaglio: ").strip().lower()
-        if action == "o":
-            workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
-            if not open_workspace(clean_text(workspace.get("path"), ""), root=root):
-                print_fn("Workspace non disponibile.")
+        selected_assignment_id = clean_text(assignments[index].get("assignment_id"), "")
+        while True:
+            assignment = find_assignment(payload, selected_assignment_id, index)
+            if assignment is None:
+                print_fn("Consegna non piu disponibile.")
+                input_fn("Premi invio per tornare alla lista...")
+                break
+            if clear:
+                clear_screen()
+            print_fn(render_assignment_detail(assignment, use_color=use_color))
+            action = input_fn("\nDettaglio: ").strip().lower()
+            if action in {"", "b", "back", "indietro"}:
+                break
+            if action in {"q", "quit", "esci"}:
+                return 0
+            if action == "o":
+                workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+                if not open_workspace(clean_text(workspace.get("path"), ""), root=root):
+                    print_fn("Workspace non disponibile.")
                 input_fn("Premi invio per continuare...")
-        if action == "a":
-            print_fn(f"Tipo aiuto: {help_choice_label()}")
-            help_choice = input_fn("Tipo: ").strip().lower()
-            help_type = HELP_MENU.get(help_choice, help_choice)
-            prompt = input_fn("Scrivi la richiesta: ").strip()
-            if not prompt:
-                print_fn("Richiesta non salvata: prompt vuoto.")
-            else:
+                continue
+            if action == "a":
+                print_fn(f"Tipo aiuto: {help_choice_label()}")
+                help_choice = input_fn("Tipo: ").strip().lower()
+                help_type = HELP_MENU.get(help_choice, help_choice)
+                prompt = input_fn("Scrivi la richiesta: ").strip()
+                if not prompt:
+                    print_fn("Richiesta non salvata: prompt vuoto.")
+                else:
+                    try:
+                        event = record_help_from_tui(
+                            assignment=assignment,
+                            root=root,
+                            help_type=help_type,
+                            prompt=prompt,
+                            now=now,
+                        )
+                        print_fn(help_result_message(event))
+                        payload = load_payload(root, student_id, now)
+                    except ValueError as error:
+                        print_fn(f"Richiesta aiuto non salvata:\n{error}")
+                input_fn("Premi invio per continuare...")
+                continue
+            if action == "h":
+                print_fn(render_help_history(assignment, root=root))
+                input_fn("Premi invio per continuare...")
+                continue
+            if action == "e":
                 try:
-                    event = record_help_from_tui(
-                        assignment=assignment,
-                        root=root,
-                        help_type=help_type,
-                        prompt=prompt,
-                        now=now,
-                    )
-                    print_fn(help_result_message(event))
+                    report = student_lab_runner.run_local_assignment(assignment, root=root)
+                    report_path = student_lab_runner.write_student_report(root, assignment, report)
+                    print_fn(runner_result_message(report, report_path))
                     payload = load_payload(root, student_id, now)
                 except ValueError as error:
-                    print_fn(f"Richiesta aiuto non salvata:\n{error}")
-            input_fn("Premi invio per continuare...")
-        if action == "h":
-            print_fn(render_help_history(assignment, root=root))
-            input_fn("Premi invio per continuare...")
-        if action == "e":
-            try:
-                report = student_lab_runner.run_local_assignment(assignment, root=root)
-                report_path = student_lab_runner.write_student_report(root, assignment, report)
-                print_fn(runner_result_message(report, report_path))
-                payload = load_payload(root, student_id, now)
-            except ValueError as error:
-                print_fn(f"Runner non disponibile:\n{error}")
-            input_fn("Premi invio per continuare...")
+                    print_fn(f"Runner non disponibile:\n{error}")
+                input_fn("Premi invio per continuare...")
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -144,6 +144,7 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "not_run" in rendered
     assert "e = esegui e salva report" in rendered
     assert "h = storico aiuti" in rendered
+    assert "invio = lista" in rendered
     assert "o = apri workspace" in rendered
 
 
@@ -256,6 +257,16 @@ def test_render_help_history_handles_empty_or_invalid_log(tmp_path) -> None:
     assert "Log aiuti non leggibile" in invalid_rendered
 
 
+def test_find_assignment_prefers_assignment_id_and_falls_back_to_index() -> None:
+    first = sample_assignment(assignment_id="assignment-a", title="Prima")
+    second = sample_assignment(assignment_id="assignment-b", title="Seconda")
+    payload = sample_payload([first, second])
+
+    assert student_lab_cli.find_assignment(payload, "assignment-b", 0) == second
+    assert student_lab_cli.find_assignment(payload, "missing", 1) == second
+    assert student_lab_cli.find_assignment(sample_payload([]), "missing", 0) is None
+
+
 def test_help_result_message_shows_policy_decision() -> None:
     message = student_lab_cli.help_result_message(
         {
@@ -297,7 +308,7 @@ def test_run_tui_can_show_detail_and_exit(monkeypatch, tmp_path) -> None:
 def test_run_tui_can_record_help_request_and_reload(monkeypatch, tmp_path) -> None:
     payload = sample_payload()
     outputs = []
-    inputs = iter(["1", "a", "3", "Mi scrivi la soluzione?", "", "q"])
+    inputs = iter(["1", "a", "3", "Mi scrivi la soluzione?", "", "", "q"])
     load_calls = []
 
     def fake_load_payload(root, student_id, now=None):
@@ -321,6 +332,7 @@ def test_run_tui_can_record_help_request_and_reload(monkeypatch, tmp_path) -> No
     assert log_path.exists()
     assert "Mi scrivi la soluzione?" in log_path.read_text(encoding="utf-8")
     assert any("Richiesta aiuto bloccata: Aiuto AI" in output for output in outputs)
+    assert sum(1 for output in outputs if "Dettaglio consegna" in output) == 2
 
 
 def test_run_tui_can_show_help_history(monkeypatch, tmp_path) -> None:
@@ -344,7 +356,7 @@ def test_run_tui_can_show_help_history(monkeypatch, tmp_path) -> None:
     )
     payload = sample_payload()
     outputs = []
-    inputs = iter(["1", "h", "", "q"])
+    inputs = iter(["1", "h", "", "", "q"])
 
     monkeypatch.setattr(student_lab_cli, "load_payload", lambda root, student_id, now=None: payload)
 
@@ -359,12 +371,13 @@ def test_run_tui_can_show_help_history(monkeypatch, tmp_path) -> None:
     assert result == 0
     assert any("Storico richieste aiuto" in output for output in outputs)
     assert any("Mi ricordi la differenza" in output for output in outputs)
+    assert sum(1 for output in outputs if "Dettaglio consegna" in output) == 2
 
 
 def test_run_tui_can_execute_runner_save_report_and_reload(monkeypatch, tmp_path) -> None:
     payload = sample_payload()
     outputs = []
-    inputs = iter(["1", "e", "", "q"])
+    inputs = iter(["1", "e", "", "", "q"])
     load_calls = []
     saved_reports = []
 
@@ -398,6 +411,7 @@ def test_run_tui_can_execute_runner_save_report_and_reload(monkeypatch, tmp_path
     assert saved_reports
     assert any("Runner completato: passed (1/1 test)" in output for output in outputs)
     assert any("Report salvato:" in output for output in outputs)
+    assert sum(1 for output in outputs if "Dettaglio consegna" in output) == 2
 
 
 def test_open_workspace_rejects_missing_path(tmp_path) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Trasforma il dettaglio della TUI studente in un piccolo loop interno.
- Dopo `a`, `h`, `e` e `o` lo studente resta nel dettaglio della stessa consegna.
- Dopo richieste di aiuto o runner, il payload viene ricaricato e la stessa consegna viene recuperata per `assignment_id`.
- `invio`, `b`, `back` o `indietro` tornano alla lista.
- `q`, `quit` o `esci` escono direttamente dalla TUI anche dal dettaglio.
- Aggiorna documentazione e test dei flussi interattivi.

## Perche

Nel flusso precedente ogni comando di dettaglio riportava alla lista generale. Questo costringeva lo studente a riselezionare la consegna per controllare budget AI, storico aiuti o report appena aggiornati.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py tests/test_student_help_service.py tests/test_student_lab_service.py
python -m py_compile scripts/student_lab_cli.py scripts/student_help_service.py scripts/student_lab_service.py
git diff --check
```

Closes #397
