### PR TITLE
Aggiungi setup demo stabile lab studente

### DIFF
--- a/doc/STUDENT_LAB_DEMO.md
+++ b/doc/STUDENT_LAB_DEMO.md
@@ -37,6 +37,34 @@ Per usare una cartella scelta:
 python scripts/student_lab_demo_smoke.py --root tmp/student-lab-demo
 ```
 
+## Setup locale ispezionabile
+
+Per preparare una demo stabile in `tmp/student-lab-demo`, cancellando eventuali residui precedenti:
+
+```bash
+python scripts/student_lab_demo_setup.py
+```
+
+Lo script stampa un JSON con i path generati e i comandi utili per continuare il collaudo. I comandi principali sono:
+
+```bash
+python scripts/student_lab_service.py --root tmp/student-lab-demo --student-id rossi-mario
+python scripts/student_lab_cli.py --root tmp/student-lab-demo --student-id rossi-mario
+python scripts/student_lab_runner.py --root tmp/student-lab-demo --student-id rossi-mario --activity-id python-demo-somma-001 --write-report
+```
+
+Se vuoi usare un'altra cartella:
+
+```bash
+python scripts/student_lab_demo_setup.py --root tmp/mia-demo-lab
+```
+
+Se vuoi conservare i file gia presenti nella root scelta:
+
+```bash
+python scripts/student_lab_demo_setup.py --root tmp/mia-demo-lab --no-reset
+```
+
 ## Collaudo manuale su GUI/TUI
 
 Quando vuoi provare la demo con dati reali o demo del repository:

--- a/doc/STUDENT_LAB_DEMO.md
+++ b/doc/STUDENT_LAB_DEMO.md
@@ -59,11 +59,8 @@ Se vuoi usare un'altra cartella:
 python scripts/student_lab_demo_setup.py --root tmp/mia-demo-lab
 ```
 
-Se vuoi conservare i file gia presenti nella root scelta:
+La root scelta viene sempre ricreata da zero: usa una cartella dedicata alla demo.
 
-```bash
-python scripts/student_lab_demo_setup.py --root tmp/mia-demo-lab --no-reset
-```
 
 ## Collaudo manuale su GUI/TUI
 

--- a/scripts/student_lab_demo_setup.py
+++ b/scripts/student_lab_demo_setup.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Prepare a stable local demo root for the student lab flow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import student_lab_demo_smoke
+
+
+DEFAULT_DEMO_ROOT = PROJECT_ROOT / "tmp" / "student-lab-demo"
+
+
+def reset_root(root: Path) -> None:
+    """Remove an existing demo root after a minimal safety check."""
+
+    resolved = root.resolve(strict=False)
+    if resolved == resolved.parent or len(resolved.parts) < 3:
+        raise ValueError(f"Root demo non sicura da resettare: {resolved}")
+    if resolved.exists():
+        shutil.rmtree(resolved)
+    resolved.mkdir(parents=True, exist_ok=True)
+
+
+def demo_commands(root: Path) -> dict[str, str]:
+    """Return useful commands for inspecting the prepared demo root."""
+
+    root_arg = str(root)
+    return {
+        "payload": f"python scripts/student_lab_service.py --root {root_arg} --student-id {student_lab_demo_smoke.STUDENT_ID}",
+        "tui": f"python scripts/student_lab_cli.py --root {root_arg} --student-id {student_lab_demo_smoke.STUDENT_ID}",
+        "runner": (
+            "python scripts/student_lab_runner.py "
+            f"--root {root_arg} "
+            f"--student-id {student_lab_demo_smoke.STUDENT_ID} "
+            f"--activity-id {student_lab_demo_smoke.ACTIVITY_ID} "
+            "--write-report"
+        ),
+    }
+
+
+def prepare_demo(root: Path, *, reset: bool = True) -> dict[str, Any]:
+    """Create a stable, inspectable demo root and return its summary."""
+
+    root = root.resolve(strict=False)
+    if reset:
+        reset_root(root)
+    else:
+        root.mkdir(parents=True, exist_ok=True)
+    summary = student_lab_demo_smoke.run_smoke(root)
+    return {
+        **summary,
+        "reset": reset,
+        "commands": demo_commands(root),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(description="Prepara una root demo stabile per il lab studente.")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=DEFAULT_DEMO_ROOT,
+        help="Root demo da preparare. Default: tmp/student-lab-demo.",
+    )
+    parser.add_argument("--no-reset", action="store_true", help="Non cancellare la root demo prima di ricrearla.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Prepare the demo root and print a JSON summary."""
+
+    args = parse_args()
+    try:
+        summary = prepare_demo(args.root, reset=not args.no_reset)
+    except Exception as error:  # noqa: BLE001
+        print(f"Setup demo non riuscito: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/student_lab_demo_setup.py
+++ b/scripts/student_lab_demo_setup.py
@@ -48,18 +48,15 @@ def demo_commands(root: Path) -> dict[str, str]:
     }
 
 
-def prepare_demo(root: Path, *, reset: bool = True) -> dict[str, Any]:
+def prepare_demo(root: Path) -> dict[str, Any]:
     """Create a stable, inspectable demo root and return its summary."""
 
     root = root.resolve(strict=False)
-    if reset:
-        reset_root(root)
-    else:
-        root.mkdir(parents=True, exist_ok=True)
+    reset_root(root)
     summary = student_lab_demo_smoke.run_smoke(root)
     return {
         **summary,
-        "reset": reset,
+        "reset": True,
         "commands": demo_commands(root),
     }
 
@@ -74,7 +71,6 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_DEMO_ROOT,
         help="Root demo da preparare. Default: tmp/student-lab-demo.",
     )
