### PR TITLE
Aggiungi il runner Python alla sandbox Docker

### DIFF
--- a/.github/workflows/assignment-runner-docker.yml
+++ b/.github/workflows/assignment-runner-docker.yml
@@ -76,6 +76,42 @@ jobs:
           assert report["status"] == "passed"
           PY
 
+      - name: Smoke test Python runner image
+        run: |
+          cat > "$RUNNER_TEMP/activity-python.json" <<'JSON'
+          {
+            "id": "docker-smoke-python",
+            "linguaggio": "python",
+            "test_cases": [
+              {
+                "name": "incremento",
+                "stdin": "4\n",
+                "expected_stdout": "5\n"
+              }
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/main.py" <<'PY'
+          value = int(input())
+          print(value + 1)
+          PY
+          python scripts/grade_activity.py \
+            --activity "$RUNNER_TEMP/activity-python.json" \
+            --source "$RUNNER_TEMP/main.py" \
+            --language python \
+            --docker \
+            --report "$RUNNER_TEMP/report-python.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "report-python.json").read_text(encoding="utf-8"))
+          assert report["passed"] is True
+          assert report["status"] == "passed"
+          assert report["language"] == "python"
+          PY
+
       - name: Smoke test student lab Docker backend
         run: |
           mkdir -p "$RUNNER_TEMP/student-root"

--- a/doc/ASSIGNMENT_GRADING.md
+++ b/doc/ASSIGNMENT_GRADING.md
@@ -15,7 +15,7 @@ Il primo runner implementato e quello per C. Gli altri linguaggi vengono previst
 | Linguaggio | Stato iniziale |
 |---|---|
 | `c` | Implementato |
-| `python` | Previsto |
+| `python` | Implementato |
 | `javascript` | Previsto |
 | `nodejs` | Previsto |
 | `html` | Previsto |
@@ -134,7 +134,7 @@ Questa e una fondazione minimale.
 
 Limiti noti:
 
-- solo il runner C e implementato in questa fase;
+- i runner C e Python sono implementati in questa fase;
 - i runner pianificati ma non implementati restituiscono `unsupported-language`;
 - la sandbox Docker e iniziale e documentata in `ASSIGNMENT_SANDBOX.md`;
 - non vengono ancora applicati limiti su memoria o filesystem;

--- a/doc/ASSIGNMENT_SANDBOX.md
+++ b/doc/ASSIGNMENT_SANDBOX.md
@@ -45,7 +45,7 @@ python scripts/grade_activity.py \
   --report reports/c_sum_report.json
 ```
 
-Il flag `--docker` chiede di eseguire lo stesso grading dentro il container.
+Il flag `--docker` chiede di eseguire lo stesso grading dentro il container. Sono supportati i runner C e Python con test basati su stdin/stdout.
 
 ## Cosa isola
 

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -15,7 +16,7 @@ DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS = 10
 DEFAULT_DOCKER_IMAGE = "thebitlab-assignment-runner"
 SUPPORTED_LANGUAGES = {
     "c": "implemented",
-    "python": "planned",
+    "python": "implemented",
     "javascript": "planned",
     "nodejs": "planned",
     "html": "planned",
@@ -122,6 +123,58 @@ def run_test_case(binary: Path, test_case: dict[str, Any], *, timeout_seconds: i
     }
 
 
+def run_python_test_case(source: Path, test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
+    """Run one Python source file against a deterministic stdin/stdout case."""
+
+    stdin = str(test_case.get("stdin", ""))
+    expected_stdout = str(test_case.get("expected_stdout", ""))
+    name = str(test_case.get("name", "test"))
+    command = [sys.executable, str(source)]
+    try:
+        result = subprocess.run(
+            command,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        return {
+            "name": name,
+            "passed": False,
+            "status": "timeout",
+            "command": command,
+            "returncode": None,
+            "stdout": error.stdout or "",
+            "stderr": error.stderr or "",
+            "expected_stdout": expected_stdout,
+        }
+    except OSError as error:
+        return {
+            "name": name,
+            "passed": False,
+            "status": "execution-error",
+            "command": command,
+            "returncode": None,
+            "stdout": "",
+            "stderr": str(error),
+            "expected_stdout": expected_stdout,
+        }
+
+    passed = result.returncode == 0 and normalize_output(result.stdout) == normalize_output(expected_stdout)
+    return {
+        "name": name,
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "command": command,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "expected_stdout": expected_stdout,
+    }
+
+
 def validate_test_cases(test_cases: Any) -> list[str]:
     """Validate minimal deterministic test case structure."""
     if not isinstance(test_cases, list) or not test_cases:
@@ -191,6 +244,9 @@ def grade_activity(
     if selected_language == "c":
         return grade_c_activity(activity, source, timeout_seconds=timeout_seconds)
 
+    if selected_language == "python":
+        return grade_python_activity(activity, source, timeout_seconds=timeout_seconds)
+
     return unsupported_language_report(activity, source, selected_language)
 
 
@@ -250,6 +306,49 @@ def grade_c_activity(activity: dict[str, Any], source: Path, *, timeout_seconds:
                 "total": len(tests),
             },
         }
+
+
+def grade_python_activity(activity: dict[str, Any], source: Path, *, timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    """Execute and grade a Python source file using activity test cases."""
+
+    if not source.exists():
+        return {
+            "passed": False,
+            "status": "source-not-found",
+            "activity_id": activity.get("id"),
+            "language": "python",
+            "source": str(source),
+            "tests": [],
+            "error": f"Sorgente non trovato: {source}",
+        }
+
+    test_cases = activity.get("test_cases", [])
+    test_case_errors = validate_test_cases(test_cases)
+    if test_case_errors:
+        return {
+            "passed": False,
+            "status": "invalid-activity",
+            "activity_id": activity.get("id"),
+            "language": "python",
+            "source": str(source),
+            "tests": [],
+            "errors": test_case_errors,
+        }
+
+    tests = [run_python_test_case(source, test_case, timeout_seconds=timeout_seconds) for test_case in test_cases]
+    passed = all(test["passed"] for test in tests)
+    return {
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "activity_id": activity.get("id"),
+        "language": "python",
+        "source": str(source),
+        "tests": tests,
+        "summary": {
+            "passed": sum(1 for test in tests if test["passed"]),
+            "total": len(tests),
+        },
+    }
 
 
 def write_report(report: dict[str, Any], path: Path) -> None:

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -271,13 +271,13 @@ def run_python_pytest(
     }
 
 
-def wrap_c_report(assignment: dict[str, Any], source: Path, report: dict[str, Any]) -> dict[str, Any]:
-    """Wrap the existing C grader output in the student lab runner contract."""
+def wrap_runner_report(assignment: dict[str, Any], source: Path, report: dict[str, Any], language: str) -> dict[str, Any]:
+    """Wrap deterministic grader output in the student lab runner contract."""
 
     summary = report.get("summary") if isinstance(report.get("summary"), dict) else {"passed": 0, "total": 0}
     tests = normalize_c_tests(report.get("tests"))
     return {
-        **report_base(assignment, language="c", source=source),
+        **report_base(assignment, language=language, source=source),
         **report,
         "schema_version": "student_lab_run.v1",
         "backend": "local",
@@ -288,20 +288,21 @@ def wrap_c_report(assignment: dict[str, Any], source: Path, report: dict[str, An
     }
 
 
-def run_c_docker(
+def run_docker_runner(
     assignment: dict[str, Any],
     *,
     activity_path: Path,
     source: Path,
     timeout_seconds: int,
+    language: str = "c",
     docker_image: str = DEFAULT_DOCKER_IMAGE,
 ) -> dict[str, Any]:
-    """Run a C assignment through the existing Docker grading sandbox."""
+    """Run a supported assignment through the existing Docker grading sandbox."""
 
     if not source.is_file():
         return error_report(
             assignment,
-            language="c",
+            language=language,
             source=source,
             status="source-not-found",
             error=f"Sorgente non trovato: {source}",
@@ -315,7 +316,7 @@ def run_c_docker(
             command = grade_activity.docker_command(
                 activity=copied_activity,
                 source=copied_source,
-                language="c",
+                language=language,
                 timeout_seconds=timeout_seconds,
                 image=docker_image,
                 workspace=workspace,
@@ -323,7 +324,7 @@ def run_c_docker(
         except (OSError, ValueError) as error:
             return error_report(
                 assignment,
-                language="c",
+                language=language,
                 source=source,
                 status="docker-setup-error",
                 error=str(error),
@@ -334,7 +335,7 @@ def run_c_docker(
         except subprocess.TimeoutExpired:
             return error_report(
                 assignment,
-                language="c",
+                language=language,
                 source=source,
                 status="docker-timeout",
                 error=f"Timeout Docker dopo {docker_timeout} secondi.",
@@ -343,7 +344,7 @@ def run_c_docker(
         except FileNotFoundError:
             return error_report(
                 assignment,
-                language="c",
+                language=language,
                 source=source,
                 status="docker-not-found",
                 error="Docker non trovato. Installa Docker oppure usa --backend local.",
@@ -354,7 +355,7 @@ def run_c_docker(
     except json.JSONDecodeError:
         return error_report(
             assignment,
-            language="c",
+            language=language,
             source=source,
             status="docker-invalid-output",
             error=result.stderr or result.stdout or "Il container non ha prodotto JSON valido.",
@@ -363,7 +364,7 @@ def run_c_docker(
     if not grade_activity.has_minimal_report_shape(report):
         return error_report(
             assignment,
-            language="c",
+            language=language,
             source=source,
             status="docker-invalid-report",
             error=result.stderr or "Il container non ha prodotto un report di grading valido.",
@@ -372,13 +373,13 @@ def run_c_docker(
     if result.returncode != 0 and report.get("passed") is True:
         return error_report(
             assignment,
-            language="c",
+            language=language,
             source=source,
             status="docker-inconsistent-report",
             error=result.stderr or "Il container ha fallito ma ha prodotto un report di successo.",
             backend="docker",
         )
-    wrapped = wrap_c_report(assignment, source, report)
+    wrapped = wrap_runner_report(assignment, source, report, language)
     wrapped["backend"] = "docker"
     return wrapped
 
@@ -418,10 +419,11 @@ def run_local_assignment(
     if language == "python":
         return run_python_pytest(assignment, workspace=workspace_path, source=source, timeout_seconds=timeout_seconds)
     if language == "c":
-        return wrap_c_report(
+        return wrap_runner_report(
             assignment,
             source,
             grade_activity.grade_activity(activity, source, timeout_seconds=timeout_seconds, language="c"),
+            "c",
         )
     return error_report(
         assignment,
@@ -470,12 +472,13 @@ def run_docker_assignment(
             error=f"Workspace non trovato: {workspace_path_value}",
             backend="docker",
         )
-    if language == "c":
-        return run_c_docker(
+    if language in {"c", "python"}:
+        return run_docker_runner(
             assignment,
             activity_path=activity_path,
             source=source,
             timeout_seconds=timeout_seconds,
+            language=language,
             docker_image=docker_image,
         )
     return error_report(

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -112,15 +112,40 @@ def test_write_report_writes_json(tmp_path) -> None:
     assert json.loads(report_path.read_text(encoding="utf-8")) == report
 
 
-def test_grade_activity_reports_unsupported_planned_language(tmp_path) -> None:
+def test_grade_activity_passes_valid_python_program(tmp_path) -> None:
     source = tmp_path / "main.py"
-    source.write_text("print(5)\n", encoding="utf-8")
+    source.write_text("value = input().strip()\nprint(int(value) + 1)\n", encoding="utf-8")
 
-    report = grade_activity.grade_activity({"id": "python-001", "linguaggio": "python", "test_cases": []}, source)
+    report = grade_activity.grade_activity(
+        {
+            "id": "python-001",
+            "linguaggio": "python",
+            "test_cases": [{"name": "incremento", "stdin": "4\n", "expected_stdout": "5\n"}],
+        },
+        source,
+    )
+
+    assert report["passed"] is True
+    assert report["status"] == "passed"
+    assert report["language"] == "python"
+
+
+def test_grade_activity_reports_python_wrong_output(tmp_path) -> None:
+    source = tmp_path / "main.py"
+    source.write_text("print('wrong')\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity(
+        {
+            "id": "python-002",
+            "linguaggio": "python",
+            "test_cases": [{"name": "output", "expected_stdout": "right\n"}],
+        },
+        source,
+    )
 
     assert report["passed"] is False
-    assert report["status"] == "unsupported-language"
-    assert report["language"] == "python"
+    assert report["status"] == "failed"
+    assert report["summary"] == {"passed": 0, "total": 1}
 
 
 def test_grade_activity_reports_unknown_language(tmp_path) -> None:

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -438,13 +438,25 @@ def test_run_docker_assignment_rejects_success_report_on_container_error(monkeyp
     assert report["passed"] is False
 
 
-def test_run_docker_assignment_reports_unsupported_language(tmp_path) -> None:
+def test_run_docker_assignment_supports_python(monkeypatch, tmp_path) -> None:
     activity_path = write_activity(tmp_path, language="python", source_name="main.py")
     write_assignment(tmp_path, activity_path)
     workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / "python-base-somma-001"
     workspace.mkdir(parents=True)
     (workspace / "main.py").write_text("print(1)\n", encoding="utf-8")
 
+    class Result:
+        returncode = 0
+        stdout = json.dumps({
+            "passed": True,
+            "status": "passed",
+            "language": "python",
+            "tests": [{"name": "output", "passed": True, "status": "passed"}],
+            "summary": {"passed": 1, "total": 1},
+        })
+        stderr = ""
+
+    monkeypatch.setattr(student_lab_runner.subprocess, "run", lambda *args, **kwargs: Result())
     report = student_lab_runner.run_student_assignment(
         root=tmp_path,
         student_id="rossi-mario",
@@ -453,7 +465,7 @@ def test_run_docker_assignment_reports_unsupported_language(tmp_path) -> None:
     )
 
     assert report["backend"] == "docker"
-    assert report["status"] == "unsupported-docker-language"
+    assert report["status"] == "passed"
     assert report["language"] == "python"
 
 


### PR DESCRIPTION
## Problema

La TUI supportava gia l'esecuzione locale di consegne Python, ma il backend Docker accettava soltanto C. Il caso demo Python quindi non poteva completare il giro isolato nel container.

## Soluzione

- implementa il grading Python deterministico con test stdin/stdout;
- mantiene lo stesso report JSON usato dal runner C;
- abilita Python nel runner Docker e nella TUI backend Docker;
- aggiunge test per successo e output errato;
- aggiunge uno smoke test CI che costruisce l'immagine ed esegue una consegna Python reale;
- aggiorna la documentazione del grading e della sandbox.

Il flusso resta separato: locale per il collaudo rapido, Docker per l'esecuzione isolata. La correzione automatica usa sempre il report prodotto dal runner.

## Verifica locale

- test Python e Docker del grader;
- suite completa `tests/test_student_lab_runner.py`;
- suite `tests/test_thebitlab_technical_services.py`;
- compilazione Python e `git diff --check`.

Nota: i test C che richiedono `gcc` non sono eseguibili su questa macchina Windows perche il compilatore non e installato; la verifica reale del container C e Python e inclusa nel workflow Linux.

Issue: #289
Commit: [ca078b7](https://github.com/TheBitPoets/2cornot2c/commit/ca078b75de35a82877333fa7d339f7de8ca69623)
