### PR TITLE
Collega il renderer utui alla CLI studente

### DIFF
--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -554,7 +554,8 @@ Esci, apri la dashboard studente, seleziona <code>rossi-mario</code>, clicca <co
    ```
 
 2. Seleziona la consegna `Demo somma in Python`.
-3. Esegui il runner con il comando indicato dalla TUI.
+3. In un terminale basso, usa `j` e `k` e verifica che i pannelli fuori dalla prima viewport siano
+   raggiungibili mentre la legenda dei comandi resta visibile; esegui quindi il runner con `e`.
 4. Esci dalla TUI.
 5. Apri `http://localhost:8765/tools/student_dashboard.html`.
 6. Seleziona `rossi-mario`.

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -550,7 +550,7 @@ Esci, apri la dashboard studente, seleziona <code>rossi-mario</code>, clicca <co
 1. Avvia la TUI:
 
    ```powershell
-   python scripts/student_lab_cli.py --root tmp/student-lab-demo --student-id rossi-mario
+   python scripts/student_lab_cli.py --root tmp/student-lab-demo --student-id rossi-mario --renderer auto
    ```
 
 2. Seleziona la consegna `Demo somma in Python`.
@@ -564,6 +564,8 @@ Risultato atteso:
 - La dashboard studente vede lo stesso report prodotto dalla TUI.
 - Workspace, report, test e ultimo tentativo sono coerenti.
 - Le richieste di aiuto registrate dalla TUI compaiono nella dashboard.
+- Con Python 3.11+ e `requirements-utui.txt` installato, il dettaglio usa il frame `utui`;
+  senza l'extra, `auto` conserva il dettaglio legacy e lo scenario resta eseguibile.
 
 ## Scenario 7 - Comandi TUI studente
 

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -34,7 +34,8 @@ La CLI espone tre modalita di rendering per il dettaglio della consegna:
 
 La modalita si puo anche impostare con `THEBITLAB_TUI_RENDERER`. Il comando `l` conserva gli stessi
 controlli di layout con entrambi i renderer; con `utui`, resize, focus, ordine e pannelli compressi
-vengono proiettati direttamente nel frame a pannelli.
+vengono proiettati direttamente nel frame a pannelli. Nel dettaglio `utui`, `j` scorre verso il basso
+e `k` verso l'alto; navigazione e azioni restano visibili sotto il frame anche nei terminali bassi.
 
 Per verificare esplicitamente il nuovo renderer:
 
@@ -189,6 +190,7 @@ Nel dettaglio della consegna i comandi sono divisi in:
 
 - azioni principali: `e` esegue il runner e salva il report, `a` registra una richiesta di aiuto, `o` apre la cartella workspace, `v` apre l'editor;
 - altri comandi: `h` mostra lo storico aiuti, `b` o invio torna alla lista, `q` esce.
+- navigazione `utui`: `j` scorre i pannelli verso il basso e `k` verso l'alto.
 
 Il comando `v` cerca un editor terminale nell'ordine `micro`, `nvim`, `vim`, `hx`, `nano` (e `notepad` su Windows).
 Per scegliere esplicitamente un editor, imposta `THEBITLAB_EDITOR`, per esempio `micro --clean` o `nvim`.

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -24,9 +24,23 @@ temporaneamente a un commit verificato:
 py -3.12 -m pip install -r requirements-utui.txt
 ```
 
-La prima integrazione espone soltanto l'adapter puro in `scripts/student_lab_utui.py` e i relativi
-snapshot. La CLI continua a usare il renderer testuale esistente: selezione del renderer, input e
-resize verranno collegati in una PR successiva, mantenendo il renderer storico come fallback.
+La CLI espone tre modalita di rendering per il dettaglio della consegna:
+
+- `--renderer auto` (predefinito): usa `utui` in un terminale interattivo quando l'extra e disponibile;
+  negli output non interattivi e in caso di errore usa il renderer testuale storico;
+- `--renderer utui`: richiede esplicitamente Python 3.11+ e `requirements-utui.txt`, segnalando
+  chiaramente un errore se il renderer non puo partire;
+- `--renderer legacy`: usa sempre il renderer testuale storico.
+
+La modalita si puo anche impostare con `THEBITLAB_TUI_RENDERER`. Il comando `l` conserva gli stessi
+controlli di layout con entrambi i renderer; con `utui`, resize, focus, ordine e pannelli compressi
+vengono proiettati direttamente nel frame a pannelli.
+
+Per verificare esplicitamente il nuovo renderer:
+
+```powershell
+py -3.12 scripts/student_lab_cli.py --student-id rossi-mario --renderer utui
+```
 
 Le richieste di aiuto non invocano provider dentro la TUI. La TUI le invia al server locale della macchina docente,
 che ricarica consegna, policy e budget dai propri dati e usa Codex CLI installato localmente. Server e TUI devono
@@ -154,6 +168,13 @@ La TUI usa colori ANSI quando il terminale li supporta. Per disattivarli:
 
 ```powershell
 python scripts/student_lab_cli.py --student-id rossi-mario --no-color
