### PR TITLE
Sostituisci i dialog nativi delle dashboard

### DIFF
--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -811,9 +811,9 @@ della pagina Percorso. Nessun passaggio deve aprire i dialog nativi del browser 
 8. Salva regolarmente il progetto. Se il provider AI è configurato, genera una sola cornice, avvia una nuova coda e usa `Annulla`; verifica che testo e indicatori di qualità tornino allo stato iniziale.
 9. Usa soltanto la tastiera per raggiungere il catalogo e aggiungere un paragrafo con il pulsante `+`.
 10. Restringi la finestra a circa `390 px`: pannelli, titoli, campi e pulsanti devono restare leggibili senza sovrapporsi.
-11. Cancella `test-manuale-percorso.json` dalla board per ripulire i dati di prova. Verifica che il dialog
-    mostri chiaramente titolo, conseguenze, `Mantieni` e il comando distruttivo evidenziato; annulla una volta
-    prima di confermare davvero.
+11. Avvia la cancellazione di `test-manuale-percorso.json`. Verifica che il dialog mostri chiaramente titolo,
+    conseguenze, `Mantieni` e il comando distruttivo evidenziato, quindi scegli `Mantieni`: il progetto serve
+    ancora allo Scenario 10.
 
 Risultato atteso:
 
@@ -864,6 +864,8 @@ Obiettivo: verificare che il calendario docente resti coerente con il percorso e
    considerare superato il controllo.
 6. Prova modalità `settimana`, `mese` e `anno`.
 7. Prova frecce avanti/indietro e filtri visibili, verificando che interruzioni e UDA restino distinguibili.
+8. Torna a `course_board.html`, seleziona `test-manuale-percorso.json` e cancellalo. Nel dialog dei calendari
+   associati inserisci `tutto`: progetto e calendario di prova devono essere rimossi insieme soltanto ora.
 
 Risultato atteso:
 
@@ -872,6 +874,7 @@ Risultato atteso:
 - I filtri non nascondono dati senza indicarlo.
 - Le UDA reali e programmate sono distinguibili quando presenti.
 - Le interruzioni sono visibili e non si confondono con consegne mancanti.
+- La pulizia finale elimina il progetto e il calendario di prova associato, senza coinvolgere altri calendari.
 
 ## Template per nuovi scenari
 

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -281,6 +281,9 @@ La cattura usa la root `tmp/student-lab-demo`, il registro `demo/python-demo-som
 6. Apri il modal degli studenti, se disponibile.
 7. Nella riga di `rossi-mario`, clicca `Apri consegna`.
 8. Seleziona `main.py` e poi `test_main.py` dalla lista dei file.
+9. Nel pannello `Genera registro consegne`, seleziona un'assegnazione e premi `Cancella assegnazione`.
+   Controlla titolo e conseguenze nel dialog, quindi scegli `Mantieni`: questo scenario non deve cancellare
+   i dati demo.
 
 Risultato atteso:
 
@@ -293,6 +296,8 @@ Risultato atteso:
 - Le richieste di aiuto risultano visibili nel riepilogo docente.
 - Il modal della consegna mostra il contenuto di `main.py` e `test_main.py` senza errori 404.
 - I file aperti appartengono alla root demo corrente, non a una precedente cartella temporanea.
+- La conferma di cancellazione è un dialog integrato nella pagina; `Mantieni` lo chiude senza rimuovere
+  l'assegnazione e senza mostrare un `confirm()` nativo del browser.
 
 ## Scenario 3 - Quadro classe ed elenco consegne
 
@@ -780,7 +785,8 @@ Prova salva, ricarica, generazione AI e annullamento; ogni stato deve avere feed
 </td></tr>
 </table>
 
-Obiettivo: verificare creazione, modifica, persistenza, protezione dagli errori e accessibilità della pagina Percorso.
+Obiettivo: verificare creazione, modifica, persistenza, protezione dagli errori, dialog grafici e accessibilità
+della pagina Percorso. Nessun passaggio deve aprire i dialog nativi del browser (`alert`, `confirm` o `prompt`).
 
 1. Ferma con `Ctrl+C` il server dello Scenario 7, se ancora attivo. Avvia quindi il server senza root demo,
    usando i dati del repository:
@@ -790,17 +796,24 @@ Obiettivo: verificare creazione, modifica, persistenza, protezione dagli errori 
    ```
 
 2. Apri `http://localhost:8765/tools/course_board.html` e autenticati con le credenziali stampate dal server.
-3. Usa `Nuovo progetto` e crea `test-manuale-percorso.json`.
+3. Usa `Nuovo progetto`. Nel dialog di conferma premi `Esc` e verifica che il progetto corrente non cambi.
+   Riaprilo, conferma, lascia vuoto il nome e verifica l'errore inline; inserisci infine
+   `test-manuale-percorso.json` e crea il progetto.
 4. Aggiungi un percorso con settimane e ore valide. Prova poi a crearne uno con `0` settimane e verifica il bordo rosso e il messaggio di errore.
 5. Nel catalogo a sinistra usa il pulsante `+` su un paragrafo, poi premilo di nuovo sullo stesso paragrafo.
 5a. Clicca il titolo di un paragrafo e poi il comando `Testo`: verifica che si apra il modal con il contenuto completo.
 5b. Dentro una UDA ripeti dal titolo e dal comando `Testo`, poi usa `Apri sorgente su GitHub` e verifica l'ancora del paragrafo.
-6. Modifica una cornice e premi `Ricarica`: annulla la conferma e verifica che la modifica resti visibile; ripeti accettando e verifica che torni l'ultimo stato salvato.
-7. Usa `Salva progetto con nome` indicando di nuovo `test-manuale-percorso.json`: annulla la richiesta di sovrascrittura e verifica che l'archivio precedente non cambi.
+6. Modifica una cornice e premi `Ricarica`: nel dialog grafico premi `Resta qui` e verifica che la modifica
+   resti visibile e che il focus torni al comando precedente. Ripeti accettando `Scarta modifiche` e verifica
+   che torni l'ultimo stato salvato.
+7. Usa `Salva progetto con nome` indicando di nuovo `test-manuale-percorso.json`: nel dialog grafico
+   annulla la sovrascrittura e verifica che l'archivio precedente non cambi. Riprova e conferma per proseguire.
 8. Salva regolarmente il progetto. Se il provider AI è configurato, genera una sola cornice, avvia una nuova coda e usa `Annulla`; verifica che testo e indicatori di qualità tornino allo stato iniziale.
 9. Usa soltanto la tastiera per raggiungere il catalogo e aggiungere un paragrafo con il pulsante `+`.
 10. Restringi la finestra a circa `390 px`: pannelli, titoli, campi e pulsanti devono restare leggibili senza sovrapporsi.
-11. Cancella `test-manuale-percorso.json` dalla board per ripulire i dati di prova.
+11. Cancella `test-manuale-percorso.json` dalla board per ripulire i dati di prova. Verifica che il dialog
+    mostri chiaramente titolo, conseguenze, `Mantieni` e il comando distruttivo evidenziato; annulla una volta
+    prima di confermare davvero.
 
 Risultato atteso:
 
@@ -809,6 +822,9 @@ Risultato atteso:
 - Il titolo e il comando `Testo` aprono il modal con contenuto, fonte, riga e link GitHub coerenti.
 - Ricarica e navigazione non scartano modifiche senza conferma.
 - Un nome già esistente richiede conferma prima della sovrascrittura.
