### PR TITLE
feat: select runner backend from student TUI

### DIFF
--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -1072,6 +1072,9 @@ def run_tui(
     server_url: str = DEFAULT_SERVER_URL,
     server_token: str = "",
     allow_insecure_http: bool = False,
+    backend: str = "local",
+    timeout_seconds: int = student_lab_runner.DEFAULT_TIMEOUT_SECONDS,
+    docker_image: str = student_lab_runner.DEFAULT_DOCKER_IMAGE,
 ) -> int:
     """Run the interactive student lab loop."""
 
@@ -1225,7 +1228,13 @@ def run_tui(
                 continue
             if action == "e":
                 try:
-                    report = student_lab_runner.run_local_assignment(assignment, root=root)
+                    report = student_lab_runner.run_assignment(
+                        assignment,
+                        root=root,
+                        backend=backend,
+                        timeout_seconds=timeout_seconds,
+                        docker_image=docker_image,
+                    )
                     report_path = student_lab_runner.write_student_report(root, assignment, report)
                 except ValueError as error:
                     print_fn(f"Runner non disponibile:\n{error}")
@@ -1258,6 +1267,23 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--no-clear", action="store_true", help="Non pulire lo schermo tra una vista e l'altra.")
     parser.add_argument("--no-color", action="store_true", help="Disabilita colori ANSI.")
     parser.add_argument(
+        "--backend",
+        choices=sorted(student_lab_runner.RUNNER_BACKENDS),
+        default="local",
+        help="Backend del runner da usare per il comando esegui test.",
+    )
+    parser.add_argument(
+        "--docker-image",
+        default=student_lab_runner.DEFAULT_DOCKER_IMAGE,
+        help="Immagine Docker da usare quando il backend e docker.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=student_lab_runner.positive_int,
+        default=student_lab_runner.DEFAULT_TIMEOUT_SECONDS,
+        help="Timeout del runner in secondi.",
+    )
+    parser.add_argument(
         "--server-url",
         default=os.environ.get("THEBITLAB_SERVER_URL", DEFAULT_SERVER_URL),
         help="URL del server locale che gestisce richieste di aiuto e provider Codex.",
@@ -1284,6 +1310,9 @@ def main() -> int:
             server_url=args.server_url,
             server_token=os.environ.get("THEBITLAB_STUDENT_HELP_TOKEN", ""),
             allow_insecure_http=args.allow_insecure_http,
+            backend=args.backend,
+            timeout_seconds=args.timeout,
+            docker_image=args.docker_image,
         )
     except ValueError as error:
         print(f"Lab studente non disponibile:\n{error}", file=sys.stderr)

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -1291,8 +1291,8 @@ def test_run_tui_can_execute_runner_save_report_and_reload(monkeypatch, tmp_path
     monkeypatch.setattr(student_lab_cli, "load_payload", fake_load_payload)
     monkeypatch.setattr(
         student_lab_cli.student_lab_runner,
-        "run_local_assignment",
-        lambda assignment, root: {"status": "passed", "passed": True, "summary": {"passed": 1, "total": 1}},
+        "run_assignment",
+        lambda assignment, root, **kwargs: {"status": "passed", "passed": True, "summary": {"passed": 1, "total": 1}},
     )
 
     def fake_write_report(root, assignment, report):
@@ -1321,6 +1321,44 @@ def test_run_tui_can_execute_runner_save_report_and_reload(monkeypatch, tmp_path
     assert sum(1 for output in outputs if "Dettaglio consegna" in output) == 2
 
 
+def test_run_tui_forwards_runner_backend_options(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    inputs = iter(["1", "e", "", "", "q"])
+    runner_calls = []
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", lambda root, student_id, now=None: payload)
+
+    def fake_run_assignment(assignment, root, **kwargs):
+        runner_calls.append((assignment, root, kwargs))
+        return {"status": "passed", "passed": True, "summary": {"passed": 1, "total": 1}}
+
+    monkeypatch.setattr(student_lab_cli.student_lab_runner, "run_assignment", fake_run_assignment)
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_runner,
+        "write_student_report",
+        lambda root, assignment, report: tmp_path / "reports" / "latest.json",
+    )
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=lambda output: None,
+        clear=False,
+        backend="docker",
+        timeout_seconds=9,
+        docker_image="custom-runner:latest",
+    )
+
+    assert result == 0
+    assert len(runner_calls) == 1
+    assert runner_calls[0][2] == {
+        "backend": "docker",
+        "timeout_seconds": 9,
+        "docker_image": "custom-runner:latest",
+    }
+
+
 def test_run_tui_refreshes_from_server_after_runner_in_remote_mode(monkeypatch, tmp_path) -> None:
     payload = sample_payload()
     outputs = []
@@ -1341,8 +1379,8 @@ def test_run_tui_refreshes_from_server_after_runner_in_remote_mode(monkeypatch, 
     monkeypatch.setattr(student_lab_cli, "load_payload", fake_load_payload)
     monkeypatch.setattr(
         student_lab_cli.student_lab_runner,
-        "run_local_assignment",
-        lambda assignment, root: {"status": "passed", "passed": True, "summary": {"passed": 1, "total": 1}},
+        "run_assignment",
+        lambda assignment, root, **kwargs: {"status": "passed", "passed": True, "summary": {"passed": 1, "total": 1}},
     )
     monkeypatch.setattr(
         student_lab_cli.student_lab_runner,
@@ -1383,8 +1421,8 @@ def test_run_tui_keeps_saved_runner_result_when_remote_refresh_fails(monkeypatch
     monkeypatch.setattr(student_lab_cli, "fetch_student_lab_payload", fake_fetch_payload)
     monkeypatch.setattr(
         student_lab_cli.student_lab_runner,
-        "run_local_assignment",
-        lambda assignment, root: {"status": "passed", "passed": True, "summary": {"passed": 1, "total": 1}},
+        "run_assignment",
+        lambda assignment, root, **kwargs: {"status": "passed", "passed": True, "summary": {"passed": 1, "total": 1}},
     )
     monkeypatch.setattr(
         student_lab_cli.student_lab_runner,


### PR DESCRIPTION
## Finding\nLa TUI invocava sempre un_local_assignment, quindi il comando e ignorava il backend Docker gia supportato dal runner generale. Anche avviando la TUI con un ambiente Docker pronto, i test partivano sempre localmente.\n\n## Fix\nLa TUI usa ora un_assignment e espone --backend local|docker, --docker-image e --timeout. local resta il default per compatibilita. Ho aggiunto una regressione che verifica il forwarding dei parametri e aggiornato i test esistenti al dispatcher comune.\n\n## Verifica\n- python -m pytest tests/test_student_lab_cli.py -q\n- python -m pytest tests/test_student_lab_runner.py tests/test_student_lab_cli.py -q\n- Collaudo reale TUI con --backend docker: report persistito e ricaricato con Backend: docker.\n\nCommit: [29bc1f9](https://github.com/TheBitPoets/2cornot2c/commit/29bc1f9)