### PR TITLE
Aggiungi risposte guidate agli aiuti studente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *~
 .vagrant
 *.log
+__pycache__/
+*.py[cod]
 .secrets/
 *.secret
 

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -243,6 +243,8 @@ Risultato atteso:
 - Dopo un comando nel dettaglio si resta nel dettaglio della consegna, non si torna alla lista generale.
 - La guida locale è distinta da una risposta AI reale e non mostra una soluzione completa.
 - Prompt e risposta restano visibili nello storico della consegna.
+- Ogni richiesta nello storico è separata da linee tratteggiate e prompt, risposta, motivo ed esito sono distinguibili per colore.
+- Con `--no-color` la stessa gerarchia resta leggibile grazie a intestazioni, rientri e separatori.
 - Il report salvato dalla TUI viene letto dalla dashboard studente.
 - Le richieste di aiuto salvate dalla TUI vengono viste dal docente.
 - Gli accenti e i testi italiani sono corretti.

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -68,7 +68,7 @@ Ogni pannello, modal, vista e comando deve avere almeno uno scenario manuale. Qu
 | TUI studente | Lista consegne | Avvia TUI e verifica legenda, colori opzionali, date compatte e selezione numerica | Test interattivo o snapshot terminale |
 | TUI studente | Dettaglio consegna | Apri una consegna e verifica sezioni, divisori, guida rapida e comandi | Test interattivo o snapshot terminale |
 | TUI studente | Comando `e` | Esegui test e salva report, poi verifica GUI studente/docente | Test interattivo piu assert su file |
-| TUI studente | Comando `a` | Chiedi aiuto, annulla con `b`/invio, valida input non valido | Test interattivo con input finto |
+| TUI studente | Comando `a` | Chiedi aiuto, verifica guida locale e storico, annulla con `b`/invio, valida input non valido | Test interattivo con input finto |
 | TUI studente | Comando `h` | Mostra storico aiuti e torna alla consegna | Test interattivo con input finto |
 | TUI studente | Comando `o` | Apre workspace se presente, mostra errore chiaro se assente | Test con mock apertura |
 | TUI studente | Comandi `b`, `r`, `q` | Torna indietro, ricarica, esce senza perdere stato | Test interattivo con input finto |
@@ -229,16 +229,20 @@ Obiettivo: verificare che la TUI sia comprensibile, robusta sugli input e coeren
 8. Premi `a`, poi invio senza testo: la richiesta deve essere annullata.
 9. Premi `a`, poi un tipo diverso da `1`, `2`, `3`, `b` o invio: deve comparire errore.
 10. Premi `a`, scegli `3`, scrivi un prompt e salva la richiesta.
-11. Premi `e` per eseguire test e salvare report.
-12. Premi `b` per tornare alla lista.
-13. Premi `r` per ricaricare.
-14. Premi `q` per uscire.
+11. Controlla che compaia una risposta etichettata `Guida locale (nessuna AI esterna)`.
+12. Premi `h` e verifica che prompt e risposta siano entrambi nello storico.
+13. Premi `e` per eseguire test e salvare report.
+14. Premi `b` per tornare alla lista.
+15. Premi `r` per ricaricare.
+16. Premi `q` per uscire.
 
 Risultato atteso:
 
 - Gli input non validi non eseguono azioni.
 - `b` e invio annullano o tornano indietro dove previsto.
 - Dopo un comando nel dettaglio si resta nel dettaglio della consegna, non si torna alla lista generale.
+- La guida locale è distinta da una risposta AI reale e non mostra una soluzione completa.
+- Prompt e risposta restano visibili nello storico della consegna.
 - Il report salvato dalla TUI viene letto dalla dashboard studente.
 - Le richieste di aiuto salvate dalla TUI vengono viste dal docente.
 - Gli accenti e i testi italiani sono corretti.

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -231,10 +231,11 @@ Obiettivo: verificare che la TUI sia comprensibile, robusta sugli input e coeren
 10. Premi `a`, scegli `3`, scrivi un prompt e salva la richiesta.
 11. Controlla che l'esito immediato sia diviso da linee tratteggiate e mostri tipo, stato e risposta a capo, etichettata `Guida locale (nessuna AI esterna)`.
 12. Premi `h` e verifica che prompt e risposta siano entrambi nello storico.
-13. Premi `e` per eseguire test e salvare report.
-14. Premi `b` per tornare alla lista.
-15. Premi `r` per ricaricare.
-16. Premi `q` per uscire.
+13. Ripeti con un URL o un identificatore lungo senza spazi e verifica che venga mandato a capo senza scorrimento orizzontale.
+14. Premi `e` per eseguire test e salvare report.
+15. Premi `b` per tornare alla lista.
+16. Premi `r` per ricaricare.
+17. Premi `q` per uscire.
 
 Risultato atteso:
 

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -229,7 +229,7 @@ Obiettivo: verificare che la TUI sia comprensibile, robusta sugli input e coeren
 8. Premi `a`, poi invio senza testo: la richiesta deve essere annullata.
 9. Premi `a`, poi un tipo diverso da `1`, `2`, `3`, `b` o invio: deve comparire errore.
 10. Premi `a`, scegli `3`, scrivi un prompt e salva la richiesta.
-11. Controlla che compaia una risposta etichettata `Guida locale (nessuna AI esterna)`.
+11. Controlla che l'esito immediato sia diviso da linee tratteggiate e mostri tipo, stato e risposta a capo, etichettata `Guida locale (nessuna AI esterna)`.
 12. Premi `h` e verifica che prompt e risposta siano entrambi nello storico.
 13. Premi `e` per eseguire test e salvare report.
 14. Premi `b` per tornare alla lista.
@@ -242,6 +242,7 @@ Risultato atteso:
 - `b` e invio annullano o tornano indietro dove previsto.
 - Dopo un comando nel dettaglio si resta nel dettaglio della consegna, non si torna alla lista generale.
 - La guida locale è distinta da una risposta AI reale e non mostra una soluzione completa.
+- L'esito immediato non ripete la motivazione della policy quando la richiesta riesce; per richieste bloccate o errori mostra subito il motivo.
 - Prompt e risposta restano visibili nello storico della consegna.
 - Ogni richiesta nello storico è separata da linee tratteggiate e prompt, risposta, motivo ed esito sono distinguibili per colore.
 - Con `--no-color` la stessa gerarchia resta leggibile grazie a intestazioni, rientri e separatori.

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -116,7 +116,9 @@ Ogni evento indica tipo di aiuto richiesto, esito consentito/bloccato, motivazio
 Quando la richiesta è consentita e viene usato un provider, l'evento contiene anche una `response` conforme a
 `student_help_response.v1`: stato, provider, messaggio, dettaglio tecnico e contatori d'uso.
 Il payload lab espone un riepilogo `help` con totale eventi, richieste consentite, richieste bloccate, ultimo esito e budget AI usato/rimanente.
-La TUI registra nuove richieste, mostra subito la risposta e la conserva nello storico. In questa fase usa
+La TUI registra nuove richieste, mostra subito la risposta e la conserva nello storico. Il comando `h` separa ogni
+evento con linee tratteggiate, distingue prompt, risposta e motivo con colori ANSI e mantiene la stessa struttura
+leggibile quando i colori sono disabilitati. In questa fase usa
 `DeterministicStudentHelpProvider`, indicato a schermo come `Guida locale (nessuna AI esterna)`: serve a collaudare
 il flusso senza credenziali e senza consumo di token. Il contratto `StudentHelpProvider` permette di sostituirlo con
 Codex o un provider API senza cambiare policy, persistenza e interfaccia.

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -113,8 +113,16 @@ Il backend può registrare richieste di aiuto dello studente in:
 `<repo-studente>/help/<activity-id>/events.json`
 
 Ogni evento indica tipo di aiuto richiesto, esito consentito/bloccato, motivazione e prompt dello studente.
+Quando la richiesta è consentita e viene usato un provider, l'evento contiene anche una `response` conforme a
+`student_help_response.v1`: stato, provider, messaggio, dettaglio tecnico e contatori d'uso.
 Il payload lab espone un riepilogo `help` con totale eventi, richieste consentite, richieste bloccate, ultimo esito e budget AI usato/rimanente.
-La TUI può registrare nuove richieste e mostrare lo storico salvato. In questa fase il log non chiama provider AI e non applica ancora limiti token reali: prepara il contratto per enforcement, budget e audit successivi.
+La TUI registra nuove richieste, mostra subito la risposta e la conserva nello storico. In questa fase usa
+`DeterministicStudentHelpProvider`, indicato a schermo come `Guida locale (nessuna AI esterna)`: serve a collaudare
+il flusso senza credenziali e senza consumo di token. Il contratto `StudentHelpProvider` permette di sostituirlo con
+Codex o un provider API senza cambiare policy, persistenza e interfaccia.
+
+Il provider locale restituisce solo metodo di lavoro, domande guida, argomenti e test su cui concentrarsi. Non genera
+soluzioni complete. Se il provider fallisce, la richiesta resta salvata e la risposta viene marcata `error`.
 
 ## Direzione
 
