### PR TITLE
Mostra gli aiuti studente in un modal

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -73,5 +73,6 @@ jobs:
           tests/test_student_help_codex_adapter.py
           tests/test_student_lab_service.py
           tests/test_student_lab_cli.py
+          tests/test_student_lab_demo_setup.py
           tests/test_track_assignments.py
           tests/test_course_board_server.py

--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -140,7 +140,12 @@ Usalo quando:
 
 - vuoi filtrare consegne mancanti, in ritardo, consegnate o con test falliti;
 - vuoi aprire la consegna di uno studente;
-- vuoi controllare grading, voti, feedback AI e stato revisione.
+- vuoi controllare grading, voti, feedback AI e stato revisione;
+- vuoi verificare quante richieste di aiuto sono state inviate per la consegna corrente e quante sono state bloccate dalla policy.
+
+Il pulsante `Dettagli aiuti` apre un modal dedicato allo studente e all'activity del registro selezionato. Per ogni richiesta mostra data, tipo di aiuto, prompt dello studente, risposta ricevuta, provider e consumo token dichiarato. Le richieste bloccate riportano l'esito della policy senza una risposta generata.
+
+La sezione `Legacy non verificati`, quando presente, contiene dati storici provenienti dal repository studente: serve per consultazione, ma non contribuisce al budget o alle metriche autorevoli. Se il log autorevole non è disponibile, il modal mostra un avviso esplicito anche in presenza di dati legacy.
 
 Screenshot previsto: `doc/images/dashboard-guides/docente-studenti.png`.
 

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -147,13 +147,19 @@ Obiettivo: verificare che il docente veda quante volte lo studente ha chiesto ai
 2. Carica il registro `demo/python-demo-somma-001.json`.
 3. Apri il pannello o modal `Studenti`.
 4. Cerca `rossi-mario`.
-5. Controlla la sezione dedicata agli aiuti.
+5. Controlla il riepilogo dedicato agli aiuti.
+6. Clicca `Dettagli aiuti`.
+7. Leggi prompt, risposta, provider, stato e utilizzo dichiarato.
+8. Chiudi il modal e verifica di tornare alla stessa vista Studenti.
 
 Risultato atteso:
 
 - Il docente vede `Aiuti 1`.
 - Il docente vede `Aiuti AI 1`.
-- Il prompt demo e visibile: `Puoi darmi un suggerimento senza scrivere la soluzione?`.
+- La cella resta compatta e non mostra direttamente i prompt lunghi.
+- `Dettagli aiuti` apre un modal dedicato.
+- Il prompt demo e visibile nel modal: `Puoi darmi un suggerimento senza scrivere la soluzione?`.
+- La risposta e il provider sono leggibili senza scorrimento orizzontale.
 - Gli aiuti bloccati sono `0`.
 
 ## Scenario 5 - Dettaglio errori test in modal

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -6,6 +6,11 @@ Questa checklist raccoglie gli scenari manuali da ripetere quando si toccano das
 
 Esegui i comandi dalla root del repository.
 
+Gli scenari possono essere eseguiti singolarmente oppure in sequenza. Nell'esecuzione sequenziale lascia
+attivo il server tra due scenari consecutivi, salvo quando un passaggio chiede esplicitamente di fermarlo
+per cambiare root dati o configurazione. Nell'esecuzione singola applica prima il setup indicato dallo
+scenario o, se non presente, questo setup comune.
+
 Se la porta `8765` e gia occupata su Windows:
 
 ```powershell
@@ -248,7 +253,8 @@ Risultato atteso:
 
 Obiettivo: verificare che la TUI sia comprensibile, robusta sugli input e coerente con dashboard e report.
 
-1. Prepara la demo e avvia il server docente con provider Codex:
+1. Se stai continuando dagli scenari precedenti, ferma con `Ctrl+C` il server avviato durante il setup
+   comune. Prepara quindi di nuovo la demo e avvia il server docente con provider Codex:
 
    ```powershell
    python scripts/student_lab_demo_setup.py
@@ -324,7 +330,8 @@ Risultato atteso:
 
 Obiettivo: verificare che percorso e calendario docente restino coerenti con la dashboard studente.
 
-1. Avvia il server senza root demo, usando i dati del repository:
+1. Ferma con `Ctrl+C` il server dello Scenario 7, se ancora attivo. Avvia quindi il server senza root demo,
+   usando i dati del repository:
 
    ```powershell
    python scripts/course_board_server.py

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -80,6 +80,16 @@ Per l'automazione futura, la scelta piu naturale per le GUI web e Playwright, pe
 
 I test GUI automatici vanno introdotti quando i punti di aggancio della UI sono abbastanza stabili, usando attributi espliciti come `data-testid` invece di selettori fragili basati sulla posizione. I test piu pesanti, soprattutto quelli con browser, screenshot, responsive e dati demo end-to-end, sono candidati per una suite notturna o manuale da lanciare quando la macchina non serve per lavorare.
 
+## Collaudo completo con dati durevoli
+
+Quando il flusso activity, assegnazione, consegna, lab e registro sara completo, eseguire tutti gli scenari di questo documento partendo da una root ricreata da zero. Non riutilizzare registri copiati da root temporanee di test: i riferimenti ai workspace devono appartenere alla root demo corrente.
+
+1. Arresta il server che usa `tmp/student-lab-demo`.
+2. Esegui `python scripts/student_lab_demo_setup.py` per ricreare dati coerenti e ripetibili.
+3. Avvia nuovamente il server con `--root tmp/student-lab-demo`.
+4. Esegui nell'ordine gli scenari TUI, dashboard studente e dashboard docente.
+5. Verifica non soltanto la visibilita in GUI, ma anche che file, assegnazioni, report, aiuti e cancellazioni siano realmente persistiti o rimossi nella root dati.
+
 ## Scenario 1 - Dashboard studente con report riuscito
 
 Obiettivo: verificare che lo studente veda consegna, workspace, report, test e aiuti.
@@ -110,6 +120,8 @@ Obiettivo: verificare che il docente possa caricare il registro generato dalla d
 4. Controlla i riepiloghi del registro selezionato.
 5. Apri il pannello `Studenti`.
 6. Apri il modal degli studenti, se disponibile.
+7. Nella riga di `rossi-mario`, clicca `Apri consegna`.
+8. Seleziona `main.py` e poi `test_main.py` dalla lista dei file.
 
 Risultato atteso:
 
@@ -120,6 +132,8 @@ Risultato atteso:
 - I test risultano `2/2`.
 - Il backend report risulta locale.
 - Le richieste di aiuto risultano visibili nel riepilogo docente.
+- Il modal della consegna mostra il contenuto di `main.py` e `test_main.py` senza errori 404.
+- I file aperti appartengono alla root demo corrente, non a una precedente cartella temporanea.
 
 ## Scenario 3 - Quadro classe ed elenco consegne
 

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -207,9 +207,20 @@ Risultato atteso:
 
 Per tornare alla demo pulita:
 
+1. Nel terminale in cui e in esecuzione il server premi `Ctrl+C` e attendi che il processo termini.
+2. Rigenera i dati della demo:
+
 ```powershell
 python scripts/student_lab_demo_setup.py
 ```
+
+3. Riavvia il server sulla root rigenerata:
+
+```powershell
+python scripts/course_board_server.py --root tmp/student-lab-demo
+```
+
+4. Ricarica la dashboard nel browser prima di continuare con gli scenari successivi.
 
 ## Scenario 6 - Dashboard studente dopo esecuzione TUI
 

--- a/doc/STUDENT_LAB_DEMO.md
+++ b/doc/STUDENT_LAB_DEMO.md
@@ -41,6 +41,8 @@ python scripts/student_lab_demo_smoke.py --root tmp/student-lab-demo
 
 Per preparare una demo stabile in `tmp/student-lab-demo`, cancellando eventuali residui precedenti:
 
+Se un server sta già usando questa root, arrestalo prima con `Ctrl+C` nella shell in cui è in esecuzione. Il setup controlla il lock prima di cancellare i dati e rifiuta il reset finché il server resta attivo.
+
 ```bash
 python scripts/student_lab_demo_setup.py
 ```
@@ -55,6 +57,8 @@ python scripts/student_lab_cli.py --root tmp/student-lab-demo --student-id rossi
 python scripts/student_lab_runner.py --root tmp/student-lab-demo --student-id rossi-mario --activity-id python-demo-somma-001 --write-report
 python scripts/course_board_server.py --root tmp/student-lab-demo
 ```
+
+Dopo ogni rigenerazione riavvia il server con l'ultimo comando e ricarica la dashboard nel browser. Non avviare due server contemporaneamente sulla stessa root.
 
 Conserva il token dashboard stampato dal server. Quando il browser mostra la richiesta di autenticazione usa
 `teacher` come nome utente e il token come password.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1161,7 +1161,7 @@ def preserve_assignment_ai_feedback(previous: dict, generated: dict) -> dict:
         return generated
     previous_assignment = str(previous.get("assignment_id", "")).strip()
     generated_assignment = str(generated.get("assignment_id", "")).strip()
-    if previous_assignment and generated_assignment and previous_assignment != generated_assignment:
+    if previous_assignment != generated_assignment:
         return generated
 
     previous_students = previous.get("students") if isinstance(previous.get("students"), list) else []

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1144,8 +1144,10 @@ def read_assignment_report(name: str) -> dict:
 def review_assignment_ai_feedback(name: str, student_id: str, decision: str) -> dict:
     """Apply a teacher review decision to draft AI feedback in a report."""
 
-    with assignment_operation_lock(f"ai-feedback-review::{name}"):
-        storage = assignment_storage()
+    storage = assignment_storage()
+    report_path = storage.safe_teacher_report_path(name)
+    operation_id = f"ai-feedback-review::{os.path.normcase(str(report_path))}"
+    with assignment_operation_lock(operation_id):
         register = storage.read_assignment_report(name)
         updated = manual_ai_feedback.review_feedback_in_register(register, student_id, decision)
         saved = storage.write_assignment_report(name, updated)

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -28,6 +28,7 @@ import secrets
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import urllib.error
 import urllib.request
@@ -138,17 +139,38 @@ def normalized_assignment_operation_id(operation_id: str) -> str:
     return f"{readable}-{digest}"
 
 
+def data_root_process_lock_dir() -> Path:
+    """Return a private, stable directory for cross-process data-root locks."""
+
+    configured = os.environ.get("THEBITLAB_LOCK_DIR", "").strip()
+    if configured:
+        return Path(configured).expanduser().resolve(strict=False)
+    if os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA") or tempfile.gettempdir())
+        return base / "TheBitLab" / "locks"
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR", "").strip()
+    if runtime_dir:
+        return Path(runtime_dir).expanduser().resolve(strict=False) / "thebitlab" / "locks"
+    cache_dir = os.environ.get("XDG_CACHE_HOME", "").strip()
+    base = Path(cache_dir).expanduser() if cache_dir else Path.home() / ".cache"
+    return base.resolve(strict=False) / "thebitlab" / "locks"
+
+
 class DataRootProcessLock:
     """Hold an operating-system lock for one server data root."""
 
     def __init__(self, root: Path) -> None:
         self.root = root.resolve(strict=False)
