### PR TITLE
Contabilizza i token reali degli aiuti AI

### DIFF
--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -143,7 +143,12 @@ Usalo quando:
 - vuoi controllare grading, voti, feedback AI e stato revisione;
 - vuoi verificare quante richieste di aiuto sono state inviate per la consegna corrente e quante sono state bloccate dalla policy.
 
-Il pulsante `Dettagli aiuti` apre un modal dedicato allo studente e all'activity del registro selezionato. Per ogni richiesta mostra data, tipo di aiuto, prompt dello studente, risposta ricevuta, provider e consumo token dichiarato. Le richieste bloccate riportano l'esito della policy senza una risposta generata.
+Il pulsante `Dettagli aiuti` apre un modal dedicato allo studente e all'activity del registro selezionato. Per ogni
+richiesta mostra data, tipo di aiuto, prompt dello studente, risposta ricevuta, provider e consumo token dichiarato.
+La cella dello studente e il modal mostrano il totale `Token AI`; il riepilogo Studenti somma lo stesso dato per il
+registro e la classe correnti. `Senza contatori` segnala risposte remote storiche che non dichiaravano usage e non
+devono essere interpretate come richieste gratuite. Le richieste bloccate riportano l'esito della policy senza una
+risposta generata.
 
 La sezione `Legacy non verificati`, quando presente, contiene dati storici provenienti dal repository studente: serve per consultazione, ma non contribuisce al budget o alle metriche autorevoli. Se il log autorevole non è disponibile, il modal mostra un avviso esplicito anche in presenza di dati legacy.
 

--- a/doc/DASHBOARD_DOCENTE_GUIDA.md
+++ b/doc/DASHBOARD_DOCENTE_GUIDA.md
@@ -145,8 +145,9 @@ Usalo quando:
 
 Il pulsante `Dettagli aiuti` apre un modal dedicato allo studente e all'activity del registro selezionato. Per ogni
 richiesta mostra data, tipo di aiuto, prompt dello studente, risposta ricevuta, provider e consumo token dichiarato.
-La cella dello studente e il modal mostrano il totale `Token AI`; il riepilogo Studenti somma lo stesso dato per il
-registro e la classe correnti. `Senza contatori` segnala risposte remote storiche che non dichiaravano usage e non
+La cella dello studente e il modal mostrano il totale `Token AI dichiarati`; il riepilogo Studenti somma lo stesso dato
+per il registro e la classe correnti e mostra anche `AI senza contatori`. `Senza contatori` segnala risposte remote
+storiche che non dichiaravano usage e non
 devono essere interpretate come richieste gratuite. Le richieste bloccate riportano l'esito della policy senza una
 risposta generata.
 

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -169,7 +169,8 @@ Obiettivo: verificare che il docente veda quante volte lo studente ha chiesto ai
 5. Controlla il riepilogo dedicato agli aiuti.
 6. Clicca `Dettagli aiuti`.
 7. Leggi prompt, risposta, provider, stato e utilizzo dichiarato.
-8. Chiudi il modal e verifica di tornare alla stessa vista Studenti.
+8. Controlla `Token AI` nella cella, nel modal e nel riepilogo Studenti.
+9. Chiudi il modal e verifica di tornare alla stessa vista Studenti.
 
 Risultato atteso:
 
@@ -177,8 +178,10 @@ Risultato atteso:
 - Il docente vede `Aiuti AI 1`.
 - La cella resta compatta e non mostra direttamente i prompt lunghi.
 - `Dettagli aiuti` apre un modal dedicato.
-- Il prompt demo e visibile nel modal: `Puoi darmi un suggerimento senza scrivere la soluzione?`.
+- Il prompt demo è visibile nel modal: `Puoi darmi un suggerimento senza scrivere la soluzione?`.
 - La risposta e il provider sono leggibili senza scorrimento orizzontale.
+- Il totale `Token AI` coincide con la somma dei contatori mostrati nelle richieste AI.
+- Eventuali risposte remote senza usage sono indicate come `Senza contatori` e non aumentano il totale.
 - Gli aiuti bloccati sono `0`.
 
 ## Scenario 5 - Dettaglio errori test in modal

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -169,7 +169,7 @@ Obiettivo: verificare che il docente veda quante volte lo studente ha chiesto ai
 5. Controlla il riepilogo dedicato agli aiuti.
 6. Clicca `Dettagli aiuti`.
 7. Leggi prompt, risposta, provider, stato e utilizzo dichiarato.
-8. Controlla `Token AI` nella cella, nel modal e nel riepilogo Studenti.
+8. Controlla `Token AI dichiarati` nella cella, nel modal e nel riepilogo Studenti.
 9. Chiudi il modal e verifica di tornare alla stessa vista Studenti.
 
 Risultato atteso:
@@ -180,7 +180,8 @@ Risultato atteso:
 - `Dettagli aiuti` apre un modal dedicato.
 - Il prompt demo è visibile nel modal: `Puoi darmi un suggerimento senza scrivere la soluzione?`.
 - La risposta e il provider sono leggibili senza scorrimento orizzontale.
-- Il totale `Token AI` coincide con la somma dei contatori mostrati nelle richieste AI.
+- Il totale `Token AI dichiarati` coincide con la somma dei contatori mostrati nelle richieste AI.
+- Il riepilogo `AI senza contatori` coincide con gli avvisi presenti nelle righe studente.
 - Eventuali risposte remote senza usage sono indicate come `Senza contatori` e non aumentano il totale.
 - Gli aiuti bloccati sono `0`.
 

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -206,7 +206,9 @@ Il payload lab aggiunge `support_policy`, cioè una descrizione leggibile per lo
 | `studio-guidato` | Lo studente può consultare richiami teorici, domande guida ed esempi approvati dal docente. |
 | `ai-assisted` | Lo studente può usare aiuto AI nei limiti di budget e policy decisi dal docente. |
 
-La TUI mostra la policy e usa la stessa logica backend per consentire o bloccare le richieste di aiuto. Per l'MVP `ai-assisted` abilita un budget minimo di richieste AI per consegna; i limiti token reali saranno introdotti nei passi successivi.
+La TUI mostra la policy e usa la stessa logica backend per consentire o bloccare le richieste di aiuto. Per l'MVP
+`ai-assisted` abilita un budget minimo basato sul numero di richieste AI per consegna. I token dichiarati dal provider
+vengono contabilizzati separatamente: servono al monitoraggio docente, ma non modificano ancora il limite.
 
 ## Log richieste di aiuto
 
@@ -222,12 +224,20 @@ senza ricostruire manualmente il path dagli ID. Il payload generale contiene sol
 Ogni evento indica tipo di aiuto richiesto, esito consentito/bloccato, motivazione e prompt dello studente.
 Quando la richiesta è consentita e viene usato un provider, l'evento contiene anche una `response` conforme a
 `student_help_response.v1`: stato, provider, messaggio, dettaglio tecnico e contatori d'uso.
