### PR TITLE
fix: normalize Docker grading paths

### DIFF
--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -439,7 +439,8 @@ def docker_timeout_seconds(activity: dict[str, Any], timeout_seconds: int) -> in
 def path_inside_workspace(path: Path, workspace: Path, label: str) -> str:
     """Return a workspace-relative path or raise a teacher-friendly error."""
     try:
-        return str(path.resolve().relative_to(workspace.resolve()))
+        # Docker runs a Linux container even when the teacher host is Windows.
+        return path.resolve().relative_to(workspace.resolve()).as_posix()
     except ValueError as error:
         raise ValueError(f"{label} deve trovarsi dentro il workspace montato: {workspace}") from error
 

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -262,6 +262,8 @@ def test_docker_command_uses_read_only_workspace(tmp_path) -> None:
     assert "--report" not in command
     assert "--language" in command
     assert "c" in command
+    assert command[command.index("--activity") + 1] == "activity.json"
+    assert command[command.index("--source") + 1] == "main.c"
 
 
 def test_prepare_docker_workspace_copies_only_runner_inputs(tmp_path) -> None:


### PR DESCRIPTION
## Finding\nOn Windows, Path.relative_to() produced backslash-separated paths such as ctivity\\activity.json. The Linux Docker container could not resolve them, so every Docker grading run failed before compiling.\n\n## Fix\nConvert workspace-relative paths to POSIX form with Path.as_posix() before passing them to the container. Added a regression assertion for activity and source paths.\n\n## Verification\n- python -m pytest tests/test_grade_activity.py -q\n- Docker image built successfully\n- C Docker smoke: passing source -> passed, wrong source -> ailed\n\nCommit: [9243353](https://github.com/TheBitPoets/2cornot2c/commit/9243353)