### PR TITLE
Completa la demo end-to-end del lab studente

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -161,6 +161,17 @@ Il comando `v` cerca un editor terminale nell'ordine `micro`, `nvim`, `vim`, `hx
 Per scegliere esplicitamente un editor, imposta `THEBITLAB_EDITOR`, per esempio `micro --clean` o `nvim`.
 L'editor viene eseguito nella cartella della consegna e apre il file sorgente indicato dall'activity.
 
+Il comando `l` apre il layout della vista consegna. La disposizione iniziale affianca a sinistra il dettaglio
+e a destra guida/comandi. In questa modalità:
+
+- `Alt+freccia sinistra/destra` restringe o allarga il pannello sinistro;
+- `Ctrl+freccia sinistra/destra` scambia i due pannelli;
+- `Ctrl+freccia su/giu` alterna disposizione affiancata e verticale;
+- `Enter` salva la disposizione, `Esc` annulla, `r` ripristina quella iniziale.
+
+La configurazione e' locale e non contiene dati didattici: viene salvata in `.student-lab-layout.json` nella root
+usata dalla TUI. Si puo' indicare un percorso diverso con `THEBITLAB_LAYOUT_PATH`.
+
 Il dettaglio mostra anche una guida rapida con i termini chiave:
 
 - consegna: lavoro assegnato dal docente;

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -162,17 +162,10 @@ Per scegliere esplicitamente un editor, imposta `THEBITLAB_EDITOR`, per esempio 
 L'editor viene eseguito nella cartella della consegna e apre il file sorgente indicato dall'activity.
 
 Il comando `l` apre il layout della vista consegna. Ogni sezione del dettaglio diventa un pannello separato;
-la disposizione iniziale li distribuisce in due colonne. In questa modalità:
+la disposizione iniziale li distribuisce in due colonne. Per ora il controllo principale e' il ridimensionamento:
 
-- `Alt+freccia sinistra/destra` restringe o allarga il pannello sinistro;
-- `Tab` seleziona il pannello successivo; il pannello selezionato e' indicato da `>` e dalla riga `Pannello attivo`;
-- `Ctrl+freccia sinistra/destra` sposta il pannello selezionato nell'ordine;
-- `Ctrl+freccia su/giu` sposta il pannello selezionato tra le righe;
-- `+` apre il pannello selezionato e `-` lo comprime lasciando visibile il titolo;
-- frecce su/giu alternano disposizione affiancata e verticale;
-- fallback senza modificatori: `[`/`]` ridimensionano, `h`/`l` spostano a sinistra/destra,
-  `k`/`j` spostano su/giu, `o` cambia orientamento;
-- `x` resta disponibile per spostare il pannello selezionato verso destra;
+- freccia sinistra/destra restringe o allarga il pannello sinistro;
+- `[`/`]` sono il fallback piu' affidabile quando il terminale intercetta `Alt`;
 - `Enter` salva la disposizione, `Esc` annulla, `r` ripristina quella iniziale.
 
 La configurazione e' locale e non contiene dati didattici: viene salvata in `.student-lab-layout.json` nella root

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -170,7 +170,9 @@ la disposizione iniziale li distribuisce in due colonne. In questa modalità:
 - `Ctrl+freccia su/giu` sposta il pannello selezionato tra le righe;
 - `+` apre il pannello selezionato e `-` lo comprime lasciando visibile il titolo;
 - frecce su/giu alternano disposizione affiancata e verticale;
-- se il terminale non trasmette i modificatori: frecce per resize/orientamento e `x` per scambiare i pannelli;
+- fallback senza modificatori: `[`/`]` ridimensionano, `h`/`l` spostano a sinistra/destra,
+  `k`/`j` spostano su/giu, `o` cambia orientamento;
+- `x` resta disponibile per spostare il pannello selezionato verso destra;
 - `Enter` salva la disposizione, `Esc` annulla, `r` ripristina quella iniziale.
 
 La configurazione e' locale e non contiene dati didattici: viene salvata in `.student-lab-layout.json` nella root

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -167,6 +167,7 @@ e a destra guida/comandi. In questa modalità:
 - `Alt+freccia sinistra/destra` restringe o allarga il pannello sinistro;
 - `Ctrl+freccia sinistra/destra` scambia i due pannelli;
 - `Ctrl+freccia su/giu` alterna disposizione affiancata e verticale;
+- se il terminale non trasmette i modificatori: frecce per resize/orientamento e `x` per scambiare i pannelli;
 - `Enter` salva la disposizione, `Esc` annulla, `r` ripristina quella iniziale.
 
 La configurazione e' locale e non contiene dati didattici: viene salvata in `.student-lab-layout.json` nella root

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -165,7 +165,7 @@ Il comando `l` apre il layout della vista consegna. Ogni sezione del dettaglio d
 la disposizione iniziale li distribuisce in due colonne. In questa modalità:
 
 - `Alt+freccia sinistra/destra` restringe o allarga il pannello sinistro;
-- `Tab` seleziona il pannello successivo; il pannello selezionato e' indicato da `>`;
+- `Tab` seleziona il pannello successivo; il pannello selezionato e' indicato da `>` e dalla riga `Pannello attivo`;
 - `Ctrl+freccia sinistra/destra` sposta il pannello selezionato nell'ordine;
 - `Ctrl+freccia su/giu` sposta il pannello selezionato tra le righe;
 - `+` apre il pannello selezionato e `-` lo comprime lasciando visibile il titolo;

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -166,6 +166,9 @@ la disposizione iniziale li distribuisce in due colonne. Per ora il controllo pr
 
 - freccia sinistra/destra restringe o allarga il pannello sinistro;
 - `[`/`]` sono il fallback piu' affidabile quando il terminale intercetta `Alt`;
+- `Tab` seleziona il pannello successivo; il pannello selezionato e' indicato da `>` e dalla riga `Pannello attivo`;
+- `h`/`l` spostano il pannello selezionato a sinistra/destra, `k`/`j` lo spostano su/giu';
+- `+`/`-` aprono o comprimono il pannello selezionato, `o` cambia orientamento e `x` lo sposta a destra;
 - `Enter` salva la disposizione, `Esc` annulla, `r` ripristina quella iniziale.
 
 La configurazione e' locale e non contiene dati didattici: viene salvata in `.student-lab-layout.json` nella root

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -154,8 +154,12 @@ Comandi disponibili nella TUI minima:
 
 Nel dettaglio della consegna i comandi sono divisi in:
 
-- azioni principali: `e` esegue il runner e salva il report, `a` registra una richiesta di aiuto, `o` apre la cartella workspace;
+- azioni principali: `e` esegue il runner e salva il report, `a` registra una richiesta di aiuto, `o` apre la cartella workspace, `v` apre l'editor;
 - altri comandi: `h` mostra lo storico aiuti, `b` o invio torna alla lista, `q` esce.
+
+Il comando `v` cerca un editor terminale nell'ordine `micro`, `nvim`, `vim`, `hx`, `nano` (e `notepad` su Windows).
+Per scegliere esplicitamente un editor, imposta `THEBITLAB_EDITOR`, per esempio `micro --clean` o `nvim`.
+L'editor viene eseguito nella cartella della consegna e apre il file sorgente indicato dall'activity.
 
 Il dettaglio mostra anche una guida rapida con i termini chiave:
 

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -161,12 +161,15 @@ Il comando `v` cerca un editor terminale nell'ordine `micro`, `nvim`, `vim`, `hx
 Per scegliere esplicitamente un editor, imposta `THEBITLAB_EDITOR`, per esempio `micro --clean` o `nvim`.
 L'editor viene eseguito nella cartella della consegna e apre il file sorgente indicato dall'activity.
 
-Il comando `l` apre il layout della vista consegna. La disposizione iniziale affianca a sinistra il dettaglio
-e a destra guida/comandi. In questa modalità:
+Il comando `l` apre il layout della vista consegna. Ogni sezione del dettaglio diventa un pannello separato;
+la disposizione iniziale li distribuisce in due colonne. In questa modalità:
 
 - `Alt+freccia sinistra/destra` restringe o allarga il pannello sinistro;
-- `Ctrl+freccia sinistra/destra` scambia i due pannelli;
-- `Ctrl+freccia su/giu` alterna disposizione affiancata e verticale;
+- `Tab` seleziona il pannello successivo; il pannello selezionato e' indicato da `>`;
+- `Ctrl+freccia sinistra/destra` sposta il pannello selezionato nell'ordine;
+- `Ctrl+freccia su/giu` sposta il pannello selezionato tra le righe;
+- `+` apre il pannello selezionato e `-` lo comprime lasciando visibile il titolo;
+- frecce su/giu alternano disposizione affiancata e verticale;
 - se il terminale non trasmette i modificatori: frecce per resize/orientamento e `x` per scambiare i pannelli;
 - `Enter` salva la disposizione, `Esc` annulla, `r` ripristina quella iniziale.
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -131,7 +131,7 @@ def policy_list(values: Any) -> str:
     return ", ".join(clean_text(value) for value in values)
 
 
-def ai_budget_label(value: Any) -> str:
+def ai_budget_label(value: Any, use_color: bool = False) -> str:
     """Return a compact AI budget summary."""
 
     if not isinstance(value, dict):
@@ -140,9 +140,37 @@ def ai_budget_label(value: Any) -> str:
     used = value.get("used")
     remaining = value.get("remaining")
     if not limit:
-        return "non disponibile"
+        return colorize("non disponibile", HELP_ERROR_COLOR, use_color)
     label = f"{used or 0}/{limit} usate, {remaining or 0} rimanenti"
