### PR TITLE
feat: separa file consegnati dal dettaglio studente

### DIFF
--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -220,6 +220,10 @@ class AssignmentOverviewService:
                             submission,
                             student.get("repo_github_url"),
                         ),
+                        "files": _submission_files(
+                            submission,
+                            student.get("repo_github_url"),
+                        ),
                         "grading": {
                             "status": grading.get("status", ""),
                             "passed": grading.get("passed"),
@@ -280,6 +284,40 @@ def _submission_file_github_urls(submission: dict[str, Any]) -> list[str]:
         ):
             urls.append(file_url)
     return urls
+
+
+def _submission_files(
+    submission: dict[str, Any],
+    repo_github_url: Any = None,
+) -> list[dict[str, str]]:
+    """Expose safe file metadata for the student file viewer."""
+
+    files = submission.get("files")
+    if not isinstance(files, list):
+        source_path = _normalized_path(submission.get("source_path"))
+        if not source_path:
+            return []
+        return [{
+            "path": source_path,
+            "role": "solution",
+            "github_url": _canonical_repo_file_url(repo_github_url, source_path) or "",
+        }]
+    result = []
+    for file_entry in files:
+        if not isinstance(file_entry, dict):
+            continue
+        path = _normalized_path(file_entry.get("path"))
+        if not path:
+            continue
+        github_url = _clean_optional_string(file_entry.get("github_url"))
+        if not github_url or _looks_like_broken_demo_url(github_url):
+            github_url = _canonical_repo_file_url(repo_github_url, path)
+        result.append({
+            "path": path,
+            "role": str(file_entry.get("role") or "supporto"),
+            "github_url": github_url or "",
+        })
+    return result
 
 
 def _normalized_path(value: Any) -> str:

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -76,6 +76,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderStudentLab,
         renderAssignment,
         renderAssignmentDetail,
+        renderAssignmentFiles,
         openAssignmentDetail,
         closeAssignmentDetail,
         renderDashboard,
@@ -193,10 +194,10 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
         assert.match(tested.els.assignments.innerHTML, /Feedback docente/);
         assert.match(tested.els.assignments.innerHTML, /Hai gestito correttamente/);
         assert.match(tested.els.assignments.innerHTML, /Test superati/);
-        assert.match(tested.els.assignments.innerHTML, /Apri consegna/);
+        assert.match(tested.els.assignments.innerHTML, /Apri file/);
         assert.match(tested.els.assignments.innerHTML, /Dettaglio/);
         assert.match(tested.els.assignments.innerHTML, /data-detail-index="0"/);
-        assert.match(tested.els.assignments.innerHTML, /data-open-assignment-detail="0"/);
+        assert.match(tested.els.assignments.innerHTML, /data-open-assignment-files="0"/);
         assert.match(tested.els.assignments.innerHTML, /href="https:\\/\\/github.com\\/TheBitPoets\\/rossi-mario\\/blob\\/main\\/assignments\\/python-base-somma-001\\/main.py"/);
         assert.match(tested.els.studentLab.innerHTML, /Workspace pronto/);
         assert.match(tested.els.studentLab.innerHTML, /Report salvato/);
@@ -781,6 +782,23 @@ def test_student_dashboard_assignment_detail_modal_renders_selected_assignment()
 
         tested.closeAssignmentDetail();
         assert.equal(tested.els.assignmentDetailModal.hidden, true);
+        """
+    )
+
+
+def test_student_dashboard_file_modal_lists_submitted_files_separately() -> None:
+    run_student_dashboard_js(
+        """
+        const html = tested.renderAssignmentFiles({
+          source_path: "assignments/python-base-somma-001/main.py",
+          source_github_url: "https://github.com/TheBitPoets/rossi-mario/blob/main/assignments/python-base-somma-001/main.py",
+        }, { path: "assignments/python-base-somma-001/main.py", content: "print(1)" });
+
+        assert.match(html, /File/);
+        assert.match(html, /main\.py/);
+        assert.match(html, /soluzione/);
+        assert.match(html, /Apri su GitHub/);
+        assert.match(html, /print\(1\)/);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -803,6 +803,38 @@ def test_student_dashboard_file_modal_lists_submitted_files_separately() -> None
     )
 
 
