### PR TITLE
Salva singoli test pytest nel report lab

### DIFF
--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -125,6 +125,31 @@ def parse_pytest_summary(output: str) -> dict[str, int | None]:
     return {"passed": counts["passed"], "total": total}
 
 
+PYTEST_RESULT_RE = re.compile(
+    r"^(?P<node>\S+::\S+)\s+(?P<status>PASSED|FAILED|ERROR|SKIPPED|XFAIL|XPASS)\b",
+    re.MULTILINE,
+)
+
+
+def parse_pytest_test_results(output: str) -> list[dict[str, Any]]:
+    """Return per-test results from pytest verbose output."""
+
+    results: list[dict[str, Any]] = []
+    for match in PYTEST_RESULT_RE.finditer(output):
+        node = match.group("node").replace("\\", "/")
+        status = match.group("status").lower()
+        passed = status in {"passed", "xpass"}
+        item: dict[str, Any] = {
+            "name": node,
+            "passed": passed,
+            "status": status,
+        }
+        if not passed:
+            item["message"] = output.strip()
+        results.append(item)
+    return results
+
+
 def pytest_report_tests(*, passed: bool, status: str, stdout: str, stderr: str) -> list[dict[str, Any]]:
     """Return an aggregate pytest test entry for dashboard grading."""
 
@@ -164,7 +189,7 @@ def run_python_pytest(
             status="no-tests",
             error="Nessun test pytest rilevato nel workspace.",
         )
-    command = [sys.executable, "-m", "pytest", "-q", *targets]
+    command = [sys.executable, "-m", "pytest", "-vv", *targets]
     try:
         result = subprocess.run(
             command,
@@ -191,6 +216,12 @@ def run_python_pytest(
         }
     status = "passed" if result.returncode == 0 else "failed"
     output = f"{result.stdout}\n{result.stderr}"
+    test_results = parse_pytest_test_results(output) or pytest_report_tests(
+        passed=result.returncode == 0,
+        status=status,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
     return {
         **report_base(assignment, language="python", source=source),
         "passed": result.returncode == 0,
@@ -198,12 +229,7 @@ def run_python_pytest(
         "command": command,
         "returncode": result.returncode,
         "summary": parse_pytest_summary(output),
-        "tests": pytest_report_tests(
-            passed=result.returncode == 0,
-            status=status,
-            stdout=result.stdout,
-            stderr=result.stderr,
-        ),
+        "tests": test_results,
         "stdout": result.stdout,
         "stderr": result.stderr,
     }

--- a/tests/test_student_lab_demo_smoke.py
+++ b/tests/test_student_lab_demo_smoke.py
@@ -14,7 +14,7 @@ def test_student_lab_demo_smoke_builds_complete_flow(tmp_path) -> None:
     assert summary["workspace"].endswith("assignments/python-demo-somma-001")
     assert summary["report"].endswith("reports/python-demo-somma-001/latest.json")
     assert summary["teacher_register"].endswith("teacher-reports/demo/python-demo-somma-001.json")
-    assert summary["tests"] == {"passed": 1, "total": 1}
+    assert summary["tests"] == {"passed": 2, "total": 2}
     assert summary["help"] == {"total": 1, "ai_total": 1, "ai_budget_remaining": 4}
     assert summary["backend"] == "local"
 

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -85,6 +85,13 @@ def test_run_student_assignment_passes_python_pytest(tmp_path) -> None:
     assert report["status"] == "passed"
     assert report["passed"] is True
     assert report["summary"] == {"passed": 1, "total": 1}
+    assert report["tests"] == [
+        {
+            "name": "tests/test_main.py::test_somma",
+            "passed": True,
+            "status": "passed",
+        }
+    ]
 
 
 def test_write_student_report_persists_latest_json_and_service_reads_it(tmp_path) -> None:
@@ -143,6 +150,10 @@ def test_run_student_assignment_reports_python_pytest_failure(tmp_path) -> None:
     assert report["status"] == "failed"
     assert report["passed"] is False
     assert report["summary"]["total"] == 1
+    assert report["tests"][0]["name"] == "tests/test_main.py::test_somma"
+    assert report["tests"][0]["passed"] is False
+    assert report["tests"][0]["status"] == "failed"
+    assert "assert -1 == 5" in report["tests"][0]["message"]
     assert "FAILED" in report["stdout"]
 
 


### PR DESCRIPTION
## Cosa cambia

- Esegue pytest in modalit? verbose per ottenere gli esiti dei singoli casi.
- Salva in `report["tests"]` nome, stato ed esito di ogni test pytest parsabile.
- Mantiene il fallback aggregato `pytest` quando l'output non ? parsabile.
- Aggiorna i test del runner Python.

## Perch?

La TUI ora sa mostrare il dettaglio dei test, ma per le consegne Python il runner produceva spesso solo un blocco aggregato. Con questa PR il report contiene casi reali come `tests/test_main.py::test_somma`, rendendo il feedback post-esecuzione pi? utile allo studente.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_runner.py tests/test_student_lab_cli.py
python -m py_compile scripts/student_lab_runner.py scripts/student_lab_cli.py
git diff --check
```

Closes #431