-Il payload lab espone un riepilogo `help` con totale eventi, richieste consentite, richieste bloccate, ultimo esito e budget AI usato/rimanente.
+Con Codex locale, il server esegue `codex exec --json`, legge i contatori dall'ultimo evento `turn.completed` e usa
+`--output-last-message` per mantenere separata la risposta didattica strutturata. Il riepilogo autorevole `help.ai_usage`
+somma `input_tokens`, `output_tokens` e `total_tokens` per studente e assegnazione. Espone inoltre il numero di risposte
+con utilizzo dichiarato e di risposte remote storiche prive di contatori. Richieste bloccate, guida locale e dati legacy
+non aumentano il totale.
+
+Il payload lab espone un riepilogo `help` con totale eventi, richieste consentite, richieste bloccate, ultimo esito,
+budget AI usato/rimanente e utilizzo token. Il costo monetario non viene stimato: Codex con abbonamento non dichiara
+un prezzo per singola richiesta e zero non deve essere confuso con un costo reale pari a zero.
 La TUI registra nuove richieste, mostra subito un esito compatto con tipo, stato e risposta a capo, poi conserva tutti
 i dettagli nello storico. La motivazione della policy compare subito solo quando la richiesta è bloccata o il provider
 non restituisce una risposta; per le richieste riuscite resta consultabile con `h`, evitando ripetizioni. Il comando
 `h` separa ogni evento con linee tratteggiate, distingue prompt, risposta e motivo con colori ANSI e mantiene la stessa
-struttura leggibile quando i colori sono disabilitati. Il server usa `CodexStudentHelpProvider` quando e configurato
+struttura leggibile quando i colori sono disabilitati. Il server usa `CodexStudentHelpProvider` quando è configurato
 su `codex`; il provider deterministico, indicato a schermo come `Guida locale (nessuna AI esterna)`, resta disponibile
 per il collaudo senza consumo e come fallback. Entrambi implementano `StudentHelpProvider`, quindi policy,
 persistenza e interfaccia non dipendono dal provider effettivo.
@@ -253,13 +263,15 @@ Quando il report esiste, il registro salva nella `submission` anche:
 
 Quando il registro è collegato a un'assegnazione, il docente legge lo stesso log server-side
 `teacher-help-events/student_id-<sha256>/assignment_id-<sha256>/events.json` e aggiunge a ogni studente il riepilogo `help`.
-La dashboard docente può così mostrare numero di richieste, richieste AI, richieste bloccate e prompt inviati dallo studente per quella consegna.
+La dashboard docente può così mostrare numero di richieste, richieste AI, richieste bloccate, token dichiarati e prompt
+inviati dallo studente per quella consegna. Il riepilogo del registro somma gli stessi token per la classe corrente.
 
 In questo modo dashboard docente, dashboard studente e TUI leggono lo stesso risultato senza ricalcolare grading o stato in modi divergenti.
 
 Le prossime PR dovranno completare questo contratto con:
 
-1. contabilizzare token/costo reali per scuola, classe, studente e consegna usando i metadati `usage`;
-2. demo end-to-end pulita con dati riproducibili;
-3. guida utente docente/studente aggiornata;
-4. valutare un adapter opzionale per layout terminale avanzato, per esempio tmux su ambienti compatibili.
+1. introdurre eventuali budget token per scuola e classe senza sostituire il limite per numero di richieste;
+2. attribuire costi monetari solo ai provider che comunicano modello, tariffazione e metadati di billing verificabili;
+3. demo end-to-end pulita con dati riproducibili;
+4. guida utente docente/studente aggiornata;
+5. valutare un adapter opzionale per layout terminale avanzato, per esempio tmux su ambienti compatibili.

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -177,6 +177,37 @@ def codex_help_package(request: StudentHelpRequest) -> dict[str, Any]:
     return package
 
 
+def codex_usage_from_jsonl(value: str) -> dict[str, int]:
+    """Return token usage from the last completed Codex turn."""
+
+    completed_usage: dict[str, int] | None = None
+    for line in value.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError("Codex non ha restituito eventi JSONL validi.") from error
+        if not isinstance(event, dict) or event.get("type") != "turn.completed":
+            continue
+        usage = event.get("usage")
+        if not isinstance(usage, dict):
+            raise ValueError("Codex non ha dichiarato l'utilizzo token.")
+        counters: dict[str, int] = {}
+        for key in ("input_tokens", "output_tokens"):
+            counter = usage.get(key)
+            if isinstance(counter, bool) or not isinstance(counter, int) or counter < 0:
+                raise ValueError("Codex ha restituito contatori token non validi.")
+            counters[key] = counter
+        completed_usage = {
+            **counters,
+            "total_tokens": counters["input_tokens"] + counters["output_tokens"],
+        }
+    if completed_usage is None:
+        raise ValueError("Codex non ha dichiarato l'utilizzo token.")
+    return completed_usage
+
+
 class CodexStudentHelpProvider:
     """Student-help adapter backed by local Codex CLI on the teacher server."""
 
@@ -208,6 +239,7 @@ class CodexStudentHelpProvider:
             with tempfile.TemporaryDirectory(prefix="thebitlab-student-help-") as temp_dir:
                 workdir = Path(temp_dir)
                 schema_path = workdir / "student_help_schema.json"
+                response_path = workdir / "student_help_response.json"
                 schema_path.write_text(json.dumps(CODEX_HELP_SCHEMA, ensure_ascii=False, indent=2), encoding="utf-8")
                 command = [
                     codex_path,
@@ -222,6 +254,9 @@ class CodexStudentHelpProvider:
                     "never",
                     "--output-schema",
                     str(schema_path),
+                    "--output-last-message",
+                    str(response_path),
+                    "--json",
                     "-c",
                     'approval_policy="never"',
                     "-c",
@@ -243,15 +278,20 @@ class CodexStudentHelpProvider:
                     timeout=self.timeout_seconds,
                     check=False,
                 )
+                try:
+                    response_text = response_path.read_text(encoding="utf-8")
+                except OSError:
+                    response_text = ""
         finally:
             _CODEX_CALL_SLOT.release()
         if completed.returncode:
             detail = (completed.stderr or completed.stdout or "Codex non ha restituito dettagli.").strip()
             raise RuntimeError(f"Codex exec non riuscito: {detail}")
         try:
-            payload = json.loads(completed.stdout)
+            payload = json.loads(response_text)
         except json.JSONDecodeError as error:
             raise ValueError("Codex non ha restituito una risposta JSON valida.") from error
+        usage = codex_usage_from_jsonl(completed.stdout)
         guidance = payload.get("guidance") if isinstance(payload, dict) else None
         check_question = payload.get("check_question") if isinstance(payload, dict) else None
         if not isinstance(guidance, list) or not 1 <= len(guidance) <= 4:
@@ -280,7 +320,7 @@ class CodexStudentHelpProvider:
             provider=self.provider,
             provider_label=self.provider_label,
             message=message,
-            usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            usage=usage,
         )
 
 

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -117,6 +117,18 @@ CODEX_HELP_SCHEMA: dict[str, Any] = {
 }
 
 
+class CodexStudentHelpResponseError(ValueError):
+    """Structured-response failure that retains usage from the completed Codex turn."""
+
+    def __init__(self, message: str, usage: dict[str, int]) -> None:
+        super().__init__(message)
+        self.usage = dict(usage)
+
+
+def _zero_usage() -> dict[str, int]:
+    return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
 def codex_subprocess_environment() -> dict[str, str]:
     """Return the minimum server environment needed by the local Codex CLI."""
 
@@ -288,14 +300,20 @@ class CodexStudentHelpProvider:
             detail = (completed.stderr or completed.stdout or "Codex non ha restituito dettagli.").strip()
             raise RuntimeError(f"Codex exec non riuscito: {detail}")
         try:
