### PR TITLE
Correggi apertura consegna nella dashboard studente

### DIFF
--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -216,7 +216,10 @@ class AssignmentOverviewService:
                         "submitted_at": submission.get("submitted_at"),
                         "commit": submission.get("commit"),
                         "source_path": submission.get("source_path"),
-                        "source_github_url": _submission_source_github_url(submission),
+                        "source_github_url": _submission_source_github_url(
+                            submission,
+                            student.get("repo_github_url"),
+                        ),
                         "grading": {
                             "status": grading.get("status", ""),
                             "passed": grading.get("passed"),
@@ -239,7 +242,10 @@ def _matches_student(student: dict[str, Any], student_id: str) -> bool:
     return student.get("student_id") == student_id or student.get("student") == student_id
 
 
-def _submission_source_github_url(submission: dict[str, Any]) -> str | None:
+def _submission_source_github_url(
+    submission: dict[str, Any],
+    repo_github_url: Any = None,
+) -> str | None:
     source_url = _clean_optional_string(submission.get("source_github_url"))
     file_urls = _submission_file_github_urls(submission)
     if source_url and not _looks_like_broken_demo_url(source_url):
@@ -247,6 +253,9 @@ def _submission_source_github_url(submission: dict[str, Any]) -> str | None:
     for file_url in file_urls:
         if not _looks_like_broken_demo_url(file_url):
             return file_url
+    canonical_url = _canonical_repo_file_url(repo_github_url, submission.get("source_path"))
+    if canonical_url:
+        return canonical_url
     return source_url
 
 
@@ -277,13 +286,32 @@ def _normalized_path(value: Any) -> str:
     return str(value or "").replace("\\", "/").lstrip("./")
 
 
+def _canonical_repo_file_url(repo_github_url: Any, source_path: Any) -> str | None:
+    repo_url = _clean_optional_string(repo_github_url)
+    path = _normalized_path(source_path)
+    if not repo_url or not path:
+        return None
+    if path.startswith("assignments/"):
+        path = path
+    elif "/assignments/" in path:
+        path = "assignments/" + path.split("/assignments/", 1)[1]
+    else:
+        return None
+    return f"{repo_url.rstrip('/')}/blob/main/{path}"
+
+
 def _clean_optional_string(value: Any) -> str | None:
     clean_value = str(value or "").strip()
     return clean_value or None
 
 
 def _looks_like_broken_demo_url(url: str) -> bool:
-    return "/blob/" in url and "/scripts/examples/assignment_tracking/" in url
+    if "/blob/" not in url:
+        return False
+    return (
+        "/scripts/examples/assignment_tracking/" in url
+        or "/tmp/" in url and "/student_repos/" in url
+    )
 
 
 def _approved_student_feedback(ai_feedback: dict[str, Any]) -> dict[str, Any] | None:

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -181,7 +181,12 @@ def github_file_path(target: TrackingTarget, file_path: str | None) -> str | Non
         resolved = raw_path.resolve()
     else:
         target_candidate = (target.path / raw_path).resolve()
-        resolved = target_candidate if target_candidate.exists() else (PROJECT_ROOT / raw_path).resolve()
+        if target_candidate.exists():
+            try:
+                return str(target_candidate.relative_to(target.path.resolve())).replace("\\", "/")
+            except ValueError:
+                pass
+        resolved = (PROJECT_ROOT / raw_path).resolve()
     root = git_root(target.path) or target.path.resolve()
     try:
         return str(resolved.relative_to(root)).replace("\\", "/")

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3209,6 +3209,17 @@ def test_assignment_dashboard_normalizes_legacy_github_submission_urls() -> None
         const expected = "https://github.com/TheBitPoets/rossi-mario/blob/main/assignments/python-demo-somma-001/main.py";
         assert.equal(tested.submissionGithubUrl(student), expected);
         assert.equal(tested.submissionFiles(student)[0].github_url, expected);
+
+        const studentWithManifest = {
+          repo_github_url: student.repo_github_url,
+          submission: {
+            files: [{
+              path: "assignments/python-demo-somma-001/main.py",
+              github_url: student.submission.source_github_url,
+            }],
+          },
+        };
+        assert.equal(tested.submissionFiles(studentWithManifest)[0].github_url, expected);
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -395,6 +395,8 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         openStudentHelpDialog,
         clearStudentHelpRows,
         renderStudents,
+        submissionFiles,
+        submissionGithubUrl,
         failedTestDetails,
         gradingDetails,
         renderTestDetailsDialogContent,
@@ -3190,6 +3192,23 @@ def test_render_students_closes_help_dialog_when_the_report_changes() -> None:
         assert.equal(tested.els.studentHelpDialog.open, false);
         assert.equal(tested.state.studentHelpDialogKey, "");
         assert.equal(tested.state.studentHelpDialogReportName, "");
+        """
+    )
+
+
+def test_assignment_dashboard_normalizes_legacy_github_submission_urls() -> None:
+    run_dashboard_js(
+        """
+        const student = {
+          repo_github_url: "https://github.com/TheBitPoets/rossi-mario",
+          submission: {
+            source_path: "assignments/python-demo-somma-001/main.py",
+            source_github_url: "https://github.com/TheBitPoets/rossi-mario/blob/main/tmp/student-lab-demo/examples/assignment_tracking/student_repos/rossi-mario/assignments/python-demo-somma-001/main.py",
+          },
+        };
+        const expected = "https://github.com/TheBitPoets/rossi-mario/blob/main/assignments/python-demo-somma-001/main.py";
+        assert.equal(tested.submissionGithubUrl(student), expected);
+        assert.equal(tested.submissionFiles(student)[0].github_url, expected);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -196,6 +196,7 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
         assert.match(tested.els.assignments.innerHTML, /Apri consegna/);
         assert.match(tested.els.assignments.innerHTML, /Dettaglio/);
         assert.match(tested.els.assignments.innerHTML, /data-detail-index="0"/);
+        assert.match(tested.els.assignments.innerHTML, /data-open-assignment-detail="0"/);
         assert.match(tested.els.assignments.innerHTML, /href="https:\\/\\/github.com\\/TheBitPoets\\/rossi-mario\\/blob\\/main\\/assignments\\/python-base-somma-001\\/main.py"/);
         assert.match(tested.els.studentLab.innerHTML, /Workspace pronto/);
         assert.match(tested.els.studentLab.innerHTML, /Report salvato/);
@@ -775,7 +776,8 @@ def test_student_dashboard_assignment_detail_modal_renders_selected_assignment()
         assert.match(tested.els.assignmentDetailBody.innerHTML, /submitted_late/);
         assert.match(tested.els.assignmentDetailBody.innerHTML, /somma con negativo/);
         assert.match(tested.els.assignmentDetailBody.innerHTML, /Controlla il secondo caso/);
-        assert.match(tested.els.assignmentDetailBody.innerHTML, /Apri consegna/);
+        assert.match(tested.els.assignmentDetailBody.innerHTML, /Repository/);
+        assert.match(tested.els.assignmentDetailBody.innerHTML, /assignments\/python-base-somma-001\/main.py/);
 
         tested.closeAssignmentDetail();
         assert.equal(tested.els.assignmentDetailModal.hidden, true);

--- a/tests/test_thebitlab_services.py
+++ b/tests/test_thebitlab_services.py
@@ -327,6 +327,43 @@ def test_student_dashboard_prefers_file_manifest_url_when_source_url_is_broken_d
     assert dashboard["assignments"][0]["source_github_url"] == good_url
 
 
+def test_student_dashboard_rebuilds_legacy_demo_source_url_from_repo_and_source_path(tmp_path) -> None:
+    service = assignment_overview_service(tmp_path)
+    reports_dir = tmp_path / "teacher-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "activity.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "student_id": "rossi-mario",
+                        "repo_github_url": "https://github.com/TheBitPoets/rossi-mario",
+                        "submitted": True,
+                        "submission": {
+                            "source_path": "assignments/python-base-somma-001/main.py",
+                            "source_github_url": (
+                                "https://github.com/TheBitPoets/rossi-mario/blob/main/"
+                                "tmp/student-lab-demo/examples/assignment_tracking/student_repos/"
+                                "rossi-mario/assignments/python-base-somma-001/main.py"
+                            ),
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dashboard = service.student_dashboard("rossi-mario")
+
+    assert dashboard["assignments"][0]["source_github_url"] == (
+        "https://github.com/TheBitPoets/rossi-mario/blob/main/"
+        "assignments/python-base-somma-001/main.py"
+    )
+
+
 def test_assignment_overview_service_accepts_protocol_compatible_storage(tmp_path) -> None:
     class FakeAssignmentStorage:
         def safe_teacher_report_path(self, name: str) -> Path:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -123,6 +123,22 @@ def test_github_file_path_uses_project_root_for_repo_relative_paths(tmp_path, mo
     assert path == "examples/assignment_tracking/student_repos/bianchi-luca/assignments/python-base-somma-001/main.py"
 
 
+def test_github_file_path_uses_student_repo_relative_path_for_local_demo(tmp_path) -> None:
+    repo = tmp_path / "student-repo"
+    source_path = repo / "assignments" / "python-base-somma-001" / "main.py"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("print(3)\n", encoding="utf-8")
+    student = track_assignments.TrackingTarget(
+        student="rossi-mario",
+        repo="TheBitPoets/rossi-mario",
+        path=repo,
+    )
+
+    path = track_assignments.github_file_path(student, "assignments/python-base-somma-001/main.py")
+
+    assert path == "assignments/python-base-somma-001/main.py"
+
+
 class MissingPathProvider:
     provider_name = "missing-path"
 

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -4521,7 +4521,7 @@ function renderStudents(students) {
         <small>${submission.source_path ? escapeHtml(submission.source_path) : "sorgente non indicato"}</small>
         ${submission.report_path ? `<br><small>report ${escapeHtml(submission.report_path)}</small>` : ""}
         ${submission.report_backend ? `<br><small>backend ${escapeHtml(submission.report_backend)}</small>` : ""}
-        ${submission.source_github_url ? `<br>${externalLink(submission.source_github_url, "Apri su GitHub")}` : ""}
+        ${submissionGithubUrl(student) ? `<br>${externalLink(submissionGithubUrl(student), "Apri su GitHub")}` : ""}
       </td>
       <td>
         ${badge(grading.status, grading.status === "graded_passed" ? "ok" : grading.status === "graded_failed" ? "bad" : "muted")}<br>
@@ -4617,6 +4617,26 @@ async function reviewAiFeedback(studentId, decision) {
   }
 }
 
+function canonicalSubmissionGithubUrl(student, filePath, githubUrl = "") {
+  const normalizedUrl = String(githubUrl || "").trim();
+  if (normalizedUrl && !(/\/tmp\/.*\/student_repos\//.test(normalizedUrl))) return normalizedUrl;
+  const repoUrl = String(student.repo_github_url || "").trim();
+  const normalizedPath = String(filePath || "").replaceAll("\\", "/");
+  if (!repoUrl || !normalizedPath) return normalizedUrl;
+  const marker = normalizedPath.indexOf("/assignments/");
+  const path = normalizedPath.startsWith("assignments/")
+    ? normalizedPath
+    : marker >= 0
+      ? `assignments/${normalizedPath.slice(marker + "/assignments/".length)}`
+      : "";
+  return path ? `${repoUrl.replace(/\/$/, "")}/blob/main/${path}` : normalizedUrl;
+}
+
+function submissionGithubUrl(student) {
+  const submission = student.submission || {};
+  return canonicalSubmissionGithubUrl(student, submission.source_path, submission.source_github_url);
+}
+
 function submissionFiles(student) {
   const submission = student.submission || {};
   const files = Array.isArray(submission.files) ? submission.files : [];
@@ -4626,11 +4646,11 @@ function submissionFiles(student) {
       .map((file) => ({
         path: String(file.path).replaceAll("\\", "/"),
         role: file.role || "support",
-        github_url: file.github_url || "",
+        github_url: canonicalSubmissionGithubUrl(student, file.path, file.github_url),
       }));
   }
   return submission.source_path
-    ? [{ path: String(submission.source_path).replaceAll("\\", "/"), role: "solution", github_url: submission.source_github_url || "" }]
+    ? [{ path: String(submission.source_path).replaceAll("\\", "/"), role: "solution", github_url: submissionGithubUrl(student) }]
     : [];
 }
 

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -1177,11 +1177,11 @@ function actionUnavailableLabel(assignment) {
     : "File consegna non disponibile";
 }
 
-function assignmentOpenAction(assignment) {
-  const actionHref = safeExternalHref(assignment.source_github_url);
-  return actionHref
-    ? `<a class="actionButton" href="${escapeHtml(actionHref)}" target="_blank" rel="noreferrer">Apri consegna</a>`
-    : `<button type="button" class="actionButton actionButtonDisabled" disabled>Apri consegna</button><span class="actionUnavailable">${escapeHtml(actionUnavailableLabel(assignment))}</span>`;
+function assignmentOpenAction(assignment, assignmentIndex = -1) {
+  if (!assignment.submitted) {
+    return `<button type="button" class="actionButton actionButtonDisabled" disabled>Apri consegna</button><span class="actionUnavailable">${escapeHtml(actionUnavailableLabel(assignment))}</span>`;
+  }
+  return `<button type="button" class="actionButton" data-open-assignment-detail="${escapeHtml(assignmentIndex)}">Apri consegna</button>`;
 }
 
 function renderAssignment(assignment, isNext = false, assignmentIndex = -1) {
@@ -1210,7 +1210,7 @@ function renderAssignment(assignment, isNext = false, assignmentIndex = -1) {
         </div>
       </div>
       <p class="assignmentActions">
-        ${assignmentOpenAction(assignment)}
+        ${assignmentOpenAction(assignment, assignmentIndex)}
         <button type="button" class="secondaryActionButton" data-detail-index="${escapeHtml(assignmentIndex)}">Dettaglio</button>
       </p>
       <p class="details">
@@ -1272,7 +1272,6 @@ function renderAssignmentDetail(assignment) {
         ${detailItem("Consegnato il", formatDate(assignment.submitted_at))}
         ${detailItem("Commit", assignment.commit || "-")}
       </div>
-      <p class="assignmentActions">${assignmentOpenAction(assignment)}</p>
       <p class="details">
         <span>Repository: ${repoLink}</span>
         <span>File: ${sourceLink}</span>
@@ -1476,6 +1475,11 @@ els.studentCalendar?.addEventListener("keydown", (event) => {
 });
 
 els.assignments?.addEventListener("click", (event) => {
+  const openButton = event.target.closest?.("[data-open-assignment-detail]");
+  if (openButton) {
+    openAssignmentDetail(openButton.dataset.openAssignmentDetail);
+    return;
+  }
   const detailButton = event.target.closest?.("[data-detail-index]");
   if (!detailButton) return;
   openAssignmentDetail(detailButton.dataset.detailIndex);


### PR DESCRIPTION
## Problema
Il pulsante `Apri consegna` della dashboard studente e i link `GitHub` dei singoli file nella revisione docente potevano usare URL costruiti con il percorso locale della demo (`tmp/...`). Questo produceva 404. I report demo gia salvati potevano contenere lo stesso URL legacy.

## Soluzione
- `Apri consegna` nella dashboard studente apre il modal di dettaglio gia presente.
- Repository e file restano disponibili nel modal come link secondari.
- I nuovi path dei file vengono convertiti in percorsi relativi al repository.
- I link legacy dei report vengono normalizzati nel servizio studente.
- La dashboard docente normalizza il link nella tabella studenti e nella lista file del modal `Revisione consegna`.
- I link dei file presenti nel manifest `files[]` sono verificati e normalizzati allo stesso modo.

## Verifica
- `python -m pytest tests/test_track_assignments.py -q`
- `python -m pytest tests/test_student_dashboard_frontend.py -q`
- `python -m pytest tests/test_thebitlab_services.py -q`
- `python -m pytest tests/test_assignment_dashboard_frontend.py -q`
- `node --check tools/student_dashboard.js`
- `node --check tools/assignment_dashboard.js`
- `git diff --check`

Commit atomico UI/path: [9408696](https://github.com/TheBitPoets/2cornot2c/commit/9408696)
Commit atomico dati legacy: [269de21](https://github.com/TheBitPoets/2cornot2c/commit/269de21)
Commit atomico revisione docente: [9ff8b5b](https://github.com/TheBitPoets/2cornot2c/commit/9ff8b5b4d9cdd50a263e2d937cffc1253cdf114f)
Test link manifest: [36821e6](https://github.com/TheBitPoets/2cornot2c/commit/36821e6)