### PR TITLE
Mostra dettagli test salvati nella TUI

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -67,6 +67,7 @@ Il flusso consigliato è: aprire il workspace, modificare i file, eseguire i tes
 Dopo un comando di dettaglio la TUI resta sulla stessa consegna e ricarica i dati quando il comando modifica lo stato, per esempio dopo una richiesta di aiuto o dopo l'esecuzione del runner.
 Quando usi `e`, la TUI mostra stato runner, esito, test passati/totali, path del report salvato e ricorda che quel report è quello letto da dashboard e registro docente.
 Se il report contiene il dettaglio dei test, la TUI mostra anche l'elenco dei casi con `[ok]` o `[ko]` e il primo messaggio utile per i test falliti.
+Quando riapri una consegna con report già salvato, il dettaglio mostra anche l'ultimo dettaglio test letto dal report.
 
 Il payload ha schema `student_lab.v1` e contiene:
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -307,6 +307,15 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Esiste:", "si" if report.get("exists") else "no"),
         detail_line("Consegnata:", compact_datetime(report.get("submitted_at"))),
         detail_line("Commit:", report.get("commit")),
+        *(
+            [
+                section_separator(),
+                "Ultimo dettaglio test",
+                *render_test_details({"tests": report.get("tests")})[1:],
+            ]
+            if report.get("exists")
+            else []
+        ),
         section_separator(),
         "Grading",
         detail_line("Stato:", grading_label(grading)),

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -162,6 +162,44 @@ def load_report(report_path: Path, activity_id: str) -> dict[str, Any] | None:
     return report
 
 
+def report_test_message(test: dict[str, Any]) -> str:
+    """Return the first compact message available for a saved test."""
+
+    for key in ("message", "detail", "error", "stderr"):
+        value = clean_text(test.get(key))
+        if value:
+            return " ".join(value.split())
+    expected = clean_text(test.get("expected_stdout"))
+    actual = clean_text(test.get("stdout"))
+    if expected or actual:
+        return f"Output atteso: {expected or '-'}; output ottenuto: {actual or '-'}"
+    return ""
+
+
+def report_tests_summary(report: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Return a compact test list from a saved runner report."""
+
+    if report is None:
+        return []
+    tests = report.get("tests")
+    if not isinstance(tests, list):
+        return []
+    summarized: list[dict[str, Any]] = []
+    for index, item in enumerate(tests, start=1):
+        if not isinstance(item, dict):
+            continue
+        test = {
+            "name": clean_text(item.get("name")) or f"test {index}",
+            "passed": item.get("passed") if isinstance(item.get("passed"), bool) else None,
+            "status": clean_text(item.get("status")),
+        }
+        message = report_test_message(item)
+        if message:
+            test["message"] = message
+        summarized.append(test)
+    return summarized
+
+
 def build_lab_assignment(
     *,
     root: Path,
@@ -213,6 +251,7 @@ def build_lab_assignment(
             "exists": report is not None,
             "submitted_at": submitted_at,
             "commit": report.get("commit") if report else None,
+            "tests": report_tests_summary(report),
         },
         "grading": grading,
         "help": help_log,

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -187,7 +187,16 @@ def test_render_assignment_detail_summarizes_grading_tests() -> None:
         status="submitted",
         submitted=True,
         grading={"status": "graded_passed", "tests_passed": 2, "tests_total": 3, "teacher_grade": 8, "score": None},
-        report={"path": "reports/latest.json", "exists": True, "submitted_at": "2026-10-18T18:00:00+02:00", "commit": "abc1234"},
+        report={
+            "path": "reports/latest.json",
+            "exists": True,
+            "submitted_at": "2026-10-18T18:00:00+02:00",
+            "commit": "abc1234",
+            "tests": [
+                {"name": "input_base", "passed": True, "status": "passed"},
+                {"name": "caso_zero", "passed": False, "status": "failed", "message": "Output atteso: 10; output ottenuto: 8"},
+            ],
+        },
     )
 
     rendered = student_lab_cli.render_assignment_detail(assignment)
@@ -195,6 +204,10 @@ def test_render_assignment_detail_summarizes_grading_tests() -> None:
     assert "graded_passed (2/3 test)" in rendered
     assert "abc1234" in rendered
     assert "8" in rendered
+    assert "Ultimo dettaglio test" in rendered
+    assert "[ok] input_base" in rendered
+    assert "[ko] caso_zero" in rendered
+    assert "Output atteso: 10; output ottenuto: 8" in rendered
 
 
 def test_runner_result_message_shows_status_tests_and_report_path(tmp_path) -> None:

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -180,6 +180,57 @@ def test_student_lab_uses_existing_report_and_grading_summary(tmp_path) -> None:
     assert assignment["grading"]["status"] == "graded_passed"
     assert assignment["grading"]["tests_passed"] == 2
     assert assignment["grading"]["tests_total"] == 2
+    assert assignment["report"]["tests"] == [
+        {"name": "somma positiva", "passed": True, "status": "passed"},
+        {"name": "somma negativa", "passed": True, "status": "passed"},
+    ]
+
+
+def test_student_lab_exposes_saved_failed_test_messages(tmp_path) -> None:
+    write_assignment(tmp_path, sample_assignment(tmp_path))
+    repo = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario"
+    workspace = repo / "assignments" / "python-base-somma-001"
+    report_path = repo / "reports" / "python-base-somma-001" / "latest.json"
+    workspace.mkdir(parents=True)
+    report_path.parent.mkdir(parents=True)
+    (workspace / "main.py").write_text("print(3)\n", encoding="utf-8")
+    report_path.write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "status": "failed",
+                "passed": False,
+                "source": "assignments/python-base-somma-001/main.py",
+                "submitted_at": "2026-10-18T18:00:00+02:00",
+                "summary": {"passed": 0, "total": 1},
+                "tests": [
+                    {
+                        "name": "somma positiva",
+                        "status": "failed",
+                        "passed": False,
+                        "expected_stdout": "5\n",
+                        "stdout": "4\n",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assignments = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-20T12:00:00+02:00",
+    )
+
+    assert assignments[0]["report"]["tests"] == [
+        {
+            "name": "somma positiva",
+            "passed": False,
+            "status": "failed",
+            "message": "Output atteso: 5; output ottenuto: 4",
+        }
+    ]
 
 
 def test_student_lab_exposes_help_summary(tmp_path) -> None:


### PR DESCRIPTION
## Cosa cambia

- Espone `report.tests` nel payload lab studente quando esiste un report salvato.
- Compatta i dettagli dei test salvati mantenendo nome, stato, esito e primo messaggio utile.
- Mostra `Ultimo dettaglio test` nella vista dettaglio TUI della consegna, prima del grading.
- Aggiorna test service, test TUI e guida lab studente.

## Perch?

Dopo l'esecuzione del runner la TUI mostra gi? i dettagli test, ma se lo studente rientrava pi? tardi nel dettaglio consegna vedeva solo il riepilogo grading. Ora il dettaglio salvato resta consultabile.

## Verifiche

```powershell
python -m pytest tests/test_student_lab_service.py tests/test_student_lab_cli.py
python -m py_compile scripts/student_lab_service.py scripts/student_lab_cli.py
git diff --check
```

Closes #435