+            usage = codex_usage_from_jsonl(completed.stdout)
+        except ValueError:
+            usage = _zero_usage()
+        try:
             payload = json.loads(response_text)
         except json.JSONDecodeError as error:
-            raise ValueError("Codex non ha restituito una risposta JSON valida.") from error
-        usage = codex_usage_from_jsonl(completed.stdout)
+            raise CodexStudentHelpResponseError(
+                "Codex non ha restituito una risposta JSON valida.",
+                usage,
+            ) from error
         guidance = payload.get("guidance") if isinstance(payload, dict) else None
         check_question = payload.get("check_question") if isinstance(payload, dict) else None
         if not isinstance(guidance, list) or not 1 <= len(guidance) <= 4:
-            raise ValueError("Codex non ha restituito una guida valida.")
+            raise CodexStudentHelpResponseError("Codex non ha restituito una guida valida.", usage)
         steps = [str(item).strip() for item in guidance]
         if any(
             not step
@@ -303,18 +321,18 @@ class CodexStudentHelpProvider:
             or contains_terminal_control_characters(step)
             for step in steps
         ):
-            raise ValueError("Codex non ha restituito una guida valida.")
+            raise CodexStudentHelpResponseError("Codex non ha restituito una guida valida.", usage)
         if (
             not isinstance(check_question, str)
             or not check_question.strip()
             or len(check_question.strip()) > MAX_CHECK_QUESTION_CHARS
             or contains_terminal_control_characters(check_question)
         ):
-            raise ValueError("Codex non ha restituito una guida valida.")
+            raise CodexStudentHelpResponseError("Codex non ha restituito una guida valida.", usage)
         message = " ".join(f"{index}. {step}" for index, step in enumerate(steps, start=1))
         message = f"{message} Domanda guida: {check_question.strip()}"
         if len(message) > MAX_RESPONSE_CHARS:
-            raise ValueError("Codex ha restituito una guida troppo grande.")
+            raise CodexStudentHelpResponseError("Codex ha restituito una guida troppo grande.", usage)
         return StudentHelpResponse(
             status="ready",
             provider=self.provider,
@@ -334,8 +352,19 @@ class FallbackStudentHelpProvider:
     def respond(self, request: StudentHelpRequest) -> StudentHelpResponse:
         try:
             return self.primary.respond(request)
-        except (OSError, RuntimeError, ValueError, subprocess.TimeoutExpired):
-            return self.fallback.respond(request)
+        except (OSError, RuntimeError, ValueError, subprocess.TimeoutExpired) as error:
+            response = self.fallback.respond(request)
+            if getattr(self.primary, "provider", "") != CODEX_PROVIDER:
+                return response
+            usage = getattr(error, "usage", _zero_usage())
+            return StudentHelpResponse(
+                status=response.status,
+                provider=f"{CODEX_PROVIDER}-fallback",
+                provider_label=f"{response.provider_label} dopo errore Codex",
+                message=response.message,
+                usage=dict(usage),
+                detail=response.detail,
+            )
 
 
 class StudentHelpProviderRouter:

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -13,6 +13,7 @@ from typing import Any, Callable
 
 from scripts import assignment_records
 from scripts.student_help_provider import (
+    DETERMINISTIC_PROVIDER,
     STUDENT_HELP_RESPONSE_SCHEMA_VERSION,
     StudentHelpProvider,
     StudentHelpRequest,
@@ -126,6 +127,44 @@ def positive_int(value: Any, default: int = 0) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed > 0 else default
+
+
+def token_counter(value: Any) -> int:
+    """Return one persisted token counter without accepting booleans."""
+
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def summarize_ai_usage(events: list[dict[str, Any]]) -> dict[str, int]:
+    """Aggregate authoritative AI token usage without including blocked or local requests."""
+
+    summary = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "requests_reported": 0,
+        "requests_without_usage": 0,
+    }
+    for event in events:
+        if normalize_help_type(event.get("help_type")) != "ai" or event.get("allowed") is not True:
+            continue
+        response = event.get("response") if isinstance(event.get("response"), dict) else {}
+        usage = response.get("usage") if isinstance(response.get("usage"), dict) else {}
+        input_tokens = token_counter(usage.get("input_tokens"))
+        output_tokens = token_counter(usage.get("output_tokens"))
+        total_tokens = token_counter(usage.get("total_tokens"))
+        if total_tokens != input_tokens + output_tokens:
+            total_tokens = input_tokens + output_tokens
+        summary["input_tokens"] += input_tokens
+        summary["output_tokens"] += output_tokens
+        summary["total_tokens"] += total_tokens
+        if total_tokens:
+            summary["requests_reported"] += 1
+            continue
+        provider = clean_text(response.get("provider"))
+        if provider and provider != DETERMINISTIC_PROVIDER:
+            summary["requests_without_usage"] += 1
+    return summary
 
 
 def provider_response_payload(response: Any) -> dict[str, Any]:
@@ -499,6 +538,7 @@ def _empty_help_summary() -> dict[str, Any]:
         "last_response_status": "",
         "last_response_provider": "",
         "counts": {},
+        "ai_usage": summarize_ai_usage([]),
     }
 
 
@@ -526,6 +566,7 @@ def _help_summary_from_events(
         "last_response_status": clean_text(last_response.get("status")),
         "last_response_provider": clean_text(last_response.get("provider_label")),
         "counts": counts,
+        "ai_usage": summarize_ai_usage(events),
     }
 
 

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -135,6 +135,19 @@ def token_counter(value: Any) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
 
 
+def normalized_token_usage(value: Any) -> dict[str, int]:
+    """Return consistent counters for persisted or historical provider usage."""
+
+    usage = value if isinstance(value, dict) else {}
+    input_tokens = token_counter(usage.get("input_tokens"))
+    output_tokens = token_counter(usage.get("output_tokens"))
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+
+
 def summarize_ai_usage(events: list[dict[str, Any]]) -> dict[str, int]:
     """Aggregate authoritative AI token usage without including blocked or local requests."""
 
@@ -149,21 +162,20 @@ def summarize_ai_usage(events: list[dict[str, Any]]) -> dict[str, int]:
         if normalize_help_type(event.get("help_type")) != "ai" or event.get("allowed") is not True:
             continue
         response = event.get("response") if isinstance(event.get("response"), dict) else {}
-        usage = response.get("usage") if isinstance(response.get("usage"), dict) else {}
-        input_tokens = token_counter(usage.get("input_tokens"))
-        output_tokens = token_counter(usage.get("output_tokens"))
-        total_tokens = token_counter(usage.get("total_tokens"))
-        if total_tokens != input_tokens + output_tokens:
-            total_tokens = input_tokens + output_tokens
+        provider = clean_text(response.get("provider"))
+        if not provider or provider == DETERMINISTIC_PROVIDER:
+            continue
+        usage = normalized_token_usage(response.get("usage"))
+        input_tokens = usage["input_tokens"]
+        output_tokens = usage["output_tokens"]
+        total_tokens = usage["total_tokens"]
         summary["input_tokens"] += input_tokens
         summary["output_tokens"] += output_tokens
         summary["total_tokens"] += total_tokens
         if total_tokens:
             summary["requests_reported"] += 1
             continue
