### PR TITLE
Permetti annullamento richiesta aiuto TUI

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -48,6 +48,7 @@ Comandi disponibili nella TUI minima:
 - `r`: ricarica le consegne;
 - `q`: esce;
 - `a` dal dettaglio: registra una richiesta di aiuto secondo la policy della consegna;
+- invio o `b` nella scelta del tipo aiuto: annulla la richiesta senza salvare eventi;
 - `h` dal dettaglio: mostra lo storico delle richieste di aiuto registrate per quella consegna;
 - `e` dal dettaglio: esegue il runner locale e salva il report;
 - `o` dal dettaglio: apre la cartella workspace, se esiste.

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -501,25 +501,28 @@ def run_tui(
                 input_fn("Premi invio per continuare...")
                 continue
             if action == "a":
-                print_fn(f"Tipo aiuto: {help_choice_label()}")
+                print_fn(f"Tipo aiuto: {help_choice_label()} | invio/b annulla")
                 help_choice = input_fn("Tipo: ").strip().lower()
-                help_type = HELP_MENU.get(help_choice, help_choice)
-                prompt = input_fn("Scrivi la richiesta: ").strip()
-                if not prompt:
-                    print_fn("Richiesta non salvata: prompt vuoto.")
+                if help_choice in {"", "b", "back", "indietro"}:
+                    print_fn("Richiesta aiuto annullata.")
                 else:
-                    try:
-                        event = record_help_from_tui(
-                            assignment=assignment,
-                            root=root,
-                            help_type=help_type,
-                            prompt=prompt,
-                            now=now,
-                        )
-                        print_fn(help_result_message(event))
-                        payload = load_payload(root, student_id, now)
-                    except ValueError as error:
-                        print_fn(f"Richiesta aiuto non salvata:\n{error}")
+                    help_type = HELP_MENU.get(help_choice, help_choice)
+                    prompt = input_fn("Scrivi la richiesta: ").strip()
+                    if not prompt:
+                        print_fn("Richiesta non salvata: prompt vuoto.")
+                    else:
+                        try:
+                            event = record_help_from_tui(
+                                assignment=assignment,
+                                root=root,
+                                help_type=help_type,
+                                prompt=prompt,
+                                now=now,
+                            )
+                            print_fn(help_result_message(event))
+                            payload = load_payload(root, student_id, now)
+                        except ValueError as error:
+                            print_fn(f"Richiesta aiuto non salvata:\n{error}")
                 input_fn("Premi invio per continuare...")
                 continue
             if action == "h":

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -335,6 +335,34 @@ def test_run_tui_can_record_help_request_and_reload(monkeypatch, tmp_path) -> No
     assert sum(1 for output in outputs if "Dettaglio consegna" in output) == 2
 
 
+def test_run_tui_can_cancel_help_request_type_choice(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "a", "b", "", "", "q"])
+    load_calls = []
+
+    def fake_load_payload(root, student_id, now=None):
+        load_calls.append((root, student_id, now))
+        return payload
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", fake_load_payload)
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+    )
+
+    log_path = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "help" / "python-base-somma-001" / "events.json"
+
+    assert result == 0
+    assert len(load_calls) == 1
+    assert not log_path.exists()
+    assert any("Richiesta aiuto annullata." in output for output in outputs)
+
+
 def test_run_tui_can_show_help_history(monkeypatch, tmp_path) -> None:
     log_path = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "help" / "python-base-somma-001" / "events.json"
     log_path.parent.mkdir(parents=True)


### PR DESCRIPTION
﻿## Cosa cambia

- Nella scelta del tipo aiuto, invio o `b` annullano la richiesta.
- Se la richiesta viene annullata, la TUI non chiede il prompt e non salva eventi.
- Mostra un feedback esplicito: `Richiesta aiuto annullata.`
- Aggiorna test e documentazione.

## Perche

Dentro il comando `a = chiedi aiuto`, lo studente doveva poter tornare indietro senza generare una richiesta vuota o scegliere per forza un tipo di aiuto.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py
python -m py_compile scripts/student_lab_cli.py
git diff --check
```

Closes #401
