### PR TITLE
Salva gli asset proposti dal wizard AI

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -61,6 +61,7 @@ from scripts import (
     thebitlab_services,
     thebitlab_storage,
     track_assignments,
+    validate_activity,
 )
 from scripts.thebitlab_contracts import normalize_activity
 from scripts.student_help_provider import DeterministicStudentHelpProvider, StudentHelpProvider
@@ -1274,6 +1275,69 @@ def list_activities() -> list[dict]:
     return assignment_service().list_activities()
 
 
+def persist_activity_draft_files(
+    *,
+    activity_id: str,
+    files: Any,
+    drafts_dir: Path,
+) -> list[dict[str, str]]:
+    """Validate and persist AI-proposed files below one activity draft root."""
+
+    if files is None:
+        return []
+    if not isinstance(files, list):
+        raise ValueError("files deve essere una lista.")
+    role_types = {
+        "starter": "starter",
+        "example": "example",
+        "fixture": "fixture",
+        "test": "visible_test",
+        "visible_test": "visible_test",
+        "solution": "teacher_only",
+        "teacher": "teacher_only",
+    }
+    allowed_types = set(validate_activity.ALLOWED_ASSET_TYPES)
+    allowed_visibility = set(validate_activity.ALLOWED_ASSET_VISIBILITIES)
+    normalized: list[tuple[Path, Path, dict[str, str]]] = []
+    seen: set[str] = set()
+    for index, file in enumerate(files):
+        if not isinstance(file, dict):
+            raise ValueError(f"files[{index}] deve essere un oggetto.")
+        source_rel = create_submission_scaffold.validate_relative_path(file.get("path"), f"files[{index}].path")
+        source_key = source_rel.as_posix()
+        if source_key in seen:
+            raise ValueError(f"File AI duplicato: {source_key}.")
+        seen.add(source_key)
+        content = file.get("content", "")
+        if not isinstance(content, str):
+            raise ValueError(f"files[{index}].content deve essere una stringa.")
+        asset_type = str(file.get("type") or role_types.get(str(file.get("role", "")).strip().lower(), "teacher_only"))
+        if asset_type not in allowed_types:
+            raise ValueError(f"Tipo asset AI non supportato: {asset_type}.")
+        visibility = str(file.get("visibility") or ("student" if asset_type in create_submission_scaffold.STUDENT_ASSET_TYPES else "teacher"))
+        if visibility not in allowed_visibility:
+            raise ValueError(f"Visibilita asset AI non supportata: {visibility}.")
+        target_path = create_submission_scaffold.validate_relative_path(
+            file.get("target_path") or source_key,
+            f"files[{index}].target_path",
+        )
+        asset_rel = Path("assets") / create_activity.slugify(activity_id) / source_rel
+        metadata = {
+            "type": asset_type,
+            "path": asset_rel.as_posix(),
+            "target_path": target_path.as_posix(),
+            "visibility": visibility,
+            "description": str(file.get("description") or "File proposto dal docente o dall'assistente AI."),
+        }
+        normalized.append((source_rel, drafts_dir / asset_rel, metadata))
+
+    for _, destination, _ in normalized:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+    for file, (_, destination, _) in zip(files, normalized):
+        destination.write_text(str(file.get("content", "")), encoding="utf-8", newline="\n")
+    return [metadata for _, _, metadata in normalized]
+
+
 def save_activity(payload: dict) -> dict:
     """Create and persist a teacher-authored activity draft."""
 
@@ -1297,7 +1361,23 @@ def save_activity(payload: dict) -> dict:
             "uda": str(payload.get("uda_id", "")).strip(),
         },
     )
-    saved = assignment_service().save_activity(activity, bool(payload.get("overwrite", False)))
+    storage = assignment_service().storage
+    overwrite = bool(payload.get("overwrite", False))
+    proposed_files = payload.get("files")
+    if proposed_files:
+        activity["assets"] = persist_activity_draft_files(
+            activity_id=activity_id,
+            files=proposed_files,
+            drafts_dir=storage.activity_drafts_dir(),
+        )
+    elif overwrite:
+        try:
+            previous = storage.read_json(storage.safe_activity_draft_path(activity_id))
+        except FileNotFoundError:
+            previous = {}
+        if isinstance(previous.get("assets"), list):
+            activity["assets"] = previous["assets"]
+    saved = assignment_service().save_activity(activity, overwrite)
     return {"ok": True, "activity": saved, "activities": list_activities()}
 
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -458,6 +458,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         selectAssignmentAiPreviewView,
         assignmentAiDraftFiles,
         renderAssignmentAiFilesReview,