-    parser.add_argument("--no-reset", action="store_true", help="Non cancellare la root demo prima di ricrearla.")
     return parser.parse_args()
 
 
@@ -83,7 +79,7 @@ def main() -> int:
 
     args = parse_args()
     try:
-        summary = prepare_demo(args.root, reset=not args.no_reset)
+        summary = prepare_demo(args.root)
     except Exception as error:  # noqa: BLE001
         print(f"Setup demo non riuscito: {error}", file=sys.stderr)
         return 1

--- a/tests/test_student_lab_demo_setup.py
+++ b/tests/test_student_lab_demo_setup.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from scripts import student_lab_demo_setup
+
+
+def test_student_lab_demo_setup_prepares_stable_root(tmp_path) -> None:
+    root = tmp_path / "student-lab-demo"
+    stale = root / "stale.txt"
+    root.mkdir()
+    stale.write_text("vecchio", encoding="utf-8")
+
+    summary = student_lab_demo_setup.prepare_demo(root)
+
+    assert summary["ok"] is True
+    assert summary["reset"] is True
+    assert not stale.exists()
+    assert (root / summary["report"]).is_file()
+    assert summary["help"]["total"] == 1
+    assert "--root" in summary["commands"]["tui"]
+    assert "--student-id rossi-mario" in summary["commands"]["tui"]
+    assert "--activity-id python-demo-somma-001" in summary["commands"]["runner"]


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `scripts/student_lab_demo_setup.py` per preparare una root demo stabile in `tmp/student-lab-demo`.
- Il setup resetta la root demo, esegue il giro end-to-end gia coperto dallo smoke e stampa i comandi utili per payload, TUI e runner.
- Aggiunge un test dedicato al reset e ai comandi prodotti.
- Aggiorna `doc/STUDENT_LAB_DEMO.md` con il nuovo flusso di collaudo locale.

## Perche

Lo smoke temporaneo e utile per CI, ma per provare manualmente la TUI serve una cartella stabile, ispezionabile e ricreabile senza sporcare i dati reali del repository.

## Verifiche

```powershell
python scripts/student_lab_demo_setup.py --root tmp/student-lab-demo-codex-test
python -m pytest tests/test_student_lab_demo_setup.py tests/test_student_lab_demo_smoke.py
python -m py_compile scripts/student_lab_demo_setup.py scripts/student_lab_demo_smoke.py
git diff --check
```

Closes #411
