### PR TITLE
Rendi accessibile il preview dei paragrafi

### DIFF
--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -93,6 +93,15 @@ def test_collapsed_heading_only_hides_its_real_descendants() -> None:
     )
 
 
+def test_catalog_paragraph_preview_uses_keyboard_accessible_button() -> None:
+    source = Path("tools/course_board.js").read_text(encoding="utf-8")
+    css = Path("tools/course_board.css").read_text(encoding="utf-8")
+
+    assert 'const titleText = document.createElement("button");' in source
+    assert 'titleText.type = "button";' in source
+    assert ".headingPreviewTrigger" in css
+
+
 def test_quick_add_does_not_duplicate_a_heading_tree() -> None:
     run_course_board_js(
         """

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -401,6 +401,16 @@ input[aria-invalid="true"] {
   cursor: pointer;
 }
 
+.headingPreviewTrigger {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  text-align: left;
+  font: inherit;
+}
+
 .headingPreviewTrigger:hover,
 .headingPreviewTrigger:focus-visible,
 .itemPreviewTrigger:hover,

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -881,7 +881,8 @@ function renderHeadings() {
       spacer.className = "treeToggleSpacer";
       title.append(spacer);
     }
-    const titleText = document.createElement("span");
+    const titleText = document.createElement("button");
+    titleText.type = "button";
     titleText.textContent = heading.title;
     titleText.className = "headingPreviewTrigger";
     titleText.title = "Mostra il testo del paragrafo.";


### PR DESCRIPTION
## Finding

Il titolo del paragrafo nel catalogo della dashboard Percorso era uno span cliccabile: funzionava col mouse ma non era raggiungibile né attivabile da tastiera.

## Fix

Il titolo è stato trasformato in un vero utton con stile visivo invariato. Il browser gestisce così Tab, Enter e Space; ho aggiunto anche un test di regressione.

## Verifica

- python -m pytest tests/test_course_board_frontend.py -q (24 passed)
- 
ode --check tools/course_board.js`r

Commit atomico: [bd36823](https://github.com/TheBitPoets/2cornot2c/commit/bd3682348e4e501e99722a0123bad7041539d1ee).