+- I dialog sono integrati nella pagina, si chiudono con `Esc`, ripristinano il focus e mostrano gli errori
+  obbligatori accanto al campo senza bloccare il browser o l'automazione Playwright.
+- Le azioni distruttive hanno un comando esplicito e visivamente distinto; l'annullamento non modifica dati.
 - L'annullamento AI ripristina sia il testo sia gli indicatori di qualità.
 - I comandi essenziali sono raggiungibili da tastiera e restano usabili su mobile.
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -202,9 +202,14 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         setItem(key, value) {{ this.store[key] = String(value); }},
         removeItem(key) {{ delete this.store[key]; }},
       }},
+      DashboardDialogs: {{
+        async confirm() {{ return true; }},
+        async prompt() {{ return null; }},
+        async message() {{}},
+        toast() {{}},
+      }},
       window: {{
         addEventListener() {{}},
-        confirm() {{ return true; }},
         location: {{
           reloaded: false,
           reload() {{ this.reloaded = true; }},
@@ -502,6 +507,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         localStorage,
         fetchCalls,
         fetchResponses,
+        DashboardDialogs,
         window,
       }};
     `, context);
@@ -688,7 +694,7 @@ def test_delete_selected_activity_stops_when_confirmation_is_cancelled() -> None
     run_dashboard_js(
         """
         (async () => {
-          tested.window.confirm = () => false;
+          tested.DashboardDialogs.confirm = async () => false;
           tested.state.activities = [{
             id: "somma-in-python",
             title: "Somma in Python",
@@ -1046,8 +1052,10 @@ def test_delete_selected_assignment_posts_confirmation_and_refreshes_list() -> N
         """
         (async () => {
           let confirmation = "";
-          tested.window.confirm = (message) => {
-            confirmation = message;
+          let confirmationOptions = null;
+          tested.DashboardDialogs.confirm = async (options) => {
+            confirmationOptions = options;
+            confirmation = options.message;
             return true;
           };
           tested.state.dueAssignments = [{
@@ -1085,6 +1093,9 @@ def test_delete_selected_assignment_posts_confirmation_and_refreshes_list() -> N
           assert.match(confirmation, /richieste di aiuto autorevoli/);
           assert.match(confirmation, /conteggio del budget/);
           assert.match(confirmation, /workspace e file.*non verranno rimossi/s);
+          assert.equal(confirmationOptions.title, "Cancella assegnazione");
+          assert.equal(confirmationOptions.confirmLabel, "Cancella assegnazione");
+          assert.equal(confirmationOptions.danger, true);
         })();
         """
     )
@@ -1157,7 +1168,7 @@ def test_delete_selected_assignment_stops_when_confirmation_is_cancelled() -> No
     run_dashboard_js(
         """
         (async () => {
-          tested.window.confirm = () => false;
+          tested.DashboardDialogs.confirm = async () => false;
           tested.state.dueAssignments = [{
             id: "assignment-python-base-somma-001-3a",
             activity_id: "python-base-somma-001",

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -339,6 +339,31 @@ def test_remove_course_can_be_cancelled_from_the_custom_dialog() -> None:
     )
 
 
+def test_project_replacement_dialogs_are_marked_as_dangerous() -> None:
+    run_course_board_js(
+        """
+        (async () => {
+          const confirmations = [];
+          DashboardDialogs.confirm = async (options) => {
+            confirmations.push(options);
+            return false;
+          };
+
+          await loadCurrentDesign();
+          await loadSavedDesignByName("archivio.json");
+          await newCourseDesign();
+
+          assert.equal(confirmations.length, 3);
+          assert.deepEqual(
+            confirmations.map((options) => options.title),
+            ["Carica progetto corrente", "Carica progetto salvato", "Crea un nuovo percorso"],
+          );
+          assert.equal(confirmations.every((options) => options.danger === true), true);
+        })();
+        """
+    )
+
+
 def test_create_course_rejects_invalid_weeks_and_hours() -> None:
     run_course_board_js(
         """

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -63,6 +63,12 @@ def run_course_board_js(assertions: str) -> None:
         toast() {{}},
       }},
     }};
+    context.window.location = {{ href: "" }};
+    context.window.openCalls = [];
+    context.window.open = (...args) => {{
+      context.window.openCalls.push(args);
+      return {{}};
+    }};
 
     let source = fs.readFileSync("tools/course_board.js", "utf8");
     source = source.replace(/loadAll\(\)\.catch\(\(error\) => \{{[\s\S]*?\}}\);\s*$/, "");
@@ -360,6 +366,31 @@ def test_project_replacement_dialogs_are_marked_as_dangerous() -> None:
           );
           assert.equal(confirmations.every((options) => options.danger === true), true);
         })();
+        """
+    )
+
+
+def test_confirmed_navigation_preserves_tab_and_window_intent() -> None:
+    run_course_board_js(
+        """
+        const link = { href: "http://localhost/tools/assignment_dashboard.html" };
+
+        continueTopNavigation(link, { newTab: true });
+        continueTopNavigation(link, { newWindow: true });
+
+        assert.equal(window.openCalls.length, 2);
+        assert.equal(window.openCalls[0][0], link.href);
+        assert.equal(window.openCalls[0][1], "_blank");
+        assert.equal(window.openCalls[0][2], undefined);
+        assert.equal(window.openCalls[1][0], link.href);
+        assert.equal(window.openCalls[1][1], "_blank");
+        assert.equal(window.openCalls[1][2], "popup");
+        assert.equal(window.location.href, "");
+        assert.equal(allowNextUnloadWithoutWarning, false);
+
+        continueTopNavigation(link);
+        assert.equal(window.location.href, link.href);
+        assert.equal(allowNextUnloadWithoutWarning, true);
         """
     )
 

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -56,8 +56,12 @@ def run_course_board_js(assertions: str) -> None:
       setInterval() {{ return 1; }},
       clearInterval() {{}},
       setTimeout(handler) {{ handler(); return 1; }},
-      confirm() {{ return true; }},
-      prompt() {{ return null; }},
+      DashboardDialogs: {{
+        async confirm() {{ return true; }},
+        async prompt() {{ return null; }},
+        async message() {{}},
+        toast() {{}},
+      }},
     }};
 
     let source = fs.readFileSync("tools/course_board.js", "utf8");
@@ -128,27 +132,29 @@ def test_quick_add_does_not_duplicate_a_heading_tree() -> None:
 def test_accessible_add_can_target_the_second_uda() -> None:
     run_course_board_js(
         """
-        renderCourse = () => {};
-        renderHeadings = () => {};
-        prompt = () => "2";
-        const heading = { id: "topic", title: "Argomento", source: "README.md", level: 2 };
-        state.headings = [heading];
-        state.design = {
-          years: [{
-            id: "path",
-            title: "Percorso",
-            udas: [
-              { id: "uda-1", title: "Prima", items: [] },
-              { id: "uda-2", title: "Seconda", items: [] },
-            ],
-          }],
-        };
+        (async () => {
+          renderCourse = () => {};
+          renderHeadings = () => {};
+          DashboardDialogs.prompt = async () => "2";
+          const heading = { id: "topic", title: "Argomento", source: "README.md", level: 2 };
+          state.headings = [heading];
+          state.design = {
+            years: [{
+              id: "path",
+              title: "Percorso",
+              udas: [
+                { id: "uda-1", title: "Prima", items: [] },
+                { id: "uda-2", title: "Seconda", items: [] },
+              ],
+            }],
+          };
 
-        addHeadingWithDestination(heading);
+          await addHeadingWithDestination(heading);
 
-        assert.equal(state.design.years[0].udas[0].items.length, 0);
-        assert.equal(state.design.years[0].udas[1].items[0].id, "topic");
-        assert.match(els.status.textContent, /UDA-2/);
+          assert.equal(state.design.years[0].udas[0].items.length, 0);
+          assert.equal(state.design.years[0].udas[1].items[0].id, "topic");
+          assert.match(els.status.textContent, /UDA-2/);
+        })();
         """
     )
 
@@ -277,6 +283,7 @@ def test_save_as_requires_confirmation_before_overwriting() -> None:
     run_course_board_js(
         """
         let requests = 0;
+        let confirmationOptions = null;
         api = async (_path, options) => {
           requests += 1;
           const body = JSON.parse(options.body);
@@ -288,7 +295,10 @@ def test_save_as_requires_confirmation_before_overwriting() -> None:
           assert.equal(body.overwrite, true);
           return { saved: { name: body.name }, designs: [{ name: body.name }] };
         };
-        confirm = () => true;
+        DashboardDialogs.confirm = async (options) => {
+          confirmationOptions = options;
+          return true;
+        };
         renderSavedDesigns = () => {};
         renderProjectTitle = () => {};
         renderCourseActions = () => {};
@@ -298,7 +308,33 @@ def test_save_as_requires_confirmation_before_overwriting() -> None:
           .then((saved) => {
             assert.equal(saved, true);
             assert.equal(requests, 2);
+            assert.equal(confirmationOptions.title, "Sostituisci progetto esistente");
+            assert.equal(confirmationOptions.confirmLabel, "Sostituisci");
+            assert.equal(confirmationOptions.danger, true);
           });
+        """
+    )
+
+
+def test_remove_course_can_be_cancelled_from_the_custom_dialog() -> None:
+    run_course_board_js(
+        """
+        (async () => {
+          let confirmationOptions = null;
+          DashboardDialogs.confirm = async (options) => {
+            confirmationOptions = options;
+            return false;
+          };
+          const year = { id: "path", title: "Percorso", udas: [] };
+          state.design = { years: [year] };
+
+          await removeYear(year);
+
+          assert.equal(state.design.years.length, 1);
+          assert.equal(confirmationOptions.title, "Elimina percorso");
+          assert.equal(confirmationOptions.confirmLabel, "Elimina percorso");
+          assert.equal(confirmationOptions.danger, true);
+        })();
         """
     )
 
@@ -495,7 +531,7 @@ def test_delete_response_does_not_replace_a_newly_opened_project() -> None:
         state.activeSavedDesign = "first.json";
 
         const deleting = deleteArchiveDesign();
-        Promise.resolve().then(() => {
+        Promise.resolve().then(() => Promise.resolve()).then(() => {
           const secondDesign = { years: [{ id: "second" }] };
           state.design = secondDesign;
           state.activeSavedDesign = "second.json";
@@ -533,7 +569,7 @@ def test_delete_response_detaches_edits_from_the_deleted_archive() -> None:
         markDesignClean();
 
         const deleting = deleteArchiveDesign();
-        Promise.resolve().then(() => {
+        Promise.resolve().then(() => Promise.resolve()).then(() => {
           state.design.years.push({ id: "edited-while-deleting" });
           completeDelete({ designs: [], deleted_calendars: [] });
           return deleting.then(() => {

--- a/tests/test_dashboard_dialogs_frontend.py
+++ b/tests/test_dashboard_dialogs_frontend.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import textwrap
+
+
+def run_dialogs_js(assertions: str) -> None:
+    script = rf"""
+    const assert = require("node:assert/strict");
+    const fs = require("node:fs");
+    const vm = require("node:vm");
+
+    class FakeClassList {{
+      constructor() {{ this.values = new Set(); }}
+      toggle(value, force) {{
+        const enabled = force === undefined ? !this.values.has(value) : Boolean(force);
+        if (enabled) this.values.add(value);
+        else this.values.delete(value);
+        return enabled;
+      }}
+      contains(value) {{ return this.values.has(value); }}
+    }}
+
+    class FakeElement {{
+      constructor(tagName = "") {{
+        this.tagName = tagName.toUpperCase();
+        this.children = [];
+        this.parentElement = null;
+        this.listeners = {{}};
+        this.attributes = {{}};
+        this.classList = new FakeClassList();
+        this.className = "";
+        this.id = "";
+        this.hidden = false;
+        this.open = false;
+        this.value = "";
+        this.textContent = "";
+        this.type = "";
+      }}
+      append(...children) {{
+        for (const child of children) {{
+          child.parentElement = this;
+          this.children.push(child);
+        }}
+      }}
+      addEventListener(type, handler) {{
+        this.listeners[type] = this.listeners[type] || [];
+        this.listeners[type].push(handler);
+      }}
+      dispatchEvent(event) {{
+        event.target ||= this;
+        for (const handler of this.listeners[event.type] || []) handler(event);
+      }}
+      setAttribute(name, value) {{
+        this.attributes[name] = String(value);
+        if (name === "open") this.open = true;
+      }}
+      removeAttribute(name) {{
+        delete this.attributes[name];
+        if (name === "open") this.open = false;
+      }}
+      showModal() {{ this.open = true; }}
+      close() {{ this.open = false; }}
+      focus() {{ document.activeElement = this; }}
+      select() {{ this.selected = true; }}
+      remove() {{
+        if (!this.parentElement) return;
+        this.parentElement.children = this.parentElement.children.filter((child) => child !== this);
+        this.parentElement = null;
+      }}
+    }}
+
+    const document = {{
+      body: new FakeElement("body"),
+      activeElement: null,
+      createElement(tagName) {{ return new FakeElement(tagName); }},
+    }};
+    const window = {{}};
+    const context = {{
+      assert,
+      console,
+      document,
+      window,
+      setTimeout(handler) {{ handler(); return 1; }},
+    }};
+    context.globalThis = context;
+    const find = (root, predicate) => {{
+      if (predicate(root)) return root;
+      for (const child of root.children || []) {{
+        const match = find(child, predicate);
+        if (match) return match;
+      }}
+      return null;
+    }};
+    context.find = find;
+
+    const source = fs.readFileSync("tools/dashboard_dialogs.js", "utf8");
+    vm.runInNewContext(source, context);
+    vm.runInNewContext(`(async () => {{
+      const flush = async () => {{
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      }};
+      {assertions}
+    }})().catch((error) => {{
+      console.error(error);
+      process.exitCode = 1;
+    }});`, context);
+    """
+    subprocess.run(["node", "-e", textwrap.dedent(script)], check=True)
+
+
+def test_shared_dialog_supports_confirm_prompt_validation_and_queue() -> None:
+    run_dialogs_js(
+        """
+        const opener = document.createElement("button");
+        document.body.append(opener);
+        opener.focus();
+
+        const first = DashboardDialogs.confirm({
+          title: "Elimina bozza",
+          message: "Operazione irreversibile",
+          confirmLabel: "Elimina",
+          danger: true,
+        });
+        const second = DashboardDialogs.prompt({
+          title: "Nome progetto",
+          required: true,
+        });
+        await flush();
+
+        const dialog = find(document.body, (item) => item.id === "dashboardActionDialog");
+        const title = find(dialog, (item) => item.id === "dashboardActionDialogTitle");
+        const form = find(dialog, (item) => item.tagName === "FORM");
+        const confirmButton = find(dialog, (item) => item.className === "dashboardDialogConfirm");
+        assert.equal(dialog.open, true);
+        assert.equal(title.textContent, "Elimina bozza");
+        assert.equal(confirmButton.classList.contains("danger"), true);
+        form.dispatchEvent({ type: "submit", preventDefault() {} });
+        assert.equal(await first, true);
+
+        await flush();
+        const input = find(dialog, (item) => item.className === "dashboardDialogInput");
+        const error = find(dialog, (item) => item.id === "dashboardActionDialogError");
+        assert.equal(title.textContent, "Nome progetto");
+        form.dispatchEvent({ type: "submit", preventDefault() {} });
+        assert.equal(dialog.open, true);
+        assert.equal(error.hidden, false);
+
+        input.value = "<script>test</script>";
+        form.dispatchEvent({ type: "submit", preventDefault() {} });
+        assert.equal(await second, "<script>test</script>");
+        assert.equal(opener, document.activeElement);
+        """
+    )
+
+
+def test_shared_dialog_escape_cancels_without_native_dialogs() -> None:
+    run_dialogs_js(
+        """
+        const pending = DashboardDialogs.confirm({ title: "Conferma" });
+        await flush();
+        const dialog = find(document.body, (item) => item.id === "dashboardActionDialog");
+        dialog.dispatchEvent({ type: "cancel", preventDefault() { this.prevented = true; } });
+        assert.equal(await pending, false);
+        assert.equal(dialog.open, false);
+        """
+    )
+
+
+def test_dashboard_pages_load_shared_dialog_assets_before_application_scripts() -> None:
+    for name, application_script in (
+        ("course_board.html", "course_board.js"),
+        ("assignment_dashboard.html", "assignment_dashboard.js"),
+    ):
+        html = (Path("tools") / name).read_text(encoding="utf-8")
+        assert "dashboard_dialogs.css" in html
+        assert html.index("dashboard_dialogs.js") < html.index(application_script)

--- a/tests/test_dashboard_dialogs_frontend.py
+++ b/tests/test_dashboard_dialogs_frontend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import subprocess
 import textwrap
 
@@ -178,3 +179,12 @@ def test_dashboard_pages_load_shared_dialog_assets_before_application_scripts() 
         html = (Path("tools") / name).read_text(encoding="utf-8")
         assert "dashboard_dialogs.css" in html
         assert html.index("dashboard_dialogs.js") < html.index(application_script)
+
+
+def test_dashboard_sources_do_not_use_native_prompt_or_confirm() -> None:
+    native_call = re.compile(r"(?<![.\w])(?:confirm|prompt)\s*(?:\?\.)?\s*\(")
+    for source_name in ("course_board.js", "assignment_dashboard.js"):
+        source = (Path("tools") / source_name).read_text(encoding="utf-8")
+        assert not native_call.search(source), source_name
+        assert "window.confirm" not in source
+        assert "window.prompt" not in source

--- a/tests/test_dashboard_dialogs_frontend.py
+++ b/tests/test_dashboard_dialogs_frontend.py
@@ -151,8 +151,12 @@ def test_shared_dialog_supports_confirm_prompt_validation_and_queue() -> None:
         form.dispatchEvent({ type: "submit", preventDefault() {} });
         assert.equal(dialog.open, true);
         assert.equal(error.hidden, false);
+        assert.equal(input.attributes["aria-invalid"], "true");
 
         input.value = "<script>test</script>";
+        input.dispatchEvent({ type: "input" });
+        assert.equal(error.hidden, true);
+        assert.equal(input.attributes["aria-invalid"], undefined);
         form.dispatchEvent({ type: "submit", preventDefault() {} });
         assert.equal(await second, "<script>test</script>");
         assert.equal(opener, document.activeElement);

--- a/tests/test_dashboard_dialogs_frontend.py
+++ b/tests/test_dashboard_dialogs_frontend.py
@@ -135,10 +135,12 @@ def test_shared_dialog_supports_confirm_prompt_validation_and_queue() -> None:
         const dialog = find(document.body, (item) => item.id === "dashboardActionDialog");
         const title = find(dialog, (item) => item.id === "dashboardActionDialogTitle");
         const form = find(dialog, (item) => item.tagName === "FORM");
+        const cancelButton = find(dialog, (item) => item.className === "dashboardDialogCancel");
         const confirmButton = find(dialog, (item) => item.className === "dashboardDialogConfirm");
         assert.equal(dialog.open, true);
         assert.equal(title.textContent, "Elimina bozza");
         assert.equal(confirmButton.classList.contains("danger"), true);
+        assert.equal(document.activeElement, cancelButton);
         form.dispatchEvent({ type: "submit", preventDefault() {} });
         assert.equal(await first, true);
 

--- a/tools/assignment_dashboard.html
+++ b/tools/assignment_dashboard.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Assignment Dashboard</title>
   <link rel="stylesheet" href="assignment_dashboard.css">
+  <link rel="stylesheet" href="dashboard_dialogs.css">
 </head>
 <body>
   <nav class="topNav" aria-label="Navigazione strumenti">
@@ -744,6 +745,7 @@ examples/assignment_tracking/student_repos/verdi-anna</textarea>
     <div id="legendBody" class="legendBody"></div>
   </dialog>
 
+  <script src="dashboard_dialogs.js"></script>
   <script src="assignment_dashboard.js"></script>
 </body>
 </html>

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2185,10 +2185,15 @@ async function deleteSelectedActivity() {
     return;
   }
   const label = activity.title || activity.id || activityPath;
-  const confirmed = window.confirm(
-    `Cancellare l'activity "${label}"?\n\n` +
+  const confirmed = await DashboardDialogs.confirm({
+    title: "Cancella activity",
+    message:
+      `Cancellare l'activity "${label}"?\n\n` +
       "Viene rimosso solo il file della bozza. Se esistono consegne o registri collegati, il server blocca la cancellazione.",
-  );
+    confirmLabel: "Cancella activity",
+    cancelLabel: "Mantieni",
+    danger: true,
+  });
   if (!confirmed) return;
   els.deleteActivityBtn.disabled = true;
   setActivityAuthorStatus("saving", "Cancellazione activity", "Controllo collegamenti e rimozione della bozza in corso...");
@@ -3745,12 +3750,17 @@ async function deleteSelectedAssignment() {
   const assignment = state.dueAssignments.find((candidate) => candidate.id === assignmentId)
     || state.assignments.find((candidate) => candidate.id === assignmentId);
   const label = assignment ? assignmentLabel(assignment) : assignmentId;
-  const confirmed = window.confirm?.(
-    `Cancellare l'assegnazione "${label}"?\n\n` +
-    "Verranno eliminati il record docente in teacher-assignments, le richieste di aiuto autorevoli " +
-    "e il relativo conteggio del budget. Eventuali workspace e file già distribuiti nei repository " +
-    "studenti non verranno rimossi."
-  );
+  const confirmed = await DashboardDialogs.confirm({
+    title: "Cancella assegnazione",
+    message:
+      `Cancellare l'assegnazione "${label}"?\n\n` +
+      "Verranno eliminati il record docente in teacher-assignments, le richieste di aiuto autorevoli " +
+      "e il relativo conteggio del budget. Eventuali workspace e file già distribuiti nei repository " +
+      "studenti non verranno rimossi.",
+    confirmLabel: "Cancella assegnazione",
+    cancelLabel: "Mantieni",
+    danger: true,
+  });
   if (!confirmed) return;
   els.deleteAssignmentBtn.disabled = true;
   setStatus("Cancellazione assegnazione...");

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Course Design Board</title>
   <link rel="stylesheet" href="course_board.css">
+  <link rel="stylesheet" href="dashboard_dialogs.css">
 </head>
 <body>
   <nav class="topNav" aria-label="Navigazione strumenti">
@@ -217,6 +218,7 @@
     </form>
   </dialog>
 
+  <script src="dashboard_dialogs.js"></script>
   <script src="course_board.js"></script>
 </body>
 </html>

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -2504,13 +2504,27 @@ document.addEventListener("click", (event) => {
   els.loadSavedDesignBtn.setAttribute("aria-expanded", "false");
 });
 
+function continueTopNavigation(link, intent = {}) {
+  if (intent.newTab || intent.newWindow) {
+    const features = intent.newWindow ? "popup" : undefined;
+    const opened = window.open(link.href, "_blank", features);
+    if (!opened) setStatus("Il browser ha bloccato l'apertura della nuova scheda o finestra.");
+    return;
+  }
+  allowNextUnloadWithoutWarning = true;
+  window.location.href = link.href;
+}
+
 for (const link of document.querySelectorAll(".topNav a:not([target='_blank'])")) {
   link.addEventListener("click", async (event) => {
     if (!hasUnsavedChanges()) return;
+    const intent = {
+      newTab: Boolean(event.ctrlKey || event.metaKey),
+      newWindow: Boolean(event.shiftKey),
+    };
     event.preventDefault();
     if (!await confirmDiscardChanges()) return;
-    allowNextUnloadWithoutWarning = true;
-    window.location.href = link.href;
+    continueTopNavigation(link, intent);
   });
 }
 

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -201,9 +201,15 @@ function isBoardContextCurrent(context) {
     && state.isNewDesign === context.isNewDesign;
 }
 
-function confirmDiscardChanges() {
+async function confirmDiscardChanges() {
   if (!hasUnsavedChanges()) return true;
-  return confirm("Ci sono modifiche non salvate. Vuoi scartarle e continuare?");
+  return DashboardDialogs.confirm({
+    title: "Modifiche non salvate",
+    message: "Ci sono modifiche non salvate. Vuoi scartarle e continuare?",
+    confirmLabel: "Scarta modifiche",
+    cancelLabel: "Resta qui",
+    danger: true,
+  });
 }
 
 async function runAsyncAction(action, label) {
@@ -471,7 +477,13 @@ async function loadDesignFromMenu(name) {
 }
 
 async function loadCurrentDesign() {
-  if (!confirm("Caricare il progetto corrente da doc/course_design.json? Le modifiche non salvate nella vista corrente saranno perse.")) return;
+  const confirmed = await DashboardDialogs.confirm({
+    title: "Carica progetto corrente",
+    message: "Caricare il progetto corrente da doc/course_design.json? Le modifiche non salvate nella vista corrente saranno perse.",
+    confirmLabel: "Carica progetto",
+    cancelLabel: "Annulla",
+  });
+  if (!confirmed) return;
   setStatus("Caricamento progetto corrente...");
   state.design = await api("/api/course-design");
   state.activeSavedDesign = "";
@@ -489,7 +501,15 @@ async function loadCurrentDesign() {
 
 async function loadSavedDesignByName(name, options = {}) {
   const { confirmFirst = true, render = true } = options;
-  if (confirmFirst && !confirm(`Caricare "${name}" nella board? Le modifiche non salvate nella vista corrente saranno perse.`)) return;
+  if (confirmFirst) {
+    const confirmed = await DashboardDialogs.confirm({
+      title: "Carica progetto salvato",
+      message: `Caricare "${name}" nella board? Le modifiche non salvate nella vista corrente saranno perse.`,
+      confirmLabel: "Carica progetto",
+      cancelLabel: "Annulla",
+    });
+    if (!confirmed) return;
+  }
   setStatus(`Caricamento progetto salvato "${name}"...`);
   const payload = await api("/api/saved-designs/load", {
     method: "POST",
@@ -521,14 +541,28 @@ async function saveArchiveDesign() {
     await saveArchiveDesignWithName(state.activeSavedDesign, { overwrite: true });
     return;
   }
-  const name = prompt("Nome file archivio JSON:", defaultName);
+  const name = await DashboardDialogs.prompt({
+    title: "Salva progetto in archivio",
+    message: "Scegli il nome del file JSON da creare nell'archivio.",
+    label: "Nome file JSON",
+    defaultValue: defaultName,
+    confirmLabel: "Salva",
+    required: true,
+  });
   if (!name) return;
   await saveArchiveDesignWithName(name);
 }
 
 async function saveArchiveDesignAs() {
   const defaultName = state.activeSavedDesign || "course_design_as_25_26.json";
-  const name = prompt("Nome file archivio JSON:", defaultName);
+  const name = await DashboardDialogs.prompt({
+    title: "Salva una copia",
+    message: "Scegli il nome del nuovo file JSON nell'archivio.",
+    label: "Nome file JSON",
+    defaultValue: defaultName,
+    confirmLabel: "Salva copia",
+    required: true,
+  });
   if (!name) return;
   await saveArchiveDesignWithName(name, { confirmOverwrite: true });
 }
@@ -562,7 +596,14 @@ async function persistArchiveDesignWithName(name, options = {}) {
     });
   } catch (error) {
     if (error.status === 409 && confirmOverwrite) {
-      if (!confirm(`Esiste già un progetto chiamato "${name}". Vuoi sostituirlo?`)) {
+      const confirmed = await DashboardDialogs.confirm({
+        title: "Sostituisci progetto esistente",
+        message: `Esiste già un progetto chiamato "${name}". Vuoi sostituirlo?`,
+        confirmLabel: "Sostituisci",
+        cancelLabel: "Mantieni esistente",
+        danger: true,
+      });
+      if (!confirmed) {
         setStatus("Salvataggio annullato: il progetto esistente non è stato modificato.");
         return false;
       }
@@ -663,23 +704,37 @@ async function deleteArchiveDesign() {
   let deleteCalendars = false;
   if (linkedCalendars.length) {
     const calendarList = linkedCalendars.map((calendar) => `- ${calendar.name}`).join("\n");
-    const choice = prompt(
-      `Il progetto "${name}" ha ${linkedCalendars.length} calendario/i associato/i:\n\n${calendarList}\n\n` +
-      "Scrivi:\n" +
-      "- progetto: cancella solo il progetto\n" +
-      "- tutto: cancella progetto e calendari associati\n" +
-      "- annulla: interrompi"
-    );
+    const choice = await DashboardDialogs.prompt({
+      title: "Cancella progetto con calendari associati",
+      message:
+        `Il progetto "${name}" ha ${linkedCalendars.length} calendario/i associato/i:\n\n${calendarList}\n\n` +
+        'Scrivi "progetto" per cancellare solo il progetto oppure "tutto" per cancellare anche i calendari associati.',
+      label: "Ambito della cancellazione",
+      placeholder: "progetto oppure tutto",
+      confirmLabel: "Continua",
+      danger: true,
+      required: true,
+      validate(value) {
+        const normalized = String(value || "").trim().toLowerCase();
+        return ["progetto", "tutto"].includes(normalized)
+          ? ""
+          : 'Inserisci "progetto" oppure "tutto".';
+      },
+    });
     const normalized = (choice || "").trim().toLowerCase();
     if (!normalized || normalized === "annulla") return;
     if (normalized === "tutto") {
       deleteCalendars = true;
-    } else if (normalized !== "progetto") {
-      setStatus("Cancellazione annullata: scelta non riconosciuta.");
-      return;
     }
-  } else if (!confirm(`Cancellare definitivamente il progetto archiviato "${name}"?`)) {
-    return;
+  } else {
+    const confirmed = await DashboardDialogs.confirm({
+      title: "Cancella progetto archiviato",
+      message: `Cancellare definitivamente il progetto archiviato "${name}"?`,
+      confirmLabel: "Cancella progetto",
+      cancelLabel: "Mantieni",
+      danger: true,
+    });
+    if (!confirmed) return;
   }
   setStatus(`Cancellazione progetto "${name}"...`);
   const payload = await api("/api/saved-designs/delete", {
@@ -722,8 +777,21 @@ async function deleteArchiveDesign() {
 }
 
 async function newCourseDesign() {
-  if (!confirm("Creare un nuovo percorso vuoto? Le modifiche non salvate nella vista corrente saranno perse.")) return;
-  const name = prompt("Nome file del nuovo percorso JSON:", "course_design_as_25_26.json");
+  const confirmed = await DashboardDialogs.confirm({
+    title: "Crea un nuovo percorso",
+    message: "Creare un nuovo percorso vuoto? Le modifiche non salvate nella vista corrente saranno perse.",
+    confirmLabel: "Crea percorso",
+    cancelLabel: "Annulla",
+  });
+  if (!confirmed) return;
+  const name = await DashboardDialogs.prompt({
+    title: "Nome del nuovo percorso",
+    message: "Scegli il nome del file JSON da creare nell'archivio.",
+    label: "Nome file JSON",
+    defaultValue: "course_design_as_25_26.json",
+    confirmLabel: "Crea e salva",
+    required: true,
+  });
   if (!name) return;
   const design = emptyCourseDesign();
   const saved = await saveArchiveDesignWithName(name, { design, confirmOverwrite: true });
@@ -942,7 +1010,7 @@ function toggleHeading(headingId) {
   renderHeadings();
 }
 
-function addHeadingWithDestination(heading) {
+async function addHeadingWithDestination(heading) {
   const destinations = (state.design.years || []).flatMap((year) =>
     (year.udas || []).map((uda) => ({ year, uda }))
   );
@@ -955,20 +1023,37 @@ function addHeadingWithDestination(heading) {
     const choices = destinations
       .map(({ year, uda }, index) => `${index + 1}. ${year.title} - ${uda.id.toUpperCase()}: ${uda.title}`)
       .join("\n");
-    const answer = prompt(`Scegli la UDA di destinazione:\n\n${choices}`, "1");
+    const answer = await DashboardDialogs.prompt({
+      title: "Scegli la UDA di destinazione",
+      message: choices,
+      label: `Numero UDA, da 1 a ${destinations.length}`,
+      defaultValue: "1",
+      confirmLabel: "Aggiungi",
+      required: true,
+      validate(value) {
+        const normalized = String(value || "").trim();
+        const selectedIndex = /^\d+$/.test(normalized) ? Number.parseInt(normalized, 10) - 1 : -1;
+        return Number.isInteger(selectedIndex) && selectedIndex >= 0 && selectedIndex < destinations.length
+          ? ""
+          : `Inserisci un numero da 1 a ${destinations.length}.`;
+      },
+    });
     if (answer === null || answer.trim() === "") {
       setStatus("Inserimento annullato: nessuna UDA selezionata.");
       return;
     }
     const normalizedAnswer = answer.trim();
     const selectedIndex = /^\d+$/.test(normalizedAnswer) ? Number.parseInt(normalizedAnswer, 10) - 1 : -1;
-    if (!Number.isInteger(selectedIndex) || selectedIndex < 0 || selectedIndex >= destinations.length) {
-      setStatus(`Scelta non valida. Inserisci un numero da 1 a ${destinations.length}.`);
-      return;
-    }
     destination = destinations[selectedIndex];
   }
   const { year, uda } = destination;
+  const destinationStillExists = (state.design.years || []).some(
+    (candidateYear) => candidateYear === year && (candidateYear.udas || []).includes(uda)
+  );
+  if (!destinationStillExists || !state.headings.includes(heading)) {
+    setStatus("Inserimento annullato: percorso o paragrafo sono cambiati durante la scelta.");
+    return;
+  }
   if (isHeadingTreeAssignedToYear(heading, year.id)) {
     setStatus(`"${heading.title}" o un suo sottoparagrafo è già presente in ${year.title}.`);
     return;
@@ -1156,9 +1241,19 @@ function renderCourse() {
   renderCourseActions();
 }
 
-function removeYear(year) {
-  const confirmed = confirm(`Eliminare "${year.title}"?\n\nSaranno eliminate anche tutte le UDA e gli argomenti collegati a questo percorso.`);
+async function removeYear(year) {
+  const confirmed = await DashboardDialogs.confirm({
+    title: "Elimina percorso",
+    message: `Eliminare "${year.title}"?\n\nSaranno eliminate anche tutte le UDA e gli argomenti collegati a questo percorso.`,
+    confirmLabel: "Elimina percorso",
+    cancelLabel: "Mantieni",
+    danger: true,
+  });
   if (!confirmed) return;
+  if (!(state.design.years || []).includes(year)) {
+    setStatus("Eliminazione annullata: il percorso aperto è cambiato.");
+    return;
+  }
   state.design.years = (state.design.years || []).filter((candidate) => candidate !== year);
   renderCourse();
   renderHeadings();
@@ -1933,21 +2028,32 @@ function updateFrameEditorQuality(details, item) {
   }
 }
 
-function showTextQuality(textarea, output, item, fieldKey, label) {
+async function showTextQuality(textarea, output, item, fieldKey, label) {
   if (!textarea.value.trim()) {
     showToolbarMessage(output, "Campo vuoto: niente da controllare.", "neutral");
     return;
   }
-  const result = applyLocalTextFixes(textarea.value);
+  const original = textarea.value;
+  const result = applyLocalTextFixes(original);
   if (!result.changes.length) {
     setFrameFieldQuality(item, fieldKey, label, "local");
     showToolbarMessage(output, "Nessuna correzione locale sicura trovata. Per dubbi di contesto usa AI grammatica.", "ok");
     return;
   }
   const message = `Trovate correzioni locali sicure:\n- ${result.changes.join("\n- ")}\n\nApplicarle al campo selezionato?`;
-  if (!confirm(message)) {
+  const confirmed = await DashboardDialogs.confirm({
+    title: "Applica correzioni locali",
+    message,
+    confirmLabel: "Applica correzioni",
+    cancelLabel: "Non applicare",
+  });
+  if (!confirmed) {
     output.innerHTML = `<strong>Correzioni non applicate:</strong><br>${result.changes.map(escapeHtml).join("<br>")}`;
     output.className = "textQuality textQualityWarn";
+    return;
+  }
+  if (textarea.value !== original) {
+    showToolbarMessage(output, "Il testo è cambiato durante la verifica: ripeti il controllo prima di applicare le correzioni.", "warn");
     return;
   }
   textarea.value = result.text;
@@ -1999,8 +2105,18 @@ async function proofreadTextWithAi(textarea, output, item, fieldKey, label) {
       changes.length ? `Modifiche:\n- ${changes.join("\n- ")}` : "Modifiche: la AI non ha fornito un elenco dettagliato.",
       notes ? `\nNote:\n${notes}` : "",
     ].join("\n");
-    if (!confirm(summary)) {
+    const confirmed = await DashboardDialogs.confirm({
+      title: "Applica correzione AI",
+      message: summary,
+      confirmLabel: "Applica correzione",
+      cancelLabel: "Non applicare",
+    });
+    if (!confirmed) {
       showToolbarMessage(output, "Correzione AI non applicata.", "neutral");
+      return;
+    }
+    if (textarea.value !== original) {
+      showToolbarMessage(output, "Il testo è cambiato durante la verifica AI: la proposta non è stata applicata.", "warn");
       return;
     }
     textarea.value = corrected;
@@ -2244,10 +2360,15 @@ async function persistDesignAsCurrent() {
     renderCourseActions();
     return;
   }
-  const confirmed = confirm(
-    "Confermi di voler impostare questo percorso come corrente?\n\n" +
-    "Questa operazione sovrascrive doc/course_design.json."
-  );
+  const confirmed = await DashboardDialogs.confirm({
+    title: "Imposta percorso corrente",
+    message:
+      "Confermi di voler impostare questo percorso come corrente?\n\n" +
+      "Questa operazione sovrascrive doc/course_design.json.",
+    confirmLabel: "Imposta corrente",
+    cancelLabel: "Annulla",
+    danger: true,
+  });
   if (!confirmed) return;
   normalizeCourseDesignFrames();
   const savedSnapshot = designSnapshot();
@@ -2313,8 +2434,8 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
-els.reloadBtn.addEventListener("click", () => {
-  if (!confirmDiscardChanges()) return;
+els.reloadBtn.addEventListener("click", async () => {
+  if (!await confirmDiscardChanges()) return;
   runAsyncAction(loadAll, "Ricarica");
 });
 els.saveBtn.addEventListener("click", () => runAsyncAction(saveDesign, "Impostazione progetto corrente"));
@@ -2381,16 +2502,12 @@ document.addEventListener("click", (event) => {
 });
 
 for (const link of document.querySelectorAll(".topNav a:not([target='_blank'])")) {
-  link.addEventListener("click", (event) => {
+  link.addEventListener("click", async (event) => {
     if (!hasUnsavedChanges()) return;
-    if (!confirmDiscardChanges()) {
-      event.preventDefault();
-      return;
-    }
+    event.preventDefault();
+    if (!await confirmDiscardChanges()) return;
     allowNextUnloadWithoutWarning = true;
-    setTimeout(() => {
-      allowNextUnloadWithoutWarning = false;
-    }, 0);
+    window.location.href = link.href;
   });
 }
 

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -482,6 +482,7 @@ async function loadCurrentDesign() {
     message: "Caricare il progetto corrente da doc/course_design.json? Le modifiche non salvate nella vista corrente saranno perse.",
     confirmLabel: "Carica progetto",
     cancelLabel: "Annulla",
+    danger: true,
   });
   if (!confirmed) return;
   setStatus("Caricamento progetto corrente...");
@@ -507,6 +508,7 @@ async function loadSavedDesignByName(name, options = {}) {
       message: `Caricare "${name}" nella board? Le modifiche non salvate nella vista corrente saranno perse.`,
       confirmLabel: "Carica progetto",
       cancelLabel: "Annulla",
+      danger: true,
     });
     if (!confirmed) return;
   }
@@ -782,6 +784,7 @@ async function newCourseDesign() {
     message: "Creare un nuovo percorso vuoto? Le modifiche non salvate nella vista corrente saranno perse.",
     confirmLabel: "Crea percorso",
     cancelLabel: "Annulla",
+    danger: true,
   });
   if (!confirmed) return;
   const name = await DashboardDialogs.prompt({

--- a/tools/dashboard_dialogs.css
+++ b/tools/dashboard_dialogs.css
@@ -1,0 +1,166 @@
+.dashboardDialog {
+  width: min(34rem, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
+  border: 1px solid rgba(17, 17, 17, .2);
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--ink, #111111);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, .22);
+  padding: 0;
+}
+
+.dashboardDialog::backdrop {
+  background: rgba(0, 0, 0, .38);
+}
+
+.dashboardDialogPanel {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+}
+
+.dashboardDialogEyebrow {
+  margin: 0;
+  color: var(--muted, #666666);
+  font: 700 .75rem/1.2 var(--mono, monospace);
+  text-transform: uppercase;
+}
+
+.dashboardDialogTitle {
+  margin: 0;
+  font: 800 1.2rem/1.3 var(--mono, monospace);
+}
+
+.dashboardDialogMessage {
+  margin: 0;
+  color: var(--ink, #111111);
+  white-space: pre-line;
+  overflow-wrap: anywhere;
+  font: .88rem/1.55 var(--mono, monospace);
+}
+
+.dashboardDialogField {
+  display: grid;
+  gap: .45rem;
+}
+
+.dashboardDialogField[hidden] {
+  display: none;
+}
+
+.dashboardDialogFieldLabel {
+  color: var(--muted, #666666);
+  font: 700 .76rem/1.2 var(--mono, monospace);
+}
+
+.dashboardDialogInput {
+  width: 100%;
+  min-height: 2.65rem;
+  border: 1px solid var(--line, #d7d7d7);
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--ink, #111111);
+  padding: .7rem .8rem;
+  font: .88rem/1.3 var(--mono, monospace);
+}
+
+.dashboardDialogInput:focus {
+  outline: 3px solid rgba(20, 100, 192, .2);
+  border-color: #1464c0;
+}
+
+.dashboardDialogInput[aria-invalid="true"] {
+  border-color: #b42318;
+  background: #fff7f6;
+}
+
+.dashboardDialogError {
+  color: #b42318;
+  font: 700 .76rem/1.35 var(--mono, monospace);
+}
+
+.dashboardDialogError[hidden] {
+  display: none;
+}
+
+.dashboardDialogActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: .55rem;
+  flex-wrap: wrap;
+}
+
+.dashboardDialogActions button {
+  min-height: 2.55rem;
+  border: 1px solid var(--line, #d7d7d7);
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--ink, #111111);
+  padding: .65rem .9rem;
+  font: 700 .84rem/1.2 var(--mono, monospace);
+  cursor: pointer;
+}
+
+.dashboardDialogActions .dashboardDialogConfirm {
+  border-color: #111111;
+  background: #111111;
+  color: #ffffff;
+}
+
+.dashboardDialogActions .dashboardDialogConfirm.danger,
+.dashboardDialogDanger .dashboardDialogConfirm {
+  border-color: #b42318;
+  background: #b42318;
+}
+
+.dashboardToastRegion {
+  position: fixed;
+  z-index: 1000;
+  right: 1rem;
+  bottom: 1rem;
+  display: grid;
+  width: min(24rem, calc(100vw - 2rem));
+  gap: .5rem;
+  pointer-events: none;
+}
+
+.dashboardToast {
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-left: 4px solid #1464c0;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111111;
+  box-shadow: 0 12px 34px rgba(0, 0, 0, .16);
+  padding: .8rem .9rem;
+  overflow-wrap: anywhere;
+  font: 700 .8rem/1.4 var(--mono, monospace);
+}
+
+.dashboardToast-success {
+  border-left-color: #168a45;
+}
+
+.dashboardToast-warning {
+  border-left-color: #c87800;
+}
+
+.dashboardToast-error {
+  border-left-color: #b42318;
+}
+
+@media (max-width: 520px) {
+  .dashboardDialog {
+    width: calc(100vw - 1rem);
+    max-height: calc(100vh - 1rem);
+  }
+
+  .dashboardDialogPanel {
+    padding: 1rem;
+  }
+
+  .dashboardDialogActions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/tools/dashboard_dialogs.js
+++ b/tools/dashboard_dialogs.js
@@ -1,0 +1,217 @@
+(() => {
+  "use strict";
+
+  let elements = null;
+  let activeRequest = null;
+  let requestQueue = Promise.resolve();
+
+  function createElement(tagName, className, text = "") {
+    const element = document.createElement(tagName);
+    if (className) element.className = className;
+    if (text) element.textContent = text;
+    return element;
+  }
+
+  function ensureElements() {
+    if (elements) return elements;
+
+    const dialog = createElement("dialog", "dashboardDialog");
+    dialog.id = "dashboardActionDialog";
+    dialog.setAttribute("aria-labelledby", "dashboardActionDialogTitle");
+    dialog.setAttribute("aria-describedby", "dashboardActionDialogMessage");
+
+    const form = createElement("form", "dashboardDialogPanel");
+    form.method = "dialog";
+    const eyebrow = createElement("p", "dashboardDialogEyebrow", "Conferma operazione");
+    const title = createElement("h2", "dashboardDialogTitle");
+    title.id = "dashboardActionDialogTitle";
+    const message = createElement("p", "dashboardDialogMessage");
+    message.id = "dashboardActionDialogMessage";
+
+    const field = createElement("label", "dashboardDialogField");
+    const fieldLabel = createElement("span", "dashboardDialogFieldLabel");
+    const input = createElement("input", "dashboardDialogInput");
+    input.type = "text";
+    const error = createElement("span", "dashboardDialogError");
+    error.id = "dashboardActionDialogError";
+    error.setAttribute("role", "alert");
+    input.setAttribute("aria-describedby", error.id);
+    field.append(fieldLabel, input, error);
+
+    const actions = createElement("div", "dashboardDialogActions");
+    const cancelButton = createElement("button", "dashboardDialogCancel", "Annulla");
+    cancelButton.type = "button";
+    const confirmButton = createElement("button", "dashboardDialogConfirm", "Conferma");
+    confirmButton.type = "submit";
+    actions.append(cancelButton, confirmButton);
+    form.append(eyebrow, title, message, field, actions);
+    dialog.append(form);
+
+    const toastRegion = createElement("div", "dashboardToastRegion");
+    toastRegion.id = "dashboardToastRegion";
+    toastRegion.setAttribute("role", "status");
+    toastRegion.setAttribute("aria-live", "polite");
+    toastRegion.setAttribute("aria-atomic", "true");
+    document.body.append(dialog, toastRegion);
+
+    elements = {
+      dialog,
+      form,
+      eyebrow,
+      title,
+      message,
+      field,
+      fieldLabel,
+      input,
+      error,
+      actions,
+      cancelButton,
+      confirmButton,
+      toastRegion,
+    };
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      completeFromInput();
+    });
+    cancelButton.addEventListener("click", () => completeRequest(null));
+    dialog.addEventListener("cancel", (event) => {
+      event.preventDefault();
+      completeRequest(null);
+    });
+    return elements;
+  }
+
+  function resetError() {
+    const ui = ensureElements();
+    ui.error.textContent = "";
+    ui.error.hidden = true;
+    ui.input.removeAttribute("aria-invalid");
+  }
+
+  function completeFromInput() {
+    if (!activeRequest) return;
+    const ui = ensureElements();
+    if (activeRequest.mode === "confirm") {
+      completeRequest(true);
+      return;
+    }
+    if (activeRequest.mode === "message") {
+      completeRequest(true);
+      return;
+    }
+    const value = ui.input.value;
+    const validationMessage = activeRequest.validate(value);
+    if (validationMessage) {
+      ui.error.textContent = validationMessage;
+      ui.error.hidden = false;
+      ui.input.setAttribute("aria-invalid", "true");
+      ui.input.focus();
+      return;
+    }
+    completeRequest(value);
+  }
+
+  function completeRequest(value) {
+    if (!activeRequest) return;
+    const ui = ensureElements();
+    const request = activeRequest;
+    activeRequest = null;
+    if (ui.dialog.open) ui.dialog.close();
+    resetError();
+    request.resolve(
+      request.mode === "confirm"
+        ? value === true
+        : request.mode === "message"
+          ? undefined
+          : value
+    );
+    setTimeout(() => request.restoreFocus?.focus?.(), 0);
+  }
+
+  function showDialog(options) {
+    const ui = ensureElements();
+    const mode = options.mode || "confirm";
+    const restoreFocus = document.activeElement;
+    ui.eyebrow.textContent = options.eyebrow || (
+      mode === "prompt" ? "Dato richiesto" : mode === "message" ? "Informazione" : "Conferma operazione"
+    );
+    ui.title.textContent = options.title || (
+      mode === "prompt" ? "Inserisci un valore" : mode === "message" ? "Operazione completata" : "Conferma"
+    );
+    ui.message.textContent = options.message || "";
+    ui.field.hidden = mode !== "prompt";
+    ui.fieldLabel.textContent = options.label || "Valore";
+    ui.input.value = options.defaultValue || "";
+    ui.input.placeholder = options.placeholder || "";
+    ui.cancelButton.hidden = mode === "message";
+    ui.cancelButton.textContent = options.cancelLabel || "Annulla";
+    ui.confirmButton.textContent = options.confirmLabel || (mode === "message" ? "Chiudi" : "Conferma");
+    ui.confirmButton.classList.toggle("danger", options.danger === true);
+    ui.dialog.classList.toggle("dashboardDialogDanger", options.danger === true);
+    resetError();
+
+    return new Promise((resolve) => {
+      activeRequest = {
+        mode,
+        resolve,
+        restoreFocus,
+        validate(value) {
+          if (options.required && !String(value).trim()) {
+            return options.requiredMessage || "Compila questo campo per continuare.";
+          }
+          return typeof options.validate === "function" ? options.validate(value) : "";
+        },
+      };
+      if (typeof ui.dialog.showModal === "function") ui.dialog.showModal();
+      else ui.dialog.setAttribute("open", "");
+      setTimeout(() => {
+        if (mode === "prompt") {
+          ui.input.focus();
+          ui.input.select?.();
+        } else {
+          ui.confirmButton.focus();
+        }
+      }, 0);
+    });
+  }
+
+  function enqueue(options) {
+    const pending = requestQueue.then(() => showDialog(options));
+    requestQueue = pending.catch(() => undefined);
+    return pending;
+  }
+
+  function confirm(options = {}) {
+    return enqueue({ ...options, mode: "confirm" });
+  }
+
+  function prompt(options = {}) {
+    return enqueue({ ...options, mode: "prompt" });
+  }
+
+  function message(options = {}) {
+    return enqueue({ ...options, mode: "message" });
+  }
+
+  function toast(text, options = {}) {
+    const ui = ensureElements();
+    const item = createElement("div", `dashboardToast dashboardToast-${options.tone || "info"}`);
+    item.textContent = String(text || "");
+    ui.toastRegion.append(item);
+    const duration = Number.isFinite(options.duration) ? Math.max(0, options.duration) : 4200;
+    setTimeout(() => item.remove(), duration);
+    return item;
+  }
+
+  const api = Object.freeze({
+    confirm,
+    prompt,
+    message,
+    toast,
+  });
+  globalThis.DashboardDialogs = api;
+  if (globalThis.window && globalThis.window !== globalThis) {
+    globalThis.window.DashboardDialogs = api;
+  }
+})();

--- a/tools/dashboard_dialogs.js
+++ b/tools/dashboard_dialogs.js
@@ -74,6 +74,7 @@
       event.preventDefault();
       completeFromInput();
     });
+    input.addEventListener("input", resetError);
     cancelButton.addEventListener("click", () => completeRequest(null));
     dialog.addEventListener("cancel", (event) => {
       event.preventDefault();

--- a/tools/dashboard_dialogs.js
+++ b/tools/dashboard_dialogs.js
@@ -169,6 +169,8 @@
         if (mode === "prompt") {
           ui.input.focus();
           ui.input.select?.();
+        } else if (options.danger === true && !ui.cancelButton.hidden) {
+          ui.cancelButton.focus();
         } else {
           ui.confirmButton.focus();
         }


### PR DESCRIPTION
Closes #490

## Cosa cambia

- introduce un componente condiviso senza dipendenze per conferme, richieste di testo, messaggi e notifiche;
- sostituisce tutti i `confirm()` e `prompt()` nativi nelle dashboard Percorso e Consegne;
- aggiunge validazione inline, gestione di `Esc`, ripristino del focus, accodamento dei dialog e stile distinto per le azioni distruttive;
- protegge le correzioni locali e AI da modifiche concorrenti del testo;
- aggiorna gli scenari manuali 2 e 9 per collaudare i nuovi dialog senza cancellare dati demo;
- aggiunge test runtime e un guard anti-regressione contro il ritorno dei dialog nativi.

## Perché

I dialog nativi bloccavano il collaudo E2E nel browser integrato, avevano uno stile incoerente e non potevano mostrare validazione o conseguenze in modo controllato. I nuovi dialog restano parte della pagina e sono quindi accessibili, testabili e coerenti tra dashboard.

## Verifica

- `python -m pytest -q`: 777 passed, 13 skipped
- test frontend mirati: 151 passed
- `git diff --check`

Il controllo visivo integrato non è stato eseguito in questa sessione perché il browser in-app non era esposto; gli scenari manuali aggiornati descrivono la verifica desktop/mobile da ripetere in Codex Desktop.