+        updateAssignmentAiDraftFileContent,
         openAssignmentAiFilesDialog,
         closeAssignmentAiFilesDialog,
         applyAssignmentAiDraftToActivityForm,
@@ -1926,13 +1927,29 @@ def test_apply_assignment_ai_draft_to_activity_form_keeps_teacher_in_control() -
         assert.equal(tested.els.activityAuthorLanguage.value, "python");
         assert.equal(tested.els.activityAuthorSourceName.value, "main.py");
         assert.match(tested.els.activityAuthorStatus.innerHTML, /Bozza AI applicata/);
-        assert.match(tested.els.activityAuthorStatus.innerHTML, /Gli asset non vengono ancora salvati automaticamente/);
+        assert.doesNotMatch(tested.els.activityAuthorStatus.innerHTML, /non vengono ancora salvati automaticamente/);
         assert.match(tested.els.status.textContent, /Revisione activity/);
         assert.equal(tested.els.activityEditorDialog.open, false);
         assert.equal(tested.els.activityEditorBody.parentElement, tested.els.activityWizardEditorMount);
         const reviewStep = tested.els.assignmentSteps.find((section) => section.dataset.assignmentStep === "review");
         assert.equal(reviewStep.hidden, false);
       """
+    )
+
+
+def test_assignment_ai_file_content_edit_updates_saved_draft() -> None:
+    run_dashboard_js(
+        """
+        tested.els.assignmentAiDraftText.value = JSON.stringify({
+          files: [{ path: "starter/main.py", role: "starter", content: "print(0)\\n" }],
+        });
+        tested.state.assignmentAiDraftFilePath = "starter/main.py";
+
+        tested.updateAssignmentAiDraftFileContent({ value: "print(1)\\n" });
+
+        const draft = JSON.parse(tested.els.assignmentAiDraftText.value);
+        assert.equal(draft.files[0].content, "print(1)\\n");
+        """
     )
 
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -3916,6 +3916,36 @@ def test_save_activity_builds_valid_draft_from_gui_payload(tmp_path, monkeypatch
     }
 
 
+def test_save_activity_persists_ai_proposed_assets(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "ACTIVITY_DIRS", [tmp_path / "activities"])
+    result = course_board_server.save_activity({
+        "title": "Asset AI",
+        "kind": "laboratorio",
+        "difficulty": "B",
+        "topics": "file",
+        "prompt": "Completa il file starter.",
+        "estimated_minutes": "20",
+        "language": "python",
+        "source_name": "main.py",
+        "files": [{
+            "path": "starter/main.py",
+            "role": "starter",
+            "content": "print('ok')\n",
+            "visibility": "student",
+            "description": "Starter per lo studente",
+        }],
+    })
+
+    activity_path = tmp_path / "activities" / "drafts" / "asset-ai.json"
+    saved = json.loads(activity_path.read_text(encoding="utf-8"))
+    asset = saved["assets"][0]
+    assert result["ok"] is True
+    assert asset["path"] == "assets/asset-ai/starter/main.py"
+    assert asset["target_path"] == "starter/main.py"
+    assert (tmp_path / "activities" / "drafts" / asset["path"]).read_text(encoding="utf-8") == "print('ok')\n"
+
+
 def test_ai_secret_status_reports_paths_and_configured_keys_without_values(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "AI_SECRET_PATH", tmp_path / ".secrets" / "ai.secret")

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -2487,6 +2487,25 @@ code {
   font: 500 .86rem/1.55 var(--mono);
 }
 
+.filePreview textarea {
+  width: 100%;
+  min-height: 0;
+  resize: none;
+  border: 0;
+  border-radius: 0;
+  padding: 1rem;
+  overflow: auto;
+  white-space: pre;
+  background: #171717;
+  color: #f6f6f6;
+  font: 500 .86rem/1.55 var(--mono);
+}
+
+.filePreview textarea:focus {
+  outline: 2px solid #8ecbff;
+  outline-offset: -2px;
+}
+
 .filePreview code {
   border-radius: 0;
   background: transparent;

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2096,6 +2096,7 @@ async function saveActivityDraft() {
         path_id: els.activityAuthorPath?.value || "",
         uda_id: els.activityAuthorUda?.value || "",
         overwrite: Boolean(els.activityAuthorOverwrite?.checked),
+        files: assignmentAiDraftFiles(),
       }),
     });
     state.activities = payload.activities || [];
@@ -3090,9 +3091,26 @@ function renderAssignmentAiFilesReview() {
         </div>
         <span>${escapeHtml(languageFromPath(selectedPath))}</span>
       </div>
-      <pre><code>${highlightCode(selectedContent, selectedPath)}</code></pre>
+      <textarea data-ai-draft-file-content aria-label="Contenuto del file AI ${escapeHtml(selectedPath)}">${escapeHtml(selectedContent)}</textarea>
     </section>
   `;
+}
+
+function updateAssignmentAiDraftFileContent(textarea) {
+  const path = state.assignmentAiDraftFilePath;
+  if (!path || !textarea) return;
+  try {
+    const draft = parseAssignmentAiDraftText();
+    const file = Array.isArray(draft.files)
+      ? draft.files.find((candidate) => String(candidate?.path || "") === path)
+      : null;
+    if (!file) return;
+    file.content = textarea.value;
+    els.assignmentAiDraftText.value = JSON.stringify(draft, null, 2);
+    updateAssignmentAiApplyState();
+  } catch (error) {
+    setStatus(`File AI non aggiornato: ${error.message}`);
+  }
 }
 
 function openAssignmentAiFilesDialog(index = 0) {
@@ -3270,7 +3288,7 @@ function applyAssignmentAiDraftToActivityForm() {
     const fileCount = files.length;
     const assetCount = Array.isArray(patch.assets) ? patch.assets.length : 0;
     const suffix = fileCount || assetCount
-      ? ` File proposti: ${fileCount}; asset dichiarati: ${assetCount}. Gli asset non vengono ancora salvati automaticamente.`
+      ? ` File proposti: ${fileCount}; asset dichiarati: ${assetCount}. I file saranno salvati nell'activity dopo la revisione.`
       : "";
     setStatus("Bozza AI pronta nello step Revisione activity: il docente puo ancora modificare tutto.");
     markActivityReviewDirty();
@@ -4940,6 +4958,10 @@ els.assignmentAiFilesReview?.addEventListener("click", (event) => {
   if (!button) return;
   state.assignmentAiDraftFilePath = button.dataset.aiDraftPreviewFile || "";
   renderAssignmentAiFilesReview();
+});
+els.assignmentAiFilesReview?.addEventListener("input", (event) => {
+  const textarea = event.target.closest("[data-ai-draft-file-content]");
+  if (textarea) updateAssignmentAiDraftFileContent(textarea);
 });
 els.assignmentAiFilesCloseBtn?.addEventListener("click", closeAssignmentAiFilesDialog);
 els.openActivityEditorBtn?.addEventListener("click", () => openActivityEditor("panel"));


### PR DESCRIPTION
## Problema

Il wizard AI mostrava i file proposti, ma il docente non poteva modificarne il contenuto e il salvataggio dell'attivita non li persisteva. Questo rendeva impossibile trasformare una proposta AI in una activity completa con starter, test o altri asset.

## Soluzione

- rende il contenuto del file selezionato modificabile nello step di revisione;
- mantiene le modifiche nel draft AI fino al salvataggio dell'activity;
- invia i file nel payload di salvataggio;
- valida percorso, tipo, visibilita, contenuto e duplicati lato server;
- salva i file sotto l'area controllata dei draft e aggiorna i metadati `assets` dell'activity;
- mantiene gli asset gia presenti durante un overwrite;
- non distribuisce automaticamente nulla agli studenti: la distribuzione resta un'azione esplicita successiva.

## Verifica

- test frontend dashboard completi;
- test server per salvataggio activity, assignment, report e coverage;
- test adapter Codex;
- test scaffold e assegnazione;
- controllo sintassi JavaScript e `git diff --check`.

Issue: #463
Commit: [3aea670](https://github.com/TheBitPoets/2cornot2c/commit/3aea670412694a659c19b6302ab5d6e3d825c881)
