### PR TITLE
Corregge la selezione periodo nel calendario

### DIFF
--- a/tests/test_school_calendar_frontend.py
+++ b/tests/test_school_calendar_frontend.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+import subprocess
 
 
 def test_associated_course_update_declares_overwrite_intent() -> None:
@@ -10,3 +12,13 @@ def test_associated_course_update_declares_overwrite_intent() -> None:
     )[0]
 
     assert "overwrite: true" in function_source
+
+
+def test_calendar_view_selection_resets_when_period_is_not_available() -> None:
+    source = Path("tools/school_calendar.js").read_text(encoding="utf-8")
+    start = source.index("function firstAvailableCalendarViewValue")
+    end = source.index("\nfunction updateCalendarNavButtons", start)
+    function_source = source[start:end]
+    script = f"{function_source}\nprocess.stdout.write(JSON.stringify([firstAvailableCalendarViewValue(['2026-06'], '2026-03'), firstAvailableCalendarViewValue(['2026-06'], '2026-06'), firstAvailableCalendarViewValue([], '2026-03')]))"
+    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    assert json.loads(result.stdout) == ["2026-06", "2026-06", ""]

--- a/tools/school_calendar.js
+++ b/tools/school_calendar.js
@@ -534,19 +534,17 @@ function renderCalendarViewControls() {
   }
   const months = calendarMonths(start, end);
   const weeks = calendarWeeks(start, end);
-  if (!state.calendarView.month && months.length) {
-    state.calendarView.month = `${months[0].getFullYear()}-${String(months[0].getMonth() + 1).padStart(2, "0")}`;
-  }
-  if (!state.calendarView.week && weeks.length) {
-    state.calendarView.week = isoDate(weeks[0].start);
-  }
-  const monthOptions = months.map((month) => {
-    const value = `${month.getFullYear()}-${String(month.getMonth() + 1).padStart(2, "0")}`;
+  const monthValues = months.map((month) => `${month.getFullYear()}-${String(month.getMonth() + 1).padStart(2, "0")}`);
+  const weekValues = weeks.map((week) => isoDate(week.start));
+  state.calendarView.month = firstAvailableCalendarViewValue(monthValues, state.calendarView.month);
+  state.calendarView.week = firstAvailableCalendarViewValue(weekValues, state.calendarView.week);
+  const monthOptions = months.map((month, index) => {
+    const value = monthValues[index];
     const label = month.toLocaleDateString("it-IT", { month: "long", year: "numeric" });
     return `<option value="${value}"${state.calendarView.month === value ? " selected" : ""}>${escapeHtml(label)}</option>`;
   });
   const weekOptions = weeks.map((week, index) => {
-    const value = isoDate(week.start);
+    const value = weekValues[index];
     const label = `Settimana ${index + 1}: ${week.start.toLocaleDateString("it-IT")} - ${week.end.toLocaleDateString("it-IT")}`;
     return `<option value="${value}"${state.calendarView.week === value ? " selected" : ""}>${escapeHtml(label)}</option>`;
   });
@@ -581,6 +579,10 @@ function renderCalendarViewControls() {
       renderCalendarView();
     });
   });
+}
+
+function firstAvailableCalendarViewValue(values, current) {
+  return values.includes(current) ? current : values[0] || "";
 }
 
 function updateCalendarNavButtons(container, months, weeks) {


### PR DESCRIPTION
## Obiettivo

Correggere la navigazione della vista calendario quando si cambia calendario o intervallo di date.

## Finding

Se il mese o la settimana selezionati non appartengono al nuovo intervallo, la vista ricadeva visivamente sul primo periodo ma conservava internamente il valore precedente. Di conseguenza le frecce di navigazione potevano risultare disabilitate fino a una nuova selezione manuale.

## Fix

La selezione viene normalizzata al primo mese/settimana disponibile quando il valore corrente non è più valido. Ho aggiunto un test di regressione eseguito tramite Node.

## Verifica

- `python -m pytest tests/test_school_calendar_frontend.py -q`
- `python -m pytest tests/test_school_calendar_frontend.py tests/test_thebitlab_storage.py tests/test_thebitlab_services.py -q`
- `node --check tools/school_calendar.js`
- Commit atomico: [`6a71530`](https://github.com/TheBitPoets/2cornot2c/commit/6a71530)

Closes #455