### PR TITLE
Rendi robusto il reset demo su Windows

### DIFF
--- a/scripts/student_lab_demo_setup.py
+++ b/scripts/student_lab_demo_setup.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -20,14 +22,50 @@ from scripts import student_lab_demo_smoke
 DEFAULT_DEMO_ROOT = PROJECT_ROOT / "tmp" / "student-lab-demo"
 
 
+def remove_tree_with_retry(path: Path, *, attempts: int = 5) -> None:
+    """Remove a directory tree, retrying transient Windows cleanup failures."""
+
+    for attempt in range(attempts):
+        if not path.exists():
+            return
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(0.2 * (attempt + 1))
+
+
+def cleanup_stale_trash(root: Path) -> None:
+    """Best-effort cleanup for old demo roots already moved aside."""
+
+    for candidate in root.parent.glob(f"{root.name}.delete-*"):
+        try:
+            remove_tree_with_retry(candidate)
+        except OSError:
+            continue
+
+
 def reset_root(root: Path) -> None:
     """Remove an existing demo root after a minimal safety check."""
 
     resolved = root.resolve(strict=False)
     if resolved == resolved.parent or len(resolved.parts) < 3:
         raise ValueError(f"Root demo non sicura da resettare: {resolved}")
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    cleanup_stale_trash(resolved)
     if resolved.exists():
-        shutil.rmtree(resolved)
+        trash = resolved.with_name(f"{resolved.name}.delete-{os.getpid()}-{time.time_ns()}")
+        try:
+            resolved.rename(trash)
+        except OSError:
+            remove_tree_with_retry(resolved)
+        else:
+            try:
+                remove_tree_with_retry(trash)
+            except OSError:
+                pass
     resolved.mkdir(parents=True, exist_ok=True)
 
 

--- a/tests/test_student_lab_demo_setup.py
+++ b/tests/test_student_lab_demo_setup.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
+
 from scripts import student_lab_demo_setup
 
 
@@ -19,3 +22,26 @@ def test_student_lab_demo_setup_prepares_stable_root(tmp_path) -> None:
     assert "--root" in summary["commands"]["tui"]
     assert "--student-id rossi-mario" in summary["commands"]["tui"]
     assert "--activity-id python-demo-somma-001" in summary["commands"]["runner"]
+
+
+def test_student_lab_demo_setup_keeps_running_when_old_root_cleanup_is_delayed(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "student-lab-demo"
+    root.mkdir()
+    (root / "stale.txt").write_text("vecchio", encoding="utf-8")
+
+    original_rmtree = shutil.rmtree
+    failures = {"remaining": 1}
+
+    def delayed_rmtree(path: str | Path) -> None:
+        if failures["remaining"]:
+            failures["remaining"] -= 1
+            raise OSError("[WinError 145] La directory non e vuota")
+        original_rmtree(path)
+
+    monkeypatch.setattr(student_lab_demo_setup.shutil, "rmtree", delayed_rmtree)
+
+    summary = student_lab_demo_setup.prepare_demo(root)
+
+    assert summary["ok"] is True
+    assert not (root / "stale.txt").exists()
+    assert (root / summary["report"]).is_file()


### PR DESCRIPTION
﻿## Cosa cambia

- Rende piu robusto il reset di `scripts/student_lab_demo_setup.py` su Windows.
- Quando la root demo esiste gia, la sposta prima in una cartella `.delete-*`, ricrea subito la root pulita e poi prova a cancellare la vecchia cartella con retry.
- Aggiunge un test che simula un errore temporaneo tipo `[WinError 145] La directory non e vuota`.

## Perche

Su Windows `shutil.rmtree` puo fallire anche quando la cartella dovrebbe essere cancellabile, per esempio se il filesystem non ha ancora completato la pulizia o qualche handle e rimasto vivo per poco. Il setup demo deve restare ripetibile e non bloccarsi su questo caso.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_demo_setup.py
python scripts/student_lab_demo_setup.py
python -m py_compile scripts/student_lab_demo_setup.py
git diff --check
```

Closes #415
