### PR TITLE
Normalizza messaggi test C nel report lab

### DIFF
--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -163,6 +163,42 @@ def pytest_report_tests(*, passed: bool, status: str, stdout: str, stderr: str) 
     ]
 
 
+def c_test_message(test: dict[str, Any]) -> str:
+    """Return a compact student-facing message for a C test result."""
+
+    for key in ("message", "detail", "error", "stderr"):
+        value = clean_text(test.get(key))
+        if value:
+            return " ".join(value.split())
+    expected = clean_text(test.get("expected_stdout"))
+    actual = clean_text(test.get("stdout"))
+    if expected or actual:
+        return f"Output atteso: {expected or '-'}; output ottenuto: {actual or '-'}"
+    status = clean_text(test.get("status"))
+    return f"Test non superato: {status}" if status else ""
+
+
+def normalize_c_tests(tests: Any) -> list[dict[str, Any]]:
+    """Return C test results with fields useful for the TUI."""
+
+    if not isinstance(tests, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(tests, start=1):
+        if not isinstance(item, dict):
+            continue
+        test = dict(item)
+        test.setdefault("name", f"test {index}")
+        if "status" not in test:
+            test["status"] = "passed" if test.get("passed") is True else "failed" if test.get("passed") is False else "unknown"
+        if test.get("passed") is not True and not clean_text(test.get("message")):
+            message = c_test_message(test)
+            if message:
+                test["message"] = message
+        normalized.append(test)
+    return normalized
+
+
 def run_python_pytest(
     assignment: dict[str, Any],
     *,
@@ -239,6 +275,7 @@ def wrap_c_report(assignment: dict[str, Any], source: Path, report: dict[str, An
     """Wrap the existing C grader output in the student lab runner contract."""
 
     summary = report.get("summary") if isinstance(report.get("summary"), dict) else {"passed": 0, "total": 0}
+    tests = normalize_c_tests(report.get("tests"))
     return {
         **report_base(assignment, language="c", source=source),
         **report,
@@ -247,6 +284,7 @@ def wrap_c_report(assignment: dict[str, Any], source: Path, report: dict[str, An
         "assignment_id": clean_text(assignment.get("assignment_id")),
         "student_id": clean_text(assignment.get("student_id")),
         "summary": summary,
+        "tests": tests,
     }
 
 

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -263,6 +263,46 @@ def test_run_local_assignment_wraps_c_compile_error(monkeypatch, tmp_path) -> No
     assert report["summary"] == {"passed": 0, "total": 0}
 
 
+def test_run_local_assignment_adds_c_failure_message(monkeypatch, tmp_path) -> None:
+    activity_id = "c-base-somma-001"
+    activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")
+    write_assignment(tmp_path, activity_path, activity_id=activity_id)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / activity_id
+    workspace.mkdir(parents=True)
+    (workspace / "main.c").write_text("int main(void){ return 0; }\n", encoding="utf-8")
+
+    def failed_test(activity, source, **kwargs):
+        return {
+            "passed": False,
+            "status": "failed",
+            "activity_id": activity["id"],
+            "language": "c",
+            "source": str(source),
+            "tests": [
+                {
+                    "name": "somma_positivi",
+                    "passed": False,
+                    "status": "failed",
+                    "expected_stdout": "5\n",
+                    "stdout": "4\n",
+                    "stderr": "",
+                }
+            ],
+            "summary": {"passed": 0, "total": 1},
+        }
+
+    monkeypatch.setattr(student_lab_runner.grade_activity, "grade_activity", failed_test)
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+    )
+
+    assert report["status"] == "failed"
+    assert report["tests"][0]["message"] == "Output atteso: 5; output ottenuto: 4"
+
+
 def test_run_docker_assignment_wraps_container_report(monkeypatch, tmp_path) -> None:
     activity_id = "c-base-somma-001"
     activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")
@@ -299,6 +339,51 @@ def test_run_docker_assignment_wraps_container_report(monkeypatch, tmp_path) -> 
     assert report["status"] == "passed"
     assert report["passed"] is True
     assert report["summary"] == {"passed": 1, "total": 1}
+
+
+def test_run_docker_assignment_adds_c_failure_message(monkeypatch, tmp_path) -> None:
+    activity_id = "c-base-somma-001"
+    activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")
+    write_assignment(tmp_path, activity_path, activity_id=activity_id)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / activity_id
+    workspace.mkdir(parents=True)
+    (workspace / "main.c").write_text("int main(void){ return 0; }\n", encoding="utf-8")
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                "passed": False,
+                "status": "failed",
+                "activity_id": activity_id,
+                "language": "c",
+                "source": "/workspace/source/main.c",
+                "tests": [
+                    {
+                        "name": "somma_negativi",
+                        "passed": False,
+                        "status": "failed",
+                        "expected_stdout": "-5\n",
+                        "stdout": "5\n",
+                    }
+                ],
+                "summary": {"passed": 0, "total": 1},
+            }
+        )
+        stderr = ""
+
+    monkeypatch.setattr(student_lab_runner.subprocess, "run", lambda *args, **kwargs: Result())
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+        backend="docker",
+    )
+
+    assert report["backend"] == "docker"
+    assert report["status"] == "failed"
+    assert report["tests"][0]["message"] == "Output atteso: -5; output ottenuto: 5"
 
 
 def test_run_docker_assignment_reports_missing_docker(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Cosa cambia

- Normalizza i test C nel report `student_lab_run.v1`.
- Aggiunge `message` ai test falliti quando il grader espone `expected_stdout`, `stdout`, `stderr` o errori tecnici.
- Applica la normalizzazione sia al runner C locale sia ai report C provenienti dal container Docker.
- Aggiorna i test del runner.

## Perch?

La TUI post-runner mostra gi? il dettaglio dei test. Per C/Docker il report aveva i campi tecnici, ma non sempre un messaggio compatto. Ora lo studente vede subito un testo come `Output atteso: 5; output ottenuto: 4`.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_runner.py tests/test_student_lab_cli.py
python -m py_compile scripts/student_lab_runner.py scripts/student_lab_cli.py
git diff --check
```

Closes #433