@@ -139,8 +147,8 @@ In questo modo dashboard docente, dashboard studente e TUI leggono lo stesso ris
 
 Le prossime PR dovranno completare questo contratto con:
 
-1. budget AI a token/costo per scuola, classe, studente e consegna;
-2. chiamata reale a provider AI o adapter Codex quando la policy lo consente;
+1. collegare un adapter Codex o provider API al contratto `StudentHelpProvider` quando la policy lo consente;
+2. contabilizzare token/costo reali per scuola, classe, studente e consegna usando i metadati `usage`;
 3. demo end-to-end pulita con dati riproducibili;
 4. guida utente docente/studente aggiornata;
 5. valutare un adapter opzionale per layout terminale avanzato, per esempio tmux su ambienti compatibili.

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -116,9 +116,11 @@ Ogni evento indica tipo di aiuto richiesto, esito consentito/bloccato, motivazio
 Quando la richiesta è consentita e viene usato un provider, l'evento contiene anche una `response` conforme a
 `student_help_response.v1`: stato, provider, messaggio, dettaglio tecnico e contatori d'uso.
 Il payload lab espone un riepilogo `help` con totale eventi, richieste consentite, richieste bloccate, ultimo esito e budget AI usato/rimanente.
-La TUI registra nuove richieste, mostra subito la risposta e la conserva nello storico. Il comando `h` separa ogni
-evento con linee tratteggiate, distingue prompt, risposta e motivo con colori ANSI e mantiene la stessa struttura
-leggibile quando i colori sono disabilitati. In questa fase usa
+La TUI registra nuove richieste, mostra subito un esito compatto con tipo, stato e risposta a capo, poi conserva tutti
+i dettagli nello storico. La motivazione della policy compare subito solo quando la richiesta è bloccata o il provider
+non restituisce una risposta; per le richieste riuscite resta consultabile con `h`, evitando ripetizioni. Il comando
+`h` separa ogni evento con linee tratteggiate, distingue prompt, risposta e motivo con colori ANSI e mantiene la stessa
+struttura leggibile quando i colori sono disabilitati. In questa fase usa
 `DeterministicStudentHelpProvider`, indicato a schermo come `Guida locale (nessuna AI esterna)`: serve a collaudare
 il flusso senza credenziali e senza consumo di token. Il contratto `StudentHelpProvider` permette di sostituirlo con
 Codex o un provider API senza cambiare policy, persistenza e interfaccia.

--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -195,3 +195,20 @@ python -m scripts.manual_ai_feedback review-feedback updated-register.json rossi
 Il flusso operativo completo e descritto in [`../MANUAL_AI_FEEDBACK_WORKFLOW.md`](../MANUAL_AI_FEEDBACK_WORKFLOW.md).
 
 Se ChatGPT cambia stile di risposta, si modifica solo l'adapter del workflow manuale o il validatore dello schema, non il resto della dashboard. Lo stesso contratto JSON puo essere riusato anche dagli adapter automatici, che inviano e ricevono dati strutturati senza legarsi al testo libero del provider.
+
+## Aiuto durante lo svolgimento
+
+Il feedback AI sul grading e l'aiuto chiesto dallo studente durante il lavoro sono due casi d'uso distinti. Il primo
+produce una bozza sottoposta al docente; il secondo deve rispettare immediatamente la policy della consegna e non
+deve ricevere dati personali o codice non autorizzato.
+
+Il confine per il secondo caso e `StudentHelpProvider`, definito in `scripts/student_help_provider.py`:
+
+- `StudentHelpRequest` contiene activity, tipo di aiuto, prompt e contesto minimo consentito;
+- `StudentHelpResponse` usa lo schema `student_help_response.v1` e include provider, messaggio, errore e uso;
+- `DeterministicStudentHelpProvider` e il primo adapter locale, senza chiamate esterne e senza soluzioni complete;
+- `student_help_service.py` applica policy e budget prima di invocare il provider e persiste richiesta e risposta;
+- la TUI conosce solo il contratto e puo quindi usare in futuro Codex o un provider API senza cambiare il flusso.
+
+I contatori `usage` sono gia presenti, ma restano a zero per il provider locale. Un adapter reale dovra valorizzarli
+con dati restituiti dal provider prima di introdurre limiti a token o costo.

--- a/scripts/student_help_provider.py
+++ b/scripts/student_help_provider.py
@@ -120,7 +120,7 @@ class DeterministicStudentHelpProvider:
         test_focus = _optional_focus(" Considera in particolare i test", failed_tests)
         return (
             f"{topic_focus}.{test_focus} Chiediti: quale ipotesi sta verificando il test, quale caso limite manca "
-            "e quale osservazione confermerebbe la prossima modifica? Questa e una guida locale a domande, "
+            "e quale osservazione confermerebbe la prossima modifica? Questa è una guida locale a domande, "
             "senza AI esterna e senza soluzione completa."
         )
 

