### PR TITLE
Aggiungi runner Node.js e SQLite

### DIFF
--- a/.github/workflows/assignment-runner-docker.yml
+++ b/.github/workflows/assignment-runner-docker.yml
@@ -112,6 +112,40 @@ jobs:
           assert report["language"] == "python"
           PY
 
+      - name: Smoke test Node.js and SQLite runner image
+        run: |
+          cat > "$RUNNER_TEMP/activity-node.json" <<'JSON'
+          {"id":"docker-smoke-node","linguaggio":"javascript","test_cases":[{"name":"incremento","stdin":"4\n","expected_stdout":"5\n"}]}
+          JSON
+          cat > "$RUNNER_TEMP/main.js" <<'JS'
+          let value = "";
+          process.stdin.on("data", chunk => value += chunk).on("end", () => console.log(Number(value) + 1));
+          JS
+          python scripts/grade_activity.py --activity "$RUNNER_TEMP/activity-node.json" --source "$RUNNER_TEMP/main.js" --language javascript --docker --report "$RUNNER_TEMP/report-node.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "report-node.json").read_text(encoding="utf-8"))
+          assert report["passed"] is True
+          assert report["language"] == "javascript"
+          PY
+          cat > "$RUNNER_TEMP/activity-sql.json" <<'JSON'
+          {"id":"docker-smoke-sql","linguaggio":"sql","test_cases":[{"name":"somma","expected_stdout":"5\n"}]}
+          JSON
+          printf 'SELECT 2 + 3;\n' > "$RUNNER_TEMP/main.sql"
+          python scripts/grade_activity.py --activity "$RUNNER_TEMP/activity-sql.json" --source "$RUNNER_TEMP/main.sql" --language sql --docker --report "$RUNNER_TEMP/report-sql.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "report-sql.json").read_text(encoding="utf-8"))
+          assert report["passed"] is True
+          assert report["language"] == "sql"
+          PY
+
       - name: Smoke test student lab Docker backend
         run: |
           mkdir -p "$RUNNER_TEMP/student-root"

--- a/doc/ASSIGNMENT_GRADING.md
+++ b/doc/ASSIGNMENT_GRADING.md
@@ -8,7 +8,7 @@ Questa PR non introduce ancora Docker, sandbox completa, GitHub automation o fee
 scheda attivita -> sorgente -> runner linguaggio -> test -> report JSON
 ```
 
-Il primo runner implementato e quello per C. Gli altri linguaggi vengono previsti nel modello per evitare di legare TheBitLab a un solo linguaggio.
+I runner iniziali sono C, Python, JavaScript/Node.js e SQL. Gli altri linguaggi vengono previsti nel modello per evitare di legare TheBitLab a un solo linguaggio.
 
 ## Linguaggi previsti
 
@@ -16,11 +16,11 @@ Il primo runner implementato e quello per C. Gli altri linguaggi vengono previst
 |---|---|
 | `c` | Implementato |
 | `python` | Implementato |
-| `javascript` | Previsto |
-| `nodejs` | Previsto |
+| `javascript` | Implementato |
+| `nodejs` | Implementato |
 | `html` | Previsto |
 | `java` | Previsto |
-| `sql` | Previsto |
+| `sql` | Implementato |
 | `golang` | Previsto |
 | `assembly` | Previsto |
 | `cpp` | Previsto |
@@ -134,7 +134,7 @@ Questa e una fondazione minimale.
 
 Limiti noti:
 
-- i runner C e Python sono implementati in questa fase;
+- i runner C, Python, JavaScript/Node.js e SQL sono implementati in questa fase;
 - i runner pianificati ma non implementati restituiscono `unsupported-language`;
 - la sandbox Docker e iniziale e documentata in `ASSIGNMENT_SANDBOX.md`;
 - non vengono ancora applicati limiti su memoria o filesystem;

--- a/doc/ASSIGNMENT_SANDBOX.md
+++ b/doc/ASSIGNMENT_SANDBOX.md
@@ -45,7 +45,7 @@ python scripts/grade_activity.py \
   --report reports/c_sum_report.json
 ```
 
