### PR TITLE
Valida i body JSON delle API docente

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -105,6 +105,7 @@ AI_COURSE_PLAN_TIMEOUT_SECONDS = 240
 COMPACT_TEXT_CHARS = 1200
 MAX_SUBMISSION_FILE_BYTES = 512 * 1024
 MAX_STUDENT_HELP_REQUEST_BYTES = 16 * 1024
+MAX_TEACHER_REQUEST_BYTES = 32 * 1024 * 1024
 MIN_TEACHER_TOKEN_CHARS = 32
 MAX_HELP_LOG_ROLLBACK_BYTES = 256 * 1024 * 1024
 HELP_DELETION_SCHEMA_VERSION = "student_help_deletion.v2"
@@ -3194,6 +3195,30 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             self.write_error_json(401, str(error))
             return None
 
+    def read_teacher_json(self) -> dict[str, Any] | None:
+        """Read one bounded JSON object from an authenticated teacher request."""
+
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except (TypeError, ValueError):
+            self.write_error_json(400, "Content-Length non valido.")
+            return None
+        if length < 1:
+            self.write_error_json(400, "Body JSON obbligatorio.")
+            return None
+        if length > MAX_TEACHER_REQUEST_BYTES:
+            self.write_error_json(413, "Richiesta docente troppo grande.")
+            return None
+        try:
+            payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            self.write_error_json(400, f"JSON non valido: {error}")
+            return None
+        if not isinstance(payload, dict):
+            self.write_error_json(400, "Il payload JSON deve essere un oggetto.")
+            return None
+        return payload
+
     def do_GET(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
         if self.reject_unauthenticated_teacher_api("GET", parsed.path):
@@ -3304,8 +3329,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             except Exception:  # noqa: BLE001
                 self.write_error_json(500, STUDENT_HELP_SERVER_ERROR)
             return
-        length = int(self.headers.get("Content-Length", "0"))
-        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        payload = self.read_teacher_json()
+        if payload is None:
+            return
         if parsed.path == "/api/course-design":
             write_design(payload)
             self.write_json({"ok": True, "path": str(DESIGN_PATH.relative_to(ROOT))})

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -3770,6 +3770,60 @@ def test_student_help_http_endpoint_records_request_on_server_root(tmp_path, mon
     assert any(event["prompt"] == "Dammi una domanda guida." for event in events)
 
 
+def test_teacher_post_rejects_invalid_and_oversized_json_bodies(tmp_path) -> None:
+    original_root = course_board_server.ROOT
+    student_lab_demo_setup.prepare_demo(tmp_path)
+    teacher_token = "teacher-dashboard-token-for-body-tests"
+    server = None
+    thread = None
+
+    try:
+        course_board_server.configure_data_root(tmp_path)
+        server = course_board_server.BoundedThreadingHTTPServer(
+            ("127.0.0.1", 0), course_board_server.CourseBoardHandler
+        )
+        server.teacher_token = teacher_token
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        authorization = "Basic " + base64.b64encode(
+            f"teacher:{teacher_token}".encode("utf-8")
+        ).decode("ascii")
+
+        malformed = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+        malformed.putrequest("POST", "/api/course-design")
+        malformed.putheader("Authorization", authorization)
+        malformed.putheader("Content-Type", "application/json")
+        malformed.putheader("Content-Length", "non-numerico")
+        malformed.endheaders()
+        malformed_response = malformed.getresponse()
+        assert malformed_response.status == 400
+        assert json.loads(malformed_response.read().decode("utf-8"))["error"] == (
+            "Content-Length non valido."
+        )
+        malformed.close()
+
+        oversized = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+        oversized.putrequest("POST", "/api/course-design")
+        oversized.putheader("Authorization", authorization)
+        oversized.putheader("Content-Type", "application/json")
+        oversized.putheader("Content-Length", str(course_board_server.MAX_TEACHER_REQUEST_BYTES + 1))
+        oversized.endheaders()
+        oversized_response = oversized.getresponse()
+        assert oversized_response.status == 413
+        assert json.loads(oversized_response.read().decode("utf-8"))["error"] == (
+            "Richiesta docente troppo grande."
+        )
+        oversized.close()
+    finally:
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+        if thread is not None:
+            thread.join(timeout=5)
+        course_board_server.configure_data_root(original_root)
+
+
 def test_student_dashboard_uses_configured_demo_data_root(tmp_path) -> None:
     original_root = course_board_server.ROOT
     student_lab_demo_setup.prepare_demo(tmp_path)


### PR DESCRIPTION
## Obiettivo

Corregge la validazione comune dei body JSON inviati alle API docente.

## Finding 1 - Content-Length non valido

Prima della correzione `do_POST` convertiva direttamente `Content-Length` con `int(...)`. Una richiesta autenticata con un valore non numerico poteva quindi uscire dal normale percorso di errore invece di ricevere una risposta HTTP JSON controllata.

### Fix

Ho centralizzato la lettura nel metodo `read_teacher_json()`, che restituisce `400 Content-Length non valido` e interrompe la richiesta senza chiamare l'endpoint.

## Finding 2 - Body docente senza limite comune

Gli endpoint docente accettavano il body senza una soglia condivisa. Questo rendeva possibile inviare payload arbitrariamente grandi e consumare memoria inutilmente.

### Fix

`read_teacher_json()` applica un limite di 32 MiB e risponde `413 Richiesta docente troppo grande` prima di leggere il body. Valida inoltre UTF-8, JSON valido e payload oggetto.

## Verifiche

- `python -m pytest tests/test_course_board_server.py -k "teacher_post_rejects_invalid_and_oversized_json_bodies" -q`
- `python -m pytest tests/test_course_board_server.py -k "assignment or report or coverage" -q`
- `git diff --check`

Commit atomico: [1282004](https://github.com/TheBitPoets/2cornot2c/commit/1282004)
