### PR TITLE
Permetti dashboard su root demo lab

### DIFF
--- a/doc/STUDENT_LAB_DEMO.md
+++ b/doc/STUDENT_LAB_DEMO.md
@@ -51,6 +51,7 @@ Lo script stampa un JSON con i path generati e i comandi utili per continuare il
 python scripts/student_lab_service.py --root tmp/student-lab-demo --student-id rossi-mario
 python scripts/student_lab_cli.py --root tmp/student-lab-demo --student-id rossi-mario
 python scripts/student_lab_runner.py --root tmp/student-lab-demo --student-id rossi-mario --activity-id python-demo-somma-001 --write-report
+python scripts/course_board_server.py --root tmp/student-lab-demo
 ```
 
 Se vuoi usare un'altra cartella:
@@ -69,7 +70,7 @@ Quando vuoi provare la demo con dati reali o demo del repository:
 1. Avvia il server:
 
    ```bash
-   python scripts/course_board_server.py
+   python scripts/course_board_server.py --root tmp/student-lab-demo
    ```
 
 2. Apri la dashboard studente:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -30,9 +30,10 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, unquote, urlparse
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+APP_ROOT = Path(__file__).resolve().parents[1]
+ROOT = APP_ROOT
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
 
 from scripts import (
     activity_ai_package,
@@ -85,6 +86,37 @@ AI_FRAME_TIMEOUT_SECONDS = 120
 AI_COURSE_PLAN_TIMEOUT_SECONDS = 240
 COMPACT_TEXT_CHARS = 1200
 MAX_SUBMISSION_FILE_BYTES = 512 * 1024
+
+
+def configure_data_root(root: Path) -> Path:
+    """Configure the repository data root used by API endpoints."""
+
+    global ROOT
+    global DESIGN_PATH
+    global COURSE_DESIGNS_DIR
+    global SCHOOL_CALENDARS_DIR
+    global TEACHER_REPORTS_DIR
+    global TEACHER_ASSIGNMENTS_DIR
+    global ACTIVITY_DIRS
+    global COURSE_PLAN_MD_PATH
+    global README_PATH
+    global AI_PROVIDERS_PATH
+    global AI_SECRET_PATH
+    global LEGACY_AI_SECRET_PATH
+
+    ROOT = root.resolve(strict=False)
+    DESIGN_PATH = ROOT / "doc" / "course_design.json"
+    COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
+    SCHOOL_CALENDARS_DIR = ROOT / "doc" / "calendars"
+    TEACHER_REPORTS_DIR = ROOT / "teacher-reports"
+    TEACHER_ASSIGNMENTS_DIR = ROOT / "teacher-assignments"
+    ACTIVITY_DIRS = [ROOT / "activities", ROOT / "examples" / "assignment_tracking"]
+    COURSE_PLAN_MD_PATH = ROOT / "doc" / "PERCORSO_DIDATTICO.md"
+    README_PATH = ROOT / "README.md"
+    AI_PROVIDERS_PATH = ROOT / "config" / "ai_providers.yaml"
+    AI_SECRET_PATH = ROOT / ".secrets" / "ai.secret"
+    LEGACY_AI_SECRET_PATH = ROOT / "scripts" / ".secrets" / "ai.secret"
+    return ROOT
 
 
 def course_storage() -> thebitlab_storage.JsonCourseStorage:
@@ -2395,9 +2427,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def serve_static(self, request_path: str) -> None:
         relative = unquote(request_path.lstrip("/")) or "tools/course_board.html"
-        target = (ROOT / relative).resolve()
+        target = (APP_ROOT / relative).resolve()
         try:
-            target.relative_to(ROOT)
+            target.relative_to(APP_ROOT)
         except ValueError:
             self.send_error(403)
             return
@@ -2421,9 +2453,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--root", type=Path, default=APP_ROOT, help="Root dati da usare per API e dashboard.")
     args = parser.parse_args()
+    data_root = configure_data_root(args.root)
     server = ThreadingHTTPServer((args.host, args.port), CourseBoardHandler)
     print(f"Course board: http://{args.host}:{args.port}/tools/course_board.html")
+    print(f"Root dati: {data_root}")
     print("Premi Ctrl+C per fermare il server.")
     try:
         server.serve_forever()

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from scripts import assignment_records, course_board_server
+from scripts import assignment_records, course_board_server, student_lab_demo_setup
 
 
 def patch_assignment_paths(tmp_path, monkeypatch) -> None:
@@ -911,6 +911,27 @@ def test_student_dashboard_endpoint_includes_student_lab_results(tmp_path, monke
     assert lab_assignment["report"]["exists"] is True
     assert lab_assignment["grading"]["status"] == "graded_passed"
     assert lab_assignment["grading"]["tests_passed"] == 2
+
+
+def test_student_dashboard_uses_configured_demo_data_root(tmp_path) -> None:
+    original_root = course_board_server.ROOT
+    student_lab_demo_setup.prepare_demo(tmp_path)
+
+    try:
+        configured = course_board_server.configure_data_root(tmp_path)
+        dashboard = course_board_server.student_dashboard("rossi-mario")
+    finally:
+        course_board_server.configure_data_root(original_root)
+
+    assert configured == tmp_path.resolve(strict=False)
+    assert dashboard["student_id"] == "rossi-mario"
+    assert dashboard["lab"]["schema_version"] == "student_lab.v1"
+    assert len(dashboard["lab"]["assignments"]) == 1
+    lab_assignment = dashboard["lab"]["assignments"][0]
+    assert lab_assignment["activity_id"] == "python-demo-somma-001"
+    assert lab_assignment["report"]["exists"] is True
+    assert lab_assignment["help"]["total"] == 1
+    assert lab_assignment["help"]["ai_budget"]["remaining"] == 4
 
 
 def test_class_roster_helpers_use_local_roster_storage(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
﻿## Cosa cambia

- Aggiunge `--root` a `scripts/course_board_server.py` per usare una root dati alternativa.
- Separa `APP_ROOT` per servire statici web dal repository e `ROOT` per leggere/scrivere dati API.
- Aggiorna la demo lab con il comando server su `tmp/student-lab-demo`.
- Aggiunge un test che prepara la demo e verifica che la dashboard studente legga report e richieste di aiuto dalla root configurata.

## Perche

Il setup demo stabile era gia utile per TUI e servizi CLI, ma la dashboard web continuava a leggere i dati reali del repository. Con questa modifica possiamo collaudare lo stesso scenario da TUI e GUI usando la stessa root demo.

## Verifiche

```powershell
python -m pytest tests/test_course_board_server.py
python -m pytest tests/test_course_board_server.py::test_student_dashboard_uses_configured_demo_data_root tests/test_student_lab_demo_setup.py tests/test_student_lab_demo_smoke.py
python -m py_compile scripts/course_board_server.py scripts/student_lab_demo_setup.py
git diff --check
```

Verifica HTTP manuale:

```powershell
python scripts/student_lab_demo_setup.py --root tmp/student-lab-demo-codex-test
python scripts/course_board_server.py --root tmp/student-lab-demo-codex-test --port 8876
# GET http://127.0.0.1:8876/api/student-dashboard?student_id=rossi-mario
```

Closes #413
