### PR TITLE
Aggiungi guida rapida al dettaglio TUI

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -55,6 +55,15 @@ Nel dettaglio della consegna i comandi sono divisi in:
 - azioni principali: `e` esegue il runner e salva il report, `a` registra una richiesta di aiuto, `o` apre la cartella workspace;
 - altri comandi: `h` mostra lo storico aiuti, `b` o invio torna alla lista, `q` esce.
 
+Il dettaglio mostra anche una guida rapida con i termini chiave:
+
+- consegna: lavoro assegnato dal docente;
+- workspace: cartella locale dove lo studente modifica i file;
+- test: controlli automatici sul lavoro;
+- report: risultato salvato e letto da dashboard e registro.
+
+Il flusso consigliato è: aprire il workspace, modificare i file, eseguire i test salvando il report, controllare l'esito e chiedere aiuto se serve.
+
 Dopo un comando di dettaglio la TUI resta sulla stessa consegna e ricarica i dati quando il comando modifica lo stato, per esempio dopo una richiesta di aiuto o dopo l'esecuzione del runner.
 Quando usi `e`, la TUI mostra stato runner, esito, test passati/totali, path del report salvato e ricorda che quel report è quello letto da dashboard e registro docente.
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -32,6 +32,12 @@ STATUS_COLORS = {
     "submitted_late": "\033[35m",
 }
 WORKSPACE_COLOR = "\033[36m"
+GUIDE_TERM_COLORS = {
+    "consegna": "\033[35m",
+    "workspace": WORKSPACE_COLOR,
+    "test": "\033[33m",
+    "report": "\033[32m",
+}
 RESET_COLOR = "\033[0m"
 
 
@@ -194,6 +200,18 @@ def section_separator(width: int = 72) -> str:
     return "-" * width
 
 
+def guide_term(text: str, use_color: bool = False) -> str:
+    """Return a highlighted guide term for the detail view."""
+
+    return colorize(text, GUIDE_TERM_COLORS.get(text.lower(), ""), use_color)
+
+
+def guide_label(text: str, use_color: bool = False) -> str:
+    """Return a padded guide term with optional coloring."""
+
+    return colorize(f"{text:<9}", GUIDE_TERM_COLORS.get(text.lower(), ""), use_color)
+
+
 def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False) -> str:
     """Render the detail page for one lab assignment."""
 
@@ -256,6 +274,18 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         "Runner",
         detail_line("Stato:", runner.get("status")),
         detail_line("Backend:", runner.get("backend")),
+        section_separator(),
+        "Guida rapida",
+        f"  {guide_label('Consegna', use_color)} lavoro assegnato dal docente.",
+        f"  {guide_label('Workspace', use_color)} cartella locale dove modifichi i file.",
+        f"  {guide_label('Test', use_color)} controlli automatici sul tuo lavoro.",
+        f"  {guide_label('Report', use_color)} risultato salvato e letto da dashboard/registro.",
+        "",
+        "Flusso consigliato",
+        f"  1. Apri {guide_term('workspace', use_color)}",
+        "  2. Modifica i file",
+        f"  3. Esegui {guide_term('test', use_color)} e salva {guide_term('report', use_color)}",
+        f"  4. Controlla esito e, se serve, chiedi aiuto sulla {guide_term('consegna', use_color)}",
         section_separator(),
         "Azioni principali",
         "  e  Esegui test e salva report",

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -143,6 +143,16 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "bloccata" in rendered
     assert "not_graded" in rendered
     assert "not_run" in rendered
+    assert "Guida rapida" in rendered
+    assert "Consegna  lavoro assegnato dal docente." in rendered
+    assert "Workspace cartella locale dove modifichi i file." in rendered
+    assert "Test      controlli automatici sul tuo lavoro." in rendered
+    assert "Report    risultato salvato e letto da dashboard/registro." in rendered
+    assert "Flusso consigliato" in rendered
+    assert "1. Apri workspace" in rendered
+    assert "2. Modifica i file" in rendered
+    assert "3. Esegui test e salva report" in rendered
+    assert "4. Controlla esito e, se serve, chiedi aiuto sulla consegna" in rendered
     assert "Azioni principali" in rendered
     assert "  e  Esegui test e salva report" in rendered
     assert "  a  Chiedi aiuto" in rendered
@@ -166,6 +176,10 @@ def test_render_assignment_detail_can_color_status() -> None:
     rendered = student_lab_cli.render_assignment_detail(sample_assignment(status="missing"), use_color=True)
 
     assert "\033[31mMancante\033[0m" in rendered
+    assert "\033[35mConsegna \033[0m" in rendered
+    assert "\033[36mWorkspace\033[0m" in rendered
+    assert "\033[33mTest     \033[0m" in rendered
+    assert "\033[32mReport   \033[0m" in rendered
 
 
 def test_render_assignment_detail_summarizes_grading_tests() -> None:


### PR DESCRIPTION
## Cosa cambia

- Aggiunge una `Guida rapida` nel dettaglio consegna della TUI studente.
- Spiega in modo compatto `consegna`, `workspace`, `test` e `report`.
- Aggiunge un `Flusso consigliato` prima dei comandi principali.
- Evidenzia i termini chiave con colori ANSI quando il terminale li supporta.
- Aggiorna test e guida lab studente.

## Perch?

Dopo aver ordinato i comandi, mancava ancora un orientamento pratico per lo studente: capire cosa sta guardando e in quale ordine usare workspace, test e report.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py
python -m py_compile scripts/student_lab_cli.py
git diff --check
```

Closes #427