-        root_name = self.root.name or "root"
-        self.path = self.root.parent / f".{root_name}.thebitlab-server.lock"
+        readable = create_activity.slugify(self.root.name)[:32] or "root"
+        root_key = os.path.normcase(str(self.root))
+        digest = hashlib.sha256(root_key.encode("utf-8")).hexdigest()
+        self.path = data_root_process_lock_dir() / f"{readable}-{digest}.lock"
         self._handle = None
 
     def acquire(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if os.name != "nt":
+            self.path.parent.chmod(0o700)
         handle = self.path.open("a+b")
         try:
             handle.seek(0, os.SEEK_END)

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1139,10 +1139,11 @@ def read_assignment_report(name: str) -> dict:
 def review_assignment_ai_feedback(name: str, student_id: str, decision: str) -> dict:
     """Apply a teacher review decision to draft AI feedback in a report."""
 
-    storage = assignment_storage()
-    register = storage.read_assignment_report(name)
-    updated = manual_ai_feedback.review_feedback_in_register(register, student_id, decision)
-    return storage.write_assignment_report(name, updated)
+    with assignment_operation_lock(f"ai-feedback-review::{name}"):
+        storage = assignment_storage()
+        register = storage.read_assignment_report(name)
+        updated = manual_ai_feedback.review_feedback_in_register(register, student_id, decision)
+        return storage.write_assignment_report(name, updated)
 
 
 def assignment_overview() -> list[dict]:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1152,7 +1152,8 @@ def save_activity(payload: dict) -> dict:
 def resolve_submission_file_path(student: dict, file_path: str) -> Path:
     """Resolve a submitted file path while keeping reads inside the student repo."""
 
-    repo = Path(str(student.get("repo", "")).strip())
+    repo_value = str(student.get("repo_path", "") or student.get("repo", "")).strip()
+    repo = Path(repo_value)
     if not str(repo):
         raise ValueError("Repository studente mancante nel registro.")
     repo_path = repo if repo.is_absolute() else (ROOT / repo).resolve()
@@ -1164,6 +1165,7 @@ def resolve_submission_file_path(student: dict, file_path: str) -> Path:
         candidates.append(raw_path.resolve())
     else:
         candidates.append((ROOT / raw_path).resolve())
+        candidates.append((APP_ROOT / raw_path).resolve())
         candidates.append((repo_path / raw_path).resolve())
     for candidate in candidates:
         try:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1154,8 +1154,8 @@ def save_activity(payload: dict) -> dict:
 def legacy_submission_repo_path(student: dict, candidate: Path) -> Path | None:
     """Infer an old local repo root from a confined assignment file path."""
 
-    trusted_roots = (ROOT.resolve(strict=False), APP_ROOT.resolve(strict=False))
-    if not any(candidate == root or candidate.is_relative_to(root) for root in trusted_roots):
+    trusted_root = ROOT.resolve(strict=False)
+    if candidate != trusted_root and not candidate.is_relative_to(trusted_root):
         return None
     repo_ref = str(student.get("repo", "")).strip().replace("\\", "/").rstrip("/")
     repo_name = repo_ref.rsplit("/", 1)[-1]

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1151,10 +1151,32 @@ def save_activity(payload: dict) -> dict:
     return {"ok": True, "activity": saved, "activities": list_activities()}
 
 
+def legacy_submission_repo_path(student: dict, candidate: Path) -> Path | None:
+    """Infer an old local repo root from a confined assignment file path."""
+
+    trusted_roots = (ROOT.resolve(strict=False), APP_ROOT.resolve(strict=False))
+    if not any(candidate == root or candidate.is_relative_to(root) for root in trusted_roots):
+        return None
+    repo_ref = str(student.get("repo", "")).strip().replace("\\", "/").rstrip("/")
+    repo_name = repo_ref.rsplit("/", 1)[-1]
+    if repo_name.endswith(".git"):
+        repo_name = repo_name[:-4]
+    if not repo_name:
+        return None
+    for parent in candidate.parents:
+        if parent.name.casefold() != "assignments":
+            continue
+        inferred_repo = parent.parent
+        if inferred_repo.name.casefold() == repo_name.casefold():
+            return inferred_repo
+    return None
+
+
 def resolve_submission_file_path(student: dict, file_path: str) -> Path:
     """Resolve a submitted file path while keeping reads inside the student repo."""
 
-    repo_value = str(student.get("repo_path", "") or student.get("repo", "")).strip()
+    explicit_repo_path = str(student.get("repo_path", "")).strip()
+    repo_value = explicit_repo_path or str(student.get("repo", "")).strip()
     repo = Path(repo_value)
     if not str(repo):
         raise ValueError("Repository studente mancante nel registro.")
@@ -1170,9 +1192,12 @@ def resolve_submission_file_path(student: dict, file_path: str) -> Path:
         candidates.append((APP_ROOT / raw_path).resolve())
         candidates.append((repo_path / raw_path).resolve())
     for candidate in candidates:
-        try:
-            candidate.relative_to(repo_path)
-        except ValueError:
+        allowed_repo_paths = [repo_path]
+        if not explicit_repo_path:
+            inferred_repo_path = legacy_submission_repo_path(student, candidate)
+            if inferred_repo_path is not None:
+                allowed_repo_paths.append(inferred_repo_path)
+        if not any(candidate == allowed or candidate.is_relative_to(allowed) for allowed in allowed_repo_paths):
             continue
         if candidate.is_file():
             return candidate

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -33,6 +33,7 @@ import threading
 import urllib.error
 import urllib.request
 import uuid
+from copy import deepcopy
 from contextlib import ExitStack, contextmanager, nullcontext
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -1141,13 +1142,67 @@ def read_assignment_report(name: str) -> dict:
     return enrich_assignment_report_help(assignment_service().read_assignment_report(name))
 
 
+def assignment_report_operation_id(
+    storage: thebitlab_storage.JsonAssignmentStorage,
+    name: str,
+) -> str:
+    """Return the canonical lock identity shared by mutations of one report."""
+
+    report_path = storage.safe_teacher_report_path(name)
+    return f"assignment-report::{os.path.normcase(str(report_path))}"
+
+
+def preserve_assignment_ai_feedback(previous: dict, generated: dict) -> dict:
+    """Keep meaningful AI feedback when regenerating the same assignment report."""
+
+    previous_activity = str(previous.get("activity_id", "")).strip()
+    generated_activity = str(generated.get("activity_id", "")).strip()
+    if not previous_activity or previous_activity != generated_activity:
+        return generated
+    previous_assignment = str(previous.get("assignment_id", "")).strip()
+    generated_assignment = str(generated.get("assignment_id", "")).strip()
+    if previous_assignment and generated_assignment and previous_assignment != generated_assignment:
+        return generated
+
+    previous_students = previous.get("students") if isinstance(previous.get("students"), list) else []
+    by_student_id = {}
+    by_student_name = {}
+    for student in previous_students:
+        if not isinstance(student, dict):
+            continue
+        student_id = str(student.get("student_id", "")).strip()
+        student_name = str(student.get("student", "")).strip()
+        if student_id:
+            by_student_id.setdefault(student_id, student)
+        if student_name:
+            by_student_name.setdefault(student_name, student)
+
+    generated_students = generated.get("students") if isinstance(generated.get("students"), list) else []
+    for student in generated_students:
+        if not isinstance(student, dict):
+            continue
+        student_id = str(student.get("student_id", "")).strip()
+        student_name = str(student.get("student", "")).strip()
+        previous_student = by_student_id.get(student_id) if student_id else None
+        if previous_student is None and student_name:
+            previous_student = by_student_name.get(student_name)
+        if previous_student is None:
+            continue
+        feedback = previous_student.get("ai_feedback")
+        if not isinstance(feedback, dict):
+            continue
+        status = str(feedback.get("status", "")).strip()
+        if not status or status == "not_generated":
+            continue
+        student["ai_feedback"] = deepcopy(feedback)
+    return generated
+
+
 def review_assignment_ai_feedback(name: str, student_id: str, decision: str) -> dict:
     """Apply a teacher review decision to draft AI feedback in a report."""
 
     storage = assignment_storage()
-    report_path = storage.safe_teacher_report_path(name)
-    operation_id = f"ai-feedback-review::{os.path.normcase(str(report_path))}"
-    with assignment_operation_lock(operation_id):
+    with assignment_operation_lock(assignment_report_operation_id(storage, name)):
         register = storage.read_assignment_report(name)
         updated = manual_ai_feedback.review_feedback_in_register(register, student_id, decision)
         saved = storage.write_assignment_report(name, updated)
@@ -1589,7 +1644,9 @@ def generate_assignment_report(payload: dict) -> dict:
     if not activity_path.is_file():
         raise FileNotFoundError(f"Activity non trovata: {activity_path}")
     targets = read_targets_from_text(str(payload.get("targets_text", "")))
-    output_path = safe_teacher_report_path(payload.get("output_name", ""))
+    output_name = str(payload.get("output_name", ""))
+    storage = assignment_storage()
+    output_path = storage.safe_teacher_report_path(output_name)
     assignment_id = str(payload.get("assignment_id", "")).strip()
     record_storage = assignment_record_storage()
     operation_lock = (
@@ -1613,7 +1670,11 @@ def generate_assignment_report(payload: dict) -> dict:
             assignment_id=canonical_assignment_id or None,
             server_root=ROOT if canonical_assignment_id else None,
         )
-        track_assignments.write_tracking_index(index, output_path)
+        with assignment_operation_lock(assignment_report_operation_id(storage, output_name)):
+            if output_path.is_file():
+                previous = storage.read_assignment_report(output_name)
+                preserve_assignment_ai_feedback(previous, index)
+            track_assignments.write_tracking_index(index, output_path)
     return {
         "ok": True,
         "report": index,

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1200,24 +1200,40 @@ def save_activity(payload: dict) -> dict:
     return {"ok": True, "activity": saved, "activities": list_activities()}
 
 
-def legacy_submission_repo_path(student: dict, candidate: Path) -> Path | None:
-    """Infer an old local repo root from a confined assignment file path."""
+def legacy_submission_repo_path(student: dict) -> Path | None:
+    """Infer an old local repo root from its recorded grading report path."""
 
     trusted_root = ROOT.resolve(strict=False)
-    if candidate != trusted_root and not candidate.is_relative_to(trusted_root):
-        return None
     repo_ref = str(student.get("repo", "")).strip().replace("\\", "/").rstrip("/")
     repo_name = repo_ref.rsplit("/", 1)[-1]
     if repo_name.endswith(".git"):
         repo_name = repo_name[:-4]
     if not repo_name:
         return None
-    for parent in candidate.parents:
-        if parent.name.casefold() != "assignments":
-            continue
-        inferred_repo = parent.parent
-        if inferred_repo.name.casefold() == repo_name.casefold():
-            return inferred_repo
+    submission = student.get("submission") if isinstance(student.get("submission"), dict) else {}
+    report_references = {
+        normalized_submission_file_reference(student.get("report_path")),
+        normalized_submission_file_reference(submission.get("report_path")),
+    }
+    report_references.discard("")
+    for reference in report_references:
+        raw_path = Path(reference)
+        candidates = [raw_path.resolve()] if raw_path.is_absolute() else [
+            (ROOT / raw_path).resolve(),
+            (APP_ROOT / raw_path).resolve(),
+            (ROOT / repo_name / raw_path).resolve(),
+        ]
+        for candidate in candidates:
+            if candidate != trusted_root and not candidate.is_relative_to(trusted_root):
+                continue
+            if not candidate.is_file():
+                continue
+            for parent in candidate.parents:
+                if parent.name.casefold() != "reports":
+                    continue
+                inferred_repo = parent.parent
+                if inferred_repo.name.casefold() == repo_name.casefold():
+                    return inferred_repo
     return None
 
 
@@ -1257,6 +1273,7 @@ def resolve_submission_file_path(student: dict, file_path: str) -> Path:
     if not str(repo):
         raise ValueError("Repository studente mancante nel registro.")
     repo_path = repo if repo.is_absolute() else (ROOT / repo).resolve()
+    legacy_repo_path = None if explicit_repo_path or repo_path.is_dir() else legacy_submission_repo_path(student)
     raw_path = Path(str(file_path).strip())
     if not str(raw_path):
         raise ValueError("File consegna non indicato.")
@@ -1269,10 +1286,8 @@ def resolve_submission_file_path(student: dict, file_path: str) -> Path:
         candidates.append((repo_path / raw_path).resolve())
     for candidate in candidates:
         allowed_repo_paths = [repo_path]
-        if not explicit_repo_path:
-            inferred_repo_path = legacy_submission_repo_path(student, candidate)
-            if inferred_repo_path is not None:
-                allowed_repo_paths.append(inferred_repo_path)
+        if legacy_repo_path is not None:
+            allowed_repo_paths.append(legacy_repo_path)
         if not any(candidate == allowed or candidate.is_relative_to(allowed) for allowed in allowed_repo_paths):
             continue
         if candidate.is_file():

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1110,10 +1110,9 @@ def read_class_roster(name: str) -> dict:
     return class_roster_service().read_class_roster(name)
 
 
-def read_assignment_report(name: str) -> dict:
-    """Read one assignment tracking report from teacher-reports."""
+def enrich_assignment_report_help(report: dict) -> dict:
+    """Attach current authoritative help summaries to one assignment report."""
 
-    report = assignment_service().read_assignment_report(name)
     assignment_id = str(report.get("assignment_id", "")).strip()
     students = report.get("students") if isinstance(report.get("students"), list) else []
     if not assignment_id:
@@ -1136,6 +1135,12 @@ def read_assignment_report(name: str) -> dict:
     return report
 
 
+def read_assignment_report(name: str) -> dict:
+    """Read one assignment tracking report from teacher-reports."""
+
+    return enrich_assignment_report_help(assignment_service().read_assignment_report(name))
+
+
 def review_assignment_ai_feedback(name: str, student_id: str, decision: str) -> dict:
     """Apply a teacher review decision to draft AI feedback in a report."""
 
@@ -1143,7 +1148,8 @@ def review_assignment_ai_feedback(name: str, student_id: str, decision: str) -> 
         storage = assignment_storage()
         register = storage.read_assignment_report(name)
         updated = manual_ai_feedback.review_feedback_in_register(register, student_id, decision)
-        return storage.write_assignment_report(name, updated)
+        saved = storage.write_assignment_report(name, updated)
+        return enrich_assignment_report_help(saved)
 
 
 def assignment_overview() -> list[dict]:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1221,9 +1221,36 @@ def legacy_submission_repo_path(student: dict, candidate: Path) -> Path | None:
     return None
 
 
+def normalized_submission_file_reference(value: Any) -> str:
+    """Return a comparable register reference for one submitted file."""
+
+    normalized = str(value or "").strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def registered_submission_file_references(student: dict) -> set[str]:
+    """Return the file references explicitly recorded for one submission."""
+
+    submission = student.get("submission") if isinstance(student.get("submission"), dict) else {}
+    references = {
+        normalized_submission_file_reference(submission.get("source_path")),
+    }
+    files = submission.get("files") if isinstance(submission.get("files"), list) else []
+    for entry in files:
+        value = entry.get("path") or entry.get("source_path") if isinstance(entry, dict) else entry
+        references.add(normalized_submission_file_reference(value))
+    references.discard("")
+    return references
+
+
 def resolve_submission_file_path(student: dict, file_path: str) -> Path:
     """Resolve a submitted file path while keeping reads inside the student repo."""
 
+    requested_reference = normalized_submission_file_reference(file_path)
+    if requested_reference not in registered_submission_file_references(student):
+        raise FileNotFoundError(f"File consegna non trovato o non consentito: {file_path}")
     explicit_repo_path = str(student.get("repo_path", "")).strip()
     repo_value = explicit_repo_path or str(student.get("repo", "")).strip()
     repo = Path(repo_value)

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -159,19 +159,20 @@ def data_root_process_lock_dir() -> Path:
 class DataRootProcessLock:
     """Hold an operating-system lock for one server data root."""
 
-    def __init__(self, root: Path) -> None:
+    def __init__(self, root: Path, *, hold_legacy_lock: bool = True) -> None:
         self.root = root.resolve(strict=False)
         readable = create_activity.slugify(self.root.name)[:32] or "root"
         root_key = os.path.normcase(str(self.root))
         digest = hashlib.sha256(root_key.encode("utf-8")).hexdigest()
         self.path = data_root_process_lock_dir() / f"{readable}-{digest}.lock"
+        self.legacy_path = self.root / ".thebitlab-server.lock"
+        self.hold_legacy_lock = hold_legacy_lock
         self._handle = None
+        self._legacy_handle = None
 
-    def acquire(self) -> None:
-        self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        if os.name != "nt":
-            self.path.parent.chmod(0o700)
-        handle = self.path.open("a+b")
+    @staticmethod
+    def _acquire_handle(path: Path):
+        handle = path.open("a+b")
         try:
             handle.seek(0, os.SEEK_END)
             if handle.tell() == 0:
@@ -186,28 +187,54 @@ class DataRootProcessLock:
                 import fcntl
 
                 fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except (OSError, BlockingIOError) as error:
+        except (OSError, BlockingIOError):
             handle.close()
+            raise
+        return handle
+
+    @staticmethod
+    def _release_handle(handle) -> None:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+    def acquire(self) -> None:
+        self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if os.name != "nt":
+            self.path.parent.chmod(0o700)
+        self.legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        private_handle = None
+        legacy_handle = None
+        try:
+            private_handle = self._acquire_handle(self.path)
+            legacy_handle = self._acquire_handle(self.legacy_path)
+        except (OSError, BlockingIOError) as error:
+            if legacy_handle is not None:
+                self._release_handle(legacy_handle)
+            if private_handle is not None:
+                self._release_handle(private_handle)
             raise RuntimeError(
                 f"Un altro server sta gia usando il root dati: {self.root}"
             ) from error
-        self._handle = handle
+        self._handle = private_handle
+        if self.hold_legacy_lock:
+            self._legacy_handle = legacy_handle
+        else:
+            self._release_handle(legacy_handle)
 
     def release(self) -> None:
-        if self._handle is None:
-            return
-        try:
-            self._handle.seek(0)
-            if os.name == "nt":
-                import msvcrt
-
-                msvcrt.locking(self._handle.fileno(), msvcrt.LK_UNLCK, 1)
-            else:
-                import fcntl
-
-                fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
-        finally:
-            self._handle.close()
+        if self._legacy_handle is not None:
+            self._release_handle(self._legacy_handle)
+            self._legacy_handle = None
+        if self._handle is not None:
+            self._release_handle(self._handle)
             self._handle = None
 
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -2909,7 +2909,8 @@ def set_ai_provider(provider: str, model: str = "") -> dict:
 class BoundedThreadingHTTPServer(ThreadingHTTPServer):
     """Serve requests with a fixed upper bound on concurrent client threads."""
 
-    daemon_threads = True
+    daemon_threads = False
+    block_on_close = True
 
     def __init__(
         self,

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -142,7 +142,9 @@ class DataRootProcessLock:
     """Hold an operating-system lock for one server data root."""
 
     def __init__(self, root: Path) -> None:
-        self.path = root.resolve(strict=False) / ".thebitlab-server.lock"
+        self.root = root.resolve(strict=False)
+        root_name = self.root.name or "root"
+        self.path = self.root.parent / f".{root_name}.thebitlab-server.lock"
         self._handle = None
 
     def acquire(self) -> None:
@@ -165,7 +167,7 @@ class DataRootProcessLock:
         except (OSError, BlockingIOError) as error:
             handle.close()
             raise RuntimeError(
-                f"Un altro server sta gia usando il root dati: {self.path.parent}"
+                f"Un altro server sta gia usando il root dati: {self.root}"
             ) from error
         self._handle = handle
 

--- a/scripts/student_lab_demo_setup.py
+++ b/scripts/student_lab_demo_setup.py
@@ -22,8 +22,8 @@ from scripts import course_board_server, student_lab_demo_smoke
 DEFAULT_DEMO_ROOT = PROJECT_ROOT / "tmp" / "student-lab-demo"
 
 
-def ensure_demo_root_available(root: Path) -> None:
-    """Fail before reset when a course-board server is using the demo root."""
+def ensure_demo_root_available(root: Path) -> course_board_server.DataRootProcessLock:
+    """Acquire and return the lock that protects the complete demo reset."""
 
     lock = course_board_server.DataRootProcessLock(root)
     try:
@@ -33,8 +33,7 @@ def ensure_demo_root_available(root: Path) -> None:
             f"Root demo in uso da un server attivo: {root.resolve(strict=False)}. "
             "Ferma il server prima di rigenerare la demo."
         ) from error
-    finally:
-        lock.release()
+    return lock
 
 
 def remove_tree_with_retry(path: Path, *, attempts: int = 5) -> None:
@@ -105,14 +104,17 @@ def prepare_demo(root: Path) -> dict[str, Any]:
     """Create a stable, inspectable demo root and return its summary."""
 
     root = root.resolve(strict=False)
-    ensure_demo_root_available(root)
-    reset_root(root)
-    summary = student_lab_demo_smoke.run_smoke(root)
-    return {
-        **summary,
-        "reset": True,
-        "commands": demo_commands(root),
-    }
+    lock = ensure_demo_root_available(root)
+    try:
+        reset_root(root)
+        summary = student_lab_demo_smoke.run_smoke(root)
+        return {
+            **summary,
+            "reset": True,
+            "commands": demo_commands(root),
+        }
+    finally:
+        lock.release()
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/student_lab_demo_setup.py
+++ b/scripts/student_lab_demo_setup.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shutil
 import sys
 import time
@@ -25,7 +24,7 @@ DEFAULT_DEMO_ROOT = PROJECT_ROOT / "tmp" / "student-lab-demo"
 def ensure_demo_root_available(root: Path) -> course_board_server.DataRootProcessLock:
     """Acquire and return the lock that protects the complete demo reset."""
 
-    lock = course_board_server.DataRootProcessLock(root, hold_legacy_lock=False)
+    lock = course_board_server.DataRootProcessLock(root)
     try:
         lock.acquire()
     except RuntimeError as error:
@@ -51,6 +50,24 @@ def remove_tree_with_retry(path: Path, *, attempts: int = 5) -> None:
             time.sleep(0.2 * (attempt + 1))
 
 
+def remove_path_with_retry(path: Path, *, attempts: int = 5) -> None:
+    """Remove one file, symlink or directory after transient Windows failures."""
+
+    for attempt in range(attempts):
+        if not path.exists() and not path.is_symlink():
+            return
+        try:
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+            return
+        except OSError:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(0.2 * (attempt + 1))
+
+
 def cleanup_stale_trash(root: Path) -> None:
     """Best-effort cleanup for old demo roots already moved aside."""
 
@@ -62,25 +79,18 @@ def cleanup_stale_trash(root: Path) -> None:
 
 
 def reset_root(root: Path) -> None:
-    """Remove an existing demo root after a minimal safety check."""
+    """Clear a demo root while preserving its actively held legacy lock file."""
 
     resolved = root.resolve(strict=False)
     if resolved == resolved.parent or len(resolved.parts) < 3:
         raise ValueError(f"Root demo non sicura da resettare: {resolved}")
     resolved.parent.mkdir(parents=True, exist_ok=True)
     cleanup_stale_trash(resolved)
-    if resolved.exists():
-        trash = resolved.with_name(f"{resolved.name}.delete-{os.getpid()}-{time.time_ns()}")
-        try:
-            resolved.rename(trash)
-        except OSError:
-            remove_tree_with_retry(resolved)
-        else:
-            try:
-                remove_tree_with_retry(trash)
-            except OSError:
-                pass
     resolved.mkdir(parents=True, exist_ok=True)
+    for candidate in resolved.iterdir():
+        if candidate.name == ".thebitlab-server.lock":
+            continue
+        remove_path_with_retry(candidate)
 
 
 def demo_commands(root: Path) -> dict[str, str]:

--- a/scripts/student_lab_demo_setup.py
+++ b/scripts/student_lab_demo_setup.py
@@ -25,7 +25,7 @@ DEFAULT_DEMO_ROOT = PROJECT_ROOT / "tmp" / "student-lab-demo"
 def ensure_demo_root_available(root: Path) -> course_board_server.DataRootProcessLock:
     """Acquire and return the lock that protects the complete demo reset."""
 
-    lock = course_board_server.DataRootProcessLock(root)
+    lock = course_board_server.DataRootProcessLock(root, hold_legacy_lock=False)
     try:
         lock.acquire()
     except RuntimeError as error:

--- a/scripts/student_lab_demo_setup.py
+++ b/scripts/student_lab_demo_setup.py
@@ -16,10 +16,25 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import student_lab_demo_smoke
+from scripts import course_board_server, student_lab_demo_smoke
 
 
 DEFAULT_DEMO_ROOT = PROJECT_ROOT / "tmp" / "student-lab-demo"
+
+
+def ensure_demo_root_available(root: Path) -> None:
+    """Fail before reset when a course-board server is using the demo root."""
+
+    lock = course_board_server.DataRootProcessLock(root)
+    try:
+        lock.acquire()
+    except RuntimeError as error:
+        raise RuntimeError(
+            f"Root demo in uso da un server attivo: {root.resolve(strict=False)}. "
+            "Ferma il server prima di rigenerare la demo."
+        ) from error
+    finally:
+        lock.release()
 
 
 def remove_tree_with_retry(path: Path, *, attempts: int = 5) -> None:
@@ -90,6 +105,7 @@ def prepare_demo(root: Path) -> dict[str, Any]:
     """Create a stable, inspectable demo root and return its summary."""
 
     root = root.resolve(strict=False)
+    ensure_demo_root_available(root)
     reset_root(root)
     summary = student_lab_demo_smoke.run_smoke(root)
     return {

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -198,6 +198,7 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
     normalized["student"] = first_text(payload, "student")
     normalized["student_id"] = first_text(payload, "student_id") or normalized["student"]
     normalized["repo"] = first_text(payload, "repo")
+    normalized["repo_path"] = first_text(payload, "repo_path")
     normalized["submitted"] = bool_value(payload.get("submitted", False))
     normalized["status"] = first_text(payload, "status")
     normalized["late"] = bool_value(payload.get("late", False))

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -92,9 +92,14 @@ def default_report_path(target: TrackingTarget, activity_id: str) -> Path:
     return target.path / "reports" / activity_id / "latest.json"
 
 
-def relative_to_root_or_repo(path: Path, repo: Path) -> str:
+def relative_to_root_or_repo(path: Path, repo: Path, server_root: Path | None = None) -> str:
     """Return a stable relative path for JSON output."""
     resolved = path.resolve()
+    if server_root is not None:
+        try:
+            return str(resolved.relative_to(server_root.resolve())).replace("\\", "/")
+        except ValueError:
+            pass
     try:
         return str(resolved.relative_to(PROJECT_ROOT)).replace("\\", "/")
     except ValueError:
@@ -102,6 +107,16 @@ def relative_to_root_or_repo(path: Path, repo: Path) -> str:
             return str(resolved.relative_to(repo.resolve())).replace("\\", "/")
         except ValueError:
             return str(resolved)
+
+
+def relative_to_repo(path: Path, repo: Path) -> str:
+    """Return a file reference that remains valid when the data root moves."""
+
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(repo.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(resolved)
 
 
 def local_repo_path(path: Path, server_root: Path | None) -> str:
@@ -247,7 +262,7 @@ def submission_files(
                 continue
             confined_path = confined_report_file_path(target, file_path)
             if confined_path is not None:
-                normalized_path = relative_to_root_or_repo(confined_path, target.path)
+                normalized_path = relative_to_repo(confined_path, target.path)
                 normalized_files.append(
                     {
                         "path": normalized_path,
@@ -268,13 +283,13 @@ def submission_files(
             resolved_files.add(path.resolve())
             files.append(
                 {
-                    "path": relative_to_root_or_repo(path, target.path),
+                    "path": relative_to_repo(path, target.path),
                     "role": submission_file_role(path, source_path),
                     "github_url": github_file_url(target, repo_url, str(path), commit),
                 }
             )
     if source_path is not None and source_path not in resolved_files:
-        normalized_source = relative_to_root_or_repo(source_path, target.path)
+        normalized_source = relative_to_repo(source_path, target.path)
         files.insert(
             0,
             {
@@ -457,7 +472,7 @@ def track_assignments(
         if report is not None:
             validate_report_activity(report, activity_id, report_path)
         relative_report_path = (
-            relative_to_root_or_repo(safe_report_path, target.path)
+            relative_to_root_or_repo(safe_report_path, target.path, server_root)
             if safe_report_path is not None
             else None
         )
@@ -476,7 +491,8 @@ def track_assignments(
         else:
             help["path"] = relative_to_root_or_repo(help_log_path, target.path) if help_log_path else ""
         help["activity_id"] = activity_id
-        source_path = report.get("source") if report else None
+        source_file_path = report_source_path(target, report.get("source")) if report else None
+        source_path = relative_to_repo(source_file_path, target.path) if source_file_path is not None else None
         submitted = report is not None
         submitted_at = report.get("submitted_at") if report else None
         status, late = submission_status(
@@ -500,7 +516,7 @@ def track_assignments(
                 "late": late,
                 "submission": {
                     "source_path": source_path,
-                    "source_github_url": github_file_url(target, repo_url, source_path, report.get("commit") if report else None),
+                    "source_github_url": github_file_url(target, repo_url, str(source_file_path) if source_file_path else None, report.get("commit") if report else None),
                     "files": submission_files(target, activity_id, report, repo_url),
                     "submitted_at": submitted_at,
                     "commit": report.get("commit") if report else None,

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -104,6 +104,18 @@ def relative_to_root_or_repo(path: Path, repo: Path) -> str:
             return str(resolved)
 
 
+def local_repo_path(path: Path, server_root: Path | None) -> str:
+    """Return the local repository path without overloading the remote repo reference."""
+
+    resolved = path.resolve()
+    if server_root is not None:
+        try:
+            return str(resolved.relative_to(server_root.resolve())).replace("\\", "/")
+        except ValueError:
+            pass
+    return str(resolved)
+
+
 def git_stdout(args: list[str], cwd: Path) -> str:
     """Run a small git query and return stdout, or an empty string."""
     completed = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False, timeout=5)
@@ -467,6 +479,7 @@ def track_assignments(
                 "student": target.student,
                 "student_id": stable_student_id,
                 "repo": target.repo,
+                "repo_path": local_repo_path(target.path, server_root),
                 "repo_github_url": repo_url,
                 "assigned": True,
                 "submitted": submitted,

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -203,14 +203,24 @@ def should_include_submission_file(path: Path) -> bool:
     return path.is_file()
 
 
-def report_source_path(target: TrackingTarget, source_value: str | None) -> Path | None:
-    """Return the submitted source path resolved from the student repository."""
-    if not source_value:
+def confined_report_file_path(target: TrackingTarget, file_value: Any) -> Path | None:
+    """Resolve a report-declared file only when it belongs to the student repository."""
+
+    if not file_value:
         return None
-    source_path = Path(source_value)
-    if source_path.is_absolute():
-        return source_path.resolve()
-    return (target.path / source_path).resolve()
+    raw_path = Path(str(file_value))
+    candidates = [raw_path] if raw_path.is_absolute() else [target.path / raw_path, PROJECT_ROOT / raw_path]
+    for candidate in candidates:
+        confined = student_identity.confined_regular_file(target.path, candidate)
+        if confined is not None:
+            return confined
+    return None
+
+
+def report_source_path(target: TrackingTarget, source_value: str | None) -> Path | None:
+    """Return a report source only when it is confined to the student repository."""
+
+    return confined_report_file_path(target, source_value)
 
 
 def submission_files(
@@ -235,13 +245,14 @@ def submission_files(
                 role = file_entry.get("role") or "support"
             else:
                 continue
-            if file_path:
-                normalized_path = str(file_path).replace("\\", "/")
+            confined_path = confined_report_file_path(target, file_path)
+            if confined_path is not None:
+                normalized_path = relative_to_root_or_repo(confined_path, target.path)
                 normalized_files.append(
                     {
                         "path": normalized_path,
                         "role": role,
-                        "github_url": github_file_url(target, repo_url, normalized_path, commit),
+                        "github_url": github_file_url(target, repo_url, str(confined_path), commit),
                     }
                 )
         if normalized_files:
@@ -262,14 +273,14 @@ def submission_files(
                     "github_url": github_file_url(target, repo_url, str(path), commit),
                 }
             )
-    if source_value and source_path not in resolved_files:
-        normalized_source = str(source_value).replace("\\", "/")
+    if source_path is not None and source_path not in resolved_files:
+        normalized_source = relative_to_root_or_repo(source_path, target.path)
         files.insert(
             0,
             {
                 "path": normalized_source,
                 "role": "solution",
-                "github_url": github_file_url(target, repo_url, normalized_source, commit),
+                "github_url": github_file_url(target, repo_url, str(source_path), commit),
             },
         )
     return files

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -270,8 +270,7 @@ def submission_files(
                         "github_url": github_file_url(target, repo_url, str(confined_path), commit),
                     }
                 )
-        if normalized_files:
-            return normalized_files
+        return normalized_files
 
     source_value = report.get("source")
     source_path = report_source_path(target, source_value)

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3061,8 +3061,7 @@ def test_loading_report_enables_students_panel_and_reports_failures() -> None:
           assert.equal(tested.state.report.students.length, 1);
           assert.match(tested.els.status.textContent, /Registro caricato/);
 
-          tested.state.report = null;
-          tested.els.studentsOpenBtn.disabled = true;
+          tested.els.reportSelect.value = "demo/registro-rimosso.json";
           tested.fetchResponses["/api/assignment-reports/load"] = {
             ok: false,
             status: 404,
@@ -3073,7 +3072,11 @@ def test_loading_report_enables_students_panel_and_reports_failures() -> None:
           const failed = await tested.loadSelectedReport();
 
           assert.equal(failed, false);
+          assert.equal(tested.state.report, null);
+          assert.equal(tested.state.reportName, "");
+          assert.equal(tested.els.reportSelect.value, "");
           assert.equal(tested.els.studentsOpenBtn.disabled, true);
+          assert.match(tested.els.reportSummary.innerHTML, /Carica un registro/);
           assert.match(tested.els.status.textContent, /Registro non caricato: 404 Not Found: Registro non trovato/);
         })();
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3147,6 +3147,68 @@ def test_loading_report_ignores_stale_successes_and_failures() -> None:
     )
 
 
+def test_report_mutation_invalidates_a_pending_load() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          const response = (payload) => ({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            json: async () => payload,
+            text: async () => "",
+          });
+          let resolveLoad;
+          context.fetch = (path) => {
+            if (path === "/api/assignment-reports/load") {
+              return new Promise((resolve) => { resolveLoad = resolve; });
+            }
+            if (path === "/api/assignment-reports/ai-feedback/review") {
+              return Promise.resolve(response({
+                report: {
+                  activity_id: "somma",
+                  students: [{
+                    student: "rossi",
+                    student_id: "rossi",
+                    ai_feedback: { status: "approved", approved_by_teacher: true },
+                  }],
+                },
+              }));
+            }
+            throw new Error(`Endpoint inatteso: ${path}`);
+          };
+          tested.state.report = {
+            activity_id: "somma",
+            students: [{
+              student: "rossi",
+              student_id: "rossi",
+              ai_feedback: { status: "draft" },
+            }],
+          };
+          tested.state.reportName = "demo/somma.json";
+          tested.els.reportSelect.value = "demo/somma.json";
+
+          const loading = tested.loadSelectedReport();
+          await tested.reviewAiFeedback("rossi", "approve");
+          assert.equal(tested.state.report.students[0].ai_feedback.status, "approved");
+
+          resolveLoad(response({
+            report: {
+              activity_id: "somma",
+              students: [{
+                student: "rossi",
+                student_id: "rossi",
+                ai_feedback: { status: "draft" },
+              }],
+            },
+          }));
+          assert.equal(await loading, false);
+          assert.equal(tested.state.report.students[0].ai_feedback.status, "approved");
+        })();
+        """
+    )
+
+
 def test_student_help_dialog_opens_from_table_click_and_closes_from_button() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3016,6 +3016,22 @@ def test_student_help_details_render_compact_summary_and_modal_content() -> None
         assert.match(modalHtml, /Dato modificabile\\./);
         assert.doesNotMatch(html, /Â|Ã/);
 
+        const legacyWithError = tested.renderStudentHelpDialogContent({
+          help: {
+            error: "Log richieste non valido",
+            total: 0,
+            events: [],
+            legacy: {
+              total: 1,
+              events: [{ requested_at: "2026-09-01T08:00:00+02:00", prompt: "Dato storico." }],
+            },
+          },
+        });
+        assert.match(legacyWithError, /role="alert"/);
+        assert.match(legacyWithError, /Log richieste non valido/);
+        assert.ok(legacyWithError.includes("Legacy non verificati (1)"));
+        assert.ok(legacyWithError.includes("Dato storico."));
+
         const empty = tested.studentHelpDetails({ total: 0, events: [] });
         assert.match(empty, /Dettagli aiuti/);
         assert.match(empty, /disabled/);

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3366,6 +3366,56 @@ def test_pending_report_mutation_does_not_replace_a_newer_loaded_report() -> Non
     )
 
 
+def test_review_does_not_cancel_a_pending_switch_to_another_report() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          const response = (payload) => ({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            json: async () => payload,
+            text: async () => "",
+          });
+          let resolveLoad;
+          let reviewCalled = false;
+          context.fetch = (path, options = {}) => {
+            if (path === "/api/assignment-reports/load") {
+              assert.equal(JSON.parse(options.body).name, "demo/moltiplicazione.json");
+              return new Promise((resolve) => { resolveLoad = resolve; });
+            }
+            if (path === "/api/assignment-reports/ai-feedback/review") {
+              reviewCalled = true;
+            }
+            throw new Error(`Endpoint inatteso: ${path}`);
+          };
+          tested.state.report = {
+            activity_id: "somma",
+            students: [{ student: "rossi", student_id: "rossi" }],
+          };
+          tested.state.reportName = "demo/somma.json";
+          tested.els.reportSelect.value = "demo/moltiplicazione.json";
+
+          const loading = tested.loadSelectedReport();
+          assert.equal(await tested.reviewAiFeedback("rossi", "approve"), false);
+          assert.equal(reviewCalled, false);
+          assert.match(tested.els.studentsDialogStatus.textContent, /Attendi il caricamento/);
+
+          resolveLoad(response({
+            report: {
+              activity_id: "moltiplicazione",
+              students: [{ student: "bianchi", student_id: "bianchi" }],
+            },
+          }));
+          assert.equal(await loading, true);
+          assert.equal(tested.state.report.activity_id, "moltiplicazione");
+          assert.equal(tested.state.reportName, "demo/moltiplicazione.json");
+          assert.equal(tested.els.reportSelect.value, "demo/moltiplicazione.json");
+        })();
+        """
+    )
+
+
 def test_student_help_dialog_opens_from_table_click_and_closes_from_button() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -393,6 +393,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         renderStudentHelpDialogContent,
         openStudentHelpDialog,
         clearStudentHelpRows,
+        renderStudents,
         failedTestDetails,
         gradingDetails,
         renderTestDetailsDialogContent,
@@ -3056,6 +3057,28 @@ def test_student_help_dialog_opens_selected_student_and_clears_stale_rows() -> N
         assert.match(tested.els.studentHelpDialogBody.innerHTML, /Un suggerimento\\?/);
 
         tested.clearStudentHelpRows();
+        assert.equal(tested.state.studentHelpRows.size, 0);
+        """
+    )
+
+
+def test_render_students_closes_open_help_dialog_before_clearing_rows() -> None:
+    run_dashboard_js(
+        """
+        tested.state.studentHelpRows = new Map([
+          ["student-help-rossi", {
+            student: "Rossi Mario",
+            activity: "Somma in Python",
+            help: { total: 1, events: [{ allowed: true, prompt: "Un suggerimento?" }] },
+          }],
+        ]);
+        tested.openStudentHelpDialog("student-help-rossi");
+        assert.equal(tested.els.studentHelpDialog.open, true);
+
+        tested.state.report = null;
+        tested.renderStudents([]);
+
+        assert.equal(tested.els.studentHelpDialog.open, false);
         assert.equal(tested.state.studentHelpRows.size, 0);
         """
     )

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3124,6 +3124,43 @@ def test_render_students_keeps_open_help_dialog_and_refreshes_its_content() -> N
     )
 
 
+def test_render_students_closes_help_dialog_when_the_report_changes() -> None:
+    run_dashboard_js(
+        """
+        tested.state.reportName = "demo/somma.json";
+        tested.state.studentHelpRows = new Map([
+          ["student-help-rossi", {
+            student: "Rossi Mario",
+            activity: "Somma in Python",
+            help: { total: 1, events: [{ allowed: true, prompt: "Prompt somma" }] },
+          }],
+        ]);
+        tested.openStudentHelpDialog("student-help-rossi");
+        assert.equal(tested.state.studentHelpDialogReportName, "demo/somma.json");
+
+        tested.state.reportName = "demo/moltiplicazione.json";
+        tested.state.report = { activity_id: "moltiplicazione", title: "Moltiplicazione" };
+        tested.renderStudents([{
+          student: "rossi",
+          student_id: "rossi",
+          repo: "demo/rossi",
+          status: "pending",
+          grading: {},
+          submission: {},
+          help: {
+            total: 1,
+            activity_id: "moltiplicazione",
+            events: [{ allowed: true, prompt: "Prompt moltiplicazione" }],
+          },
+        }]);
+
+        assert.equal(tested.els.studentHelpDialog.open, false);
+        assert.equal(tested.state.studentHelpDialogKey, "");
+        assert.equal(tested.state.studentHelpDialogReportName, "");
+        """
+    )
+
+
 def test_loading_report_enables_students_panel_and_reports_failures() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3088,6 +3088,65 @@ def test_loading_report_enables_students_panel_and_reports_failures() -> None:
     )
 
 
+def test_loading_report_ignores_stale_successes_and_failures() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          const pending = new Map();
+          context.fetch = (path, options = {}) => new Promise((resolve) => {
+            const name = JSON.parse(options.body).name;
+            pending.set(name, resolve);
+          });
+          const success = (activityId) => ({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            json: async () => ({
+              report: { activity_id: activityId, students: [] },
+            }),
+            text: async () => "",
+          });
+          const failure = (message) => ({
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            json: async () => ({}),
+            text: async () => JSON.stringify({ error: message }),
+          });
+
+          tested.els.reportSelect.value = "demo/registro-lento.json";
+          const staleFailure = tested.loadSelectedReport();
+          tested.els.reportSelect.value = "demo/registro-corrente.json";
+          const currentSuccess = tested.loadSelectedReport();
+
+          pending.get("demo/registro-corrente.json")(success("corrente"));
+          assert.equal(await currentSuccess, true);
+          pending.get("demo/registro-lento.json")(failure("Registro non trovato"));
+          assert.equal(await staleFailure, false);
+          assert.equal(tested.state.report.activity_id, "corrente");
+          assert.equal(tested.state.reportName, "demo/registro-corrente.json");
+          assert.equal(tested.els.reportSelect.value, "demo/registro-corrente.json");
+          assert.equal(tested.els.studentsOpenBtn.disabled, false);
+
+          tested.els.reportSelect.value = "demo/registro-obsoleto.json";
+          const staleSuccess = tested.loadSelectedReport();
+          tested.els.reportSelect.value = "demo/registro-nuovo.json";
+          const latestSuccess = tested.loadSelectedReport();
+
+          pending.get("demo/registro-nuovo.json")(success("nuovo"));
+          assert.equal(await latestSuccess, true);
+          pending.get("demo/registro-obsoleto.json")(success("obsoleto"));
+          assert.equal(await staleSuccess, false);
+          assert.equal(tested.state.report.activity_id, "nuovo");
+          assert.equal(tested.state.reportName, "demo/registro-nuovo.json");
+          assert.ok(tested.els.status.textContent.includes(
+            "Registro caricato: demo/registro-nuovo.json",
+          ));
+        })();
+        """
+    )
+
+
 def test_student_help_dialog_opens_from_table_click_and_closes_from_button() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3252,6 +3252,69 @@ def test_report_mutation_invalidates_a_pending_load() -> None:
     )
 
 
+def test_pending_report_mutation_does_not_replace_a_newer_loaded_report() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          const response = (payload) => ({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            json: async () => payload,
+            text: async () => "",
+          });
+          let resolveReview;
+          context.fetch = (path, options = {}) => {
+            if (path === "/api/assignment-reports/ai-feedback/review") {
+              return new Promise((resolve) => { resolveReview = resolve; });
+            }
+            if (path === "/api/assignment-reports/load") {
+              const name = JSON.parse(options.body).name;
+              assert.equal(name, "demo/moltiplicazione.json");
+              return Promise.resolve(response({
+                report: {
+                  activity_id: "moltiplicazione",
+                  students: [{ student: "bianchi", student_id: "bianchi" }],
+                },
+              }));
+            }
+            throw new Error(`Endpoint inatteso: ${path}`);
+          };
+          tested.state.report = {
+            activity_id: "somma",
+            students: [{
+              student: "rossi",
+              student_id: "rossi",
+              ai_feedback: { status: "draft" },
+            }],
+          };
+          tested.state.reportName = "demo/somma.json";
+          tested.els.reportSelect.value = "demo/somma.json";
+
+          const reviewing = tested.reviewAiFeedback("rossi", "approve");
+          tested.els.reportSelect.value = "demo/moltiplicazione.json";
+          assert.equal(await tested.loadSelectedReport(), true);
+
+          resolveReview(response({
+            report: {
+              activity_id: "somma",
+              students: [{
+                student: "rossi",
+                student_id: "rossi",
+                ai_feedback: { status: "approved", approved_by_teacher: true },
+              }],
+            },
+          }));
+
+          assert.equal(await reviewing, false);
+          assert.equal(tested.state.report.activity_id, "moltiplicazione");
+          assert.equal(tested.state.reportName, "demo/moltiplicazione.json");
+          assert.equal(tested.els.reportSelect.value, "demo/moltiplicazione.json");
+        })();
+        """
+    )
+
+
 def test_student_help_dialog_opens_from_table_click_and_closes_from_button() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3127,6 +3127,34 @@ def test_loading_report_enables_students_panel_and_reports_failures() -> None:
     )
 
 
+def test_report_load_errors_are_visible_inside_calling_modals() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.fetchResponses["/api/assignment-reports/load"] = {
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            text: '{"error":"Registro non trovato"}',
+          };
+
+          tested.els.reportSelect.value = "demo/registro-rimosso.json";
+          assert.equal(await tested.loadSelectedReport({
+            statusElement: tested.els.coverageDialogStatus,
+          }), false);
+          assert.match(tested.els.coverageDialogStatus.textContent, /Registro non caricato: 404 Not Found/);
+
+          tested.els.reportSelect.value = "demo/registro-rimosso.json";
+          assert.equal(await tested.loadSelectedReport({
+            statusElement: tested.els.overviewDialogStatus,
+          }), false);
+          assert.match(tested.els.overviewDialogStatus.textContent, /Registro non caricato: 404 Not Found/);
+          assert.match(tested.els.status.textContent, /Registro non caricato: 404 Not Found/);
+        })();
+        """
+    )
+
+
 def test_selecting_empty_report_clears_the_active_report() -> None:
     run_dashboard_js(
         """
@@ -3442,6 +3470,13 @@ def test_student_help_dialog_markup_has_accessible_title_and_close_action() -> N
     assert 'id="studentHelpDialogStatus"' in html
     assert 'id="studentHelpDialogBody"' in html
     assert 'id="studentHelpCloseBtn"' in html
+
+
+def test_report_modals_have_local_live_status_messages() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
+
+    assert 'id="coverageDialogStatus" class="status" aria-live="polite"' in html
+    assert 'id="overviewDialogStatus" class="status" aria-live="polite"' in html
 
 
 def test_report_loader_controls_live_in_selected_report_panel() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3161,6 +3161,78 @@ def test_render_students_closes_help_dialog_when_the_report_changes() -> None:
     )
 
 
+def test_student_help_dialog_restores_focus_to_the_rebuilt_button() -> None:
+    run_dashboard_js(
+        """
+        tested.state.reportName = "demo/somma.json";
+        tested.state.studentHelpRows = new Map([
+          ["student-help-rossi", {
+            student: "Rossi Mario",
+            activity: "Somma in Python",
+            help: { total: 1, events: [{ allowed: true, prompt: "Prompt precedente" }] },
+          }],
+        ]);
+        tested.openStudentHelpDialog("student-help-rossi");
+        tested.state.report = { activity_id: "somma", title: "Somma aggiornata" };
+        tested.renderStudents([{
+          student: "rossi",
+          student_id: "rossi",
+          repo: "demo/rossi",
+          status: "pending",
+          grading: {},
+          submission: {},
+          help: {
+            total: 1,
+            activity_id: "somma",
+            events: [{ allowed: true, prompt: "Prompt aggiornato" }],
+          },
+        }]);
+        let focused = false;
+        const rebuiltButton = {
+          dataset: { studentHelpKey: "student-help-rossi" },
+          focus() { focused = true; },
+        };
+        context.document.querySelectorAll = (selector) => (
+          selector === "[data-student-help-key]" ? [rebuiltButton] : []
+        );
+
+        tested.els.studentHelpCloseBtn.dispatchEvent({ type: "click" });
+
+        assert.equal(tested.els.studentHelpDialog.open, false);
+        assert.equal(focused, true);
+        """
+    )
+
+
+def test_automatic_help_dialog_close_does_not_move_focus() -> None:
+    run_dashboard_js(
+        """
+        tested.state.reportName = "demo/somma.json";
+        tested.state.studentHelpRows = new Map([
+          ["student-help-rossi", {
+            student: "Rossi Mario",
+            activity: "Somma in Python",
+            help: { total: 1, events: [{ allowed: true, prompt: "Prompt" }] },
+          }],
+        ]);
+        tested.openStudentHelpDialog("student-help-rossi");
+        let focused = false;
+        const staleButton = {
+          dataset: { studentHelpKey: "student-help-rossi" },
+          focus() { focused = true; },
+        };
+        context.document.querySelectorAll = (selector) => (
+          selector === "[data-student-help-key]" ? [staleButton] : []
+        );
+
+        tested.renderStudents([]);
+
+        assert.equal(tested.els.studentHelpDialog.open, false);
+        assert.equal(focused, false);
+        """
+    )
+
+
 def test_loading_report_enables_students_panel_and_reports_failures() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -390,6 +390,9 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         aiFeedbackReviewDetails,
         aiFeedbackTeacherAction,
         studentHelpDetails,
+        renderStudentHelpDialogContent,
+        openStudentHelpDialog,
+        clearStudentHelpRows,
         failedTestDetails,
         gradingDetails,
         renderTestDetailsDialogContent,
@@ -2921,10 +2924,10 @@ def test_test_details_rows_are_cleared_by_view_prefix() -> None:
     )
 
 
-def test_student_help_details_render_counts_and_prompts() -> None:
+def test_student_help_details_render_compact_summary_and_modal_content() -> None:
     run_dashboard_js(
         """
-        const html = tested.studentHelpDetails({
+        const help = {
           activity_id: "python-base-somma-001",
           total: 3,
           ai_total: 2,
@@ -2937,6 +2940,14 @@ def test_student_help_details_render_counts_and_prompts() -> None:
               allowed: true,
               reason: "Consentito dalla policy.",
               prompt: "Puoi ricordarmi come funziona input()?",
+              provider_status: "completed",
+              response: {
+                status: "ready",
+                provider: "deterministic-local",
+                provider_label: "Guida locale (nessuna AI esterna)",
+                message: "Parti dal primo test fallito.",
+                usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+              },
             },
             {
               requested_at: "2026-10-20T08:15:00+02:00",
@@ -2968,26 +2979,126 @@ def test_student_help_details_render_counts_and_prompts() -> None:
             total: 1,
             events: [{ requested_at: "2026-09-01T08:00:00+02:00", prompt: "Dato modificabile." }],
           },
-        });
+        };
+        const html = tested.studentHelpDetails(help, { detailsKey: "student-help-rossi" });
 
         assert.match(html, /Aiuti 3/);
         assert.match(html, /Consegna: python-base-somma-001/);
         assert.match(html, /AI: 2/);
         assert.match(html, /Bloccate: 1/);
-        assert.match(html, /Prompt aiuti/);
-        assert.match(html, /Puoi ricordarmi come funziona input\\(\\)\\?/);
-        assert.match(html, /Scrivimi la soluzione completa\\./);
-        assert.match(html, /Bloccata/);
-        assert.match(html, /In elaborazione/);
-        assert.match(html, /Risposta non disponibile/);
-        assert.match(html, /Consentita/);
-        assert.match(html, /Legacy non verificati \\(1\\)/);
-        assert.match(html, /non incidono su budget e metriche/);
-        assert.match(html, /Dato modificabile\\./);
+        assert.match(html, /Dettagli aiuti/);
+        assert.match(html, /data-student-help-key="student-help-rossi"/);
+        assert.doesNotMatch(html, /Prompt aiuti/);
+        assert.doesNotMatch(html, /Puoi ricordarmi come funziona input\\(\\)\\?/);
+
+        const modalHtml = tested.renderStudentHelpDialogContent({ help });
+        assert.match(modalHtml, /Prompt dello studente/);
+        assert.match(modalHtml, /Puoi ricordarmi come funziona input\\(\\)\\?/);
+        assert.match(modalHtml, /Scrivimi la soluzione completa\\./);
+        assert.match(modalHtml, /Bloccata/);
+        assert.match(modalHtml, /In elaborazione/);
+        assert.match(modalHtml, /Risposta non disponibile/);
+        assert.match(modalHtml, /Consentita/);
+        assert.match(modalHtml, /Nessuna risposta generata: la richiesta e stata bloccata dalla policy\\./);
+        assert.match(modalHtml, /Risposta in elaborazione\\./);
+        assert.match(modalHtml, /Non invocato/);
+        assert.match(modalHtml, /Parti dal primo test fallito\\./);
+        assert.match(modalHtml, /Guida locale \\(nessuna AI esterna\\)/);
+        assert.match(modalHtml, /3 token \\(1 input, 2 output\\)/);
+        assert.match(modalHtml, /Legacy non verificati \\(1\\)/);
+        assert.match(modalHtml, /non incidono su budget e metriche/);
+        assert.match(modalHtml, /Dato modificabile\\./);
         assert.doesNotMatch(html, /Â|Ã/);
 
         const empty = tested.studentHelpDetails({ total: 0, events: [] });
-        assert.match(empty, /Nessuna richiesta registrata/);
+        assert.match(empty, /Dettagli aiuti/);
+        assert.match(empty, /disabled/);
+        """
+    )
+
+
+def test_student_help_dialog_opens_selected_student_and_clears_stale_rows() -> None:
+    run_dashboard_js(
+        """
+        tested.state.studentHelpRows = new Map([
+          ["student-help-rossi", {
+            student: "Rossi Mario",
+            activity: "Somma in Python",
+            help: { total: 1, events: [{ allowed: true, prompt: "Un suggerimento?" }] },
+          }],
+        ]);
+
+        tested.openStudentHelpDialog("student-help-rossi");
+        assert.equal(tested.els.studentHelpDialog.open, true);
+        assert.equal(tested.els.studentHelpDialogStatus.textContent, "Rossi Mario - Somma in Python.");
+        assert.match(tested.els.studentHelpDialogBody.innerHTML, /Un suggerimento\\?/);
+
+        tested.clearStudentHelpRows();
+        assert.equal(tested.state.studentHelpRows.size, 0);
+        """
+    )
+
+
+def test_student_help_dialog_opens_from_table_click_and_closes_from_button() -> None:
+    run_dashboard_js(
+        """
+        tested.state.studentHelpRows = new Map([
+          ["student-help-rossi", {
+            student: "Rossi Mario",
+            activity: "Somma in Python",
+            help: { total: 1, events: [{ allowed: true, prompt: "Aiutami" }] },
+          }],
+        ]);
+        const helpButton = {
+          disabled: false,
+          dataset: { studentHelpKey: "student-help-rossi" },
+        };
+        const event = {
+          prevented: false,
+          stopped: false,
+          target: {
+            closest(selector) {
+              return selector === "[data-student-help-key]" ? helpButton : null;
+            },
+          },
+          preventDefault() { this.prevented = true; },
+          stopPropagation() { this.stopped = true; },
+        };
+
+        tested.els.studentsBody.listeners.click[0](event);
+        assert.equal(event.prevented, true);
+        assert.equal(event.stopped, true);
+        assert.equal(tested.els.studentHelpDialog.open, true);
+
+        tested.els.studentHelpCloseBtn.dispatchEvent({ type: "click" });
+        assert.equal(tested.els.studentHelpDialog.open, false);
+        """
+    )
+
+
+def test_student_help_dialog_escapes_untrusted_prompt_and_response() -> None:
+    run_dashboard_js(
+        """
+        const html = tested.renderStudentHelpDialogContent({
+          help: {
+            total: 1,
+            events: [{
+              allowed: true,
+              prompt: '<img src=x onerror="boom">',
+              response: {
+                status: "ready",
+                provider_label: '<b>Provider</b>',
+                message: '</p><script>boom</script>',
+              },
+            }],
+          },
+        });
+
+        assert.doesNotMatch(html, /<img/);
+        assert.doesNotMatch(html, /<script/);
+        assert.doesNotMatch(html, /<b>Provider<\\/b>/);
+        assert.match(html, /&lt;img src=x onerror=&quot;boom&quot;&gt;/);
+        assert.match(html, /&lt;script&gt;boom&lt;\\/script&gt;/);
         """
     )
 
@@ -3016,7 +3127,22 @@ def test_ai_feedback_details_css_limits_expanded_content_height() -> None:
     assert "overflow-y: auto;" in css
     assert "text-align: justify;" in css
     assert ".aiFeedbackActions" in css
-    assert ".studentHelpDetails dl" in css
+    assert ".studentHelpDialogBody" in css
+    assert ".studentHelpDialogText" in css
+    assert ".studentHelpDialogProvider" in css
+    assert "text-align: start;" in css
+    assert "max-height: 94dvh;" in css
+
+
+def test_student_help_dialog_markup_has_accessible_title_and_close_action() -> None:
+    html = open("tools/assignment_dashboard.html", encoding="utf-8").read()
+
+    assert 'id="studentHelpDialog"' in html
+    assert 'aria-labelledby="studentHelpDialogTitle"' in html
+    assert 'aria-describedby="studentHelpDialogStatus"' in html
+    assert 'id="studentHelpDialogStatus"' in html
+    assert 'id="studentHelpDialogBody"' in html
+    assert 'id="studentHelpCloseBtn"' in html
 
 
 def test_report_loader_controls_live_in_selected_report_panel() -> None:

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3204,6 +3204,55 @@ def test_student_help_dialog_restores_focus_to_the_rebuilt_button() -> None:
     )
 
 
+def test_student_help_dialog_escape_restores_focus_after_rerender() -> None:
+    run_dashboard_js(
+        """
+        tested.state.reportName = "demo/somma.json";
+        tested.state.studentHelpRows = new Map([
+          ["student-help-rossi", {
+            student: "Rossi Mario",
+            activity: "Somma in Python",
+            help: { total: 1, events: [{ allowed: true, prompt: "Prompt precedente" }] },
+          }],
+        ]);
+        tested.openStudentHelpDialog("student-help-rossi");
+        tested.state.report = { activity_id: "somma", title: "Somma aggiornata" };
+        tested.renderStudents([{
+          student: "rossi",
+          student_id: "rossi",
+          repo: "demo/rossi",
+          status: "pending",
+          grading: {},
+          submission: {},
+          help: {
+            total: 1,
+            activity_id: "somma",
+            events: [{ allowed: true, prompt: "Prompt aggiornato" }],
+          },
+        }]);
+        let focused = false;
+        let prevented = false;
+        const rebuiltButton = {
+          dataset: { studentHelpKey: "student-help-rossi" },
+          focus() { focused = true; },
+        };
+        context.document.querySelectorAll = (selector) => (
+          selector === "[data-student-help-key]" ? [rebuiltButton] : []
+        );
+
+        tested.els.studentHelpDialog.listeners.cancel[0]({
+          preventDefault() { prevented = true; },
+        });
+
+        assert.equal(prevented, true);
+        assert.equal(tested.els.studentHelpDialog.open, false);
+        assert.equal(tested.state.studentHelpDialogKey, "");
+        assert.equal(tested.state.studentHelpDialogReportName, "");
+        assert.equal(focused, true);
+        """
+    )
+
+
 def test_automatic_help_dialog_close_does_not_move_focus() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3456,6 +3456,59 @@ def test_review_does_not_cancel_a_pending_switch_to_another_report() -> None:
     )
 
 
+def test_second_ai_review_is_rejected_while_the_first_is_pending() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          const response = (payload) => ({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            json: async () => payload,
+            text: async () => "",
+          });
+          let resolveReview;
+          let reviewCalls = 0;
+          context.fetch = (path) => {
+            if (path !== "/api/assignment-reports/ai-feedback/review") {
+              throw new Error(`Endpoint inatteso: ${path}`);
+            }
+            reviewCalls += 1;
+            return new Promise((resolve) => { resolveReview = resolve; });
+          };
+          tested.state.report = {
+            activity_id: "somma",
+            students: [{
+              student: "rossi",
+              student_id: "rossi",
+              ai_feedback: { status: "draft" },
+            }],
+          };
+          tested.state.reportName = "demo/somma.json";
+          tested.els.reportSelect.value = "demo/somma.json";
+
+          const firstReview = tested.reviewAiFeedback("rossi", "approve");
+          assert.equal(await tested.reviewAiFeedback("rossi", "reject"), false);
+          assert.equal(reviewCalls, 1);
+          assert.match(tested.els.studentsDialogStatus.textContent, /revisione AI gia in corso/);
+
+          resolveReview(response({
+            report: {
+              activity_id: "somma",
+              students: [{
+                student: "rossi",
+                student_id: "rossi",
+                ai_feedback: { status: "approved", approved_by_teacher: true },
+              }],
+            },
+          }));
+          assert.equal(await firstReview, true);
+          assert.equal(tested.state.aiFeedbackReviewPending, false);
+        })();
+        """
+    )
+
+
 def test_student_help_dialog_opens_from_table_click_and_closes_from_button() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -476,6 +476,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         distributeAssignment,
         deleteSelectedAssignment,
         generateReport,
+        loadSelectedReport,
         loadAssignments,
         renderAssignmentSelect,
         clearSelectedAssignment,
@@ -3035,6 +3036,46 @@ def test_student_help_dialog_opens_selected_student_and_clears_stale_rows() -> N
 
         tested.clearStudentHelpRows();
         assert.equal(tested.state.studentHelpRows.size, 0);
+        """
+    )
+
+
+def test_loading_report_enables_students_panel_and_reports_failures() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.els.reportSelect.value = "demo/python-demo-somma-001.json";
+          tested.els.studentsOpenBtn.disabled = true;
+          tested.fetchResponses["/api/assignment-reports/load"] = {
+            report: {
+              activity_id: "python-demo-somma-001",
+              title: "Demo somma in Python",
+              students: [{ student: "rossi-mario", submitted: false }],
+            },
+          };
+
+          const loaded = await tested.loadSelectedReport();
+
+          assert.equal(loaded, true);
+          assert.equal(tested.els.studentsOpenBtn.disabled, false);
+          assert.equal(tested.state.report.students.length, 1);
+          assert.match(tested.els.status.textContent, /Registro caricato/);
+
+          tested.state.report = null;
+          tested.els.studentsOpenBtn.disabled = true;
+          tested.fetchResponses["/api/assignment-reports/load"] = {
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            text: '{"error":"Registro non trovato"}',
+          };
+
+          const failed = await tested.loadSelectedReport();
+
+          assert.equal(failed, false);
+          assert.equal(tested.els.studentsOpenBtn.disabled, true);
+          assert.match(tested.els.status.textContent, /Registro non caricato: 404 Not Found: Registro non trovato/);
+        })();
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -2981,7 +2981,11 @@ def test_student_help_details_render_compact_summary_and_modal_content() -> None
             events: [{ requested_at: "2026-09-01T08:00:00+02:00", prompt: "Dato modificabile." }],
           },
         };
-        const html = tested.studentHelpDetails(help, { detailsKey: "student-help-rossi" });
+        const html = tested.studentHelpDetails(help, {
+          detailsKey: "student-help-rossi",
+          student: 'Rossi "Mario"',
+          activity: "Somma & media",
+        });
 
         assert.match(html, /Aiuti 3/);
         assert.match(html, /Consegna: python-base-somma-001/);
@@ -2989,6 +2993,7 @@ def test_student_help_details_render_compact_summary_and_modal_content() -> None
         assert.match(html, /Bloccate: 1/);
         assert.match(html, /Dettagli aiuti/);
         assert.match(html, /data-student-help-key="student-help-rossi"/);
+        assert.match(html, /aria-label="Dettagli aiuti di Rossi &quot;Mario&quot; per Somma &amp; media"/);
         assert.doesNotMatch(html, /Prompt aiuti/);
         assert.doesNotMatch(html, /Puoi ricordarmi come funziona input\\(\\)\\?/);
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3084,6 +3084,46 @@ def test_render_students_closes_open_help_dialog_before_clearing_rows() -> None:
     )
 
 
+def test_render_students_keeps_open_help_dialog_and_refreshes_its_content() -> None:
+    run_dashboard_js(
+        """
+        tested.state.studentHelpRows = new Map([
+          ["student-help-rossi", {
+            student: "Rossi Mario",
+            activity: "Somma in Python",
+            help: { total: 1, events: [{ allowed: true, prompt: "Prompt precedente" }] },
+          }],
+        ]);
+        tested.openStudentHelpDialog("student-help-rossi");
+        assert.equal(tested.els.studentHelpDialog.open, true);
+
+        tested.state.report = { activity_id: "somma", title: "Somma aggiornata" };
+        tested.renderStudents([{
+          student: "rossi",
+          student_id: "rossi",
+          repo: "demo/rossi",
+          status: "pending",
+          grading: {},
+          submission: {},
+          help: {
+            total: 1,
+            activity_id: "somma",
+            events: [{ allowed: true, prompt: "Prompt aggiornato" }],
+          },
+        }]);
+
+        assert.equal(tested.els.studentHelpDialog.open, true);
+        assert.equal(tested.state.studentHelpDialogKey, "student-help-rossi");
+        assert.match(tested.els.studentHelpDialogBody.innerHTML, /Prompt aggiornato/);
+        assert.doesNotMatch(tested.els.studentHelpDialogBody.innerHTML, /Prompt precedente/);
+
+        tested.renderStudents([]);
+        assert.equal(tested.els.studentHelpDialog.open, false);
+        assert.equal(tested.state.studentHelpDialogKey, "");
+        """
+    )
+
+
 def test_loading_report_enables_students_panel_and_reports_failures() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3088,6 +3088,33 @@ def test_loading_report_enables_students_panel_and_reports_failures() -> None:
     )
 
 
+def test_selecting_empty_report_clears_the_active_report() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.state.report = {
+            activity_id: "registro-precedente",
+            students: [{ student: "rossi-mario" }],
+          };
+          tested.state.reportName = "demo/registro-precedente.json";
+          tested.els.studentsOpenBtn.disabled = false;
+          tested.els.studentHelpDialog.open = true;
+          tested.els.reportSelect.value = "";
+
+          const loaded = await tested.loadSelectedReport();
+
+          assert.equal(loaded, false);
+          assert.equal(tested.state.report, null);
+          assert.equal(tested.state.reportName, "");
+          assert.equal(tested.els.reportSelect.value, "");
+          assert.equal(tested.els.studentsOpenBtn.disabled, true);
+          assert.equal(tested.els.studentHelpDialog.open, false);
+          assert.match(tested.els.reportSummary.innerHTML, /Carica un registro/);
+        })();
+        """
+    )
+
+
 def test_loading_report_ignores_stale_successes_and_failures() -> None:
     run_dashboard_js(
         """

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3718,6 +3718,7 @@ def test_review_ai_feedback_posts_decision_and_updates_modal_status() -> None:
     run_dashboard_js(
         """
         tested.state.reportName = "demo/ai-feedback-states.json";
+        tested.els.reportSelect.value = "demo/ai-feedback-states.json";
         tested.state.report = { students: [] };
 
         tested.reviewAiFeedback("rossi-mario", "approve").then(() => {

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -2806,6 +2806,55 @@ def test_review_assignment_ai_feedback_persists_teacher_decision(tmp_path, monke
     assert saved["students"][0]["ai_feedback"]["approved_by_teacher"] is True
 
 
+def test_review_assignment_ai_feedback_returns_current_help_without_persisting_it(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+    report_path = tmp_path / "teacher-reports" / "activity.json"
+    report_path.parent.mkdir(parents=True)
+    report_path.write_text(
+        json.dumps(
+            {
+                "activity_id": "activity",
+                "assignment_id": "assignment-001",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "student_id": "rossi-mario",
+                        "help": {"total": 0, "events": []},
+                        "ai_feedback": {
+                            "status": "draft",
+                            "summary": "Bozza",
+                            "approved_by_teacher": False,
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    current_help = {
+        "total": 2,
+        "events": [{"help_type": "ai", "prompt": "Spiegami il ciclo."}],
+        "ai_total": 1,
+    }
+    monkeypatch.setattr(
+        course_board_server.student_help_service,
+        "teacher_help_summary",
+        lambda _path: json.loads(json.dumps(current_help)),
+    )
+
+    reviewed = course_board_server.review_assignment_ai_feedback(
+        "activity.json",
+        "rossi-mario",
+        "approve",
+    )
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+
+    assert reviewed["students"][0]["help"]["total"] == 2
+    assert reviewed["students"][0]["help"]["events"][0]["prompt"] == "Spiegami il ciclo."
+    assert persisted["students"][0]["help"] == {"total": 0, "events": []}
+
+
 def test_review_assignment_ai_feedback_serializes_updates_to_one_register(monkeypatch) -> None:
     class ConcurrentStorage:
         def __init__(self) -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -334,6 +334,40 @@ def test_bounded_http_server_limits_workers_and_sets_client_timeout(monkeypatch)
         server.server_close()
 
 
+def test_bounded_http_server_waits_for_active_handlers_before_closing() -> None:
+    handler_started = threading.Event()
+    release_handler = threading.Event()
+    close_finished = threading.Event()
+    server = course_board_server.BoundedThreadingHTTPServer(
+        ("127.0.0.1", 0),
+        course_board_server.CourseBoardHandler,
+        max_workers=1,
+        max_workers_per_client=1,
+    )
+
+    def slow_handler(_request, _client_address) -> None:
+        handler_started.set()
+        release_handler.wait(timeout=5)
+
+    server.process_request_thread = slow_handler
+    server.process_request(object(), ("127.0.0.1", 12345))
+    assert handler_started.wait(timeout=2)
+
+    def close_server() -> None:
+        server.server_close()
+        close_finished.set()
+
+    close_thread = threading.Thread(target=close_server)
+    close_thread.start()
+    try:
+        assert close_finished.wait(timeout=0.05) is False
+        release_handler.set()
+        assert close_finished.wait(timeout=2) is True
+    finally:
+        release_handler.set()
+        close_thread.join(timeout=2)
+
+
 def test_bounded_http_server_rejects_overload_without_blocking(monkeypatch) -> None:
     class FakeRequest:
         def __init__(self) -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -73,6 +73,59 @@ def test_teacher_dashboard_token_console_line_shows_generated_value() -> None:
     assert "temporaneo" in line
 
 
+def test_submission_file_uses_local_repo_path_separately_from_remote_repo(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "data"
+    repo = root / "examples" / "student_repos" / "rossi-mario"
+    source = repo / "assignments" / "somma-001" / "main.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("print(2 + 3)\n", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "ROOT", root)
+
+    resolved = course_board_server.resolve_submission_file_path(
+        {
+            "repo": "TheBitPoets/rossi-mario",
+            "repo_path": "examples/student_repos/rossi-mario",
+        },
+        "assignments/somma-001/main.py",
+    )
+
+    assert resolved == source
+
+
+def test_submission_file_accepts_legacy_project_relative_path_inside_absolute_repo(tmp_path, monkeypatch) -> None:
+    app_root = tmp_path / "app"
+    root = app_root / "tmp" / "student-lab-demo"
+    repo = root / "examples" / "student_repos" / "rossi-mario"
+    source = repo / "assignments" / "somma-001" / "main.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("print(2 + 3)\n", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "APP_ROOT", app_root)
+    monkeypatch.setattr(course_board_server, "ROOT", root)
+
+    resolved = course_board_server.resolve_submission_file_path(
+        {"repo": str(repo)},
+        "tmp/student-lab-demo/examples/student_repos/rossi-mario/assignments/somma-001/main.py",
+    )
+
+    assert resolved == source
+
+
+def test_submission_file_rejects_path_outside_local_student_repo(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "data"
+    repo = root / "examples" / "student_repos" / "rossi-mario"
+    repo.mkdir(parents=True)
+    outside = root / "teacher-reports" / "secret.txt"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("riservato", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "ROOT", root)
+
+    with pytest.raises(FileNotFoundError, match="non trovato o non consentito"):
+        course_board_server.resolve_submission_file_path(
+            {"repo_path": "examples/student_repos/rossi-mario"},
+            "teacher-reports/secret.txt",
+        )
+
+
 def test_data_root_process_lock_rejects_a_second_server(tmp_path) -> None:
     first_lock = course_board_server.DataRootProcessLock(tmp_path)
     second_lock = course_board_server.DataRootProcessLock(tmp_path)

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -21,6 +21,12 @@ from scripts import (
 from scripts.student_help_provider import StudentHelpResponse
 
 
+@pytest.fixture(autouse=True)
+def isolated_process_lock_dir(tmp_path, monkeypatch) -> None:
+    lock_dir = tmp_path.parent / f"{tmp_path.name}-process-locks"
+    monkeypatch.setenv("THEBITLAB_LOCK_DIR", str(lock_dir))
+
+
 def test_server_bind_rejects_clear_text_network_exposure_by_default() -> None:
     assert course_board_server.is_loopback_bind_host("127.0.0.1") is True
     assert course_board_server.is_loopback_bind_host("::1") is True
@@ -161,10 +167,14 @@ def test_submission_file_rejects_path_outside_local_student_repo(tmp_path, monke
 
 
 def test_data_root_process_lock_rejects_a_second_server(tmp_path) -> None:
-    first_lock = course_board_server.DataRootProcessLock(tmp_path)
-    second_lock = course_board_server.DataRootProcessLock(tmp_path)
-    assert first_lock.path.parent == tmp_path.parent
-    assert first_lock.path.name == f".{tmp_path.name}.thebitlab-server.lock"
+    root = tmp_path / "data"
+    first_lock = course_board_server.DataRootProcessLock(root)
+    second_lock = course_board_server.DataRootProcessLock(root)
+    assert first_lock.path.parent == (
+        tmp_path.parent / f"{tmp_path.name}-process-locks"
+    ).resolve()
+    assert first_lock.path.name.startswith("data-")
+    assert first_lock.path.suffix == ".lock"
     first_lock.acquire()
     try:
         with pytest.raises(RuntimeError, match="Un altro server"):
@@ -174,6 +184,23 @@ def test_data_root_process_lock_rejects_a_second_server(tmp_path) -> None:
 
     second_lock.acquire()
     second_lock.release()
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="I permessi POSIX sul parent non sono verificabili in questo ambiente.",
+)
+def test_data_root_process_lock_does_not_require_writable_root_parent(tmp_path) -> None:
+    root_parent = tmp_path / "read-only-parent"
+    root = root_parent / "data"
+    root.mkdir(parents=True)
+    root_parent.chmod(0o500)
+    try:
+        lock = course_board_server.DataRootProcessLock(root)
+        lock.acquire()
+        lock.release()
+    finally:
+        root_parent.chmod(0o700)
 
 
 def test_bounded_http_server_limits_workers_and_sets_client_timeout(monkeypatch) -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -129,6 +129,8 @@ def test_submission_file_rejects_path_outside_local_student_repo(tmp_path, monke
 def test_data_root_process_lock_rejects_a_second_server(tmp_path) -> None:
     first_lock = course_board_server.DataRootProcessLock(tmp_path)
     second_lock = course_board_server.DataRootProcessLock(tmp_path)
+    assert first_lock.path.parent == tmp_path.parent
+    assert first_lock.path.name == f".{tmp_path.name}.thebitlab-server.lock"
     first_lock.acquire()
     try:
         with pytest.raises(RuntimeError, match="Un altro server"):

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -131,7 +131,7 @@ def test_submission_file_infers_legacy_local_repo_from_remote_reference(tmp_path
 def test_submission_file_does_not_infer_legacy_repo_outside_trusted_roots(tmp_path, monkeypatch) -> None:
     app_root = tmp_path / "app"
     root = app_root / "data"
-    outside = tmp_path / "outside" / "rossi-mario" / "assignments" / "somma-001" / "main.py"
+    outside = app_root / "archive" / "rossi-mario" / "assignments" / "somma-001" / "main.py"
     outside.parent.mkdir(parents=True)
     outside.write_text("riservato\n", encoding="utf-8")
     monkeypatch.setattr(course_board_server, "APP_ROOT", app_root)
@@ -140,7 +140,7 @@ def test_submission_file_does_not_infer_legacy_repo_outside_trusted_roots(tmp_pa
     with pytest.raises(FileNotFoundError, match="non trovato o non consentito"):
         course_board_server.resolve_submission_file_path(
             {"repo": "TheBitPoets/rossi-mario"},
-            str(outside),
+            "archive/rossi-mario/assignments/somma-001/main.py",
         )
 
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -5,6 +5,7 @@ import http.client
 import json
 import os
 import threading
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -2803,6 +2804,84 @@ def test_review_assignment_ai_feedback_persists_teacher_decision(tmp_path, monke
     assert report["students"][0]["ai_feedback"]["approved_by_teacher"] is True
     assert saved["students"][0]["ai_feedback"]["status"] == "approved"
     assert saved["students"][0]["ai_feedback"]["approved_by_teacher"] is True
+
+
+def test_review_assignment_ai_feedback_serializes_updates_to_one_register(monkeypatch) -> None:
+    class ConcurrentStorage:
+        def __init__(self) -> None:
+            self.data = {
+                "activity_id": "activity",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "student_id": "rossi-mario",
+                        "ai_feedback": {
+                            "status": "draft",
+                            "summary": "Bozza Rossi",
+                            "approved_by_teacher": False,
+                        },
+                    },
+                    {
+                        "student": "bianchi-luca",
+                        "student_id": "bianchi-luca",
+                        "ai_feedback": {
+                            "status": "draft",
+                            "summary": "Bozza Bianchi",
+                            "approved_by_teacher": False,
+                        },
+                    },
+                ],
+            }
+            self.guard = threading.Lock()
+            self.active = 0
+            self.max_active = 0
+
+        def read_assignment_report(self, _name: str) -> dict:
+            with self.guard:
+                self.active += 1
+                self.max_active = max(self.max_active, self.active)
+            time.sleep(0.05)
+            return json.loads(json.dumps(self.data))
+
+        def write_assignment_report(self, _name: str, payload: dict) -> dict:
+            self.data = json.loads(json.dumps(payload))
+            with self.guard:
+                self.active -= 1
+            return json.loads(json.dumps(payload))
+
+    storage = ConcurrentStorage()
+    monkeypatch.setattr(course_board_server, "assignment_storage", lambda: storage)
+    start = threading.Barrier(3)
+    errors = []
+
+    def review(student_id: str) -> None:
+        try:
+            start.wait(timeout=2)
+            course_board_server.review_assignment_ai_feedback(
+                "demo/activity.json",
+                student_id,
+                "approve",
+            )
+        except Exception as error:  # noqa: BLE001
+            errors.append(error)
+
+    threads = [
+        threading.Thread(target=review, args=("rossi-mario",)),
+        threading.Thread(target=review, args=("bianchi-luca",)),
+    ]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=2)
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert errors == []
+    assert storage.max_active == 1
+    assert storage.active == 0
+    assert [student["ai_feedback"]["status"] for student in storage.data["students"]] == [
+        "approved",
+        "approved",
+    ]
 
 
 def test_review_assignment_ai_feedback_reopens_reviewed_feedback(tmp_path, monkeypatch) -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -133,12 +133,16 @@ def test_submission_file_infers_legacy_local_repo_from_remote_reference(tmp_path
     source = repo / "assignments" / "somma-001" / "main.py"
     source.parent.mkdir(parents=True)
     source.write_text("print(2 + 3)\n", encoding="utf-8")
+    report_path = repo / "reports" / "somma-001" / "latest.json"
+    report_path.parent.mkdir(parents=True)
+    report_path.write_text("{}\n", encoding="utf-8")
     monkeypatch.setattr(course_board_server, "APP_ROOT", app_root)
     monkeypatch.setattr(course_board_server, "ROOT", root)
 
     resolved = course_board_server.resolve_submission_file_path(
         {
             "repo": "TheBitPoets/rossi-mario",
+            "report_path": "tmp/student-help-modal-test/examples/assignment_tracking/student_repos/rossi-mario/reports/somma-001/latest.json",
             "submission": {
                 "files": [
                     {
@@ -151,6 +155,32 @@ def test_submission_file_infers_legacy_local_repo_from_remote_reference(tmp_path
     )
 
     assert resolved == source
+
+
+def test_submission_file_rejects_registered_path_outside_inferred_legacy_repo(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "data"
+    repo = root / "students" / "rossi-mario"
+    report_path = repo / "reports" / "somma-001" / "latest.json"
+    secret = root / "teacher-private" / "rossi-mario" / "assignments" / "x" / "secret.txt"
+    report_path.parent.mkdir(parents=True)
+    secret.parent.mkdir(parents=True)
+    report_path.write_text("{}\n", encoding="utf-8")
+    secret.write_text("riservato\n", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "ROOT", root)
+
+    with pytest.raises(FileNotFoundError, match="non trovato o non consentito"):
+        course_board_server.resolve_submission_file_path(
+            {
+                "repo": "TheBitPoets/rossi-mario",
+                "report_path": "students/rossi-mario/reports/somma-001/latest.json",
+                "submission": {
+                    "files": [
+                        {"path": "teacher-private/rossi-mario/assignments/x/secret.txt"}
+                    ]
+                },
+            },
+            "teacher-private/rossi-mario/assignments/x/secret.txt",
+        )
 
 
 def test_submission_file_does_not_infer_legacy_repo_outside_trusted_roots(tmp_path, monkeypatch) -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -2226,6 +2226,167 @@ def test_generate_assignment_report_preserves_assignment_id(tmp_path, monkeypatc
     assert saved_payload["assignment_id"] == "assignment-python-base-somma-001-3a"
 
 
+def test_regenerated_report_preserves_reviewed_ai_feedback() -> None:
+    approved = {
+        "status": "approved",
+        "approved_by_teacher": True,
+        "suggested_grade": 8,
+        "summary": "Feedback approvato",
+        "teacher_notes": "Controllato dal docente",
+    }
+    rejected = {
+        "status": "rejected",
+        "approved_by_teacher": False,
+        "suggested_grade": 5,
+        "summary": "Feedback respinto",
+    }
+    previous = {
+        "activity_id": "activity",
+        "assignment_id": "assignment-001",
+        "students": [
+            {"student": "rossi", "student_id": "student-rossi", "ai_feedback": approved},
+            {"student": "bianchi", "student_id": "student-bianchi", "ai_feedback": rejected},
+        ],
+    }
+    generated = {
+        "activity_id": "activity",
+        "assignment_id": "assignment-001",
+        "students": [
+            {"student": "rossi", "student_id": "student-rossi", "ai_feedback": {"status": "not_generated"}},
+            {"student": "bianchi", "student_id": "student-bianchi", "ai_feedback": {"status": "not_generated"}},
+        ],
+    }
+
+    course_board_server.preserve_assignment_ai_feedback(previous, generated)
+
+    assert generated["students"][0]["ai_feedback"] == approved
+    assert generated["students"][1]["ai_feedback"] == rejected
+    assert generated["students"][0]["ai_feedback"] is not approved
+    assert generated["students"][1]["ai_feedback"] is not rejected
+
+
+def test_regenerated_report_does_not_copy_feedback_from_another_activity() -> None:
+    previous = {
+        "activity_id": "activity-a",
+        "students": [{
+            "student": "rossi",
+            "student_id": "student-rossi",
+            "ai_feedback": {"status": "approved", "approved_by_teacher": True},
+        }],
+    }
+    generated = {
+        "activity_id": "activity-b",
+        "students": [{
+            "student": "rossi",
+            "student_id": "student-rossi",
+            "ai_feedback": {"status": "not_generated", "approved_by_teacher": False},
+        }],
+    }
+
+    course_board_server.preserve_assignment_ai_feedback(previous, generated)
+
+    assert generated["students"][0]["ai_feedback"]["status"] == "not_generated"
+
+
+def test_regenerated_report_does_not_copy_feedback_from_another_assignment() -> None:
+    previous = {
+        "activity_id": "activity",
+        "assignment_id": "assignment-a",
+        "students": [{
+            "student": "rossi",
+            "student_id": "student-rossi",
+            "ai_feedback": {"status": "approved", "approved_by_teacher": True},
+        }],
+    }
+    generated = {
+        "activity_id": "activity",
+        "assignment_id": "assignment-b",
+        "students": [{
+            "student": "rossi",
+            "student_id": "student-rossi",
+            "ai_feedback": {"status": "not_generated", "approved_by_teacher": False},
+        }],
+    }
+
+    course_board_server.preserve_assignment_ai_feedback(previous, generated)
+
+    assert generated["students"][0]["ai_feedback"]["status"] == "not_generated"
+
+
+def test_generate_report_preserves_review_completed_while_tracking(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+    activity_path = tmp_path / "activity.json"
+    activity_path.write_text("{}", encoding="utf-8")
+    storage = course_board_server.assignment_storage()
+    report_name = "demo/activity.json"
+    storage.write_assignment_report(
+        report_name,
+        {
+            "activity_id": "activity",
+            "students": [{
+                "student": "rossi",
+                "student_id": "rossi",
+                "ai_feedback": {
+                    "status": "draft",
+                    "summary": "Bozza da revisionare",
+                    "approved_by_teacher": False,
+                },
+            }],
+        },
+    )
+    generated = {
+        "activity_id": "activity",
+        "students": [{
+            "student": "rossi",
+            "student_id": "rossi",
+            "ai_feedback": {"status": "not_generated", "approved_by_teacher": False},
+        }],
+    }
+    tracking_started = threading.Event()
+    continue_tracking = threading.Event()
+    generation_errors = []
+
+    def track_report(**_kwargs) -> dict:
+        tracking_started.set()
+        assert continue_tracking.wait(timeout=2)
+        return json.loads(json.dumps(generated))
+
+    monkeypatch.setattr(course_board_server, "read_targets_from_text", lambda _value: [])
+    monkeypatch.setattr(course_board_server.track_assignments, "track_assignments", track_report)
+
+    def generate() -> None:
+        try:
+            course_board_server.generate_assignment_report({
+                "activity_path": str(activity_path),
+                "output_name": report_name,
+                "targets_text": "",
+            })
+        except Exception as error:  # noqa: BLE001
+            generation_errors.append(error)
+
+    thread = threading.Thread(target=generate)
+    thread.start()
+    assert tracking_started.wait(timeout=2)
+
+    try:
+        reviewed = course_board_server.review_assignment_ai_feedback(
+            report_name,
+            "rossi",
+            "approve",
+        )
+    finally:
+        continue_tracking.set()
+    thread.join(timeout=2)
+
+    saved = storage.read_assignment_report(report_name)
+    assert generation_errors == []
+    assert not thread.is_alive()
+    assert reviewed["students"][0]["ai_feedback"]["status"] == "approved"
+    assert saved["students"][0]["ai_feedback"]["status"] == "approved"
+    assert saved["students"][0]["ai_feedback"]["approved_by_teacher"] is True
+
+
 def test_read_assignment_report_refreshes_authoritative_help_without_rewriting_file(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -2885,6 +2885,10 @@ def test_review_assignment_ai_feedback_serializes_updates_to_one_register(monkey
             self.active = 0
             self.max_active = 0
 
+        def safe_teacher_report_path(self, name: str) -> Path:
+            normalized = name.strip().replace("\\", "/")
+            return (Path("teacher-reports") / normalized).resolve()
+
         def read_assignment_report(self, _name: str) -> dict:
             with self.guard:
                 self.active += 1
@@ -2903,11 +2907,11 @@ def test_review_assignment_ai_feedback_serializes_updates_to_one_register(monkey
     start = threading.Barrier(3)
     errors = []
 
-    def review(student_id: str) -> None:
+    def review(report_name: str, student_id: str) -> None:
         try:
             start.wait(timeout=2)
             course_board_server.review_assignment_ai_feedback(
-                "demo/activity.json",
+                report_name,
                 student_id,
                 "approve",
             )
@@ -2915,8 +2919,8 @@ def test_review_assignment_ai_feedback_serializes_updates_to_one_register(monkey
             errors.append(error)
 
     threads = [
-        threading.Thread(target=review, args=("rossi-mario",)),
-        threading.Thread(target=review, args=("bianchi-luca",)),
+        threading.Thread(target=review, args=("demo/activity.json", "rossi-mario")),
+        threading.Thread(target=review, args=(r"demo\activity.json", "bianchi-luca")),
     ]
     for thread in threads:
         thread.start()

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -110,6 +110,40 @@ def test_submission_file_accepts_legacy_project_relative_path_inside_absolute_re
     assert resolved == source
 
 
+def test_submission_file_infers_legacy_local_repo_from_remote_reference(tmp_path, monkeypatch) -> None:
+    app_root = tmp_path / "app"
+    root = app_root / "tmp" / "student-help-modal-test"
+    repo = root / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario"
+    source = repo / "assignments" / "somma-001" / "main.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("print(2 + 3)\n", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "APP_ROOT", app_root)
+    monkeypatch.setattr(course_board_server, "ROOT", root)
+
+    resolved = course_board_server.resolve_submission_file_path(
+        {"repo": "TheBitPoets/rossi-mario"},
+        "tmp/student-help-modal-test/examples/assignment_tracking/student_repos/rossi-mario/assignments/somma-001/main.py",
+    )
+
+    assert resolved == source
+
+
+def test_submission_file_does_not_infer_legacy_repo_outside_trusted_roots(tmp_path, monkeypatch) -> None:
+    app_root = tmp_path / "app"
+    root = app_root / "data"
+    outside = tmp_path / "outside" / "rossi-mario" / "assignments" / "somma-001" / "main.py"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("riservato\n", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "APP_ROOT", app_root)
+    monkeypatch.setattr(course_board_server, "ROOT", root)
+
+    with pytest.raises(FileNotFoundError, match="non trovato o non consentito"):
+        course_board_server.resolve_submission_file_path(
+            {"repo": "TheBitPoets/rossi-mario"},
+            str(outside),
+        )
+
+
 def test_submission_file_rejects_path_outside_local_student_repo(tmp_path, monkeypatch) -> None:
     root = tmp_path / "data"
     repo = root / "examples" / "student_repos" / "rossi-mario"

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -91,6 +91,7 @@ def test_submission_file_uses_local_repo_path_separately_from_remote_repo(tmp_pa
         {
             "repo": "TheBitPoets/rossi-mario",
             "repo_path": "examples/student_repos/rossi-mario",
+            "submission": {"files": [{"path": "assignments/somma-001/main.py"}]},
         },
         "assignments/somma-001/main.py",
     )
@@ -109,7 +110,16 @@ def test_submission_file_accepts_legacy_project_relative_path_inside_absolute_re
     monkeypatch.setattr(course_board_server, "ROOT", root)
 
     resolved = course_board_server.resolve_submission_file_path(
-        {"repo": str(repo)},
+        {
+            "repo": str(repo),
+            "submission": {
+                "files": [
+                    {
+                        "path": "tmp/student-lab-demo/examples/student_repos/rossi-mario/assignments/somma-001/main.py"
+                    }
+                ]
+            },
+        },
         "tmp/student-lab-demo/examples/student_repos/rossi-mario/assignments/somma-001/main.py",
     )
 
@@ -127,7 +137,16 @@ def test_submission_file_infers_legacy_local_repo_from_remote_reference(tmp_path
     monkeypatch.setattr(course_board_server, "ROOT", root)
 
     resolved = course_board_server.resolve_submission_file_path(
-        {"repo": "TheBitPoets/rossi-mario"},
+        {
+            "repo": "TheBitPoets/rossi-mario",
+            "submission": {
+                "files": [
+                    {
+                        "path": "tmp/student-help-modal-test/examples/assignment_tracking/student_repos/rossi-mario/assignments/somma-001/main.py"
+                    }
+                ]
+            },
+        },
         "tmp/student-help-modal-test/examples/assignment_tracking/student_repos/rossi-mario/assignments/somma-001/main.py",
     )
 
@@ -145,7 +164,14 @@ def test_submission_file_does_not_infer_legacy_repo_outside_trusted_roots(tmp_pa
 
     with pytest.raises(FileNotFoundError, match="non trovato o non consentito"):
         course_board_server.resolve_submission_file_path(
-            {"repo": "TheBitPoets/rossi-mario"},
+            {
+                "repo": "TheBitPoets/rossi-mario",
+                "submission": {
+                    "files": [
+                        {"path": "archive/rossi-mario/assignments/somma-001/main.py"}
+                    ]
+                },
+            },
             "archive/rossi-mario/assignments/somma-001/main.py",
         )
 
@@ -161,8 +187,35 @@ def test_submission_file_rejects_path_outside_local_student_repo(tmp_path, monke
 
     with pytest.raises(FileNotFoundError, match="non trovato o non consentito"):
         course_board_server.resolve_submission_file_path(
-            {"repo_path": "examples/student_repos/rossi-mario"},
+            {
+                "repo_path": "examples/student_repos/rossi-mario",
+                "submission": {"files": [{"path": "teacher-reports/secret.txt"}]},
+            },
             "teacher-reports/secret.txt",
+        )
+
+
+def test_submission_file_rejects_unregistered_legacy_path_in_same_named_repo(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "data"
+    legitimate = root / "students" / "rossi-mario" / "assignments" / "somma-001" / "main.py"
+    secret = root / "teacher-private" / "rossi-mario" / "assignments" / "x" / "secret.txt"
+    legitimate.parent.mkdir(parents=True)
+    secret.parent.mkdir(parents=True)
+    legitimate.write_text("print(5)\n", encoding="utf-8")
+    secret.write_text("riservato\n", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "ROOT", root)
+
+    with pytest.raises(FileNotFoundError, match="non trovato o non consentito"):
+        course_board_server.resolve_submission_file_path(
+            {
+                "repo": "TheBitPoets/rossi-mario",
+                "submission": {
+                    "files": [
+                        {"path": "students/rossi-mario/assignments/somma-001/main.py"}
+                    ]
+                },
+            },
+            "teacher-private/rossi-mario/assignments/x/secret.txt",
         )
 
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -186,6 +186,22 @@ def test_data_root_process_lock_rejects_a_second_server(tmp_path) -> None:
     second_lock.release()
 
 
+def test_data_root_process_lock_rejects_a_legacy_server(tmp_path) -> None:
+    root = tmp_path / "data"
+    root.mkdir()
+    legacy_path = root / ".thebitlab-server.lock"
+    legacy_handle = course_board_server.DataRootProcessLock._acquire_handle(legacy_path)
+    try:
+        current_lock = course_board_server.DataRootProcessLock(root)
+        with pytest.raises(RuntimeError, match="Un altro server"):
+            current_lock.acquire()
+    finally:
+        course_board_server.DataRootProcessLock._release_handle(legacy_handle)
+
+    current_lock.acquire()
+    current_lock.release()
+
+
 @pytest.mark.skipif(
     os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
     reason="I permessi POSIX sul parent non sono verificabili in questo ambiente.",

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -2313,6 +2313,43 @@ def test_regenerated_report_does_not_copy_feedback_from_another_assignment() -> 
     assert generated["students"][0]["ai_feedback"]["status"] == "not_generated"
 
 
+@pytest.mark.parametrize(
+    ("previous_assignment", "generated_assignment"),
+    [
+        ("assignment-a", None),
+        (None, "assignment-a"),
+    ],
+)
+def test_regenerated_report_does_not_copy_feedback_when_only_one_assignment_id_is_missing(
+    previous_assignment: str | None,
+    generated_assignment: str | None,
+) -> None:
+    previous = {
+        "activity_id": "activity",
+        "students": [{
+            "student": "rossi",
+            "student_id": "student-rossi",
+            "ai_feedback": {"status": "approved", "approved_by_teacher": True},
+        }],
+    }
+    generated = {
+        "activity_id": "activity",
+        "students": [{
+            "student": "rossi",
+            "student_id": "student-rossi",
+            "ai_feedback": {"status": "not_generated", "approved_by_teacher": False},
+        }],
+    }
+    if previous_assignment is not None:
+        previous["assignment_id"] = previous_assignment
+    if generated_assignment is not None:
+        generated["assignment_id"] = generated_assignment
+
+    course_board_server.preserve_assignment_ai_feedback(previous, generated)
+
+    assert generated["students"][0]["ai_feedback"]["status"] == "not_generated"
+
+
 def test_generate_report_preserves_review_completed_while_tracking(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")

--- a/tests/test_student_lab_demo_setup.py
+++ b/tests/test_student_lab_demo_setup.py
@@ -69,3 +69,23 @@ def test_student_lab_demo_setup_does_not_reset_root_when_server_lock_is_busy(tmp
         student_lab_demo_setup.prepare_demo(root)
 
     assert existing_report.read_text(encoding="utf-8") == '{"activity_id": "existing"}'
+
+
+def test_student_lab_demo_setup_holds_lock_through_smoke(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "student-lab-demo"
+    original_run_smoke = student_lab_demo_setup.student_lab_demo_smoke.run_smoke
+
+    def assert_locked(current_root: Path):
+        competing_lock = student_lab_demo_setup.course_board_server.DataRootProcessLock(current_root)
+        with pytest.raises(RuntimeError, match="Un altro server"):
+            competing_lock.acquire()
+        return original_run_smoke(current_root)
+
+    monkeypatch.setattr(student_lab_demo_setup.student_lab_demo_smoke, "run_smoke", assert_locked)
+
+    summary = student_lab_demo_setup.prepare_demo(root)
+
+    assert summary["ok"] is True
+    released_lock = student_lab_demo_setup.course_board_server.DataRootProcessLock(root)
+    released_lock.acquire()
+    released_lock.release()

--- a/tests/test_student_lab_demo_setup.py
+++ b/tests/test_student_lab_demo_setup.py
@@ -8,6 +8,12 @@ import pytest
 from scripts import student_lab_demo_setup
 
 
+@pytest.fixture(autouse=True)
+def isolated_process_lock_dir(tmp_path, monkeypatch) -> None:
+    lock_dir = tmp_path.parent / f"{tmp_path.name}-process-locks"
+    monkeypatch.setenv("THEBITLAB_LOCK_DIR", str(lock_dir))
+
+
 def test_student_lab_demo_setup_prepares_stable_root(tmp_path) -> None:
     root = tmp_path / "student-lab-demo"
     stale = root / "stale.txt"

--- a/tests/test_student_lab_demo_setup.py
+++ b/tests/test_student_lab_demo_setup.py
@@ -85,6 +85,10 @@ def test_student_lab_demo_setup_holds_lock_through_smoke(tmp_path, monkeypatch) 
         competing_lock = student_lab_demo_setup.course_board_server.DataRootProcessLock(current_root)
         with pytest.raises(RuntimeError, match="Un altro server"):
             competing_lock.acquire()
+        with pytest.raises((OSError, BlockingIOError)):
+            student_lab_demo_setup.course_board_server.DataRootProcessLock._acquire_handle(
+                current_root / ".thebitlab-server.lock"
+            )
         return original_run_smoke(current_root)
 
     monkeypatch.setattr(student_lab_demo_setup.student_lab_demo_smoke, "run_smoke", assert_locked)

--- a/tests/test_student_lab_demo_setup.py
+++ b/tests/test_student_lab_demo_setup.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+import pytest
+
 from scripts import student_lab_demo_setup
 
 
@@ -45,3 +47,25 @@ def test_student_lab_demo_setup_keeps_running_when_old_root_cleanup_is_delayed(t
     assert summary["ok"] is True
     assert not (root / "stale.txt").exists()
     assert (root / summary["report"]).is_file()
+
+
+def test_student_lab_demo_setup_does_not_reset_root_when_server_lock_is_busy(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "student-lab-demo"
+    root.mkdir()
+    existing_report = root / "teacher-reports" / "demo" / "existing.json"
+    existing_report.parent.mkdir(parents=True)
+    existing_report.write_text('{"activity_id": "existing"}', encoding="utf-8")
+
+    def reject_lock(_self) -> None:
+        raise RuntimeError("root occupata")
+
+    monkeypatch.setattr(
+        student_lab_demo_setup.course_board_server.DataRootProcessLock,
+        "acquire",
+        reject_lock,
+    )
+
+    with pytest.raises(RuntimeError, match="Root demo in uso da un server attivo"):
+        student_lab_demo_setup.prepare_demo(root)
+
+    assert existing_report.read_text(encoding="utf-8") == '{"activity_id": "existing"}'

--- a/tests/test_student_lab_demo_smoke.py
+++ b/tests/test_student_lab_demo_smoke.py
@@ -26,6 +26,8 @@ def test_student_lab_demo_smoke_builds_complete_flow(tmp_path) -> None:
     register = json.loads((tmp_path / summary["teacher_register"]).read_text(encoding="utf-8"))
     student = register["students"][0]
     assert student["submitted"] is True
+    assert student["repo"] == "TheBitPoets/rossi-mario"
+    assert student["repo_path"] == "examples/assignment_tracking/student_repos/rossi-mario"
     assert student["grading"]["status"] == "graded_passed"
     assert student["submission"]["report_backend"] == "local"
     assert student["help"]["total"] == 1

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -397,6 +397,8 @@ def test_track_assignments_uses_report_file_manifest_when_available(tmp_path) ->
     student = target(tmp_path, "rossi-mario")
     write_report(student.path, "2026-10-18T18:22:10+02:00")
     report_path = student.path / "reports" / "python-base-somma-001" / "latest.json"
+    utils_path = student.path / "assignments" / "python-base-somma-001" / "utils.py"
+    utils_path.write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
     report = json.loads(report_path.read_text(encoding="utf-8"))
     report["files"] = [
         {"path": "assignments/python-base-somma-001/main.py", "role": "solution"},
@@ -415,6 +417,32 @@ def test_track_assignments_uses_report_file_manifest_when_available(tmp_path) ->
         ("assignments/python-base-somma-001/main.py", "solution"),
         ("assignments/python-base-somma-001/utils.py", "support"),
     ]
+
+
+def test_track_assignments_ignores_report_files_outside_student_repo(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    write_report(student.path, "2026-10-18T18:22:10+02:00")
+    report_path = student.path / "reports" / "python-base-somma-001" / "latest.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    secret = tmp_path / "teacher-private" / "secret.txt"
+    secret.parent.mkdir()
+    secret.write_text("riservato\n", encoding="utf-8")
+    report["files"] = [
+        {"path": str(secret), "role": "support"},
+        {"path": "assignments/python-base-somma-001/main.py", "role": "solution"},
+    ]
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-19T23:59:00+02:00",
+    )
+
+    files = index["students"][0]["submission"]["files"]
+    assert [entry["role"] for entry in files] == ["solution"]
+    assert files[0]["path"].endswith("assignments/python-base-somma-001/main.py")
 
 
 def test_track_assignments_marks_pending_before_due_date(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sys
 from pathlib import Path
 
 import pytest
 
-from scripts import assignment_records, student_help_service, student_identity, student_support_policy, track_assignments
+from scripts import (
+    assignment_records,
+    course_board_server,
+    student_help_service,
+    student_identity,
+    student_support_policy,
+    track_assignments,
+)
 from scripts.thebitlab_repository_providers import LocalRepositoryProvider, StudentRepository
 
 
@@ -366,6 +374,42 @@ def test_track_assignments_lists_multiple_submission_files(tmp_path) -> None:
     assert any(path.endswith("assignments/python-base-somma-001/utils.py") for path in paths)
     assert any(path.endswith("assignments/python-base-somma-001/README.md") for path in paths)
     assert not any("__pycache__" in path for path in paths)
+
+
+def test_tracking_file_references_survive_moving_the_server_root(tmp_path, monkeypatch) -> None:
+    project_root = tmp_path / "project"
+    original_root = project_root / "demo-a"
+    moved_root = project_root / "moved-demo"
+    original_root.mkdir(parents=True)
+    activity_path = write_activity(original_root)
+    student = target(original_root, "rossi-mario")
+    write_report(student.path, "2026-10-18T18:22:10+02:00")
+    monkeypatch.setattr(track_assignments, "PROJECT_ROOT", project_root)
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-19T23:59:00+02:00",
+        server_root=original_root,
+    )
+    tracked_student = index["students"][0]
+    source_reference = tracked_student["submission"]["files"][0]["path"]
+    assert source_reference == "assignments/python-base-somma-001/main.py"
+    assert tracked_student["submission"]["source_path"] == source_reference
+
+    shutil.move(original_root, moved_root)
+    monkeypatch.setattr(course_board_server, "ROOT", moved_root)
+    monkeypatch.setattr(course_board_server, "APP_ROOT", project_root)
+
+    resolved = course_board_server.resolve_submission_file_path(tracked_student, source_reference)
+
+    assert resolved == (
+        moved_root
+        / "rossi-mario"
+        / "assignments"
+        / "python-base-somma-001"
+        / "main.py"
+    )
 
 
 def test_track_assignments_resolves_relative_report_source_from_student_repo(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -246,6 +247,7 @@ def test_track_assignments_marks_submitted_on_time(tmp_path) -> None:
     assert row["grading"]["status"] == "graded_passed"
     assert row["grading"]["tests_passed"] == 2
     assert row["ai_feedback"]["status"] == "not_generated"
+    assert Path(row["repo_path"]) == student.path.resolve()
     assert row["submission"]["files"][0]["path"].endswith("assignments/python-base-somma-001/main.py")
     assert row["submission"]["files"][0]["role"] == "solution"
 

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -489,6 +489,29 @@ def test_track_assignments_ignores_report_files_outside_student_repo(tmp_path) -
     assert files[0]["path"].endswith("assignments/python-base-somma-001/main.py")
 
 
+def test_track_assignments_does_not_scan_assignment_when_explicit_manifest_is_empty(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    write_report(student.path, "2026-10-18T18:22:10+02:00")
+    assignment_path = student.path / "assignments" / "python-base-somma-001"
+    unlisted_path = assignment_path / "non-inviato.txt"
+    unlisted_path.write_text("Non dichiarato nel manifest.\n", encoding="utf-8")
+    report_path = student.path / "reports" / "python-base-somma-001" / "latest.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report["files"] = [
+        {"path": "assignments/python-base-somma-001/mancante.py", "role": "solution"},
+    ]
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        due_at="2026-10-19T23:59:00+02:00",
+    )
+
+    assert index["students"][0]["submission"]["files"] == []
+
+
 def test_track_assignments_marks_pending_before_due_date(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "bianchi-luca")

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -2288,6 +2288,16 @@ code {
   margin-bottom: 1rem;
 }
 
+.studentHelpDialogError {
+  margin: 0 0 1rem;
+  border: 1px solid #d97757;
+  border-radius: 8px;
+  background: #fff8f5;
+  padding: .75rem;
+  color: #8f1d14;
+  overflow-wrap: anywhere;
+}
+
 .studentHelpDialogList {
   display: grid;
   gap: 1rem;

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -1677,18 +1677,7 @@ label > textarea {
   font-size: .78rem;
 }
 
-.studentHelpDetails {
-  margin-top: .45rem;
-  font-size: .78rem;
-}
-
 .aiFeedbackDetails summary {
-  cursor: pointer;
-  color: #111111;
-  font-weight: 800;
-}
-
-.studentHelpDetails summary {
   cursor: pointer;
   color: #111111;
   font-weight: 800;
@@ -1707,35 +1696,11 @@ label > textarea {
   scrollbar-gutter: stable;
 }
 
-.studentHelpDetails dl {
-  display: grid;
-  gap: .45rem;
-  margin: .45rem 0 0;
-  max-height: 14rem;
-  overflow-y: auto;
-  padding: .55rem;
-  border: 1px solid rgba(17, 17, 17, .12);
-  border-radius: 8px;
-  background: #fafafa;
-  scrollbar-gutter: stable;
-}
-
 .aiFeedbackDetails div {
   min-width: 0;
 }
 
-.studentHelpDetails div {
-  min-width: 0;
-}
-
 .aiFeedbackDetails dt {
-  color: var(--muted);
-  font-size: .68rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.studentHelpDetails dt {
   color: var(--muted);
   font-size: .68rem;
   font-weight: 800;
@@ -1748,14 +1713,9 @@ label > textarea {
   text-align: justify;
 }
 
-.studentHelpDetails dd {
-  margin: .12rem 0 0;
-  overflow-wrap: anywhere;
-  text-align: justify;
-}
-
-.studentHelpDetails p {
-  margin: .35rem 0;
+.studentHelpButton {
+  width: fit-content;
+  margin-top: .45rem;
 }
 
 .aiFeedbackActions {
@@ -2314,6 +2274,95 @@ code {
   gap: .8rem;
 }
 
+.studentHelpDialogBody {
+  min-height: 0;
+  padding: 1.1rem;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
+.studentHelpDialogSummary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .45rem;
+  margin-bottom: 1rem;
+}
+
+.studentHelpDialogList {
+  display: grid;
+  gap: 1rem;
+}
+
+.studentHelpDialogItem {
+  display: grid;
+  gap: .7rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 1rem;
+}
+
+.studentHelpDialogItemHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: .75rem;
+}
+
+.studentHelpDialogItem h3,
+.studentHelpLegacyBlock h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.studentHelpDialogItem strong {
+  display: block;
+  margin-bottom: .25rem;
+  color: var(--muted);
+  font-size: .76rem;
+  text-transform: uppercase;
+}
+
+.studentHelpDialogMeta {
+  margin: 0;
+  color: var(--muted);
+  font-size: .78rem;
+}
+
+.studentHelpDialogText {
+  margin: 0;
+  overflow-wrap: anywhere;
+  text-align: start;
+  white-space: pre-wrap;
+}
+
+.studentHelpDialogProvider {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .8rem;
+}
+
+.studentHelpDialogProvider span,
+.studentHelpDialogProvider small {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.studentHelpLegacyBlock {
+  display: grid;
+  gap: .75rem;
+  border-top: 2px solid #d97757;
+  padding-top: 1rem;
+}
+
+.studentHelpLegacyBlock > p {
+  margin: 0;
+}
+
+.studentHelpLegacyItem {
+  background: #fff8f5;
+}
+
 .reviewGrid {
   display: grid;
   grid-template-columns: minmax(11rem, var(--review-list-width, 20rem)) 8px minmax(0, 1fr);
@@ -2509,5 +2558,19 @@ code {
 
   .testDetailsDialogColumns {
     grid-template-columns: 1fr;
+  }
+
+  .studentHelpDialogProvider {
+    grid-template-columns: 1fr;
+  }
+
+  .studentHelpDialog {
+    height: min(94dvh, 52rem);
+    min-height: 0;
+    max-height: 94dvh;
+  }
+
+  .studentHelpDialogItemHead {
+    display: grid;
   }
 }

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -630,6 +630,22 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
     </div>
   </dialog>
 
+  <dialog id="studentHelpDialog" class="reviewDialog studentHelpDialog" aria-labelledby="studentHelpDialogTitle" aria-describedby="studentHelpDialogStatus">
+    <div class="reviewDialogHead">
+      <div>
+        <p class="modalBreadcrumb" aria-label="Percorso modal">Dashboard &gt; Studenti &gt; Dettaglio aiuti</p>
+        <h2 id="studentHelpDialogTitle">Dettaglio richieste di aiuto</h2>
+        <p id="studentHelpDialogStatus" class="status">Seleziona una richiesta di aiuto dalla tabella studenti.</p>
+      </div>
+      <div class="reviewDialogActions">
+        <button id="studentHelpCloseBtn" type="button" class="smallButton" title="Chiudi il dettaglio aiuti e torna agli studenti.">Chiudi</button>
+      </div>
+    </div>
+    <div id="studentHelpDialogBody" class="studentHelpDialogBody">
+      Nessuna richiesta di aiuto selezionata.
+    </div>
+  </dialog>
+
   <dialog id="coverageDialog" class="coverageDialog" aria-labelledby="coverageDialogTitle">
     <div class="coverageDialogHead">
       <div>

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -499,7 +499,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
     <div class="overviewDialogHead">
       <div>
         <h2 id="overviewDialogTitle">Quadro classe</h2>
-        <p class="status">Elenco e matrice delle consegne filtrate.</p>
+        <p id="overviewDialogStatus" class="status" aria-live="polite">Elenco e matrice delle consegne filtrate.</p>
       </div>
       <div class="dialogActions">
         <button id="overviewCloseBtn" type="button" class="smallButton" title="Chiudi il quadro classe e torna alla dashboard.">Chiudi</button>
@@ -651,7 +651,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
       <div>
         <p id="coverageBreadcrumb" class="modalBreadcrumb" aria-label="Percorso modal">Dashboard &gt; Copertura registri</p>
         <h2 id="coverageDialogTitle">Copertura registri</h2>
-        <p class="status">Activity con registri generati, mancanti e ultimi output disponibili.</p>
+        <p id="coverageDialogStatus" class="status" aria-live="polite">Activity con registri generati, mancanti e ultimi output disponibili.</p>
       </div>
       <div class="dialogActions">
         <button id="coverageCloseBtn" type="button" class="smallButton" title="Chiudi la copertura registri e torna alla dashboard.">Chiudi</button>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -130,6 +130,7 @@ const state = {
   overviewRows: [],
   report: null,
   reportName: "",
+  reportLoadRevision: 0,
   filter: "all",
   overviewFilters: {
     class: "",
@@ -1122,6 +1123,7 @@ function renderRosterPanel() {
 }
 
 async function loadSelectedReport() {
+  const revision = ++state.reportLoadRevision;
   const name = els.reportSelect.value;
   if (!name) {
     setStatus("Seleziona un registro consegne.");
@@ -1138,6 +1140,9 @@ async function loadSelectedReport() {
       throw new Error("il server ha restituito un registro non valido");
     }
   } catch (error) {
+    if (revision !== state.reportLoadRevision || els.reportSelect.value !== name) {
+      return false;
+    }
     state.report = null;
     state.reportName = "";
     els.reportSelect.value = "";
@@ -1146,6 +1151,9 @@ async function loadSelectedReport() {
     closeStudentHelpDialog();
     renderDashboard();
     setStatus(`Registro non caricato: ${error.message}`);
+    return false;
+  }
+  if (revision !== state.reportLoadRevision || els.reportSelect.value !== name) {
     return false;
   }
   state.report = payload.report;

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -4065,10 +4065,16 @@ function renderStudentHelpDialogContent(entry) {
   const data = entry?.help || {};
   const events = Array.isArray(data.events) ? data.events : [];
   const legacy = data.legacy && typeof data.legacy === "object" ? data.legacy : {};
+  const errorNotice = data.error ? `
+    <p class="studentHelpDialogError" role="alert">
+      <strong>Log autorevole non disponibile:</strong> ${escapeHtml(data.error)}
+    </p>
+  ` : "";
   if (!events.length && !Number(legacy.total || 0)) {
-    return `<p class="status">${escapeHtml(data.error || "Nessuna richiesta di aiuto disponibile.")}</p>`;
+    return errorNotice || '<p class="status">Nessuna richiesta di aiuto disponibile.</p>';
   }
   return `
+    ${errorNotice}
     <div class="studentHelpDialogSummary">
       ${badge(`Aiuti ${Number(data.total || 0)}`, Number(data.denied || 0) ? "bad" : "ok")}
       ${badge(`AI ${Number(data.ai_total || data.counts?.ai || 0)}`, "warn")}

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -194,6 +194,7 @@ const els = {
   coverageStatus: document.querySelector("#coverageStatus"),
   coverageSummary: document.querySelector("#coverageSummary"),
   coverageDialogSummary: document.querySelector("#coverageDialogSummary"),
+  coverageDialogStatus: document.querySelector("#coverageDialogStatus"),
   coverageDialog: document.querySelector("#coverageDialog"),
   coverageBreadcrumb: document.querySelector("#coverageBreadcrumb"),
   coverageOpenBtn: document.querySelector("#coverageOpenBtn"),
@@ -205,6 +206,7 @@ const els = {
   overviewBody: document.querySelector("#overviewBody"),
   overviewSummary: document.querySelector("#overviewSummary"),
   overviewDialogSummary: document.querySelector("#overviewDialogSummary"),
+  overviewDialogStatus: document.querySelector("#overviewDialogStatus"),
   overviewClassFilter: document.querySelector("#overviewClassFilter"),
   overviewStudentFilter: document.querySelector("#overviewStudentFilter"),
   overviewActivityFilter: document.querySelector("#overviewActivityFilter"),
@@ -1136,15 +1138,20 @@ function clearActiveReport() {
   renderDashboard();
 }
 
-async function loadSelectedReport() {
+function setReportLoadStatus(message, statusElement = null) {
+  setStatus(message);
+  if (statusElement) statusElement.textContent = message;
+}
+
+async function loadSelectedReport({ statusElement = null } = {}) {
   const revision = ++state.reportLoadRevision;
   const name = els.reportSelect.value;
   if (!name) {
     clearActiveReport();
-    setStatus("Seleziona un registro consegne.");
+    setReportLoadStatus("Seleziona un registro consegne.", statusElement);
     return false;
   }
-  setStatus(`Caricamento registro ${name}...`);
+  setReportLoadStatus(`Caricamento registro ${name}...`, statusElement);
   let payload;
   try {
     payload = await api("/api/assignment-reports/load", {
@@ -1159,7 +1166,7 @@ async function loadSelectedReport() {
       return false;
     }
     clearActiveReport();
-    setStatus(`Registro non caricato: ${error.message}`);
+    setReportLoadStatus(`Registro non caricato: ${error.message}`, statusElement);
     return false;
   }
   if (revision !== state.reportLoadRevision || els.reportSelect.value !== name) {
@@ -1172,7 +1179,7 @@ async function loadSelectedReport() {
   focusOverviewClassFromReport(state.report);
   renderOverview();
   renderDashboard();
-  setStatus(`Registro caricato: ${name}.`);
+  setReportLoadStatus(`Registro caricato: ${name}.`, statusElement);
   return true;
 }
 
@@ -4829,7 +4836,7 @@ function closeStudentsDialog() {
   }
 }
 
-els.loadReportBtn.addEventListener("click", loadSelectedReport);
+els.loadReportBtn.addEventListener("click", () => loadSelectedReport());
 els.reloadBtn.addEventListener("click", async () => {
   await loadReports();
   await loadAssignments();
@@ -4873,7 +4880,7 @@ els.saveAssignmentBtn?.addEventListener("click", saveAssignmentRecord);
 els.distributeAssignmentBtn?.addEventListener("click", distributeAssignment);
 els.deleteAssignmentBtn?.addEventListener("click", deleteSelectedAssignment);
 els.generateReportBtn.addEventListener("click", generateReport);
-els.reportSelect.addEventListener("change", loadSelectedReport);
+els.reportSelect.addEventListener("change", () => loadSelectedReport());
 els.coverageOpenBtn.addEventListener("click", openCoverageDialog);
 els.coverageCloseBtn.addEventListener("click", closeCoverageDialog);
 els.overviewOpenBtn.addEventListener("click", openOverviewDialog);
@@ -5046,7 +5053,7 @@ els.coverageBody.addEventListener("click", async (event) => {
   }
   if (reportButton && reportButton.dataset.coverageReport) {
     els.reportSelect.value = reportButton.dataset.coverageReport;
-    const loaded = await loadSelectedReport();
+    const loaded = await loadSelectedReport({ statusElement: els.coverageDialogStatus });
     if (loaded && reportButton.dataset.coverageOpenStudents === "true") {
       openStudentsDialog();
     }
@@ -5086,7 +5093,7 @@ els.overviewBody.addEventListener("click", async (event) => {
   const button = event.target.closest("[data-overview-report]");
   if (!button) return;
   els.reportSelect.value = button.dataset.overviewReport;
-  const loaded = await loadSelectedReport();
+  const loaded = await loadSelectedReport({ statusElement: els.overviewDialogStatus });
   if (loaded && button.dataset.overviewStudent) {
     openSubmission(button.dataset.overviewStudent, "", "overview");
   }
@@ -5095,7 +5102,7 @@ els.overviewMatrixBody.addEventListener("click", async (event) => {
   const button = event.target.closest("[data-overview-report]");
   if (!button || button.disabled) return;
   els.reportSelect.value = button.dataset.overviewReport;
-  const loaded = await loadSelectedReport();
+  const loaded = await loadSelectedReport({ statusElement: els.overviewDialogStatus });
   if (loaded && button.dataset.overviewStudent) {
     openSubmission(button.dataset.overviewStudent, "", "overview");
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -4382,6 +4382,7 @@ function filteredStudents(students) {
 }
 
 function renderStudents(students) {
+  closeStudentHelpDialog();
   const visible = filteredStudents(students);
   els.tableStatus.textContent = state.report
     ? `Mostrati ${visible.length}/${students.length} studenti.`

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1122,6 +1122,10 @@ function renderRosterPanel() {
   }).join("");
 }
 
+function invalidateReportLoads() {
+  state.reportLoadRevision += 1;
+}
+
 async function loadSelectedReport() {
   const revision = ++state.reportLoadRevision;
   const name = els.reportSelect.value;
@@ -3759,6 +3763,7 @@ async function generateReport() {
         assignment_id: state.selectedAssignmentId,
       }),
     });
+    invalidateReportLoads();
     state.report = payload.report;
     state.reportName = payload.saved?.name || "";
     state.reports = payload.reports || [];
@@ -4483,6 +4488,7 @@ async function reviewAiFeedback(studentId, decision) {
       decision,
     }),
   });
+  invalidateReportLoads();
   state.report = payload.report;
   renderDashboard();
   const outcome = {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1137,7 +1137,7 @@ function clearActiveReport() {
   els.reportSelect.value = "";
   els.studentsOpenBtn.disabled = true;
   clearReview();
-  closeStudentHelpDialog();
+  closeStudentHelpDialog({ restoreFocus: false });
   renderDashboard();
 }
 
@@ -4228,12 +4228,21 @@ function openStudentHelpDialog(detailsKey) {
   }
 }
 
-function closeStudentHelpDialog() {
+function studentHelpButtonForKey(detailsKey) {
+  return Array.from(document.querySelectorAll("[data-student-help-key]"))
+    .find((button) => button.dataset.studentHelpKey === detailsKey) || null;
+}
+
+function closeStudentHelpDialog({ restoreFocus = true } = {}) {
+  const detailsKey = state.studentHelpDialogKey;
   if (els.studentHelpDialog?.open) {
     els.studentHelpDialog.close();
   }
   state.studentHelpDialogKey = "";
   state.studentHelpDialogReportName = "";
+  if (restoreFocus && detailsKey) {
+    requestAnimationFrame(() => studentHelpButtonForKey(detailsKey)?.focus());
+  }
 }
 
 function clearStudentHelpRows() {
@@ -4409,7 +4418,7 @@ function renderStudents(students) {
     && visible.some((student) => studentHelpRowKey(student) === activeStudentHelpKey),
   );
   if (els.studentHelpDialog?.open && !keepStudentHelpDialogOpen) {
-    closeStudentHelpDialog();
+    closeStudentHelpDialog({ restoreFocus: false });
   }
   els.tableStatus.textContent = state.report
     ? `Mostrati ${visible.length}/${students.length} studenti.`

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -147,6 +147,7 @@ const state = {
   legendTopic: "overview",
   coverageCollapsedActivities: new Set(),
   testDetailsRows: new Map(),
+  studentHelpRows: new Map(),
   reviewStudent: null,
   reviewSource: "",
   reviewFilePath: "",
@@ -241,6 +242,10 @@ const els = {
   testDetailsCloseBtn: document.querySelector("#testDetailsCloseBtn"),
   testDetailsDialogStatus: document.querySelector("#testDetailsDialogStatus"),
   testDetailsDialogBody: document.querySelector("#testDetailsDialogBody"),
+  studentHelpDialog: document.querySelector("#studentHelpDialog"),
+  studentHelpCloseBtn: document.querySelector("#studentHelpCloseBtn"),
+  studentHelpDialogStatus: document.querySelector("#studentHelpDialogStatus"),
+  studentHelpDialogBody: document.querySelector("#studentHelpDialogBody"),
   legendDialog: document.querySelector("#legendDialog"),
   legendCloseBtn: document.querySelector("#legendCloseBtn"),
   legendStatus: document.querySelector("#legendDialogStatus"),
@@ -3914,7 +3919,19 @@ function aiFeedbackReviewDetails(ai) {
   `;
 }
 
-function studentHelpDetails(help) {
+function studentHelpStatusBadge(event) {
+  const response = event?.response && typeof event.response === "object" ? event.response : {};
+  if (!event?.allowed) return badge("Bloccata", "bad");
+  if (event.provider_status === "pending") return badge("In elaborazione", "warn");
+  if (
+    event.provider_status === "interrupted"
+    || response.status === "error"
+    || (event.provider_status === "completed" && !response.status)
+  ) return badge("Risposta non disponibile", "bad");
+  return badge("Consentita", "ok");
+}
+
+function studentHelpDetails(help, options = {}) {
   const data = help || {};
   const total = Number(data.total || 0);
   const aiTotal = Number(data.ai_total || data.counts?.ai || 0);
@@ -3923,52 +3940,103 @@ function studentHelpDetails(help) {
   const events = Array.isArray(data.events) ? data.events : [];
   const legacy = data.legacy && typeof data.legacy === "object" ? data.legacy : {};
   const legacyTotal = Number(legacy.total || 0);
-  const legacyEvents = Array.isArray(legacy.events) ? legacy.events : [];
-  const rows = events.length
-    ? events.map((event) => {
-      const response = event.response && typeof event.response === "object" ? event.response : {};
-      let responseBadge = badge("Consentita", "ok");
-      if (!event.allowed) responseBadge = badge("Bloccata", "bad");
-      else if (event.provider_status === "pending") responseBadge = badge("In elaborazione", "warn");
-      else if (
-        event.provider_status === "interrupted"
-        || response.status === "error"
-        || (event.provider_status === "completed" && !response.status)
-      ) responseBadge = badge("Risposta non disponibile", "bad");
-      return `
-        <div>
-          <dt>${escapeHtml(formatDate(event.requested_at))} - ${escapeHtml(event.label || event.help_type || "aiuto")}</dt>
-          <dd>
-            ${responseBadge}
-            ${event.prompt ? `<p>${escapeHtml(event.prompt)}</p>` : "<p>Prompt non disponibile.</p>"}
-            ${event.reason ? `<small>${escapeHtml(event.reason)}</small>` : ""}
-          </dd>
-        </div>
-      `;
-    }).join("")
-    : `<div><dt>Prompt</dt><dd>${escapeHtml(data.error || "Nessuna richiesta registrata.")}</dd></div>`;
-  const legacyRows = legacyEvents.map((event) => `
-    <div>
-      <dt>${escapeHtml(formatDate(event.requested_at))} - ${escapeHtml(event.label || event.help_type || "aiuto")}</dt>
-      <dd>${event.prompt ? `<p>${escapeHtml(event.prompt)}</p>` : "<p>Prompt non disponibile.</p>"}</dd>
-    </div>
-  `).join("");
+  const hasDetails = total > 0 || legacyTotal > 0 || Boolean(data.error);
   return `
     <div class="studentHelpCell">
       ${badge(`Aiuti ${total}`, kind)}<br>
       <small>Consegna: ${escapeHtml(data.activity_id || "-")}</small><br>
       <small>AI: ${escapeHtml(aiTotal)} - Bloccate: ${escapeHtml(denied)}</small>
-      <details class="studentHelpDetails">
-        <summary>Prompt aiuti</summary>
-        <dl>${rows}</dl>
-      </details>
-      ${legacyTotal ? `
-        <details class="studentHelpDetails studentHelpLegacy">
-          <summary>Legacy non verificati (${escapeHtml(legacyTotal)})</summary>
-          <p><strong>Attenzione:</strong> dati storici provenienti dal repository studente; non incidono su budget e metriche.</p>
-          ${legacyRows ? `<dl>${legacyRows}</dl>` : ""}
-        </details>
-      ` : ""}
+      <button
+        type="button"
+        class="smallButton studentHelpButton"
+        data-student-help-key="${escapeHtml(options.detailsKey || "")}"
+        title="${hasDetails ? "Apri prompt, risposte e dati delle richieste di aiuto." : "Nessuna richiesta di aiuto disponibile."}"
+        ${hasDetails ? "" : "disabled"}
+      >Dettagli aiuti</button>
+    </div>
+  `;
+}
+
+function renderStudentHelpUsage(response) {
+  const usage = response?.usage && typeof response.usage === "object" ? response.usage : null;
+  if (!usage) return "";
+  const input = Number(usage.input_tokens || 0);
+  const output = Number(usage.output_tokens || 0);
+  const total = Number(usage.total_tokens || 0);
+  return `<small>Utilizzo dichiarato: ${escapeHtml(total)} token (${escapeHtml(input)} input, ${escapeHtml(output)} output).</small>`;
+}
+
+function renderStudentHelpEvent(event, index) {
+  const response = event?.response && typeof event.response === "object" ? event.response : {};
+  const provider = !event?.allowed
+    ? "Non invocato"
+    : response.provider_label || response.provider || "Provider non indicato";
+  let responseText = response.message || response.detail || "Nessuna risposta disponibile.";
+  if (!event?.allowed) responseText = "Nessuna risposta generata: la richiesta e stata bloccata dalla policy.";
+  else if (event.provider_status === "pending") responseText = "Risposta in elaborazione.";
+  else if (event.provider_status === "interrupted") responseText = response.message || response.detail || "Elaborazione interrotta.";
+  return `
+    <article class="studentHelpDialogItem">
+      <div class="studentHelpDialogItemHead">
+        <h3>Richiesta ${escapeHtml(index + 1)} - ${escapeHtml(event.label || event.help_type || "Aiuto")}</h3>
+        ${studentHelpStatusBadge(event)}
+      </div>
+      <p class="studentHelpDialogMeta">${escapeHtml(formatDate(event.requested_at))}</p>
+      <div>
+        <strong>Prompt dello studente</strong>
+        <p class="studentHelpDialogText">${escapeHtml(event.prompt || "Prompt non disponibile.")}</p>
+      </div>
+      <div>
+        <strong>Risposta</strong>
+        <p class="studentHelpDialogText">${escapeHtml(responseText)}</p>
+      </div>
+      <div class="studentHelpDialogProvider">
+        <span><strong>Provider</strong>${escapeHtml(provider)}</span>
+        ${renderStudentHelpUsage(response)}
+      </div>
+      ${event.reason ? `<div><strong>Esito della policy</strong><p class="studentHelpDialogText">${escapeHtml(event.reason)}</p></div>` : ""}
+    </article>
+  `;
+}
+
+function renderStudentHelpLegacy(legacy) {
+  const events = Array.isArray(legacy?.events) ? legacy.events : [];
+  const total = Number(legacy?.total || 0);
+  if (!total) return "";
+  return `
+    <section class="studentHelpLegacyBlock">
+      <h3>Legacy non verificati (${escapeHtml(total)})</h3>
+      <p><strong>Attenzione:</strong> dati storici provenienti dal repository studente; non incidono su budget e metriche.</p>
+      ${events.map((event, index) => `
+        <article class="studentHelpDialogItem studentHelpLegacyItem">
+          <h3>Richiesta legacy ${escapeHtml(index + 1)} - ${escapeHtml(event.label || event.help_type || "Aiuto")}</h3>
+          <p class="studentHelpDialogMeta">${escapeHtml(formatDate(event.requested_at))}</p>
+          <div>
+            <strong>Prompt dello studente</strong>
+            <p class="studentHelpDialogText">${escapeHtml(event.prompt || "Prompt non disponibile.")}</p>
+          </div>
+        </article>
+      `).join("")}
+    </section>
+  `;
+}
+
+function renderStudentHelpDialogContent(entry) {
+  const data = entry?.help || {};
+  const events = Array.isArray(data.events) ? data.events : [];
+  const legacy = data.legacy && typeof data.legacy === "object" ? data.legacy : {};
+  if (!events.length && !Number(legacy.total || 0)) {
+    return `<p class="status">${escapeHtml(data.error || "Nessuna richiesta di aiuto disponibile.")}</p>`;
+  }
+  return `
+    <div class="studentHelpDialogSummary">
+      ${badge(`Aiuti ${Number(data.total || 0)}`, Number(data.denied || 0) ? "bad" : "ok")}
+      ${badge(`AI ${Number(data.ai_total || data.counts?.ai || 0)}`, "warn")}
+      ${badge(`Bloccate ${Number(data.denied || 0)}`, Number(data.denied || 0) ? "bad" : "muted")}
+    </div>
+    <div class="studentHelpDialogList">
+      ${events.map(renderStudentHelpEvent).join("")}
+      ${renderStudentHelpLegacy(legacy)}
     </div>
   `;
 }
@@ -4090,6 +4158,26 @@ function clearTestDetailsRows(prefix) {
       state.testDetailsRows.delete(key);
     }
   }
+}
+
+function openStudentHelpDialog(detailsKey) {
+  const entry = state.studentHelpRows.get(detailsKey);
+  if (!entry || !els.studentHelpDialog) return;
+  els.studentHelpDialogStatus.textContent = `${entry.student || "Studente"} - ${entry.activity || "activity non indicata"}.`;
+  els.studentHelpDialogBody.innerHTML = renderStudentHelpDialogContent(entry);
+  if (!els.studentHelpDialog.open) {
+    els.studentHelpDialog.showModal();
+  }
+}
+
+function closeStudentHelpDialog() {
+  if (els.studentHelpDialog?.open) {
+    els.studentHelpDialog.close();
+  }
+}
+
+function clearStudentHelpRows() {
+  state.studentHelpRows.clear();
 }
 
 function externalLink(url, label = "GitHub") {
@@ -4263,6 +4351,7 @@ function renderStudents(students) {
   }
   els.studentsBody.innerHTML = "";
   clearTestDetailsRows("students-");
+  clearStudentHelpRows();
   if (!state.report) {
     els.studentsBody.innerHTML = '<tr><td colspan="8">Carica un registro consegne.</td></tr>';
     setupResizableTable(els.studentsTable, "students");
@@ -4279,10 +4368,16 @@ function renderStudents(students) {
     const help = student.help || {};
     const submission = student.submission || {};
     const testDetailsKey = `students-${student.student || student.student_id || ""}`;
+    const studentHelpKey = `student-help-${student.student_id || student.student || ""}`;
     state.testDetailsRows.set(testDetailsKey, {
       title: state.report?.title || state.report?.activity_id || "Activity",
       subtitle: `${student.student || student.student_id || "Studente"} - ${classValue(state.report) || "classe non indicata"}`,
       grading,
+    });
+    state.studentHelpRows.set(studentHelpKey, {
+      student: student.student || student.student_id || "Studente",
+      activity: help.activity_id || state.report?.title || state.report?.activity_id || "Activity",
+      help,
     });
     const files = submissionFiles(student);
     const canReview = student.submitted && files.length > 0;
@@ -4314,7 +4409,7 @@ function renderStudents(students) {
       <td>
         <div data-ai-feedback-student="${escapeHtml(student.student_id || student.student)}">
           ${aiFeedbackDetails(ai)}
-          ${studentHelpDetails(help)}
+          ${studentHelpDetails(help, { detailsKey: studentHelpKey })}
         </div>
       </td>
       <td>
@@ -4735,6 +4830,7 @@ els.reviewPrevBtn.addEventListener("click", () => openAdjacentSubmission(-1));
 els.reviewNextBtn.addEventListener("click", () => openAdjacentSubmission(1));
 els.reviewCloseBtn.addEventListener("click", closeReviewDialog);
 els.testDetailsCloseBtn.addEventListener("click", closeTestDetailsDialog);
+els.studentHelpCloseBtn.addEventListener("click", closeStudentHelpDialog);
 els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) {
     clearSelectedAssignment();
@@ -4946,6 +5042,13 @@ els.studentsBody.addEventListener("click", (event) => {
     event.preventDefault();
     event.stopPropagation();
     openTestDetailsDialog(detailButton.dataset.testDetailsKey);
+    return;
+  }
+  const helpButton = event.target.closest("[data-student-help-key]");
+  if (helpButton && !helpButton.disabled) {
+    event.preventDefault();
+    event.stopPropagation();
+    openStudentHelpDialog(helpButton.dataset.studentHelpKey);
     return;
   }
   const aiButton = event.target.closest("[data-ai-feedback-decision]");

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -4489,7 +4489,13 @@ async function reviewAiFeedback(studentId, decision) {
     const message = "Carica un registro prima di revisionare il feedback AI.";
     setStatus(message);
     setStudentsDialogStatus(message);
-    return;
+    return false;
+  }
+  if (els.reportSelect.value !== state.reportName) {
+    const message = "Attendi il caricamento del registro selezionato prima di revisionare il feedback AI.";
+    setStatus(message);
+    setStudentsDialogStatus(message);
+    return false;
   }
   const reportName = state.reportName;
   invalidateReportLoads();

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -151,6 +151,7 @@ const state = {
   testDetailsRows: new Map(),
   studentHelpRows: new Map(),
   studentHelpDialogKey: "",
+  studentHelpDialogReportName: "",
   reviewStudent: null,
   reviewSource: "",
   reviewFilePath: "",
@@ -4219,6 +4220,7 @@ function openStudentHelpDialog(detailsKey) {
   const entry = state.studentHelpRows.get(detailsKey);
   if (!entry || !els.studentHelpDialog) return;
   state.studentHelpDialogKey = detailsKey;
+  state.studentHelpDialogReportName = state.reportName;
   els.studentHelpDialogStatus.textContent = `${entry.student || "Studente"} - ${entry.activity || "activity non indicata"}.`;
   els.studentHelpDialogBody.innerHTML = renderStudentHelpDialogContent(entry);
   if (!els.studentHelpDialog.open) {
@@ -4231,6 +4233,7 @@ function closeStudentHelpDialog() {
     els.studentHelpDialog.close();
   }
   state.studentHelpDialogKey = "";
+  state.studentHelpDialogReportName = "";
 }
 
 function clearStudentHelpRows() {
@@ -4402,6 +4405,7 @@ function renderStudents(students) {
   const keepStudentHelpDialogOpen = Boolean(
     els.studentHelpDialog?.open
     && activeStudentHelpKey
+    && state.studentHelpDialogReportName === state.reportName
     && visible.some((student) => studentHelpRowKey(student) === activeStudentHelpKey),
   );
   if (els.studentHelpDialog?.open && !keepStudentHelpDialogOpen) {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1125,20 +1125,31 @@ async function loadSelectedReport() {
   const name = els.reportSelect.value;
   if (!name) {
     setStatus("Seleziona un registro consegne.");
-    return;
+    return false;
   }
   setStatus(`Caricamento registro ${name}...`);
-  const payload = await api("/api/assignment-reports/load", {
-    method: "POST",
-    body: JSON.stringify({ name }),
-  });
+  let payload;
+  try {
+    payload = await api("/api/assignment-reports/load", {
+      method: "POST",
+      body: JSON.stringify({ name }),
+    });
+    if (!payload.report || !Array.isArray(payload.report.students)) {
+      throw new Error("il server ha restituito un registro non valido");
+    }
+  } catch (error) {
+    setStatus(`Registro non caricato: ${error.message}`);
+    return false;
+  }
   state.report = payload.report;
   state.reportName = name;
+  els.studentsOpenBtn.disabled = false;
   clearReview();
   focusOverviewClassFromReport(state.report);
   renderOverview();
   renderDashboard();
   setStatus(`Registro caricato: ${name}.`);
+  return true;
 }
 
 function readReviewSplit() {
@@ -4830,7 +4841,7 @@ els.reviewPrevBtn.addEventListener("click", () => openAdjacentSubmission(-1));
 els.reviewNextBtn.addEventListener("click", () => openAdjacentSubmission(1));
 els.reviewCloseBtn.addEventListener("click", closeReviewDialog);
 els.testDetailsCloseBtn.addEventListener("click", closeTestDetailsDialog);
-els.studentHelpCloseBtn.addEventListener("click", closeStudentHelpDialog);
+els.studentHelpCloseBtn?.addEventListener("click", closeStudentHelpDialog);
 els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) {
     clearSelectedAssignment();
@@ -4982,8 +4993,8 @@ els.coverageBody.addEventListener("click", async (event) => {
   }
   if (reportButton && reportButton.dataset.coverageReport) {
     els.reportSelect.value = reportButton.dataset.coverageReport;
-    await loadSelectedReport();
-    if (reportButton.dataset.coverageOpenStudents === "true") {
+    const loaded = await loadSelectedReport();
+    if (loaded && reportButton.dataset.coverageOpenStudents === "true") {
       openStudentsDialog();
     }
   }
@@ -5022,8 +5033,8 @@ els.overviewBody.addEventListener("click", async (event) => {
   const button = event.target.closest("[data-overview-report]");
   if (!button) return;
   els.reportSelect.value = button.dataset.overviewReport;
-  await loadSelectedReport();
-  if (button.dataset.overviewStudent) {
+  const loaded = await loadSelectedReport();
+  if (loaded && button.dataset.overviewStudent) {
     openSubmission(button.dataset.overviewStudent, "", "overview");
   }
 });
@@ -5031,8 +5042,8 @@ els.overviewMatrixBody.addEventListener("click", async (event) => {
   const button = event.target.closest("[data-overview-report]");
   if (!button || button.disabled) return;
   els.reportSelect.value = button.dataset.overviewReport;
-  await loadSelectedReport();
-  if (button.dataset.overviewStudent) {
+  const loaded = await loadSelectedReport();
+  if (loaded && button.dataset.overviewStudent) {
     openSubmission(button.dataset.overviewStudent, "", "overview");
   }
 });

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -149,6 +149,7 @@ const state = {
   coverageCollapsedActivities: new Set(),
   testDetailsRows: new Map(),
   studentHelpRows: new Map(),
+  studentHelpDialogKey: "",
   reviewStudent: null,
   reviewSource: "",
   reviewFilePath: "",
@@ -4216,6 +4217,7 @@ function clearTestDetailsRows(prefix) {
 function openStudentHelpDialog(detailsKey) {
   const entry = state.studentHelpRows.get(detailsKey);
   if (!entry || !els.studentHelpDialog) return;
+  state.studentHelpDialogKey = detailsKey;
   els.studentHelpDialogStatus.textContent = `${entry.student || "Studente"} - ${entry.activity || "activity non indicata"}.`;
   els.studentHelpDialogBody.innerHTML = renderStudentHelpDialogContent(entry);
   if (!els.studentHelpDialog.open) {
@@ -4227,6 +4229,7 @@ function closeStudentHelpDialog() {
   if (els.studentHelpDialog?.open) {
     els.studentHelpDialog.close();
   }
+  state.studentHelpDialogKey = "";
 }
 
 function clearStudentHelpRows() {
@@ -4388,9 +4391,21 @@ function filteredStudents(students) {
   return students;
 }
 
+function studentHelpRowKey(student) {
+  return `student-help-${student.student_id || student.student || ""}`;
+}
+
 function renderStudents(students) {
-  closeStudentHelpDialog();
   const visible = filteredStudents(students);
+  const activeStudentHelpKey = state.studentHelpDialogKey;
+  const keepStudentHelpDialogOpen = Boolean(
+    els.studentHelpDialog?.open
+    && activeStudentHelpKey
+    && visible.some((student) => studentHelpRowKey(student) === activeStudentHelpKey),
+  );
+  if (els.studentHelpDialog?.open && !keepStudentHelpDialogOpen) {
+    closeStudentHelpDialog();
+  }
   els.tableStatus.textContent = state.report
     ? `Mostrati ${visible.length}/${students.length} studenti.`
     : "Nessun registro caricato.";
@@ -4422,7 +4437,7 @@ function renderStudents(students) {
     const help = student.help || {};
     const submission = student.submission || {};
     const testDetailsKey = `students-${student.student || student.student_id || ""}`;
-    const studentHelpKey = `student-help-${student.student_id || student.student || ""}`;
+    const studentHelpKey = studentHelpRowKey(student);
     const studentName = student.student || student.student_id || "Studente";
     const helpActivity = help.activity_id || state.report?.title || state.report?.activity_id || "Activity";
     state.testDetailsRows.set(testDetailsKey, {
@@ -4480,6 +4495,9 @@ function renderStudents(students) {
       </td>
     `;
     els.studentsBody.append(row);
+  }
+  if (keepStudentHelpDialogOpen) {
+    openStudentHelpDialog(activeStudentHelpKey);
   }
   setupResizableTable(els.studentsTable, "students");
 }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -4483,6 +4483,9 @@ async function reviewAiFeedback(studentId, decision) {
     setStudentsDialogStatus(message);
     return;
   }
+  const reportName = state.reportName;
+  invalidateReportLoads();
+  const reportRevision = state.reportLoadRevision;
   const label = {
     approve: "approvazione",
     reject: "respinta",
@@ -4494,12 +4497,18 @@ async function reviewAiFeedback(studentId, decision) {
   const payload = await api("/api/assignment-reports/ai-feedback/review", {
     method: "POST",
     body: JSON.stringify({
-      name: state.reportName,
+      name: reportName,
       student_id: studentId,
       decision,
     }),
   });
-  invalidateReportLoads();
+  if (
+    reportRevision !== state.reportLoadRevision
+    || state.reportName !== reportName
+    || els.reportSelect.value !== reportName
+  ) {
+    return false;
+  }
   state.report = payload.report;
   renderDashboard();
   const outcome = {
@@ -4510,6 +4519,7 @@ async function reviewAiFeedback(studentId, decision) {
   const doneMessage = `Feedback AI ${outcome} per ${studentId}.`;
   setStatus(doneMessage);
   setStudentsDialogStatus(doneMessage);
+  return true;
 }
 
 function submissionFiles(student) {

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1126,10 +1126,21 @@ function invalidateReportLoads() {
   state.reportLoadRevision += 1;
 }
 
+function clearActiveReport() {
+  state.report = null;
+  state.reportName = "";
+  els.reportSelect.value = "";
+  els.studentsOpenBtn.disabled = true;
+  clearReview();
+  closeStudentHelpDialog();
+  renderDashboard();
+}
+
 async function loadSelectedReport() {
   const revision = ++state.reportLoadRevision;
   const name = els.reportSelect.value;
   if (!name) {
+    clearActiveReport();
     setStatus("Seleziona un registro consegne.");
     return false;
   }
@@ -1147,13 +1158,7 @@ async function loadSelectedReport() {
     if (revision !== state.reportLoadRevision || els.reportSelect.value !== name) {
       return false;
     }
-    state.report = null;
-    state.reportName = "";
-    els.reportSelect.value = "";
-    els.studentsOpenBtn.disabled = true;
-    clearReview();
-    closeStudentHelpDialog();
-    renderDashboard();
+    clearActiveReport();
     setStatus(`Registro non caricato: ${error.message}`);
     return false;
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -1138,6 +1138,13 @@ async function loadSelectedReport() {
       throw new Error("il server ha restituito un registro non valido");
     }
   } catch (error) {
+    state.report = null;
+    state.reportName = "";
+    els.reportSelect.value = "";
+    els.studentsOpenBtn.disabled = true;
+    clearReview();
+    closeStudentHelpDialog();
+    renderDashboard();
     setStatus(`Registro non caricato: ${error.message}`);
     return false;
   }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -3959,6 +3959,9 @@ function studentHelpDetails(help, options = {}) {
   const legacy = data.legacy && typeof data.legacy === "object" ? data.legacy : {};
   const legacyTotal = Number(legacy.total || 0);
   const hasDetails = total > 0 || legacyTotal > 0 || Boolean(data.error);
+  const detailsLabel = options.student && options.activity
+    ? `Dettagli aiuti di ${options.student} per ${options.activity}`
+    : "Dettagli aiuti";
   return `
     <div class="studentHelpCell">
       ${badge(`Aiuti ${total}`, kind)}<br>
@@ -3968,6 +3971,7 @@ function studentHelpDetails(help, options = {}) {
         type="button"
         class="smallButton studentHelpButton"
         data-student-help-key="${escapeHtml(options.detailsKey || "")}"
+        aria-label="${escapeHtml(detailsLabel)}"
         title="${hasDetails ? "Apri prompt, risposte e dati delle richieste di aiuto." : "Nessuna richiesta di aiuto disponibile."}"
         ${hasDetails ? "" : "disabled"}
       >Dettagli aiuti</button>
@@ -4387,14 +4391,16 @@ function renderStudents(students) {
     const submission = student.submission || {};
     const testDetailsKey = `students-${student.student || student.student_id || ""}`;
     const studentHelpKey = `student-help-${student.student_id || student.student || ""}`;
+    const studentName = student.student || student.student_id || "Studente";
+    const helpActivity = help.activity_id || state.report?.title || state.report?.activity_id || "Activity";
     state.testDetailsRows.set(testDetailsKey, {
       title: state.report?.title || state.report?.activity_id || "Activity",
       subtitle: `${student.student || student.student_id || "Studente"} - ${classValue(state.report) || "classe non indicata"}`,
       grading,
     });
     state.studentHelpRows.set(studentHelpKey, {
-      student: student.student || student.student_id || "Studente",
-      activity: help.activity_id || state.report?.title || state.report?.activity_id || "Activity",
+      student: studentName,
+      activity: helpActivity,
       help,
     });
     const files = submissionFiles(student);
@@ -4427,7 +4433,11 @@ function renderStudents(students) {
       <td>
         <div data-ai-feedback-student="${escapeHtml(student.student_id || student.student)}">
           ${aiFeedbackDetails(ai)}
-          ${studentHelpDetails(help, { detailsKey: studentHelpKey })}
+          ${studentHelpDetails(help, {
+            detailsKey: studentHelpKey,
+            student: studentName,
+            activity: helpActivity,
+          })}
         </div>
       </td>
       <td>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -4951,6 +4951,10 @@ els.reviewNextBtn.addEventListener("click", () => openAdjacentSubmission(1));
 els.reviewCloseBtn.addEventListener("click", closeReviewDialog);
 els.testDetailsCloseBtn.addEventListener("click", closeTestDetailsDialog);
 els.studentHelpCloseBtn?.addEventListener("click", closeStudentHelpDialog);
+els.studentHelpDialog?.addEventListener("cancel", (event) => {
+  event.preventDefault();
+  closeStudentHelpDialog();
+});
 els.activitySelect.addEventListener("change", () => {
   if (els.activitySelect.value) {
     clearSelectedAssignment();

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -131,6 +131,7 @@ const state = {
   report: null,
   reportName: "",
   reportLoadRevision: 0,
+  aiFeedbackReviewPending: false,
   filter: "all",
   overviewFilters: {
     class: "",
@@ -4515,6 +4516,12 @@ async function reviewAiFeedback(studentId, decision) {
     setStudentsDialogStatus(message);
     return false;
   }
+  if (state.aiFeedbackReviewPending) {
+    const message = "Attendi il completamento della revisione AI gia in corso.";
+    setStatus(message);
+    setStudentsDialogStatus(message);
+    return false;
+  }
   const reportName = state.reportName;
   invalidateReportLoads();
   const reportRevision = state.reportLoadRevision;
@@ -4526,32 +4533,37 @@ async function reviewAiFeedback(studentId, decision) {
   const progressMessage = `Salvataggio ${label} feedback AI per ${studentId}...`;
   setStatus(progressMessage);
   setStudentsDialogStatus(progressMessage);
-  const payload = await api("/api/assignment-reports/ai-feedback/review", {
-    method: "POST",
-    body: JSON.stringify({
-      name: reportName,
-      student_id: studentId,
-      decision,
-    }),
-  });
-  if (
-    reportRevision !== state.reportLoadRevision
-    || state.reportName !== reportName
-    || els.reportSelect.value !== reportName
-  ) {
-    return false;
+  state.aiFeedbackReviewPending = true;
+  try {
+    const payload = await api("/api/assignment-reports/ai-feedback/review", {
+      method: "POST",
+      body: JSON.stringify({
+        name: reportName,
+        student_id: studentId,
+        decision,
+      }),
+    });
+    if (
+      reportRevision !== state.reportLoadRevision
+      || state.reportName !== reportName
+      || els.reportSelect.value !== reportName
+    ) {
+      return false;
+    }
+    state.report = payload.report;
+    renderDashboard();
+    const outcome = {
+      approve: "approvato",
+      reject: "respinto",
+      reopen: "riaperto come bozza",
+    }[decision] || "revisionato";
+    const doneMessage = `Feedback AI ${outcome} per ${studentId}.`;
+    setStatus(doneMessage);
+    setStudentsDialogStatus(doneMessage);
+    return true;
+  } finally {
+    state.aiFeedbackReviewPending = false;
   }
-  state.report = payload.report;
-  renderDashboard();
-  const outcome = {
-    approve: "approvato",
-    reject: "respinto",
-    reopen: "riaperto come bozza",
-  }[decision] || "revisionato";
-  const doneMessage = `Feedback AI ${outcome} per ${studentId}.`;
-  setStatus(doneMessage);
-  setStudentsDialogStatus(doneMessage);
-  return true;
 }
 
 function submissionFiles(student) {
@@ -5153,12 +5165,16 @@ els.studentsBody.addEventListener("click", (event) => {
     const container = aiButton.closest("[data-ai-feedback-student]");
     if (!container?.dataset.aiFeedbackStudent) return;
     aiButton.disabled = true;
-    reviewAiFeedback(container.dataset.aiFeedbackStudent, aiButton.dataset.aiFeedbackDecision).catch((error) => {
-      aiButton.disabled = false;
-      const message = `Errore feedback AI: ${error.message}`;
-      setStatus(message);
-      setStudentsDialogStatus(message);
-    });
+    reviewAiFeedback(container.dataset.aiFeedbackStudent, aiButton.dataset.aiFeedbackDecision)
+      .then((completed) => {
+        if (!completed) aiButton.disabled = false;
+      })
+      .catch((error) => {
+        aiButton.disabled = false;
+        const message = `Errore feedback AI: ${error.message}`;
+        setStatus(message);
+        setStudentsDialogStatus(message);
+      });
     return;
   }
   const button = event.target.closest("[data-review-student]");


### PR DESCRIPTION
## Cosa cambia
- sostituisce la linguetta `Prompt aiuti` con il bottone `Dettagli aiuti`
- mostra richieste, prompt, risposte, provider, stato e utilizzo in un modal dedicato
- separa chiaramente gli eventi legacy non autorevoli
- rende il dialog leggibile e accessibile anche su viewport mobili bassi
- aggiorna lo scenario di collaudo manuale
- impedisce al setup demo di svuotare parzialmente una root usata da un server attivo

## Verifica
- `python -m pytest tests/test_assignment_dashboard_frontend.py tests/test_track_assignments.py -q`
- `python -m pytest tests/test_assignment_dashboard_frontend.py -q -k student_help`
- `python -m pytest tests/test_student_lab_demo_setup.py -q`
- collaudo Windows reale: setup rifiutato con server attivo e hash del registro invariato
- `node --check tools/assignment_dashboard.js`
- `git diff --check`

Closes #446
Closes #448