### PR TITLE
Annulla richiesta aiuto con prompt vuoto

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -48,7 +48,7 @@ Comandi disponibili nella TUI minima:
 - `r`: ricarica le consegne;
 - `q`: esce;
 - `a` dal dettaglio: registra una richiesta di aiuto secondo la policy della consegna;
-- invio o `b` nella scelta del tipo aiuto: annulla la richiesta senza salvare eventi;
+- invio o `b` nella scelta del tipo aiuto, oppure prompt vuoto: annulla la richiesta senza salvare eventi;
 - `h` dal dettaglio: mostra lo storico delle richieste di aiuto registrate per quella consegna;
 - `e` dal dettaglio: esegue il runner locale e salva il report;
 - `o` dal dettaglio: apre la cartella workspace, se esiste.

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -509,7 +509,7 @@ def run_tui(
                     help_type = HELP_MENU.get(help_choice, help_choice)
                     prompt = input_fn("Scrivi la richiesta: ").strip()
                     if not prompt:
-                        print_fn("Richiesta non salvata: prompt vuoto.")
+                        print_fn("Richiesta aiuto annullata: prompt vuoto.")
                     else:
                         try:
                             event = record_help_from_tui(

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -363,6 +363,34 @@ def test_run_tui_can_cancel_help_request_type_choice(monkeypatch, tmp_path) -> N
     assert any("Richiesta aiuto annullata." in output for output in outputs)
 
 
+def test_run_tui_can_cancel_help_request_with_empty_prompt(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "a", "3", "", "", "", "q"])
+    load_calls = []
+
+    def fake_load_payload(root, student_id, now=None):
+        load_calls.append((root, student_id, now))
+        return payload
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", fake_load_payload)
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+    )
+
+    log_path = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "help" / "python-base-somma-001" / "events.json"
+
+    assert result == 0
+    assert len(load_calls) == 1
+    assert not log_path.exists()
+    assert any("Richiesta aiuto annullata: prompt vuoto." in output for output in outputs)
+
+
 def test_run_tui_can_show_help_history(monkeypatch, tmp_path) -> None:
     log_path = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "help" / "python-base-somma-001" / "events.json"
     log_path.parent.mkdir(parents=True)


### PR DESCRIPTION
﻿## Cosa cambia

- Dopo aver scelto il tipo di aiuto, un prompt vuoto annulla la richiesta.
- Non viene salvato nessun evento nel log aiuti.
- Aggiorna il messaggio TUI, la guida e il test del flusso interattivo.

## Perche

Premere invio senza scrivere il prompt deve comportarsi come un annullamento, non come una richiesta valida o un errore ambiguo.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py
python -m py_compile scripts/student_lab_cli.py
git diff --check
```

Closes #403