+def test_student_dashboard_file_modal_keeps_second_file_selected_after_loading() -> None:
+    run_student_dashboard_js(
+        """
+        const html = tested.renderAssignmentFiles({
+          files: [
+            {
+              path: "assignments/python-base-somma-001/main.py",
+              role: "solution",
+              github_url: "https://github.com/TheBitPoets/rossi-mario/blob/main/assignments/python-base-somma-001/main.py",
+            },
+            {
+              path: "assignments/python-base-somma-001/test_main.py",
+              role: "test",
+              github_url: "https://github.com/TheBitPoets/rossi-mario/blob/main/assignments/python-base-somma-001/test_main.py",
+            },
+          ],
+        }, {
+          requestedPath: "assignments/python-base-somma-001/test_main.py",
+          path: "assignments/python-base-somma-001/test_main.py",
+          displayPath: "examples/assignment_tracking/student_repos/rossi-mario/assignments/python-base-somma-001/test_main.py",
+          content: "assert somma([1, 2]) == 3",
+        });
+
+        assert.match(html, /fileChoice isActive[^>]*data-assignment-file-path="assignments\/python-base-somma-001\/test_main\.py"/);
+        assert.match(html, /test_main\.py/);
+        assert.match(html, /examples\/assignment_tracking\/student_repos\/rossi-mario\/assignments\/python-base-somma-001\/test_main\.py/);
+        assert.match(html, /blob\/main\/assignments\/python-base-somma-001\/test_main\.py/);
+        assert.match(html, /assert somma/);
+        """
+    )
+
+
 def test_student_dashboard_closes_assignment_detail_when_dashboard_changes() -> None:
     run_student_dashboard_js(
         """

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -53,13 +53,15 @@ def run_student_dashboard_js(assertions: str) -> None:
           ? [elementFor("[data-student-calendar-display=calendar]"), elementFor("[data-student-calendar-display=list]")]
           : [],
       }},
-      fetch: async () => ({{
+      fetchImpl: async () => ({{
         ok: true,
         status: 200,
         statusText: "OK",
         json: async () => ({{ student_id: "rossi-mario", assignments: [] }}),
         text: async () => "",
       }}),
+      fetch: (...args) => context.fetchImpl(...args),
+      setFetch: (handler) => {{ context.fetchImpl = handler; }},
       window: {{ location: {{ href: "http://localhost:8765/tools/student_dashboard.html" }} }},
     }};
     context.globalThis = context;
@@ -77,6 +79,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderAssignment,
         renderAssignmentDetail,
         renderAssignmentFiles,
+        openAssignmentFiles,
         openAssignmentDetail,
         closeAssignmentDetail,
         renderDashboard,
@@ -105,6 +108,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         setStudentCalendarDisplay: (display) => {{ currentStudentCalendarView.display = display; }},
         setVisibleStudentPathIds: (ids) => {{ visibleStudentPathIds = new Set(ids); }},
         els,
+        setFetch: globalThis.setFetch,
       }};
     `, context);
 
@@ -831,6 +835,46 @@ def test_student_dashboard_file_modal_keeps_second_file_selected_after_loading()
         assert.match(html, /examples\/assignment_tracking\/student_repos\/rossi-mario\/assignments\/python-base-somma-001\/test_main\.py/);
         assert.match(html, /blob\/main\/assignments\/python-base-somma-001\/test_main\.py/);
         assert.match(html, /assert somma/);
+        """
+    )
+
+
+def test_student_dashboard_file_modal_ignores_stale_file_response() -> None:
+    run_student_dashboard_js(
+        """
+        let resolveFirst;
+        let resolveSecond;
+        tested.setFetch(async (_path, options) => {
+          const request = JSON.parse(options.body);
+          return new Promise((resolve) => {
+          if (request.path.endsWith("/main.py")) resolveFirst = resolve;
+            else resolveSecond = resolve;
+          });
+        });
+        tested.renderDashboard({
+          student_id: "rossi-mario",
+          assignments: [{
+            activity_id: "python-base-somma-001",
+            title: "Somma in Python",
+            report_name: "python-demo.json",
+            submitted: true,
+            files: [
+              { path: "assignments/python-base-somma-001/main.py", role: "solution" },
+              { path: "assignments/python-base-somma-001/test_main.py", role: "test" },
+            ],
+          }],
+        });
+
+        const first = tested.openAssignmentFiles(0, "assignments/python-base-somma-001/main.py");
+        const second = tested.openAssignmentFiles(0, "assignments/python-base-somma-001/test_main.py");
+        resolveFirst({ ok: true, json: async () => ({ file: { path: "local/main.py", content: "STALE" } }) });
+        resolveSecond({ ok: true, json: async () => ({ file: { path: "local/test_main.py", content: "CURRENT" } }) });
+        await first;
+        await second;
+
+        assert.match(tested.els.assignmentFilesBody.innerHTML, /CURRENT/);
+        assert.doesNotMatch(tested.els.assignmentFilesBody.innerHTML, /STALE/);
+        assert.match(tested.els.assignmentFilesBody.innerHTML, /data-assignment-file-path="assignments\/python-base-somma-001\/test_main\.py"/);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -879,6 +879,36 @@ def test_student_dashboard_file_modal_ignores_stale_file_response() -> None:
     )
 
 
+def test_student_dashboard_closes_file_modal_when_dashboard_changes() -> None:
+    run_student_dashboard_js(
+        """
+        tested.renderDashboard({
+          student_id: "rossi-mario",
+          assignments: [{
+            activity_id: "python-base-somma-001",
+            title: "Somma in Python",
+            submitted: true,
+            source_path: "assignments/python-base-somma-001/main.py",
+          }],
+        });
+        const pending = tested.openAssignmentFiles(0);
+        assert.equal(tested.els.assignmentFilesModal.hidden, false);
+
+        tested.renderDashboard({
+          student_id: "bianchi-luca",
+          assignments: [{
+            activity_id: "python-loop-001",
+            title: "Loop in Python",
+            submitted: false,
+          }],
+        });
+        await pending;
+
+        assert.equal(tested.els.assignmentFilesModal.hidden, true);
+        """
+    )
+
+
 def test_student_dashboard_closes_assignment_detail_when_dashboard_changes() -> None:
     run_student_dashboard_js(
         """

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -1026,6 +1026,83 @@ button:hover { transform: translateY(-1px); }
   font-weight: 800;
 }
 
