### PR TITLE
Aggiorna roadmap per revisione dashboard docente con gpt-5.6-sol

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -665,7 +665,12 @@ Ordine consigliato:
 10. Dashboard studente MVP per consegne, calendario, percorso, stato e feedback deterministico, collegata ai risultati prodotti dal backend lab.
 11. Consolidamento grading Docker per flusso reale di consegna.
 12. Collegamento automatico report/artifact al registro consegne.
-13. Revisione dashboard docente contro il flusso MVP reale.
+13. Revisione completa della dashboard docente contro il flusso MVP reale, usando `gpt-5.6-sol` con reasoning `high`:
+   - estendere la revisione gia fatta sulla pagina Percorso alle altre pagine docente;
+   - verificare coerenza di font, colori, spaziature, pannelli, modal, tooltip, legenda e stati di errore;
+   - verificare responsive, accessibilita e leggibilita dei contenuti lunghi nelle viste e nei modal;
+   - eseguire gli scenari manuali aggiornati e trasformare i problemi in issue/PR atomiche;
+   - aggiornare la guida utente e la checklist dopo ogni comportamento stabilizzato.
 14. Stabilizzazione test manuali e automazione GUI/TUI:
    - mantenere aggiornata la checklist `doc/SCENARI_TEST_MANUALI_GUI.md` per ogni pannello, modal, vista e comando TUI;
    - aggiungere `data-testid` o altri punti di aggancio stabili alle GUI prima di automatizzare;


### PR DESCRIPTION
## Obiettivo

Pianificare la revisione delle altre pagine della dashboard docente dopo la pagina Percorso, usando `gpt-5.6-sol` con reasoning `high`.

## Contenuto

- verifica di font, colori, spaziature, pannelli, modal, tooltip, legenda e stati di errore;
- verifica responsive, accessibilita e leggibilita dei contenuti lunghi;
- esecuzione degli scenari manuali e apertura di issue/PR atomiche per i problemi trovati;
- aggiornamento della guida utente e della checklist quando i comportamenti sono stabili.

## Verifica

- `git diff --check`
- modifica limitata a `doc/ROADMAP.md`.

Il file non tracciato `doc/ideas/learning-lab-project-plan-v2-federated-knowledge.md` presente localmente non e stato incluso.