+```
+
+Per confrontare il renderer a pannelli con quello storico senza cambiare dati:
+
+```powershell
+python scripts/student_lab_cli.py --student-id rossi-mario --renderer utui
+python scripts/student_lab_cli.py --student-id rossi-mario --renderer legacy
 ```
 
 Comandi disponibili nella TUI minima:

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -521,6 +521,7 @@ def render_assignment_view(
     terminal_width: int | None = None,
     terminal_height: int | None = None,
     interaction: dict[str, Any] | None = None,
+    renderer_observer: Callable[[str], None] | None = None,
 ) -> str:
     """Render one assignment through the selected CLI presentation backend."""
 
@@ -537,9 +538,17 @@ def render_assignment_view(
         )
 
     if renderer == "legacy":
+        if renderer_observer is not None:
+            renderer_observer("legacy")
         return legacy()
     if renderer == "auto":
-        return student_lab_utui.render_assignment_or_fallback(
+        fallback_used = False
+
+        def mark_fallback() -> None:
+            nonlocal fallback_used
+            fallback_used = True
+
+        rendered = student_lab_utui.render_assignment_or_fallback(
             assignment,
             layout,
             width=width,
@@ -547,9 +556,13 @@ def render_assignment_view(
             color=use_color,
             fallback=legacy,
             interaction=interaction,
+            on_fallback=mark_fallback,
         )
+        if renderer_observer is not None:
+            renderer_observer("legacy" if fallback_used else "utui")
+        return rendered
     try:
-        return "\n".join(
+        rendered = "\n".join(
             student_lab_utui.render_assignment_frame(
                 assignment,
                 layout,
@@ -559,6 +572,9 @@ def render_assignment_view(
                 interaction=interaction,
             )
         )
+        if renderer_observer is not None:
+            renderer_observer("utui")
+        return rendered
     except Exception as error:
         raise ValueError(f"Renderer utui non riuscito: {error}") from error
 
@@ -1227,6 +1243,7 @@ def run_tui(
                 break
             if clear:
                 clear_screen()
+            rendered_with = ["utui" if selected_renderer == "auto" else selected_renderer]
             print_fn(
                 render_assignment_view(
                     assignment,
@@ -1237,19 +1254,23 @@ def run_tui(
                         "dashboard_offset": dashboard_offset,
                         "expand_sections": True,
                     },
+                    renderer_observer=lambda actual: rendered_with.__setitem__(0, actual),
                 )
             )
-            if selected_renderer != "legacy":
+            actual_renderer = rendered_with[0]
+            if selected_renderer == "auto" and actual_renderer == "legacy":
+                selected_renderer = "legacy"
+            if actual_renderer == "utui":
                 print_fn(render_utui_detail_commands())
             action = input_fn("\nDettaglio: ").strip().lower()
             if action in {"", "b", "back", "indietro"}:
                 break
             if action in {"q", "quit", "esci"}:
                 return 0
-            if selected_renderer != "legacy" and action in {"j", "down", "giu"}:
+            if actual_renderer == "utui" and action in {"j", "down", "giu"}:
                 dashboard_offset += 5
                 continue
-            if selected_renderer != "legacy" and action in {"k", "up", "su"}:
+            if actual_renderer == "utui" and action in {"k", "up", "su"}:
                 dashboard_offset = max(0, dashboard_offset - 5)
                 continue
             if action == "o":

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -520,12 +520,13 @@ def render_assignment_view(
     renderer: str,
     terminal_width: int | None = None,
     terminal_height: int | None = None,
+    interaction: dict[str, Any] | None = None,
 ) -> str:
     """Render one assignment through the selected CLI presentation backend."""
 
     terminal_size = shutil.get_terminal_size((120, 40))
     width = terminal_width or terminal_size.columns
-    height = terminal_height or max(8, terminal_size.lines - 2)
+    height = terminal_height or max(8, terminal_size.lines - 5)
 
     def legacy() -> str:
         return render_assignment_detail(
@@ -545,6 +546,7 @@ def render_assignment_view(
             height=height,
             color=use_color,
             fallback=legacy,
+            interaction=interaction,
         )
     try:
         return "\n".join(
@@ -554,10 +556,23 @@ def render_assignment_view(
                 width=width,
                 height=height,
                 color=use_color,
+                interaction=interaction,
             )
         )
     except Exception as error:
         raise ValueError(f"Renderer utui non riuscito: {error}") from error
+
+
+def render_utui_detail_commands() -> str:
+    """Keep navigation and assignment actions visible below the clipped frame."""
+
+    return "\n".join(
+        (
+            "Navigazione: j = scorri giu | k = scorri su | l = modifica layout",
+            "Azioni: e = test/report | a = aiuto | o = workspace | v = editor",
+            "Altri: h = storico aiuti | b/invio = lista | q = esci",
+        )
+    )
 
 
 def runner_result_message(report: dict[str, Any], report_path: Path, use_color: bool = False) -> str:
@@ -1203,6 +1218,7 @@ def run_tui(
         if index < 0 or index >= len(assignments):
             continue
         selected_assignment_id = clean_text(assignments[index].get("assignment_id"), "")
+        dashboard_offset = 0
         while True:
             assignment = find_assignment(payload, selected_assignment_id, index)
             if assignment is None:
@@ -1217,13 +1233,22 @@ def run_tui(
                     use_color=use_color,
                     layout=student_lab_layout.load_layout(root),
                     renderer=selected_renderer,
+                    interaction={"dashboard_offset": dashboard_offset},
                 )
             )
+            if selected_renderer != "legacy":
+                print_fn(render_utui_detail_commands())
             action = input_fn("\nDettaglio: ").strip().lower()
             if action in {"", "b", "back", "indietro"}:
                 break
             if action in {"q", "quit", "esci"}:
                 return 0
+            if selected_renderer != "legacy" and action in {"j", "down", "giu"}:
+                dashboard_offset += 5
+                continue
+            if selected_renderer != "legacy" and action in {"k", "up", "su"}:
+                dashboard_offset = max(0, dashboard_offset - 5)
+                continue
             if action == "o":
                 workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
                 if not open_workspace(clean_text(workspace.get("path"), ""), root=root):

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -1233,7 +1233,10 @@ def run_tui(
                     use_color=use_color,
                     layout=student_lab_layout.load_layout(root),
                     renderer=selected_renderer,
-                    interaction={"dashboard_offset": dashboard_offset},
+                    interaction={
+                        "dashboard_offset": dashboard_offset,
+                        "expand_sections": True,
+                    },
                 )
             )
             if selected_renderer != "legacy":

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -22,13 +22,20 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import student_help_service, student_lab_layout, student_lab_runner, student_lab_service
+from scripts import (
+    student_help_service,
+    student_lab_layout,
+    student_lab_runner,
+    student_lab_service,
+    student_lab_utui,
+)
 
 
 InputFn = Callable[[str], str]
 PrintFn = Callable[[str], None]
 DEFAULT_SERVER_URL = "http://127.0.0.1:8765"
 HELP_REQUEST_TIMEOUT_SECONDS = 150
+TUI_RENDERERS = {"auto", "legacy", "utui"}
 
 
 class StudentHelpRequestPendingError(ValueError):
@@ -364,6 +371,7 @@ def render_assignment_detail(
     assignment: dict[str, Any],
     use_color: bool = False,
     layout: dict[str, Any] | None = None,
+    terminal_width: int | None = None,
 ) -> str:
     """Render the detail page for one lab assignment."""
 
@@ -471,8 +479,85 @@ def render_assignment_detail(
         "  q  Esci",
     ]
     if layout is not None:
-        return student_lab_layout.render_layout(lines, layout, use_color=use_color)
+        return student_lab_layout.render_layout(
+            lines,
+            layout,
+            terminal_width=terminal_width,
+            use_color=use_color,
+        )
     return "\n".join(lines)
+
+
+def resolve_tui_renderer(
+    requested: str,
+    *,
+    interactive: bool | None = None,
+) -> str:
+    """Resolve the requested renderer without changing non-interactive output."""
+
+    renderer = clean_text(requested, "auto").lower()
+    if renderer not in TUI_RENDERERS:
+        choices = ", ".join(sorted(TUI_RENDERERS))
+        raise ValueError(f"Renderer TUI non supportato: {renderer}. Valori: {choices}.")
+    if renderer == "legacy":
+        return "legacy"
+    if renderer == "utui":
+        if not student_lab_utui.is_available():
+            raise ValueError(
+                "Renderer utui non disponibile. Usa Python 3.11 o successivo e "
+                "installa requirements-utui.txt, oppure scegli --renderer legacy."
+            )
+        return "utui"
+    terminal_interactive = sys.stdout.isatty() if interactive is None else interactive
+    return "auto" if terminal_interactive and student_lab_utui.is_available() else "legacy"
+
+
+def render_assignment_view(
+    assignment: dict[str, Any],
+    *,
+    use_color: bool,
+    layout: dict[str, Any],
+    renderer: str,
+    terminal_width: int | None = None,
+    terminal_height: int | None = None,
+) -> str:
+    """Render one assignment through the selected CLI presentation backend."""
+
+    terminal_size = shutil.get_terminal_size((120, 40))
+    width = terminal_width or terminal_size.columns
+    height = terminal_height or max(8, terminal_size.lines - 2)
+
+    def legacy() -> str:
+        return render_assignment_detail(
+            assignment,
+            use_color=use_color,
+            layout=layout,
+            terminal_width=width,
+        )
+
+    if renderer == "legacy":
+        return legacy()
+    if renderer == "auto":
+        return student_lab_utui.render_assignment_or_fallback(
+            assignment,
+            layout,
+            width=width,
+            height=height,
+            color=use_color,
+            fallback=legacy,
+        )
+    try:
+        return "\n".join(
+            student_lab_utui.render_assignment_frame(
+                assignment,
+                layout,
+                width=width,
+                height=height,
+                color=use_color,
+            )
+        )
+    except Exception as error:
+        raise ValueError(f"Renderer utui non riuscito: {error}") from error
 
 
 def runner_result_message(report: dict[str, Any], report_path: Path, use_color: bool = False) -> str:
@@ -1075,9 +1160,12 @@ def run_tui(
     backend: str = "local",
     timeout_seconds: int = student_lab_runner.DEFAULT_TIMEOUT_SECONDS,
     docker_image: str = student_lab_runner.DEFAULT_DOCKER_IMAGE,
+    renderer: str = "auto",
+    interactive: bool | None = None,
 ) -> int:
     """Run the interactive student lab loop."""
 
+    selected_renderer = resolve_tui_renderer(renderer, interactive=interactive)
     payload = load_current_payload(
         root=root,
         student_id=student_id,
@@ -1124,10 +1212,11 @@ def run_tui(
             if clear:
                 clear_screen()
             print_fn(
-                render_assignment_detail(
+                render_assignment_view(
                     assignment,
                     use_color=use_color,
                     layout=student_lab_layout.load_layout(root),
+                    renderer=selected_renderer,
                 )
             )
             action = input_fn("\nDettaglio: ").strip().lower()
@@ -1153,12 +1242,23 @@ def run_tui(
                 input_fn("Premi invio per continuare...")
                 continue
             if action in {"l", "layout"}:
+                layout_renderer = None
+                if selected_renderer != "legacy":
+                    layout_renderer = lambda current, width, height: render_assignment_view(
+                        assignment,
+                        use_color=use_color,
+                        layout=current,
+                        renderer=selected_renderer,
+                        terminal_width=width,
+                        terminal_height=height,
+                    )
                 student_lab_layout.run_layout_editor(
                     render_assignment_detail(assignment, use_color=use_color).splitlines(),
                     root=root,
                     use_color=use_color,
                     clear=clear,
                     print_fn=print_fn,
+                    layout_renderer=layout_renderer,
                 )
                 continue
             if action == "a":
@@ -1267,6 +1367,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--no-clear", action="store_true", help="Non pulire lo schermo tra una vista e l'altra.")
     parser.add_argument("--no-color", action="store_true", help="Disabilita colori ANSI.")
     parser.add_argument(
+        "--renderer",
+        choices=sorted(TUI_RENDERERS),
+        default=os.environ.get("THEBITLAB_TUI_RENDERER", "auto"),
+        help="Renderer dettaglio: auto usa utui se disponibile, legacy conserva quello storico.",
+    )
+    parser.add_argument(
         "--backend",
         choices=sorted(student_lab_runner.RUNNER_BACKENDS),
         default="local",
@@ -1313,6 +1419,7 @@ def main() -> int:
             backend=args.backend,
             timeout_seconds=args.timeout,
             docker_image=args.docker_image,
+            renderer=args.renderer,
         )
     except ValueError as error:
         print(f"Lab studente non disponibile:\n{error}", file=sys.stderr)

--- a/scripts/student_lab_layout.py
+++ b/scripts/student_lab_layout.py
@@ -39,6 +39,7 @@ SELECTED_PANEL_BACKGROUND = "\033[48;5;253m"
 PANEL_TITLE_STYLE = "\033[1;97m"
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 KeyReader = Callable[[], str]
+LayoutRenderer = Callable[[dict, int, int], str]
 
 
 def normalize_layout(value: object) -> dict:
@@ -381,6 +382,7 @@ def run_layout_editor(
     terminal_width: int | None = None,
     clear: bool = True,
     print_fn: Callable[[str], None] = print,
+    layout_renderer: LayoutRenderer | None = None,
 ) -> dict:
     """Edit and save the layout until Enter, Escape or q is pressed."""
 
@@ -391,15 +393,21 @@ def run_layout_editor(
         while True:
             if clear:
                 print_fn("\x1b[2J\x1b[H")
-            print_fn(
-                render_layout(
+            terminal_size = shutil.get_terminal_size((120, 40))
+            width = terminal_width or terminal_size.columns
+            content_height = max(8, terminal_size.lines - 7)
+            rendered = (
+                layout_renderer(layout, width, content_height)
+                if layout_renderer is not None
+                else render_layout(
                     lines,
                     layout,
-                    terminal_width,
+                    width,
                     use_color=use_color,
                     highlight_focus=True,
                 )
             )
+            print_fn(rendered)
             print_fn(f"Pannello attivo: {PANEL_TITLES[layout['focus']]} (indicato da >)")
             print_fn("\nResize: frecce sinistra/destra o [ ] ridimensionano il pannello sinistro")
             print_fn("Tab seleziona | h/l sposta orizzontalmente | k/j sposta verticalmente")

--- a/scripts/student_lab_utui.py
+++ b/scripts/student_lab_utui.py
@@ -75,7 +75,7 @@ class _DashboardFrame:
 def is_available() -> bool:
     """Return whether the optional renderer can be used."""
 
-    return UTUI_IMPORT_ERROR is None
+    return sys.version_info >= MINIMUM_PYTHON and UTUI_IMPORT_ERROR is None
 
 
 def _require_utui() -> None:

--- a/scripts/student_lab_utui.py
+++ b/scripts/student_lab_utui.py
@@ -591,6 +591,7 @@ def render_assignment_or_fallback(
     color: bool,
     fallback: Callable[[], str],
     interaction: Mapping[str, Any] | None = None,
+    on_fallback: Callable[[], None] | None = None,
 ) -> str:
     """Render with uTUI and use the existing renderer after any adapter failure."""
 
@@ -606,4 +607,6 @@ def render_assignment_or_fallback(
             )
         )
     except Exception:
+        if on_fallback is not None:
+            on_fallback()
         return fallback()

--- a/scripts/student_lab_utui.py
+++ b/scripts/student_lab_utui.py
@@ -426,6 +426,7 @@ def _build_panel(
     focused: bool,
     collapsed: bool,
     scroll_offset: int,
+    expand_body: bool,
 ) -> tuple[Any, int]:
     title = SECTION_TITLES[identifier]
     rows: Sequence[Any] = ()
@@ -444,7 +445,11 @@ def _build_panel(
         )[: len(normalized_rows)]
     )
     body_limit = 7 if identifier == "assignment" else PANEL_BODY_ROWS
-    body_height = min(body_limit, len(normalized_rows))
+    body_height = (
+        len(normalized_rows)
+        if expand_body
+        else min(body_limit, len(normalized_rows))
+    )
     height = 3 if collapsed else max(3, body_height + 2)
     labels = [
         Label(row, style=style)
@@ -509,6 +514,9 @@ def build_dashboard(
         or dashboard_offset < 0
     ):
         raise ValueError("dashboard_offset deve essere un intero non negativo")
+    expand_sections = transient.get("expand_sections", False)
+    if not isinstance(expand_sections, bool):
+        raise ValueError("expand_sections deve essere booleano")
     entries = [
         _build_panel(
             identifier,
@@ -516,6 +524,7 @@ def build_dashboard(
             focused=normalized["focus"] == identifier,
             collapsed=identifier in normalized["collapsed"],
             scroll_offset=section_offsets.get(identifier, 0),
+            expand_body=expand_sections,
         )
         for identifier in order
     ]

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -1155,10 +1155,10 @@ def test_run_tui_scrolls_the_utui_detail(monkeypatch, tmp_path) -> None:
 
     assert result == 0
     assert interactions == [
-        {"dashboard_offset": 0},
-        {"dashboard_offset": 5},
-        {"dashboard_offset": 10},
-        {"dashboard_offset": 5},
+        {"dashboard_offset": 0, "expand_sections": True},
+        {"dashboard_offset": 5, "expand_sections": True},
+        {"dashboard_offset": 10, "expand_sections": True},
+        {"dashboard_offset": 5, "expand_sections": True},
     ]
 
 

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -155,6 +155,7 @@ def test_assignment_view_uses_auto_renderer_with_legacy_fallback(monkeypatch) ->
     assert captured["kwargs"]["width"] == 96
     assert captured["kwargs"]["height"] == 28
     assert captured["kwargs"]["interaction"] is None
+    assert callable(captured["kwargs"]["on_fallback"])
     assert "Dettaglio consegna" in captured["kwargs"]["fallback"]()
 
 
@@ -1160,6 +1161,44 @@ def test_run_tui_scrolls_the_utui_detail(monkeypatch, tmp_path) -> None:
         {"dashboard_offset": 10, "expand_sections": True},
         {"dashboard_offset": 5, "expand_sections": True},
     ]
+
+
+def test_run_tui_hides_utui_controls_after_auto_fallback(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "j", "", "q"])
+    render_attempts = []
+    monkeypatch.setattr(
+        student_lab_cli,
+        "load_payload",
+        lambda root, student_id, now=None: payload,
+    )
+    monkeypatch.setattr(student_lab_cli.student_lab_utui, "is_available", lambda: True)
+
+    def fail_render(*args, **kwargs):
+        render_attempts.append(True)
+        raise RuntimeError("frame rotto")
+
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_utui,
+        "render_assignment_frame",
+        fail_render,
+    )
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+        renderer="auto",
+        interactive=True,
+    )
+
+    assert result == 0
+    assert render_attempts == [True]
+    assert any("Dettaglio consegna" in output for output in outputs)
+    assert not any("Navigazione: j = scorri giu" in output for output in outputs)
 
 
 def test_run_tui_connects_utui_to_the_layout_editor(monkeypatch, tmp_path) -> None:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -154,6 +154,7 @@ def test_assignment_view_uses_auto_renderer_with_legacy_fallback(monkeypatch) ->
     assert captured["presentation"] == student_lab_cli.student_lab_layout.DEFAULT_LAYOUT
     assert captured["kwargs"]["width"] == 96
     assert captured["kwargs"]["height"] == 28
+    assert captured["kwargs"]["interaction"] is None
     assert "Dettaglio consegna" in captured["kwargs"]["fallback"]()
 
 
@@ -1118,6 +1119,47 @@ def test_run_tui_uses_utui_in_an_interactive_terminal(monkeypatch, tmp_path) -> 
 
     assert result == 0
     assert "frame utui interattivo" in outputs
+    assert any("Navigazione: j = scorri giu" in output for output in outputs)
+
+
+def test_run_tui_scrolls_the_utui_detail(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    inputs = iter(["1", "j", "j", "k", "", "q"])
+    interactions = []
+    monkeypatch.setattr(
+        student_lab_cli,
+        "load_payload",
+        lambda root, student_id, now=None: payload,
+    )
+    monkeypatch.setattr(student_lab_cli.student_lab_utui, "is_available", lambda: True)
+
+    def fake_render(*args, **kwargs):
+        interactions.append(kwargs["interaction"].copy())
+        return "frame utui"
+
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_utui,
+        "render_assignment_or_fallback",
+        fake_render,
+    )
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=lambda output: None,
+        clear=False,
+        renderer="auto",
+        interactive=True,
+    )
+
+    assert result == 0
+    assert interactions == [
+        {"dashboard_offset": 0},
+        {"dashboard_offset": 5},
+        {"dashboard_offset": 10},
+        {"dashboard_offset": 5},
+    ]
 
 
 def test_run_tui_connects_utui_to_the_layout_editor(monkeypatch, tmp_path) -> None:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -94,6 +94,7 @@ def test_main_reads_student_token_only_from_environment(monkeypatch, tmp_path) -
 
     assert student_lab_cli.main() == 0
     assert captured["server_token"] == "token-da-ambiente"
+    assert captured["renderer"] == "auto"
 
     monkeypatch.setattr(
         sys,
@@ -102,6 +103,74 @@ def test_main_reads_student_token_only_from_environment(monkeypatch, tmp_path) -
     )
     with pytest.raises(SystemExit):
         student_lab_cli.parse_args()
+
+
+def test_renderer_selection_preserves_legacy_for_non_interactive_output(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(student_lab_cli.student_lab_utui, "is_available", lambda: True)
+
+    assert student_lab_cli.resolve_tui_renderer("auto", interactive=False) == "legacy"
+    assert student_lab_cli.resolve_tui_renderer("auto", interactive=True) == "auto"
+    assert student_lab_cli.resolve_tui_renderer("legacy", interactive=True) == "legacy"
+
+
+def test_explicit_utui_requires_the_optional_renderer(monkeypatch) -> None:
+    monkeypatch.setattr(student_lab_cli.student_lab_utui, "is_available", lambda: False)
+
+    with pytest.raises(ValueError, match="requirements-utui.txt"):
+        student_lab_cli.resolve_tui_renderer("utui", interactive=True)
+
+
+def test_assignment_view_uses_auto_renderer_with_legacy_fallback(monkeypatch) -> None:
+    assignment = sample_assignment()
+    captured = {}
+
+    def fake_render(assignment, presentation, **kwargs):
+        captured.update(
+            assignment=assignment,
+            presentation=presentation,
+            kwargs=kwargs,
+        )
+        return "frame utui"
+
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_utui,
+        "render_assignment_or_fallback",
+        fake_render,
+    )
+
+    rendered = student_lab_cli.render_assignment_view(
+        assignment,
+        use_color=False,
+        layout=student_lab_cli.student_lab_layout.DEFAULT_LAYOUT,
+        renderer="auto",
+        terminal_width=96,
+        terminal_height=28,
+    )
+
+    assert rendered == "frame utui"
+    assert captured["assignment"] is assignment
+    assert captured["presentation"] == student_lab_cli.student_lab_layout.DEFAULT_LAYOUT
+    assert captured["kwargs"]["width"] == 96
+    assert captured["kwargs"]["height"] == 28
+    assert "Dettaglio consegna" in captured["kwargs"]["fallback"]()
+
+
+def test_assignment_view_reports_explicit_utui_failures(monkeypatch) -> None:
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_utui,
+        "render_assignment_frame",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("frame rotto")),
+    )
+
+    with pytest.raises(ValueError, match="Renderer utui non riuscito: frame rotto"):
+        student_lab_cli.render_assignment_view(
+            sample_assignment(),
+            use_color=False,
+            layout=student_lab_cli.student_lab_layout.DEFAULT_LAYOUT,
+            renderer="utui",
+        )
 
 
 def sample_payload(assignments=None):
@@ -1019,6 +1088,81 @@ def test_run_tui_can_show_detail_and_exit(monkeypatch, tmp_path) -> None:
     assert result == 0
     assert any("TheBitLab - lab studente" in output for output in outputs)
     assert any("Dettaglio consegna" in output for output in outputs)
+
+
+def test_run_tui_uses_utui_in_an_interactive_terminal(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "", "q"])
+    monkeypatch.setattr(
+        student_lab_cli,
+        "load_payload",
+        lambda root, student_id, now=None: payload,
+    )
+    monkeypatch.setattr(student_lab_cli.student_lab_utui, "is_available", lambda: True)
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_utui,
+        "render_assignment_or_fallback",
+        lambda *args, **kwargs: "frame utui interattivo",
+    )
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+        renderer="auto",
+        interactive=True,
+    )
+
+    assert result == 0
+    assert "frame utui interattivo" in outputs
+
+
+def test_run_tui_connects_utui_to_the_layout_editor(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    inputs = iter(["1", "l", "", "q"])
+    captured = {}
+    monkeypatch.setattr(
+        student_lab_cli,
+        "load_payload",
+        lambda root, student_id, now=None: payload,
+    )
+    monkeypatch.setattr(student_lab_cli.student_lab_utui, "is_available", lambda: True)
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_utui,
+        "render_assignment_or_fallback",
+        lambda *args, **kwargs: "frame utui layout",
+    )
+
+    def fake_layout_editor(lines, **kwargs):
+        captured.update(lines=lines, kwargs=kwargs)
+        return student_lab_cli.student_lab_layout.DEFAULT_LAYOUT
+
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_layout,
+        "run_layout_editor",
+        fake_layout_editor,
+    )
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=lambda output: None,
+        clear=False,
+        renderer="auto",
+        interactive=True,
+    )
+
+    assert result == 0
+    renderer = captured["kwargs"]["layout_renderer"]
+    assert renderer is not None
+    assert (
+        renderer(student_lab_cli.student_lab_layout.DEFAULT_LAYOUT, 100, 30)
+        == "frame utui layout"
+    )
 
 
 def test_run_tui_can_record_help_request_and_reload(monkeypatch, tmp_path) -> None:

--- a/tests/test_student_lab_layout.py
+++ b/tests/test_student_lab_layout.py
@@ -121,3 +121,27 @@ def test_run_layout_editor_saves_with_injected_keys(tmp_path: Path) -> None:
     assert student_lab_layout.load_layout(tmp_path) == layout
     assert any("Pannello spostato" in output for output in outputs)
     assert any("Pannello attivo:" in output for output in outputs)
+
+
+def test_layout_editor_can_use_a_consumer_renderer(tmp_path: Path) -> None:
+    keys = iter(["right", "tab", "enter"])
+    render_calls = []
+
+    layout = student_lab_layout.run_layout_editor(
+        ["contenuto legacy"],
+        root=tmp_path,
+        key_reader=lambda: next(keys),
+        terminal_width=96,
+        clear=False,
+        print_fn=lambda _output: None,
+        layout_renderer=lambda current, width, height: (
+            render_calls.append((current.copy(), width, height)) or "frame consumer"
+        ),
+    )
+
+    assert len(render_calls) == 3
+    assert all(width == 96 for _current, width, _height in render_calls)
+    assert all(height >= 8 for _current, _width, height in render_calls)
+    assert render_calls[1][0]["left_width"] == 66
+    assert render_calls[2][0]["focus"] == "workspace"
+    assert layout == render_calls[2][0]

--- a/tests/test_student_lab_utui.py
+++ b/tests/test_student_lab_utui.py
@@ -310,6 +310,7 @@ def test_render_falls_back_after_adapter_failure(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(student_lab_utui, "render_assignment_frame", fail)
 
+    fallback_calls = []
     rendered = student_lab_utui.render_assignment_or_fallback(
         ASSIGNMENT,
         student_lab_layout.DEFAULT_LAYOUT,
@@ -317,6 +318,8 @@ def test_render_falls_back_after_adapter_failure(monkeypatch: pytest.MonkeyPatch
         height=30,
         color=False,
         fallback=lambda: "legacy renderer",
+        on_fallback=lambda: fallback_calls.append(True),
     )
 
     assert rendered == "legacy renderer"
+    assert fallback_calls == [True]

--- a/tests/test_student_lab_utui.py
+++ b/tests/test_student_lab_utui.py
@@ -241,6 +241,29 @@ def test_panel_and_dashboard_offsets_reveal_later_rows_without_mutation() -> Non
 
 
 @pytest.mark.skipif(not student_lab_utui.is_available(), reason="utui non installato")
+def test_dashboard_offset_reveals_lower_panels_in_a_24_line_terminal() -> None:
+    first_page = student_lab_utui.render_assignment_frame(
+        ASSIGNMENT,
+        student_lab_layout.DEFAULT_LAYOUT,
+        width=120,
+        height=19,
+        color=False,
+        interaction={"dashboard_offset": 0},
+    )
+    lower_page = student_lab_utui.render_assignment_frame(
+        ASSIGNMENT,
+        student_lab_layout.DEFAULT_LAYOUT,
+        width=120,
+        height=19,
+        color=False,
+        interaction={"dashboard_offset": 10},
+    )
+
+    assert not any("Richieste aiuto" in line for line in first_page)
+    assert any("Richieste aiuto" in line for line in lower_page)
+
+
+@pytest.mark.skipif(not student_lab_utui.is_available(), reason="utui non installato")
 def test_reordered_collapsed_focus_snapshot_without_layout_mutation() -> None:
     layout = {
         **student_lab_layout.DEFAULT_LAYOUT,

--- a/tests/test_student_lab_utui.py
+++ b/tests/test_student_lab_utui.py
@@ -264,6 +264,25 @@ def test_dashboard_offset_reveals_lower_panels_in_a_24_line_terminal() -> None:
 
 
 @pytest.mark.skipif(not student_lab_utui.is_available(), reason="utui non installato")
+def test_expanded_sections_make_every_internal_row_globally_scrollable() -> None:
+    frame = student_lab_utui.render_assignment_frame(
+        ASSIGNMENT,
+        student_lab_layout.DEFAULT_LAYOUT,
+        width=120,
+        height=19,
+        color=False,
+        interaction={
+            "dashboard_offset": 40,
+            "expand_sections": True,
+        },
+    )
+    rendered = "\n".join(frame)
+
+    assert "Errore log:" in rendered
+    assert "q  Esci" in rendered
+
+
+@pytest.mark.skipif(not student_lab_utui.is_available(), reason="utui non installato")
 def test_reordered_collapsed_focus_snapshot_without_layout_mutation() -> None:
     layout = {
         **student_lab_layout.DEFAULT_LAYOUT,


### PR DESCRIPTION
## Cosa cambia

- collega il renderer opzionale `utui` alla vista dettaglio della CLI studente;
- aggiunge `--renderer auto|utui|legacy` e la variabile `THEBITLAB_TUI_RENDERER`;
- applica resize, focus, ordine e pannelli compressi anche al frame `utui`;
- conserva il renderer testuale storico come fallback in modalita `auto`;
- documenta installazione, selezione e collaudo manuale.

## Perche

La prima integrazione esponeva soltanto l'adapter e gli snapshot. Questa PR porta l'adapter nel flusso CLI reale senza modificare backend, persistenza, runner o comandi studente.

Closes #492
Parent: #288, #292

## Verifica

- `py -3.12 -m pytest tests/test_student_lab_layout.py tests/test_student_lab_utui.py tests/test_student_lab_cli.py -q`
- `py -3.12 -m pytest -q` (794 passed, 8 skipped)
- smoke reale su root isolata con `--renderer utui --no-clear --no-color`