### PR TITLE
Estendi demo lab con richieste aiuto

### DIFF
--- a/doc/STUDENT_LAB_DEMO.md
+++ b/doc/STUDENT_LAB_DEMO.md
@@ -15,13 +15,15 @@ Lo script crea una root temporanea e simula il flusso:
 1. crea una activity Python;
 2. crea una assegnazione per `rossi-mario`;
 3. crea il workspace studente;
-4. esegue il runner locale;
-5. salva `reports/<activity_id>/latest.json`;
-6. legge lo stesso risultato dal payload lab studente;
-7. genera il registro docente in `teacher-reports`;
-8. verifica che il grading docente sia coerente.
+4. registra una richiesta di aiuto AI consentita;
+5. esegue il runner locale;
+6. salva `reports/<activity_id>/latest.json`;
+7. legge lo stesso risultato dal payload lab studente;
+8. verifica che il payload studente esponga richiesta di aiuto e budget AI;
+9. genera il registro docente in `teacher-reports`;
+10. verifica che grading e riepilogo aiuto docente siano coerenti.
 
-L'output atteso e un JSON con `ok: true`, il path del workspace, il path del report, il registro docente e `tests.passed` uguale a `tests.total`.
+L'output atteso e un JSON con `ok: true`, il path del workspace, il path del report, il registro docente, `tests.passed` uguale a `tests.total` e `help.total` uguale a `1`.
 
 Per conservare la cartella e ispezionare i file:
 
@@ -65,6 +67,7 @@ Quando vuoi provare la demo con dati reali o demo del repository:
    - report salvato;
    - test passati/totali;
    - ultimo tentativo valorizzato.
+   - richieste di aiuto e budget AI valorizzati, se la consegna consente AI.
 
 6. Rigenera o ricarica il registro docente relativo alla stessa activity e controlla nel pannello studenti:
 
@@ -72,6 +75,7 @@ Quando vuoi provare la demo con dati reali o demo del repository:
    - test;
    - path report;
    - backend del report.
+   - riepilogo richieste di aiuto e prompt inviati dallo studente.
 
 ## Cosa non copre ancora
 

--- a/scripts/student_lab_demo_smoke.py
+++ b/scripts/student_lab_demo_smoke.py
@@ -18,6 +18,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from scripts import (
     assignment_records,
     create_activity,
+    student_help_service,
     student_lab_runner,
     student_lab_service,
     track_assignments,
@@ -52,6 +53,7 @@ def write_demo_activity(root: Path) -> Path:
         source_name="main.py",
         context={"classe": "3A-TPSI", "team_github": "team-3a-tpsi", "percorso": "demo-lab"},
     )
+    activity["student_support_mode"] = "ai-assisted"
     output = root / "activities" / f"{ACTIVITY_ID}.json"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(activity, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -135,6 +137,16 @@ def run_smoke(root: Path) -> dict[str, Any]:
     assignment_record = write_demo_assignment(root, activity_path)
     workspace = write_demo_workspace(root)
     assignment = student_lab_runner.load_student_assignment(root=root, student_id=STUDENT_ID, activity_id=ACTIVITY_ID, now=NOW)
+    help_event = student_help_service.record_help_request(
+        repo_path=root / "examples" / "assignment_tracking" / "student_repos" / STUDENT_ID,
+        activity_id=ACTIVITY_ID,
+        support_policy=assignment["support_policy"],
+        help_type="ai",
+        prompt="Puoi darmi un suggerimento senza scrivere la soluzione?",
+        now="2026-10-18T18:35:00+02:00",
+    )
+    if help_event.get("allowed") is not True:
+        raise RuntimeError(f"Richiesta aiuto demo non consentita: {help_event.get('reason')}")
     report = student_lab_runner.run_assignment(assignment, root=root, backend="local")
     if not report.get("passed"):
         raise RuntimeError(f"Runner demo fallito: {report.get('status')}")
@@ -143,11 +155,15 @@ def run_smoke(root: Path) -> dict[str, Any]:
     lab_assignment = lab_payload["assignments"][0]
     if not lab_assignment["report"]["exists"]:
         raise RuntimeError("La dashboard lab non vede il report appena salvato.")
+    if lab_assignment["help"]["total"] != 1 or lab_assignment["help"]["ai_budget"]["remaining"] != 4:
+        raise RuntimeError("La dashboard lab non vede la richiesta di aiuto della demo.")
     register_path = write_teacher_register(root)
     register = json.loads(register_path.read_text(encoding="utf-8"))
     student = register["students"][0]
     if student["grading"]["status"] != "graded_passed":
         raise RuntimeError(f"Registro docente non coerente: {student['grading']['status']}")
+    if student["help"]["total"] != 1 or student["help"]["ai_total"] != 1:
+        raise RuntimeError("Registro docente non coerente con le richieste di aiuto.")
     return {
         "ok": True,
         "root": str(root),
@@ -160,6 +176,11 @@ def run_smoke(root: Path) -> dict[str, Any]:
         "tests": {
             "passed": student["grading"]["tests_passed"],
             "total": student["grading"]["tests_total"],
+        },
+        "help": {
+            "total": lab_assignment["help"]["total"],
+            "ai_total": student["help"]["ai_total"],
+            "ai_budget_remaining": lab_assignment["help"]["ai_budget"]["remaining"],
         },
         "backend": student["submission"].get("report_backend"),
     }

--- a/tests/test_student_lab_demo_smoke.py
+++ b/tests/test_student_lab_demo_smoke.py
@@ -15,6 +15,7 @@ def test_student_lab_demo_smoke_builds_complete_flow(tmp_path) -> None:
     assert summary["report"].endswith("reports/python-demo-somma-001/latest.json")
     assert summary["teacher_register"].endswith("teacher-reports/demo/python-demo-somma-001.json")
     assert summary["tests"] == {"passed": 1, "total": 1}
+    assert summary["help"] == {"total": 1, "ai_total": 1, "ai_budget_remaining": 4}
     assert summary["backend"] == "local"
 
     register = json.loads((tmp_path / summary["teacher_register"]).read_text(encoding="utf-8"))
@@ -22,3 +23,6 @@ def test_student_lab_demo_smoke_builds_complete_flow(tmp_path) -> None:
     assert student["submitted"] is True
     assert student["grading"]["status"] == "graded_passed"
     assert student["submission"]["report_backend"] == "local"
+    assert student["help"]["total"] == 1
+    assert student["help"]["ai_total"] == 1
+    assert student["help"]["events"][0]["prompt"] == "Puoi darmi un suggerimento senza scrivere la soluzione?"


### PR DESCRIPTION
﻿## Cosa cambia

- Estende lo smoke test end-to-end del lab studente con una richiesta di aiuto AI consentita.
- Verifica che il payload studente esponga totale richieste e budget AI residuo.
- Verifica che il registro docente legga il riepilogo aiuto e il prompt inviato dallo studente.
- Aggiorna la guida della demo end-to-end.

## Perche

Il lab aveva gia un giro riproducibile per activity, assegnazione, workspace, runner, report e registro. Dopo l'aggiunta delle policy di aiuto, serve che la demo ufficiale copra anche il tratto studente chiede aiuto -> docente vede riepilogo.

## Verifiche

```powershell
python scripts/student_lab_demo_smoke.py
python -m pytest tests/test_student_lab_demo_smoke.py tests/test_student_lab_service.py tests/test_track_assignments.py
python -m py_compile scripts/student_lab_demo_smoke.py
git diff --check
```

Closes #409
