### PR TITLE
Valida tipo aiuto nella TUI studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -48,6 +48,7 @@ Comandi disponibili nella TUI minima:
 - `r`: ricarica le consegne;
 - `q`: esce;
 - `a` dal dettaglio: registra una richiesta di aiuto secondo la policy della consegna;
+- tipo aiuto nella richiesta: `1`, `2`, `3`; altri valori sono rifiutati;
 - invio o `b` nella scelta del tipo aiuto, oppure prompt vuoto: annulla la richiesta senza salvare eventi;
 - `h` dal dettaglio: mostra lo storico delle richieste di aiuto registrate per quella consegna;
 - `e` dal dettaglio: esegue il runner locale e salva il report;

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -274,14 +274,8 @@ def runner_result_message(report: dict[str, Any], report_path: Path) -> str:
 
 HELP_MENU = {
     "1": "feedback-tecnico",
-    "f": "feedback-tecnico",
-    "feedback": "feedback-tecnico",
     "2": "teoria",
-    "t": "teoria",
-    "teoria": "teoria",
     "3": "ai",
-    "a": "ai",
-    "ai": "ai",
 }
 
 
@@ -505,6 +499,8 @@ def run_tui(
                 help_choice = input_fn("Tipo: ").strip().lower()
                 if help_choice in {"", "b", "back", "indietro"}:
                     print_fn("Richiesta aiuto annullata.")
+                elif help_choice not in HELP_MENU:
+                    print_fn("Tipo aiuto non valido. Usa 1, 2, 3, invio o b.")
                 else:
                     help_type = HELP_MENU.get(help_choice, help_choice)
                     prompt = input_fn("Scrivi la richiesta: ").strip()

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -391,6 +391,34 @@ def test_run_tui_can_cancel_help_request_with_empty_prompt(monkeypatch, tmp_path
     assert any("Richiesta aiuto annullata: prompt vuoto." in output for output in outputs)
 
 
+def test_run_tui_rejects_invalid_help_type_without_saving(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "a", "x", "", "", "q"])
+    load_calls = []
+
+    def fake_load_payload(root, student_id, now=None):
+        load_calls.append((root, student_id, now))
+        return payload
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", fake_load_payload)
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+    )
+
+    log_path = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "help" / "python-base-somma-001" / "events.json"
+
+    assert result == 0
+    assert len(load_calls) == 1
+    assert not log_path.exists()
+    assert any("Tipo aiuto non valido" in output for output in outputs)
+
+
 def test_run_tui_can_show_help_history(monkeypatch, tmp_path) -> None:
     log_path = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "help" / "python-base-somma-001" / "events.json"
     log_path.parent.mkdir(parents=True)


### PR DESCRIPTION
﻿## Cosa cambia

- La TUI valida subito il tipo aiuto nella richiesta studente.
- Accetta solo valori noti (`1`, `2`, `3` e alias gia supportati) oppure invio/`b` per annullare.
- Per valori non validi mostra errore e non chiede il prompt.
- Non salva eventi quando il tipo non e valido.
- Aggiorna test e documentazione.

## Perche

Un valore casuale non deve arrivare fino al backend come richiesta bloccata: nella TUI e piu chiaro segnalarlo subito come errore di input.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py
python -m py_compile scripts/student_lab_cli.py
git diff --check
```

Closes #405