-        provider = clean_text(response.get("provider"))
-        if provider and provider != DETERMINISTIC_PROVIDER:
-            summary["requests_without_usage"] += 1
+        summary["requests_without_usage"] += 1
     return summary
 
 
@@ -199,6 +211,9 @@ def provider_response_payload(response: Any) -> dict[str, Any]:
         if isinstance(value, bool) or not isinstance(value, int) or value < 0:
             raise ValueError(f"Contatore provider non valido: {key}.")
         normalized_usage[key] = value
+    normalized_usage["total_tokens"] = (
+        normalized_usage["input_tokens"] + normalized_usage["output_tokens"]
+    )
     return {
         "schema_version": STUDENT_HELP_RESPONSE_SCHEMA_VERSION,
         "status": status,
@@ -685,16 +700,12 @@ def _teacher_response(value: Any) -> dict[str, Any]:
 
     if not isinstance(value, dict):
         return {}
-    usage = value.get("usage") if isinstance(value.get("usage"), dict) else {}
+    usage = normalized_token_usage(value.get("usage"))
     return {
         "status": clean_text(value.get("status")),
         "provider": clean_text(value.get("provider")),
         "provider_label": clean_text(value.get("provider_label")),
         "message": clean_text(value.get("message")),
         "detail": clean_text(value.get("detail")),
-        "usage": {
-            "input_tokens": max(positive_int(usage.get("input_tokens")), 0),
-            "output_tokens": max(positive_int(usage.get("output_tokens")), 0),
-            "total_tokens": max(positive_int(usage.get("total_tokens")), 0),
-        },
+        "usage": usage,
     }

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -390,6 +390,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         aiFeedbackReviewDetails,
         aiFeedbackTeacherAction,
         studentHelpDetails,
+        renderStudentHelpUsage,
         renderStudentHelpDialogContent,
         openStudentHelpDialog,
         clearStudentHelpRows,
@@ -2769,6 +2770,7 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           helpRequests: 0,
           helpAiRequests: 0,
           helpAiTokens: 0,
+          helpAiMissingUsage: 0,
           helpDenied: 0,
           averageGrade: 6.5,
           missingGrades: 3,
@@ -2800,7 +2802,8 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           ["Voti mancanti", 3],
           ["Aiuti", 0],
           ["Aiuti AI", 0],
-          ["Token AI", 0],
+          ["Token AI dichiarati", 0],
+          ["AI senza contatori", 0],
           ["Aiuti bloccati", 0],
         ]));
         tested.state.filter = "all";
@@ -2933,23 +2936,23 @@ def test_student_help_details_render_compact_summary_and_modal_content() -> None
         """
         const help = {
           activity_id: "python-base-somma-001",
-          total: 3,
-          ai_total: 2,
+          total: 4,
+          ai_total: 4,
           denied: 1,
           ai_usage: { total_tokens: 3, requests_without_usage: 1 },
           events: [
             {
               requested_at: "2026-10-20T08:10:00+02:00",
-              help_type: "teoria",
-              label: "Richiamo teorico",
+              help_type: "ai",
+              label: "Aiuto AI",
               allowed: true,
               reason: "Consentito dalla policy.",
               prompt: "Puoi ricordarmi come funziona input()?",
               provider_status: "completed",
               response: {
                 status: "ready",
-                provider: "deterministic-local",
-                provider_label: "Guida locale (nessuna AI esterna)",
+                provider: "codex-local",
+                provider_label: "Codex locale (macchina docente)",
                 message: "Parti dal primo test fallito.",
                 usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
               },
@@ -2991,11 +2994,11 @@ def test_student_help_details_render_compact_summary_and_modal_content() -> None
           activity: "Somma & media",
         });
 
-        assert.match(html, /Aiuti 3/);
+        assert.match(html, /Aiuti 4/);
         assert.match(html, /Consegna: python-base-somma-001/);
-        assert.match(html, /AI: 2/);
+        assert.match(html, /AI: 4/);
         assert.match(html, /Bloccate: 1/);
-        assert.match(html, /Token AI: 3 - Senza contatori: 1/);
+        assert.match(html, /Token AI dichiarati: 3 - Senza contatori: 1/);
         assert.match(html, /Dettagli aiuti/);
         assert.match(html, /data-student-help-key="student-help-rossi"/);
         assert.match(html, /aria-label="Dettagli aiuti di Rossi &quot;Mario&quot; per Somma &amp; media"/);
@@ -3014,10 +3017,17 @@ def test_student_help_details_render_compact_summary_and_modal_content() -> None
         assert.match(modalHtml, /Risposta in elaborazione\\./);
         assert.match(modalHtml, /Non invocato/);
         assert.match(modalHtml, /Parti dal primo test fallito\\./);
-        assert.match(modalHtml, /Guida locale \\(nessuna AI esterna\\)/);
+        assert.match(modalHtml, /Codex locale \\(macchina docente\\)/);
         assert.match(modalHtml, /3 token \\(1 input, 2 output\\)/);
-        assert.match(modalHtml, /Token AI 3/);
+        assert.match(modalHtml, /Token AI dichiarati 3/);
         assert.match(modalHtml, /Senza contatori 1/);
+        assert.match(
+          tested.renderStudentHelpUsage({
+            provider: "codex-local",
+            usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+          }),
+          /Contatori token non disponibili/,
+        );
         assert.match(modalHtml, /Legacy non verificati \\(1\\)/);
         assert.match(modalHtml, /non incidono su budget e metriche/);
         assert.match(modalHtml, /Dato modificabile\\./);
@@ -3741,16 +3751,18 @@ def test_summary_counts_include_student_help_requests() -> None:
     run_dashboard_js(
         """
         const counts = tested.summaryCounts([
-          { help: { total: 3, ai_total: 2, denied: 1, ai_usage: { total_tokens: 15 } }, grading: {}, status: "pending" },
-          { help: { total: 1, counts: { ai: 1 }, denied: 0, ai_usage: { total_tokens: 7 } }, grading: {}, status: "pending" },
+          { help: { total: 3, ai_total: 2, denied: 1, ai_usage: { total_tokens: 15, requests_without_usage: 1 } }, grading: {}, status: "pending" },
+          { help: { total: 1, counts: { ai: 1 }, denied: 0, ai_usage: { total_tokens: 7, requests_without_usage: 2 } }, grading: {}, status: "pending" },
         ]);
 
         assert.equal(counts.helpRequests, 4);
         assert.equal(counts.helpAiRequests, 3);
         assert.equal(counts.helpAiTokens, 22);
+        assert.equal(counts.helpAiMissingUsage, 3);
         assert.equal(counts.helpDenied, 1);
         assert.equal(tested.summaryTooltip("Aiuti AI"), "Numero di richieste di aiuto AI registrate dagli studenti per questa consegna.");
-        assert.equal(tested.summaryTooltip("Token AI"), "Token input e output dichiarati dai provider AI per il registro selezionato.");
+        assert.equal(tested.summaryTooltip("Token AI dichiarati"), "Token input e output dichiarati dai provider AI per il registro selezionato.");
+        assert.equal(tested.summaryTooltip("AI senza contatori"), "Risposte AI remote per cui il provider non ha dichiarato i contatori token.");
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -2768,6 +2768,7 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           failed: 1,
           helpRequests: 0,
           helpAiRequests: 0,
+          helpAiTokens: 0,
           helpDenied: 0,
           averageGrade: 6.5,
           missingGrades: 3,
