### PR TITLE
Rendi portabile il runner SQL locale

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -71,13 +71,15 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt
 
-      - name: Test storage, lab and deletion workflows
+      - name: Test storage, lab, runner and deletion workflows
         run: >-
           python -m pytest
           tests/test_assignment_records.py
+          tests/test_grade_activity.py
           tests/test_student_help_service.py
           tests/test_student_help_codex_adapter.py
           tests/test_student_lab_service.py
+          tests/test_student_lab_runner.py
           tests/test_student_lab_cli.py
           tests/test_student_lab_utui.py
           tests/test_student_lab_demo_setup.py

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -71,20 +71,25 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt
 
-      - name: Test storage, lab, runner and deletion workflows
+      - name: Test storage, lab and deletion workflows
         run: >-
           python -m pytest
           tests/test_assignment_records.py
-          tests/test_grade_activity.py
           tests/test_student_help_service.py
           tests/test_student_help_codex_adapter.py
           tests/test_student_lab_service.py
-          tests/test_student_lab_runner.py
           tests/test_student_lab_cli.py
           tests/test_student_lab_utui.py
           tests/test_student_lab_demo_setup.py
           tests/test_track_assignments.py
           tests/test_course_board_server.py
+
+      - name: Test portable Node.js and SQL runners
+        run: >-
+          python -m pytest
+          tests/test_grade_activity.py
+          tests/test_student_lab_runner.py
+          -k "javascript or node or sql"
 
   minimum-python:
     runs-on: ubuntu-latest

--- a/doc/ASSIGNMENT_GRADING.md
+++ b/doc/ASSIGNMENT_GRADING.md
@@ -10,6 +10,10 @@ scheda attivita -> sorgente -> runner linguaggio -> test -> report JSON
 
 I runner iniziali sono C, Python, JavaScript/Node.js e SQL. Gli altri linguaggi vengono previsti nel modello per evitare di legare TheBitLab a un solo linguaggio.
 
+Nel backend locale, C richiede `gcc` e JavaScript/Node.js richiede il comando `node`. Python usa l'interprete che
+avvia TheBitLab; SQL usa il modulo `sqlite3` della standard library Python e non richiede l'omonima CLI esterna.
+Il backend Docker include tutti questi runtime nell'immagine del runner.
+
 ## Linguaggi previsti
 
 | Linguaggio | Stato iniziale |

--- a/doc/ASSIGNMENT_SANDBOX.md
+++ b/doc/ASSIGNMENT_SANDBOX.md
@@ -21,6 +21,8 @@ L'immagine contiene:
 - `gcc`;
 - librerie C essenziali;
 - `python3`;
+- `nodejs`;
+- `sqlite3`;
 - utente non root `runner`;
 - working directory `/workspace`.
 

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -4,9 +4,11 @@ import argparse
 import json
 import os
 import shutil
