### PR TITLE
Documenta configurazione globale Codex

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -1,0 +1,23 @@
+# Istruzioni globali Codex
+
+## Sub-agenti
+
+Per lavori complessi, lunghi o naturalmente parallelizzabili, valuta l'uso di sub-agenti invece di accumulare tutto nel thread principale.
+
+Usa sub-agenti soprattutto per:
+
+- review PR con focus separati, per esempio bug, test, sicurezza, manutenibilita;
+- esplorazione read-only del codice o della documentazione;
+- analisi log, failure CI e output lunghi;
+- confronto tra alternative architetturali;
+- preparazione di riepiloghi indipendenti prima della sintesi finale.
+
+Quando usi sub-agenti:
+
+- assegna a ogni sub-agente un compito piccolo e indipendente;
+- attendi tutti i risultati prima di decidere;
+- fai tornare al thread principale solo sintesi, finding e riferimenti ai file;
+- evita modifiche parallele sugli stessi file, salvo istruzioni esplicite;
+- mantieni nel thread principale decisioni, priorita e piano finale.
+
+Per lavori semplici o modifiche piccole, resta su un singolo agente.

--- a/config/codex/codex-system.config.toml
+++ b/config/codex/codex-system.config.toml
@@ -1,0 +1,16 @@
+# Template globale Codex per usare GPT-5.6 Sol con reasoning ultra e sub-agenti.
+# Copialo o installalo in: %USERPROFILE%\.codex\config.toml
+#
+# Questo file non contiene segreti, token, path locali, plugin personali o MCP.
+# Lo script scripts/install_codex_system_config.ps1 puo applicare queste chiavi
+# preservando il resto della configurazione gia presente sulla macchina.
+
+model = "gpt-5.6-sol"
+model_reasoning_effort = "ultra"
+service_tier = "default"
+
+[agents]
+max_threads = 6
+max_depth = 1
+job_max_runtime_seconds = 1800
+interrupt_message = true

--- a/doc/CODEX_SYSTEM_CONFIG.md
+++ b/doc/CODEX_SYSTEM_CONFIG.md
@@ -65,6 +65,36 @@ powershell -ExecutionPolicy Bypass -File scripts/install_codex_system_config.ps1
 
 Usa `-Overwrite` solo su una macchina nuova o quando vuoi eliminare consapevolmente la configurazione precedente.
 
+## Installazione su Linux
+
+Da Bash, nella root del repository:
+
+```bash
+bash scripts/install_codex_system_config.sh
+```
+
+Lo script installa in `$HOME/.codex`, fa backup dei file esistenti e preserva le altre sezioni gia presenti nel `config.toml`.
+
+Per vedere cosa farebbe senza scrivere:
+
+```bash
+bash scripts/install_codex_system_config.sh --dry-run
+```
+
+Per usare una home Codex diversa, utile nei test o su macchine condivise:
+
+```bash
+bash scripts/install_codex_system_config.sh --codex-home /percorso/.codex
+```
+
+Per sovrascrivere completamente `config.toml` con il template minimo:
+
+```bash
+bash scripts/install_codex_system_config.sh --overwrite
+```
+
+Usa `--overwrite` solo su una macchina nuova o quando vuoi eliminare consapevolmente la configurazione precedente.
+
 ## Dopo l'installazione
 
 Chiudi e riapri:

--- a/doc/CODEX_SYSTEM_CONFIG.md
+++ b/doc/CODEX_SYSTEM_CONFIG.md
@@ -1,0 +1,85 @@
+# Configurazione globale Codex
+
+Questa pagina spiega come portare su una nuova macchina la configurazione Codex usata per lavorare con GPT-5.6 Sol, reasoning ultra e sub-agenti.
+
+## Cosa viene configurato
+
+Il template sicuro e in [`config/codex/codex-system.config.toml`](../config/codex/codex-system.config.toml):
+
+```toml
+model = "gpt-5.6-sol"
+model_reasoning_effort = "ultra"
+service_tier = "default"
+
+[agents]
+max_threads = 6
+max_depth = 1
+job_max_runtime_seconds = 1800
+interrupt_message = true
+```
+
+Il file [`config/codex/AGENTS.md`](../config/codex/AGENTS.md) aggiunge istruzioni globali per usare sub-agenti quando il lavoro e complesso, lungo o parallelizzabile.
+
+## Cosa non contiene
+
+Il template non contiene:
+
+- token;
+- API key;
+- `auth.json`;
+- path locali della macchina;
+- configurazioni MCP personali;
+- configurazioni plugin personali;
+- segreti AI provider.
+
+Questi dati restano nella macchina locale e non vanno committati.
+
+## Installazione su Windows
+
+Da PowerShell, nella root del repository:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/install_codex_system_config.ps1
+```
+
+Lo script:
+
+1. crea `%USERPROFILE%\.codex` se manca;
+2. fa backup di `%USERPROFILE%\.codex\config.toml`, se esiste;
+3. applica `model`, `model_reasoning_effort`, `service_tier` e `[agents]`;
+4. preserva le altre sezioni gia presenti nel `config.toml`, per esempio plugin, MCP e progetti trusted;
+5. installa `%USERPROFILE%\.codex\AGENTS.md`;
+6. fa backup di un eventuale `AGENTS.md` gia presente.
+
+Per vedere cosa farebbe senza scrivere:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/install_codex_system_config.ps1 -WhatIf
+```
+
+Per sovrascrivere completamente `config.toml` con il template minimo:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/install_codex_system_config.ps1 -Overwrite
+```
+
+Usa `-Overwrite` solo su una macchina nuova o quando vuoi eliminare consapevolmente la configurazione precedente.
+
+## Dopo l'installazione
+
+Chiudi e riapri:
+
+- VS Code;
+- eventuale estensione Codex;
+- Codex CLI;
+- ChatGPT desktop app, se la stai usando.
+
+Le app possono leggere `config.toml` all'avvio, quindi una sessione gia aperta potrebbe non vedere subito le modifiche.
+
+## Note operative
+
+`model_reasoning_effort = "ultra"` aumenta qualita e profondita sui task complessi, ma puo aumentare tempo e consumo.
+
+I sub-agenti sono utili soprattutto per review, esplorazione codice, analisi log e test. Non conviene usarli sempre: per modifiche piccole un singolo agente resta piu veloce e piu controllabile.
+
+La disponibilita effettiva di `gpt-5.6-sol` e del reasoning `ultra` dipende dall'account, dal piano e dalla superficie Codex usata.

--- a/doc/CODEX_SYSTEM_CONFIG.md
+++ b/doc/CODEX_SYSTEM_CONFIG.md
@@ -106,6 +106,94 @@ Chiudi e riapri:
 
 Le app possono leggere `config.toml` all'avvio, quindi una sessione gia aperta potrebbe non vedere subito le modifiche.
 
+## Verifica della configurazione
+
+### Windows
+
+Dopo aver chiuso e riaperto VS Code, Codex o ChatGPT desktop, apri una nuova sessione Codex:
+
+```powershell
+codex
+```
+
+Poi dentro Codex esegui:
+
+```text
+/status
+```
+
+Dovresti vedere una configurazione coerente con:
+
+```text
+model: gpt-5.6-sol
+reasoning effort: ultra
+```
+
+Per controllare direttamente il file:
+
+```powershell
+Get-Content $env:USERPROFILE\.codex\config.toml | Select-String "model|model_reasoning_effort|\[agents\]|max_threads|max_depth"
+```
+
+Output atteso:
+
+```text
+model = "gpt-5.6-sol"
+model_reasoning_effort = "ultra"
+[agents]
+max_threads = 6
+max_depth = 1
+```
+
+### Linux
+
+Dopo aver riaperto terminale, editor o Codex:
+
+```bash
+codex
+```
+
+Poi dentro Codex esegui:
+
+```text
+/status
+```
+
+Dovresti vedere una configurazione coerente con:
+
+```text
+model: gpt-5.6-sol
+reasoning effort: ultra
+```
+
+Per controllare direttamente il file:
+
+```bash
+grep -E '^(model|model_reasoning_effort|max_threads|max_depth)|^\[agents\]' ~/.codex/config.toml
+```
+
+Output atteso:
+
+```text
+model = "gpt-5.6-sol"
+model_reasoning_effort = "ultra"
+[agents]
+max_threads = 6
+max_depth = 1
+```
+
+### Sub-agenti
+
+Per verificare che i sub-agenti siano disponibili, in una nuova sessione Codex prova un prompt di questo tipo:
+
+```text
+Usa sub-agenti per fare una review di questa branch: uno per bug, uno per test mancanti, uno per manutenibilita. Aspetta tutti e poi riassumi.
+```
+
+Se la superficie Codex che stai usando supporta i sub-agenti, dovresti vedere attivita o thread separati nell'interfaccia. Nella CLI puoi usare `/agent` per ispezionare e cambiare thread agente mentre sono in esecuzione.
+
+Se il file e corretto ma il modello non e disponibile per il tuo account o per quella superficie Codex, `/status` o l'avvio della sessione lo rendono visibile con un fallback o con un errore di modello non disponibile.
+
 ## Note operative
 
 `model_reasoning_effort = "ultra"` aumenta qualita e profondita sui task complessi, ma puo aumentare tempo e consumo.

--- a/doc/CODEX_SYSTEM_CONFIG.md
+++ b/doc/CODEX_SYSTEM_CONFIG.md
@@ -73,7 +73,9 @@ Da Bash, nella root del repository:
 bash scripts/install_codex_system_config.sh
 ```
 