-    return f"{label} (esaurito)" if value.get("exhausted") else label
+    if value.get("exhausted") or not remaining:
+        color = HELP_ERROR_COLOR
+    elif remaining <= max(1, (limit + 1) // 2):
+        color = HELP_PROMPT_COLOR
+    else:
+        color = HELP_RESPONSE_COLOR
+    return colorize(f"{label} (esaurito)" if value.get("exhausted") else label, color, use_color)
+
+
+def help_decision_label(value: Any, use_color: bool = False) -> str:
+    """Return the latest help decision with an actionable status color."""
+
+    decision = clean_text(value, "")
+    if decision == "consentita":
+        return colorize(decision, HELP_RESPONSE_COLOR, use_color)
+    if decision == "bloccata":
+        return colorize(decision, HELP_ERROR_COLOR, use_color)
+    return colorize("nessuna richiesta", HELP_PROMPT_COLOR, use_color) if use_color else "nessuna richiesta"
+
+
+def runner_status_label(value: Any, use_color: bool = False) -> str:
+    """Return runner state with red pending/error and green completed status."""
+
+    status = clean_text(value, "not_run")
+    if status == "not_run":
+        return colorize(status, HELP_ERROR_COLOR, use_color)
+    if status == "passed":
+        return colorize(status, HELP_RESPONSE_COLOR, use_color)
+    return colorize(status, HELP_ERROR_COLOR, use_color)
 
 
 def truncate(text: str, width: int) -> str:
@@ -260,15 +288,15 @@ def guide_label(text: str, use_color: bool = False) -> str:
     return colorize(f"{text:<9}", GUIDE_TERM_COLORS.get(text.lower(), ""), use_color)
 
 
-def test_result_label(test: dict[str, Any]) -> str:
+def test_result_label(test: dict[str, Any], use_color: bool = False) -> str:
     """Return a compact label for one test result."""
 
     if test.get("passed") is True:
-        return "[ok]"
+        return colorize("[ok]", HELP_RESPONSE_COLOR, use_color)
     if test.get("passed") is False:
-        return "[ko]"
+        return colorize("[ko]", HELP_ERROR_COLOR, use_color)
     status = clean_text(test.get("status"), "")
-    return f"[{status}]" if status else "[?]"
+    return colorize(f"[{status}]" if status else "[?]", HELP_PROMPT_COLOR, use_color)
 
 
 def test_result_detail(test: dict[str, Any]) -> str:
@@ -281,7 +309,7 @@ def test_result_detail(test: dict[str, Any]) -> str:
     return ""
 
 
-def render_test_details(report: dict[str, Any]) -> list[str]:
+def render_test_details(report: dict[str, Any], use_color: bool = False) -> list[str]:
     """Render test details from a runner report."""
 
     tests = report.get("tests")
@@ -292,7 +320,7 @@ def render_test_details(report: dict[str, Any]) -> list[str]:
         if not isinstance(item, dict):
             continue
         name = clean_text(item.get("name"), f"test {index}")
-        lines.append(f"  {test_result_label(item)} {name}")
+        lines.append(f"  {test_result_label(item, use_color=use_color)} {name}")
         detail = test_result_detail(item)
         if detail and item.get("passed") is not True:
             lines.append(f"      {truncate(detail, 96)}")
@@ -346,9 +374,9 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Eventi:", help_summary.get("total")),
         detail_line("Consentite:", help_summary.get("allowed")),
         detail_line("Bloccate:", help_summary.get("denied")),
-        detail_line("AI budget:", ai_budget_label(help_summary.get("ai_budget"))),
+        detail_line("AI budget:", ai_budget_label(help_summary.get("ai_budget"), use_color), formatted=True),
         detail_line("Ultima:", compact_datetime(help_summary.get("last_requested_at"))),
-        detail_line("Esito ultima:", help_summary.get("last_decision")),
+        detail_line("Esito ultima:", help_decision_label(help_summary.get("last_decision"), use_color), formatted=True),
         section_separator(),
         "Report",
         detail_line("Path:", report.get("path")),
@@ -359,7 +387,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
             [
                 section_separator(),
                 "Ultimo dettaglio test",
-                *render_test_details({"tests": report.get("tests")})[1:],
+                *render_test_details({"tests": report.get("tests")}, use_color=use_color)[1:],
             ]
             if report.get("exists")
             else []
@@ -370,7 +398,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         detail_line("Voto:", grading.get("teacher_grade") if grading.get("teacher_grade") is not None else grading.get("score")),
         section_separator(),
         "Runner",
-        detail_line("Stato:", runner.get("status")),
+        detail_line("Stato:", runner_status_label(runner.get("status"), use_color), formatted=True),
         detail_line("Backend:", runner.get("backend")),
         section_separator(),
         "Guida rapida",
@@ -399,7 +427,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
     return "\n".join(lines)
 
 
-def runner_result_message(report: dict[str, Any], report_path: Path) -> str:
+def runner_result_message(report: dict[str, Any], report_path: Path, use_color: bool = False) -> str:
     """Return a clear message after a runner execution."""
 
     status = clean_text(report.get("status"))
@@ -418,7 +446,7 @@ def runner_result_message(report: dict[str, Any], report_path: Path) -> str:
             detail_line("Test:", tests),
             detail_line("Report salvato:", report_path),
             "",
-            *render_test_details(report),
+            *render_test_details(report, use_color=use_color),
             "",
             "Questo report è quello letto da dashboard e registro docente.",
         ]