+import sqlite3
 import subprocess
 import tempfile
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -190,7 +192,64 @@ def run_sql_test_case(source: Path, test_case: dict[str, Any], *, timeout_second
     """Run one SQL script against an isolated in-memory SQLite database."""
 
     sql = source.read_text(encoding="utf-8") + "\n" + str(test_case.get("stdin", ""))
-    return run_command_test_case(["sqlite3", ":memory:"], {**test_case, "stdin": sql}, timeout_seconds=timeout_seconds)
+    expected_stdout = str(test_case.get("expected_stdout", ""))
+    name = str(test_case.get("name", "test"))
+    command = ["python-stdlib", "sqlite3", ":memory:"]
+    deadline = time.monotonic() + timeout_seconds
+    timed_out = False
+    output_lines: list[str] = []
+
+    def stop_after_deadline() -> int:
+        nonlocal timed_out
+        timed_out = time.monotonic() >= deadline
+        return 1 if timed_out else 0
+
+    try:
+        with sqlite3.connect(":memory:") as connection:
+            connection.set_progress_handler(stop_after_deadline, 1000)
+            statement_buffer = ""
+            for character in sql:
+                statement_buffer += character
+                if character != ";" or not sqlite3.complete_statement(statement_buffer):
+                    continue
+                cursor = connection.execute(statement_buffer)
+                if cursor.description:
+                    output_lines.extend(
+                        "|".join("" if value is None else str(value) for value in row)
+                        for row in cursor.fetchall()
+                    )
+                statement_buffer = ""
+            if statement_buffer.strip():
+                cursor = connection.execute(statement_buffer)
+                if cursor.description:
+                    output_lines.extend(
+                        "|".join("" if value is None else str(value) for value in row)
+                        for row in cursor.fetchall()
+                    )
+    except sqlite3.Error as error:
+        return {
+            "name": name,
+            "passed": False,
+            "status": "timeout" if timed_out else "execution-error",
+            "command": command,
+            "returncode": None if timed_out else 1,
+            "stdout": "\n".join(output_lines) + ("\n" if output_lines else ""),
+            "stderr": f"Timeout dopo {timeout_seconds} secondi." if timed_out else str(error),
+            "expected_stdout": expected_stdout,
+        }
+
+    actual_stdout = "\n".join(output_lines) + ("\n" if output_lines else "")
+    passed = normalize_output(actual_stdout) == normalize_output(expected_stdout)
+    return {
+        "name": name,
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "command": command,
+        "returncode": 0,
+        "stdout": actual_stdout,
+        "stderr": "",
+        "expected_stdout": expected_stdout,
+    }
 
 
 def validate_test_cases(test_cases: Any) -> list[str]:

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -387,7 +387,12 @@ def grade_activity(
         return grade_python_activity(activity, source, timeout_seconds=timeout_seconds)
 
     if selected_language in {"javascript", "nodejs"}:
-        return grade_node_activity(activity, source, timeout_seconds=timeout_seconds)
+        return grade_node_activity(
+            activity,
+            source,
+            timeout_seconds=timeout_seconds,
+            language=selected_language,
+        )
 
     if selected_language == "sql":
         return grade_sql_activity(activity, source, timeout_seconds=timeout_seconds)
@@ -515,13 +520,19 @@ def grade_python_activity(activity: dict[str, Any], source: Path, *, timeout_sec
     )
 
 
-def grade_node_activity(activity: dict[str, Any], source: Path, *, timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+def grade_node_activity(
+    activity: dict[str, Any],
+    source: Path,
+    *,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    language: str = "javascript",
+) -> dict[str, Any]:
     """Execute and grade a Node.js source file using activity test cases."""
 
     return grade_script_activity(
         activity,
         source,
-        language="javascript",
+        language=language,
         test_runner=run_node_test_case,
         timeout_seconds=timeout_seconds,
     )

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -14,7 +14,7 @@ from typing import Any
 
 
 DEFAULT_TIMEOUT_SECONDS = 5
-DEFAULT_NODE_STARTUP_GRACE_SECONDS = 5
+DEFAULT_NODE_STARTUP_GRACE_SECONDS = 10
 DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS = 10
 DEFAULT_DOCKER_IMAGE = "thebitlab-assignment-runner"
 SUPPORTED_LANGUAGES = {
@@ -186,10 +186,43 @@ def run_python_test_case(source: Path, test_case: dict[str, Any], *, timeout_sec
 def run_node_test_case(source: Path, test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
     """Run one JavaScript source file through Node.js."""
 
+    name = str(test_case.get("name", "test"))
+    expected_stdout = str(test_case.get("expected_stdout", ""))
+    startup_command = ["node", "--check", str(source)]
+    try:
+        subprocess.run(
+            startup_command,
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_NODE_STARTUP_GRACE_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        return {
+            "name": name,
+            "passed": False,
+            "status": "runtime-startup-timeout",
+            "command": startup_command,
+            "returncode": None,
+            "stdout": error.stdout or "",
+            "stderr": error.stderr or "",
+            "expected_stdout": expected_stdout,
+        }
+    except OSError as error:
+        return {
+            "name": name,
+            "passed": False,
+            "status": "execution-error",
+            "command": startup_command,
+            "returncode": None,
+            "stdout": "",
+            "stderr": str(error),
+            "expected_stdout": expected_stdout,
+        }
     return run_command_test_case(
         ["node", str(source)],
         test_case,
-        timeout_seconds=timeout_seconds + DEFAULT_NODE_STARTUP_GRACE_SECONDS,
+        timeout_seconds=timeout_seconds,
     )
 
 

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -14,6 +14,7 @@ from typing import Any
 
 
 DEFAULT_TIMEOUT_SECONDS = 5
+DEFAULT_NODE_STARTUP_GRACE_SECONDS = 5
 DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS = 10
 DEFAULT_DOCKER_IMAGE = "thebitlab-assignment-runner"
 SUPPORTED_LANGUAGES = {
@@ -185,7 +186,11 @@ def run_python_test_case(source: Path, test_case: dict[str, Any], *, timeout_sec
 def run_node_test_case(source: Path, test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
     """Run one JavaScript source file through Node.js."""
 
-    return run_command_test_case(["node", str(source)], test_case, timeout_seconds=timeout_seconds)
+    return run_command_test_case(
+        ["node", str(source)],
+        test_case,
+        timeout_seconds=timeout_seconds + DEFAULT_NODE_STARTUP_GRACE_SECONDS,
+    )
 
 
 def sqlite_output_value(value: Any) -> str:
@@ -516,7 +521,10 @@ def docker_timeout_seconds(activity: dict[str, Any], timeout_seconds: int) -> in
     """Return the outer Docker timeout for compile plus all declared test cases."""
     test_cases = activity.get("test_cases", [])
     test_count = len(test_cases) if isinstance(test_cases, list) else 0
-    return ((test_count + 1) * timeout_seconds) + DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS
+    test_timeout = timeout_seconds
+    if activity_language(activity) in {"javascript", "nodejs"}:
+        test_timeout += DEFAULT_NODE_STARTUP_GRACE_SECONDS
+    return (test_count * test_timeout) + timeout_seconds + DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS
 
 
 def path_inside_workspace(path: Path, workspace: Path, label: str) -> str:

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -199,6 +199,12 @@ def run_sql_test_case(source: Path, test_case: dict[str, Any], *, timeout_second
     timed_out = False
     output_lines: list[str] = []
 
+    def ensure_before_deadline() -> None:
+        nonlocal timed_out
+        if time.monotonic() >= deadline:
+            timed_out = True
+            raise TimeoutError
+
     def stop_after_deadline() -> int:
         nonlocal timed_out
         timed_out = time.monotonic() >= deadline
@@ -207,26 +213,34 @@ def run_sql_test_case(source: Path, test_case: dict[str, Any], *, timeout_second
     try:
         with sqlite3.connect(":memory:") as connection:
             connection.set_progress_handler(stop_after_deadline, 1000)
-            statement_buffer = ""
-            for character in sql:
-                statement_buffer += character
-                if character != ";" or not sqlite3.complete_statement(statement_buffer):
+            statement_buffer: list[str] = []
+            for index, character in enumerate(sql):
+                if index % 1024 == 0:
+                    ensure_before_deadline()
+                statement_buffer.append(character)
+                if character != ";":
                     continue
-                cursor = connection.execute(statement_buffer)
+                statement = "".join(statement_buffer)
+                if not sqlite3.complete_statement(statement):
+                    continue
+                ensure_before_deadline()
+                cursor = connection.execute(statement)
                 if cursor.description:
                     output_lines.extend(
                         "|".join("" if value is None else str(value) for value in row)
                         for row in cursor.fetchall()
                     )
-                statement_buffer = ""
-            if statement_buffer.strip():
-                cursor = connection.execute(statement_buffer)
+                statement_buffer.clear()
+            trailing_statement = "".join(statement_buffer)
+            if trailing_statement.strip():
+                ensure_before_deadline()
+                cursor = connection.execute(trailing_statement)
                 if cursor.description:
                     output_lines.extend(
                         "|".join("" if value is None else str(value) for value in row)
                         for row in cursor.fetchall()
                     )
-    except sqlite3.Error as error:
+    except (sqlite3.Error, TimeoutError) as error:
         return {
             "name": name,
             "passed": False,

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -550,12 +550,16 @@ def has_minimal_report_shape(value: Any) -> bool:
     return isinstance(value, dict) and isinstance(value.get("passed"), bool) and isinstance(value.get("status"), str)
 
 
-def docker_timeout_seconds(activity: dict[str, Any], timeout_seconds: int) -> int:
+def docker_timeout_seconds(
+    activity: dict[str, Any],
+    timeout_seconds: int,
+    language: str | None = None,
+) -> int:
     """Return the outer Docker timeout for compile plus all declared test cases."""
     test_cases = activity.get("test_cases", [])
     test_count = len(test_cases) if isinstance(test_cases, list) else 0
     test_timeout = timeout_seconds
-    if activity_language(activity) in {"javascript", "nodejs"}:
+    if activity_language(activity, language) in {"javascript", "nodejs"}:
         test_timeout += DEFAULT_NODE_STARTUP_GRACE_SECONDS
     return (test_count * test_timeout) + timeout_seconds + DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS
 
@@ -653,7 +657,7 @@ def run_docker_grading(args: argparse.Namespace) -> int:
         temp_root = Path(temp_dir)
         try:
             workspace, activity, source = prepare_docker_workspace(args.activity, args.source, temp_root)
-            docker_timeout = docker_timeout_seconds(load_activity(activity), args.timeout)
+            docker_timeout = docker_timeout_seconds(load_activity(activity), args.timeout, args.language)
             command = docker_command(
                 activity=activity,
                 source=source,

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -188,6 +188,16 @@ def run_node_test_case(source: Path, test_case: dict[str, Any], *, timeout_secon
     return run_command_test_case(["node", str(source)], test_case, timeout_seconds=timeout_seconds)
 
 
+def sqlite_output_value(value: Any) -> str:
+    """Serialize one SQLite value like the previous text-mode CLI runner."""
+
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
 def run_sql_test_case(source: Path, test_case: dict[str, Any], *, timeout_seconds: int) -> dict[str, Any]:
     """Run one SQL script against an isolated in-memory SQLite database."""
 
@@ -227,7 +237,7 @@ def run_sql_test_case(source: Path, test_case: dict[str, Any], *, timeout_second
                 cursor = connection.execute(statement)
                 if cursor.description:
                     output_lines.extend(
-                        "|".join("" if value is None else str(value) for value in row)
+                        "|".join(sqlite_output_value(value) for value in row)
                         for row in cursor.fetchall()
                     )
                 statement_buffer.clear()
@@ -237,7 +247,7 @@ def run_sql_test_case(source: Path, test_case: dict[str, Any], *, timeout_second
                 cursor = connection.execute(trailing_statement)
                 if cursor.description:
                     output_lines.extend(
-                        "|".join("" if value is None else str(value) for value in row)
+                        "|".join(sqlite_output_value(value) for value in row)
                         for row in cursor.fetchall()
                     )
     except (sqlite3.Error, TimeoutError) as error:

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -24,6 +24,9 @@ RUNNER_BACKENDS = {"local", "docker"}
 DEFAULT_SOURCE_NAMES = {
     "c": "main.c",
     "python": "main.py",
+    "javascript": "main.js",
+    "nodejs": "main.js",
+    "sql": "main.sql",
 }
 
 

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -315,7 +315,11 @@ def run_docker_runner(
         temp_root = Path(temp_dir)
         try:
             workspace, copied_activity, copied_source = grade_activity.prepare_docker_workspace(activity_path, source, temp_root)
-            docker_timeout = grade_activity.docker_timeout_seconds(grade_activity.load_activity(copied_activity), timeout_seconds)
+            docker_timeout = grade_activity.docker_timeout_seconds(
+                grade_activity.load_activity(copied_activity),
+                timeout_seconds,
+                language,
+            )
             command = grade_activity.docker_command(
                 activity=copied_activity,
                 source=copied_source,

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -164,18 +164,32 @@ def test_grade_activity_passes_valid_javascript_program(tmp_path) -> None:
     assert report["language"] == "javascript"
 
 
-def test_node_runner_adds_runtime_startup_grace(monkeypatch, tmp_path) -> None:
-    captured: dict[str, int] = {}
+def test_node_runner_keeps_startup_grace_separate_from_student_timeout(monkeypatch, tmp_path) -> None:
+    captured: dict[str, int | list[str]] = {}
+
+    class StartupResult:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_startup(command, **kwargs):
+        captured["startup_command"] = command
+        captured["startup_timeout"] = kwargs["timeout"]
+        return StartupResult()
 
     def fake_run(command, test_case, *, timeout_seconds):
-        captured["timeout_seconds"] = timeout_seconds
+        captured["student_timeout"] = timeout_seconds
         return {"passed": True, "status": "passed"}
 
+    monkeypatch.setattr(grade_activity.subprocess, "run", fake_startup)
     monkeypatch.setattr(grade_activity, "run_command_test_case", fake_run)
+    source = tmp_path / "main.js"
 
-    grade_activity.run_node_test_case(tmp_path / "main.js", {}, timeout_seconds=2)
+    grade_activity.run_node_test_case(source, {}, timeout_seconds=2)
 
-    assert captured["timeout_seconds"] == 2 + grade_activity.DEFAULT_NODE_STARTUP_GRACE_SECONDS
+    assert captured["startup_command"] == ["node", "--check", str(source)]
+    assert captured["startup_timeout"] == grade_activity.DEFAULT_NODE_STARTUP_GRACE_SECONDS
+    assert captured["student_timeout"] == 2
 
 
 def test_grade_activity_passes_valid_sql_script(tmp_path) -> None:
@@ -446,7 +460,7 @@ def test_docker_timeout_scales_with_test_cases() -> None:
     activity = {"test_cases": [{"name": "uno"}, {"name": "due"}, {"name": "tre"}]}
 
     assert grade_activity.docker_timeout_seconds(activity, 5) == 30
-    assert grade_activity.docker_timeout_seconds({**activity, "linguaggio": "javascript"}, 5) == 45
+    assert grade_activity.docker_timeout_seconds({**activity, "linguaggio": "javascript"}, 5) == 60
 
 
 def test_run_docker_grading_reports_missing_input_before_docker(tmp_path) -> None:

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -164,6 +164,20 @@ def test_grade_activity_passes_valid_javascript_program(tmp_path) -> None:
     assert report["language"] == "javascript"
 
 
+def test_node_runner_adds_runtime_startup_grace(monkeypatch, tmp_path) -> None:
+    captured: dict[str, int] = {}
+
+    def fake_run(command, test_case, *, timeout_seconds):
+        captured["timeout_seconds"] = timeout_seconds
+        return {"passed": True, "status": "passed"}
+
+    monkeypatch.setattr(grade_activity, "run_command_test_case", fake_run)
+
+    grade_activity.run_node_test_case(tmp_path / "main.js", {}, timeout_seconds=2)
+
+    assert captured["timeout_seconds"] == 2 + grade_activity.DEFAULT_NODE_STARTUP_GRACE_SECONDS
+
+
 def test_grade_activity_passes_valid_sql_script(tmp_path) -> None:
     source = tmp_path / "main.sql"
     source.write_text("SELECT 2 + 3;\n", encoding="utf-8")
@@ -432,6 +446,7 @@ def test_docker_timeout_scales_with_test_cases() -> None:
     activity = {"test_cases": [{"name": "uno"}, {"name": "due"}, {"name": "tre"}]}
 
     assert grade_activity.docker_timeout_seconds(activity, 5) == 30
+    assert grade_activity.docker_timeout_seconds({**activity, "linguaggio": "javascript"}, 5) == 45
 
 
 def test_run_docker_grading_reports_missing_input_before_docker(tmp_path) -> None:

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -199,6 +199,23 @@ def test_grade_activity_sql_matches_sqlite_cli_rows_and_nulls(tmp_path) -> None:
     assert report["tests"][0]["stdout"] == "Ada|9\nLinus|\n"
 
 
+def test_grade_activity_sql_matches_sqlite_cli_blob_output(tmp_path) -> None:
+    source = tmp_path / "main.sql"
+    source.write_text("SELECT X'4142';\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity(
+        {
+            "id": "sql-blob-001",
+            "linguaggio": "sql",
+            "test_cases": [{"expected_stdout": "AB\n"}],
+        },
+        source,
+    )
+
+    assert report["passed"] is True
+    assert report["tests"][0]["stdout"] == "AB\n"
+
+
 def test_grade_activity_reports_sql_error(tmp_path) -> None:
     source = tmp_path / "main.sql"
     source.write_text("SELECT colonna_inesistente FROM studenti;\n", encoding="utf-8")

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -461,6 +461,7 @@ def test_docker_timeout_scales_with_test_cases() -> None:
 
     assert grade_activity.docker_timeout_seconds(activity, 5) == 30
     assert grade_activity.docker_timeout_seconds({**activity, "linguaggio": "javascript"}, 5) == 60
+    assert grade_activity.docker_timeout_seconds({**activity, "linguaggio": "c"}, 5, "javascript") == 60
 
 
 def test_run_docker_grading_reports_missing_input_before_docker(tmp_path) -> None:

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -164,7 +164,6 @@ def test_grade_activity_passes_valid_javascript_program(tmp_path) -> None:
     assert report["language"] == "javascript"
 
 
-@pytest.mark.skipif(shutil.which("sqlite3") is None, reason="sqlite3 non disponibile nell'ambiente di test")
 def test_grade_activity_passes_valid_sql_script(tmp_path) -> None:
     source = tmp_path / "main.sql"
     source.write_text("SELECT 2 + 3;\n", encoding="utf-8")
@@ -176,6 +175,72 @@ def test_grade_activity_passes_valid_sql_script(tmp_path) -> None:
 
     assert report["passed"] is True
     assert report["language"] == "sql"
+
+
+def test_grade_activity_sql_matches_sqlite_cli_rows_and_nulls(tmp_path) -> None:
+    source = tmp_path / "main.sql"
+    source.write_text(
+        "CREATE TABLE studenti (nome TEXT, voto INTEGER);\n"
+        "INSERT INTO studenti VALUES ('Ada', 9), ('Linus', NULL);\n"
+        "SELECT nome, voto FROM studenti ORDER BY nome;\n",
+        encoding="utf-8",
+    )
+
+    report = grade_activity.grade_activity(
+        {
+            "id": "sql-rows-001",
+            "linguaggio": "sql",
+            "test_cases": [{"expected_stdout": "Ada|9\nLinus|\n"}],
+        },
+        source,
+    )
+
+    assert report["passed"] is True
+    assert report["tests"][0]["stdout"] == "Ada|9\nLinus|\n"
+
+
+def test_grade_activity_reports_sql_error(tmp_path) -> None:
+    source = tmp_path / "main.sql"
+    source.write_text("SELECT colonna_inesistente FROM studenti;\n", encoding="utf-8")
+
+    report = grade_activity.grade_activity(
+        {
+            "id": "sql-error-001",
+            "linguaggio": "sql",
+            "test_cases": [{"expected_stdout": ""}],
+        },
+        source,
+    )
+
+    assert report["passed"] is False
+    assert report["status"] == "failed"
+    assert report["tests"][0]["status"] == "execution-error"
+    assert report["tests"][0]["returncode"] == 1
+    assert report["tests"][0]["stderr"]
+
+
+def test_grade_activity_reports_sql_timeout(tmp_path) -> None:
+    source = tmp_path / "main.sql"
+    source.write_text(
+        "WITH RECURSIVE numeri(n) AS ("
+        "SELECT 1 UNION ALL SELECT n + 1 FROM numeri WHERE n < 1000000"
+        ") SELECT sum(n) FROM numeri;\n",
+        encoding="utf-8",
+    )
+
+    report = grade_activity.grade_activity(
+        {
+            "id": "sql-timeout-001",
+            "linguaggio": "sql",
+            "test_cases": [{"expected_stdout": ""}],
+        },
+        source,
+        timeout_seconds=0,
+    )
+
+    assert report["passed"] is False
+    assert report["tests"][0]["status"] == "timeout"
+    assert report["tests"][0]["returncode"] is None
 
 
 def test_grade_activity_reports_unknown_language(tmp_path) -> None:

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -151,17 +151,18 @@ def test_grade_activity_reports_python_wrong_output(tmp_path) -> None:
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node non disponibile nell'ambiente di test")
-def test_grade_activity_passes_valid_javascript_program(tmp_path) -> None:
+@pytest.mark.parametrize("language", ["javascript", "nodejs"])
+def test_grade_activity_passes_valid_javascript_program(tmp_path, language) -> None:
     source = tmp_path / "main.js"
     source.write_text("let value = ''; process.stdin.on('data', chunk => value += chunk).on('end', () => console.log(Number(value) + 1));\n", encoding="utf-8")
 
     report = grade_activity.grade_activity(
-        {"id": "js-001", "linguaggio": "javascript", "test_cases": [{"stdin": "4\n", "expected_stdout": "5\n"}]},
+        {"id": "js-001", "linguaggio": language, "test_cases": [{"stdin": "4\n", "expected_stdout": "5\n"}]},
         source,
     )
 
     assert report["passed"] is True
-    assert report["language"] == "javascript"
+    assert report["language"] == language
 
 
 def test_node_runner_keeps_startup_grace_separate_from_student_timeout(monkeypatch, tmp_path) -> None:

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -243,6 +243,24 @@ def test_grade_activity_reports_sql_timeout(tmp_path) -> None:
     assert report["tests"][0]["returncode"] is None
 
 
+def test_grade_activity_applies_sql_timeout_during_parsing(tmp_path) -> None:
+    source = tmp_path / "main.sql"
+    source.write_text("-- " + ("commento " * 10000), encoding="utf-8")
+
+    report = grade_activity.grade_activity(
+        {
+            "id": "sql-parse-timeout-001",
+            "linguaggio": "sql",
+            "test_cases": [{"expected_stdout": ""}],
+        },
+        source,
+        timeout_seconds=0,
+    )
+
+    assert report["passed"] is False
+    assert report["tests"][0]["status"] == "timeout"
+
+
 def test_grade_activity_reports_unknown_language(tmp_path) -> None:
     source = tmp_path / "main.xyz"
     source.write_text("contenuto\n", encoding="utf-8")

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
+
+import pytest
 
 from scripts import assignment_records, student_lab_runner, student_lab_service
 
@@ -63,6 +66,56 @@ def write_python_workspace(root, *, source: str, test_source: str) -> None:
     tests.mkdir(parents=True)
     (workspace / "main.py").write_text(source, encoding="utf-8")
     (tests / "test_main.py").write_text(test_source, encoding="utf-8")
+
+
+def run_store_and_reload_script_assignment(
+    root,
+    *,
+    activity_id: str,
+    language: str,
+    source_name: str,
+    source: str,
+    test_cases: list[dict],
+) -> tuple[dict, dict]:
+    """Run a script assignment and reload its grading through the lab service."""
+
+    activity_path = write_activity(
+        root,
+        activity_id=activity_id,
+        language=language,
+        source_name=source_name,
+        test_cases=test_cases,
+    )
+    write_assignment(root, activity_path, activity_id=activity_id)
+    workspace = (
+        root
+        / "examples"
+        / "assignment_tracking"
+        / "student_repos"
+        / "rossi-mario"
+        / "assignments"
+        / activity_id
+    )
+    workspace.mkdir(parents=True)
+    (workspace / source_name).write_text(source, encoding="utf-8")
+
+    assignment = student_lab_runner.load_student_assignment(
+        root=root,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+        now="2026-10-18T12:00:00+02:00",
+    )
+    report = student_lab_runner.run_local_assignment(assignment, root=root)
+    student_lab_runner.write_student_report(root, assignment, report)
+    payload = student_lab_service.student_lab_payload(
+        root=root,
+        student_id="rossi-mario",
+        now="2026-10-20T12:00:00+02:00",
+    )
+    assignment_payload = next(
+        item for item in payload["assignments"] if item["activity_id"] == activity_id
+    )
+    return report, assignment_payload
 
 
 def test_run_student_assignment_passes_python_pytest(tmp_path) -> None:
@@ -127,6 +180,67 @@ def test_write_student_report_persists_latest_json_and_service_reads_it(tmp_path
     assert assignment_payload["submitted"] is True
     assert assignment_payload["report"]["exists"] is True
     assert assignment_payload["report"]["submitted_at"] == report["generated_at"]
+    assert assignment_payload["grading"]["status"] == "graded_passed"
+    assert assignment_payload["grading"]["tests_passed"] == 1
+    assert assignment_payload["grading"]["tests_total"] == 1
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node non disponibile nell'ambiente di test")
+def test_node_assignment_flows_from_runner_to_service_grading(tmp_path) -> None:
+    report, assignment_payload = run_store_and_reload_script_assignment(
+        tmp_path,
+        activity_id="javascript-incremento-001",
+        language="javascript",
+        source_name="main.js",
+        source=(
+            "let value = '';\n"
+            "process.stdin.on('data', chunk => value += chunk)\n"
+            "  .on('end', () => console.log(Number(value) + 1));\n"
+        ),
+        test_cases=[
+            {
+                "name": "incremento",
+                "stdin": "4\n",
+                "expected_stdout": "5\n",
+            }
+        ],
+    )
+
+    assert report["backend"] == "local"
+    assert report["language"] == "javascript"
+    assert report["status"] == "passed"
+    assert report["summary"] == {"passed": 1, "total": 1}
+    assert assignment_payload["report"]["exists"] is True
+    assert assignment_payload["grading"]["status"] == "graded_passed"
+    assert assignment_payload["grading"]["tests_passed"] == 1
+    assert assignment_payload["grading"]["tests_total"] == 1
+
+
+def test_sql_assignment_flows_from_runner_to_service_grading(tmp_path) -> None:
+    report, assignment_payload = run_store_and_reload_script_assignment(
+        tmp_path,
+        activity_id="sql-studenti-001",
+        language="sql",
+        source_name="main.sql",
+        source=(
+            "CREATE TABLE studenti (nome TEXT, voto INTEGER);\n"
+            "INSERT INTO studenti VALUES ('Ada', 9), ('Linus', 8);\n"
+            "SELECT nome, voto FROM studenti ORDER BY nome;\n"
+        ),
+        test_cases=[
+            {
+                "name": "elenco studenti",
+                "expected_stdout": "Ada|9\nLinus|8\n",
+            }
+        ],
+    )
+
+    assert report["backend"] == "local"
+    assert report["language"] == "sql"
+    assert report["status"] == "passed"
+    assert report["summary"] == {"passed": 1, "total": 1}
+    assert report["tests"][0]["command"][0] == "python-stdlib"
+    assert assignment_payload["report"]["exists"] is True
     assert assignment_payload["grading"]["status"] == "graded_passed"
     assert assignment_payload["grading"]["tests_passed"] == 1
     assert assignment_payload["grading"]["tests_total"] == 1

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -86,6 +86,10 @@ def run_store_and_reload_script_assignment(
         source_name=source_name,
         test_cases=test_cases,
     )
+    activity_file = root / activity_path
+    activity_payload = json.loads(activity_file.read_text(encoding="utf-8"))
+    activity_payload.pop("source_name")
+    activity_file.write_text(json.dumps(activity_payload), encoding="utf-8")
     write_assignment(root, activity_path, activity_id=activity_id)
     workspace = (
         root


### PR DESCRIPTION
## Cosa cambia

- sostituisce la dipendenza locale dalla CLI `sqlite3` con il modulo SQLite della standard library Python;
- mantiene il confronto deterministico stdin/stdout e il formato dei report;
- gestisce righe, valori `NULL`, errori e timeout SQL;
- verifica Node.js e SQL lungo il flusso consegna -> workspace -> runner -> report -> grading;
- documenta i runtime richiesti dai backend locale e Docker.

## Verifica

- `python -m pytest -q tests/test_grade_activity.py tests/test_student_lab_runner.py`
- `python -m pytest -q`
- `python -m compileall -q scripts`

Suite completa: verde; restano soltanto gli skip gia previsti per tool/permessi non disponibili nell'ambiente.

Closes #496
Related to #292
Related to #288