-Lo script installa in `$HOME/.codex`, fa backup dei file esistenti e preserva le altre sezioni gia presenti nel `config.toml`.
+Prerequisiti: Bash e Python 3 disponibili sulla macchina.
+
+Lo script installa in `$HOME/.codex`, fa backup dei file esistenti e preserva le altre sezioni gia presenti nel `config.toml`. Per il merge della configurazione usa `python3` quando disponibile, con fallback a `python`.
 
 Per vedere cosa farebbe senza scrivere:
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -76,6 +76,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | [`SCENARI_TEST_MANUALI_GUI.md`](SCENARI_TEST_MANUALI_GUI.md) | Quando devi collaudare manualmente dashboard, modal, viste e TUI prima di automatizzare |
 | [`images/dashboard-guides/README.md`](images/dashboard-guides/README.md) | Quando devi catturare o aggiornare gli screenshot delle guide dashboard |
 | [`STUDENT_DASHBOARD.md`](STUDENT_DASHBOARD.md) | Quando devi provare la vista studente minima su consegne, grading e feedback approvato |
+| [`CODEX_SYSTEM_CONFIG.md`](CODEX_SYSTEM_CONFIG.md) | Quando devi installare su una macchina nuova la configurazione Codex globale per GPT-5.6 Sol, reasoning ultra e sub-agenti |
 | [`STUDENT_REPOSITORY_TEMPLATE.md`](STUDENT_REPOSITORY_TEMPLATE.md) | Quando devi creare o mantenere il template repository studente |
 | [`ASSIGNMENT_GRADING.md`](ASSIGNMENT_GRADING.md) | Quando devi correggere in modo deterministico una consegna TheBitLab |
 | [`ASSIGNMENT_SANDBOX.md`](ASSIGNMENT_SANDBOX.md) | Quando devi eseguire il grading in una sandbox Docker |