@@ -2799,6 +2800,7 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           ["Voti mancanti", 3],
           ["Aiuti", 0],
           ["Aiuti AI", 0],
+          ["Token AI", 0],
           ["Aiuti bloccati", 0],
         ]));
         tested.state.filter = "all";
@@ -2934,6 +2936,7 @@ def test_student_help_details_render_compact_summary_and_modal_content() -> None
           total: 3,
           ai_total: 2,
           denied: 1,
+          ai_usage: { total_tokens: 3, requests_without_usage: 1 },
           events: [
             {
               requested_at: "2026-10-20T08:10:00+02:00",
@@ -2992,6 +2995,7 @@ def test_student_help_details_render_compact_summary_and_modal_content() -> None
         assert.match(html, /Consegna: python-base-somma-001/);
         assert.match(html, /AI: 2/);
         assert.match(html, /Bloccate: 1/);
+        assert.match(html, /Token AI: 3 - Senza contatori: 1/);
         assert.match(html, /Dettagli aiuti/);
         assert.match(html, /data-student-help-key="student-help-rossi"/);
         assert.match(html, /aria-label="Dettagli aiuti di Rossi &quot;Mario&quot; per Somma &amp; media"/);
@@ -3012,6 +3016,8 @@ def test_student_help_details_render_compact_summary_and_modal_content() -> None
         assert.match(modalHtml, /Parti dal primo test fallito\\./);
         assert.match(modalHtml, /Guida locale \\(nessuna AI esterna\\)/);
         assert.match(modalHtml, /3 token \\(1 input, 2 output\\)/);
+        assert.match(modalHtml, /Token AI 3/);
+        assert.match(modalHtml, /Senza contatori 1/);
         assert.match(modalHtml, /Legacy non verificati \\(1\\)/);
         assert.match(modalHtml, /non incidono su budget e metriche/);
         assert.match(modalHtml, /Dato modificabile\\./);
@@ -3735,14 +3741,16 @@ def test_summary_counts_include_student_help_requests() -> None:
     run_dashboard_js(
         """
         const counts = tested.summaryCounts([
-          { help: { total: 3, ai_total: 2, denied: 1 }, grading: {}, status: "pending" },
-          { help: { total: 1, counts: { ai: 1 }, denied: 0 }, grading: {}, status: "pending" },
+          { help: { total: 3, ai_total: 2, denied: 1, ai_usage: { total_tokens: 15 } }, grading: {}, status: "pending" },
+          { help: { total: 1, counts: { ai: 1 }, denied: 0, ai_usage: { total_tokens: 7 } }, grading: {}, status: "pending" },
         ]);
 
         assert.equal(counts.helpRequests, 4);
         assert.equal(counts.helpAiRequests, 3);
+        assert.equal(counts.helpAiTokens, 22);
         assert.equal(counts.helpDenied, 1);
         assert.equal(tested.summaryTooltip("Aiuti AI"), "Numero di richieste di aiuto AI registrate dagli studenti per questa consegna.");
+        assert.equal(tested.summaryTooltip("Token AI"), "Token input e output dichiarati dai provider AI per il registro selezionato.");
         """
     )
 

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -30,6 +31,33 @@ def sample_request() -> StudentHelpRequest:
     )
 
 
+def completed_codex_run(
+    command: list[str],
+    payload: object,
+    *,
+    usage: dict[str, int] | None = None,
+    events: list[object] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    response_path = Path(command[command.index("--output-last-message") + 1])
+    response_path.write_text(json.dumps(payload), encoding="utf-8")
+    if events is None:
+        events = [{
+            "type": "turn.completed",
+            "usage": usage or {
+                "input_tokens": 120,
+                "cached_input_tokens": 40,
+                "output_tokens": 30,
+                "reasoning_output_tokens": 10,
+            },
+        }]
+    return subprocess.CompletedProcess(
+        command,
+        0,
+        stdout="\n".join(json.dumps(event) for event in events),
+        stderr="",
+    )
+
+
 def test_codex_provider_runs_in_empty_read_only_ephemeral_workspace(monkeypatch) -> None:
     captured = {}
     monkeypatch.setenv("THEBITLAB_STUDENT_HELP_SECRET", "segreto-server")
@@ -50,16 +78,12 @@ def test_codex_provider_runs_in_empty_read_only_ephemeral_workspace(monkeypatch)
         captured["input"] = json.loads(kwargs["input"])
         schema_path = command[command.index("--output-schema") + 1]
         captured["schema"] = json.loads(open(schema_path, encoding="utf-8").read())
-        return subprocess.CompletedProcess(
+        return completed_codex_run(
             command,
-            0,
-            stdout=json.dumps(
-                {
-                    "guidance": ["Controlla il caso vuoto.", "Confronta atteso e ottenuto."],
-                    "check_question": "Quale ipotesi verifica il test?",
-                }
-            ),
-            stderr="",
+            {
+                "guidance": ["Controlla il caso vuoto.", "Confronta atteso e ottenuto."],
+                "check_question": "Quale ipotesi verifica il test?",
+            },
         )
 
     monkeypatch.setattr(student_help_codex_adapter.subprocess, "run", fake_run)
@@ -71,7 +95,7 @@ def test_codex_provider_runs_in_empty_read_only_ephemeral_workspace(monkeypatch)
         "1. Controlla il caso vuoto. 2. Confronta atteso e ottenuto. "
         "Domanda guida: Quale ipotesi verifica il test?"
     )
-    assert response.usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    assert response.usage == {"input_tokens": 120, "output_tokens": 30, "total_tokens": 150}
     assert "--ephemeral" in captured["command"]
     assert "--ignore-user-config" in captured["command"]
     disabled_features = {
@@ -82,6 +106,8 @@ def test_codex_provider_runs_in_empty_read_only_ephemeral_workspace(monkeypatch)
     assert disabled_features == set(student_help_codex_adapter.DISABLED_CODEX_FEATURES)
     assert {"shell_tool", "apps", "browser_use", "computer_use", "multi_agent", "plugins"} <= disabled_features
     assert "read-only" in captured["command"]
+    assert "--json" in captured["command"]
+    assert "--output-last-message" in captured["command"]
     assert 'web_search="disabled"' in captured["command"]
     assert captured["command"][captured["command"].index("--model") + 1] == "gpt-test"
     assert captured["cwd"].name.startswith("thebitlab-student-help-")
@@ -154,7 +180,7 @@ def test_codex_provider_rejects_invalid_structured_output(monkeypatch) -> None:
     monkeypatch.setattr(
         student_help_codex_adapter.subprocess,
         "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, stdout="{}", stderr=""),
+        lambda *args, **kwargs: completed_codex_run(args[0], {}),
     )
 
     with pytest.raises(ValueError, match="guida valida"):
@@ -166,16 +192,12 @@ def test_codex_provider_rejects_terminal_escape_sequences(monkeypatch) -> None:
     monkeypatch.setattr(
         student_help_codex_adapter.subprocess,
         "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(
+        lambda *args, **kwargs: completed_codex_run(
             args[0],
-            0,
-            stdout=json.dumps(
-                {
-                    "guidance": ["Controlla l'input.\u001b]52;c;dGVzdA==\u0007"],
-                    "check_question": "Quale caso stai verificando?",
-                }
-            ),
-            stderr="",
+            {
+                "guidance": ["Controlla l'input.\u001b]52;c;dGVzdA==\u0007"],
+                "check_question": "Quale caso stai verificando?",
+            },
         ),
     )
 
@@ -188,21 +210,68 @@ def test_codex_provider_rejects_output_that_would_truncate_check_question(monkey
     monkeypatch.setattr(
         student_help_codex_adapter.subprocess,
         "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(
+        lambda *args, **kwargs: completed_codex_run(
             args[0],
-            0,
-            stdout=json.dumps(
-                {
-                    "guidance": ["x" * (student_help_codex_adapter.MAX_GUIDANCE_STEP_CHARS + 1)],
-                    "check_question": "La domanda deve restare visibile?",
-                }
-            ),
-            stderr="",
+            {
+                "guidance": ["x" * (student_help_codex_adapter.MAX_GUIDANCE_STEP_CHARS + 1)],
+                "check_question": "La domanda deve restare visibile?",
+            },
         ),
     )
 
     with pytest.raises(ValueError, match="guida valida"):
         student_help_codex_adapter.CodexStudentHelpProvider().respond(sample_request())
+
+
+def test_codex_provider_rejects_missing_token_usage(monkeypatch) -> None:
+    monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
+    monkeypatch.setattr(
+        student_help_codex_adapter.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_codex_run(
+            args[0],
+            {
+                "guidance": ["Controlla l'input."],
+                "check_question": "Quale caso stai verificando?",
+            },
+            events=[{"type": "turn.completed"}],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="utilizzo token"):
+        student_help_codex_adapter.CodexStudentHelpProvider().respond(sample_request())
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        ["evento-non-valido"],
+        [{"type": "turn.completed", "usage": {"input_tokens": -1, "output_tokens": 2}}],
+        [{"type": "turn.completed", "usage": {"input_tokens": True, "output_tokens": 2}}],
+    ],
+)
+def test_codex_provider_rejects_invalid_token_usage(monkeypatch, events) -> None:
+    monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
+    monkeypatch.setattr(
+        student_help_codex_adapter.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_codex_run(
+            args[0],
+            {
+                "guidance": ["Controlla l'input."],
+                "check_question": "Quale caso stai verificando?",
+            },
+            events=events,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="eventi JSONL|contatori token|utilizzo token"):
+        student_help_codex_adapter.CodexStudentHelpProvider().respond(sample_request())
+
+
+def test_codex_usage_rejects_malformed_jsonl() -> None:
+    with pytest.raises(ValueError, match="eventi JSONL"):
+        student_help_codex_adapter.codex_usage_from_jsonl("not-json")
 
 
 def test_fallback_provider_uses_local_guide_when_codex_fails() -> None:

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -56,6 +58,46 @@ def completed_codex_run(
         stdout="\n".join(json.dumps(event) for event in events),
         stderr="",
     )
+
+
+def fake_codex_executable(tmp_path: Path) -> Path:
+    script_path = tmp_path / "fake_codex.py"
+    script_path.write_text(
+        """import json
+import sys
+
+arguments = sys.argv[1:]
+response_path = arguments[arguments.index("--output-last-message") + 1]
+with open(response_path, "w", encoding="utf-8") as response_file:
+    json.dump(
+        {
+            "guidance": ["Controlla il primo caso limite."],
+            "check_question": "Quale risultato ti aspetti?",
+        },
+        response_file,
+    )
+print(json.dumps({
+    "type": "turn.completed",
+    "usage": {"input_tokens": 17, "output_tokens": 5},
+}))
+""",
+        encoding="utf-8",
+    )
+    if os.name == "nt":
+        launcher_path = tmp_path / "codex.cmd"
+        launcher_path.write_text(
+            f'@echo off\r\n"{sys.executable}" "{script_path}" %*\r\n',
+            encoding="utf-8",
+        )
+        return launcher_path
+
+    launcher_path = tmp_path / "codex"
+    launcher_path.write_text(
+        f'#!/bin/sh\nexec "{sys.executable}" "{script_path}" "$@"\n',
+        encoding="utf-8",
+    )
+    launcher_path.chmod(0o755)
+    return launcher_path
 
 
 def test_codex_provider_runs_in_empty_read_only_ephemeral_workspace(monkeypatch) -> None:
@@ -131,6 +173,19 @@ def test_codex_provider_runs_in_empty_read_only_ephemeral_workspace(monkeypatch)
     }
     assert "secret_solution" not in json.dumps(captured["input"])
     assert captured["schema"]["additionalProperties"] is False
+
+
+def test_codex_provider_reads_sidecar_and_jsonl_from_real_subprocess(monkeypatch, tmp_path) -> None:
+    codex_path = fake_codex_executable(tmp_path)
+    monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: str(codex_path))
+
+    response = student_help_codex_adapter.CodexStudentHelpProvider().respond(sample_request())
+
+    assert response.provider == "codex-local"
+    assert response.message == (
+        "1. Controlla il primo caso limite. Domanda guida: Quale risultato ti aspetti?"
+    )
+    assert response.usage == {"input_tokens": 17, "output_tokens": 5, "total_tokens": 22}
 
 
 def test_codex_provider_rejects_missing_cli(monkeypatch) -> None:

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -223,7 +223,7 @@ def test_codex_provider_rejects_output_that_would_truncate_check_question(monkey
         student_help_codex_adapter.CodexStudentHelpProvider().respond(sample_request())
 
 
-def test_codex_provider_rejects_missing_token_usage(monkeypatch) -> None:
+def test_codex_provider_marks_missing_token_usage_without_losing_response(monkeypatch) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(
         student_help_codex_adapter.subprocess,
@@ -238,8 +238,10 @@ def test_codex_provider_rejects_missing_token_usage(monkeypatch) -> None:
         ),
     )
 
-    with pytest.raises(ValueError, match="utilizzo token"):
-        student_help_codex_adapter.CodexStudentHelpProvider().respond(sample_request())
+    response = student_help_codex_adapter.CodexStudentHelpProvider().respond(sample_request())
+
+    assert response.provider == "codex-local"
+    assert response.usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
 
 
 @pytest.mark.parametrize(
@@ -250,7 +252,7 @@ def test_codex_provider_rejects_missing_token_usage(monkeypatch) -> None:
         [{"type": "turn.completed", "usage": {"input_tokens": True, "output_tokens": 2}}],
     ],
 )
-def test_codex_provider_rejects_invalid_token_usage(monkeypatch, events) -> None:
+def test_codex_provider_marks_invalid_token_usage_without_losing_response(monkeypatch, events) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(
         student_help_codex_adapter.subprocess,
@@ -265,8 +267,10 @@ def test_codex_provider_rejects_invalid_token_usage(monkeypatch, events) -> None
         ),
     )
 
