### PR TITLE
Conserva i token dopo errori del processo Codex

### DIFF
--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -323,10 +323,8 @@ class CodexStudentHelpProvider:
                         command,
                         cwd=workdir,
                         env=codex_subprocess_environment(),
-                        input=json.dumps(package, ensure_ascii=False, indent=2),
+                        input=json.dumps(package, ensure_ascii=False, indent=2).encode("utf-8"),
                         capture_output=True,
-                        text=True,
-                        encoding="utf-8",
                         timeout=self.timeout_seconds,
                         check=False,
                     )
@@ -343,7 +341,11 @@ class CodexStudentHelpProvider:
             _CODEX_CALL_SLOT.release()
         usage = _codex_usage_or_zero(completed.stdout)
         if completed.returncode:
-            detail = (completed.stderr or completed.stdout or "Codex non ha restituito dettagli.").strip()
+            detail = (
+                _subprocess_output_text(completed.stderr)
+                or _subprocess_output_text(completed.stdout)
+                or "Codex non ha restituito dettagli."
+            ).strip()
             raise CodexStudentHelpProcessError(f"Codex exec non riuscito: {detail}", usage)
         try:
             payload = json.loads(response_text)

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -276,20 +276,6 @@ def _terminate_process_tree(process: subprocess.Popen[bytes], windows_job: Any =
         if windows_job:
             _close_windows_job(windows_job, terminate=True)
             return
-        taskkill = shutil.which("taskkill")
-        if taskkill:
-            try:
-                completed = subprocess.run(
-                    [taskkill, "/PID", str(process.pid), "/T", "/F"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=False,
-                    timeout=10,
-                )
-                if completed.returncode == 0:
-                    return
-            except (OSError, subprocess.TimeoutExpired):
-                pass
     else:
         try:
             os.killpg(process.pid, signal.SIGKILL)
@@ -329,6 +315,10 @@ def _run_codex_process(
         process_options["start_new_session"] = True
     process = subprocess.Popen(command, **process_options)
     windows_job = _create_windows_kill_job(process)
+    if os.name == "nt" and not windows_job:
+        process.kill()
+        process.wait(timeout=10)
+        raise RuntimeError("Impossibile isolare il processo Codex in un Job Object Windows.")
     try:
         _resume_windows_process(process)
     except OSError:

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -169,10 +169,99 @@ def _codex_usage_or_zero(value: Any, *, allow_incomplete_tail: bool = False) -> 
         return _zero_usage()
 
 
-def _terminate_process_tree(process: subprocess.Popen[bytes]) -> None:
-    if process.poll() is not None:
+def _create_windows_kill_job(process: subprocess.Popen[bytes]) -> Any:
+    """Assign one Windows process tree to a kill-on-close Job Object."""
+
+    if os.name != "nt":
+        return None
+    import ctypes
+    from ctypes import wintypes
+
+    class JobObjectBasicLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_longlong),
+            ("PerJobUserTimeLimit", ctypes.c_longlong),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class IoCounters(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class JobObjectExtendedLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", JobObjectBasicLimitInformation),
+            ("IoInfo", IoCounters),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    kernel32.SetInformationJobObject.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    ]
+    kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    job = kernel32.CreateJobObjectW(None, None)
+    if not job:
+        return None
+    information = JobObjectExtendedLimitInformation()
+    information.BasicLimitInformation.LimitFlags = 0x00002000
+    configured = kernel32.SetInformationJobObject(
+        job,
+        9,
+        ctypes.byref(information),
+        ctypes.sizeof(information),
+    )
+    assigned = configured and kernel32.AssignProcessToJobObject(
+        job,
+        wintypes.HANDLE(int(process._handle)),
+    )
+    if assigned:
+        return job
+    kernel32.CloseHandle(job)
+    return None
+
+
+def _close_windows_job(job: Any, *, terminate: bool = False) -> None:
+    if os.name != "nt" or not job:
         return
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.TerminateJobObject.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    if terminate:
+        kernel32.TerminateJobObject(job, 1)
+    kernel32.CloseHandle(job)
+
+
+def _terminate_process_tree(process: subprocess.Popen[bytes], windows_job: Any = None) -> None:
     if os.name == "nt":
+        if windows_job:
+            _close_windows_job(windows_job, terminate=True)
+            return
         taskkill = shutil.which("taskkill")
         if taskkill:
             try:
@@ -193,7 +282,8 @@ def _terminate_process_tree(process: subprocess.Popen[bytes]) -> None:
             return
         except (OSError, ProcessLookupError):
             pass
-    process.kill()
+    if process.poll() is None:
+        process.kill()
 
 
 def _run_codex_process(
@@ -222,22 +312,28 @@ def _run_codex_process(
     else:
         process_options["start_new_session"] = True
     process = subprocess.Popen(command, **process_options)
+    windows_job = _create_windows_kill_job(process)
     try:
-        stdout, stderr = process.communicate(input=input, timeout=timeout)
-    except subprocess.TimeoutExpired as error:
-        _terminate_process_tree(process)
         try:
-            stdout, stderr = process.communicate(timeout=10)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            stdout = error.stdout or b""
-            stderr = error.stderr or b""
-        raise subprocess.TimeoutExpired(
-            command,
-            timeout,
-            output=stdout or error.stdout,
-            stderr=stderr or error.stderr,
-        ) from error
+            stdout, stderr = process.communicate(input=input, timeout=timeout)
+        except subprocess.TimeoutExpired as error:
+            _terminate_process_tree(process, windows_job)
+            windows_job = None
+            try:
+                stdout, stderr = process.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                if process.poll() is None:
+                    process.kill()
+                stdout = error.stdout or b""
+                stderr = error.stderr or b""
+            raise subprocess.TimeoutExpired(
+                command,
+                timeout,
+                output=stdout or error.stdout,
+                stderr=stderr or error.stderr,
+            ) from error
+    finally:
+        _close_windows_job(windows_job)
     completed = subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
     if check:
         completed.check_returncode()

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -333,20 +333,25 @@ class CodexStudentHelpProvider:
                         "Codex exec ha superato il tempo massimo consentito.",
                         _codex_usage_or_zero(error.stdout, allow_incomplete_tail=True),
                     ) from error
+                usage = _codex_usage_or_zero(completed.stdout)
+                if completed.returncode:
+                    detail = (
+                        _subprocess_output_text(completed.stderr)
+                        or _subprocess_output_text(completed.stdout)
+                        or "Codex non ha restituito dettagli."
+                    ).strip()
+                    raise CodexStudentHelpProcessError(f"Codex exec non riuscito: {detail}", usage)
                 try:
                     response_text = response_path.read_text(encoding="utf-8")
+                except UnicodeDecodeError as error:
+                    raise CodexStudentHelpResponseError(
+                        "Codex non ha restituito una risposta UTF-8 valida.",
+                        usage,
+                    ) from error
                 except OSError:
                     response_text = ""
         finally:
             _CODEX_CALL_SLOT.release()
-        usage = _codex_usage_or_zero(completed.stdout)
-        if completed.returncode:
-            detail = (
-                _subprocess_output_text(completed.stderr)
-                or _subprocess_output_text(completed.stdout)
-                or "Codex non ha restituito dettagli."
-            ).strip()
-            raise CodexStudentHelpProcessError(f"Codex exec non riuscito: {detail}", usage)
         try:
             payload = json.loads(response_text)
         except json.JSONDecodeError as error:

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import codecs
 import json
 import os
+import signal
 import shutil
 import subprocess
 import tempfile
@@ -168,6 +169,81 @@ def _codex_usage_or_zero(value: Any, *, allow_incomplete_tail: bool = False) -> 
         return _zero_usage()
 
 
+def _terminate_process_tree(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        taskkill = shutil.which("taskkill")
+        if taskkill:
+            try:
+                completed = subprocess.run(
+                    [taskkill, "/PID", str(process.pid), "/T", "/F"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                    timeout=10,
+                )
+                if completed.returncode == 0:
+                    return
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+            return
+        except (OSError, ProcessLookupError):
+            pass
+    process.kill()
+
+
+def _run_codex_process(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    input: bytes,
+    capture_output: bool,
+    timeout: int | float,
+    check: bool,
+) -> subprocess.CompletedProcess[bytes]:
+    """Run Codex and terminate its whole process tree when the timeout expires."""
+
+    if not capture_output:
+        raise ValueError("Il runner Codex richiede la cattura dell'output.")
+    process_options: dict[str, Any] = {
+        "cwd": cwd,
+        "env": env,
+        "stdin": subprocess.PIPE,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+    }
+    if os.name == "nt":
+        process_options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        process_options["start_new_session"] = True
+    process = subprocess.Popen(command, **process_options)
+    try:
+        stdout, stderr = process.communicate(input=input, timeout=timeout)
+    except subprocess.TimeoutExpired as error:
+        _terminate_process_tree(process)
+        try:
+            stdout, stderr = process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout = error.stdout or b""
+            stderr = error.stderr or b""
+        raise subprocess.TimeoutExpired(
+            command,
+            timeout,
+            output=stdout or error.stdout,
+            stderr=stderr or error.stderr,
+        ) from error
+    completed = subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+    if check:
+        completed.check_returncode()
+    return completed
+
+
 def codex_subprocess_environment() -> dict[str, str]:
     """Return the minimum server environment needed by the local Codex CLI."""
 
@@ -319,7 +395,7 @@ class CodexStudentHelpProvider:
                     command.extend(["--model", self.model])
                 command.append(codex_help_prompt())
                 try:
-                    completed = subprocess.run(
+                    completed = _run_codex_process(
                         command,
                         cwd=workdir,
                         env=codex_subprocess_environment(),

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import codecs
 import json
 import os
 import shutil
@@ -137,20 +138,32 @@ def _zero_usage() -> dict[str, int]:
     return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
 
 
-def _subprocess_output_text(value: Any) -> str:
+def _subprocess_output_text(value: Any, *, allow_incomplete_tail: bool = False) -> str:
     if isinstance(value, str):
         return value
     if isinstance(value, bytes):
         try:
+            if allow_incomplete_tail:
+                decoder = codecs.getincrementaldecoder("utf-8")()
+                return decoder.decode(value, final=False)
             return value.decode("utf-8")
         except UnicodeDecodeError:
             return ""
     return ""
 
 
-def _codex_usage_or_zero(value: Any) -> dict[str, int]:
+def _codex_usage_or_zero(value: Any, *, allow_incomplete_tail: bool = False) -> dict[str, int]:
+    text = _subprocess_output_text(value, allow_incomplete_tail=allow_incomplete_tail)
     try:
-        return codex_usage_from_jsonl(_subprocess_output_text(value))
+        return codex_usage_from_jsonl(text)
+    except ValueError:
+        if not allow_incomplete_tail:
+            return _zero_usage()
+    last_line_break = max(text.rfind("\n"), text.rfind("\r"))
+    if last_line_break < 0:
+        return _zero_usage()
+    try:
+        return codex_usage_from_jsonl(text[: last_line_break + 1])
     except ValueError:
         return _zero_usage()
 
@@ -320,7 +333,7 @@ class CodexStudentHelpProvider:
                 except subprocess.TimeoutExpired as error:
                     raise CodexStudentHelpProcessError(
                         "Codex exec ha superato il tempo massimo consentito.",
-                        _codex_usage_or_zero(error.stdout),
+                        _codex_usage_or_zero(error.stdout, allow_incomplete_tail=True),
                     ) from error
                 try:
                     response_text = response_path.read_text(encoding="utf-8")

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -257,6 +257,20 @@ def _close_windows_job(job: Any, *, terminate: bool = False) -> None:
     kernel32.CloseHandle(job)
 
 
+def _resume_windows_process(process: subprocess.Popen[bytes]) -> None:
+    if os.name != "nt":
+        return
+    import ctypes
+    from ctypes import wintypes
+
+    ntdll = ctypes.WinDLL("ntdll", use_last_error=True)
+    ntdll.NtResumeProcess.argtypes = [wintypes.HANDLE]
+    ntdll.NtResumeProcess.restype = ctypes.c_long
+    status = ntdll.NtResumeProcess(wintypes.HANDLE(int(process._handle)))
+    if status != 0:
+        raise OSError(f"Impossibile riprendere il processo Codex sospeso: NTSTATUS {status}.")
+
+
 def _terminate_process_tree(process: subprocess.Popen[bytes], windows_job: Any = None) -> None:
     if os.name == "nt":
         if windows_job:
@@ -308,11 +322,23 @@ def _run_codex_process(
         "stderr": subprocess.PIPE,
     }
     if os.name == "nt":
-        process_options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        process_options["creationflags"] = (
+            subprocess.CREATE_NEW_PROCESS_GROUP | 0x00000004
+        )
     else:
         process_options["start_new_session"] = True
     process = subprocess.Popen(command, **process_options)
     windows_job = _create_windows_kill_job(process)
+    try:
+        _resume_windows_process(process)
+    except OSError:
+        if windows_job:
+            _close_windows_job(windows_job, terminate=True)
+            windows_job = None
+        elif process.poll() is None:
+            process.kill()
+        process.wait(timeout=10)
+        raise
     try:
         try:
             stdout, stderr = process.communicate(input=input, timeout=timeout)

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -225,22 +225,24 @@ def _create_windows_kill_job(process: subprocess.Popen[bytes]) -> Any:
     job = kernel32.CreateJobObjectW(None, None)
     if not job:
         return None
-    information = JobObjectExtendedLimitInformation()
-    information.BasicLimitInformation.LimitFlags = 0x00002000
-    configured = kernel32.SetInformationJobObject(
-        job,
-        9,
-        ctypes.byref(information),
-        ctypes.sizeof(information),
-    )
-    assigned = configured and kernel32.AssignProcessToJobObject(
-        job,
-        wintypes.HANDLE(int(process._handle)),
-    )
-    if assigned:
-        return job
-    kernel32.CloseHandle(job)
-    return None
+    assigned = False
+    try:
+        information = JobObjectExtendedLimitInformation()
+        information.BasicLimitInformation.LimitFlags = 0x00002000
+        configured = kernel32.SetInformationJobObject(
+            job,
+            9,
+            ctypes.byref(information),
+            ctypes.sizeof(information),
+        )
+        assigned = bool(configured and kernel32.AssignProcessToJobObject(
+            job,
+            wintypes.HANDLE(int(process._handle)),
+        ))
+        return job if assigned else None
+    finally:
+        if not assigned:
+            kernel32.CloseHandle(job)
 
 
 def _close_windows_job(job: Any, *, terminate: bool = False) -> None:
@@ -314,24 +316,16 @@ def _run_codex_process(
     else:
         process_options["start_new_session"] = True
     process = subprocess.Popen(command, **process_options)
-    windows_job = _create_windows_kill_job(process)
-    if os.name == "nt" and not windows_job:
-        process.kill()
-        process.wait(timeout=10)
-        raise RuntimeError("Impossibile isolare il processo Codex in un Job Object Windows.")
+    windows_job = None
+    finished = False
     try:
+        windows_job = _create_windows_kill_job(process)
+        if os.name == "nt" and not windows_job:
+            raise RuntimeError("Impossibile isolare il processo Codex in un Job Object Windows.")
         _resume_windows_process(process)
-    except OSError:
-        if windows_job:
-            _close_windows_job(windows_job, terminate=True)
-            windows_job = None
-        elif process.poll() is None:
-            process.kill()
-        process.wait(timeout=10)
-        raise
-    try:
         try:
             stdout, stderr = process.communicate(input=input, timeout=timeout)
+            finished = True
         except subprocess.TimeoutExpired as error:
             _terminate_process_tree(process, windows_job)
             windows_job = None
@@ -349,6 +343,14 @@ def _run_codex_process(
                 stderr=stderr or error.stderr,
             ) from error
     finally:
+        if not finished:
+            _terminate_process_tree(process, windows_job)
+            windows_job = None
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                if process.poll() is None:
+                    process.kill()
         _close_windows_job(windows_job)
     completed = subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
     if check:

--- a/scripts/student_help_codex_adapter.py
+++ b/scripts/student_help_codex_adapter.py
@@ -125,8 +125,34 @@ class CodexStudentHelpResponseError(ValueError):
         self.usage = dict(usage)
 
 
+class CodexStudentHelpProcessError(RuntimeError):
+    """Codex process failure that retains usage emitted before termination."""
+
+    def __init__(self, message: str, usage: dict[str, int]) -> None:
+        super().__init__(message)
+        self.usage = dict(usage)
+
+
 def _zero_usage() -> dict[str, int]:
     return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+def _subprocess_output_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return ""
+    return ""
+
+
+def _codex_usage_or_zero(value: Any) -> dict[str, int]:
+    try:
+        return codex_usage_from_jsonl(_subprocess_output_text(value))
+    except ValueError:
+        return _zero_usage()
 
 
 def codex_subprocess_environment() -> dict[str, str]:
@@ -279,30 +305,33 @@ class CodexStudentHelpProvider:
                 if self.model:
                     command.extend(["--model", self.model])
                 command.append(codex_help_prompt())
-                completed = subprocess.run(
-                    command,
-                    cwd=workdir,
-                    env=codex_subprocess_environment(),
-                    input=json.dumps(package, ensure_ascii=False, indent=2),
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    timeout=self.timeout_seconds,
-                    check=False,
-                )
+                try:
+                    completed = subprocess.run(
+                        command,
+                        cwd=workdir,
+                        env=codex_subprocess_environment(),
+                        input=json.dumps(package, ensure_ascii=False, indent=2),
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        timeout=self.timeout_seconds,
+                        check=False,
+                    )
+                except subprocess.TimeoutExpired as error:
+                    raise CodexStudentHelpProcessError(
+                        "Codex exec ha superato il tempo massimo consentito.",
+                        _codex_usage_or_zero(error.stdout),
+                    ) from error
                 try:
                     response_text = response_path.read_text(encoding="utf-8")
                 except OSError:
                     response_text = ""
         finally:
             _CODEX_CALL_SLOT.release()
+        usage = _codex_usage_or_zero(completed.stdout)
         if completed.returncode:
             detail = (completed.stderr or completed.stdout or "Codex non ha restituito dettagli.").strip()
-            raise RuntimeError(f"Codex exec non riuscito: {detail}")
-        try:
-            usage = codex_usage_from_jsonl(completed.stdout)
-        except ValueError:
-            usage = _zero_usage()
+            raise CodexStudentHelpProcessError(f"Codex exec non riuscito: {detail}", usage)
         try:
             payload = json.loads(response_text)
         except json.JSONDecodeError as error:

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -41,7 +41,7 @@ def completed_codex_run(
     events: list[object] | None = None,
     returncode: int = 0,
     stderr: str = "",
-) -> subprocess.CompletedProcess[str]:
+) -> subprocess.CompletedProcess[bytes]:
     response_path = Path(command[command.index("--output-last-message") + 1])
     response_path.write_text(json.dumps(payload), encoding="utf-8")
     if events is None:
@@ -57,8 +57,8 @@ def completed_codex_run(
     return subprocess.CompletedProcess(
         command,
         returncode,
-        stdout="\n".join(json.dumps(event) for event in events),
-        stderr=stderr,
+        stdout="\n".join(json.dumps(event) for event in events).encode("utf-8"),
+        stderr=stderr.encode("utf-8"),
     )
 
 
@@ -116,10 +116,9 @@ def test_codex_provider_runs_in_empty_read_only_ephemeral_workspace(monkeypatch)
     def fake_run(command, **kwargs):
         captured["command"] = command
         captured["cwd"] = kwargs["cwd"]
-        captured["encoding"] = kwargs["encoding"]
         captured["env"] = kwargs["env"]
-        captured["raw_input"] = kwargs["input"]
-        captured["input"] = json.loads(kwargs["input"])
+        captured["raw_input"] = kwargs["input"].decode("utf-8")
+        captured["input"] = json.loads(captured["raw_input"])
         schema_path = command[command.index("--output-schema") + 1]
         captured["schema"] = json.loads(open(schema_path, encoding="utf-8").read())
         return completed_codex_run(
@@ -155,7 +154,7 @@ def test_codex_provider_runs_in_empty_read_only_ephemeral_workspace(monkeypatch)
     assert 'web_search="disabled"' in captured["command"]
     assert captured["command"][captured["command"].index("--model") + 1] == "gpt-test"
     assert captured["cwd"].name.startswith("thebitlab-student-help-")
-    assert captured["encoding"] == "utf-8"
+    assert isinstance(captured["raw_input"], str)
     assert captured["env"]["CODEX_HOME"] == "/home/docente/.codex"
     assert captured["env"]["OPENAI_API_KEY"] == "chiave-codex"
     assert "PATH" in captured["env"]
@@ -436,6 +435,33 @@ def test_codex_fallback_preserves_usage_from_timed_out_process(monkeypatch, part
 
     assert response.provider == "codex-local-fallback"
     assert response.usage == {"input_tokens": 21, "output_tokens": 8, "total_tokens": 29}
+
+
+def test_real_timeout_keeps_complete_jsonl_before_truncated_utf8_tail() -> None:
+    completed_event = json.dumps({
+        "type": "turn.completed",
+        "usage": {"input_tokens": 34, "output_tokens": 13},
+    }).encode("utf-8")
+    partial_output = completed_event + b'\n{"message":"troncato-\xc3'
+    script = (
+        "import sys, time; "
+        f"sys.stdout.buffer.write({partial_output!r}); "
+        "sys.stdout.buffer.flush(); time.sleep(5)"
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired) as captured:
+        subprocess.run(
+            [sys.executable, "-c", script],
+            input=b"",
+            capture_output=True,
+            timeout=0.5,
+            check=False,
+        )
+
+    assert student_help_codex_adapter._codex_usage_or_zero(
+        captured.value.stdout,
+        allow_incomplete_tail=True,
+    ) == {"input_tokens": 34, "output_tokens": 13, "total_tokens": 47}
 
 
 def test_fallback_provider_does_not_hide_unexpected_programming_errors() -> None:

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -369,6 +369,34 @@ def test_codex_fallback_preserves_usage_from_invalid_structured_response(monkeyp
     assert response.usage == {"input_tokens": 120, "output_tokens": 30, "total_tokens": 150}
 
 
+def test_codex_fallback_preserves_usage_from_non_utf8_sidecar(monkeypatch) -> None:
+    monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
+
+    def corrupt_sidecar(command, **kwargs):
+        completed = completed_codex_run(
+            command,
+            {
+                "guidance": ["Controlla l'input."],
+                "check_question": "Quale caso stai verificando?",
+            },
+            usage={"input_tokens": 9, "output_tokens": 4},
+        )
+        response_path = Path(command[command.index("--output-last-message") + 1])
+        response_path.write_bytes(b"\xff")
+        return completed
+
+    monkeypatch.setattr(student_help_codex_adapter.subprocess, "run", corrupt_sidecar)
+    provider = student_help_codex_adapter.FallbackStudentHelpProvider(
+        student_help_codex_adapter.CodexStudentHelpProvider(),
+        DeterministicStudentHelpProvider(),
+    )
+
+    response = provider.respond(sample_request())
+
+    assert response.provider == "codex-local-fallback"
+    assert response.usage == {"input_tokens": 9, "output_tokens": 4, "total_tokens": 13}
+
+
 def test_codex_fallback_preserves_usage_when_process_exits_with_error(monkeypatch) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -464,6 +464,19 @@ def test_real_timeout_keeps_complete_jsonl_before_truncated_utf8_tail() -> None:
     ) == {"input_tokens": 34, "output_tokens": 13, "total_tokens": 47}
 
 
+def test_partial_usage_rejects_complete_corruption_before_incomplete_tail() -> None:
+    completed_event = json.dumps({
+        "type": "turn.completed",
+        "usage": {"input_tokens": 34, "output_tokens": 13},
+    })
+    partial_output = f'{completed_event}\nnot-json\n{{"type":'
+
+    assert student_help_codex_adapter._codex_usage_or_zero(
+        partial_output,
+        allow_incomplete_tail=True,
+    ) == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
 def test_fallback_provider_does_not_hide_unexpected_programming_errors() -> None:
     class BrokenProvider:
         def respond(self, request):

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -542,6 +542,29 @@ time.sleep(5)
     ) == {"input_tokens": 6, "output_tokens": 2, "total_tokens": 8}
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Job Object disponibile solo su Windows")
+def test_codex_runner_fails_closed_before_resume_when_job_setup_fails(monkeypatch, tmp_path) -> None:
+    marker_path = tmp_path / "started.txt"
+    monkeypatch.setattr(student_help_codex_adapter, "_create_windows_kill_job", lambda process: None)
+
+    with pytest.raises(RuntimeError, match="Job Object Windows"):
+        student_help_codex_adapter._run_codex_process(
+            [
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(marker_path)!r}).write_text('started')",
+            ],
+            cwd=tmp_path,
+            env=dict(os.environ),
+            input=b"",
+            capture_output=True,
+            timeout=1,
+            check=False,
+        )
+
+    assert not marker_path.exists()
+
+
 def test_partial_usage_rejects_complete_corruption_before_incomplete_tail() -> None:
     completed_event = json.dumps({
         "type": "turn.completed",

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -565,6 +565,60 @@ def test_codex_runner_fails_closed_before_resume_when_job_setup_fails(monkeypatc
     assert not marker_path.exists()
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Job Object disponibile solo su Windows")
+def test_codex_runner_cleans_suspended_process_when_job_setup_raises(monkeypatch, tmp_path) -> None:
+    marker_path = tmp_path / "started.txt"
+
+    def fail_job_setup(process):
+        raise RuntimeError("setup job interrotto")
+
+    monkeypatch.setattr(student_help_codex_adapter, "_create_windows_kill_job", fail_job_setup)
+
+    with pytest.raises(RuntimeError, match="setup job interrotto"):
+        student_help_codex_adapter._run_codex_process(
+            [
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(marker_path)!r}).write_text('started')",
+            ],
+            cwd=tmp_path,
+            env=dict(os.environ),
+            input=b"",
+            capture_output=True,
+            timeout=1,
+            check=False,
+        )
+
+    assert not marker_path.exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Job Object disponibile solo su Windows")
+def test_codex_runner_terminates_job_when_resume_raises(monkeypatch, tmp_path) -> None:
+    marker_path = tmp_path / "started.txt"
+
+    def fail_resume(process):
+        raise ValueError("resume interrotto")
+
+    monkeypatch.setattr(student_help_codex_adapter, "_resume_windows_process", fail_resume)
+
+    with pytest.raises(ValueError, match="resume interrotto"):
+        student_help_codex_adapter._run_codex_process(
+            [
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(marker_path)!r}).write_text('started')",
+            ],
+            cwd=tmp_path,
+            env=dict(os.environ),
+            input=b"",
+            capture_output=True,
+            timeout=1,
+            check=False,
+        )
+
+    assert not marker_path.exists()
+
+
 def test_partial_usage_rejects_complete_corruption_before_incomplete_tail() -> None:
     completed_event = json.dumps({
         "type": "turn.completed",

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -511,13 +511,13 @@ time.sleep(5)
     if os.name == "nt":
         launcher_path = tmp_path / "slow_codex.cmd"
         launcher_path.write_text(
-            f'@echo off\r\n"{sys.executable}" "{child_path}"\r\n',
+            f'@echo off\r\nstart "" /B "{sys.executable}" "{child_path}"\r\n',
             encoding="utf-8",
         )
     else:
         launcher_path = tmp_path / "slow_codex"
         launcher_path.write_text(
-            f'#!/bin/sh\n"{sys.executable}" "{child_path}"\n',
+            f'#!/bin/sh\n"{sys.executable}" "{child_path}" &\n',
             encoding="utf-8",
         )
         launcher_path.chmod(0o755)

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -39,6 +39,8 @@ def completed_codex_run(
     *,
     usage: dict[str, int] | None = None,
     events: list[object] | None = None,
+    returncode: int = 0,
+    stderr: str = "",
 ) -> subprocess.CompletedProcess[str]:
     response_path = Path(command[command.index("--output-last-message") + 1])
     response_path.write_text(json.dumps(payload), encoding="utf-8")
@@ -54,9 +56,9 @@ def completed_codex_run(
         }]
     return subprocess.CompletedProcess(
         command,
-        0,
+        returncode,
         stdout="\n".join(json.dumps(event) for event in events),
-        stderr="",
+        stderr=stderr,
     )
 
 
@@ -366,6 +368,60 @@ def test_codex_fallback_preserves_usage_from_invalid_structured_response(monkeyp
     assert response.provider == "codex-local-fallback"
     assert response.provider_label == "Guida locale (nessuna AI esterna) dopo errore Codex"
     assert response.usage == {"input_tokens": 120, "output_tokens": 30, "total_tokens": 150}
+
+
+def test_codex_fallback_preserves_usage_when_process_exits_with_error(monkeypatch) -> None:
+    monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
+    monkeypatch.setattr(
+        student_help_codex_adapter.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_codex_run(
+            args[0],
+            {},
+            returncode=1,
+            stderr="errore dopo il turno",
+        ),
+    )
+    provider = student_help_codex_adapter.FallbackStudentHelpProvider(
+        student_help_codex_adapter.CodexStudentHelpProvider(),
+        DeterministicStudentHelpProvider(),
+    )
+
+    response = provider.respond(sample_request())
+
+    assert response.provider == "codex-local-fallback"
+    assert response.usage == {"input_tokens": 120, "output_tokens": 30, "total_tokens": 150}
+
+
+@pytest.mark.parametrize(
+    "partial_output",
+    [
+        json.dumps({
+            "type": "turn.completed",
+            "usage": {"input_tokens": 21, "output_tokens": 8},
+        }),
+        json.dumps({
+            "type": "turn.completed",
+            "usage": {"input_tokens": 21, "output_tokens": 8},
+        }).encode("utf-8"),
+    ],
+)
+def test_codex_fallback_preserves_usage_from_timed_out_process(monkeypatch, partial_output) -> None:
+    monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
+
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], 1, output=partial_output)
+
+    monkeypatch.setattr(student_help_codex_adapter.subprocess, "run", timeout)
+    provider = student_help_codex_adapter.FallbackStudentHelpProvider(
+        student_help_codex_adapter.CodexStudentHelpProvider(),
+        DeterministicStudentHelpProvider(),
+    )
+
+    response = provider.respond(sample_request())
+
+    assert response.provider == "codex-local-fallback"
+    assert response.usage == {"input_tokens": 21, "output_tokens": 8, "total_tokens": 29}
 
 
 def test_fallback_provider_does_not_hide_unexpected_programming_errors() -> None:

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -404,6 +404,20 @@ def test_codex_fallback_preserves_usage_when_process_exits_with_error(monkeypatc
             "type": "turn.completed",
             "usage": {"input_tokens": 21, "output_tokens": 8},
         }).encode("utf-8"),
+        (
+            json.dumps({
+                "type": "turn.completed",
+                "usage": {"input_tokens": 21, "output_tokens": 8},
+            })
+            + '\n{"type":'
+        ),
+        (
+            json.dumps({
+                "type": "turn.completed",
+                "usage": {"input_tokens": 21, "output_tokens": 8},
+            }).encode("utf-8")
+            + b'\n{"message":"troncato-\xc3'
+        ),
     ],
 )
 def test_codex_fallback_preserves_usage_from_timed_out_process(monkeypatch, partial_output) -> None:

--- a/tests/test_student_help_codex_adapter.py
+++ b/tests/test_student_help_codex_adapter.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -129,7 +130,7 @@ def test_codex_provider_runs_in_empty_read_only_ephemeral_workspace(monkeypatch)
             },
         )
 
-    monkeypatch.setattr(student_help_codex_adapter.subprocess, "run", fake_run)
+    monkeypatch.setattr(student_help_codex_adapter, "_run_codex_process", fake_run)
 
     response = student_help_codex_adapter.CodexStudentHelpProvider(model="gpt-test").respond(sample_request())
 
@@ -234,8 +235,8 @@ def test_codex_provider_rejects_parallel_process_when_slot_is_busy(monkeypatch) 
 def test_codex_provider_rejects_invalid_structured_output(monkeypatch) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(
-        student_help_codex_adapter.subprocess,
-        "run",
+        student_help_codex_adapter,
+        "_run_codex_process",
         lambda *args, **kwargs: completed_codex_run(args[0], {}),
     )
 
@@ -246,8 +247,8 @@ def test_codex_provider_rejects_invalid_structured_output(monkeypatch) -> None:
 def test_codex_provider_rejects_terminal_escape_sequences(monkeypatch) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(
-        student_help_codex_adapter.subprocess,
-        "run",
+        student_help_codex_adapter,
+        "_run_codex_process",
         lambda *args, **kwargs: completed_codex_run(
             args[0],
             {
@@ -264,8 +265,8 @@ def test_codex_provider_rejects_terminal_escape_sequences(monkeypatch) -> None:
 def test_codex_provider_rejects_output_that_would_truncate_check_question(monkeypatch) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(
-        student_help_codex_adapter.subprocess,
-        "run",
+        student_help_codex_adapter,
+        "_run_codex_process",
         lambda *args, **kwargs: completed_codex_run(
             args[0],
             {
@@ -282,8 +283,8 @@ def test_codex_provider_rejects_output_that_would_truncate_check_question(monkey
 def test_codex_provider_marks_missing_token_usage_without_losing_response(monkeypatch) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(
-        student_help_codex_adapter.subprocess,
-        "run",
+        student_help_codex_adapter,
+        "_run_codex_process",
         lambda *args, **kwargs: completed_codex_run(
             args[0],
             {
@@ -311,8 +312,8 @@ def test_codex_provider_marks_missing_token_usage_without_losing_response(monkey
 def test_codex_provider_marks_invalid_token_usage_without_losing_response(monkeypatch, events) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(
-        student_help_codex_adapter.subprocess,
-        "run",
+        student_help_codex_adapter,
+        "_run_codex_process",
         lambda *args, **kwargs: completed_codex_run(
             args[0],
             {
@@ -353,8 +354,8 @@ def test_fallback_provider_uses_local_guide_when_codex_fails() -> None:
 def test_codex_fallback_preserves_usage_from_invalid_structured_response(monkeypatch) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(
-        student_help_codex_adapter.subprocess,
-        "run",
+        student_help_codex_adapter,
+        "_run_codex_process",
         lambda *args, **kwargs: completed_codex_run(args[0], {}),
     )
     provider = student_help_codex_adapter.FallbackStudentHelpProvider(
@@ -385,7 +386,7 @@ def test_codex_fallback_preserves_usage_from_non_utf8_sidecar(monkeypatch) -> No
         response_path.write_bytes(b"\xff")
         return completed
 
-    monkeypatch.setattr(student_help_codex_adapter.subprocess, "run", corrupt_sidecar)
+    monkeypatch.setattr(student_help_codex_adapter, "_run_codex_process", corrupt_sidecar)
     provider = student_help_codex_adapter.FallbackStudentHelpProvider(
         student_help_codex_adapter.CodexStudentHelpProvider(),
         DeterministicStudentHelpProvider(),
@@ -400,8 +401,8 @@ def test_codex_fallback_preserves_usage_from_non_utf8_sidecar(monkeypatch) -> No
 def test_codex_fallback_preserves_usage_when_process_exits_with_error(monkeypatch) -> None:
     monkeypatch.setattr(student_help_codex_adapter.shutil, "which", lambda command: "/bin/codex")
     monkeypatch.setattr(
-        student_help_codex_adapter.subprocess,
-        "run",
+        student_help_codex_adapter,
+        "_run_codex_process",
         lambda *args, **kwargs: completed_codex_run(
             args[0],
             {},
@@ -453,7 +454,7 @@ def test_codex_fallback_preserves_usage_from_timed_out_process(monkeypatch, part
     def timeout(*args, **kwargs):
         raise subprocess.TimeoutExpired(args[0], 1, output=partial_output)
 
-    monkeypatch.setattr(student_help_codex_adapter.subprocess, "run", timeout)
+    monkeypatch.setattr(student_help_codex_adapter, "_run_codex_process", timeout)
     provider = student_help_codex_adapter.FallbackStudentHelpProvider(
         student_help_codex_adapter.CodexStudentHelpProvider(),
         DeterministicStudentHelpProvider(),
@@ -490,6 +491,55 @@ def test_real_timeout_keeps_complete_jsonl_before_truncated_utf8_tail() -> None:
         captured.value.stdout,
         allow_incomplete_tail=True,
     ) == {"input_tokens": 34, "output_tokens": 13, "total_tokens": 47}
+
+
+def test_codex_runner_kills_launcher_process_tree_on_timeout(tmp_path) -> None:
+    child_path = tmp_path / "slow_codex.py"
+    child_path.write_text(
+        """import json
+import sys
+import time
+
+print(json.dumps({
+    "type": "turn.completed",
+    "usage": {"input_tokens": 6, "output_tokens": 2},
+}), flush=True)
+time.sleep(5)
+""",
+        encoding="utf-8",
+    )
+    if os.name == "nt":
+        launcher_path = tmp_path / "slow_codex.cmd"
+        launcher_path.write_text(
+            f'@echo off\r\n"{sys.executable}" "{child_path}"\r\n',
+            encoding="utf-8",
+        )
+    else:
+        launcher_path = tmp_path / "slow_codex"
+        launcher_path.write_text(
+            f'#!/bin/sh\n"{sys.executable}" "{child_path}"\n',
+            encoding="utf-8",
+        )
+        launcher_path.chmod(0o755)
+
+    started_at = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired) as captured:
+        student_help_codex_adapter._run_codex_process(
+            [str(launcher_path)],
+            cwd=tmp_path,
+            env=dict(os.environ),
+            input=b"",
+            capture_output=True,
+            timeout=0.5,
+            check=False,
+        )
+    elapsed = time.monotonic() - started_at
+
+    assert elapsed < 3
+    assert student_help_codex_adapter._codex_usage_or_zero(
+        captured.value.stdout,
+        allow_incomplete_tail=True,
+    ) == {"input_tokens": 6, "output_tokens": 2, "total_tokens": 8}
 
 
 def test_partial_usage_rejects_complete_corruption_before_incomplete_tail() -> None:


### PR DESCRIPTION
## Obiettivo

Corregge il caso individuato dal controllo asincrono successivo alla PR #451: Codex può dichiarare i contatori del turno e terminare comunque con errore o timeout.

## Modifiche

- Analizza l'usage JSONL prima di valutare il codice di uscita.
- Trasporta i contatori disponibili nell'errore di processo.
- Recupera l'output parziale dei timeout sia come testo sia come byte UTF-8.
- Mantiene zero e l'avviso “senza contatori” quando non esiste usage valido.
- Aggiunge test per uscita non zero e timeout.

## Verifica

- 20 test dell'adapter Codex superati.
- Suite backend/TUI del blocco superata, con 2 test esclusi come previsto.
- `git diff --check` superato.

Fixes #452.