### PR TITLE
fix: riusa root demo nel collaudo lab

### DIFF
--- a/doc/STUDENT_LAB_DEMO.md
+++ b/doc/STUDENT_LAB_DEMO.md
@@ -37,9 +37,16 @@ Per usare una cartella scelta:
 python scripts/student_lab_demo_smoke.py --root tmp/student-lab-demo
 ```
 
-Lo smoke test con `--root` richiede una cartella nuova o vuota: non usare la stessa root gia
-preparata da `student_lab_demo_setup.py`. Se la cartella contiene dati, lo script si interrompe
-prima di scrivere per evitare assegnazioni duplicate o dati sovrascritti.
+Lo smoke test completo con `--root` richiede una cartella nuova o vuota. Se vuoi riusare la root
+creata dal setup, usa la modalita non distruttiva:
+
+```bash
+python scripts/student_lab_demo_smoke.py --root tmp/student-lab-demo --existing
+```
+
+La modalita `--existing` verifica la root senza ricreare activity, assegnazioni o report ed e quella
+da usare quando il server e gia attivo o quando vuoi conservare i risultati del collaudo. Se la root
+contiene dati ma non e una demo riconoscibile, lo script si interrompe senza modificare nulla.
 
 ## Setup locale ispezionabile
 

--- a/scripts/student_lab_demo_smoke.py
+++ b/scripts/student_lab_demo_smoke.py
@@ -42,7 +42,8 @@ def ensure_root_is_usable_for_cli(root: Path) -> None:
     entries = list(root.iterdir())
     if any(entry.name != ".thebitlab-server.lock" for entry in entries):
         raise RuntimeError(
-            f"Root smoke non vuota: {root}. Usa una root nuova oppure student_lab_demo_setup.py."
+            f"Root smoke non vuota: {root}. Usa --existing per riusare una root preparata "
+            "oppure una root nuova per eseguire uno smoke completo."
         )
     if any(entry.name == ".thebitlab-server.lock" for entry in entries):
         raise RuntimeError(
@@ -275,13 +276,37 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Esegue una demo end-to-end temporanea del lab studente.")
     parser.add_argument("--root", type=Path, help="Root demo da usare invece di una cartella temporanea.")
     parser.add_argument("--keep", action="store_true", help="Conserva la cartella temporanea al termine.")
+    parser.add_argument(
+        "--existing",
+        action="store_true",
+        help="Verifica una root gia preparata senza ricreare activity, assegnazioni o report.",
+    )
     return parser.parse_args()
+
+
+def run_existing_check(root: Path) -> dict[str, Any]:
+    """Validate an existing demo root without rewriting its data."""
+
+    from scripts import student_lab_demo_check
+
+    return student_lab_demo_check.run_guided_check(root, prepare=False)
 
 
 def main() -> int:
     """Run the smoke test and print a JSON summary."""
 
     args = parse_args()
+    if args.existing:
+        if not args.root:
+            print("Usa --existing insieme a --root per indicare la root gia preparata.", file=sys.stderr)
+            return 1
+        try:
+            summary = run_existing_check(args.root.resolve(strict=False))
+        except Exception as error:  # noqa: BLE001
+            print(f"Smoke existing non riuscito: {error}", file=sys.stderr)
+            return 1
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+        return 0
     if args.root:
         root = args.root.resolve(strict=False)
         try:

--- a/tests/test_student_lab_demo_smoke.py
+++ b/tests/test_student_lab_demo_smoke.py
@@ -14,6 +14,23 @@ def test_student_lab_demo_smoke_rejects_populated_cli_root(tmp_path) -> None:
         student_lab_demo_smoke.ensure_root_is_usable_for_cli(tmp_path)
 
 
+def test_student_lab_demo_smoke_existing_mode_uses_non_destructive_check(tmp_path, monkeypatch) -> None:
+    called = {}
+
+    def fake_check(root):
+        called.update(root=root)
+        return {"ok": True, "root": str(root), "automatic_checks": {"existing_root": True}}
+
+    monkeypatch.setattr(student_lab_demo_smoke, "run_existing_check", fake_check)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["student_lab_demo_smoke.py", "--root", str(tmp_path), "--existing"],
+    )
+
+    assert student_lab_demo_smoke.main() == 0
+    assert called == {"root": tmp_path.resolve()}
+
+
 def test_student_lab_demo_smoke_builds_complete_flow(tmp_path) -> None:
     summary = student_lab_demo_smoke.run_smoke(tmp_path)
 


### PR DESCRIPTION
## Obiettivo\n\nRendere esplicita e non distruttiva la modalita di riuso della root demo dopo il setup.\n\n## Modifiche\n\n- aggiunto student_lab_demo_smoke.py --root ... --existing;\n- la modalita esistente delega al check guidato senza ricreare dati;\n- aggiornato doc/STUDENT_LAB_DEMO.md con il flusso prepare/reuse;\n- aggiunto test della modalita non distruttiva.\n\n## Verifica\n\n- python -m pytest tests/test_student_lab_demo_smoke.py tests/test_student_lab_demo_check.py -q;\n- prova reale setup seguito da smoke --existing: OK.\n\nIssue: #478