--- a/scripts/student_help_provider.py
+++ b/scripts/student_help_provider.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol
+
+
+STUDENT_HELP_RESPONSE_SCHEMA_VERSION = "student_help_response.v1"
+DETERMINISTIC_PROVIDER = "deterministic-local"
+DETERMINISTIC_PROVIDER_LABEL = "Guida locale (nessuna AI esterna)"
+
+
+@dataclass(frozen=True)
+class StudentHelpRequest:
+    """Input shared by local and future provider-backed student help."""
+
+    activity_id: str
+    help_type: str
+    prompt: str
+    context: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class StudentHelpResponse:
+    """Provider-independent response returned to the student help flow."""
+
+    status: Literal["ready", "error"]
+    provider: str
+    provider_label: str
+    message: str
+    usage: dict[str, int]
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable response payload used at integration boundaries."""
+
+        return {
+            "schema_version": STUDENT_HELP_RESPONSE_SCHEMA_VERSION,
+            "status": self.status,
+            "provider": self.provider,
+            "provider_label": self.provider_label,
+            "message": self.message,
+            "usage": dict(self.usage),
+            "detail": self.detail,
+        }
+
+
+class StudentHelpProvider(Protocol):
+    """Mockable port for producing a student-facing help response."""
+
+    def respond(self, request: StudentHelpRequest) -> StudentHelpResponse: ...
+
+
+class DeterministicStudentHelpProvider:
+    """Local student guide that never invokes AI or another external service."""
+
+    provider = DETERMINISTIC_PROVIDER
+    provider_label = DETERMINISTIC_PROVIDER_LABEL
+
+    def respond(self, request: StudentHelpRequest) -> StudentHelpResponse:
+        """Return bounded guidance without generating a complete solution."""
+
+        activity_id = request.activity_id.strip()
+        help_type = request.help_type.strip().lower()
+        prompt = request.prompt.strip()
+        if not activity_id:
+            return self._error("Activity non indicata.")
+        if not prompt:
+            return self._error("Richiesta di aiuto vuota.")
+
+        topics = _context_labels(request.context, "topics")
+        failed_tests = _context_labels(request.context, "failed_tests")
+        if help_type == "feedback-tecnico":
+            guidance = self._technical_guidance(failed_tests)
+        elif help_type == "teoria":
+            guidance = self._theory_guidance(topics, failed_tests)
+        elif help_type == "ai":
+            guidance = self._ai_guidance(topics, failed_tests)
+        else:
+            return self._error(f"Tipo di aiuto non supportato: {help_type or 'non indicato'}.")
+
+        return StudentHelpResponse(
+            status="ready",
+            provider=self.provider,
+            provider_label=self.provider_label,
+            message=guidance,
+            usage=_zero_usage(),
+        )
+
+    def _error(self, detail: str) -> StudentHelpResponse:
+        return StudentHelpResponse(
+            status="error",
+            provider=self.provider,
+            provider_label=self.provider_label,
+            message="Guida non disponibile per questa richiesta.",
+            usage=_zero_usage(),
+            detail=detail,
+        )
+
+    @staticmethod
+    def _technical_guidance(failed_tests: list[str]) -> str:
+        test_focus = _focus("Parti dai test falliti", failed_tests, "Parti dal primo test che non passa")
+        return (
+            f"{test_focus}. Leggi il primo messaggio di errore, confronta risultato atteso e ottenuto, "
+            "formula un'ipotesi e verifica una sola modifica alla volta. La guida indica il metodo di debug, "
+            "non una soluzione completa."
+        )
+
+    @staticmethod
+    def _theory_guidance(topics: list[str], failed_tests: list[str]) -> str:
+        topic_focus = _focus("Ripassa questi argomenti", topics, "Individua il concetto centrale della consegna")
+        test_link = _optional_focus(" Collega poi il richiamo ai test", failed_tests)
+        return (
+            f"{topic_focus}.{test_link} Scrivi con parole tue la regola rilevante, costruisci un piccolo esempio "
+            "su carta e spiega quale passaggio resta dubbio. La guida offre un richiamo, non una soluzione completa."
+        )
+
+    @staticmethod
+    def _ai_guidance(topics: list[str], failed_tests: list[str]) -> str:
+        topic_focus = _focus("Usa come traccia gli argomenti", topics, "Rileggi requisiti, input e output attesi")
+        test_focus = _optional_focus(" Considera in particolare i test", failed_tests)
+        return (
+            f"{topic_focus}.{test_focus} Chiediti: quale ipotesi sta verificando il test, quale caso limite manca "
+            "e quale osservazione confermerebbe la prossima modifica? Questa e una guida locale a domande, "
+            "senza AI esterna e senza soluzione completa."
+        )
+
+
+def _zero_usage() -> dict[str, int]:
+    return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+def _context_labels(context: dict[str, Any], key: str) -> list[str]:
+    if not isinstance(context, dict):
+        return []
+    values = context.get(key)
+    if not isinstance(values, (list, tuple)):
+        return []
+    labels: list[str] = []
+    for value in values:
+        label = str(value or "").strip()
+        if label and label not in labels:
+            labels.append(label)
+    return labels
+
+
+def _focus(prefix: str, labels: list[str], fallback: str) -> str:
+    return f"{prefix}: {', '.join(labels)}" if labels else fallback
+
+
+def _optional_focus(prefix: str, labels: list[str]) -> str:
+    return f"{prefix}: {', '.join(labels)}." if labels else ""

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -132,7 +132,7 @@ def provider_response_payload(response: Any) -> dict[str, Any]:
         "provider_label": provider_label.strip(),
         "message": message.strip(),
         "usage": normalized_usage,
-        "detail": detail.strip(),
+        "detail": PROVIDER_ERROR_DETAIL if status == "error" else detail.strip(),
     }
 
 

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -16,20 +16,20 @@ HELP_TYPES: dict[str, dict[str, str]] = {
     "feedback-tecnico": {
         "label": "Feedback tecnico",
         "policy_key": "debug_allowed",
-        "allowed_reason": "La modalita consente feedback tecnico, errori e risultati dei test.",
-        "denied_reason": "La modalita scelta dal docente non consente feedback tecnico aggiuntivo.",
+        "allowed_reason": "La modalità consente feedback tecnico, errori e risultati dei test.",
+        "denied_reason": "La modalità scelta dal docente non consente feedback tecnico aggiuntivo.",
     },
     "teoria": {
         "label": "Richiamo teorico",
         "policy_key": "theory_allowed",
-        "allowed_reason": "La modalita consente richiami teorici e materiali guida.",
-        "denied_reason": "La modalita scelta dal docente non consente richiami teorici aggiuntivi.",
+        "allowed_reason": "La modalità consente richiami teorici e materiali guida.",
+        "denied_reason": "La modalità scelta dal docente non consente richiami teorici aggiuntivi.",
     },
     "ai": {
         "label": "Aiuto AI",
         "policy_key": "ai_allowed",
-        "allowed_reason": "La modalita consente aiuto AI nei limiti decisi dal docente.",
-        "denied_reason": "La modalita scelta dal docente non consente aiuto AI.",
+        "allowed_reason": "La modalità consente aiuto AI nei limiti decisi dal docente.",
+        "denied_reason": "La modalità scelta dal docente non consente aiuto AI.",
     },
 }
 

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -130,7 +130,7 @@ def provider_response_payload(response: Any) -> dict[str, Any]:
         "status": status,
         "provider": provider.strip(),
         "provider_label": provider_label.strip(),
-        "message": message.strip(),
+        "message": "" if status == "error" else message.strip(),
         "usage": normalized_usage,
         "detail": PROVIDER_ERROR_DETAIL if status == "error" else detail.strip(),
     }

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -6,7 +6,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from scripts.student_help_provider import StudentHelpProvider, StudentHelpRequest
+from scripts.student_help_provider import (
+    STUDENT_HELP_RESPONSE_SCHEMA_VERSION,
+    StudentHelpProvider,
+    StudentHelpRequest,
+)
 
 
 HELP_LOG_SCHEMA_VERSION = "student_help_log.v1"
@@ -88,6 +92,47 @@ def positive_int(value: Any, default: int = 0) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed > 0 else default
+
+
+def provider_response_payload(response: Any) -> dict[str, Any]:
+    """Validate and normalize a provider response into JSON-safe values."""
+
+    payload = response.to_dict()
+    if not isinstance(payload, dict):
+        raise ValueError("La risposta del provider deve essere un oggetto.")
+    status = payload.get("status")
+    if status not in {"ready", "error"}:
+        raise ValueError("Stato risposta provider non valido.")
+    provider = payload.get("provider")
+    provider_label = payload.get("provider_label")
+    message = payload.get("message")
+    detail = payload.get("detail", "")
+    if not isinstance(provider, str) or not provider.strip():
+        raise ValueError("Provider risposta non valido.")
+    if not isinstance(provider_label, str) or not provider_label.strip():
+        raise ValueError("Etichetta provider non valida.")
+    if not isinstance(message, str) or (status == "ready" and not message.strip()):
+        raise ValueError("Messaggio risposta provider non valido.")
+    if not isinstance(detail, str):
+        raise ValueError("Dettaglio risposta provider non valido.")
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        raise ValueError("Contatori uso provider non validi.")
+    normalized_usage: dict[str, int] = {}
+    for key in ("input_tokens", "output_tokens", "total_tokens"):
+        value = usage.get(key)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"Contatore provider non valido: {key}.")
+        normalized_usage[key] = value
+    return {
+        "schema_version": STUDENT_HELP_RESPONSE_SCHEMA_VERSION,
+        "status": status,
+        "provider": provider.strip(),
+        "provider_label": provider_label.strip(),
+        "message": message.strip(),
+        "usage": normalized_usage,
+        "detail": detail.strip(),
+    }
 
 
 def ai_events_used(events: list[dict[str, Any]]) -> int:
@@ -191,7 +236,7 @@ def record_help_request(
                     context=dict(context or {}),
                 )
             )
-            event["response"] = response.to_dict()
+            event["response"] = provider_response_payload(response)
         except Exception as error:  # Provider failures must not discard the student's request.
             event["response"] = {
                 "schema_version": "student_help_response.v1",

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from scripts.student_help_provider import StudentHelpProvider, StudentHelpRequest
+
 
 HELP_LOG_SCHEMA_VERSION = "student_help_log.v1"
 HELP_EVENT_SCHEMA_VERSION = "student_help_event.v1"
@@ -160,6 +162,8 @@ def record_help_request(
     help_type: Any,
     prompt: str = "",
     now: str | None = None,
+    provider: StudentHelpProvider | None = None,
+    context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     path = help_log_path(repo_path, activity_id)
     events = load_help_events(path)
@@ -177,6 +181,27 @@ def record_help_request(
     }
     if "budget" in decision:
         event["budget"] = decision["budget"]
+    if decision["allowed"] is True and provider is not None:
+        try:
+            response = provider.respond(
+                StudentHelpRequest(
+                    activity_id=clean_text(activity_id),
+                    help_type=decision["help_type"],
+                    prompt=clean_text(prompt),
+                    context=dict(context or {}),
+                )
+            )
+            event["response"] = response.to_dict()
+        except Exception as error:  # Provider failures must not discard the student's request.
+            event["response"] = {
+                "schema_version": "student_help_response.v1",
+                "status": "error",
+                "provider": type(provider).__name__,
+                "provider_label": "Provider aiuto non disponibile",
+                "message": "",
+                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "detail": clean_text(error) or "Errore provider senza dettagli.",
+            }
     events.append(event)
     write_help_events(path, events)
     return event
@@ -194,6 +219,8 @@ def help_summary(log_path: Path | None) -> dict[str, Any]:
             "denied": 0,
             "last_requested_at": "",
             "last_decision": "",
+            "last_response_status": "",
+            "last_response_provider": "",
             "counts": {},
         }
     events, error = read_help_log(log_path)
@@ -202,6 +229,7 @@ def help_summary(log_path: Path | None) -> dict[str, Any]:
         help_type = clean_text(event.get("help_type")) or "sconosciuto"
         counts[help_type] = counts.get(help_type, 0) + 1
     last = events[-1] if events else {}
+    last_response = last.get("response") if isinstance(last.get("response"), dict) else {}
     return {
         "path": str(log_path).replace("\\", "/"),
         "exists": bool(events),
@@ -212,6 +240,8 @@ def help_summary(log_path: Path | None) -> dict[str, Any]:
         "denied": sum(1 for event in events if event.get("allowed") is False),
         "last_requested_at": clean_text(last.get("requested_at")),
         "last_decision": "consentita" if last.get("allowed") is True else ("bloccata" if last.get("allowed") is False else ""),
+        "last_response_status": clean_text(last_response.get("status")),
+        "last_response_provider": clean_text(last_response.get("provider_label")),
         "counts": counts,
     }
 
@@ -233,6 +263,7 @@ def teacher_help_summary(log_path: Path | None) -> dict[str, Any]:
             "allowed": event.get("allowed") is True,
             "reason": clean_text(event.get("reason")),
             "prompt": clean_text(event.get("prompt")),
+            "response": _teacher_response(event.get("response")),
         }
         for event in events
     ]
@@ -246,3 +277,23 @@ def teacher_help_summary(log_path: Path | None) -> dict[str, Any]:
 def help_budget_summary(log_path: Path | None, support_policy: dict[str, Any]) -> dict[str, Any]:
     events = load_help_events(log_path) if log_path is not None else []
     return ai_budget_status(support_policy, events)
+
+
+def _teacher_response(value: Any) -> dict[str, Any]:
+    """Return safe response fields for teacher-facing help history."""
+
+    if not isinstance(value, dict):
+        return {}
+    usage = value.get("usage") if isinstance(value.get("usage"), dict) else {}
+    return {
+        "status": clean_text(value.get("status")),
+        "provider": clean_text(value.get("provider")),
+        "provider_label": clean_text(value.get("provider_label")),
+        "message": clean_text(value.get("message")),
+        "detail": clean_text(value.get("detail")),
+        "usage": {
+            "input_tokens": max(positive_int(usage.get("input_tokens")), 0),
+            "output_tokens": max(positive_int(usage.get("output_tokens")), 0),
+            "total_tokens": max(positive_int(usage.get("total_tokens")), 0),
+        },
+    }

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -15,6 +15,7 @@ from scripts.student_help_provider import (
 
 HELP_LOG_SCHEMA_VERSION = "student_help_log.v1"
 HELP_EVENT_SCHEMA_VERSION = "student_help_event.v1"
+PROVIDER_ERROR_DETAIL = "Il provider non ha potuto completare la richiesta. Riprova più tardi o avvisa il docente."
 
 HELP_TYPES: dict[str, dict[str, str]] = {
     "feedback-tecnico": {
@@ -237,7 +238,7 @@ def record_help_request(
                 )
             )
             event["response"] = provider_response_payload(response)
-        except Exception as error:  # Provider failures must not discard the student's request.
+        except Exception:  # Provider failures must not discard the student's request.
             event["response"] = {
                 "schema_version": "student_help_response.v1",
                 "status": "error",
@@ -245,7 +246,7 @@ def record_help_request(
                 "provider_label": "Provider aiuto non disponibile",
                 "message": "",
                 "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-                "detail": clean_text(error) or "Errore provider senza dettagli.",
+                "detail": PROVIDER_ERROR_DETAIL,
             }
     events.append(event)
     write_help_events(path, events)

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -550,29 +550,47 @@ def record_help_from_tui(
     )
 
 
-def help_result_message(event: dict[str, Any]) -> str:
-    """Return a compact message after recording a help request."""
+def help_result_message(event: dict[str, Any], use_color: bool = False) -> str:
+    """Return a structured result after recording a help request."""
 
-    status = "consentita" if event.get("allowed") else "bloccata"
+    allowed = event.get("allowed") is True
+    status = "consentita" if allowed else "bloccata"
+    status_color = HELP_RESPONSE_COLOR if allowed else HELP_ERROR_COLOR
     lines = [
-        f"Richiesta aiuto {status}: {clean_text(event.get('label'))}",
-        clean_text(event.get("reason")),
+        colorize("Esito richiesta aiuto", HELP_REQUEST_COLOR, use_color),
+        section_separator(),
+        detail_line("Tipo:", event.get("label")),
+        detail_line("Esito:", colorize(status, status_color, use_color)),
     ]
     response = event.get("response") if isinstance(event.get("response"), dict) else {}
     if response.get("status") == "ready":
+        provider_label = clean_text(response.get("provider_label"), "Provider aiuto")
         lines.extend(
-            [
-                f"Risposta - {clean_text(response.get('provider_label'))}:",
-                clean_text(response.get("message")),
-            ]
+            help_history_block(
+                f"Risposta - {provider_label}",
+                response.get("message"),
+                HELP_RESPONSE_COLOR,
+                use_color,
+            )
         )
     elif response:
+        provider_label = clean_text(response.get("provider_label"), "Provider aiuto")
         lines.extend(
-            [
-                f"Risposta non disponibile - {clean_text(response.get('provider_label'))}:",
-                clean_text(response.get("detail")),
-            ]
+            help_history_block(
+                f"Risposta non disponibile - {provider_label}",
+                response.get("detail"),
+                HELP_ERROR_COLOR,
+                use_color,
+            )
         )
+    if not allowed or not response:
+        lines.extend(help_history_block("Motivo", event.get("reason"), HELP_REASON_COLOR, use_color))
+    lines.extend(
+        [
+            section_separator(),
+            f"Richiesta salvata. Usa {colorize('h', HELP_REQUEST_COLOR, use_color)} per rileggerla nello storico.",
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -706,7 +724,7 @@ def run_tui(
                                 prompt=prompt,
                                 now=now,
                             )
-                            print_fn(help_result_message(event))
+                            print_fn(help_result_message(event, use_color=use_color))
                             payload = load_payload(root, student_id, now)
                         except ValueError as error:
                             print_fn(f"Richiesta aiuto non salvata:\n{error}")

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -438,7 +438,7 @@ def help_history_block(label: str, value: Any, color: str, use_color: bool = Fal
     """Render one labelled, wrapped text block in the help history."""
 
     text = clean_text(value)
-    wrapped = textwrap.wrap(text, width=68, break_long_words=False, break_on_hyphens=False) or ["-"]
+    wrapped = textwrap.wrap(text, width=68, break_long_words=True, break_on_hyphens=False) or ["-"]
     return [colorize(label, color, use_color), *(f"  {line}" for line in wrapped)]
 
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import subprocess
 import sys
+import textwrap
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
@@ -33,6 +34,11 @@ STATUS_COLORS = {
     "submitted_late": "\033[35m",
 }
 WORKSPACE_COLOR = "\033[36m"
+HELP_REQUEST_COLOR = "\033[36m"
+HELP_PROMPT_COLOR = "\033[33m"
+HELP_REASON_COLOR = "\033[35m"
+HELP_RESPONSE_COLOR = "\033[32m"
+HELP_ERROR_COLOR = "\033[31m"
 GUIDE_TERM_COLORS = {
     "consegna": "\033[35m",
     "workspace": WORKSPACE_COLOR,
@@ -428,11 +434,23 @@ def assignment_help_log_path(assignment: dict[str, Any], root: Path = PROJECT_RO
     return student_help_service.help_log_path(repo_path, activity_id)
 
 
-def render_help_history(assignment: dict[str, Any], root: Path = PROJECT_ROOT) -> str:
+def help_history_block(label: str, value: Any, color: str, use_color: bool = False) -> list[str]:
+    """Render one labelled, wrapped text block in the help history."""
+
+    text = clean_text(value)
+    wrapped = textwrap.wrap(text, width=68, break_long_words=False, break_on_hyphens=False) or ["-"]
+    return [colorize(label, color, use_color), *(f"  {line}" for line in wrapped)]
+
+
+def render_help_history(
+    assignment: dict[str, Any],
+    root: Path = PROJECT_ROOT,
+    use_color: bool = False,
+) -> str:
     """Render the help request history for one assignment."""
 
     log_path = assignment_help_log_path(assignment, root=root)
-    lines = ["Storico richieste aiuto", ""]
+    lines = ["Storico richieste aiuto"]
     if log_path is None:
         lines.append("Log aiuti non disponibile per questa consegna.")
         return "\n".join(lines)
@@ -447,20 +465,40 @@ def render_help_history(assignment: dict[str, Any], root: Path = PROJECT_ROOT) -
         return "\n".join(lines)
     for index, event in enumerate(events, start=1):
         decision = "consentita" if event.get("allowed") is True else "bloccata"
+        decision_color = HELP_RESPONSE_COLOR if event.get("allowed") is True else HELP_ERROR_COLOR
         response = event.get("response") if isinstance(event.get("response"), dict) else {}
         lines.extend(
             [
-                f"{index}. {compact_datetime(event.get('requested_at'))} | {clean_text(event.get('label'))} | {decision}",
-                f"   Motivo: {clean_text(event.get('reason'))}",
-                f"   Prompt: {truncate(clean_text(event.get('prompt')), 100)}",
+                section_separator(),
+                colorize(f"Richiesta {index}", HELP_REQUEST_COLOR, use_color),
+                detail_line("Data:", compact_datetime(event.get("requested_at"))),
+                detail_line("Tipo:", event.get("label")),
+                detail_line("Esito:", colorize(decision, decision_color, use_color)),
+                *help_history_block("Prompt studente", event.get("prompt"), HELP_PROMPT_COLOR, use_color),
             ]
         )
         if response:
             provider_label = clean_text(response.get("provider_label")) or "Provider aiuto"
             if response.get("status") == "ready":
-                lines.append(f"   Risposta - {provider_label}: {clean_text(response.get('message'))}")
+                lines.extend(
+                    help_history_block(
+                        f"Risposta - {provider_label}",
+                        response.get("message"),
+                        HELP_RESPONSE_COLOR,
+                        use_color,
+                    )
+                )
             else:
-                lines.append(f"   Risposta non disponibile - {provider_label}: {clean_text(response.get('detail'))}")
+                lines.extend(
+                    help_history_block(
+                        f"Risposta non disponibile - {provider_label}",
+                        response.get("detail"),
+                        HELP_ERROR_COLOR,
+                        use_color,
+                    )
+                )
+        lines.extend(help_history_block("Motivo della decisione", event.get("reason"), HELP_REASON_COLOR, use_color))
+    lines.append(section_separator())
     return "\n".join(lines)
 
 
@@ -675,7 +713,7 @@ def run_tui(
                 input_fn("Premi invio per continuare...")
                 continue
             if action == "h":
-                print_fn(render_help_history(assignment, root=root))
+                print_fn(render_help_history(assignment, root=root, use_color=use_color))
                 input_fn("Premi invio per continuare...")
                 continue
             if action == "e":

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -13,6 +13,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts import student_help_service, student_lab_runner, student_lab_service
+from scripts.student_help_provider import DeterministicStudentHelpProvider
 
 
 InputFn = Callable[[str], str]
@@ -383,6 +384,8 @@ HELP_MENU = {
     "3": "ai",
 }
 
+DEFAULT_HELP_PROVIDER = DeterministicStudentHelpProvider()
+
 
 def help_choice_label() -> str:
     """Return a compact help-type menu label."""
@@ -444,6 +447,7 @@ def render_help_history(assignment: dict[str, Any], root: Path = PROJECT_ROOT) -
         return "\n".join(lines)
     for index, event in enumerate(events, start=1):
         decision = "consentita" if event.get("allowed") is True else "bloccata"
+        response = event.get("response") if isinstance(event.get("response"), dict) else {}
         lines.extend(
             [
                 f"{index}. {compact_datetime(event.get('requested_at'))} | {clean_text(event.get('label'))} | {decision}",
@@ -451,7 +455,35 @@ def render_help_history(assignment: dict[str, Any], root: Path = PROJECT_ROOT) -
                 f"   Prompt: {truncate(clean_text(event.get('prompt')), 100)}",
             ]
         )
+        if response:
+            provider_label = clean_text(response.get("provider_label")) or "Provider aiuto"
+            if response.get("status") == "ready":
+                lines.append(f"   Risposta - {provider_label}: {clean_text(response.get('message'))}")
+            else:
+                lines.append(f"   Risposta non disponibile - {provider_label}: {clean_text(response.get('detail'))}")
     return "\n".join(lines)
+
+
+def help_provider_context(assignment: dict[str, Any]) -> dict[str, Any]:
+    """Return the minimal assignment context allowed for the local help provider."""
+
+    activity = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
+    grading = assignment.get("grading") if isinstance(assignment.get("grading"), dict) else {}
+    report = assignment.get("report") if isinstance(assignment.get("report"), dict) else {}
+    tests = report.get("tests") if isinstance(report.get("tests"), list) else []
+    failed_tests = [
+        clean_text(test.get("name"))
+        for test in tests
+        if isinstance(test, dict) and test.get("passed") is False and clean_text(test.get("name"))
+    ]
+    raw_topics = activity.get("topics")
+    topics = raw_topics if isinstance(raw_topics, list) else []
+    return {
+        "title": clean_text(assignment.get("title")),
+        "topics": [clean_text(topic) for topic in topics if clean_text(topic)],
+        "grading_status": clean_text(grading.get("status")),
+        "failed_tests": failed_tests,
+    }
 
 
 def record_help_from_tui(
@@ -475,6 +507,8 @@ def record_help_from_tui(
         help_type=help_type,
         prompt=prompt,
         now=now,
+        provider=DEFAULT_HELP_PROVIDER,
+        context=help_provider_context(assignment),
     )
 
 
@@ -482,12 +516,26 @@ def help_result_message(event: dict[str, Any]) -> str:
     """Return a compact message after recording a help request."""
 
     status = "consentita" if event.get("allowed") else "bloccata"
-    return "\n".join(
-        [
-            f"Richiesta aiuto {status}: {clean_text(event.get('label'))}",
-            clean_text(event.get("reason")),
-        ]
-    )
+    lines = [
+        f"Richiesta aiuto {status}: {clean_text(event.get('label'))}",
+        clean_text(event.get("reason")),
+    ]
+    response = event.get("response") if isinstance(event.get("response"), dict) else {}
+    if response.get("status") == "ready":
+        lines.extend(
+            [
+                f"Risposta - {clean_text(response.get('provider_label'))}:",
+                clean_text(response.get("message")),
+            ]
+        )
+    elif response:
+        lines.extend(
+            [
+                f"Risposta non disponibile - {clean_text(response.get('provider_label'))}:",
+                clean_text(response.get("detail")),
+            ]
+        )
+    return "\n".join(lines)
 
 
 def clear_screen() -> None:

--- a/scripts/student_lab_demo_smoke.py
+++ b/scripts/student_lab_demo_smoke.py
@@ -23,6 +23,7 @@ from scripts import (
     student_lab_service,
     track_assignments,
 )
+from scripts.student_help_provider import DeterministicStudentHelpProvider
 
 
 STUDENT_ID = "rossi-mario"
@@ -144,9 +145,13 @@ def run_smoke(root: Path) -> dict[str, Any]:
         help_type="ai",
         prompt="Puoi darmi un suggerimento senza scrivere la soluzione?",
         now="2026-10-18T18:35:00+02:00",
+        provider=DeterministicStudentHelpProvider(),
+        context={"topics": ["funzioni", "somma"]},
     )
     if help_event.get("allowed") is not True:
         raise RuntimeError(f"Richiesta aiuto demo non consentita: {help_event.get('reason')}")
+    if help_event.get("response", {}).get("status") != "ready":
+        raise RuntimeError("Il provider locale non ha prodotto la risposta di aiuto demo.")
     report = student_lab_runner.run_assignment(assignment, root=root, backend="local")
     if not report.get("passed"):
         raise RuntimeError(f"Runner demo fallito: {report.get('status')}")
@@ -181,6 +186,7 @@ def run_smoke(root: Path) -> dict[str, Any]:
             "total": lab_assignment["help"]["total"],
             "ai_total": student["help"]["ai_total"],
             "ai_budget_remaining": lab_assignment["help"]["ai_budget"]["remaining"],
+            "response_provider": help_event["response"]["provider"],
         },
         "backend": student["submission"].get("report_backend"),
     }

--- a/scripts/student_support_policy.py
+++ b/scripts/student_support_policy.py
@@ -33,7 +33,7 @@ SUPPORT_POLICIES: dict[str, dict[str, Any]] = {
     "studio-guidato": {
         "mode": "studio-guidato",
         "label": "Studio guidato",
-        "summary": "Puoi consultare materiali, richiami teorici e domande guida collegate all'attivita.",
+        "summary": "Puoi consultare materiali, richiami teorici e domande guida collegate all'attività.",
         "allowed": ["riferimenti alla teoria", "domande guida", "esempi approvati dal docente", "feedback tecnico"],
         "not_allowed": ["soluzioni complete non approvate", "AI generativa libera"],
         "ai_allowed": False,

--- a/tests/test_student_help_provider.py
+++ b/tests/test_student_help_provider.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from scripts.student_help_provider import (
+    DeterministicStudentHelpProvider,
+    StudentHelpProvider,
+    StudentHelpRequest,
+    StudentHelpResponse,
+)
+
+
+ZERO_USAGE = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+def request(
+    help_type: str,
+    *,
+    context: dict | None = None,
+    activity_id: str = "python-base-somma-001",
+    prompt: str = "Come posso procedere?",
+) -> StudentHelpRequest:
+    return StudentHelpRequest(
+        activity_id=activity_id,
+        help_type=help_type,
+        prompt=prompt,
+        context=context or {},
+    )
+
+
+def assert_local_response(response: StudentHelpResponse) -> None:
+    assert response.status == "ready"
+    assert response.provider == "deterministic-local"
+    assert response.provider_label == "Guida locale (nessuna AI esterna)"
+    assert not response.message.startswith(response.provider_label)
+    assert response.usage == ZERO_USAGE
+    assert response.detail == ""
+    assert "soluzione completa" in response.message
+
+
+def test_student_help_response_to_dict_includes_the_complete_stable_contract() -> None:
+    response = StudentHelpResponse(
+        status="ready",
+        provider="fake",
+        provider_label="Provider fake",
+        message="Una guida breve.",
+        usage={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+        detail="dettaglio",
+    )
+
+    assert response.to_dict() == {
+        "schema_version": "student_help_response.v1",
+        "status": "ready",
+        "provider": "fake",
+        "provider_label": "Provider fake",
+        "message": "Una guida breve.",
+        "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+        "detail": "dettaglio",
+    }
+
+
+def test_student_help_provider_contract_accepts_a_test_double() -> None:
+    class FakeStudentHelpProvider:
+        def respond(self, help_request: StudentHelpRequest) -> StudentHelpResponse:
+            return StudentHelpResponse(
+                status="ready",
+                provider="fake",
+                provider_label="Fake",
+                message=help_request.prompt,
+                usage=ZERO_USAGE,
+            )
+
+    provider: StudentHelpProvider = FakeStudentHelpProvider()
+
+    assert provider.respond(request("teoria", prompt="Richiamo sui cicli")).message == "Richiamo sui cicli"
+
+
+def test_feedback_tecnico_uses_failed_tests_as_bounded_debug_context() -> None:
+    response = DeterministicStudentHelpProvider().respond(
+        request(
+            "feedback-tecnico",
+            context={"failed_tests": ["somma_negativi", "somma_limite"]},
+        )
+    )
+
+    assert_local_response(response)
+    assert "somma_negativi, somma_limite" in response.message
+    assert "risultato atteso e ottenuto" in response.message
+
+
+def test_teoria_uses_topics_and_failed_tests_without_writing_a_solution() -> None:
+    response = DeterministicStudentHelpProvider().respond(
+        request(
+            "teoria",
+            context={
+                "topics": ["cicli", "condizioni"],
+                "failed_tests": ["caso_vuoto"],
+            },
+        )
+    )
+
+    assert_local_response(response)
+    assert "cicli, condizioni" in response.message
+    assert "caso_vuoto" in response.message
+    assert "esempio su carta" in response.message
+    assert "```" not in response.message
+
+
+def test_ai_is_explicitly_local_and_uses_context_for_guiding_questions() -> None:
+    response = DeterministicStudentHelpProvider().respond(
+        request(
+            "ai",
+            context={"topics": ["liste"], "failed_tests": ["lista_vuota"]},
+        )
+    )
+
+    assert_local_response(response)
+    assert "liste" in response.message
+    assert "lista_vuota" in response.message
+    assert "senza AI esterna" in response.message
+    assert "quale caso limite manca" in response.message
+
+
+def test_optional_context_can_be_empty_or_malformed() -> None:
+    provider = DeterministicStudentHelpProvider()
+
+    without_context = provider.respond(request("feedback-tecnico"))
+    malformed_context = provider.respond(
+        request("teoria", context={"topics": "cicli", "failed_tests": None})
+    )
+
+    assert_local_response(without_context)
+    assert "primo test che non passa" in without_context.message
+    assert_local_response(malformed_context)
+    assert "concetto centrale" in malformed_context.message
+
+
+def test_context_labels_are_cleaned_deduplicated_and_deterministic() -> None:
+    provider = DeterministicStudentHelpProvider()
+    help_request = request(
+        "ai",
+        context={"topics": [" cicli ", "", "cicli", "condizioni"]},
+    )
+
+    first = provider.respond(help_request)
+    second = provider.respond(help_request)
+
+    assert first == second
+    assert first.message.count("cicli") == 1
+    assert "cicli, condizioni" in first.message
+
+
+def test_each_response_gets_an_independent_zero_usage_mapping() -> None:
+    provider = DeterministicStudentHelpProvider()
+    first = provider.respond(request("teoria"))
+    second = provider.respond(request("teoria"))
+
+    first.usage["input_tokens"] = 99
+
+    assert second.usage == ZERO_USAGE
+
+
+def test_unknown_help_type_returns_a_local_error_with_zero_usage() -> None:
+    response = DeterministicStudentHelpProvider().respond(request("soluzione"))
+
+    assert response.status == "error"
+    assert response.provider == "deterministic-local"
+    assert response.provider_label == "Guida locale (nessuna AI esterna)"
+    assert response.usage == ZERO_USAGE
+    assert response.detail == "Tipo di aiuto non supportato: soluzione."
+
+
+def test_missing_required_request_text_returns_errors_without_raising() -> None:
+    provider = DeterministicStudentHelpProvider()
+
+    missing_activity = provider.respond(request("teoria", activity_id=" "))
+    missing_prompt = provider.respond(request("teoria", prompt=" "))
+
+    assert missing_activity.status == "error"
+    assert missing_activity.detail == "Activity non indicata."
+    assert missing_activity.usage == ZERO_USAGE
+    assert missing_prompt.status == "error"
+    assert missing_prompt.detail == "Richiesta di aiuto vuota."
+    assert missing_prompt.usage == ZERO_USAGE

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -24,6 +24,17 @@ class RecordingHelpProvider:
         )
 
 
+class NonSerializableHelpProvider:
+    def respond(self, request):
+        return StudentHelpResponse(
+            status="ready",
+            provider="malformed-provider",
+            provider_label="Provider malformato",
+            message="Risposta apparentemente valida.",
+            usage={"input_tokens": object(), "output_tokens": 0, "total_tokens": 0},
+        )
+
+
 def test_evaluate_help_request_denies_ai_when_policy_does_not_allow_it() -> None:
     policy = student_support_policy.support_policy("feedback-tecnico")
 
@@ -131,6 +142,27 @@ def test_record_help_request_persists_provider_error_without_losing_request(tmp_
     assert event["allowed"] is True
     assert event["response"]["status"] == "error"
     assert "non raggiungibile" in event["response"]["detail"]
+
+
+def test_record_help_request_persists_request_when_provider_response_is_not_json_safe(tmp_path) -> None:
+    repo = tmp_path / "student-repo"
+
+    event = student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=student_support_policy.support_policy("ai-assisted"),
+        help_type="ai",
+        prompt="Conserva questa richiesta.",
+        provider=NonSerializableHelpProvider(),
+    )
+
+    log_path = repo / "help" / "python-base-somma-001" / "events.json"
+    persisted = json.loads(log_path.read_text(encoding="utf-8"))["events"][0]
+
+    assert event["response"]["status"] == "error"
+    assert persisted["prompt"] == "Conserva questa richiesta."
+    assert persisted["response"]["status"] == "error"
+    assert persisted["response"]["usage"] == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
 
 
 def test_record_help_request_blocks_ai_when_budget_is_exhausted(tmp_path) -> None:

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -14,7 +14,7 @@ class RecordingHelpProvider:
     def respond(self, request):
         self.requests.append(request)
         if self.fail:
-            raise RuntimeError("Provider di prova non raggiungibile")
+            raise RuntimeError("Provider non raggiungibile: token=segreto-di-prova")
         return StudentHelpResponse(
             status="ready",
             provider="test-provider",
@@ -139,9 +139,14 @@ def test_record_help_request_persists_provider_error_without_losing_request(tmp_
         provider=provider,
     )
 
+    log_path = tmp_path / "student-repo" / "help" / "python-base-somma-001" / "events.json"
+    persisted_text = log_path.read_text(encoding="utf-8")
+
     assert event["allowed"] is True
     assert event["response"]["status"] == "error"
-    assert "non raggiungibile" in event["response"]["detail"]
+    assert event["response"]["detail"] == student_help_service.PROVIDER_ERROR_DETAIL
+    assert "segreto-di-prova" not in persisted_text
+    assert "non raggiungibile" not in persisted_text
 
 
 def test_record_help_request_persists_request_when_provider_response_is_not_json_safe(tmp_path) -> None:

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -3,6 +3,25 @@ from __future__ import annotations
 import json
 
 from scripts import student_help_service, student_support_policy
+from scripts.student_help_provider import StudentHelpResponse
+
+
+class RecordingHelpProvider:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.requests = []
+
+    def respond(self, request):
+        self.requests.append(request)
+        if self.fail:
+            raise RuntimeError("Provider di prova non raggiungibile")
+        return StudentHelpResponse(
+            status="ready",
+            provider="test-provider",
+            provider_label="Provider test",
+            message="Prova un caso minimo e confronta il risultato.",
+            usage={"input_tokens": 3, "output_tokens": 7, "total_tokens": 10},
+        )
 
 
 def test_evaluate_help_request_denies_ai_when_policy_does_not_allow_it() -> None:
@@ -50,6 +69,68 @@ def test_record_help_request_appends_event_and_summary(tmp_path) -> None:
     assert summary["allowed"] == 1
     assert summary["denied"] == 0
     assert summary["last_decision"] == "consentita"
+
+
+def test_record_help_request_persists_provider_response_for_allowed_request(tmp_path) -> None:
+    repo = tmp_path / "student-repo"
+    policy = student_support_policy.support_policy("ai-assisted")
+    provider = RecordingHelpProvider()
+
+    event = student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=policy,
+        help_type="ai",
+        prompt="Come posso trovare il caso che fallisce?",
+        provider=provider,
+        context={"failed_tests": ["test_negativi"]},
+    )
+
+    assert len(provider.requests) == 1
+    assert provider.requests[0].context == {"failed_tests": ["test_negativi"]}
+    assert event["response"]["status"] == "ready"
+    assert event["response"]["message"].startswith("Prova un caso minimo")
+    assert event["response"]["usage"]["total_tokens"] == 10
+    log_path = repo / "help" / "python-base-somma-001" / "events.json"
+    summary = student_help_service.help_summary(log_path)
+    teacher_summary = student_help_service.teacher_help_summary(log_path)
+    assert summary["last_response_status"] == "ready"
+    assert summary["last_response_provider"] == "Provider test"
+    assert teacher_summary["events"][0]["response"]["message"].startswith("Prova un caso minimo")
+    assert teacher_summary["events"][0]["response"]["usage"]["total_tokens"] == 10
+
+
+def test_record_help_request_does_not_call_provider_when_policy_blocks_request(tmp_path) -> None:
+    provider = RecordingHelpProvider()
+
+    event = student_help_service.record_help_request(
+        repo_path=tmp_path / "student-repo",
+        activity_id="python-base-somma-001",
+        support_policy=student_support_policy.support_policy("feedback-tecnico"),
+        help_type="ai",
+        prompt="Dammi un suggerimento.",
+        provider=provider,
+    )
+
+    assert provider.requests == []
+    assert "response" not in event
+
+
+def test_record_help_request_persists_provider_error_without_losing_request(tmp_path) -> None:
+    provider = RecordingHelpProvider(fail=True)
+
+    event = student_help_service.record_help_request(
+        repo_path=tmp_path / "student-repo",
+        activity_id="python-base-somma-001",
+        support_policy=student_support_policy.support_policy("ai-assisted"),
+        help_type="ai",
+        prompt="Dammi un suggerimento.",
+        provider=provider,
+    )
+
+    assert event["allowed"] is True
+    assert event["response"]["status"] == "error"
+    assert "non raggiungibile" in event["response"]["detail"]
 
 
 def test_record_help_request_blocks_ai_when_budget_is_exhausted(tmp_path) -> None:

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -35,6 +35,18 @@ class NonSerializableHelpProvider:
         )
 
 
+class StructuredErrorHelpProvider:
+    def respond(self, request):
+        return StudentHelpResponse(
+            status="error",
+            provider="structured-error-provider",
+            provider_label="Provider con errore strutturato",
+            message="",
+            usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            detail="Errore remoto: token=segreto-strutturato",
+        )
+
+
 def test_evaluate_help_request_denies_ai_when_policy_does_not_allow_it() -> None:
     policy = student_support_policy.support_policy("feedback-tecnico")
 
@@ -168,6 +180,27 @@ def test_record_help_request_persists_request_when_provider_response_is_not_json
     assert persisted["prompt"] == "Conserva questa richiesta."
     assert persisted["response"]["status"] == "error"
     assert persisted["response"]["usage"] == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+def test_record_help_request_sanitizes_structured_provider_errors(tmp_path) -> None:
+    repo = tmp_path / "student-repo"
+
+    event = student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=student_support_policy.support_policy("ai-assisted"),
+        help_type="ai",
+        prompt="Conserva la richiesta senza il segreto.",
+        provider=StructuredErrorHelpProvider(),
+    )
+
+    log_path = repo / "help" / "python-base-somma-001" / "events.json"
+    persisted_text = log_path.read_text(encoding="utf-8")
+
+    assert event["response"]["status"] == "error"
+    assert event["response"]["detail"] == student_help_service.PROVIDER_ERROR_DETAIL
+    assert "segreto-strutturato" not in persisted_text
+    assert "Errore remoto" not in persisted_text
 
 
 def test_record_help_request_blocks_ai_when_budget_is_exhausted(tmp_path) -> None:

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -41,7 +41,7 @@ class StructuredErrorHelpProvider:
             status="error",
             provider="structured-error-provider",
             provider_label="Provider con errore strutturato",
-            message="",
+            message="Stack trace remoto: api_key=segreto-nel-messaggio",
             usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
             detail="Errore remoto: token=segreto-strutturato",
         )
@@ -198,7 +198,10 @@ def test_record_help_request_sanitizes_structured_provider_errors(tmp_path) -> N
     persisted_text = log_path.read_text(encoding="utf-8")
 
     assert event["response"]["status"] == "error"
+    assert event["response"]["message"] == ""
     assert event["response"]["detail"] == student_help_service.PROVIDER_ERROR_DETAIL
+    assert "segreto-nel-messaggio" not in persisted_text
+    assert "Stack trace remoto" not in persisted_text
     assert "segreto-strutturato" not in persisted_text
     assert "Errore remoto" not in persisted_text
 

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -304,11 +304,56 @@ def test_render_help_history_shows_events(tmp_path) -> None:
     rendered = student_lab_cli.render_help_history(assignment, root=tmp_path)
 
     assert "Storico richieste aiuto" in rendered
-    assert "2026-10-18 17:20 | Aiuto AI | bloccata" in rendered
+    assert "Richiesta 1" in rendered
+    assert "Data:              2026-10-18 17:20" in rendered
+    assert "Tipo:              Aiuto AI" in rendered
+    assert "Esito:             bloccata" in rendered
+    assert rendered.count(student_lab_cli.section_separator()) == 2
+    assert "Prompt studente" in rendered
+    assert "Motivo della decisione" in rendered
     assert "non consente aiuto AI" in rendered
     assert "Mi scrivi la soluzione completa?" in rendered
     assert "Risposta - Guida locale (nessuna AI esterna)" in rendered
     assert "Prova prima un caso minimo" in rendered
+
+
+def test_render_help_history_uses_colors_and_wraps_long_text(tmp_path) -> None:
+    log_path = tmp_path / "student" / "help" / "python-base-somma-001" / "events.json"
+    log_path.parent.mkdir(parents=True)
+    long_prompt = "Vorrei capire come analizzare il primo test fallito senza ricevere la soluzione completa e senza saltare i passaggi di debug."
+    log_path.write_text(
+        json.dumps(
+            {
+                "events": [
+                    {
+                        "requested_at": "2026-10-18T17:20:00+02:00",
+                        "label": "Aiuto AI",
+                        "allowed": True,
+                        "reason": "La modalità consente aiuto AI.",
+                        "prompt": long_prompt,
+                        "response": {
+                            "status": "ready",
+                            "provider_label": "Guida locale (nessuna AI esterna)",
+                            "message": "Parti dal primo test fallito e verifica una sola ipotesi alla volta.",
+                        },
+                    }
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    assignment = sample_assignment(help={"path": "student/help/python-base-somma-001/events.json"})
+
+    rendered = student_lab_cli.render_help_history(assignment, root=tmp_path, use_color=True)
+
+    assert "\033[36mRichiesta 1\033[0m" in rendered
+    assert "\033[33mPrompt studente\033[0m" in rendered
+    assert "\033[32mRisposta - Guida locale (nessuna AI esterna)\033[0m" in rendered
+    assert "\033[35mMotivo della decisione\033[0m" in rendered
+    assert "\033[32mconsentita\033[0m" in rendered
+    assert "\n  la soluzione completa e senza saltare i passaggi di debug." in rendered
+    assert long_prompt not in rendered
 
 
 def test_render_help_history_handles_empty_or_invalid_log(tmp_path) -> None:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -288,6 +288,11 @@ def test_render_help_history_shows_events(tmp_path) -> None:
                         "allowed": False,
                         "reason": "La modalità scelta dal docente non consente aiuto AI.",
                         "prompt": "Mi scrivi la soluzione completa?",
+                        "response": {
+                            "status": "ready",
+                            "provider_label": "Guida locale (nessuna AI esterna)",
+                            "message": "Prova prima un caso minimo.",
+                        },
                     }
                 ]
             }
@@ -302,6 +307,8 @@ def test_render_help_history_shows_events(tmp_path) -> None:
     assert "2026-10-18 17:20 | Aiuto AI | bloccata" in rendered
     assert "non consente aiuto AI" in rendered
     assert "Mi scrivi la soluzione completa?" in rendered
+    assert "Risposta - Guida locale (nessuna AI esterna)" in rendered
+    assert "Prova prima un caso minimo" in rendered
 
 
 def test_render_help_history_handles_empty_or_invalid_log(tmp_path) -> None:
@@ -341,6 +348,47 @@ def test_help_result_message_shows_policy_decision() -> None:
 
     assert "Richiesta aiuto bloccata: Aiuto AI" in message
     assert "non consente aiuto AI" in message
+
+
+def test_help_result_message_shows_local_provider_response() -> None:
+    message = student_lab_cli.help_result_message(
+        {
+            "allowed": True,
+            "label": "Aiuto AI",
+            "reason": "La modalità consente aiuto AI.",
+            "response": {
+                "status": "ready",
+                "provider_label": "Guida locale (nessuna AI esterna)",
+                "message": "Parti dal primo test fallito.",
+            },
+        }
+    )
+
+    assert "Richiesta aiuto consentita: Aiuto AI" in message
+    assert "Risposta - Guida locale (nessuna AI esterna)" in message
+    assert "Parti dal primo test fallito" in message
+
+
+def test_help_provider_context_contains_only_minimal_assignment_data() -> None:
+    assignment = sample_assignment(
+        report={
+            "tests": [
+                {"name": "test_base", "passed": True},
+                {"name": "test_negativi", "passed": False},
+            ]
+        },
+        grading={"status": "graded_failed"},
+    )
+
+    context = student_lab_cli.help_provider_context(assignment)
+
+    assert context == {
+        "title": "Somma in Python",
+        "topics": ["variabili", "input-output"],
+        "grading_status": "graded_failed",
+        "failed_tests": ["test_negativi"],
+    }
+    assert "student_id" not in context
 
 
 def test_ai_budget_label_handles_missing_and_exhausted_budget() -> None:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -391,8 +391,13 @@ def test_help_result_message_shows_policy_decision() -> None:
         }
     )
 
-    assert "Richiesta aiuto bloccata: Aiuto AI" in message
+    assert "Esito richiesta aiuto" in message
+    assert "Tipo:              Aiuto AI" in message
+    assert "Esito:             bloccata" in message
+    assert "Motivo" in message
     assert "non consente aiuto AI" in message
+    assert message.count(student_lab_cli.section_separator()) == 2
+    assert "Richiesta salvata. Usa h per rileggerla nello storico." in message
 
 
 def test_help_result_message_shows_local_provider_response() -> None:
@@ -409,9 +414,38 @@ def test_help_result_message_shows_local_provider_response() -> None:
         }
     )
 
-    assert "Richiesta aiuto consentita: Aiuto AI" in message
+    assert "Esito richiesta aiuto" in message
+    assert "Esito:             consentita" in message
     assert "Risposta - Guida locale (nessuna AI esterna)" in message
     assert "Parti dal primo test fallito" in message
+    assert "La modalità consente aiuto AI" not in message
+
+
+def test_help_result_message_uses_colors_and_wraps_long_response() -> None:
+    long_response = (
+        "Inizia dal primo test fallito e ricostruisci i valori delle variabili "
+        "passaggio per passaggio, poi confronta il risultato atteso con quello ottenuto."
+    )
+
+    message = student_lab_cli.help_result_message(
+        {
+            "allowed": True,
+            "label": "Aiuto AI",
+            "response": {
+                "status": "ready",
+                "provider_label": "Guida locale",
+                "message": long_response,
+            },
+        },
+        use_color=True,
+    )
+
+    assert "\033[36mEsito richiesta aiuto\033[0m" in message
+    assert "\033[32mconsentita\033[0m" in message
+    assert "\033[32mRisposta - Guida locale\033[0m" in message
+    assert "Usa \033[36mh\033[0m per rileggerla" in message
+    assert "\n  variabili passaggio per passaggio" in message
+    assert long_response not in message
 
 
 def test_help_provider_context_contains_only_minimal_assignment_data() -> None:
@@ -487,7 +521,7 @@ def test_run_tui_can_record_help_request_and_reload(monkeypatch, tmp_path) -> No
     assert len(load_calls) == 2
     assert log_path.exists()
     assert "Mi scrivi la soluzione?" in log_path.read_text(encoding="utf-8")
-    assert any("Richiesta aiuto bloccata: Aiuto AI" in output for output in outputs)
+    assert any("Esito richiesta aiuto" in output and "Esito:             bloccata" in output for output in outputs)
     assert sum(1 for output in outputs if "Dettaglio consegna" in output) == 2
 
 

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -448,6 +448,16 @@ def test_help_result_message_uses_colors_and_wraps_long_response() -> None:
     assert long_response not in message
 
 
+def test_help_history_block_wraps_long_urls_without_horizontal_overflow() -> None:
+    long_url = "https://example.test/" + ("percorso" * 24)
+
+    lines = student_lab_cli.help_history_block("Prompt studente", long_url, "", use_color=False)
+
+    assert len(lines) > 2
+    assert all(len(line) <= 70 for line in lines[1:])
+    assert "".join(line.removeprefix("  ") for line in lines[1:]) == long_url
+
+
 def test_help_provider_context_contains_only_minimal_assignment_data() -> None:
     assignment = sample_assignment(
         report={

--- a/tests/test_student_lab_demo_smoke.py
+++ b/tests/test_student_lab_demo_smoke.py
@@ -15,7 +15,12 @@ def test_student_lab_demo_smoke_builds_complete_flow(tmp_path) -> None:
     assert summary["report"].endswith("reports/python-demo-somma-001/latest.json")
     assert summary["teacher_register"].endswith("teacher-reports/demo/python-demo-somma-001.json")
     assert summary["tests"] == {"passed": 2, "total": 2}
-    assert summary["help"] == {"total": 1, "ai_total": 1, "ai_budget_remaining": 4}
+    assert summary["help"] == {
+        "total": 1,
+        "ai_total": 1,
+        "ai_budget_remaining": 4,
+        "response_provider": "deterministic-local",
+    }
     assert summary["backend"] == "local"
 
     register = json.loads((tmp_path / summary["teacher_register"]).read_text(encoding="utf-8"))
@@ -26,3 +31,5 @@ def test_student_lab_demo_smoke_builds_complete_flow(tmp_path) -> None:
     assert student["help"]["total"] == 1
     assert student["help"]["ai_total"] == 1
     assert student["help"]["events"][0]["prompt"] == "Puoi darmi un suggerimento senza scrivere la soluzione?"
+    assert student["help"]["events"][0]["response"]["status"] == "ready"
+    assert student["help"]["events"][0]["response"]["provider"] == "deterministic-local"


### PR DESCRIPTION
## Cosa cambia

- introduce il contratto mockabile `StudentHelpProvider` con richiesta, risposta e metadati `usage`;
- aggiunge una guida deterministica locale che non usa AI esterna e non produce soluzioni complete;
- invoca il provider soltanto dopo policy e budget, conservando comunque la richiesta in caso di errore;
- salva la risposta nello storico e la mostra subito nella TUI;
- espone al docente una versione sanificata della risposta;
- aggiorna demo end-to-end, scenari manuali e documentazione architetturale;
- ignora le cache Python generate dai test.

## Perché

Il flusso di aiuto registrava il prompt dello studente ma non produceva ancora alcuna risposta. Questo incremento completa il percorso richiesta -> policy -> provider -> risposta -> storico senza richiedere credenziali o consumare token. Il provider locale è sostituibile in una PR successiva con Codex o un provider API.

## Impatto

Nella TUI, una richiesta consentita mostra una risposta etichettata `Guida locale (nessuna AI esterna)`. I log precedenti senza `response` restano leggibili. Nessuna chiamata esterna viene eseguita.

## Verifica

- `python -m pytest tests/test_student_help_provider.py tests/test_student_help_service.py tests/test_student_lab_cli.py tests/test_student_lab_service.py tests/test_student_lab_demo_smoke.py tests/test_student_lab_demo_check.py tests/test_track_assignments.py` -> 82 passati.
- `python scripts/student_lab_demo_smoke.py` -> `ok: true` e provider `deterministic-local`.
- Suite quasi completa: 471 passati, 1 saltato, 2 esclusi. I due test esclusi richiedono `gcc`, non presente nel PATH di questa macchina Windows.

Closes #442
Parte di #288, #289 e #292.