### PR TITLE
test: make lab demo checks safe to reuse

### DIFF
--- a/doc/STUDENT_LAB_DEMO.md
+++ b/doc/STUDENT_LAB_DEMO.md
@@ -37,6 +37,10 @@ Per usare una cartella scelta:
 python scripts/student_lab_demo_smoke.py --root tmp/student-lab-demo
 ```
 
+Lo smoke test con `--root` richiede una cartella nuova o vuota: non usare la stessa root gia
+preparata da `student_lab_demo_setup.py`. Se la cartella contiene dati, lo script si interrompe
+prima di scrivere per evitare assegnazioni duplicate o dati sovrascritti.
+
 ## Setup locale ispezionabile
 
 Per preparare una demo stabile in `tmp/student-lab-demo`, cancellando eventuali residui precedenti:
@@ -95,7 +99,16 @@ Per ottenere lo stesso risultato in formato JSON, utile per automazione o debug:
 python scripts/student_lab_demo_check.py --json
 ```
 
-Esegui un solo collaudo alla volta sulla stessa root demo: il comando ricrea la cartella per garantire dati puliti.
+Il comando precedente ricrea la cartella per garantire dati puliti e va eseguito prima di avviare
+il server sulla stessa root. Per controllare invece una root gia preparata o gia usata dal server,
+senza cancellarla e senza rigenerare assegnazioni, usa:
+
+```bash
+python scripts/student_lab_demo_check.py --root tmp/student-lab-demo --existing --json
+```
+
+Esegui un solo comando di reset alla volta sulla stessa root demo. La modalita `--existing` e
+quella da usare durante il collaudo GUI/TUI quando il server deve restare attivo.
 
 ## Collaudo manuale su GUI/TUI
 

--- a/scripts/student_lab_demo_check.py
+++ b/scripts/student_lab_demo_check.py
@@ -135,7 +135,8 @@ def run_guided_check(
         "student_id": student_lab_demo_smoke.STUDENT_ID,
         "activity_id": student_lab_demo_smoke.ACTIVITY_ID,
         "automatic_checks": {
-            "setup": True,
+            "setup": prepare,
+            "existing_root": not prepare,
             "passing_and_failing_results": True,
             "student_lab_payload": True,
             "student_dashboard_api": True,
@@ -160,7 +161,7 @@ def render_text_check(result: dict[str, Any]) -> str:
         "Controlli automatici",
         "--------------------",
     ]
-    for key in ("setup", "passing_and_failing_results", "student_lab_payload", "student_dashboard_api"):
+    for key in ("setup", "existing_root", "passing_and_failing_results", "student_lab_payload", "student_dashboard_api"):
         status = "OK" if checks.get(key) else "NO"
         lines.append(f"- {status} {key}")
     lines.extend(["", "Passi manuali", "-------------"])

--- a/scripts/student_lab_demo_check.py
+++ b/scripts/student_lab_demo_check.py
@@ -52,6 +52,31 @@ def assert_demo_scenarios(summary: dict[str, Any]) -> None:
         raise RuntimeError(f"Scenari demo non coerenti: {summary.get('scenarios')}")
 
 
+def assert_existing_demo_root(root: Path) -> None:
+    """Validate the passing and failing assignments in a prepared root without resetting it."""
+
+    expected = {
+        student_lab_demo_smoke.STUDENT_ID: "graded_passed",
+        student_lab_demo_smoke.FAILING_STUDENT_ID: "graded_failed",
+    }
+    for student_id, expected_status in expected.items():
+        payload = student_lab_service.student_lab_payload(
+            root=root,
+            student_id=student_id,
+            now=student_lab_demo_smoke.NOW,
+        )
+        assignment = first_assignment(payload)
+        if assignment.get("activity_id") != student_lab_demo_smoke.ACTIVITY_ID:
+            raise RuntimeError(f"Activity demo non coerente per {student_id}.")
+        if assignment.get("report", {}).get("exists") is not True:
+            raise RuntimeError(f"Report demo non visibile per {student_id}.")
+        if assignment.get("grading", {}).get("status") != expected_status:
+            raise RuntimeError(
+                f"Grading demo non coerente per {student_id}: "
+                f"{assignment.get('grading', {}).get('status')}"
+            )
+
+
 def guided_steps(root: Path, commands: dict[str, str], *, host: str, port: int) -> list[str]:
     """Return the manual steps printed after automatic checks pass."""
 
@@ -68,12 +93,25 @@ def guided_steps(root: Path, commands: dict[str, str], *, host: str, port: int) 
     ]
 
 
-def run_guided_check(root: Path, *, host: str = "127.0.0.1", port: int = 8765) -> dict[str, Any]:
+def run_guided_check(
+    root: Path,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8765,
+    prepare: bool = True,
+) -> dict[str, Any]:
     """Prepare the demo root and verify backend/dashboard data contracts."""
 
