### PR TITLE
Mostra contenuto paragrafi nel percorso docente

### DIFF
--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -345,6 +345,8 @@ Obiettivo: verificare creazione, modifica, persistenza, protezione dagli errori 
 3. Usa `Nuovo progetto` e crea `test-manuale-percorso.json`.
 4. Aggiungi un percorso con settimane e ore valide. Prova poi a crearne uno con `0` settimane e verifica il bordo rosso e il messaggio di errore.
 5. Nel catalogo a sinistra usa il pulsante `+` su un paragrafo, poi premilo di nuovo sullo stesso paragrafo.
+5a. Clicca il titolo di un paragrafo e poi il comando `Testo`: verifica che si apra il modal con il contenuto completo.
+5b. Dentro una UDA ripeti dal titolo e dal comando `Testo`, poi usa `Apri sorgente su GitHub` e verifica l'ancora del paragrafo.
 6. Modifica una cornice e premi `Ricarica`: annulla la conferma e verifica che la modifica resti visibile; ripeti accettando e verifica che torni l'ultimo stato salvato.
 7. Usa `Salva progetto con nome` indicando di nuovo `test-manuale-percorso.json`: annulla la richiesta di sovrascrittura e verifica che l'archivio precedente non cambi.
 8. Salva regolarmente il progetto. Se il provider AI è configurato, genera una sola cornice, avvia una nuova coda e usa `Annulla`; verifica che testo e indicatori di qualità tornino allo stato iniziale.
@@ -356,6 +358,7 @@ Risultato atteso:
 
 - I dati non validi non entrano nel progetto.
 - Lo stesso paragrafo non viene duplicato nello stesso percorso.
+- Il titolo e il comando `Testo` aprono il modal con contenuto, fonte, riga e link GitHub coerenti.
 - Ricarica e navigazione non scartano modifiche senza conferma.
 - Un nome già esistente richiede conferma prima della sovrascrittura.
 - L'annullamento AI ripristina sia il testo sia gli indicatori di qualità.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -1945,6 +1945,7 @@ def extract_headings() -> list[dict]:
                     "title": TAG_RE.sub("", title).strip(),
                     "anchor": anchor,
                     "href": f"../{source}#{anchor}",
+                    "github_url": github_blob_url(source, anchor),
                     "line": lineno,
                 }
             )
@@ -3334,6 +3335,19 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/api/headings":
             self.write_json({"headings": extract_headings()})
+            return
+        if parsed.path == "/api/heading-content":
+            heading_id = parse_qs(parsed.query).get("id", [""])[0]
+            heading = next((item for item in extract_headings() if item["id"] == heading_id), None)
+            if heading is None:
+                self.write_error_json(404, "Paragrafo non trovato.")
+                return
+            self.write_json({
+                "heading": {
+                    **heading,
+                    "content": section_text(heading["source"], heading["line"], heading["level"]),
+                }
+            })
             return
         if parsed.path == "/api/course-design":
             self.write_json(read_design())

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -8,6 +8,7 @@ import subprocess
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -79,6 +80,54 @@ def test_teacher_dashboard_token_console_line_shows_generated_value() -> None:
 
     assert generated in line
     assert "temporaneo" in line
