### PR TITLE
Verifica Node.js e SQL nel lab Docker completo

### DIFF
--- a/.github/workflows/assignment-runner-docker.yml
+++ b/.github/workflows/assignment-runner-docker.yml
@@ -11,6 +11,7 @@ on:
       - "scripts/grade_activity.py"
       - "scripts/student_lab_runner.py"
       - "tests/test_student_lab_runner.py"
+      - "tests/test_student_lab_runner_docker.py"
       - ".github/workflows/assignment-runner-docker.yml"
   push:
     branches:
@@ -20,6 +21,7 @@ on:
       - "scripts/grade_activity.py"
       - "scripts/student_lab_runner.py"
       - "tests/test_student_lab_runner.py"
+      - "tests/test_student_lab_runner_docker.py"
       - ".github/workflows/assignment-runner-docker.yml"
 
 jobs:
@@ -31,6 +33,9 @@ jobs:
 
       - name: Build assignment runner image
         run: docker build -t thebitlab-assignment-runner -f docker/assignment-runner/Dockerfile .
+
+      - name: Install integration test dependencies
+        run: python -m pip install -r requirements-dev.txt
 
       - name: Smoke test assignment runner image
         run: |
@@ -251,3 +256,8 @@ jobs:
           assert report["status"] == "passed"
           assert report["summary"] == {"passed": 1, "total": 1}
           PY
+
+      - name: Test Node.js and SQL through the student lab
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+        run: python -m pytest -q tests/test_student_lab_runner_docker.py

--- a/.github/workflows/assignment-runner-docker.yml
+++ b/.github/workflows/assignment-runner-docker.yml
@@ -8,8 +8,12 @@ on:
   pull_request:
     paths:
       - "docker/assignment-runner/**"
+      - "scripts/assignment_records.py"
+      - "scripts/create_activity.py"
       - "scripts/grade_activity.py"
-      - "scripts/student_lab_runner.py"
+      - "scripts/student_*.py"
+      - "scripts/thebitlab_contracts.py"
+      - "scripts/track_assignments.py"
       - "tests/test_student_lab_runner.py"
       - "tests/test_student_lab_runner_docker.py"
       - ".github/workflows/assignment-runner-docker.yml"
@@ -18,8 +22,12 @@ on:
       - main
     paths:
       - "docker/assignment-runner/**"
+      - "scripts/assignment_records.py"
+      - "scripts/create_activity.py"
       - "scripts/grade_activity.py"
-      - "scripts/student_lab_runner.py"
+      - "scripts/student_*.py"
+      - "scripts/thebitlab_contracts.py"
+      - "scripts/track_assignments.py"
       - "tests/test_student_lab_runner.py"
       - "tests/test_student_lab_runner_docker.py"
       - ".github/workflows/assignment-runner-docker.yml"

--- a/.github/workflows/assignment-runner-docker.yml
+++ b/.github/workflows/assignment-runner-docker.yml
@@ -8,12 +8,7 @@ on:
   pull_request:
     paths:
       - "docker/assignment-runner/**"
-      - "scripts/assignment_records.py"
-      - "scripts/create_activity.py"
-      - "scripts/grade_activity.py"
-      - "scripts/student_*.py"
-      - "scripts/thebitlab_contracts.py"
-      - "scripts/track_assignments.py"
+      - "scripts/**"
       - "tests/test_student_lab_runner.py"
       - "tests/test_student_lab_runner_docker.py"
       - ".github/workflows/assignment-runner-docker.yml"
@@ -22,12 +17,7 @@ on:
       - main
     paths:
       - "docker/assignment-runner/**"