-    with pytest.raises(ValueError, match="eventi JSONL|contatori token|utilizzo token"):
-        student_help_codex_adapter.CodexStudentHelpProvider().respond(sample_request())
+    response = student_help_codex_adapter.CodexStudentHelpProvider().respond(sample_request())
+
+    assert response.provider == "codex-local"
+    assert response.usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
 
 
 def test_codex_usage_rejects_malformed_jsonl() -> None:
@@ -288,6 +292,25 @@ def test_fallback_provider_uses_local_guide_when_codex_fails() -> None:
 
     assert response.provider == "deterministic-local"
     assert response.status == "ready"
+
+
+def test_codex_fallback_preserves_usage_from_invalid_structured_response(monkeypatch) -> None:
+    monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
+    monkeypatch.setattr(
+        student_help_codex_adapter.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_codex_run(args[0], {}),
+    )
+    provider = student_help_codex_adapter.FallbackStudentHelpProvider(
+        student_help_codex_adapter.CodexStudentHelpProvider(),
+        DeterministicStudentHelpProvider(),
+    )
+
+    response = provider.respond(sample_request())
+
+    assert response.provider == "codex-local-fallback"
+    assert response.provider_label == "Guida locale (nessuna AI esterna) dopo errore Codex"
+    assert response.usage == {"input_tokens": 120, "output_tokens": 30, "total_tokens": 150}
 
 
 def test_fallback_provider_does_not_hide_unexpected_programming_errors() -> None:

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -216,9 +216,66 @@ def test_record_help_request_persists_provider_response_for_allowed_request(tmp_
     teacher_summary = student_help_service.teacher_help_summary(log_path)
     assert summary["last_response_status"] == "ready"
     assert summary["last_response_provider"] == "Provider test"
+    assert summary["ai_usage"] == {
+        "input_tokens": 3,
+        "output_tokens": 7,
+        "total_tokens": 10,
+        "requests_reported": 1,
+        "requests_without_usage": 0,
+    }
     assert teacher_summary["events"][0]["response"]["message"].startswith("Prova un caso minimo")
     assert teacher_summary["events"][0]["response"]["usage"]["total_tokens"] == 10
     assert teacher_summary["events"][0]["provider_status"] == "completed"
+
+
+def test_ai_usage_distinguishes_reported_missing_local_and_blocked_requests(tmp_path) -> None:
+    log_path = tmp_path / "teacher-help-events" / "student" / "assignment" / "events.json"
+    events = [
+        {
+            "help_type": "ai",
+            "allowed": True,
+            "response": {
+                "provider": "codex-local",
+                "usage": {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15},
+            },
+        },
+        {
+            "help_type": "ai",
+            "allowed": True,
+            "response": {
+                "provider": "codex-local",
+                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            },
+        },
+        {
+            "help_type": "ai",
+            "allowed": True,
+            "response": {
+                "provider": "deterministic-local",
+                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            },
+        },
+        {"help_type": "ai", "allowed": False},
+        {
+            "help_type": "teoria",
+            "allowed": True,
+            "response": {
+                "provider": "remote-provider",
+                "usage": {"input_tokens": 99, "output_tokens": 1, "total_tokens": 100},
+            },
+        },
+    ]
+    student_help_service.write_help_events(log_path, events)
+
+    summary = student_help_service.teacher_help_summary(log_path)
+
+    assert summary["ai_usage"] == {
+        "input_tokens": 12,
+        "output_tokens": 3,
+        "total_tokens": 15,
+        "requests_reported": 1,
+        "requests_without_usage": 1,
+    }
 
 
 def test_teacher_help_summary_exposes_only_known_provider_states(tmp_path) -> None:

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -141,7 +141,21 @@ class StructuredErrorHelpProvider:
             message="Stack trace remoto: api_key=segreto-nel-messaggio",
             usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
             detail="Errore remoto: token=segreto-strutturato",
-        )
+    )
+
+
+def test_provider_response_normalizes_total_tokens() -> None:
+    response = StudentHelpResponse(
+        status="ready",
+        provider="test-provider",
+        provider_label="Provider test",
+        message="Guida",
+        usage={"input_tokens": 3, "output_tokens": 7, "total_tokens": 999},
+    )
+
+    payload = student_help_service.provider_response_payload(response)
+
+    assert payload["usage"] == {"input_tokens": 3, "output_tokens": 7, "total_tokens": 10}
 
 
 def test_evaluate_help_request_denies_ai_when_policy_does_not_allow_it() -> None:
@@ -236,7 +250,7 @@ def test_ai_usage_distinguishes_reported_missing_local_and_blocked_requests(tmp_
             "allowed": True,
             "response": {
                 "provider": "codex-local",
-                "usage": {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15},
+                "usage": {"input_tokens": 12, "output_tokens": 3, "total_tokens": 999},
             },
         },
         {
@@ -276,6 +290,7 @@ def test_ai_usage_distinguishes_reported_missing_local_and_blocked_requests(tmp_
         "requests_reported": 1,
         "requests_without_usage": 1,
     }
+    assert summary["events"][0]["response"]["usage"]["total_tokens"] == 15
 
 
 def test_teacher_help_summary_exposes_only_known_provider_states(tmp_path) -> None:

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -3998,7 +3998,7 @@ function studentHelpDetails(help, options = {}) {
       ${badge(`Aiuti ${total}`, kind)}<br>
       <small>Consegna: ${escapeHtml(data.activity_id || "-")}</small><br>
       <small>AI: ${escapeHtml(aiTotal)} - Bloccate: ${escapeHtml(denied)}</small><br>
-      <small>Token AI: ${escapeHtml(aiTokens)}${missingUsage ? ` - Senza contatori: ${escapeHtml(missingUsage)}` : ""}</small>
+      <small>Token AI dichiarati: ${escapeHtml(aiTokens)}${missingUsage ? ` - Senza contatori: ${escapeHtml(missingUsage)}` : ""}</small>
       <button
         type="button"
         class="smallButton studentHelpButton"
@@ -4017,6 +4017,10 @@ function renderStudentHelpUsage(response) {
   const input = Number(usage.input_tokens || 0);
   const output = Number(usage.output_tokens || 0);
   const total = Number(usage.total_tokens || 0);
+  const provider = String(response?.provider || "");
+  if (!total && provider && provider !== "deterministic-local") {
+    return "<small>Contatori token non disponibili.</small>";
+  }
   return `<small>Utilizzo dichiarato: ${escapeHtml(total)} token (${escapeHtml(input)} input, ${escapeHtml(output)} output).</small>`;
 }
 
@@ -4093,7 +4097,7 @@ function renderStudentHelpDialogContent(entry) {
     <div class="studentHelpDialogSummary">
       ${badge(`Aiuti ${Number(data.total || 0)}`, Number(data.denied || 0) ? "bad" : "ok")}
       ${badge(`AI ${Number(data.ai_total || data.counts?.ai || 0)}`, "warn")}
-      ${badge(`Token AI ${Number(aiUsage.total_tokens || 0)}`, "muted")}
+      ${badge(`Token AI dichiarati ${Number(aiUsage.total_tokens || 0)}`, "muted")}
       ${badge(`Bloccate ${Number(data.denied || 0)}`, Number(data.denied || 0) ? "bad" : "muted")}
       ${Number(aiUsage.requests_without_usage || 0) ? badge(`Senza contatori ${Number(aiUsage.requests_without_usage)}`, "warn") : ""}
     </div>
@@ -4291,7 +4295,8 @@ const SUMMARY_TOOLTIPS = {
   "Voti mancanti": "Numero di studenti senza voto numerico disponibile.",
   Aiuti: "Numero totale di richieste di aiuto registrate dagli studenti per questa consegna.",
   "Aiuti AI": "Numero di richieste di aiuto AI registrate dagli studenti per questa consegna.",
-  "Token AI": "Token input e output dichiarati dai provider AI per il registro selezionato.",
+  "Token AI dichiarati": "Token input e output dichiarati dai provider AI per il registro selezionato.",
+  "AI senza contatori": "Risposte AI remote per cui il provider non ha dichiarato i contatori token.",
   "Aiuti bloccati": "Numero di richieste di aiuto non consentite dalla policy della consegna.",
 };
 
@@ -4320,6 +4325,10 @@ function summaryCounts(students) {
     helpRequests: students.reduce((total, student) => total + Number(student.help?.total || 0), 0),
     helpAiRequests: students.reduce((total, student) => total + Number(student.help?.ai_total || student.help?.counts?.ai || 0), 0),
     helpAiTokens: students.reduce((total, student) => total + Number(student.help?.ai_usage?.total_tokens || 0), 0),
+    helpAiMissingUsage: students.reduce(
+      (total, student) => total + Number(student.help?.ai_usage?.requests_without_usage || 0),
+      0,
+    ),
     helpDenied: students.reduce((total, student) => total + Number(student.help?.denied || 0), 0),
     averageGrade: grades.length ? grades.reduce((sum, grade) => sum + grade, 0) / grades.length : null,
     missingGrades: students.length - grades.length,
@@ -4370,7 +4379,8 @@ function detailedStudentsSummaryItems(counts) {
     ["Voti mancanti", counts.missingGrades],
     ["Aiuti", counts.helpRequests],
     ["Aiuti AI", counts.helpAiRequests],
-    ["Token AI", counts.helpAiTokens],
+    ["Token AI dichiarati", counts.helpAiTokens],
+    ["AI senza contatori", counts.helpAiMissingUsage],
     ["Aiuti bloccati", counts.helpDenied],
   ];
 }

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -3984,6 +3984,9 @@ function studentHelpDetails(help, options = {}) {
   const denied = Number(data.denied || 0);
   const kind = denied > 0 ? "bad" : aiTotal > 0 ? "warn" : total > 0 ? "ok" : "muted";
   const events = Array.isArray(data.events) ? data.events : [];
+  const aiUsage = data.ai_usage && typeof data.ai_usage === "object" ? data.ai_usage : {};
+  const aiTokens = Number(aiUsage.total_tokens || 0);
+  const missingUsage = Number(aiUsage.requests_without_usage || 0);
   const legacy = data.legacy && typeof data.legacy === "object" ? data.legacy : {};
   const legacyTotal = Number(legacy.total || 0);
   const hasDetails = total > 0 || legacyTotal > 0 || Boolean(data.error);
@@ -3994,7 +3997,8 @@ function studentHelpDetails(help, options = {}) {
     <div class="studentHelpCell">
       ${badge(`Aiuti ${total}`, kind)}<br>
       <small>Consegna: ${escapeHtml(data.activity_id || "-")}</small><br>
-      <small>AI: ${escapeHtml(aiTotal)} - Bloccate: ${escapeHtml(denied)}</small>
+      <small>AI: ${escapeHtml(aiTotal)} - Bloccate: ${escapeHtml(denied)}</small><br>
+      <small>Token AI: ${escapeHtml(aiTokens)}${missingUsage ? ` - Senza contatori: ${escapeHtml(missingUsage)}` : ""}</small>
       <button
         type="button"
         class="smallButton studentHelpButton"
@@ -4075,6 +4079,7 @@ function renderStudentHelpDialogContent(entry) {
   const data = entry?.help || {};
   const events = Array.isArray(data.events) ? data.events : [];
   const legacy = data.legacy && typeof data.legacy === "object" ? data.legacy : {};
+  const aiUsage = data.ai_usage && typeof data.ai_usage === "object" ? data.ai_usage : {};
   const errorNotice = data.error ? `
     <p class="studentHelpDialogError" role="alert">
       <strong>Log autorevole non disponibile:</strong> ${escapeHtml(data.error)}
@@ -4088,7 +4093,9 @@ function renderStudentHelpDialogContent(entry) {
     <div class="studentHelpDialogSummary">
       ${badge(`Aiuti ${Number(data.total || 0)}`, Number(data.denied || 0) ? "bad" : "ok")}
       ${badge(`AI ${Number(data.ai_total || data.counts?.ai || 0)}`, "warn")}
+      ${badge(`Token AI ${Number(aiUsage.total_tokens || 0)}`, "muted")}
       ${badge(`Bloccate ${Number(data.denied || 0)}`, Number(data.denied || 0) ? "bad" : "muted")}
+      ${Number(aiUsage.requests_without_usage || 0) ? badge(`Senza contatori ${Number(aiUsage.requests_without_usage)}`, "warn") : ""}
     </div>
     <div class="studentHelpDialogList">
       ${events.map(renderStudentHelpEvent).join("")}
@@ -4284,6 +4291,7 @@ const SUMMARY_TOOLTIPS = {
   "Voti mancanti": "Numero di studenti senza voto numerico disponibile.",
   Aiuti: "Numero totale di richieste di aiuto registrate dagli studenti per questa consegna.",
   "Aiuti AI": "Numero di richieste di aiuto AI registrate dagli studenti per questa consegna.",
+  "Token AI": "Token input e output dichiarati dai provider AI per il registro selezionato.",
   "Aiuti bloccati": "Numero di richieste di aiuto non consentite dalla policy della consegna.",
 };
 
@@ -4311,6 +4319,7 @@ function summaryCounts(students) {
     failed: students.filter((student) => student.grading?.status === "graded_failed").length,
     helpRequests: students.reduce((total, student) => total + Number(student.help?.total || 0), 0),
     helpAiRequests: students.reduce((total, student) => total + Number(student.help?.ai_total || student.help?.counts?.ai || 0), 0),
+    helpAiTokens: students.reduce((total, student) => total + Number(student.help?.ai_usage?.total_tokens || 0), 0),
     helpDenied: students.reduce((total, student) => total + Number(student.help?.denied || 0), 0),
     averageGrade: grades.length ? grades.reduce((sum, grade) => sum + grade, 0) / grades.length : null,
     missingGrades: students.length - grades.length,
@@ -4361,6 +4370,7 @@ function detailedStudentsSummaryItems(counts) {
     ["Voti mancanti", counts.missingGrades],
     ["Aiuti", counts.helpRequests],
     ["Aiuti AI", counts.helpAiRequests],
+    ["Token AI", counts.helpAiTokens],
     ["Aiuti bloccati", counts.helpDenied],
   ];
 }


### PR DESCRIPTION
## Obiettivo

Contabilizzare i token realmente dichiarati da Codex per le richieste di aiuto AI e renderli visibili al docente senza confonderli con il budget per numero di richieste o con un costo monetario.

## Modifiche

- usa `codex exec --json` e legge `turn.completed.usage`;
- salva la risposta strutturata tramite `--output-last-message`;
- persiste i token nell'event log autorevole già esistente;
- aggiunge `help.ai_usage` per studente e assegnazione;
- mostra token e richieste senza contatori nella cella e nel modal Studenti;
- somma i token nel riepilogo del registro e della classe correnti;
- documenta differenza tra richieste, token e costi;
- aggiorna gli scenari manuali.

Il costo monetario non viene stimato: Codex con abbonamento non espone un prezzo verificabile per singola richiesta.

## Verifica

- 273 test backend/TUI superati, 2 saltati;
- 117 test frontend superati;
- diff check pulito.

Fixes #450