### PR TITLE
Verifica il consumer uTUI su Windows e Linux

### DIFF
--- a/.github/workflows/utui-consumer.yml
+++ b/.github/workflows/utui-consumer.yml
@@ -7,9 +7,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - "scripts/student_lab_cli.py"
-      - "scripts/student_lab_layout.py"
-      - "scripts/student_lab_utui.py"
+      - "scripts/**"
       - "tests/test_student_lab_cli.py"
       - "tests/test_student_lab_layout.py"
       - "tests/test_student_lab_utui.py"
@@ -21,9 +19,7 @@ on:
     branches:
       - main
     paths:
-      - "scripts/student_lab_cli.py"
-      - "scripts/student_lab_layout.py"
-      - "scripts/student_lab_utui.py"
+      - "scripts/**"
       - "tests/test_student_lab_cli.py"
       - "tests/test_student_lab_layout.py"
       - "tests/test_student_lab_utui.py"

--- a/.github/workflows/utui-consumer.yml
+++ b/.github/workflows/utui-consumer.yml
@@ -1,0 +1,78 @@
+name: uTUI consumer evidence
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/student_lab_cli.py"
+      - "scripts/student_lab_layout.py"
+      - "scripts/student_lab_utui.py"
+      - "tests/test_student_lab_cli.py"
+      - "tests/test_student_lab_layout.py"
+      - "tests/test_student_lab_utui.py"
+      - "tests/snapshots/student_lab_utui/**"
+      - "requirements-dev.txt"
+      - "requirements-utui.txt"
+      - ".github/workflows/utui-consumer.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/student_lab_cli.py"
+      - "scripts/student_lab_layout.py"
+      - "scripts/student_lab_utui.py"
+      - "tests/test_student_lab_cli.py"
+      - "tests/test_student_lab_layout.py"
+      - "tests/test_student_lab_utui.py"
+      - "tests/snapshots/student_lab_utui/**"
+      - "requirements-dev.txt"
+      - "requirements-utui.txt"
+      - ".github/workflows/utui-consumer.yml"
+
+jobs:
+  consumer:
+    name: ${{ matrix.os }} / Python ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        python:
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    env:
+      THEBITLAB_REQUIRE_UTUI: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: |
+            requirements-dev.txt
+            requirements-utui.txt
+
+      - name: Install consumer dependencies
+        run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt
+
+      - name: Require the real uTUI adapter
+        run: >-
+          python -c
+          "from scripts import student_lab_utui;
+          assert student_lab_utui.is_available(), repr(student_lab_utui.UTUI_IMPORT_ERROR)"
+
+      - name: Run consumer adapter, layout, and CLI tests
+        run: >-
+          python -m pytest
+          tests/test_student_lab_utui.py
+          tests/test_student_lab_layout.py
+          tests/test_student_lab_cli.py

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -43,6 +43,16 @@ Per verificare esplicitamente il nuovo renderer:
 py -3.12 scripts/student_lab_cli.py --student-id rossi-mario --renderer utui
 ```
 
+La GitHub Action `uTUI consumer evidence` installa obbligatoriamente l'extra ed esegue adapter,
+layout e smoke CLI su Windows e Linux con Python 3.11, 3.12 e 3.13. Per riprodurre localmente
+il nucleo della stessa verifica:
+
+```powershell
+py -3.12 -m pip install -r requirements-dev.txt -r requirements-utui.txt
+$env:THEBITLAB_REQUIRE_UTUI="1"
+py -3.12 -m pytest tests/test_student_lab_utui.py tests/test_student_lab_layout.py tests/test_student_lab_cli.py
+```
+
 Le richieste di aiuto non invocano provider dentro la TUI. La TUI le invia al server locale della macchina docente,
 che ricarica consegna, policy e budget dai propri dati e usa Codex CLI installato localmente. Server e TUI devono
 puntare alla stessa root dati. Per la demo:

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -53,6 +53,14 @@ $env:THEBITLAB_REQUIRE_UTUI="1"
 py -3.12 -m pytest tests/test_student_lab_utui.py tests/test_student_lab_layout.py tests/test_student_lab_cli.py
 ```
 
+Su Linux con Bash:
+
+```bash
+python3 -m pip install -r requirements-dev.txt -r requirements-utui.txt
+export THEBITLAB_REQUIRE_UTUI=1
+python3 -m pytest tests/test_student_lab_utui.py tests/test_student_lab_layout.py tests/test_student_lab_cli.py
+```
+
 Le richieste di aiuto non invocano provider dentro la TUI. La TUI le invia al server locale della macchina docente,
 che ricarica consegna, policy e budget dai propri dati e usa Codex CLI installato localmente. Server e TUI devono
 puntare alla stessa root dati. Per la demo:

--- a/tests/test_student_lab_utui.py
+++ b/tests/test_student_lab_utui.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts import student_lab_layout, student_lab_utui
+from scripts import student_lab_cli, student_lab_layout, student_lab_utui
 
 
 SNAPSHOT_ROOT = Path(__file__).with_name("snapshots") / "student_lab_utui"
