### PR TITLE
Chiarisci esito runner nella TUI studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -56,6 +56,7 @@ Comandi disponibili nella TUI minima:
 - invio o `b` dal dettaglio: torna alla lista delle consegne;
 
 Dopo un comando di dettaglio la TUI resta sulla stessa consegna e ricarica i dati quando il comando modifica lo stato, per esempio dopo una richiesta di aiuto o dopo l'esecuzione del runner.
+Quando usi `e`, la TUI mostra stato runner, esito, test passati/totali, path del report salvato e ricorda che quel report e quello letto da dashboard e registro docente.
 
 Il payload ha schema `student_lab.v1` e contiene:
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -263,17 +263,24 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
 
 
 def runner_result_message(report: dict[str, Any], report_path: Path) -> str:
-    """Return a compact message after a runner execution."""
+    """Return a clear message after a runner execution."""
 
     status = clean_text(report.get("status"))
     summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
     passed = summary.get("passed")
     total = summary.get("total")
-    tests = f" ({passed}/{total} test)" if passed is not None and total is not None else ""
+    tests = f"{passed}/{total} test" if passed is not None and total is not None else "non disponibili"
+    outcome = "consegna superata" if report.get("passed") is True else "consegna da ricontrollare"
+    if report.get("passed") is None:
+        outcome = "esito non disponibile"
     return "\n".join(
         [
-            f"Runner completato: {status}{tests}",
-            f"Report salvato: {report_path}",
+            "Esecuzione completata",
+            detail_line("Stato runner:", status),
+            detail_line("Esito:", outcome),
+            detail_line("Test:", tests),
+            detail_line("Report salvato:", report_path),
+            "Questo report e quello letto da dashboard e registro docente.",
         ]
     )
 

--- a/scripts/student_lab_demo_check.py
+++ b/scripts/student_lab_demo_check.py
@@ -51,7 +51,7 @@ def guided_steps(root: Path, commands: dict[str, str], *, host: str, port: int) 
         f"TUI studente: {commands['tui']}",
         f"Server dashboard: python scripts/course_board_server.py --root {root} --host {host} --port {port}",
         f"Dashboard studente: {dashboard_url}",
-        "In TUI: apri la consegna con il numero, verifica dettaglio, storico aiuti con h, runner con e.",
+        "In TUI: apri la consegna con il numero, verifica dettaglio, storico aiuti con h, runner con e e path report salvato.",
         "In dashboard: seleziona rossi-mario e verifica Demo somma in Python, report, test e richieste aiuto.",
     ]
 

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -179,12 +179,17 @@ def test_render_assignment_detail_summarizes_grading_tests() -> None:
 
 def test_runner_result_message_shows_status_tests_and_report_path(tmp_path) -> None:
     message = student_lab_cli.runner_result_message(
-        {"status": "passed", "summary": {"passed": 2, "total": 3}},
+        {"status": "passed", "passed": True, "summary": {"passed": 2, "total": 3}},
         tmp_path / "reports" / "latest.json",
     )
 
-    assert "Runner completato: passed (2/3 test)" in message
+    assert "Esecuzione completata" in message
+    assert "Stato runner:" in message
+    assert "passed" in message
+    assert "consegna superata" in message
+    assert "2/3 test" in message
     assert "Report salvato:" in message
+    assert "dashboard e registro docente" in message
 
 
 def test_assignment_repo_path_uses_help_or_workspace_path(tmp_path) -> None:
@@ -474,7 +479,7 @@ def test_run_tui_can_execute_runner_save_report_and_reload(monkeypatch, tmp_path
     monkeypatch.setattr(
         student_lab_cli.student_lab_runner,
         "run_local_assignment",
-        lambda assignment, root: {"status": "passed", "summary": {"passed": 1, "total": 1}},
+        lambda assignment, root: {"status": "passed", "passed": True, "summary": {"passed": 1, "total": 1}},
     )
 
     def fake_write_report(root, assignment, report):
@@ -494,8 +499,11 @@ def test_run_tui_can_execute_runner_save_report_and_reload(monkeypatch, tmp_path
     assert result == 0
     assert len(load_calls) == 2
     assert saved_reports
-    assert any("Runner completato: passed (1/1 test)" in output for output in outputs)
+    assert any("Esecuzione completata" in output for output in outputs)
+    assert any("consegna superata" in output for output in outputs)
+    assert any("1/1 test" in output for output in outputs)
     assert any("Report salvato:" in output for output in outputs)
+    assert any("dashboard e registro docente" in output for output in outputs)
     assert sum(1 for output in outputs if "Dettaglio consegna" in output) == 2
 
 


### PR DESCRIPTION
﻿## Cosa cambia

- Migliora il messaggio mostrato dalla TUI dopo il comando `e`.
- Mostra stato runner, esito, test passati/totali, path report salvato.
- Chiarisce che il report salvato e quello letto da dashboard e registro docente.
- Aggiorna test, collaudo guidato e documentazione lab.

## Perche

La TUI e l'ambiente operativo prioritario dello studente. Dopo l'esecuzione della consegna deve essere chiaro cosa e successo e quale dato verra poi letto dal docente.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py tests/test_student_lab_demo_check.py
python scripts/student_lab_demo_check.py --port 8876
python -m py_compile scripts/student_lab_cli.py scripts/student_lab_demo_check.py
git diff --check
```

Closes #421