+
+
+def test_extract_headings_and_section_text_include_paragraph_content(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "lesson.md"
+    source.write_text(
+        "# Corso\n\nIntroduzione.\n\n## Array\n\nTesto del paragrafo.\n\n### Esempio\n\nCodice di esempio.\n\n## Dopo\n\nAltro testo.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "read_design", lambda: {"source_files": ["lesson.md"]})
+
+    headings = course_board_server.extract_headings()
+    array = next(heading for heading in headings if heading["title"] == "Array")
+
+    assert array["github_url"].endswith("lesson.md#array")
+    assert course_board_server.section_text(array["source"], array["line"], array["level"]) == (
+        "Testo del paragrafo.\n\n### Esempio\n\nCodice di esempio."
+    )
+
+
+def test_heading_content_endpoint_returns_selected_section(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "lesson.md"
+    source.write_text("# Corso\n\n## Array\n\nTesto leggibile.\n", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "read_design", lambda: {"source_files": ["lesson.md"]})
+    teacher_token = "teacher-dashboard-token-for-heading-content-tests"
+    server = course_board_server.BoundedThreadingHTTPServer(
+        ("127.0.0.1", 0), course_board_server.CourseBoardHandler
+    )
+    server.teacher_token = teacher_token
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        heading = next(item for item in course_board_server.extract_headings() if item["title"] == "Array")
+        authorization = "Basic " + base64.b64encode(f"teacher:{teacher_token}".encode("utf-8")).decode("ascii")
+        request = urllib.request.Request(
+            "http://127.0.0.1:%s/api/heading-content?id=%s"
+            % (server.server_address[1], urllib.parse.quote(heading["id"], safe="")),
+            headers={"Authorization": authorization},
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload["heading"]["title"] == "Array"
+        assert payload["heading"]["content"] == "Testo leggibile."
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 def test_generate_course_plan_uses_temporary_design_without_promoting_it(tmp_path, monkeypatch) -> None:

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -396,6 +396,20 @@ input[aria-invalid="true"] {
   line-height: 1.18;
 }
 
+.headingPreviewTrigger,
+.itemPreviewTrigger {
+  cursor: pointer;
+}
+
+.headingPreviewTrigger:hover,
+.headingPreviewTrigger:focus-visible,
+.itemPreviewTrigger:hover,
+.itemPreviewTrigger:focus-visible {
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: .16em;
+}
+
 .treeToggle,
 .treeToggleSpacer {
   flex: 0 0 1.15rem;
@@ -709,6 +723,37 @@ input[aria-invalid="true"] {
   display: grid;
   gap: 1rem;
   padding: 1.25rem;
+}
+
+.paragraphDialog {
+  width: min(64rem, calc(100vw - 2rem));
+}
+
+.paragraphDialogMeta {
+  margin: .35rem 0 0;
+  color: var(--muted);
+  font: .75rem/1.35 var(--mono);
+}
+
+.paragraphContent {
+  min-height: 16rem;
+  max-height: min(58vh, 40rem);
+  margin: 0;
+  overflow: auto;
+  border: 1px solid rgba(17, 17, 17, .12);
+  border-radius: 16px;
+  background: #fafafa;
+  color: var(--ink);
+  padding: 1rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font: .86rem/1.6 var(--mono);
+}
+
+.paragraphSourceLink {
+  color: var(--ink);
+  font-size: .78rem;
+  font-weight: 700;
 }
 
 .courseAiHead,

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -745,9 +745,59 @@ input[aria-invalid="true"] {
   background: #fafafa;
   color: var(--ink);
   padding: 1rem;
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
   font: .86rem/1.6 var(--mono);
+}
+
+.paragraphContent p,
+.paragraphContent h1,
+.paragraphContent h2,
+.paragraphContent h3,
+.paragraphContent h4,
+.paragraphContent h5,
+.paragraphContent h6 {
+  margin: 0 0 .8rem;
+}
+
+.paragraphContent h1,
+.paragraphContent h2,
+.paragraphContent h3,
+.paragraphContent h4,
+.paragraphContent h5,
+.paragraphContent h6 {
+  font-family: inherit;
+  line-height: 1.25;
+}
+
+.paragraphContent ul,
+.paragraphContent ol {
+  margin: 0 0 .8rem;
+  padding-left: 1.5rem;
+}
+
+.paragraphContent pre {
+  overflow: auto;
+  margin: 0 0 .8rem;
+  border-radius: 10px;
+  background: #eeeeee;
+  padding: .8rem;
+  white-space: pre;
+}
+
+.paragraphContent code {
+  border-radius: .25rem;
+  background: #eeeeee;
+  padding: .08rem .25rem;
+}
+
+.paragraphContent pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.paragraphContent a {
+  color: var(--ink);
+  font-weight: 700;
 }
 
 .paragraphSourceLink {

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -212,7 +212,7 @@
         </div>
         <button id="paragraphCloseBtn" type="button" title="Chiude il testo del paragrafo.">Chiudi</button>
       </header>
-      <pre id="paragraphContent" class="paragraphContent" tabindex="0">Seleziona un paragrafo per visualizzarne il contenuto.</pre>
+      <div id="paragraphContent" class="paragraphContent" tabindex="0">Seleziona un paragrafo per visualizzarne il contenuto.</div>
       <a id="paragraphSourceLink" class="paragraphSourceLink" href="#" target="_blank" rel="noreferrer" hidden>Apri sorgente su GitHub</a>
     </form>
   </dialog>

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -202,6 +202,21 @@
     </form>
   </dialog>
 
+  <dialog id="paragraphDialog" class="courseAiDialog paragraphDialog" aria-labelledby="paragraphDialogTitle">
+    <form method="dialog" class="courseAiPanel">
+      <header class="courseAiHead">
+        <div>
+          <p class="eyebrow">Contenuto della dispensa</p>
+          <h2 id="paragraphDialogTitle">Testo del paragrafo</h2>
+          <p id="paragraphDialogMeta" class="paragraphDialogMeta"></p>
+        </div>
+        <button id="paragraphCloseBtn" type="button" title="Chiude il testo del paragrafo.">Chiudi</button>
+      </header>
+      <pre id="paragraphContent" class="paragraphContent" tabindex="0">Seleziona un paragrafo per visualizzarne il contenuto.</pre>
+      <a id="paragraphSourceLink" class="paragraphSourceLink" href="#" target="_blank" rel="noreferrer" hidden>Apri sorgente su GitHub</a>
+    </form>
+  </dialog>
+
   <script src="course_board.js"></script>
 </body>
 </html>

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -49,6 +49,12 @@ const els = {
   yearWeeksInput: document.querySelector("#yearWeeksInput"),
   yearWeeklyHoursInput: document.querySelector("#yearWeeklyHoursInput"),
   yearDescriptionInput: document.querySelector("#yearDescriptionInput"),
+  paragraphDialog: document.querySelector("#paragraphDialog"),
+  paragraphCloseBtn: document.querySelector("#paragraphCloseBtn"),
+  paragraphDialogTitle: document.querySelector("#paragraphDialogTitle"),
+  paragraphDialogMeta: document.querySelector("#paragraphDialogMeta"),
+  paragraphContent: document.querySelector("#paragraphContent"),
+  paragraphSourceLink: document.querySelector("#paragraphSourceLink"),
   courseAiDialog: document.querySelector("#courseAiDialog"),
   courseAiTitle: document.querySelector("#courseAiTitle"),
   courseAiCloseBtn: document.querySelector("#courseAiCloseBtn"),
@@ -877,6 +883,12 @@ function renderHeadings() {
     }
     const titleText = document.createElement("span");
     titleText.textContent = heading.title;
+    titleText.className = "headingPreviewTrigger";
+    titleText.title = "Mostra il testo del paragrafo.";
+    titleText.addEventListener("click", (event) => {
+      event.stopPropagation();
+      openParagraphPreview(heading);
+    });
     title.append(titleText);
     const usedLabel = usedInYears.size ? ` · inserito in ${[...usedInYears].join(", ")}` : "";
     node.querySelector(".headingMeta").textContent = `${heading.source}:${heading.line} · H${heading.level}${usedLabel}`;
@@ -1231,6 +1243,7 @@ function renderItem(year, uda, siblings, item, index, depth) {
       </div>
       <div class="itemActions">
         <span class="contextBadge">${escapeHtml(contextLabel(index, siblings, item))}</span>
+        <button type="button" data-action="preview" title="Mostra il testo completo del paragrafo.">Testo</button>
         <button type="button" data-action="ai" title="Usa il provider AI configurato per aprire o generare la cornice didattica di questo argomento e dei suoi sottoparagrafi.">AI cornice</button>
         <button type="button" data-action="up" title="Sposta questo argomento verso l'alto nella UDA.">Su</button>
         <button type="button" data-action="down" title="Sposta questo argomento verso il basso nella UDA.">Giu</button>
@@ -1259,7 +1272,14 @@ function renderItem(year, uda, siblings, item, index, depth) {
   }
   const titleText = document.createElement("span");
   titleText.textContent = item.title;
+  titleText.className = "itemPreviewTrigger";
+  titleText.title = "Mostra il testo del paragrafo.";
+  titleText.addEventListener("click", (event) => {
+    event.stopPropagation();
+    openParagraphPreview(item);
+  });
   title.append(titleText);
+  node.querySelector('[data-action="preview"]').addEventListener("click", () => openParagraphPreview(item));
   node.querySelector('[data-action="ai"]').addEventListener("click", () => fillFrameWithAi(year, uda, item));
   node.querySelector('[data-action="up"]').addEventListener("click", () => moveItem(siblings, index, -1));
   node.querySelector('[data-action="down"]').addEventListener("click", () => moveItem(siblings, index, 1));
@@ -1276,6 +1296,27 @@ function renderItem(year, uda, siblings, item, index, depth) {
 
 function courseItemCollapseKey(year, uda, item) {
   return JSON.stringify([year.id, uda.id, item.id]);
+}
+
+async function openParagraphPreview(paragraph) {
+  els.paragraphDialogTitle.textContent = paragraph.title || "Testo del paragrafo";
+  els.paragraphDialogMeta.textContent = `${paragraph.source || "Sorgente n/d"} · riga ${paragraph.line || "?"} · H${paragraph.level || "?"}`;
+  els.paragraphContent.textContent = "Caricamento del contenuto...";
+  els.paragraphSourceLink.hidden = true;
+  els.paragraphDialog.showModal();
+  try {
+    const payload = await api(`/api/heading-content?id=${encodeURIComponent(paragraph.id)}`);
+    const heading = payload.heading || paragraph;
+    els.paragraphDialogTitle.textContent = heading.title || paragraph.title || "Testo del paragrafo";
+    els.paragraphDialogMeta.textContent = `${heading.source || "Sorgente n/d"} · riga ${heading.line || "?"} · H${heading.level || "?"}`;
+    els.paragraphContent.textContent = heading.content || "Questo paragrafo non contiene testo oltre al titolo.";
+    if (heading.github_url) {
+      els.paragraphSourceLink.href = heading.github_url;
+      els.paragraphSourceLink.hidden = false;
+    }
+  } catch (error) {
+    els.paragraphContent.textContent = `Contenuto non disponibile. Dettaglio: ${error.message}`;
+  }
 }
 
 function defaultCourseBrief(year) {
@@ -2198,6 +2239,7 @@ els.addYearBtn.addEventListener("click", openYearDialog);
 els.yearCloseBtn.addEventListener("click", () => els.yearDialog.close());
 els.yearCancelBtn.addEventListener("click", () => els.yearDialog.close());
 els.yearCreateBtn.addEventListener("click", createYearFromDialog);
+els.paragraphCloseBtn.addEventListener("click", () => els.paragraphDialog.close());
 els.yearIdInput.addEventListener("input", () => {
   els.yearIdInput.dataset.touched = "true";
 });

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1298,6 +1298,93 @@ function courseItemCollapseKey(year, uda, item) {
   return JSON.stringify([year.id, uda.id, item.id]);
 }
 
+function normalizeParagraphSource(source) {
+  return String(source || "")
+    .replace(/<br\s*\/?\s*>/gi, "\n")
+    .replace(/<h([1-6])\b[^>]*>/gi, (_, level) => `\n${"#".repeat(Number(level))} `)
+    .replace(/<li\b[^>]*>/gi, "\n- ")
+    .replace(/<\/?(?:details|summary|p|div|section|article|table|thead|tbody|tr|ul|ol|li|pre|h[1-6])\b[^>]*>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function renderParagraphInline(value) {
+  let html = escapeHtml(value);
+  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+  html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+  html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>');
+  return html;
+}
+
+function renderParagraphContent(source) {
+  const lines = normalizeParagraphSource(source).split("\n");
+  const blocks = [];
+  let paragraph = [];
+  let listType = "";
+  let listItems = [];
+  let codeLines = null;
+
+  const flushParagraph = () => {
+    if (!paragraph.length) return;
+    blocks.push(`<p>${paragraph.map(renderParagraphInline).join("<br>")}</p>`);
+    paragraph = [];
+  };
+  const flushList = () => {
+    if (!listItems.length) return;
+    const tag = listType === "ordered" ? "ol" : "ul";
+    blocks.push(`<${tag}>${listItems.map((item) => `<li>${renderParagraphInline(item)}</li>`).join("")}</${tag}>`);
+    listType = "";
+    listItems = [];
+  };
+  const flushCode = () => {
+    if (codeLines === null) return;
+    blocks.push(`<pre><code>${escapeHtml(codeLines.join("\n"))}</code></pre>`);
+    codeLines = null;
+  };
+
+  for (const line of lines) {
+    if (line.trim().startsWith("```")) {
+      flushParagraph();
+      flushList();
+      if (codeLines === null) codeLines = [];
+      else flushCode();
+      continue;
+    }
+    if (codeLines !== null) {
+      codeLines.push(line);
+      continue;
+    }
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    const unordered = line.match(/^\s*[-*]\s+(.+)$/);
+    const ordered = line.match(/^\s*\d+\.\s+(.+)$/);
+    if (!line.trim()) {
+      flushParagraph();
+      flushList();
+    } else if (heading) {
+      flushParagraph();
+      flushList();
+      const level = heading[1].length;
+      blocks.push(`<h${level}>${renderParagraphInline(heading[2])}</h${level}>`);
+    } else if (unordered || ordered) {
+      flushParagraph();
+      const nextType = unordered ? "unordered" : "ordered";
+      if (listType && listType !== nextType) flushList();
+      listType = nextType;
+      listItems.push((unordered || ordered)[1]);
+    } else {
+      flushList();
+      paragraph.push(line);
+    }
+  }
+  flushParagraph();
+  flushList();
+  flushCode();
+  return blocks.join("") || '<p class="empty">Questo paragrafo non contiene testo oltre al titolo.</p>';
+}
+
 async function openParagraphPreview(paragraph) {
   els.paragraphDialogTitle.textContent = paragraph.title || "Testo del paragrafo";
   els.paragraphDialogMeta.textContent = `${paragraph.source || "Sorgente n/d"} · riga ${paragraph.line || "?"} · H${paragraph.level || "?"}`;
@@ -1309,7 +1396,7 @@ async function openParagraphPreview(paragraph) {
     const heading = payload.heading || paragraph;
     els.paragraphDialogTitle.textContent = heading.title || paragraph.title || "Testo del paragrafo";
     els.paragraphDialogMeta.textContent = `${heading.source || "Sorgente n/d"} · riga ${heading.line || "?"} · H${heading.level || "?"}`;
-    els.paragraphContent.textContent = heading.content || "Questo paragrafo non contiene testo oltre al titolo.";
+    els.paragraphContent.innerHTML = renderParagraphContent(heading.content);
     if (heading.github_url) {
       els.paragraphSourceLink.href = heading.github_url;
       els.paragraphSourceLink.hidden = false;


### PR DESCRIPTION
## Obiettivo

Permettere al docente di leggere il contenuto completo di un paragrafo senza lasciare la dashboard Percorso.

## Modifiche

- aggiunto un modal condiviso per catalogo e UDA;
- titolo cliccabile e comando Testo;
- nuovo endpoint autenticato /api/heading-content;
- link alla sorgente GitHub con ancora;
- test backend e scenario manuale aggiornato.

## Verifica

- python -m pytest tests/test_course_board_server.py tests/test_course_board_frontend.py -q`r
- 
ode --check tools/course_board.js`r

Commit atomico: [f9a1b7f](https://github.com/TheBitPoets/2cornot2c/commit/f9a1b7f).