@@ -302,6 +302,42 @@ def test_reordered_collapsed_focus_snapshot_without_layout_mutation() -> None:
 
     assert layout == original
     assert_snapshot("reordered-collapsed.txt", "\n".join(frame))
+
+
+@pytest.mark.skipif(not student_lab_utui.is_available(), reason="utui non installato")
+def test_explicit_utui_cli_smoke_uses_the_real_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    payload = {
+        "schema_version": "student_lab.v1",
+        "student_id": "rossi-mario",
+        "assignments": [ASSIGNMENT],
+    }
+    outputs: list[str] = []
+    inputs = iter(("1", "", "q"))
+    monkeypatch.setattr(
+        student_lab_cli,
+        "load_payload",
+        lambda root, student_id, now=None: payload,
+    )
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda _prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+        use_color=False,
+        renderer="utui",
+        interactive=False,
+    )
+
+    assert result == 0
+    rendered = "\n".join(outputs)
+    assert "+ > Dettaglio consegna" in rendered
+    assert "Navigazione: j = scorri giu" in rendered
+    assert "Azioni: e = test/report" in rendered
 
 
 def test_render_falls_back_after_adapter_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_student_lab_utui.py
+++ b/tests/test_student_lab_utui.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import copy
 import os
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -305,36 +307,56 @@ def test_reordered_collapsed_focus_snapshot_without_layout_mutation() -> None:
 
 
 @pytest.mark.skipif(not student_lab_utui.is_available(), reason="utui non installato")
-def test_explicit_utui_cli_smoke_uses_the_real_adapter(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    payload = {
-        "schema_version": "student_lab.v1",
-        "student_id": "rossi-mario",
-        "assignments": [ASSIGNMENT],
+def test_explicit_utui_cli_smoke_uses_a_real_demo_root(tmp_path: Path) -> None:
+    demo_root = tmp_path / "student-lab-utui"
+    environment = {
+        **os.environ,
+        "PYTHONUTF8": "1",
+        "THEBITLAB_REQUIRE_UTUI": "1",
     }
-    outputs: list[str] = []
-    inputs = iter(("1", "", "q"))
-    monkeypatch.setattr(
-        student_lab_cli,
-        "load_payload",
-        lambda root, student_id, now=None: payload,
+    setup = subprocess.run(
+        [
+            sys.executable,
+            str(student_lab_cli.PROJECT_ROOT / "scripts" / "student_lab_demo_setup.py"),
+            "--root",
+            str(demo_root),
+        ],
+        cwd=student_lab_cli.PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+        check=False,
+    )
+    assert setup.returncode == 0, setup.stderr
+
+    cli = subprocess.run(
+        [
+            sys.executable,
+            str(student_lab_cli.PROJECT_ROOT / "scripts" / "student_lab_cli.py"),
+            "--root",
+            str(demo_root),
+            "--student-id",
+            "rossi-mario",
+            "--renderer",
+            "utui",
+            "--no-clear",
+            "--no-color",
+        ],
+        cwd=student_lab_cli.PROJECT_ROOT,
+        env=environment,
+        input="1\n\nq\n",
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+        check=False,
     )
 
-    result = student_lab_cli.run_tui(
-        student_id="rossi-mario",
-        root=tmp_path,
-        input_fn=lambda _prompt: next(inputs),
-        print_fn=outputs.append,
-        clear=False,
-        use_color=False,
-        renderer="utui",
-        interactive=False,
-    )
-
-    assert result == 0
-    rendered = "\n".join(outputs)
+    assert cli.returncode == 0, cli.stderr
+    rendered = cli.stdout
+    assert "Demo somma in Python" in rendered
     assert "+ > Dettaglio consegna" in rendered
     assert "Navigazione: j = scorri giu" in rendered
     assert "Azioni: e = test/report" in rendered


### PR DESCRIPTION
## Cosa cambia

- aggiunge una matrice consumer uTUI su Ubuntu e Windows con Python 3.11, 3.12 e 3.13;
- installa obbligatoriamente il pin `requirements-utui.txt` e fallisce se l'adapter non e disponibile;
- esegue adapter, layout e CLI in ogni combinazione;
- aggiunge uno smoke CLI con `--renderer utui` che usa l'adapter reale;
- documenta il comando locale equivalente.

## Perche

I job principali coprivano soltanto parte della matrice. Questa PR produce l'evidenza consumer cross-platform richiesta per il closeout di `TheBitPoets/utui#25`, evitando che snapshot saltati vengano scambiati per integrazione verificata.

Closes #494
Parent: #288, #292
Upstream: TheBitPoets/utui#25

## Verifica locale

`$env:THEBITLAB_REQUIRE_UTUI='1'; py -3.12 -m pytest tests/test_student_lab_utui.py tests/test_student_lab_layout.py tests/test_student_lab_cli.py -q`

Risultato: 92 test passati, nessuno skip.