### PR TITLE
Rendi leggibile il collaudo lab

### DIFF
--- a/doc/STUDENT_LAB_DEMO.md
+++ b/doc/STUDENT_LAB_DEMO.md
@@ -80,6 +80,14 @@ Il comando stampa:
 - URL della dashboard studente;
 - cosa controllare manualmente nella TUI e nel browser.
 
+Per ottenere lo stesso risultato in formato JSON, utile per automazione o debug:
+
+```bash
+python scripts/student_lab_demo_check.py --json
+```
+
+Esegui un solo collaudo alla volta sulla stessa root demo: il comando ricrea la cartella per garantire dati puliti.
+
 ## Collaudo manuale su GUI/TUI
 
 Quando vuoi provare la demo con dati reali o demo del repository:

--- a/scripts/student_lab_demo_check.py
+++ b/scripts/student_lab_demo_check.py
@@ -92,6 +92,31 @@ def run_guided_check(root: Path, *, host: str = "127.0.0.1", port: int = 8765) -
     }
 
 
+def render_text_check(result: dict[str, Any]) -> str:
+    """Render the guided check in a human-readable terminal format."""
+
+    checks = result.get("automatic_checks", {})
+    lines = [
+        "Collaudo lab studente",
+        "=====================",
+        "",
+        f"OK: {result.get('ok')}",
+        f"Root demo: {result.get('root')}",
+        f"Studente: {result.get('student_id')}",
+        f"Activity: {result.get('activity_id')}",
+        "",
+        "Controlli automatici",
+        "--------------------",
+    ]
+    for key in ("setup", "student_lab_payload", "student_dashboard_api"):
+        status = "OK" if checks.get(key) else "NO"
+        lines.append(f"- {status} {key}")
+    lines.extend(["", "Passi manuali", "-------------"])
+    for index, step in enumerate(result.get("manual_steps", []), start=1):
+        lines.append(f"{index}. {step}")
+    return "\n".join(lines)
+
+
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
 
@@ -99,11 +124,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--root", type=Path, default=student_lab_demo_setup.DEFAULT_DEMO_ROOT)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--json", action="store_true", help="Stampa il risultato in JSON invece della checklist testuale.")
     return parser.parse_args()
 
 
 def main() -> int:
-    """Run the guided check and print the checklist as JSON."""
+    """Run the guided check and print the checklist."""
 
     args = parse_args()
     try:
@@ -111,7 +137,10 @@ def main() -> int:
     except Exception as error:  # noqa: BLE001
         print(f"Collaudo guidato non riuscito: {error}", file=sys.stderr)
         return 1
-    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(render_text_check(result))
     return 0
 
 

--- a/tests/test_student_lab_demo_check.py
+++ b/tests/test_student_lab_demo_check.py
@@ -17,3 +17,10 @@ def test_student_lab_demo_check_returns_guided_manual_steps(tmp_path) -> None:
     assert any("student_lab_cli.py" in step for step in result["manual_steps"])
     assert any("course_board_server.py" in step for step in result["manual_steps"])
     assert any("http://127.0.0.1:8876/tools/student_dashboard.html" in step for step in result["manual_steps"])
+
+    rendered = student_lab_demo_check.render_text_check(result)
+
+    assert "Collaudo lab studente" in rendered
+    assert "- OK setup" in rendered
+    assert "Passi manuali" in rendered
+    assert "student_lab_cli.py" in rendered


### PR DESCRIPTION
﻿## Cosa cambia

- Rende testuale e leggibile l'output predefinito di `student_lab_demo_check.py`.
- Mantiene il formato JSON con `--json` per automazione/debug.
- Aggiorna test e guida demo.

## Perche

Il collaudo guidato viene usato da PowerShell: una checklist testuale e piu immediata del blocco JSON, ma il JSON resta utile per script e test.

## Verifiche

```powershell
python scripts/student_lab_demo_check.py --port 8876
python scripts/student_lab_demo_check.py --port 8876 --json
python -m pytest tests/test_student_lab_demo_check.py
python -m py_compile scripts/student_lab_demo_check.py
git diff --check
```

Closes #419
