### PR TITLE
Mostra comando indietro nella TUI studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -51,7 +51,7 @@ Comandi disponibili nella TUI minima:
 - `h` dal dettaglio: mostra lo storico delle richieste di aiuto registrate per quella consegna;
 - `e` dal dettaglio: esegue il runner locale e salva il report;
 - `o` dal dettaglio: apre la cartella workspace, se esiste.
-- invio dal dettaglio: torna alla lista delle consegne;
+- invio o `b` dal dettaglio: torna alla lista delle consegne;
 
 Dopo un comando di dettaglio la TUI resta sulla stessa consegna e ricarica i dati quando il comando modifica lo stato, per esempio dopo una richiesta di aiuto o dopo l'esecuzione del runner.
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -251,7 +251,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Stato:", runner.get("status")),
         detail_line("Backend:", runner.get("backend")),
         "",
-        "Comandi: a = chiedi aiuto | h = storico aiuti | e = esegui e salva report | o = apri workspace | invio = lista | q = esci",
+        "Comandi: a = chiedi aiuto | h = storico aiuti | e = esegui e salva report | o = apri workspace | invio/b = lista | q = esci",
     ]
     return "\n".join(lines)
 

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -144,7 +144,7 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "not_run" in rendered
     assert "e = esegui e salva report" in rendered
     assert "h = storico aiuti" in rendered
-    assert "invio = lista" in rendered
+    assert "invio/b = lista" in rendered
     assert "o = apri workspace" in rendered
 
 


### PR DESCRIPTION
﻿## Cosa cambia

- Rende esplicito nella riga comandi del dettaglio TUI il comando `b` per tornare alla lista.
- Aggiorna la guida del lab studente.
- Aggiorna il test di rendering del dettaglio.

## Perche

Il comando `b` era gia supportato dal loop del dettaglio, ma non era visibile nella UI. Questo rendeva poco scopribile il modo per tornare indietro senza usare invio.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py
python -m py_compile scripts/student_lab_cli.py
git diff --check
```

Closes #399