-      - "scripts/assignment_records.py"
-      - "scripts/create_activity.py"
-      - "scripts/grade_activity.py"
-      - "scripts/student_*.py"
-      - "scripts/thebitlab_contracts.py"
-      - "scripts/track_assignments.py"
+      - "scripts/**"
       - "tests/test_student_lab_runner.py"
       - "tests/test_student_lab_runner_docker.py"
       - ".github/workflows/assignment-runner-docker.yml"

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -175,13 +175,29 @@ Per salvare il risultato nel path standard dello studente:
 python scripts/student_lab_runner.py --student-id rossi-mario --activity-id python-base-somma-001 --write-report
 ```
 
-Per usare la sandbox Docker minima, per ora sulle consegne C:
+Per usare la sandbox Docker minima sulle consegne C, Python, JavaScript/Node.js o SQL:
 
 ```powershell
 python scripts/student_lab_runner.py --student-id rossi-mario --activity-id c-base-somma-001 --backend docker --write-report
 ```
 
 Il backend Docker usa l'immagine `thebitlab-assignment-runner`. Se Docker non è installato o non è avviato, il runner produce un report `docker-not-found` invece di interrompere la TUI con uno stack trace.
+
+Il collaudo reale Node.js/SQL, comprensivo di report persistito e grading riletto dal servizio, si esegue dopo aver
+costruito l'immagine:
+
+```powershell
+docker build -t thebitlab-assignment-runner -f docker/assignment-runner/Dockerfile .
+$env:THEBITLAB_RUN_DOCKER_TESTS = "1"
+python -m pytest -q tests/test_student_lab_runner_docker.py
+```
+
+Su Linux:
+
+```bash
+docker build -t thebitlab-assignment-runner -f docker/assignment-runner/Dockerfile .
+THEBITLAB_RUN_DOCKER_TESTS=1 python -m pytest -q tests/test_student_lab_runner_docker.py
+```
 
 La TUI usa colori ANSI quando il terminale li supporta. Per disattivarli:
 

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -587,6 +587,67 @@ def test_run_docker_assignment_supports_python(monkeypatch, tmp_path) -> None:
     assert report["language"] == "python"
 
 
+@pytest.mark.parametrize(
+    ("language", "source_name"),
+    [
+        ("javascript", "main.js"),
+        ("nodejs", "main.js"),
+        ("sql", "main.sql"),
+    ],
+)
+def test_run_docker_assignment_supports_node_and_sql(
+    monkeypatch,
+    tmp_path,
+    language,
+    source_name,
+) -> None:
+    activity_id = f"{language}-docker-001"
+    activity_path = write_activity(
+        tmp_path,
+        activity_id=activity_id,
+        language=language,
+        source_name=source_name,
+    )
+    write_assignment(tmp_path, activity_path, activity_id=activity_id)
+    workspace = (
+        tmp_path
+        / "examples"
+        / "assignment_tracking"
+        / "student_repos"
+        / "rossi-mario"
+        / "assignments"
+        / activity_id
+    )
+    workspace.mkdir(parents=True)
+    (workspace / source_name).write_text("SELECT 1;\n" if language == "sql" else "console.log(1);\n", encoding="utf-8")
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                "passed": True,
+                "status": "passed",
+                "language": language,
+                "tests": [{"name": "output", "passed": True, "status": "passed"}],
+                "summary": {"passed": 1, "total": 1},
+            }
+        )
+        stderr = ""
+
+    monkeypatch.setattr(student_lab_runner.subprocess, "run", lambda *args, **kwargs: Result())
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+        backend="docker",
+    )
+
+    assert report["backend"] == "docker"
+    assert report["status"] == "passed"
+    assert report["language"] == language
+
+
 def test_select_assignment_requires_disambiguation() -> None:
     try:
         student_lab_runner.select_assignment(

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -634,7 +634,13 @@ def test_run_docker_assignment_supports_node_and_sql(
         )
         stderr = ""
 
-    monkeypatch.setattr(student_lab_runner.subprocess, "run", lambda *args, **kwargs: Result())
+    captured: dict[str, list[str]] = {}
+
+    def run_docker(command, **kwargs):
+        captured["command"] = command
+        return Result()
+
+    monkeypatch.setattr(student_lab_runner.subprocess, "run", run_docker)
 
     report = student_lab_runner.run_student_assignment(
         root=tmp_path,
@@ -646,6 +652,8 @@ def test_run_docker_assignment_supports_node_and_sql(
     assert report["backend"] == "docker"
     assert report["status"] == "passed"
     assert report["language"] == language
+    language_index = captured["command"].index("--language")
+    assert captured["command"][language_index + 1] == language
 
 
 def test_select_assignment_requires_disambiguation() -> None:

--- a/tests/test_student_lab_runner_docker.py
+++ b/tests/test_student_lab_runner_docker.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from scripts import assignment_records, student_lab_runner, student_lab_service
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1",
+    reason="test Docker reale abilitato solo con THEBITLAB_RUN_DOCKER_TESTS=1",
+)
+
+
+@pytest.mark.parametrize(
+    ("language", "source_name", "source", "test_case"),
+    [
+        (
+            "nodejs",
+            "main.js",
+            (
+                "let value = '';\n"
+                "process.stdin.on('data', chunk => value += chunk)\n"
+                "  .on('end', () => console.log(Number(value) + 1));\n"
+            ),
+            {
+                "name": "incremento",
+                "stdin": "4\n",
+                "expected_stdout": "5\n",
+            },
+        ),
+        (
+            "sql",
+            "main.sql",
+            "SELECT 2 + 3;\n",
+            {
+                "name": "somma",
+                "expected_stdout": "5\n",
+            },
+        ),
+    ],
+)
+def test_docker_assignment_flows_through_report_and_service(
+    tmp_path,
+    language,
+    source_name,
+    source,
+    test_case,
+) -> None:
+    activity_id = f"{language}-docker-e2e-001"
+    activity_path = tmp_path / "activities" / f"{activity_id}.json"
+    activity_path.parent.mkdir(parents=True)
+    activity_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": activity_id,
+                "title": f"Demo Docker {language}",
+                "kind": "laboratorio",
+                "difficulty": "B",
+                "topics": ["runner"],
+                "language": language,
+                "source_name": source_name,
+                "instructions": "Completa la consegna.",
+                "grading_policy": {
+                    "compila": True,
+                    "test": True,
+                    "sandbox": True,
+                    "ai_feedback": False,
+                },
+                "test_cases": [test_case],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assignment = assignment_records.build_assignment_record(
+        activity_id=activity_id,
+        activity_path=f"activities/{activity_id}.json",
+        target_type="student",
+        assigned_at="2026-10-12T09:00:00+02:00",
+        due_at="2026-10-19T23:59:00+02:00",
+        targets=[
+            {
+                "student_id": "rossi-mario",
+                "display_name": "Rossi Mario",
+                "path": "examples/assignment_tracking/student_repos/rossi-mario",
+            }
+        ],
+    )
+    assignment_records.JsonAssignmentRecordStorage(tmp_path).write_assignment(assignment)
+    workspace = (
+        tmp_path
+        / "examples"
+        / "assignment_tracking"
+        / "student_repos"
+        / "rossi-mario"
+        / "assignments"
+        / activity_id
+    )
+    workspace.mkdir(parents=True)
+    (workspace / source_name).write_text(source, encoding="utf-8")
+
+    loaded_assignment = student_lab_runner.load_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+        now="2026-10-18T12:00:00+02:00",
+    )
+    report = student_lab_runner.run_docker_assignment(
+        loaded_assignment,
+        root=tmp_path,
+    )
+    report_path = student_lab_runner.write_student_report(
+        tmp_path,
+        loaded_assignment,
+        report,
+    )
+
+    assert report_path.is_file()
+    assert report["backend"] == "docker"
+    assert report["language"] == language
+    assert report["passed"] is True
+    assert report["status"] == "passed"
+    assert report["summary"] == {"passed": 1, "total": 1}
+
+    payload = student_lab_service.student_lab_payload(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-18T12:00:00+02:00",
+    )
+    assignment_payload = next(
+        item for item in payload["assignments"] if item["activity_id"] == activity_id
+    )
+    assert assignment_payload["report"]["exists"] is True
+    assert assignment_payload["grading"]["status"] == "graded_passed"
+    assert assignment_payload["grading"]["tests_passed"] == 1
+    assert assignment_payload["grading"]["tests_total"] == 1


### PR DESCRIPTION
## Cosa cambia

- copre il dispatch Docker di `javascript`, `nodejs` e `sql`;
- aggiunge un test d'integrazione Docker reale e riusabile;
- verifica assegnazione, workspace, runner, `latest.json` e grading del servizio per Node.js e SQL;
- esegue il collaudo nella workflow dell'immagine assignment runner;
- documenta i linguaggi Docker e i comandi locali Windows/Linux.

## Verifica

- `python -m pytest -q tests/test_student_lab_runner.py tests/test_student_lab_runner_docker.py`
- build locale di `thebitlab-assignment-runner`
- `$env:THEBITLAB_RUN_DOCKER_TESTS='1'; python -m pytest -q tests/test_student_lab_runner_docker.py` -> 2 passed
- `python -m pytest -q`
- `python -m compileall -q scripts`

Closes #498
Related to #292
Related to #288