-    setup = student_lab_demo_setup.prepare_demo(root)
-    assert_demo_scenarios(setup)
-    data_root = Path(setup["root"])
+    if prepare:
+        setup = student_lab_demo_setup.prepare_demo(root)
+        assert_demo_scenarios(setup)
+        data_root = Path(setup["root"])
+    else:
+        data_root = root.resolve(strict=False)
+        if not data_root.exists():
+            raise RuntimeError(f"Root demo non trovata: {data_root}")
+        assert_existing_demo_root(data_root)
+        setup = {"commands": student_lab_demo_setup.demo_commands(data_root)}
     payload = student_lab_service.student_lab_payload(
         root=data_root,
         student_id=student_lab_demo_smoke.STUDENT_ID,
@@ -139,6 +177,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--json", action="store_true", help="Stampa il risultato in JSON invece della checklist testuale.")
+    parser.add_argument(
+        "--existing",
+        action="store_true",
+        help="Verifica una root gia preparata senza cancellarla o rigenerarla.",
+    )
     return parser.parse_args()
 
 
@@ -147,7 +190,7 @@ def main() -> int:
 
     args = parse_args()
     try:
-        result = run_guided_check(args.root, host=args.host, port=args.port)
+        result = run_guided_check(args.root, host=args.host, port=args.port, prepare=not args.existing)
     except Exception as error:  # noqa: BLE001
         print(f"Collaudo guidato non riuscito: {error}", file=sys.stderr)
         return 1

--- a/scripts/student_lab_demo_smoke.py
+++ b/scripts/student_lab_demo_smoke.py
@@ -34,6 +34,22 @@ DUE_AT = "2026-10-19T23:59:00+02:00"
 NOW = "2026-10-18T18:30:00+02:00"
 
 
+def ensure_root_is_usable_for_cli(root: Path) -> None:
+    """Reject a populated root instead of failing halfway through the smoke flow."""
+
+    if not root.exists():
+        return
+    entries = list(root.iterdir())
+    if any(entry.name != ".thebitlab-server.lock" for entry in entries):
+        raise RuntimeError(
+            f"Root smoke non vuota: {root}. Usa una root nuova oppure student_lab_demo_setup.py."
+        )
+    if any(entry.name == ".thebitlab-server.lock" for entry in entries):
+        raise RuntimeError(
+            f"Root smoke protetta da un server attivo: {root}. Ferma il server prima dello smoke test."
+        )
+
+
 def relative(path: Path, root: Path) -> str:
     """Return a root-relative path for compact smoke output."""
 
@@ -252,6 +268,11 @@ def main() -> int:
     args = parse_args()
     if args.root:
         root = args.root.resolve(strict=False)
+        try:
+            ensure_root_is_usable_for_cli(root)
+        except RuntimeError as error:
+            print(f"Smoke test non riuscito: {error}", file=sys.stderr)
+            return 1
         root.mkdir(parents=True, exist_ok=True)
         summary = run_smoke(root)
         print(json.dumps(summary, ensure_ascii=False, indent=2))

--- a/tests/test_student_lab_demo_check.py
+++ b/tests/test_student_lab_demo_check.py
@@ -12,6 +12,7 @@ def test_student_lab_demo_check_returns_guided_manual_steps(tmp_path) -> None:
     assert result["activity_id"] == "python-demo-somma-001"
     assert result["automatic_checks"] == {
         "setup": True,
+        "existing_root": False,
         "passing_and_failing_results": True,
         "student_lab_payload": True,
         "student_dashboard_api": True,
@@ -36,4 +37,10 @@ def test_student_lab_demo_check_can_validate_existing_root_without_resetting(tmp
     result = student_lab_demo_check.run_guided_check(tmp_path, port=8877, prepare=False)
 
     assert result["ok"] is True
-    assert result["automatic_checks"]["setup"] is True
+    assert result["automatic_checks"] == {
+        "setup": False,
+        "existing_root": True,
+        "passing_and_failing_results": True,
+        "student_lab_payload": True,
+        "student_dashboard_api": True,
+    }

--- a/tests/test_student_lab_demo_check.py
+++ b/tests/test_student_lab_demo_check.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from scripts import student_lab_demo_check
+from scripts import student_lab_demo_smoke
 
 
 def test_student_lab_demo_check_returns_guided_manual_steps(tmp_path) -> None:
@@ -27,3 +28,12 @@ def test_student_lab_demo_check_returns_guided_manual_steps(tmp_path) -> None:
     assert "- OK passing_and_failing_results" in rendered
     assert "Passi manuali" in rendered
     assert "student_lab_cli.py" in rendered
+
+
+def test_student_lab_demo_check_can_validate_existing_root_without_resetting(tmp_path) -> None:
+    student_lab_demo_smoke.run_smoke(tmp_path)
+
+    result = student_lab_demo_check.run_guided_check(tmp_path, port=8877, prepare=False)
+
+    assert result["ok"] is True
+    assert result["automatic_checks"]["setup"] is True

--- a/tests/test_student_lab_demo_smoke.py
+++ b/tests/test_student_lab_demo_smoke.py
@@ -2,7 +2,16 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from scripts import student_lab_demo_smoke
+
+
+def test_student_lab_demo_smoke_rejects_populated_cli_root(tmp_path) -> None:
+    (tmp_path / "teacher-assignments").mkdir()
+
+    with pytest.raises(RuntimeError, match="Root smoke non vuota"):
+        student_lab_demo_smoke.ensure_root_is_usable_for_cli(tmp_path)
 
 
 def test_student_lab_demo_smoke_builds_complete_flow(tmp_path) -> None:


### PR DESCRIPTION
## Finding\n\nDurante il collaudo end-to-end, riusare la stessa root preparata faceva fallire lo smoke test con un errore di assegnazione duplicata. Inoltre il controllo guidato resettava la root e quindi non poteva essere usato mentre il server la serviva.\n\n## Fix\n\n- lo smoke test rifiuta una root popolata o protetta con un messaggio chiaro;\n- student_lab_demo_check.py --existing valida una root gia preparata senza cancellarla o rigenerarla;\n- la guida documenta il flusso reset vs riuso;\n- aggiunti test automatici per entrambe le modalita.\n\n## Verifica\n\n8 passed sui test di setup, smoke e guided check; smoke su root nuova e check --existing eseguiti con successo.