--- a/scripts/install_codex_system_config.ps1
+++ b/scripts/install_codex_system_config.ps1
@@ -1,0 +1,119 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$CodexHome = (Join-Path $env:USERPROFILE ".codex"),
+    [string]$TemplatePath = "",
+    [string]$AgentsTemplatePath = "",
+    [switch]$Overwrite
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+if (-not $TemplatePath) {
+    $TemplatePath = Join-Path $repoRoot "config\codex\codex-system.config.toml"
+}
+if (-not $AgentsTemplatePath) {
+    $AgentsTemplatePath = Join-Path $repoRoot "config\codex\AGENTS.md"
+}
+
+function New-Backup {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $null
+    }
+
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $backup = "$Path.bak-$stamp"
+    Copy-Item -LiteralPath $Path -Destination $backup
+    return $backup
+}
+
+function Set-Or-AddTopLevelString {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Key,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+
+    $line = "$Key = `"$Value`""
+    $pattern = "(?m)^$([regex]::Escape($Key))\s*=\s*`"[^`"]*`""
+    if ($Text -match $pattern) {
+        return [regex]::Replace($Text, $pattern, $line)
+    }
+    return $line + "`r`n" + $Text
+}
+
+function Remove-Section {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][string]$SectionName
+    )
+
+    $escaped = [regex]::Escape($SectionName)
+    $pattern = "(?ms)^\[$escaped\]\s*.*?(?=^\[[^\]]+\]\s*|\z)"
+    return [regex]::Replace($Text, $pattern, "").TrimEnd() + "`r`n"
+}
+
+function Merge-CodexConfig {
+    param(
+        [Parameter(Mandatory = $true)][string]$CurrentText,
+        [Parameter(Mandatory = $true)][string]$TemplateText
+    )
+
+    $result = $CurrentText
+    foreach ($key in @("model", "model_reasoning_effort", "service_tier")) {
+        $match = [regex]::Match($TemplateText, "(?m)^$key\s*=\s*`"([^`"]+)`"")
+        if ($match.Success) {
+            $result = Set-Or-AddTopLevelString -Text $result -Key $key -Value $match.Groups[1].Value
+        }
+    }
+
+    $agentsMatch = [regex]::Match($TemplateText, "(?ms)^\[agents\]\s*.*?(?=^\[[^\]]+\]\s*|\z)")
+    if ($agentsMatch.Success) {
+        $result = Remove-Section -Text $result -SectionName "agents"
+        $result = $result.TrimEnd() + "`r`n`r`n" + $agentsMatch.Value.Trim() + "`r`n"
+    }
+
+    return $result
+}
+
+$resolvedCodexHome = [System.IO.Path]::GetFullPath($CodexHome)
+$resolvedTemplatePath = [System.IO.Path]::GetFullPath($TemplatePath)
+$resolvedAgentsTemplatePath = [System.IO.Path]::GetFullPath($AgentsTemplatePath)
+$configPath = Join-Path $resolvedCodexHome "config.toml"
+$agentsPath = Join-Path $resolvedCodexHome "AGENTS.md"
+
+if (-not (Test-Path -LiteralPath $resolvedTemplatePath)) {
+    throw "Template TOML non trovato: $resolvedTemplatePath"
+}
+if (-not (Test-Path -LiteralPath $resolvedAgentsTemplatePath)) {
+    throw "Template AGENTS.md non trovato: $resolvedAgentsTemplatePath"
+}
+
+if ($PSCmdlet.ShouldProcess($resolvedCodexHome, "Install Codex system configuration")) {
+    New-Item -ItemType Directory -Force -Path $resolvedCodexHome | Out-Null
+
+    $template = Get-Content -LiteralPath $resolvedTemplatePath -Raw
+    $configBackup = New-Backup -Path $configPath
+    if ($Overwrite -or -not (Test-Path -LiteralPath $configPath)) {
+        Set-Content -LiteralPath $configPath -Value $template -Encoding utf8
+    } else {
+        $current = Get-Content -LiteralPath $configPath -Raw
+        $merged = Merge-CodexConfig -CurrentText $current -TemplateText $template
+        Set-Content -LiteralPath $configPath -Value $merged -Encoding utf8
+    }
+
+    $agentsBackup = New-Backup -Path $agentsPath
+    Copy-Item -LiteralPath $resolvedAgentsTemplatePath -Destination $agentsPath -Force
+
+    Write-Output "Configurazione Codex installata in: $resolvedCodexHome"
+    if ($configBackup) {
+        Write-Output "Backup config.toml: $configBackup"
+    }
+    if ($agentsBackup) {
+        Write-Output "Backup AGENTS.md: $agentsBackup"
+    }
+    Write-Output "Riavvia VS Code, Codex CLI o ChatGPT desktop per caricare le nuove impostazioni."
+}

--- a/scripts/install_codex_system_config.sh
+++ b/scripts/install_codex_system_config.sh
@@ -71,6 +71,17 @@ if [[ ! -f "$agents_template_path" ]]; then
   exit 1
 fi
 
+python_bin=""
+if command -v python3 >/dev/null 2>&1; then
+  python_bin="python3"
+elif command -v python >/dev/null 2>&1; then
+  python_bin="python"
+fi
+if [[ -z "$python_bin" ]]; then
+  echo "Python 3 non trovato: installa python3 oppure rendi disponibile un comando python compatibile." >&2
+  exit 1
+fi
+
 config_path="$codex_home/config.toml"
 agents_path="$codex_home/AGENTS.md"
 
@@ -87,7 +98,7 @@ backup_file() {
 render_merged_config() {
   local current="$1"
   local template="$2"
-  python - "$current" "$template" <<'PY'
+  "$python_bin" - "$current" "$template" <<'PY'
 from __future__ import annotations
 
 import re

--- a/scripts/install_codex_system_config.sh
+++ b/scripts/install_codex_system_config.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Installa la configurazione globale Codex su Linux/macOS.
+
+Uso:
+  scripts/install_codex_system_config.sh [--codex-home PATH] [--template PATH] [--agents-template PATH] [--overwrite] [--dry-run]
+
+Default:
+  --codex-home        $HOME/.codex
+  --template          config/codex/codex-system.config.toml
+  --agents-template   config/codex/AGENTS.md
+
+Opzioni:
+  --overwrite         Sovrascrive completamente config.toml con il template minimo.
+  --dry-run           Mostra cosa farebbe senza scrivere.
+  -h, --help          Mostra questa guida.
+EOF
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+codex_home="${HOME}/.codex"
+template_path="$repo_root/config/codex/codex-system.config.toml"
+agents_template_path="$repo_root/config/codex/AGENTS.md"
+overwrite=false
+dry_run=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --codex-home)
+      codex_home="${2:?Manca il valore per --codex-home}"
+      shift 2
+      ;;
+    --template)
+      template_path="${2:?Manca il valore per --template}"
+      shift 2
+      ;;
+    --agents-template)
+      agents_template_path="${2:?Manca il valore per --agents-template}"
+      shift 2
+      ;;
+    --overwrite)
+      overwrite=true
+      shift
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Opzione non riconosciuta: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$template_path" ]]; then
+  echo "Template TOML non trovato: $template_path" >&2
+  exit 1
+fi
+if [[ ! -f "$agents_template_path" ]]; then
+  echo "Template AGENTS.md non trovato: $agents_template_path" >&2
+  exit 1
+fi
+
+config_path="$codex_home/config.toml"
+agents_path="$codex_home/AGENTS.md"
+
+backup_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    return 0
+  fi
+  local backup="${path}.bak-$(date +%Y%m%d-%H%M%S)"
+  cp "$path" "$backup"
+  echo "$backup"
+}
+
+render_merged_config() {
+  local current="$1"
+  local template="$2"
+  python - "$current" "$template" <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+current_path = Path(sys.argv[1])
+template_path = Path(sys.argv[2])
+current = current_path.read_text(encoding="utf-8") if current_path.exists() else ""
+template = template_path.read_text(encoding="utf-8")
+
+
+def top_level_value(text: str, key: str) -> str | None:
+    match = re.search(rf'^{re.escape(key)}\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def set_or_add_top_level(text: str, key: str, value: str) -> str:
+    line = f'{key} = "{value}"'
+    pattern = rf'^{re.escape(key)}\s*=\s*"[^"]*"'
+    if re.search(pattern, text, flags=re.MULTILINE):
+        return re.sub(pattern, line, text, flags=re.MULTILINE)
+    return line + "\n" + text
+
+
+def section(text: str, name: str) -> str | None:
+    match = re.search(rf'^\[{re.escape(name)}\]\s*.*?(?=^\[[^\]]+\]\s*|\Z)', text, flags=re.MULTILINE | re.DOTALL)
+    return match.group(0).strip() if match else None
+
+
+result = current
+for key in ("model", "model_reasoning_effort", "service_tier"):
+    value = top_level_value(template, key)
+    if value is not None:
+        result = set_or_add_top_level(result, key, value)
+
+agents = section(template, "agents")
+if agents:
+    result = re.sub(r'^\[agents\]\s*.*?(?=^\[[^\]]+\]\s*|\Z)', "", result, flags=re.MULTILINE | re.DOTALL).rstrip()
+    result = result + "\n\n" + agents + "\n"
+
+sys.stdout.write(result)
+PY
+}
+
+echo "Codex home: $codex_home"
+echo "Template TOML: $template_path"
+echo "Template AGENTS.md: $agents_template_path"
+
+if [[ "$dry_run" == true ]]; then
+  echo "Dry run: nessun file verra scritto."
+  if [[ -f "$config_path" && "$overwrite" != true ]]; then
+    echo "Merge previsto su: $config_path"
+  else
+    echo "Scrittura prevista: $config_path"
+  fi
+  echo "Scrittura prevista: $agents_path"
+  exit 0
+fi
+
+mkdir -p "$codex_home"
+
+config_backup="$(backup_file "$config_path" || true)"
+if [[ "$overwrite" == true || ! -f "$config_path" ]]; then
+  cp "$template_path" "$config_path"
+else
+  tmp_config="$(mktemp)"
+  render_merged_config "$config_path" "$template_path" > "$tmp_config"
+  mv "$tmp_config" "$config_path"
+fi
+
+agents_backup="$(backup_file "$agents_path" || true)"
+cp "$agents_template_path" "$agents_path"
+
+echo "Configurazione Codex installata in: $codex_home"
+if [[ -n "$config_backup" ]]; then
+  echo "Backup config.toml: $config_backup"
+fi
+if [[ -n "$agents_backup" ]]; then
+  echo "Backup AGENTS.md: $agents_backup"
+fi
+echo "Riavvia VS Code, Codex CLI o ChatGPT desktop per caricare le nuove impostazioni."


### PR DESCRIPTION
## Cosa cambia
- Aggiunge un template sicuro `config/codex/codex-system.config.toml` per configurare Codex con `gpt-5.6-sol`, reasoning `ultra` e sub-agenti.
- Aggiunge `config/codex/AGENTS.md` con istruzioni globali per usare sub-agenti su review, esplorazione, test e analisi log.
- Aggiunge `scripts/install_codex_system_config.ps1`, che installa la configurazione in `%USERPROFILE%\.codex`, facendo backup e preservando le sezioni esistenti del `config.toml`.
- Aggiunge `scripts/install_codex_system_config.sh`, equivalente Linux/macOS per installare in `$HOME/.codex`, con `--dry-run`, `--overwrite` e `--codex-home`.
- Aggiunge `.gitattributes` per mantenere LF sugli script `.sh`.
- Documenta il flusso in `doc/CODEX_SYSTEM_CONFIG.md`, incluse verifica Windows/Linux con `/status`, controllo dei file e prova sub-agenti.
- Collega la guida da `doc/README.md`.

## Sicurezza
- Nessun segreto incluso.
- Nessun `auth.json`, API key, token, path locali personali, plugin runtime o MCP personali nel template.
- Gli script preservano plugin/MCP/progetti trusted gia presenti, salvo uso esplicito di `-Overwrite`/`--overwrite`.

## Test
- `powershell -ExecutionPolicy Bypass -File scripts/install_codex_system_config.ps1 -CodexHome tmp/codex-config-whatif -WhatIf`
- `powershell -ExecutionPolicy Bypass -File scripts/install_codex_system_config.ps1 -CodexHome tmp/codex-config-test`
- test merge PowerShell su config finta con sezione plugin preservata
- controllo statico script Linux e file LF
- `git diff --check`

## Nota test Linux
Su questa macchina `bash` non e disponibile perche WSL intercetta il comando ma non trova `/bin/bash`. Lo script Linux va verificato esecutivamente su una macchina Linux/macOS con Bash e Python disponibili.