### PR TITLE
Mostra dettaglio test dopo runner TUI

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -66,6 +66,7 @@ Il flusso consigliato è: aprire il workspace, modificare i file, eseguire i tes
 
 Dopo un comando di dettaglio la TUI resta sulla stessa consegna e ricarica i dati quando il comando modifica lo stato, per esempio dopo una richiesta di aiuto o dopo l'esecuzione del runner.
 Quando usi `e`, la TUI mostra stato runner, esito, test passati/totali, path del report salvato e ricorda che quel report è quello letto da dashboard e registro docente.
+Se il report contiene il dettaglio dei test, la TUI mostra anche l'elenco dei casi con `[ok]` o `[ko]` e il primo messaggio utile per i test falliti.
 
 Il payload ha schema `student_lab.v1` e contiene:
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -212,6 +212,47 @@ def guide_label(text: str, use_color: bool = False) -> str:
     return colorize(f"{text:<9}", GUIDE_TERM_COLORS.get(text.lower(), ""), use_color)
 
 
+def test_result_label(test: dict[str, Any]) -> str:
+    """Return a compact label for one test result."""
+
+    if test.get("passed") is True:
+        return "[ok]"
+    if test.get("passed") is False:
+        return "[ko]"
+    status = clean_text(test.get("status"), "")
+    return f"[{status}]" if status else "[?]"
+
+
+def test_result_detail(test: dict[str, Any]) -> str:
+    """Return the first useful detail for one test result."""
+
+    for key in ("detail", "message", "error", "stderr", "stdout"):
+        value = clean_text(test.get(key), "")
+        if value:
+            return " ".join(value.split())
+    return ""
+
+
+def render_test_details(report: dict[str, Any]) -> list[str]:
+    """Render test details from a runner report."""
+
+    tests = report.get("tests")
+    if not isinstance(tests, list) or not tests:
+        return ["Dettaglio test", "  non disponibile nel report"]
+    lines = ["Dettaglio test"]
+    for index, item in enumerate(tests, start=1):
+        if not isinstance(item, dict):
+            continue
+        name = clean_text(item.get("name"), f"test {index}")
+        lines.append(f"  {test_result_label(item)} {name}")
+        detail = test_result_detail(item)
+        if detail and item.get("passed") is not True:
+            lines.append(f"      {truncate(detail, 96)}")
+    if len(lines) == 1:
+        lines.append("  non disponibile nel report")
+    return lines
+
+
 def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False) -> str:
     """Render the detail page for one lab assignment."""
 
@@ -319,6 +360,9 @@ def runner_result_message(report: dict[str, Any], report_path: Path) -> str:
             detail_line("Esito:", outcome),
             detail_line("Test:", tests),
             detail_line("Report salvato:", report_path),
+            "",
+            *render_test_details(report),
+            "",
             "Questo report è quello letto da dashboard e registro docente.",
         ]
     )

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -199,18 +199,41 @@ def test_render_assignment_detail_summarizes_grading_tests() -> None:
 
 def test_runner_result_message_shows_status_tests_and_report_path(tmp_path) -> None:
     message = student_lab_cli.runner_result_message(
-        {"status": "passed", "passed": True, "summary": {"passed": 2, "total": 3}},
+        {
+            "status": "failed",
+            "passed": False,
+            "summary": {"passed": 2, "total": 3},
+            "tests": [
+                {"name": "input_base", "passed": True, "status": "passed"},
+                {"name": "caso_zero", "passed": False, "status": "failed", "message": "Output atteso: 10, ottenuto: 8"},
+            ],
+        },
         tmp_path / "reports" / "latest.json",
     )
 
     assert "Esecuzione completata" in message
     assert "Stato runner:" in message
-    assert "passed" in message
-    assert "consegna superata" in message
+    assert "failed" in message
+    assert "consegna da ricontrollare" in message
     assert "2/3 test" in message
     assert "Report salvato:" in message
+    assert "Dettaglio test" in message
+    assert "[ok] input_base" in message
+    assert "[ko] caso_zero" in message
+    assert "Output atteso: 10, ottenuto: 8" in message
     assert "Questo report è quello letto da dashboard e registro docente." in message
     assert "Questo report e quello" not in message
+
+
+def test_runner_result_message_handles_missing_test_details(tmp_path) -> None:
+    message = student_lab_cli.runner_result_message(
+        {"status": "passed", "passed": True, "summary": {"passed": 2, "total": 2}},
+        tmp_path / "reports" / "latest.json",
+    )
+
+    assert "consegna superata" in message
+    assert "Dettaglio test" in message
+    assert "non disponibile nel report" in message
 
 
 def test_assignment_repo_path_uses_help_or_workspace_path(tmp_path) -> None:


### PR DESCRIPTION
## Cosa cambia

- Aggiunge il dettaglio dei test nel messaggio mostrato dopo `e = Esegui test e salva report`.
- Mostra `[ok]` e `[ko]` per i test presenti nel report.
- Mostra il primo messaggio utile per i test falliti, quando disponibile.
- Gestisce i report senza dettagli con `non disponibile nel report`.
- Aggiorna test e guida lab studente.

## Perch?

Dopo l'esecuzione dei test, lo studente deve capire subito dove guardare: non basta sapere che 2/3 test sono passati, serve vedere quale caso ? fallito e il primo dettaglio disponibile.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_cli.py
python -m py_compile scripts/student_lab_cli.py
git diff --check
```

Closes #429