@@ -1067,7 +1095,7 @@ def run_tui(
                 except ValueError as error:
                     print_fn(f"Runner non disponibile:\n{error}")
                 else:
-                    print_fn(runner_result_message(report, report_path))
+                    print_fn(runner_result_message(report, report_path, use_color=use_color))
                     try:
                         payload = load_current_payload(
                             root=root,

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -471,7 +471,7 @@ def render_assignment_detail(
         "  q  Esci",
     ]
     if layout is not None:
-        return student_lab_layout.render_layout(lines, layout)
+        return student_lab_layout.render_layout(lines, layout, use_color=use_color)
     return "\n".join(lines)
 
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -471,7 +471,12 @@ def render_assignment_detail(
         "  q  Esci",
     ]
     if layout is not None:
-        return student_lab_layout.render_layout(lines, layout, use_color=use_color)
+        return student_lab_layout.render_layout(
+            lines,
+            layout,
+            use_color=use_color,
+            highlight_focus=True,
+        )
     return "\n".join(lines)
 
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -471,12 +471,7 @@ def render_assignment_detail(
         "  q  Esci",
     ]
     if layout is not None:
-        return student_lab_layout.render_layout(
-            lines,
-            layout,
-            use_color=use_color,
-            highlight_focus=True,
-        )
+        return student_lab_layout.render_layout(lines, layout, use_color=use_color)
     return "\n".join(lines)
 
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -57,6 +57,8 @@ GUIDE_TERM_COLORS = {
     "test": "\033[33m",
     "report": "\033[32m",
 }
+GUIDE_TERM_BOLD_COLOR = "\033[1;37m"
+GUIDE_DESCRIPTION_COLOR = "\033[3;90m"
 RESET_COLOR = "\033[0m"
 
 
@@ -171,6 +173,24 @@ def runner_status_label(value: Any, use_color: bool = False) -> str:
     if status == "passed":
         return colorize(status, HELP_RESPONSE_COLOR, use_color)
     return colorize(status, HELP_ERROR_COLOR, use_color)
+
+
+def grade_label(value: Any, use_color: bool = False) -> str:
+    """Return a grade with a quick visual indication of its range."""
+
+    if value is None or isinstance(value, bool):
+        return "-"
+    try:
+        grade = float(str(value).replace(",", "."))
+    except (TypeError, ValueError):
+        return clean_text(value, "-")
+    if 7 <= grade <= 10:
+        color = HELP_RESPONSE_COLOR
+    elif 5 <= grade < 7:
+        color = HELP_PROMPT_COLOR
+    else:
+        color = HELP_ERROR_COLOR
+    return colorize(str(value), color, use_color)
 
 
 def truncate(text: str, width: int) -> str:
@@ -288,6 +308,15 @@ def guide_label(text: str, use_color: bool = False) -> str:
     return colorize(f"{text:<9}", GUIDE_TERM_COLORS.get(text.lower(), ""), use_color)
 
 
+def guide_definition(term: str, description: str, use_color: bool = False) -> str:
+    """Render one compact glossary definition for the assignment detail view."""
+
+    styled_term = colorize(term, GUIDE_TERM_BOLD_COLOR, use_color)
+    styled_description = colorize(description, GUIDE_DESCRIPTION_COLOR, use_color)
+    padding = " " * max(1, 10 - len(term))
+    return f"  {styled_term}{padding}{styled_description}"
+
+
 def test_result_label(test: dict[str, Any], use_color: bool = False) -> str:
     """Return a compact label for one test result."""
 
@@ -395,17 +424,26 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         section_separator(),
         "Grading",
         detail_line("Stato:", grading_label(grading)),
-        detail_line("Voto:", grading.get("teacher_grade") if grading.get("teacher_grade") is not None else grading.get("score")),
+        detail_line(
+            "Voto:",
+            grade_label(
+                grading.get("teacher_grade")
+                if grading.get("teacher_grade") is not None
+                else grading.get("score"),
+                use_color,
+            ),
+            formatted=True,
+        ),
         section_separator(),
         "Runner",
         detail_line("Stato:", runner_status_label(runner.get("status"), use_color), formatted=True),
         detail_line("Backend:", runner.get("backend")),
         section_separator(),
         "Guida rapida",
-        f"  {guide_label('Consegna', use_color)} lavoro assegnato dal docente.",
-        f"  {guide_label('Workspace', use_color)} cartella locale dove modifichi i file.",
-        f"  {guide_label('Test', use_color)} controlli automatici sul tuo lavoro.",
-        f"  {guide_label('Report', use_color)} risultato salvato e letto da dashboard/registro.",
+        guide_definition("Consegna", "lavoro assegnato dal docente.", use_color),
+        guide_definition("Workspace", "cartella locale dove modifichi i file.", use_color),
+        guide_definition("Test", "controlli automatici sul tuo lavoro.", use_color),
+        guide_definition("Report", "risultato salvato e letto da dashboard/registro.", use_color),
         "",
         "Flusso consigliato",
         f"  1. Apri {guide_term('workspace', use_color)}",
@@ -441,8 +479,20 @@ def runner_result_message(report: dict[str, Any], report_path: Path, use_color: 
     return "\n".join(
         [
             "Esecuzione completata",
-            detail_line("Stato runner:", status),
-            detail_line("Esito:", outcome),
+            detail_line("Stato runner:", runner_status_label(status, use_color), formatted=True),
+            detail_line(
+                "Esito:",
+                colorize(
+                    outcome,
+                    HELP_RESPONSE_COLOR
+                    if report.get("passed") is True
+                    else HELP_ERROR_COLOR
+                    if report.get("passed") is False
+                    else HELP_PROMPT_COLOR,
+                    use_color,
+                ),
+                formatted=True,
+            ),
             detail_line("Test:", tests),
             detail_line("Report salvato:", report_path),
             "",

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -22,7 +22,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import student_help_service, student_lab_runner, student_lab_service
+from scripts import student_help_service, student_lab_layout, student_lab_runner, student_lab_service
 
 
 InputFn = Callable[[str], str]
@@ -458,6 +458,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         "  a  Chiedi aiuto",
         "  o  Apri workspace",
         "  v  Apri editor",
+        "  l  Modifica layout pannelli",
         "",
         "Altri comandi",
         "  h  Storico aiuti",
@@ -1135,6 +1136,15 @@ def run_tui(
                 )
                 print_fn(message)
                 input_fn("Premi invio per continuare...")
+                continue
+            if action in {"l", "layout"}:
+                student_lab_layout.run_layout_editor(
+                    render_assignment_detail(assignment, use_color=use_color).splitlines(),
+                    root=root,
+                    use_color=use_color,
+                    clear=clear,
+                    print_fn=print_fn,
+                )
                 continue
             if action == "a":
                 print_fn(f"Tipo aiuto: {help_choice_label()} | invio/b annulla")

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -360,7 +360,11 @@ def render_test_details(report: dict[str, Any], use_color: bool = False) -> list
     return lines
 
 
-def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False) -> str:
+def render_assignment_detail(
+    assignment: dict[str, Any],
+    use_color: bool = False,
+    layout: dict[str, Any] | None = None,
+) -> str:
     """Render the detail page for one lab assignment."""
 
     workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
@@ -466,6 +470,8 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         "  invio  Torna alla lista",
         "  q  Esci",
     ]
+    if layout is not None:
+        return student_lab_layout.render_layout(lines, layout)
     return "\n".join(lines)
 
 
@@ -1114,7 +1120,13 @@ def run_tui(
                 break
             if clear:
                 clear_screen()
-            print_fn(render_assignment_detail(assignment, use_color=use_color))
+            print_fn(
+                render_assignment_detail(
+                    assignment,
+                    use_color=use_color,
+                    layout=student_lab_layout.load_layout(root),
+                )
+            )
             action = input_fn("\nDettaglio: ").strip().lower()
             if action in {"", "b", "back", "indietro"}:
                 break

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -4,6 +4,8 @@ import argparse
 import ipaddress
 import json
 import os
+import shlex
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -455,6 +457,7 @@ def render_assignment_detail(assignment: dict[str, Any], use_color: bool = False
         "  e  Esegui test e salva report",
         "  a  Chiedi aiuto",
         "  o  Apri workspace",
+        "  v  Apri editor",
         "",
         "Altri comandi",
         "  h  Storico aiuti",
@@ -864,6 +867,55 @@ def open_workspace(path_value: str, root: Path = PROJECT_ROOT) -> bool:
     return True
 
 
+EDITOR_CANDIDATES = ("micro", "nvim", "vim", "hx", "nano")
+WINDOWS_EDITOR_CANDIDATES = EDITOR_CANDIDATES + ("notepad",)
+
+
+def editor_command(editor: str | None = None) -> list[str] | None:
+    """Resolve the configured editor without adding a Python dependency."""
+
+    configured = str(editor or os.environ.get("THEBITLAB_EDITOR", "")).strip()
+    if configured:
+        try:
+            command = shlex.split(configured, posix=os.name != "nt")
+        except ValueError:
+            return None
+        if not command or shutil.which(command[0]) is None:
+            return None
+        return command
+    candidates = WINDOWS_EDITOR_CANDIDATES if os.name == "nt" else EDITOR_CANDIDATES
+    for candidate in candidates:
+        if shutil.which(candidate):
+            return [candidate]
+    return None
+
+
+def open_editor(
+    workspace_path: str,
+    source_name: str = "",
+    root: Path = PROJECT_ROOT,
+    editor: str | None = None,
+) -> tuple[bool, str]:
+    """Open the activity source with a user-selected terminal editor."""
+
+    raw_workspace = Path(workspace_path)
+    workspace = raw_workspace if raw_workspace.is_absolute() else (root / raw_workspace).resolve(strict=False)
+    if not workspace.is_dir():
+        return False, "Workspace non disponibile."
+    command = editor_command(editor)
+    if command is None:
+        return False, "Nessun editor disponibile. Imposta THEBITLAB_EDITOR o installa micro."
+    source = clean_text(source_name, "")
+    target = workspace / source if source else workspace
+    if target != workspace and not target.is_file():
+        target = workspace
+    try:
+        subprocess.run([*command, str(target)], cwd=str(workspace), check=False)
+    except OSError as error:
+        return False, f"Editor non avviabile: {error}"
+    return True, f"Editor chiuso: {command[0]}"
+
+
 def load_payload(root: Path, student_id: str, now: str | None = None) -> dict[str, Any]:
     """Load the current student lab payload."""
 
@@ -1071,6 +1123,17 @@ def run_tui(
                 workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
                 if not open_workspace(clean_text(workspace.get("path"), ""), root=root):
                     print_fn("Workspace non disponibile.")
+                input_fn("Premi invio per continuare...")
+                continue
+            if action == "v":
+                workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+                activity = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
+                _, message = open_editor(
+                    clean_text(workspace.get("path"), ""),
+                    clean_text(activity.get("source_name"), ""),
+                    root=root,
+                )
+                print_fn(message)
                 input_fn("Premi invio per continuare...")
                 continue
             if action == "a":

--- a/scripts/student_lab_demo_check.py
+++ b/scripts/student_lab_demo_check.py
@@ -41,6 +41,17 @@ def assert_demo_assignment(assignment: dict[str, Any]) -> None:
         raise RuntimeError("Budget AI demo non coerente.")
 
 
+def assert_demo_scenarios(summary: dict[str, Any]) -> None:
+    """Validate both the passing and failing automatic-grading scenarios."""
+
+    expected = {
+        "passing": {"student_id": student_lab_demo_smoke.STUDENT_ID, "status": "graded_passed"},
+        "failing": {"student_id": student_lab_demo_smoke.FAILING_STUDENT_ID, "status": "graded_failed"},
+    }
+    if summary.get("scenarios") != expected:
+        raise RuntimeError(f"Scenari demo non coerenti: {summary.get('scenarios')}")
+
+
 def guided_steps(root: Path, commands: dict[str, str], *, host: str, port: int) -> list[str]:
     """Return the manual steps printed after automatic checks pass."""
 
@@ -53,6 +64,7 @@ def guided_steps(root: Path, commands: dict[str, str], *, host: str, port: int) 
         f"Dashboard studente: {dashboard_url}",
         "In TUI: apri la consegna con il numero, verifica dettaglio, storico aiuti con h, runner con e e path report salvato.",
         "In dashboard: seleziona rossi-mario e verifica Demo somma in Python, report, test e richieste aiuto.",
+        "In dashboard: seleziona bianchi-luca e verifica test falliti, report presente e stato di grading negativo.",
     ]
 
 
@@ -60,6 +72,7 @@ def run_guided_check(root: Path, *, host: str = "127.0.0.1", port: int = 8765) -
     """Prepare the demo root and verify backend/dashboard data contracts."""
 
     setup = student_lab_demo_setup.prepare_demo(root)
+    assert_demo_scenarios(setup)
     data_root = Path(setup["root"])
     payload = student_lab_service.student_lab_payload(
         root=data_root,
@@ -85,6 +98,7 @@ def run_guided_check(root: Path, *, host: str = "127.0.0.1", port: int = 8765) -
         "activity_id": student_lab_demo_smoke.ACTIVITY_ID,
         "automatic_checks": {
             "setup": True,
+            "passing_and_failing_results": True,
             "student_lab_payload": True,
             "student_dashboard_api": True,
         },
@@ -108,7 +122,7 @@ def render_text_check(result: dict[str, Any]) -> str:
         "Controlli automatici",
         "--------------------",
     ]
-    for key in ("setup", "student_lab_payload", "student_dashboard_api"):
+    for key in ("setup", "passing_and_failing_results", "student_lab_payload", "student_dashboard_api"):
         status = "OK" if checks.get(key) else "NO"
         lines.append(f"- {status} {key}")
     lines.extend(["", "Passi manuali", "-------------"])

--- a/scripts/student_lab_demo_smoke.py
+++ b/scripts/student_lab_demo_smoke.py
@@ -27,6 +27,7 @@ from scripts.student_help_provider import DeterministicStudentHelpProvider
 
 
 STUDENT_ID = "rossi-mario"
+FAILING_STUDENT_ID = "bianchi-luca"
 ACTIVITY_ID = "python-demo-somma-001"
 ASSIGNED_AT = "2026-10-12T09:00:00+02:00"
 DUE_AT = "2026-10-19T23:59:00+02:00"
@@ -68,7 +69,7 @@ def write_demo_assignment(root: Path, activity_path: Path) -> dict[str, Any]:
     assignment = assignment_records.build_assignment_record(
         activity_id=ACTIVITY_ID,
         activity_path=relative(activity_path, root),
-        target_type="student",
+        target_type="class",
         class_id="3A-TPSI",
         class_label="3A TPSI",
         github_team="team-3a-tpsi",
@@ -80,21 +81,28 @@ def write_demo_assignment(root: Path, activity_path: Path) -> dict[str, Any]:
                 "display_name": "Rossi Mario",
                 "repo_ref": f"TheBitPoets/{STUDENT_ID}",
                 "path": f"examples/assignment_tracking/student_repos/{STUDENT_ID}",
-            }
+            },
+            {
+                "student_id": FAILING_STUDENT_ID,
+                "display_name": "Bianchi Luca",
+                "repo_ref": f"TheBitPoets/{FAILING_STUDENT_ID}",
+                "path": f"examples/assignment_tracking/student_repos/{FAILING_STUDENT_ID}",
+            },
         ],
     )
     return storage.write_assignment(assignment)
 
 
-def write_demo_workspace(root: Path) -> Path:
+def write_demo_workspace(root: Path, *, student_id: str = STUDENT_ID, passing: bool = True) -> Path:
     """Create the student workspace with source and pytest checks."""
 
-    workspace = root / "examples" / "assignment_tracking" / "student_repos" / STUDENT_ID / "assignments" / ACTIVITY_ID
+    workspace = root / "examples" / "assignment_tracking" / "student_repos" / student_id / "assignments" / ACTIVITY_ID
     tests_dir = workspace / "tests"
     tests_dir.mkdir(parents=True, exist_ok=True)
+    operation = "+" if passing else "-"
     (workspace / "main.py").write_text(
         "def somma(a, b):\n"
-        "    return a + b\n",
+        f"    return a {operation} b\n",
         encoding="utf-8",
     )
     (tests_dir / "test_main.py").write_text(
@@ -112,14 +120,21 @@ def write_teacher_register(root: Path, assignment_id: str) -> Path:
     """Generate the teacher register from the report produced by the runner."""
 
     output = root / "teacher-reports" / "demo" / f"{ACTIVITY_ID}.json"
-    target = track_assignments.TrackingTarget(
-        student=STUDENT_ID,
-        repo=f"TheBitPoets/{STUDENT_ID}",
-        path=root / "examples" / "assignment_tracking" / "student_repos" / STUDENT_ID,
-    )
+    targets = [
+        track_assignments.TrackingTarget(
+            student=STUDENT_ID,
+            repo=f"TheBitPoets/{STUDENT_ID}",
+            path=root / "examples" / "assignment_tracking" / "student_repos" / STUDENT_ID,
+        ),
+        track_assignments.TrackingTarget(
+            student=FAILING_STUDENT_ID,
+            repo=f"TheBitPoets/{FAILING_STUDENT_ID}",
+            path=root / "examples" / "assignment_tracking" / "student_repos" / FAILING_STUDENT_ID,
+        ),
+    ]
     index = track_assignments.track_assignments(
         activity_path=root / "activities" / f"{ACTIVITY_ID}.json",
-        targets=[target],
+        targets=targets,
         assigned_at=ASSIGNED_AT,
         due_at=DUE_AT,
         now=NOW,
@@ -139,6 +154,7 @@ def run_smoke(root: Path) -> dict[str, Any]:
     activity_path = write_demo_activity(root)
     assignment_record = write_demo_assignment(root, activity_path)
     workspace = write_demo_workspace(root)
+    failing_workspace = write_demo_workspace(root, student_id=FAILING_STUDENT_ID, passing=False)
     assignment = student_lab_runner.load_student_assignment(root=root, student_id=STUDENT_ID, activity_id=ACTIVITY_ID, now=NOW)
     help_event = student_help_service.record_help_request(
         activity_id=ACTIVITY_ID,
@@ -164,11 +180,31 @@ def run_smoke(root: Path) -> dict[str, Any]:
         raise RuntimeError("La dashboard lab non vede il report appena salvato.")
     if lab_assignment["help"]["total"] != 1 or lab_assignment["help"]["ai_budget"]["remaining"] != 4:
         raise RuntimeError("La dashboard lab non vede la richiesta di aiuto della demo.")
+
+    failing_assignment = student_lab_runner.load_student_assignment(
+        root=root,
+        student_id=FAILING_STUDENT_ID,
+        activity_id=ACTIVITY_ID,
+        now=NOW,
+    )
+    failing_report = student_lab_runner.run_assignment(failing_assignment, root=root, backend="local")
+    if failing_report.get("passed") is not False or failing_report.get("status") != "failed":
+        raise RuntimeError(f"Runner demo negativo non coerente: {failing_report.get('status')}")
+    failing_report_path = student_lab_runner.write_student_report(root, failing_assignment, failing_report)
+    failing_payload = student_lab_service.student_lab_payload(root=root, student_id=FAILING_STUDENT_ID, now=NOW)
+    failing_lab_assignment = failing_payload["assignments"][0]
+    if failing_lab_assignment["grading"]["status"] != "graded_failed":
+        raise RuntimeError("La dashboard lab non vede il report negativo della demo.")
+
     register_path = write_teacher_register(root, assignment_record["id"])
     register = json.loads(register_path.read_text(encoding="utf-8"))
-    student = register["students"][0]
+    students = {entry["student"]: entry for entry in register["students"]}
+    student = students[STUDENT_ID]
+    failing_student = students[FAILING_STUDENT_ID]
     if student["grading"]["status"] != "graded_passed":
-        raise RuntimeError(f"Registro docente non coerente: {student['grading']['status']}")
+        raise RuntimeError(f"Registro docente non coerente per Rossi: {student['grading']['status']}")
+    if failing_student["grading"]["status"] != "graded_failed":
+        raise RuntimeError(f"Registro docente non coerente per Bianchi: {failing_student['grading']['status']}")
     if student["help"]["total"] != 1 or student["help"]["ai_total"] != 1:
         raise RuntimeError("Registro docente non coerente con le richieste di aiuto.")
     return {
@@ -179,7 +215,14 @@ def run_smoke(root: Path) -> dict[str, Any]:
         "assignment_id": assignment_record["id"],
         "workspace": relative(workspace, root),
         "report": relative(report_path, root),
+        "failing_student_id": FAILING_STUDENT_ID,
+        "failing_workspace": relative(failing_workspace, root),
+        "failing_report": relative(failing_report_path, root),
         "teacher_register": relative(register_path, root),
+        "scenarios": {
+            "passing": {"student_id": STUDENT_ID, "status": student["grading"]["status"]},
+            "failing": {"student_id": FAILING_STUDENT_ID, "status": failing_student["grading"]["status"]},
+        },
         "tests": {
             "passed": student["grading"]["tests_passed"],
             "total": student["grading"]["tests_total"],

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -14,12 +14,27 @@ from pathlib import Path
 from typing import Callable, Iterator
 
 
+PANEL_TITLES = {
+    "assignment": "Dettaglio consegna",
+    "workspace": "Workspace",
+    "activity": "Activity",
+    "support": "Aiuto consentito",
+    "help": "Richieste aiuto",
+    "report": "Report",
+    "tests": "Ultimo dettaglio test",
+    "grading": "Grading",
+    "runner": "Runner",
+    "guide": "Guida rapida",
+}
+DEFAULT_PANEL_ORDER = list(PANEL_TITLES)
 DEFAULT_LAYOUT = {
     "orientation": "horizontal",
-    "order": ["detail", "guide"],
+    "order": DEFAULT_PANEL_ORDER,
     "left_width": 62,
+    "collapsed": [],
+    "focus": "assignment",
 }
-PANEL_NAMES = ("detail", "guide")
+PANEL_NAMES = tuple(PANEL_TITLES)
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 KeyReader = Callable[[], str]
 
@@ -27,7 +42,13 @@ KeyReader = Callable[[], str]
 def normalize_layout(value: object) -> dict:
     """Return a valid, bounded layout configuration."""
 
-    layout = dict(DEFAULT_LAYOUT)
+    layout = {
+        "orientation": DEFAULT_LAYOUT["orientation"],
+        "order": list(DEFAULT_LAYOUT["order"]),
+        "left_width": DEFAULT_LAYOUT["left_width"],
+        "collapsed": list(DEFAULT_LAYOUT["collapsed"]),
+        "focus": DEFAULT_LAYOUT["focus"],
+    }
     if isinstance(value, dict):
         if value.get("orientation") in {"horizontal", "vertical"}:
             layout["orientation"] = value["orientation"]
@@ -38,6 +59,12 @@ def normalize_layout(value: object) -> dict:
             layout["left_width"] = max(36, min(120, int(value.get("left_width", layout["left_width"]))))
         except (TypeError, ValueError):
             pass
+        collapsed = value.get("collapsed")
+        if isinstance(collapsed, list):
+            layout["collapsed"] = [panel for panel in collapsed if panel in PANEL_NAMES]
+        focus = value.get("focus")
+        if focus in PANEL_NAMES:
+            layout["focus"] = focus
     return layout
 
 
@@ -46,6 +73,7 @@ def apply_layout_key(layout: dict, key: str) -> tuple[dict, str]:
 
     updated = normalize_layout(layout)
     clean_key = str(key or "").strip().lower()
+    focus_index = updated["order"].index(updated["focus"])
     if clean_key == "alt+left":
         updated["left_width"] -= 4
         return normalize_layout(updated), "Pannello sinistro ristretto."
@@ -56,13 +84,38 @@ def apply_layout_key(layout: dict, key: str) -> tuple[dict, str]:
         updated["left_width"] -= 4
         return normalize_layout(updated), "Pannello sinistro ristretto."
     if clean_key in {"ctrl+left", "ctrl+right", "x", "swap"}:
-        updated["order"].reverse()
-        return updated, "Pannelli scambiati."
+        offset = -1 if clean_key == "ctrl+left" else 1
+        if clean_key in {"x", "swap"}:
+            offset = 1
+        target_index = max(0, min(len(updated["order"]) - 1, focus_index + offset))
+        updated["order"][focus_index], updated["order"][target_index] = (
+            updated["order"][target_index],
+            updated["order"][focus_index],
+        )
+        return updated, "Pannello spostato."
     if clean_key in {"ctrl+up", "ctrl+down", "up", "down"}:
-        updated["orientation"] = "vertical" if updated["orientation"] == "horizontal" else "horizontal"
-        return updated, "Orientamento dei pannelli cambiato."
+        if clean_key in {"up", "down"}:
+            updated["orientation"] = "vertical" if updated["orientation"] == "horizontal" else "horizontal"
+            return updated, "Orientamento dei pannelli cambiato."
+        offset = -2 if clean_key == "ctrl+up" else 2
+        target_index = max(0, min(len(updated["order"]) - 1, focus_index + offset))
+        updated["order"][focus_index], updated["order"][target_index] = (
+            updated["order"][target_index],
+            updated["order"][focus_index],
+        )
+        return updated, "Pannello spostato."
+    if clean_key == "tab":
+        updated["focus"] = updated["order"][(focus_index + 1) % len(updated["order"])]
+        return updated, f"Pannello selezionato: {PANEL_TITLES[updated['focus']]}"
+    if clean_key in {"+", "="}:
+        updated["collapsed"] = [panel for panel in updated["collapsed"] if panel != updated["focus"]]
+        return updated, f"Pannello aperto: {PANEL_TITLES[updated['focus']]}"
+    if clean_key == "-":
+        if updated["focus"] not in updated["collapsed"]:
+            updated["collapsed"].append(updated["focus"])
+        return updated, f"Pannello chiuso: {PANEL_TITLES[updated['focus']]}"
     if clean_key in {"r", "reset"}:
-        return dict(DEFAULT_LAYOUT), "Layout ripristinato."
+        return normalize_layout(DEFAULT_LAYOUT), "Layout ripristinato."
     return updated, ""
 
 
@@ -80,7 +133,7 @@ def load_layout(root: Path) -> dict:
     try:
         return normalize_layout(json.loads(path.read_text(encoding="utf-8")))
     except (OSError, ValueError, TypeError):
-        return dict(DEFAULT_LAYOUT)
+        return normalize_layout(DEFAULT_LAYOUT)
 
 
 def save_layout(root: Path, layout: dict) -> Path:
@@ -120,16 +173,48 @@ def split_detail_lines(lines: list[str]) -> tuple[list[str], list[str]]:
     return lines[:index], lines[index:]
 
 
+def sectionize_lines(lines: list[str]) -> dict[str, list[str]]:
+    """Group detail output into the named panels shown by the layout editor."""
+
+    title_to_panel = {title: panel for panel, title in PANEL_TITLES.items()}
+    sections: dict[str, list[str]] = {}
+    current_panel: str | None = None
+    for line in lines:
+        panel = title_to_panel.get(visible_text(line).strip())
+        if panel is not None:
+            if current_panel is not None and current_panel not in sections:
+                sections[current_panel] = []
+            current_panel = panel
+            sections[current_panel] = [line]
+            continue
+        if line.startswith("-") and len(line) >= 12:
+            continue
+        if current_panel is not None:
+            sections[current_panel].append(line)
+    return sections
+
+
+def panel_lines(panel: str, sections: dict[str, list[str]], layout: dict) -> list[str]:
+    """Render one panel, including focus and collapsed state markers."""
+
+    title = PANEL_TITLES[panel]
+    focused = ">" if panel == layout["focus"] else " "
+    if panel in layout["collapsed"]:
+        return [f"{focused} [+] {title}"]
+    content = sections.get(panel) or [title, "  non disponibile"]
+    return [f"{focused} [-] {title}", *content[1:]]
+
+
 def render_layout(
     lines: list[str],
     layout: dict,
     terminal_width: int | None = None,
 ) -> str:
-    """Render detail and guide as stable terminal panels."""
+    """Render detail sections as stable, reorderable and collapsible panels."""
 
     normalized = normalize_layout(layout)
-    detail, guide = split_detail_lines(lines)
-    panels = {"detail": detail, "guide": guide}
+    sections = sectionize_lines(lines)
+    panels = {name: panel_lines(name, sections, normalized) for name in PANEL_NAMES}
     width = terminal_width or shutil.get_terminal_size((120, 40)).columns
     if width < 90:
         normalized["orientation"] = "vertical"
@@ -144,12 +229,17 @@ def render_layout(
     right_width = max(30, width - left_width - 3)
     columns = [left_width, right_width]
     ordered = [panels[name] for name in normalized["order"]]
-    row_count = max(len(ordered[0]), len(ordered[1]))
+    split = max(1, (len(ordered) + 1) // 2)
+    left_panels = ordered[:split]
+    right_panels = ordered[split:]
+    left = [line for panel in left_panels for line in (*panel, "-" * min(left_width, 120))]
+    right = [line for panel in right_panels for line in (*panel, "-" * min(right_width, 120))]
+    row_count = max(len(left), len(right))
     rendered = []
     for index in range(row_count):
-        left = ordered[0][index] if index < len(ordered[0]) else ""
-        right = ordered[1][index] if index < len(ordered[1]) else ""
-        rendered.append(f"{fit_line(left, columns[0])} | {fit_line(right, columns[1])}")
+        left_line = left[index] if index < len(left) else ""
+        right_line = right[index] if index < len(right) else ""
+        rendered.append(f"{fit_line(left_line, columns[0])} | {fit_line(right_line, columns[1])}")
     return "\n".join(rendered)
 
 

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -49,13 +49,16 @@ def apply_layout_key(layout: dict, key: str) -> tuple[dict, str]:
     if clean_key == "alt+left":
         updated["left_width"] -= 4
         return normalize_layout(updated), "Pannello sinistro ristretto."
-    if clean_key == "alt+right":
+    if clean_key in {"alt+right", "right"}:
         updated["left_width"] += 4
         return normalize_layout(updated), "Pannello sinistro allargato."
-    if clean_key in {"ctrl+left", "ctrl+right"}:
+    if clean_key == "left":
+        updated["left_width"] -= 4
+        return normalize_layout(updated), "Pannello sinistro ristretto."
+    if clean_key in {"ctrl+left", "ctrl+right", "x", "swap"}:
         updated["order"].reverse()
         return updated, "Pannelli scambiati."
-    if clean_key in {"ctrl+up", "ctrl+down"}:
+    if clean_key in {"ctrl+up", "ctrl+down", "up", "down"}:
         updated["orientation"] = "vertical" if updated["orientation"] == "horizontal" else "horizontal"
         return updated, "Orientamento dei pannelli cambiato."
     if clean_key in {"r", "reset"}:
@@ -212,7 +215,7 @@ def read_terminal_key() -> str:
         character = sys.stdin.read(1)
     if character == "\x1b":
         sequence = _read_escape_sequence(character)
-        return {
+        known = {
             "\x1b[1;3D": "alt+left",
             "\x1b[1;3C": "alt+right",
             "\x1b[1;3A": "alt+up",
@@ -222,7 +225,18 @@ def read_terminal_key() -> str:
             "\x1b[1;5A": "ctrl+up",
             "\x1b[1;5B": "ctrl+down",
             "\x1b": "escape",
-        }.get(sequence, "")
+        }
+        if sequence in known:
+            return known[sequence]
+        if sequence.endswith("D"):
+            return "left"
+        if sequence.endswith("C"):
+            return "right"
+        if sequence.endswith("A"):
+            return "up"
+        if sequence.endswith("B"):
+            return "down"
+        return "escape" if sequence == "\x1b" else ""
     if character in {"\r", "\n"}:
         return "enter"
     if character == "q":
@@ -251,7 +265,7 @@ def run_layout_editor(
                 print_fn("\x1b[2J\x1b[H")
             print_fn(render_layout(lines, layout, terminal_width))
             print_fn("\nLayout: Alt+frecce resize | Ctrl+frecce sposta | Ctrl+su/giu cambia orientamento")
-            print_fn("Enter salva | Esc annulla | r ripristina")
+            print_fn("Fallback: frecce resize/orientamento | x scambia | Enter salva | Esc annulla | r ripristina")
             key = reader()
             if key == "enter":
                 save_layout(root, layout)

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -218,6 +218,7 @@ def render_layout(
     layout: dict,
     terminal_width: int | None = None,
     use_color: bool = False,
+    highlight_focus: bool = False,
 ) -> str:
     """Render detail sections as stable, reorderable and collapsible panels."""
 
@@ -230,7 +231,7 @@ def render_layout(
 
     def render_row(value: str, panel: str, width: int) -> str:
         fitted = fit_line(value, width)
-        if use_color and panel == normalized["focus"]:
+        if use_color and highlight_focus and panel == normalized["focus"]:
             return f"{SELECTED_PANEL_BACKGROUND}\033[30m{fitted}\033[0m"
         return fitted
 
@@ -384,7 +385,15 @@ def run_layout_editor(
         while True:
             if clear:
                 print_fn("\x1b[2J\x1b[H")
-            print_fn(render_layout(lines, layout, terminal_width, use_color=use_color))
+            print_fn(
+                render_layout(
+                    lines,
+                    layout,
+                    terminal_width,
+                    use_color=use_color,
+                    highlight_focus=True,
+                )
+            )
             print_fn(f"Pannello attivo: {PANEL_TITLES[layout['focus']]} (indicato da >)")
             print_fn("\nResize: frecce sinistra/destra o [ ] ridimensionano il pannello sinistro")
             print_fn("Tab seleziona | h/l sposta orizzontalmente | k/j sposta verticalmente")

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -78,7 +78,7 @@ def apply_layout_key(layout: dict, key: str) -> tuple[dict, str]:
     if clean_key in {"alt+left", "["}:
         updated["left_width"] -= 4
         return normalize_layout(updated), "Pannello sinistro ristretto."
-    if clean_key in {"alt+right", "]"}:
+    if clean_key in {"alt+right", "right", "]"}:
         updated["left_width"] += 4
         return normalize_layout(updated), "Pannello sinistro allargato."
     if clean_key == "left":
@@ -364,8 +364,8 @@ def run_layout_editor(
                 print_fn("\x1b[2J\x1b[H")
             print_fn(render_layout(lines, layout, terminal_width))
             print_fn(f"Pannello attivo: {PANEL_TITLES[layout['focus']]} (indicato da >)")
-            print_fn("\nLayout: Alt+frecce resize | Ctrl+frecce sposta | Ctrl+su/giu cambia orientamento")
-            print_fn("Fallback: frecce resize/orientamento | x scambia | Enter salva | Esc annulla | r ripristina")
+            print_fn("\nLayout: frecce sinistra/destra o [ ] ridimensionano il pannello sinistro")
+            print_fn("Enter salva | Esc annulla | r ripristina")
             key = reader()
             if key == "enter":
                 save_layout(root, layout)

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -216,12 +216,23 @@ def render_layout(
     lines: list[str],
     layout: dict,
     terminal_width: int | None = None,
+    use_color: bool = False,
 ) -> str:
     """Render detail sections as stable, reorderable and collapsible panels."""
 
     normalized = normalize_layout(layout)
     sections = sectionize_lines(lines)
-    panels = {name: panel_lines(name, sections, normalized) for name in PANEL_NAMES}
+    panels = {
+        name: [(line, name) for line in panel_lines(name, sections, normalized)]
+        for name in PANEL_NAMES
+    }
+
+    def render_row(value: str, panel: str, width: int) -> str:
+        fitted = fit_line(value, width)
+        if use_color and panel == normalized["focus"]:
+            return f"\033[48;5;253m\033[30m{fitted}\033[0m"
+        return fitted
+
     width = terminal_width or shutil.get_terminal_size((120, 40)).columns
     if width < 90:
         normalized["orientation"] = "vertical"
@@ -230,7 +241,7 @@ def render_layout(
         for index, panel_name in enumerate(normalized["order"]):
             if index:
                 rendered.append("-" * min(120, width))
-            rendered.extend(panels[panel_name])
+            rendered.extend(render_row(line, panel_name, width) for line, _ in panels[panel_name])
         return "\n".join(rendered)
     left_width = min(normalized["left_width"], max(36, width - 39))
     right_width = max(30, width - left_width - 3)
@@ -239,14 +250,25 @@ def render_layout(
     split = max(1, (len(ordered) + 1) // 2)
     left_panels = ordered[:split]
     right_panels = ordered[split:]
-    left = [line for panel in left_panels for line in (*panel, "-" * min(left_width, 120))]
-    right = [line for panel in right_panels for line in (*panel, "-" * min(right_width, 120))]
+    left = [
+        (line, panel)
+        for panel_name, panel in zip(normalized["order"][:split], left_panels)
+        for line, panel in (*panel, ("-" * min(left_width, 120), panel_name))
+    ]
+    right = [
+        (line, panel)
+        for panel_name, panel in zip(normalized["order"][split:], right_panels)
+        for line, panel in (*panel, ("-" * min(right_width, 120), panel_name))
+    ]
     row_count = max(len(left), len(right))
     rendered = []
     for index in range(row_count):
-        left_line = left[index] if index < len(left) else ""
-        right_line = right[index] if index < len(right) else ""
-        rendered.append(f"{fit_line(left_line, columns[0])} | {fit_line(right_line, columns[1])}")
+        left_line, left_panel = left[index] if index < len(left) else ("", "")
+        right_line, right_panel = right[index] if index < len(right) else ("", "")
+        rendered.append(
+            f"{render_row(left_line, left_panel, columns[0])} | "
+            f"{render_row(right_line, right_panel, columns[1])}"
+        )
     return "\n".join(rendered)
 
 
@@ -354,7 +376,6 @@ def run_layout_editor(
 ) -> dict:
     """Edit and save the layout until Enter, Escape or q is pressed."""
 
-    del use_color  # Lines are already styled by the caller when needed.
     layout = load_layout(root)
     reader = key_reader or read_terminal_key
     context = nullcontext() if key_reader else raw_terminal()
@@ -362,7 +383,7 @@ def run_layout_editor(
         while True:
             if clear:
                 print_fn("\x1b[2J\x1b[H")
-            print_fn(render_layout(lines, layout, terminal_width))
+            print_fn(render_layout(lines, layout, terminal_width, use_color=use_color))
             print_fn(f"Pannello attivo: {PANEL_TITLES[layout['focus']]} (indicato da >)")
             print_fn("\nResize: frecce sinistra/destra o [ ] ridimensionano il pannello sinistro")
             print_fn("Tab seleziona | h/l sposta orizzontalmente | k/j sposta verticalmente")

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -237,7 +237,7 @@ def render_layout(
         if use_color and highlight_focus and panel == normalized["focus"]:
             foreground = PANEL_TITLE_STYLE if is_title else "\033[30m"
             return f"{SELECTED_PANEL_BACKGROUND}{foreground}{fitted}\033[0m"
-        if use_color and highlight_focus and is_title:
+        if use_color and is_title:
             return f"{PANEL_TITLE_STYLE}{fitted}\033[0m"
         return fitted
 

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -35,6 +35,7 @@ DEFAULT_LAYOUT = {
     "focus": "assignment",
 }
 PANEL_NAMES = tuple(PANEL_TITLES)
+SELECTED_PANEL_BACKGROUND = "\033[48;5;253m"
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 KeyReader = Callable[[], str]
 
@@ -230,7 +231,7 @@ def render_layout(
     def render_row(value: str, panel: str, width: int) -> str:
         fitted = fit_line(value, width)
         if use_color and panel == normalized["focus"]:
-            return f"\033[48;5;253m\033[30m{fitted}\033[0m"
+            return f"{SELECTED_PANEL_BACKGROUND}\033[30m{fitted}\033[0m"
         return fitted
 
     width = terminal_width or shutil.get_terminal_size((120, 40)).columns

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -364,7 +364,9 @@ def run_layout_editor(
                 print_fn("\x1b[2J\x1b[H")
             print_fn(render_layout(lines, layout, terminal_width))
             print_fn(f"Pannello attivo: {PANEL_TITLES[layout['focus']]} (indicato da >)")
-            print_fn("\nLayout: frecce sinistra/destra o [ ] ridimensionano il pannello sinistro")
+            print_fn("\nResize: frecce sinistra/destra o [ ] ridimensionano il pannello sinistro")
+            print_fn("Tab seleziona | h/l sposta orizzontalmente | k/j sposta verticalmente")
+            print_fn("+/- apre o comprime | o cambia orientamento | x sposta a destra")
             print_fn("Enter salva | Esc annulla | r ripristina")
             key = reader()
             if key == "enter":

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -156,9 +156,12 @@ def visible_text(value: str) -> str:
 def fit_line(value: str, width: int) -> str:
     """Fit a panel line without allowing it to change the layout."""
 
+    width = max(1, width)
     plain = visible_text(value)
     if len(plain) > width:
-        return plain[: max(1, width - 1)] + "..."
+        if width <= 3:
+            return "." * width
+        return plain[: width - 3] + "..."
     return value + " " * (width - len(plain))
 
 
@@ -354,6 +357,7 @@ def run_layout_editor(
             if clear:
                 print_fn("\x1b[2J\x1b[H")
             print_fn(render_layout(lines, layout, terminal_width))
+            print_fn(f"Pannello attivo: {PANEL_TITLES[layout['focus']]} (indicato da >)")
             print_fn("\nLayout: Alt+frecce resize | Ctrl+frecce sposta | Ctrl+su/giu cambia orientamento")
             print_fn("Fallback: frecce resize/orientamento | x scambia | Enter salva | Esc annulla | r ripristina")
             key = reader()

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -36,6 +36,7 @@ DEFAULT_LAYOUT = {
 }
 PANEL_NAMES = tuple(PANEL_TITLES)
 SELECTED_PANEL_BACKGROUND = "\033[48;5;253m"
+PANEL_TITLE_STYLE = "\033[1;97m"
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 KeyReader = Callable[[], str]
 
@@ -231,8 +232,13 @@ def render_layout(
 
     def render_row(value: str, panel: str, width: int) -> str:
         fitted = fit_line(value, width)
+        plain = visible_text(value).strip().lstrip("> ")
+        is_title = plain.startswith("[-] ") or plain.startswith("[+] ")
         if use_color and highlight_focus and panel == normalized["focus"]:
-            return f"{SELECTED_PANEL_BACKGROUND}\033[30m{fitted}\033[0m"
+            foreground = PANEL_TITLE_STYLE if is_title else "\033[30m"
+            return f"{SELECTED_PANEL_BACKGROUND}{foreground}{fitted}\033[0m"
+        if use_color and highlight_focus and is_title:
+            return f"{PANEL_TITLE_STYLE}{fitted}\033[0m"
         return fitted
 
     width = terminal_width or shutil.get_terminal_size((120, 40)).columns

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -72,19 +72,20 @@ def apply_layout_key(layout: dict, key: str) -> tuple[dict, str]:
     """Apply one symbolic layout key and return the new state and feedback."""
 
     updated = normalize_layout(layout)
-    clean_key = str(key or "").strip().lower()
+    raw_key = str(key or "").lower()
+    clean_key = raw_key if raw_key == "\t" else raw_key.strip()
     focus_index = updated["order"].index(updated["focus"])
-    if clean_key == "alt+left":
+    if clean_key in {"alt+left", "["}:
         updated["left_width"] -= 4
         return normalize_layout(updated), "Pannello sinistro ristretto."
-    if clean_key in {"alt+right", "right"}:
+    if clean_key in {"alt+right", "]"}:
         updated["left_width"] += 4
         return normalize_layout(updated), "Pannello sinistro allargato."
     if clean_key == "left":
         updated["left_width"] -= 4
         return normalize_layout(updated), "Pannello sinistro ristretto."
-    if clean_key in {"ctrl+left", "ctrl+right", "x", "swap"}:
-        offset = -1 if clean_key == "ctrl+left" else 1
+    if clean_key in {"ctrl+left", "ctrl+right", "h", "l", "x", "swap"}:
+        offset = -1 if clean_key in {"ctrl+left", "h"} else 1
         if clean_key in {"x", "swap"}:
             offset = 1
         target_index = max(0, min(len(updated["order"]) - 1, focus_index + offset))
@@ -93,18 +94,21 @@ def apply_layout_key(layout: dict, key: str) -> tuple[dict, str]:
             updated["order"][focus_index],
         )
         return updated, "Pannello spostato."
-    if clean_key in {"ctrl+up", "ctrl+down", "up", "down"}:
+    if clean_key in {"ctrl+up", "ctrl+down", "j", "k", "up", "down", "o"}:
+        if clean_key == "o":
+            updated["orientation"] = "vertical" if updated["orientation"] == "horizontal" else "horizontal"
+            return updated, "Orientamento dei pannelli cambiato."
         if clean_key in {"up", "down"}:
             updated["orientation"] = "vertical" if updated["orientation"] == "horizontal" else "horizontal"
             return updated, "Orientamento dei pannelli cambiato."
-        offset = -2 if clean_key == "ctrl+up" else 2
+        offset = -2 if clean_key in {"ctrl+up", "k"} else 2
         target_index = max(0, min(len(updated["order"]) - 1, focus_index + offset))
         updated["order"][focus_index], updated["order"][target_index] = (
             updated["order"][target_index],
             updated["order"][focus_index],
         )
         return updated, "Pannello spostato."
-    if clean_key == "tab":
+    if clean_key in {"tab", "\t"}:
         updated["focus"] = updated["order"][(focus_index + 1) % len(updated["order"])]
         return updated, f"Pannello selezionato: {PANEL_TITLES[updated['focus']]}"
     if clean_key in {"+", "="}:
@@ -332,6 +336,8 @@ def read_terminal_key() -> str:
         return "escape" if sequence == "\x1b" else ""
     if character in {"\r", "\n"}:
         return "enter"
+    if character == "\t":
+        return "tab"
     if character == "q":
         return "q"
     return character

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -1,0 +1,263 @@
+"""Keyboard layout support for the student lab TUI."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import select
+import shutil
+import sys
+import time
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from typing import Callable, Iterator
+
+
+DEFAULT_LAYOUT = {
+    "orientation": "horizontal",
+    "order": ["detail", "guide"],
+    "left_width": 62,
+}
+PANEL_NAMES = ("detail", "guide")
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+KeyReader = Callable[[], str]
+
+
+def normalize_layout(value: object) -> dict:
+    """Return a valid, bounded layout configuration."""
+
+    layout = dict(DEFAULT_LAYOUT)
+    if isinstance(value, dict):
+        if value.get("orientation") in {"horizontal", "vertical"}:
+            layout["orientation"] = value["orientation"]
+        order = value.get("order")
+        if isinstance(order, list) and sorted(order) == sorted(PANEL_NAMES):
+            layout["order"] = list(order)
+        try:
+            layout["left_width"] = max(36, min(120, int(value.get("left_width", layout["left_width"]))))
+        except (TypeError, ValueError):
+            pass
+    return layout
+
+
+def apply_layout_key(layout: dict, key: str) -> tuple[dict, str]:
+    """Apply one symbolic layout key and return the new state and feedback."""
+
+    updated = normalize_layout(layout)
+    clean_key = str(key or "").strip().lower()
+    if clean_key == "alt+left":
+        updated["left_width"] -= 4
+        return normalize_layout(updated), "Pannello sinistro ristretto."
+    if clean_key == "alt+right":
+        updated["left_width"] += 4
+        return normalize_layout(updated), "Pannello sinistro allargato."
+    if clean_key in {"ctrl+left", "ctrl+right"}:
+        updated["order"].reverse()
+        return updated, "Pannelli scambiati."
+    if clean_key in {"ctrl+up", "ctrl+down"}:
+        updated["orientation"] = "vertical" if updated["orientation"] == "horizontal" else "horizontal"
+        return updated, "Orientamento dei pannelli cambiato."
+    if clean_key in {"r", "reset"}:
+        return dict(DEFAULT_LAYOUT), "Layout ripristinato."
+    return updated, ""
+
+
+def layout_path(root: Path) -> Path:
+    """Return the local, non-didactic layout configuration path."""
+
+    configured = os.environ.get("THEBITLAB_LAYOUT_PATH", "").strip()
+    return Path(configured) if configured else root / ".student-lab-layout.json"
+
+
+def load_layout(root: Path) -> dict:
+    """Load a local layout, falling back to the default on invalid data."""
+
+    path = layout_path(root)
+    try:
+        return normalize_layout(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, ValueError, TypeError):
+        return dict(DEFAULT_LAYOUT)
+
+
+def save_layout(root: Path, layout: dict) -> Path:
+    """Persist a normalized layout atomically."""
+
+    path = layout_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(normalize_layout(layout), indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+    return path
+
+
+def visible_text(value: str) -> str:
+    """Remove ANSI styling before measuring terminal text."""
+
+    return ANSI_RE.sub("", value)
+
+
+def fit_line(value: str, width: int) -> str:
+    """Fit a panel line without allowing it to change the layout."""
+
+    plain = visible_text(value)
+    if len(plain) > width:
+        return plain[: max(1, width - 1)] + "..."
+    return value + " " * (width - len(plain))
+
+
+def split_detail_lines(lines: list[str]) -> tuple[list[str], list[str]]:
+    """Split the existing detail rendering at the quick-guide section."""
+
+    try:
+        index = lines.index("Guida rapida")
+    except ValueError:
+        midpoint = max(1, len(lines) // 2)
+        return lines[:midpoint], lines[midpoint:]
+    return lines[:index], lines[index:]
+
+
+def render_layout(
+    lines: list[str],
+    layout: dict,
+    terminal_width: int | None = None,
+) -> str:
+    """Render detail and guide as stable terminal panels."""
+
+    normalized = normalize_layout(layout)
+    detail, guide = split_detail_lines(lines)
+    panels = {"detail": detail, "guide": guide}
+    width = terminal_width or shutil.get_terminal_size((120, 40)).columns
+    if width < 90:
+        normalized["orientation"] = "vertical"
+    if normalized["orientation"] == "vertical":
+        rendered: list[str] = []
+        for index, panel_name in enumerate(normalized["order"]):
+            if index:
+                rendered.append("-" * min(120, width))
+            rendered.extend(panels[panel_name])
+        return "\n".join(rendered)
+    left_width = min(normalized["left_width"], max(36, width - 39))
+    right_width = max(30, width - left_width - 3)
+    columns = [left_width, right_width]
+    ordered = [panels[name] for name in normalized["order"]]
+    row_count = max(len(ordered[0]), len(ordered[1]))
+    rendered = []
+    for index in range(row_count):
+        left = ordered[0][index] if index < len(ordered[0]) else ""
+        right = ordered[1][index] if index < len(ordered[1]) else ""
+        rendered.append(f"{fit_line(left, columns[0])} | {fit_line(right, columns[1])}")
+    return "\n".join(rendered)
+
+
+@contextmanager
+def raw_terminal() -> Iterator[None]:
+    """Temporarily read individual keys from a Unix terminal."""
+
+    if os.name == "nt":
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.GetStdHandle(-10)  # STD_INPUT_HANDLE
+        mode = ctypes.c_uint32()
+        if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            yield
+            return
+        enable_virtual_terminal_input = 0x0200
+        previous = mode.value
+        try:
+            kernel32.SetConsoleMode(handle, previous | enable_virtual_terminal_input)
+            yield
+        finally:
+            kernel32.SetConsoleMode(handle, previous)
+        return
+    import termios
+    import tty
+
+    descriptor = sys.stdin.fileno()
+    previous = termios.tcgetattr(descriptor)
+    try:
+        tty.setcbreak(descriptor)
+        yield
+    finally:
+        termios.tcsetattr(descriptor, termios.TCSADRAIN, previous)
+
+
+def _read_escape_sequence(first: str) -> str:
+    """Read the short VT sequence following Escape."""
+
+    sequence = first
+    if os.name == "nt":
+        import msvcrt
+
+        time.sleep(0.01)
+        while msvcrt.kbhit():
+            sequence += msvcrt.getwch()
+        return sequence
+    while select.select([sys.stdin], [], [], 0.03)[0]:
+        sequence += sys.stdin.read(1)
+    return sequence
+
+
+def read_terminal_key() -> str:
+    """Read arrows with Alt/Ctrl modifiers on common terminal hosts."""
+
+    if os.name == "nt":
+        import msvcrt
+
+        character = msvcrt.getwch()
+        if character in {"\x00", "\xe0"}:
+            return {"K": "left", "M": "right", "H": "up", "P": "down"}.get(msvcrt.getwch(), "")
+    else:
+        character = sys.stdin.read(1)
+    if character == "\x1b":
+        sequence = _read_escape_sequence(character)
+        return {
+            "\x1b[1;3D": "alt+left",
+            "\x1b[1;3C": "alt+right",
+            "\x1b[1;3A": "alt+up",
+            "\x1b[1;3B": "alt+down",
+            "\x1b[1;5D": "ctrl+left",
+            "\x1b[1;5C": "ctrl+right",
+            "\x1b[1;5A": "ctrl+up",
+            "\x1b[1;5B": "ctrl+down",
+            "\x1b": "escape",
+        }.get(sequence, "")
+    if character in {"\r", "\n"}:
+        return "enter"
+    if character == "q":
+        return "q"
+    return character
+
+
+def run_layout_editor(
+    lines: list[str],
+    root: Path,
+    use_color: bool = False,
+    key_reader: KeyReader | None = None,
+    terminal_width: int | None = None,
+    clear: bool = True,
+    print_fn: Callable[[str], None] = print,
+) -> dict:
+    """Edit and save the layout until Enter, Escape or q is pressed."""
+
+    del use_color  # Lines are already styled by the caller when needed.
+    layout = load_layout(root)
+    reader = key_reader or read_terminal_key
+    context = nullcontext() if key_reader else raw_terminal()
+    with context:
+        while True:
+            if clear:
+                print_fn("\x1b[2J\x1b[H")
+            print_fn(render_layout(lines, layout, terminal_width))
+            print_fn("\nLayout: Alt+frecce resize | Ctrl+frecce sposta | Ctrl+su/giu cambia orientamento")
+            print_fn("Enter salva | Esc annulla | r ripristina")
+            key = reader()
+            if key == "enter":
+                save_layout(root, layout)
+                return layout
+            if key in {"escape", "q"}:
+                return load_layout(root)
+            layout, message = apply_layout_key(layout, key)
+            if message:
+                print_fn(message)

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -256,6 +256,8 @@ def build_lab_assignment(
             )
     help_log.pop("path", None)
     grading = track_assignments.grading_summary(report)
+    runner_status = clean_text(report.get("status")) if report and clean_text(report.get("status")) else "not_run"
+    runner_backend = clean_text(report.get("backend")) if report and clean_text(report.get("backend")) else "student_lab_service"
     return {
         "assignment_id": normalized["id"],
         "activity_id": activity_id,
@@ -302,8 +304,8 @@ def build_lab_assignment(
         "grading": grading,
         "help": help_log,
         "runner": {
-            "status": "not_run",
-            "backend": "student_lab_service",
+            "status": runner_status,
+            "backend": runner_backend,
         },
     }
 

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -203,10 +203,11 @@ def test_render_assignment_detail_can_color_status() -> None:
     rendered = student_lab_cli.render_assignment_detail(sample_assignment(status="missing"), use_color=True)
 
     assert "\033[31mMancante\033[0m" in rendered
-    assert "\033[35mConsegna \033[0m" in rendered
-    assert "\033[36mWorkspace\033[0m" in rendered
-    assert "\033[33mTest     \033[0m" in rendered
-    assert "\033[32mReport   \033[0m" in rendered
+    assert "\033[1;37mConsegna\033[0m" in rendered
+    assert "\033[1;37mWorkspace\033[0m" in rendered
+    assert "\033[1;37mTest\033[0m" in rendered
+    assert "\033[1;37mReport\033[0m" in rendered
+    assert "\033[3;90mcartella locale dove modifichi i file.\033[0m" in rendered
 
 
 def test_render_assignment_detail_summarizes_grading_tests() -> None:
@@ -237,6 +238,13 @@ def test_render_assignment_detail_summarizes_grading_tests() -> None:
     assert "Output atteso: 10; output ottenuto: 8" in rendered
 
 
+def test_grade_label_uses_requested_ranges() -> None:
+    assert student_lab_cli.grade_label(8, use_color=True) == "\033[32m8\033[0m"
+    assert student_lab_cli.grade_label(6, use_color=True) == "\033[33m6\033[0m"
+    assert student_lab_cli.grade_label(4, use_color=True) == "\033[31m4\033[0m"
+    assert student_lab_cli.grade_label(None, use_color=True) == "-"
+
+
 def test_runner_result_message_shows_status_tests_and_report_path(tmp_path) -> None:
     message = student_lab_cli.runner_result_message(
         {
@@ -261,6 +269,25 @@ def test_runner_result_message_shows_status_tests_and_report_path(tmp_path) -> N
     assert "[ok] input_base" in message
     assert "[ko] caso_zero" in message
     assert "Output atteso: 10, ottenuto: 8" in message
+    failed_message = student_lab_cli.runner_result_message(
+        {
+            "status": "failed",
+            "passed": False,
+            "summary": {"passed": 2, "total": 3},
+            "tests": [],
+        },
+        tmp_path / "reports" / "latest.json",
+        use_color=True,
+    )
+    assert "\033[31mfailed\033[0m" in failed_message
+    assert "\033[31mconsegna da ricontrollare\033[0m" in failed_message
+    passed_message = student_lab_cli.runner_result_message(
+        {"status": "passed", "passed": True, "summary": {"passed": 2, "total": 2}, "tests": []},
+        tmp_path / "reports" / "latest.json",
+        use_color=True,
+    )
+    assert "\033[32mpassed\033[0m" in passed_message
+    assert "\033[32mconsegna superata\033[0m" in passed_message
     assert "Questo report è quello letto da dashboard e registro docente." in message
     assert "Questo report e quello" not in message
 

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -1424,6 +1424,43 @@ def test_open_workspace_resolves_relative_path_from_root(monkeypatch, tmp_path) 
     assert opened == [workspace.resolve()]
 
 
+def test_editor_command_prefers_configured_editor(monkeypatch) -> None:
+    monkeypatch.setenv("THEBITLAB_EDITOR", "micro --clean")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: f"/bin/{name}")
+
+    assert student_lab_cli.editor_command() == ["micro", "--clean"]
+
+
+def test_open_editor_runs_source_in_workspace(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = workspace / "main.py"
+    source.write_text("print(1)\n", encoding="utf-8")
+    calls = []
+    monkeypatch.setenv("THEBITLAB_EDITOR", "micro")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(student_lab_cli.subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    opened, message = student_lab_cli.open_editor(str(workspace), "main.py", root=tmp_path)
+
+    assert opened is True
+    assert message == "Editor chiuso: micro"
+    assert calls[0][0][0] == ["micro", str(source)]
+    assert calls[0][1]["cwd"] == str(workspace)
+
+
+def test_open_editor_reports_missing_editor(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.delenv("THEBITLAB_EDITOR", raising=False)
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: None)
+
+    opened, message = student_lab_cli.open_editor(str(workspace), root=tmp_path)
+
+    assert opened is False
+    assert "Nessun editor disponibile" in message
+
+
 def test_truncate_keeps_short_text_and_clips_long_text() -> None:
     assert student_lab_cli.truncate("abc", 5) == "abc"
     assert student_lab_cli.truncate("abcdef", 5) == "ab..."

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -625,6 +625,27 @@ def test_ai_budget_label_handles_missing_and_exhausted_budget() -> None:
     assert student_lab_cli.ai_budget_label({"limit": 2, "used": 2, "remaining": 0, "exhausted": True}) == "2/2 usate, 0 rimanenti (esaurito)"
 
 
+def test_detail_statuses_use_actionable_colors() -> None:
+    assert "\033[33m3/5 usate, 2 rimanenti\033[0m" in student_lab_cli.ai_budget_label(
+        {"limit": 5, "used": 3, "remaining": 2}, use_color=True
+    )
+    assert "\033[31mbloccata\033[0m" == student_lab_cli.help_decision_label("bloccata", use_color=True)
+    assert "\033[32mconsentita\033[0m" == student_lab_cli.help_decision_label("consentita", use_color=True)
+    assert "\033[31mnot_run\033[0m" == student_lab_cli.runner_status_label("not_run", use_color=True)
+    assert "\033[32mpassed\033[0m" == student_lab_cli.runner_status_label("passed", use_color=True)
+
+
+def test_test_details_use_green_and_red_result_colors() -> None:
+    rendered = "\n".join(
+        student_lab_cli.render_test_details(
+            {"tests": [{"name": "ok", "passed": True}, {"name": "ko", "passed": False}]},
+            use_color=True,
+        )
+    )
+    assert "\033[32m[ok]\033[0m ok" in rendered
+    assert "\033[31m[ko]\033[0m ko" in rendered
+
+
 def test_report_detail_removes_terminal_control_sequences() -> None:
     detail = student_lab_cli.test_result_detail(
         {"stderr": "errore\u001b]52;c;dGVzdA==\u0007\nseconda riga"}

--- a/tests/test_student_lab_demo_check.py
+++ b/tests/test_student_lab_demo_check.py
@@ -11,16 +11,19 @@ def test_student_lab_demo_check_returns_guided_manual_steps(tmp_path) -> None:
     assert result["activity_id"] == "python-demo-somma-001"
     assert result["automatic_checks"] == {
         "setup": True,
+        "passing_and_failing_results": True,
         "student_lab_payload": True,
         "student_dashboard_api": True,
     }
     assert any("student_lab_cli.py" in step for step in result["manual_steps"])
     assert any("course_board_server.py" in step for step in result["manual_steps"])
+    assert any("bianchi-luca" in step for step in result["manual_steps"])
     assert any("http://127.0.0.1:8876/tools/student_dashboard.html" in step for step in result["manual_steps"])
 
     rendered = student_lab_demo_check.render_text_check(result)
 
     assert "Collaudo lab studente" in rendered
     assert "- OK setup" in rendered
+    assert "- OK passing_and_failing_results" in rendered
     assert "Passi manuali" in rendered
     assert "student_lab_cli.py" in rendered

--- a/tests/test_student_lab_demo_smoke.py
+++ b/tests/test_student_lab_demo_smoke.py
@@ -11,6 +11,10 @@ def test_student_lab_demo_smoke_builds_complete_flow(tmp_path) -> None:
     assert summary["ok"] is True
     assert summary["student_id"] == "rossi-mario"
     assert summary["activity_id"] == "python-demo-somma-001"
+    assert summary["scenarios"] == {
+        "passing": {"student_id": "rossi-mario", "status": "graded_passed"},
+        "failing": {"student_id": "bianchi-luca", "status": "graded_failed"},
+    }
     assert summary["workspace"].endswith("assignments/python-demo-somma-001")
     assert summary["report"].endswith("reports/python-demo-somma-001/latest.json")
     assert summary["teacher_register"].endswith("teacher-reports/demo/python-demo-somma-001.json")

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -68,6 +68,18 @@ def test_fit_line_keeps_ellipsis_inside_panel_width() -> None:
     assert student_lab_layout.fit_line("testo", 3) == "..."
 
 
+def test_selected_panel_uses_a_subtle_background_when_colors_are_enabled() -> None:
+    rendered = student_lab_layout.render_layout(
+        ["Dettaglio consegna", "Titolo: esempio"],
+        student_lab_layout.DEFAULT_LAYOUT,
+        terminal_width=100,
+        use_color=True,
+    )
+
+    assert "\033[48;5;253m" in rendered
+    assert "Titolo: esempio" in rendered
+
+
 def test_layout_has_modifier_free_keyboard_fallbacks() -> None:
     resized, _ = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "]")
     arrow_resized, _ = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "right")

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -11,18 +11,24 @@ def test_layout_commands_resize_swap_and_change_orientation() -> None:
     assert "allargato" in message
 
     swapped, _ = student_lab_layout.apply_layout_key(resized, "ctrl+left")
-    assert swapped["order"] == ["guide", "detail"]
+    assert swapped["order"][:2] == ["assignment", "workspace"]
 
-    stacked, _ = student_lab_layout.apply_layout_key(swapped, "ctrl+down")
+    stacked, _ = student_lab_layout.apply_layout_key(swapped, "down")
     assert stacked["orientation"] == "vertical"
 
     fallback, _ = student_lab_layout.apply_layout_key(layout, "x")
-    assert fallback["order"] == ["guide", "detail"]
+    assert fallback["order"][:2] == ["workspace", "assignment"]
 
 
 def test_layout_persists_and_invalid_values_fall_back(tmp_path: Path) -> None:
     path = tmp_path / "layout.json"
-    layout = {"orientation": "vertical", "order": ["guide", "detail"], "left_width": 80}
+    layout = {
+        "orientation": "vertical",
+        "order": list(reversed(student_lab_layout.DEFAULT_PANEL_ORDER)),
+        "left_width": 80,
+        "collapsed": ["guide"],
+        "focus": "guide",
+    }
     path.write_text("{\"orientation\": \"invalid\"}", encoding="utf-8")
 
     student_lab_layout.save_layout(tmp_path, layout)
@@ -31,20 +37,33 @@ def test_layout_persists_and_invalid_values_fall_back(tmp_path: Path) -> None:
     assert loaded == layout
 
 
-def test_render_layout_keeps_detail_and_guide_in_two_columns() -> None:
+def test_render_layout_keeps_sections_in_two_columns() -> None:
     rendered = student_lab_layout.render_layout(
-        ["Titolo", "Runner", "Guida rapida", "Consegna: lavoro assegnato"],
-        {"orientation": "horizontal", "order": ["detail", "guide"], "left_width": 20},
+        ["Dettaglio consegna", "Titolo: esempio", "Runner", "Stato: ok", "Guida rapida", "Comandi"],
+        {"orientation": "horizontal", "order": list(student_lab_layout.DEFAULT_PANEL_ORDER), "left_width": 40},
         terminal_width=100,
     )
 
-    assert "Titolo" in rendered
+    assert "Dettaglio consegna" in rendered
     assert "Guida rapida" in rendered
+    assert "Runner" in rendered
     assert " | " in rendered
 
 
+def test_layout_can_collapse_the_focused_panel() -> None:
+    layout, message = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "-")
+
+    rendered = student_lab_layout.render_layout(
+        ["Dettaglio consegna", "Titolo: esempio"], layout, terminal_width=100
+    )
+
+    assert "Pannello chiuso" in message
+    assert "[+] Dettaglio consegna" in rendered
+    assert "Titolo: esempio" not in rendered
+
+
 def test_run_layout_editor_saves_with_injected_keys(tmp_path: Path) -> None:
-    keys = iter(["alt+right", "ctrl+left", "enter"])
+    keys = iter(["alt+right", "tab", "ctrl+left", "enter"])
     outputs = []
 
     layout = student_lab_layout.run_layout_editor(
@@ -57,6 +76,6 @@ def test_run_layout_editor_saves_with_injected_keys(tmp_path: Path) -> None:
     )
 
     assert layout["left_width"] == 66
-    assert layout["order"] == ["guide", "detail"]
+    assert layout["order"][:2] == ["workspace", "assignment"]
     assert student_lab_layout.load_layout(tmp_path) == layout
-    assert any("Pannelli scambiati" in output for output in outputs)
+    assert any("Pannello spostato" in output for output in outputs)

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -76,7 +76,7 @@ def test_selected_panel_uses_a_subtle_background_when_colors_are_enabled() -> No
         use_color=True,
     )
 
-    assert "\033[48;5;253m" in rendered
+    assert student_lab_layout.SELECTED_PANEL_BACKGROUND in rendered
     assert "Titolo: esempio" in rendered
 
 

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -74,10 +74,19 @@ def test_selected_panel_uses_a_subtle_background_when_colors_are_enabled() -> No
         student_lab_layout.DEFAULT_LAYOUT,
         terminal_width=100,
         use_color=True,
+        highlight_focus=True,
     )
 
     assert student_lab_layout.SELECTED_PANEL_BACKGROUND in rendered
     assert "Titolo: esempio" in rendered
+
+    plain = student_lab_layout.render_layout(
+        ["Dettaglio consegna", "Titolo: esempio"],
+        student_lab_layout.DEFAULT_LAYOUT,
+        terminal_width=100,
+        use_color=True,
+    )
+    assert student_lab_layout.SELECTED_PANEL_BACKGROUND not in plain
 
 
 def test_layout_has_modifier_free_keyboard_fallbacks() -> None:

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -70,10 +70,12 @@ def test_fit_line_keeps_ellipsis_inside_panel_width() -> None:
 
 def test_layout_has_modifier_free_keyboard_fallbacks() -> None:
     resized, _ = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "]")
+    arrow_resized, _ = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "right")
     moved, _ = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "l")
     focused, _ = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "\t")
 
     assert resized["left_width"] == 66
+    assert arrow_resized["left_width"] == 66
     assert moved["order"][:2] == ["workspace", "assignment"]
     assert focused["focus"] == "workspace"
 

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -62,6 +62,12 @@ def test_layout_can_collapse_the_focused_panel() -> None:
     assert "Titolo: esempio" not in rendered
 
 
+def test_fit_line_keeps_ellipsis_inside_panel_width() -> None:
+    assert len(student_lab_layout.fit_line("testo molto lungo", 10)) == 10
+    assert student_lab_layout.fit_line("testo molto lungo", 10).endswith("...")
+    assert student_lab_layout.fit_line("testo", 3) == "..."
+
+
 def test_run_layout_editor_saves_with_injected_keys(tmp_path: Path) -> None:
     keys = iter(["alt+right", "tab", "ctrl+left", "enter"])
     outputs = []
@@ -79,3 +85,4 @@ def test_run_layout_editor_saves_with_injected_keys(tmp_path: Path) -> None:
     assert layout["order"][:2] == ["workspace", "assignment"]
     assert student_lab_layout.load_layout(tmp_path) == layout
     assert any("Pannello spostato" in output for output in outputs)
+    assert any("Pannello attivo:" in output for output in outputs)

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -68,6 +68,16 @@ def test_fit_line_keeps_ellipsis_inside_panel_width() -> None:
     assert student_lab_layout.fit_line("testo", 3) == "..."
 
 
+def test_layout_has_modifier_free_keyboard_fallbacks() -> None:
+    resized, _ = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "]")
+    moved, _ = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "l")
+    focused, _ = student_lab_layout.apply_layout_key(student_lab_layout.DEFAULT_LAYOUT, "\t")
+
+    assert resized["left_width"] == 66
+    assert moved["order"][:2] == ["workspace", "assignment"]
+    assert focused["focus"] == "workspace"
+
+
 def test_run_layout_editor_saves_with_injected_keys(tmp_path: Path) -> None:
     keys = iter(["alt+right", "tab", "ctrl+left", "enter"])
     outputs = []

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -81,13 +81,14 @@ def test_selected_panel_uses_a_subtle_background_when_colors_are_enabled() -> No
     assert student_lab_layout.PANEL_TITLE_STYLE in rendered
     assert "Titolo: esempio" in rendered
 
-    plain = student_lab_layout.render_layout(
+    detail = student_lab_layout.render_layout(
         ["Dettaglio consegna", "Titolo: esempio"],
         student_lab_layout.DEFAULT_LAYOUT,
         terminal_width=100,
         use_color=True,
+        highlight_focus=True,
     )
-    assert student_lab_layout.SELECTED_PANEL_BACKGROUND not in plain
+    assert student_lab_layout.SELECTED_PANEL_BACKGROUND in detail
 
 
 def test_layout_has_modifier_free_keyboard_fallbacks() -> None:

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -88,6 +88,7 @@ def test_selected_panel_uses_a_subtle_background_when_colors_are_enabled() -> No
         use_color=True,
     )
     assert student_lab_layout.SELECTED_PANEL_BACKGROUND not in detail
+    assert student_lab_layout.PANEL_TITLE_STYLE in detail
 
 
 def test_layout_has_modifier_free_keyboard_fallbacks() -> None:

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -16,6 +16,9 @@ def test_layout_commands_resize_swap_and_change_orientation() -> None:
     stacked, _ = student_lab_layout.apply_layout_key(swapped, "ctrl+down")
     assert stacked["orientation"] == "vertical"
 
+    fallback, _ = student_lab_layout.apply_layout_key(layout, "x")
+    assert fallback["order"] == ["guide", "detail"]
+
 
 def test_layout_persists_and_invalid_values_fall_back(tmp_path: Path) -> None:
     path = tmp_path / "layout.json"

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -86,9 +86,8 @@ def test_selected_panel_uses_a_subtle_background_when_colors_are_enabled() -> No
         student_lab_layout.DEFAULT_LAYOUT,
         terminal_width=100,
         use_color=True,
-        highlight_focus=True,
     )
-    assert student_lab_layout.SELECTED_PANEL_BACKGROUND in detail
+    assert student_lab_layout.SELECTED_PANEL_BACKGROUND not in detail
 
 
 def test_layout_has_modifier_free_keyboard_fallbacks() -> None:

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from scripts import student_lab_layout
+
+
+def test_layout_commands_resize_swap_and_change_orientation() -> None:
+    layout = dict(student_lab_layout.DEFAULT_LAYOUT)
+
+    resized, message = student_lab_layout.apply_layout_key(layout, "alt+right")
+    assert resized["left_width"] == 66
+    assert "allargato" in message
+
+    swapped, _ = student_lab_layout.apply_layout_key(resized, "ctrl+left")
+    assert swapped["order"] == ["guide", "detail"]
+
+    stacked, _ = student_lab_layout.apply_layout_key(swapped, "ctrl+down")
+    assert stacked["orientation"] == "vertical"
+
+
+def test_layout_persists_and_invalid_values_fall_back(tmp_path: Path) -> None:
+    path = tmp_path / "layout.json"
+    layout = {"orientation": "vertical", "order": ["guide", "detail"], "left_width": 80}
+    path.write_text("{\"orientation\": \"invalid\"}", encoding="utf-8")
+
+    student_lab_layout.save_layout(tmp_path, layout)
+    loaded = student_lab_layout.load_layout(tmp_path)
+
+    assert loaded == layout
+
+
+def test_render_layout_keeps_detail_and_guide_in_two_columns() -> None:
+    rendered = student_lab_layout.render_layout(
+        ["Titolo", "Runner", "Guida rapida", "Consegna: lavoro assegnato"],
+        {"orientation": "horizontal", "order": ["detail", "guide"], "left_width": 20},
+        terminal_width=100,
+    )
+
+    assert "Titolo" in rendered
+    assert "Guida rapida" in rendered
+    assert " | " in rendered
+
+
+def test_run_layout_editor_saves_with_injected_keys(tmp_path: Path) -> None:
+    keys = iter(["alt+right", "ctrl+left", "enter"])
+    outputs = []
+
+    layout = student_lab_layout.run_layout_editor(
+        ["Dettaglio", "Guida rapida", "Comandi"],
+        root=tmp_path,
+        key_reader=lambda: next(keys),
+        terminal_width=80,
+        clear=False,
+        print_fn=outputs.append,
+    )
+
+    assert layout["left_width"] == 66
+    assert layout["order"] == ["guide", "detail"]
+    assert student_lab_layout.load_layout(tmp_path) == layout
+    assert any("Pannelli scambiati" in output for output in outputs)

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -78,6 +78,7 @@ def test_selected_panel_uses_a_subtle_background_when_colors_are_enabled() -> No
     )
 
     assert student_lab_layout.SELECTED_PANEL_BACKGROUND in rendered
+    assert student_lab_layout.PANEL_TITLE_STYLE in rendered
     assert "Titolo: esempio" in rendered
 
     plain = student_lab_layout.render_layout(

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -714,6 +714,7 @@ def test_student_lab_uses_existing_report_and_grading_summary(tmp_path) -> None:
     assert assignment["report"]["path"] == "examples/assignment_tracking/student_repos/rossi-mario/reports/python-base-somma-001/latest.json"
     assert assignment["report"]["submitted_at"] == "2026-10-18T18:00:00+02:00"
     assert assignment["report"]["commit"] == "abc1234"
+    assert assignment["runner"] == {"status": "passed", "backend": "student_lab_service"}
     assert assignment["grading"]["status"] == "graded_passed"
     assert assignment["grading"]["tests_passed"] == 2
     assert assignment["grading"]["tests_total"] == 2
@@ -768,6 +769,7 @@ def test_student_lab_exposes_saved_failed_test_messages(tmp_path) -> None:
             "message": "Output atteso: 5; output ottenuto: 4",
         }
     ]
+    assert assignments[0]["runner"] == {"status": "failed", "backend": "student_lab_service"}
 
 
 def test_student_lab_exposes_help_summary(tmp_path) -> None:


### PR DESCRIPTION
## Cosa cambia
- estende la demo lab a due scenari sulla stessa activity: `rossi-mario` passa i test e `bianchi-luca` li fallisce;
- verifica che il report JSON venga salvato nel workspace di ciascuno;
- verifica che dashboard lab e registro docente riflettano rispettivamente `graded_passed` e `graded_failed`;
- rende il collaudo guidato esplicito anche per il caso negativo.

## Perche
Il giro positivo era gia coperto, ma non dimostrava che la correzione automatica e il registro distinguessero un lavoro corretto da uno errato. Questa demo rende il percorso riproducibile prima del collaudo Docker reale.

## Verifiche
- `python -m pytest tests/test_student_lab_demo_smoke.py tests/test_student_lab_demo_setup.py tests/test_student_lab_demo_check.py -q`
- `python -m pytest tests/test_student_lab_runner.py tests/test_student_lab_service.py tests/test_student_lab_cli.py -q`
- `python scripts/student_lab_demo_setup.py --root tmp/student-lab-audit-manual`
- `python scripts/student_lab_demo_check.py --root tmp/student-lab-audit-guided --json`
- `node --check` e `git diff --check`