-Il flag `--docker` chiede di eseguire lo stesso grading dentro il container. Sono supportati i runner C e Python con test basati su stdin/stdout.
+Il flag `--docker` chiede di eseguire lo stesso grading dentro il container. Sono supportati i runner C, Python e JavaScript con test stdin/stdout, oltre a SQL su SQLite temporaneo.
 
 ## Cosa isola
 

--- a/docker/assignment-runner/Dockerfile
+++ b/docker/assignment-runner/Dockerfile
@@ -1,9 +1,8 @@
 FROM debian:bookworm-slim
 
-# Immagine iniziale orientata al runner C.
-# I runner futuri dovranno aggiungere dipendenze specifiche per linguaggio.
+# Immagine minimale per i runner C, Python, Node.js e SQLite.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc libc6-dev python3 \
+    && apt-get install -y --no-install-recommends gcc libc6-dev python3 nodejs sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /usr/sbin/nologin runner

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -17,11 +17,11 @@ DEFAULT_DOCKER_IMAGE = "thebitlab-assignment-runner"
 SUPPORTED_LANGUAGES = {
     "c": "implemented",
     "python": "implemented",
-    "javascript": "planned",
-    "nodejs": "planned",
+    "javascript": "implemented",
+    "nodejs": "implemented",
     "html": "planned",
     "java": "planned",
-    "sql": "planned",
+    "sql": "implemented",
     "golang": "planned",
     "assembly": "planned",
     "cpp": "planned",
@@ -123,13 +123,12 @@ def run_test_case(binary: Path, test_case: dict[str, Any], *, timeout_seconds: i
     }
 
 
-def run_python_test_case(source: Path, test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
-    """Run one Python source file against a deterministic stdin/stdout case."""
+def run_command_test_case(command: list[str], test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
+    """Run one command against a deterministic stdin/stdout case."""
 
     stdin = str(test_case.get("stdin", ""))
     expected_stdout = str(test_case.get("expected_stdout", ""))
     name = str(test_case.get("name", "test"))
-    command = [sys.executable, str(source)]
     try:
         result = subprocess.run(
             command,
@@ -173,6 +172,25 @@ def run_python_test_case(source: Path, test_case: dict[str, Any], *, timeout_sec
         "stderr": result.stderr,
         "expected_stdout": expected_stdout,
     }
+
+
+def run_python_test_case(source: Path, test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
+    """Run one Python source file against a deterministic stdin/stdout case."""
+
+    return run_command_test_case([sys.executable, str(source)], test_case, timeout_seconds=timeout_seconds)
+
+
+def run_node_test_case(source: Path, test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
+    """Run one JavaScript source file through Node.js."""
+
+    return run_command_test_case(["node", str(source)], test_case, timeout_seconds=timeout_seconds)
+
+
+def run_sql_test_case(source: Path, test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
+    """Run one SQL script against an isolated in-memory SQLite database."""
+
+    sql = source.read_text(encoding="utf-8") + "\n" + str(test_case.get("stdin", ""))
+    return run_command_test_case(["sqlite3", ":memory:"], {**test_case, "stdin": sql}, timeout_seconds=timeout_seconds)
 
 
 def validate_test_cases(test_cases: Any) -> list[str]:
@@ -247,6 +265,12 @@ def grade_activity(
     if selected_language == "python":
         return grade_python_activity(activity, source, timeout_seconds=timeout_seconds)
 
+    if selected_language in {"javascript", "nodejs"}:
+        return grade_node_activity(activity, source, timeout_seconds=timeout_seconds)
+
+    if selected_language == "sql":
+        return grade_sql_activity(activity, source, timeout_seconds=timeout_seconds)
+
     return unsupported_language_report(activity, source, selected_language)
 
 
@@ -308,15 +332,22 @@ def grade_c_activity(activity: dict[str, Any], source: Path, *, timeout_seconds:
         }
 
 
-def grade_python_activity(activity: dict[str, Any], source: Path, *, timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
-    """Execute and grade a Python source file using activity test cases."""
+def grade_script_activity(
+    activity: dict[str, Any],
+    source: Path,
+    *,
+    language: str,
+    test_runner: Any,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Execute and grade a script source file using activity test cases."""
 
     if not source.exists():
         return {
             "passed": False,
             "status": "source-not-found",
             "activity_id": activity.get("id"),
-            "language": "python",
+            "language": language,
             "source": str(source),
             "tests": [],
             "error": f"Sorgente non trovato: {source}",
@@ -329,19 +360,19 @@ def grade_python_activity(activity: dict[str, Any], source: Path, *, timeout_sec
             "passed": False,
             "status": "invalid-activity",
             "activity_id": activity.get("id"),
-            "language": "python",
+            "language": language,
             "source": str(source),
             "tests": [],
             "errors": test_case_errors,
         }
 
-    tests = [run_python_test_case(source, test_case, timeout_seconds=timeout_seconds) for test_case in test_cases]
+    tests = [test_runner(source, test_case, timeout_seconds=timeout_seconds) for test_case in test_cases]
     passed = all(test["passed"] for test in tests)
     return {
         "passed": passed,
         "status": "passed" if passed else "failed",
         "activity_id": activity.get("id"),
-        "language": "python",
+        "language": language,
         "source": str(source),
         "tests": tests,
         "summary": {
@@ -349,6 +380,42 @@ def grade_python_activity(activity: dict[str, Any], source: Path, *, timeout_sec
             "total": len(tests),
         },
     }
+
+
+def grade_python_activity(activity: dict[str, Any], source: Path, *, timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    """Execute and grade a Python source file using activity test cases."""
+
+    return grade_script_activity(
+        activity,
+        source,
+        language="python",
+        test_runner=run_python_test_case,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def grade_node_activity(activity: dict[str, Any], source: Path, *, timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    """Execute and grade a Node.js source file using activity test cases."""
+
+    return grade_script_activity(
+        activity,
+        source,
+        language="javascript",
+        test_runner=run_node_test_case,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def grade_sql_activity(activity: dict[str, Any], source: Path, *, timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    """Execute and grade a SQL script in an isolated SQLite database."""
+
+    return grade_script_activity(
+        activity,
+        source,
+        language="sql",
+        test_runner=run_sql_test_case,
+        timeout_seconds=timeout_seconds,
+    )
 
 
 def write_report(report: dict[str, Any], path: Path) -> None:

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -418,12 +418,12 @@ def run_local_assignment(
         )
     if language == "python":
         return run_python_pytest(assignment, workspace=workspace_path, source=source, timeout_seconds=timeout_seconds)
-    if language == "c":
+    if language in {"c", "javascript", "nodejs", "sql"}:
         return wrap_runner_report(
             assignment,
             source,
-            grade_activity.grade_activity(activity, source, timeout_seconds=timeout_seconds, language="c"),
-            "c",
+            grade_activity.grade_activity(activity, source, timeout_seconds=timeout_seconds, language=language),
+            language,
         )
     return error_report(
         assignment,
@@ -472,7 +472,7 @@ def run_docker_assignment(
             error=f"Workspace non trovato: {workspace_path_value}",
             backend="docker",
         )
-    if language in {"c", "python"}:
+    if language in {"c", "python", "javascript", "nodejs", "sql"}:
         return run_docker_runner(
             assignment,
             activity_path=activity_path,

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -148,6 +148,34 @@ def test_grade_activity_reports_python_wrong_output(tmp_path) -> None:
     assert report["summary"] == {"passed": 0, "total": 1}
 
 
+@pytest.mark.skipif(shutil.which("node") is None, reason="node non disponibile nell'ambiente di test")
+def test_grade_activity_passes_valid_javascript_program(tmp_path) -> None:
+    source = tmp_path / "main.js"
+    source.write_text("let value = ''; process.stdin.on('data', chunk => value += chunk).on('end', () => console.log(Number(value) + 1));\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity(
+        {"id": "js-001", "linguaggio": "javascript", "test_cases": [{"stdin": "4\n", "expected_stdout": "5\n"}]},
+        source,
+    )
+
+    assert report["passed"] is True
+    assert report["language"] == "javascript"
+
+
+@pytest.mark.skipif(shutil.which("sqlite3") is None, reason="sqlite3 non disponibile nell'ambiente di test")
+def test_grade_activity_passes_valid_sql_script(tmp_path) -> None:
+    source = tmp_path / "main.sql"
+    source.write_text("SELECT 2 + 3;\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity(
+        {"id": "sql-001", "linguaggio": "sql", "test_cases": [{"expected_stdout": "5\n"}]},
+        source,
+    )
+
+    assert report["passed"] is True
+    assert report["language"] == "sql"
+
+
 def test_grade_activity_reports_unknown_language(tmp_path) -> None:
     source = tmp_path / "main.xyz"
     source.write_text("contenuto\n", encoding="utf-8")

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -198,11 +198,11 @@ def test_run_local_assignment_reports_missing_source(tmp_path) -> None:
 
 
 def test_run_local_assignment_reports_unsupported_language(tmp_path) -> None:
-    activity_path = write_activity(tmp_path, language="sql", source_name="query.sql")
+    activity_path = write_activity(tmp_path, language="html", source_name="index.html")
     write_assignment(tmp_path, activity_path)
     workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / "python-base-somma-001"
     workspace.mkdir(parents=True)
-    (workspace / "query.sql").write_text("select 1;", encoding="utf-8")
+    (workspace / "index.html").write_text("<p>demo</p>", encoding="utf-8")
 
     report = student_lab_runner.run_student_assignment(
         root=tmp_path,
@@ -211,7 +211,7 @@ def test_run_local_assignment_reports_unsupported_language(tmp_path) -> None:
     )
 
     assert report["status"] == "unsupported-language"
-    assert report["language"] == "sql"
+    assert report["language"] == "html"
 
 
 def test_run_local_assignment_rejects_source_name_outside_workspace(tmp_path) -> None:


### PR DESCRIPTION
## Problema

Il runner Docker supportava C e Python, ma non JavaScript/Node.js e SQL. Le attivita di questi linguaggi risultavano quindi non eseguibili nel backend isolato.

## Soluzione

- aggiunge runner Node.js tramite `node`;
- aggiunge runner SQL su database SQLite temporaneo in memoria;
- usa test stdin/stdout e report JSON coerenti con C e Python;
- abilita i quattro linguaggi nel runner della TUI e nel backend Docker;
- installa `nodejs` e `sqlite3` nell'immagine;
- aggiunge test locali e smoke test CI per Node.js e SQL;
- aggiorna la documentazione dei linguaggi supportati.

La scelta SQL e intenzionalmente minimale: ogni caso parte da un database in memoria, esegue lo script dell'attivita e il blocco SQL del test, poi confronta l'output.

## Verifica

- test grader Python, JavaScript, SQL e Docker;
- suite `tests/test_student_lab_runner.py`;
- suite `tests/test_thebitlab_technical_services.py`;
- compilazione Python e `git diff --check`.

Nota: su questa macchina Windows `gcc` e `sqlite3` non sono installati; i test locali dipendenti da questi binari vengono saltati. Il workflow Linux verifica i runner dentro l'immagine Docker.

Issue: #289
Commit: [70d61cf](https://github.com/TheBitPoets/2cornot2c/commit/70d61cfc93cf2e8deb5b214675e4b6446fd71037)