+.submissionFilesGrid {
+  display: grid;
+  grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr);
+  gap: 1rem;
+  min-height: 22rem;
+}
+
+.submissionFileList,
+.submissionFilePreview {
+  min-width: 0;
+}
+
+.submissionFileList {
+  display: grid;
+  align-content: start;
+  gap: .5rem;
+}
+
+.submissionFileList h3 {
+  margin: 0 0 .25rem;
+}
+
+.fileChoice {
+  display: grid;
+  gap: .15rem;
+  width: 100%;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 8px;
+  padding: .65rem .75rem;
+  text-align: left;
+  background: #fafafa;
+}
+
+.fileChoice.isActive {
+  border-color: var(--accent, #235c9f);
+  background: #eef5ff;
+}
+
+.fileChoice small {
+  color: var(--muted);
+}
+
+.submissionFilePreview {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: .5rem;
+  min-height: 0;
+}
+
+.submissionFilePreview header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  min-width: 0;
+}
+
+.submissionFilePreview pre {
+  min-height: 18rem;
+  max-height: 32rem;
+  margin: 0;
+  overflow: auto;
+  border: 1px solid rgba(17, 17, 17, .14);
+  border-radius: 8px;
+  padding: 1rem;
+  background: #17191d;
+  color: #f4f6f8;
+  white-space: pre;
+}
+
+.submissionFilePreview pre.fileError {
+  background: #fff1f0;
+  color: #9f1c18;
+  white-space: pre-wrap;
+}
+
 @media (max-width: 720px) {
   .topNav {
     overflow-x: auto;
@@ -1100,5 +1177,9 @@ button:hover { transform: translateY(-1px); }
 
   .detailModalHead {
     display: grid;
+  }
+
+  .submissionFilesGrid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -148,6 +148,19 @@
     </section>
   </div>
 
+  <div id="assignmentFilesModal" class="modalOverlay" hidden>
+    <section class="detailModal fileModal" role="dialog" aria-modal="true" aria-labelledby="assignmentFilesTitle">
+      <header class="detailModalHead">
+        <div>
+          <p class="modalEyebrow">File consegnati</p>
+          <h2 id="assignmentFilesTitle">Consegna</h2>
+        </div>
+        <button id="assignmentFilesClose" type="button" class="secondaryActionButton">Chiudi</button>
+      </header>
+      <div id="assignmentFilesBody" class="detailModalBody"></div>
+    </section>
+  </div>
+
   <script src="student_dashboard.js"></script>
 </body>
 </html>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -1476,6 +1476,7 @@ function isNextDeadlineAssignment(assignment, nextAssignment) {
 
 function renderDashboard(payload) {
   closeAssignmentDetail();
+  closeAssignmentFiles();
   const assignments = Array.isArray(payload.assignments) ? payload.assignments : [];
   currentDashboardPayload = { ...payload, assignments };
   const filterValue = els.assignmentFilter?.value || "all";

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -23,6 +23,10 @@ const els = {
   assignmentDetailTitle: document.querySelector("#assignmentDetailTitle"),
   assignmentDetailBody: document.querySelector("#assignmentDetailBody"),
   assignmentDetailClose: document.querySelector("#assignmentDetailClose"),
+  assignmentFilesModal: document.querySelector("#assignmentFilesModal"),
+  assignmentFilesTitle: document.querySelector("#assignmentFilesTitle"),
+  assignmentFilesBody: document.querySelector("#assignmentFilesBody"),
+  assignmentFilesClose: document.querySelector("#assignmentFilesClose"),
 };
 
 const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
@@ -39,6 +43,7 @@ let currentStudentCalendarView = {
   week: "",
 };
 let visibleStudentPathIds = null;
+let currentAssignmentFilesIndex = -1;
 
 async function api(path, options = {}) {
   const response = await fetch(path, options);
@@ -1178,10 +1183,10 @@ function actionUnavailableLabel(assignment) {
 }
 
 function assignmentOpenAction(assignment, assignmentIndex = -1) {
-  if (!assignment.submitted) {
+  if (!assignment.submitted || !submissionFiles(assignment).length) {
     return `<button type="button" class="actionButton actionButtonDisabled" disabled>Apri consegna</button><span class="actionUnavailable">${escapeHtml(actionUnavailableLabel(assignment))}</span>`;
   }
-  return `<button type="button" class="actionButton" data-open-assignment-detail="${escapeHtml(assignmentIndex)}">Apri consegna</button>`;
+  return `<button type="button" class="actionButton" data-open-assignment-files="${escapeHtml(assignmentIndex)}">Apri file</button>`;
 }
 
 function renderAssignment(assignment, isNext = false, assignmentIndex = -1) {
@@ -1300,6 +1305,98 @@ function openAssignmentDetail(assignmentIndex) {
   els.assignmentDetailModal.hidden = false;
   document.body?.classList?.add("modalOpen");
   els.assignmentDetailClose?.focus?.();
+}
+
+function submissionFiles(assignment) {
+  const files = Array.isArray(assignment?.files) ? assignment.files : [];
+  if (files.length) {
+    return files
+      .filter((file) => file && file.path)
+      .map((file) => ({
+        path: String(file.path).replaceAll("\\", "/"),
+        role: file.role || "supporto",
+        github_url: safeExternalHref(file.github_url || ""),
+      }));
+  }
+  return assignment?.source_path
+    ? [{
+        path: String(assignment.source_path).replaceAll("\\", "/"),
+        role: "soluzione",
+        github_url: safeExternalHref(assignment.source_github_url || ""),
+      }]
+    : [];
+}
+
+function renderAssignmentFiles(assignment, fileState = {}) {
+  const files = submissionFiles(assignment);
+  const selectedPath = fileState.path || files[0]?.path || "";
+  const selected = files.find((file) => file.path === selectedPath) || files[0];
+  const content = fileState.loading
+    ? "Caricamento file..."
+    : fileState.error
+      ? `Errore apertura file: ${fileState.error}`
+      : fileState.content ?? "Seleziona un file per visualizzarne il contenuto.";
+  if (!files.length) {
+    return '<p class="emptyFeedback">Nessun file consegnato disponibile.</p>';
+  }
+  return `
+    <div class="submissionFilesGrid">
+      <aside class="submissionFileList" aria-label="File consegnati">
+        <h3>File</h3>
+        ${files.map((file) => `
+          <button type="button" class="fileChoice${file.path === selected?.path ? " isActive" : ""}" data-assignment-file-path="${escapeHtml(file.path)}">
+            <strong>${escapeHtml(file.path.split("/").pop())}</strong>
+            <small>${escapeHtml(file.role)}</small>
+          </button>
+          ${file.github_url ? safeExternalLink(file.github_url, "Apri su GitHub") : ""}
+        `).join("")}
+      </aside>
+      <section class="submissionFilePreview">
+        <header>
+          <strong>${escapeHtml(fileState.path || selected?.path || "File")}</strong>
+          ${selected?.github_url ? safeExternalLink(selected.github_url, "Apri su GitHub") : ""}
+        </header>
+        <pre class="${fileState.error ? "fileError" : ""}"><code>${escapeHtml(content)}</code></pre>
+      </section>
+    </div>
+  `;
+}
+
+async function openAssignmentFiles(assignmentIndex, preferredPath = "") {
+  const index = Number(assignmentIndex);
+  const assignment = currentDashboardPayload.assignments[index];
+  if (!assignment || !els.assignmentFilesModal || !els.assignmentFilesBody || !els.assignmentFilesTitle) return;
+  currentAssignmentFilesIndex = index;
+  const files = submissionFiles(assignment);
+  if (!files.length) {
+    els.assignmentFilesTitle.textContent = assignment.title || assignment.activity_id || "Consegna";
+    els.assignmentFilesBody.innerHTML = '<p class="emptyFeedback">Nessun file consegnato disponibile.</p>';
+    els.assignmentFilesModal.hidden = false;
+    document.body?.classList?.add("modalOpen");
+    return;
+  }
+  let fileState = { path: preferredPath || files[0].path, loading: true };
+  els.assignmentFilesTitle.textContent = assignment.title || assignment.activity_id || "Consegna";
+  els.assignmentFilesBody.innerHTML = renderAssignmentFiles(assignment, fileState);
+  els.assignmentFilesModal.hidden = false;
+  document.body?.classList?.add("modalOpen");
+  try {
+    const payload = await api("/api/assignment-submissions/read", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        report_name: assignment.report_name,
+        student: currentDashboardPayload.student_id,
+        path: fileState.path,
+      }),
+    });
+    fileState = { path: payload.file.path, content: payload.file.content };
+  } catch (error) {
+    fileState = { path: fileState.path, error: error.message };
+  }
+  if (!els.assignmentFilesModal.hidden) {
+    els.assignmentFilesBody.innerHTML = renderAssignmentFiles(assignment, fileState);
+  }
 }
 
 function closeAssignmentDetail() {
@@ -1475,9 +1572,9 @@ els.studentCalendar?.addEventListener("keydown", (event) => {
 });
 
 els.assignments?.addEventListener("click", (event) => {
-  const openButton = event.target.closest?.("[data-open-assignment-detail]");
+  const openButton = event.target.closest?.("[data-open-assignment-files]");
   if (openButton) {
-    openAssignmentDetail(openButton.dataset.openAssignmentDetail);
+    openAssignmentFiles(openButton.dataset.openAssignmentFiles);
     return;
   }
   const detailButton = event.target.closest?.("[data-detail-index]");
@@ -1491,8 +1588,27 @@ els.assignmentDetailModal?.addEventListener("click", (event) => {
   if (event.target === els.assignmentDetailModal) closeAssignmentDetail();
 });
 
+function closeAssignmentFiles() {
+  if (!els.assignmentFilesModal) return;
+  els.assignmentFilesModal.hidden = true;
+  document.body?.classList?.remove("modalOpen");
+}
+
+els.assignmentFilesClose?.addEventListener("click", closeAssignmentFiles);
+els.assignmentFilesModal?.addEventListener("click", (event) => {
+  if (event.target === els.assignmentFilesModal) closeAssignmentFiles();
+  const fileButton = event.target.closest?.("[data-assignment-file-path]");
+  if (!fileButton) return;
+  if (currentAssignmentFilesIndex >= 0) {
+    openAssignmentFiles(currentAssignmentFilesIndex, fileButton.dataset.assignmentFilePath);
+  }
+});
+
 document.addEventListener?.("keydown", (event) => {
-  if (event.key === "Escape") closeAssignmentDetail();
+  if (event.key === "Escape") {
+    closeAssignmentDetail();
+    closeAssignmentFiles();
+  }
 });
 
 loadStudentOptions(els.studentId.value)

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -44,6 +44,7 @@ let currentStudentCalendarView = {
 };
 let visibleStudentPathIds = null;
 let currentAssignmentFilesIndex = -1;
+let assignmentFilesRequestToken = 0;
 
 async function api(path, options = {}) {
   const response = await fetch(path, options);
@@ -1366,6 +1367,7 @@ async function openAssignmentFiles(assignmentIndex, preferredPath = "") {
   const index = Number(assignmentIndex);
   const assignment = currentDashboardPayload.assignments[index];
   if (!assignment || !els.assignmentFilesModal || !els.assignmentFilesBody || !els.assignmentFilesTitle) return;
+  const requestToken = ++assignmentFilesRequestToken;
   currentAssignmentFilesIndex = index;
   const files = submissionFiles(assignment);
   if (!files.length) {
@@ -1407,7 +1409,7 @@ async function openAssignmentFiles(assignmentIndex, preferredPath = "") {
       error: error.message,
     };
   }
-  if (!els.assignmentFilesModal.hidden) {
+  if (requestToken === assignmentFilesRequestToken && !els.assignmentFilesModal.hidden) {
     els.assignmentFilesBody.innerHTML = renderAssignmentFiles(assignment, fileState);
   }
 }
@@ -1603,6 +1605,7 @@ els.assignmentDetailModal?.addEventListener("click", (event) => {
 
 function closeAssignmentFiles() {
   if (!els.assignmentFilesModal) return;
+  assignmentFilesRequestToken += 1;
   els.assignmentFilesModal.hidden = true;
   document.body?.classList?.remove("modalOpen");
 }

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -1329,7 +1329,7 @@ function submissionFiles(assignment) {
 
 function renderAssignmentFiles(assignment, fileState = {}) {
   const files = submissionFiles(assignment);
-  const selectedPath = fileState.path || files[0]?.path || "";
+  const selectedPath = fileState.requestedPath || fileState.path || files[0]?.path || "";
   const selected = files.find((file) => file.path === selectedPath) || files[0];
   const content = fileState.loading
     ? "Caricamento file..."
@@ -1353,7 +1353,7 @@ function renderAssignmentFiles(assignment, fileState = {}) {
       </aside>
       <section class="submissionFilePreview">
         <header>
-          <strong>${escapeHtml(fileState.path || selected?.path || "File")}</strong>
+          <strong>${escapeHtml(fileState.displayPath || fileState.path || selected?.path || "File")}</strong>
           ${selected?.github_url ? safeExternalLink(selected.github_url, "Apri su GitHub") : ""}
         </header>
         <pre class="${fileState.error ? "fileError" : ""}"><code>${escapeHtml(content)}</code></pre>
@@ -1375,7 +1375,11 @@ async function openAssignmentFiles(assignmentIndex, preferredPath = "") {
     document.body?.classList?.add("modalOpen");
     return;
   }
-  let fileState = { path: preferredPath || files[0].path, loading: true };
+  let fileState = {
+    path: preferredPath || files[0].path,
+    requestedPath: preferredPath || files[0].path,
+    loading: true,
+  };
   els.assignmentFilesTitle.textContent = assignment.title || assignment.activity_id || "Consegna";
   els.assignmentFilesBody.innerHTML = renderAssignmentFiles(assignment, fileState);
   els.assignmentFilesModal.hidden = false;
@@ -1390,9 +1394,18 @@ async function openAssignmentFiles(assignmentIndex, preferredPath = "") {
         path: fileState.path,
       }),
     });
-    fileState = { path: payload.file.path, content: payload.file.content };
+    fileState = {
+      path: fileState.requestedPath,
+      requestedPath: fileState.requestedPath,
+      displayPath: payload.file.path,
+      content: payload.file.content,
+    };
   } catch (error) {
-    fileState = { path: fileState.path, error: error.message };
+    fileState = {
+      path: fileState.requestedPath,
+      requestedPath: fileState.requestedPath,
+      error: error.message,
+    };
   }
   if (!els.assignmentFilesModal.hidden) {
     els.assignmentFilesBody.innerHTML = renderAssignmentFiles(assignment, fileState);


### PR DESCRIPTION
## Obiettivo\n\nSepara l'apertura dei file consegnati dal modal del dettaglio consegna nella dashboard studente.\n\n## Modifiche\n\n- Apri file apre un modal con elenco, ruolo, contenuto locale e link GitHub dei file.\n- Dettaglio mantiene stato, date, grading e feedback.\n- Il backend espone metadati sicuri per tutti i file consegnati.\n- Gestiti caricamento, file mancanti ed errori senza aprire link GitHub non validi.\n\n## Verifica\n\n- python -m pytest tests/test_course_board_server.py tests/test_thebitlab_services.py tests/test_student_dashboard_frontend.py -q\n- python -m py_compile scripts/thebitlab_services.py scripts/course_board_server.py\n\nCommit: [6af6f4d](https://github.com/TheBitPoets/2cornot2c/commit/6af6f4d)