### PR TITLE
Abilita Salva progetto solo dopo modifiche

### DIFF
--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -332,6 +332,27 @@ def test_dirty_tracking_detects_changes_and_resets_after_save() -> None:
     )
 
 
+def test_save_project_follows_dirty_state() -> None:
+    run_course_board_js(
+        """
+        state.design = { years: [{ id: "first" }] };
+        state.activeSavedDesign = "course.json";
+        state.isNewDesign = false;
+        markDesignClean();
+        renderCourseActions();
+        assert.equal(els.saveArchiveBtn.disabled, true);
+
+        state.design.years.push({ id: "changed" });
+        renderCourseActions();
+        assert.equal(els.saveArchiveBtn.disabled, false);
+
+        markDesignClean();
+        renderCourseActions();
+        assert.equal(els.saveArchiveBtn.disabled, true);
+        """
+    )
+
+
 def test_change_during_current_project_save_remains_dirty() -> None:
     run_course_board_js(
         """

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -418,6 +418,7 @@ function renderProjectTitle() {
 
 function renderCourseActions() {
   const isCurrent = !state.activeSavedDesign && !state.isNewDesign;
+  const hasChanges = hasUnsavedChanges();
   if (isCurrent) {
     els.saveArchiveBtn.title = "Salva le modifiche direttamente nel progetto corrente doc/course_design.json.";
   } else if (state.activeSavedDesign) {
@@ -426,6 +427,10 @@ function renderCourseActions() {
     els.saveArchiveBtn.title = "Salva il nuovo progetto nell'archivio dei progetti didattici.";
   }
   els.saveArchiveAsBtn.title = "Salva una copia del progetto con un nuovo nome nell'archivio; poi potrai impostarla come progetto corrente.";
+  els.saveArchiveBtn.disabled = saveOperationInProgress || !hasChanges;
+  if (!hasChanges) {
+    els.saveArchiveBtn.title = "Nessuna modifica da salvare nel progetto attualmente caricato.";
+  }
   els.deleteArchiveBtn.disabled = isCurrent;
   els.deleteArchiveBtn.title = isCurrent
     ? "Il progetto corrente doc/course_design.json non puo essere eliminato dalla board."
@@ -1109,6 +1114,7 @@ function renderCourse() {
   els.courseTree.innerHTML = "";
   if (!(state.design.years || []).length) {
     els.courseTree.innerHTML = '<p class="empty">Nessun percorso definito. Usa "Aggiungi percorso" per creare il primo contenitore UDA.</p>';
+    renderCourseActions();
     return;
   }
   for (const year of state.design.years || []) {
@@ -1134,6 +1140,7 @@ function renderCourse() {
     }
     els.courseTree.append(yearNode);
   }
+  renderCourseActions();
 }
 
 function removeYear(year) {
@@ -1699,6 +1706,7 @@ function renderFrameEditor(item) {
       setFrameLabelQuality(label, "none");
       updateFrameEditorQuality(details, item);
       quality.hidden = true;
+      renderCourseActions();
     });
     grid.append(label);
   }


### PR DESCRIPTION
## Obiettivo

Il pulsante Salva progetto deve essere disabilitato quando il percorso aperto coincide con l'ultimo snapshot salvato e deve riabilitarsi alla prima modifica.

## Modifica
- collega saveArchiveBtn a hasUnsavedChanges();
- aggiorna lo stato dopo il rendering del percorso e dopo la modifica delle textarea;
- mantiene Salva progetto con nome sempre disponibile;
- aggiunge un test per stato pulito, modifica e nuovo salvataggio.

## Verifica
- 23 test frontend passati
- node --check tools/course_board.js
- git diff --check

Commit: [7d0cd83](https://github.com/TheBitPoets/2cornot2c/commit/7d0cd83)