### PR TITLE
feat: conserva lo storico dei tentativi del lab studente

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -74,16 +74,24 @@ assignments/c-base-somma-001/
   README.md
 
 reports/c-base-somma-001/
-  attempt-001.json
   latest.json
+  assignments/<assignment-key>/
+    latest.json
+    final.json
+    attempts/
+      attempt-20260724T090000000000Z-a1b2c3d4.json
 
 feedback/c-base-somma-001/
   latest.md
 ```
 
-Il file `latest.json` rappresenta l'ultimo esito noto.
+Il file `latest.json` al livello activity rappresenta l'ultimo esito noto e mantiene la compatibilita con registro e
+dashboard esistenti.
 
-I file `attempt-*.json` permettono di conservare la storia dei tentativi.
+I file `attempt-*.json` sono immutabili e conservano la storia tecnica della singola assegnazione. Il `latest.json`
+interno identifica l'ultimo tentativo di quella consegna, mentre `final.json` contiene solo il riferimento al
+tentativo scelto esplicitamente come definitivo. Il miglior tentativo viene calcolato dai report e non viene
+salvato come copia separata.
 
 Nell'MVP, pero, il report autorevole e quello prodotto dalla GitHub Action come artifact o raccolto dal docente tramite automazione dedicata. I file dentro `reports/` nel repository studente sono copie informative o cache locali: non devono essere usati come unica fonte per metriche ufficiali, perche lo studente potrebbe modificarli manualmente.
 

--- a/doc/DATA_MODEL_MVP.md
+++ b/doc/DATA_MODEL_MVP.md
@@ -461,7 +461,9 @@ runner_ref
 grading_report_id
 ```
 
-Per l'MVP puo essere derivato dal report `latest.json`, ma va previsto per vista studente, storico e modalita esame.
+Per l'MVP ogni esecuzione salvata produce un report immutabile separato per `assignment_id`. `latest.json` resta una
+proiezione compatibile; il miglior tentativo viene calcolato e la consegna definitiva richiede una selezione
+esplicita. I report locali restano modificabili dallo studente e non costituiscono da soli una fonte ufficiale.
 
 ### GradingReport
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -455,7 +455,11 @@ Il grading attuale e una base, ma il flusso reale richiede altri passi.
 6. Integrare GitHub Actions dedicate alle consegne studenti.
 7. Scaricare artifact/report GitHub Actions e collegarli ai registri.
 8. Garantire che i job che eseguono codice studente non abbiano segreti.
-9. Modellare i tentativi (`Attempt`) separatamente dalla consegna finale (`Submission`), cosi lo storico tecnico puo alimentare feedback, analytics e modalita esame senza confondere voto e processo.
+9. Estendere il backend gia introdotto per i tentativi (`Attempt`) separati dalla consegna finale (`Submission`):
+   - mostrare lo storico nella GUI/TUI;
+   - permettere allo studente e al docente di selezionare il tentativo definitivo secondo policy;
+   - usare una fonte autorevole server/GitHub per metriche ufficiali;
+   - aggiungere retention, fingerprint di activity/test e analytics senza confondere voto e processo.
 
 ## Priorita 5 - UI comune e pagine nuove
 

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -299,6 +299,11 @@ reports/<activity_id>/
 
 Il primo `latest.json` conserva il contratto storico. La directory indicizzata da `assignment-key` evita che due
 assegnazioni della stessa activity condividano tentativi, migliore risultato o selezione definitiva.
+
+Il servizio carica al massimo 500 tentativi e 20 MiB per assegnazione in una singola risposta. Se lo storico supera
+uno dei limiti, `attempts.truncated` vale `true`, `attempts.count` conserva il numero di file rilevati e il tentativo
+`final` viene comunque caricato direttamente dal suo identificativo. Retention e indice autorevole restano passi
+successivi prima di usare lo storico locale per analytics ufficiali.
 Quando il report è salvato, il servizio lab lo rilegge e aggiorna stato consegna e riepilogo grading.
 
 ## Stati minimi

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -300,10 +300,10 @@ reports/<activity_id>/
 Il primo `latest.json` conserva il contratto storico. La directory indicizzata da `assignment-key` evita che due
 assegnazioni della stessa activity condividano tentativi, migliore risultato o selezione definitiva.
 
-Il servizio carica al massimo 500 tentativi e 20 MiB per assegnazione in una singola risposta. Se lo storico supera
-uno dei limiti, `attempts.truncated` vale `true`, `attempts.count` conserva il numero di file rilevati e il tentativo
-`final` viene comunque caricato direttamente dal suo identificativo. Retention e indice autorevole restano passi
-successivi prima di usare lo storico locale per analytics ufficiali.
+Il servizio esamina al massimo 5000 file e carica al massimo 500 tentativi o 20 MiB per assegnazione in una singola
+risposta. Se lo storico supera uno dei limiti, `attempts.truncated` vale `true`, `attempts.count` conserva il numero
+di file rilevati prima del limite e il tentativo `final` viene comunque caricato direttamente dal suo identificativo.
+Retention e indice autorevole restano passi successivi prima di usare lo storico locale per analytics ufficiali.
 Quando il report è salvato, il servizio lab lo rilegge e aggiorna stato consegna e riepilogo grading.
 
 ## Stati minimi

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -175,6 +175,23 @@ Per salvare il risultato nel path standard dello studente:
 python scripts/student_lab_runner.py --student-id rossi-mario --activity-id python-base-somma-001 --write-report
 ```
 
+Ogni salvataggio standard conserva un tentativo immutabile e aggiorna il report compatibile `latest.json`.
+Se la stessa activity compare in piu consegne, usa `--assignment-id`: gli storici restano separati per
+assegnazione. Per marcare esplicitamente l'esecuzione appena prodotta come consegna definitiva:
+
+```powershell
+python scripts/student_lab_runner.py --student-id rossi-mario --assignment-id <assignment-id> --write-report --final
+```
+
+`latest`, `best` e `final` hanno significati diversi:
+
+- `latest` e l'ultima esecuzione salvata;
+- `best` e il risultato tecnico migliore, calcolato dai test con spareggio sul tentativo piu recente;
+- `final` e soltanto il tentativo scelto esplicitamente come definitivo e non cambia quando lo studente riprova.
+
+La dashboard e il registro continuano a usare il report `latest` per stato e grading finche il flusso docente non
+introdurra una decisione esplicita basata su `final`.
+
 Per usare la sandbox Docker minima sulle consegne C, Python, JavaScript/Node.js o SQL:
 
 ```powershell
@@ -268,7 +285,20 @@ Il payload ha schema `student_lab.v1` e contiene:
 - `runner`: stato del runner lab nel payload di consultazione.
 
 Nel payload di consultazione la TUI espone ancora `not_run`, perché l'esecuzione è un comando separato.
-Il runner locale produce un report JSON su stdout e, con `--write-report`, lo salva in `reports/<activity_id>/latest.json`.
+Il runner locale produce un report JSON su stdout e, con `--write-report`, salva:
+
+```text
+reports/<activity_id>/
+  latest.json
+  assignments/<assignment-key>/
+    latest.json
+    final.json                 # presente solo dopo una scelta esplicita
+    attempts/
+      attempt-<timestamp>-<id>.json
+```
+
+Il primo `latest.json` conserva il contratto storico. La directory indicizzata da `assignment-key` evita che due
+assegnazioni della stessa activity condividano tentativi, migliore risultato o selezione definitiva.
 Quando il report è salvato, il servizio lab lo rilegge e aggiorna stato consegna e riepilogo grading.
 
 ## Stati minimi

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -303,7 +303,9 @@ assegnazioni della stessa activity condividano tentativi, migliore risultato o s
 Il servizio esamina al massimo 5000 file e carica al massimo 500 tentativi o 20 MiB per assegnazione in una singola
 risposta. Se lo storico supera uno dei limiti, `attempts.truncated` vale `true`, `attempts.count` conserva il numero
 di file rilevati prima del limite e il tentativo `final` viene comunque caricato direttamente dal suo identificativo.
-Retention e indice autorevole restano passi successivi prima di usare lo storico locale per analytics ufficiali.
+Il `latest` viene letto dalla proiezione canonica della consegna; se la scansione e troncata, `best` resta vuoto
+perche non sarebbe possibile garantirlo. Retention e indice autorevole restano passi successivi prima di usare lo
+storico locale per analytics ufficiali.
 Quando il report è salvato, il servizio lab lo rilegge e aggiorna stato consegna e riepilogo grading.
 
 ## Stati minimi

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
@@ -16,6 +17,18 @@ from scripts import create_activity
 
 ASSIGNMENT_SCHEMA_VERSION = "1.0"
 DEFAULT_ASSIGNMENTS_DIR = Path("teacher-assignments")
+ASSIGNMENT_STORAGE_KEY_PATTERN = re.compile(r"[^a-z0-9]+")
+
+
+def assignment_storage_key(assignment_id: str) -> str:
+    """Return a readable collision-resistant storage key."""
+
+    normalized = str(assignment_id or "").strip()
+    if not normalized:
+        raise ValueError("assignment_id mancante per lo storico tentativi.")
+    slug = ASSIGNMENT_STORAGE_KEY_PATTERN.sub("-", normalized.lower()).strip("-")[:48] or "assignment"
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+    return f"{slug}-{digest}"
 
 
 def sync_directory(path: Path) -> None:

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -195,8 +195,12 @@ def persist_attempt(
         if confined_regular_file(write_base, assignment_latest_path)
         else None
     )
-    if current_latest is None or attempt_sort_key(stored) >= attempt_sort_key(current_latest):
-        write_json_atomic(assignment_latest_path, stored, base_dir=write_base)
+    try:
+        if current_latest is None or attempt_sort_key(stored) >= attempt_sort_key(current_latest):
+            write_json_atomic(assignment_latest_path, stored, base_dir=write_base)
+    except BaseException:
+        attempt_path.unlink(missing_ok=True)
+        raise
     return attempt_path, assignment_latest_path
 
 

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts import track_assignments
+from scripts.student_identity import confined_regular_file
+
+
+ATTEMPT_SELECTION_SCHEMA = "student_lab_attempt_selection.v1"
+SAFE_KEY_PATTERN = re.compile(r"[^a-z0-9]+")
+
+
+def clean_text(value: Any) -> str:
+    """Return a stripped string value."""
+
+    return str(value or "").strip()
+
+
+def assignment_storage_key(assignment_id: str) -> str:
+    """Return a readable collision-resistant directory name."""
+
+    normalized = clean_text(assignment_id)
+    if not normalized:
+        raise ValueError("assignment_id mancante per lo storico tentativi.")
+    slug = SAFE_KEY_PATTERN.sub("-", normalized.lower()).strip("-")[:48] or "assignment"
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+    return f"{slug}-{digest}"
+
+
+def assignment_history_dir(report_path: Path, assignment_id: str) -> Path:
+    """Return the canonical history directory for one assignment."""
+
+    return report_path.parent / "assignments" / assignment_storage_key(assignment_id)
+
+
+def new_attempt_id() -> str:
+    """Return a sortable identifier that remains unique within one second."""
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    return f"attempt-{timestamp}-{uuid.uuid4().hex[:8]}"
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    """Write one JSON object atomically in the destination directory."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def persist_attempt(report_path: Path, assignment_id: str, report: dict[str, Any]) -> tuple[Path, Path]:
+    """Persist an immutable attempt and the assignment-specific latest report."""
+
+    history_dir = assignment_history_dir(report_path, assignment_id)
+    attempt_id = new_attempt_id()
+    stored = dict(report)
+    stored["attempt_id"] = attempt_id
+    stored["assignment_id"] = assignment_id
+    attempt_path = history_dir / "attempts" / f"{attempt_id}.json"
+    if attempt_path.exists():
+        raise ValueError(f"ID tentativo già esistente: {attempt_id}")
+    write_json_atomic(attempt_path, stored)
+    assignment_latest_path = history_dir / "latest.json"
+    write_json_atomic(assignment_latest_path, stored)
+    return attempt_path, assignment_latest_path
+
+
+def load_attempts(
+    report_path: Path,
+    assignment_id: str,
+    activity_id: str,
+    *,
+    base_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Load valid immutable attempts for one assignment."""
+
+    attempts_dir = assignment_history_dir(report_path, assignment_id) / "attempts"
+    if not attempts_dir.is_dir():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(attempts_dir.glob("attempt-*.json")):
+        safe_path = confined_regular_file(base_dir, path) if base_dir is not None else path
+        if safe_path is None:
+            continue
+        try:
+            report = track_assignments.load_report(safe_path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if report is None:
+            continue
+        if clean_text(report.get("assignment_id")) != assignment_id:
+            continue
+        if clean_text(report.get("activity_id")) != activity_id:
+            continue
+        attempt_id = clean_text(report.get("attempt_id"))
+        if not attempt_id or path.name != f"{attempt_id}.json":
+            continue
+        attempts.append(report)
+    return attempts
+
+
+def attempt_sort_key(report: dict[str, Any]) -> tuple[str, str]:
+    """Return the stable chronological key used for latest selection."""
+
+    created_at = clean_text(report.get("submitted_at")) or clean_text(report.get("generated_at"))
+    return created_at, clean_text(report.get("attempt_id"))
+
+
+def best_attempt_sort_key(report: dict[str, Any]) -> tuple[int, float, int, int, str, str]:
+    """Return a deterministic technical quality key for best selection."""
+
+    grading = track_assignments.grading_summary(report)
+    passed_count = grading.get("tests_passed")
+    total_count = grading.get("tests_total")
+    passed_tests = passed_count if isinstance(passed_count, int) and passed_count >= 0 else 0
+    total_tests = total_count if isinstance(total_count, int) and total_count > 0 else 0
+    ratio = passed_tests / total_tests if total_tests else -1.0
+    valid = int(total_tests > 0 or isinstance(report.get("passed"), bool))
+    passed = int(report.get("passed") is True)
+    created_at, attempt_id = attempt_sort_key(report)
+    return valid, ratio, passed, passed_tests, created_at, attempt_id
+
+
+def select_latest_attempt(attempts: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the most recent valid attempt."""
+
+    return max(attempts, key=attempt_sort_key, default=None)
+
+
+def select_best_attempt(attempts: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the technically strongest valid attempt."""
+
+    return max(attempts, key=best_attempt_sort_key, default=None)
+
+
+def attempt_summary(report: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return compact metadata for a service payload."""
+
+    if report is None:
+        return None
+    grading = track_assignments.grading_summary(report)
+    return {
+        "id": clean_text(report.get("attempt_id")),
+        "submitted_at": clean_text(report.get("submitted_at")) or clean_text(report.get("generated_at")),
+        "status": clean_text(report.get("status")),
+        "passed": report.get("passed") if isinstance(report.get("passed"), bool) else None,
+        "tests_passed": grading.get("tests_passed"),
+        "tests_total": grading.get("tests_total"),
+    }
+
+
+def set_final_attempt(report_path: Path, assignment_id: str, activity_id: str, attempt_id: str) -> Path:
+    """Select an existing attempt as the final submission."""
+
+    clean_attempt_id = clean_text(attempt_id)
+    attempts = load_attempts(report_path, assignment_id, activity_id)
+    selected = next((item for item in attempts if clean_text(item.get("attempt_id")) == clean_attempt_id), None)
+    if selected is None:
+        raise ValueError(f"Tentativo non trovato per la consegna: {clean_attempt_id}")
+    output = assignment_history_dir(report_path, assignment_id) / "final.json"
+    write_json_atomic(
+        output,
+        {
+            "schema_version": ATTEMPT_SELECTION_SCHEMA,
+            "assignment_id": assignment_id,
+            "activity_id": activity_id,
+            "attempt_id": clean_attempt_id,
+            "selected_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        },
+    )
+    return output
+
+
+def load_final_attempt(
+    report_path: Path,
+    assignment_id: str,
+    activity_id: str,
+    *,
+    base_dir: Path | None = None,
+) -> dict[str, Any] | None:
+    """Return the explicitly selected final attempt, if valid."""
+
+    final_path = assignment_history_dir(report_path, assignment_id) / "final.json"
+    safe_final_path = confined_regular_file(base_dir, final_path) if base_dir is not None else final_path
+    if safe_final_path is None:
+        return None
+    try:
+        selection = track_assignments.load_report(safe_final_path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    if selection is None:
+        return None
+    if selection.get("schema_version") != ATTEMPT_SELECTION_SCHEMA:
+        return None
+    if clean_text(selection.get("assignment_id")) != assignment_id:
+        return None
+    if clean_text(selection.get("activity_id")) != activity_id:
+        return None
+    attempt_id = clean_text(selection.get("attempt_id"))
+    return next(
+        (
+            attempt
+            for attempt in load_attempts(report_path, assignment_id, activity_id, base_dir=base_dir)
+            if clean_text(attempt.get("attempt_id")) == attempt_id
+        ),
+        None,
+    )

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -128,14 +128,18 @@ def write_json_exclusive(path: Path, payload: dict[str, Any], *, base_dir: Path)
         suffix=".tmp",
     )
     temporary_path = Path(temporary_name)
+    published = False
     try:
         with os.fdopen(descriptor, "wb") as stream:
             stream.write(json_bytes(payload))
             stream.flush()
             os.fsync(stream.fileno())
         os.link(temporary_path, output)
+        published = True
         sync_directory(output.parent)
     except BaseException:
+        if published:
+            output.unlink(missing_ok=True)
         raise
     finally:
         temporary_path.unlink(missing_ok=True)
@@ -260,17 +264,19 @@ def load_attempt_history(
     total_bytes = 0
     newest_names: list[str] = []
     scanned_count = 0
+    candidate_count = 0
     scan_truncated = False
     with os.scandir(attempts_dir) as entries:
         for entry in entries:
-            if not entry.name.startswith("attempt-") or not entry.name.endswith(".json"):
-                continue
-            if not entry.is_file(follow_symlinks=False):
-                continue
             scanned_count += 1
             if scanned_count > MAX_ATTEMPT_FILES_SCANNED:
                 scan_truncated = True
                 break
+            if not entry.name.startswith("attempt-") or not entry.name.endswith(".json"):
+                continue
+            if not entry.is_file(follow_symlinks=False):
+                continue
+            candidate_count += 1
             if len(newest_names) < MAX_ATTEMPTS_LOADED:
                 heapq.heappush(newest_names, entry.name)
             elif entry.name > newest_names[0]:
@@ -302,8 +308,8 @@ def load_attempt_history(
         attempts.append(report)
     return {
         "attempts": attempts,
-        "count": scanned_count,
-        "truncated": scan_truncated or scanned_count > len(attempts),
+        "count": candidate_count,
+        "truncated": scan_truncated or candidate_count > len(attempts),
     }
 
 
@@ -352,6 +358,35 @@ def load_attempt_by_id(
     if clean_text(report.get("assignment_id")) != assignment_id:
         return None
     if clean_text(report.get("activity_id")) != activity_id:
+        return None
+    return report
+
+
+def load_assignment_latest(
+    report_path: Path,
+    assignment_id: str,
+    activity_id: str,
+    *,
+    base_dir: Path,
+) -> dict[str, Any] | None:
+    """Load and validate the assignment-specific latest projection."""
+
+    path = assignment_history_dir(report_path, assignment_id) / "latest.json"
+    safe_path = confined_regular_file(base_dir, path)
+    if safe_path is None:
+        return None
+    try:
+        report = track_assignments.load_report(safe_path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    if report is None:
+        return None
+    if clean_text(report.get("assignment_id")) != assignment_id:
+        return None
+    if clean_text(report.get("activity_id")) != activity_id:
+        return None
+    attempt_id = clean_text(report.get("attempt_id"))
+    if not attempt_id:
         return None
     return report
 

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -62,6 +62,28 @@ def confined_destination(base_dir: Path, candidate: Path) -> Path:
     return lexical_candidate
 
 
+def confined_directory(base_dir: Path, candidate: Path) -> Path | None:
+    """Return a real directory confined below base_dir without symlinks."""
+
+    lexical_base = base_dir.absolute()
+    lexical_candidate = candidate.absolute()
+    try:
+        relative = lexical_candidate.relative_to(lexical_base)
+    except ValueError:
+        return None
+    current = lexical_base
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            return None
+    try:
+        resolved_candidate = candidate.resolve(strict=True)
+        resolved_candidate.relative_to(base_dir.resolve(strict=True))
+    except (FileNotFoundError, ValueError):
+        return None
+    return resolved_candidate if resolved_candidate.is_dir() else None
+
+
 def json_bytes(payload: dict[str, Any]) -> bytes:
     """Serialize a JSON object using the repository text contract."""
 
@@ -250,7 +272,12 @@ def load_attempt_history(
     """Load a bounded attempt window and disclose when it is truncated."""
 
     attempts_dir = assignment_history_dir(report_path, assignment_id) / "attempts"
-    if not attempts_dir.is_dir():
+    if base_dir is not None:
+        safe_attempts_dir = confined_directory(base_dir, attempts_dir)
+        if safe_attempts_dir is None:
+            return {"attempts": [], "count": 0, "truncated": False}
+        attempts_dir = safe_attempts_dir
+    elif not attempts_dir.is_dir():
         return {"attempts": [], "count": 0, "truncated": False}
     attempts: list[dict[str, Any]] = []
     total_bytes = 0

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -6,9 +6,10 @@ import os
 import re
 import tempfile
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from scripts import track_assignments
 from scripts.student_identity import confined_regular_file
@@ -16,6 +17,8 @@ from scripts.student_identity import confined_regular_file
 
 ATTEMPT_SELECTION_SCHEMA = "student_lab_attempt_selection.v1"
 SAFE_KEY_PATTERN = re.compile(r"[^a-z0-9]+")
+MAX_ATTEMPTS_LOADED = 500
+MAX_ATTEMPT_HISTORY_BYTES = 20 * 1024 * 1024
 
 
 def clean_text(value: Any) -> str:
@@ -48,29 +51,131 @@ def new_attempt_id() -> str:
     return f"attempt-{timestamp}-{uuid.uuid4().hex[:8]}"
 
 
-def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
-    """Write one JSON object atomically in the destination directory."""
+def confined_destination(base_dir: Path, candidate: Path) -> Path:
+    """Validate a write destination without following symlinked parents."""
 
-    path.parent.mkdir(parents=True, exist_ok=True)
+    lexical_base = base_dir.absolute()
+    lexical_candidate = candidate.absolute()
+    try:
+        relative = lexical_candidate.relative_to(lexical_base)
+    except ValueError as error:
+        raise ValueError("Destinazione report fuori dal repository studente.") from error
+    current = lexical_base
+    for part in relative.parts:
+        current /= part
+        if current.exists() and current.is_symlink():
+            raise ValueError("Destinazione report attraversa un collegamento simbolico.")
+    return lexical_candidate
+
+
+def json_bytes(payload: dict[str, Any]) -> bytes:
+    """Serialize a JSON object using the repository text contract."""
+
+    return (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+
+def sync_directory(path: Path) -> None:
+    """Sync directory metadata where the platform exposes POSIX fsync."""
+
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def write_bytes_atomic(path: Path, content: bytes, *, base_dir: Path | None = None) -> None:
+    """Write bytes atomically in the destination directory."""
+
+    output = confined_destination(base_dir, path) if base_dir is not None else path
+    output.parent.mkdir(parents=True, exist_ok=True)
     descriptor, temporary_name = tempfile.mkstemp(
-        dir=path.parent,
-        prefix=f".{path.name}.",
+        dir=output.parent,
+        prefix=f".{output.name}.",
         suffix=".tmp",
     )
     temporary_path = Path(temporary_name)
     try:
-        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
-            json.dump(payload, stream, ensure_ascii=False, indent=2)
-            stream.write("\n")
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(content)
             stream.flush()
             os.fsync(stream.fileno())
-        os.replace(temporary_path, path)
+        os.replace(temporary_path, output)
+        sync_directory(output.parent)
     except BaseException:
         temporary_path.unlink(missing_ok=True)
         raise
 
 
-def persist_attempt(report_path: Path, assignment_id: str, report: dict[str, Any]) -> tuple[Path, Path]:
+def write_json_atomic(path: Path, payload: dict[str, Any], *, base_dir: Path | None = None) -> None:
+    """Write one JSON object atomically in the destination directory."""
+
+    write_bytes_atomic(path, json_bytes(payload), base_dir=base_dir)
+
+
+def write_json_exclusive(path: Path, payload: dict[str, Any], *, base_dir: Path) -> None:
+    """Publish an immutable JSON file without replacing an existing attempt."""
+
+    output = confined_destination(base_dir, path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=output.parent,
+        prefix=f".{output.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(json_bytes(payload))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary_path, output)
+        sync_directory(output.parent)
+    except BaseException:
+        raise
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+@contextmanager
+def report_history_lock(report_path: Path, *, base_dir: Path) -> Iterator[None]:
+    """Serialize report-history updates using only the Python standard library."""
+
+    lock_path = confined_destination(base_dir, report_path.parent / ".attempt-history.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as stream:
+        stream.seek(0, os.SEEK_END)
+        if stream.tell() == 0:
+            stream.write(b"\0")
+            stream.flush()
+        stream.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(stream.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            stream.seek(0)
+            if os.name == "nt":
+                msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+
+def persist_attempt(
+    report_path: Path,
+    assignment_id: str,
+    report: dict[str, Any],
+    *,
+    base_dir: Path | None = None,
+) -> tuple[Path, Path]:
     """Persist an immutable attempt and the assignment-specific latest report."""
 
     history_dir = assignment_history_dir(report_path, assignment_id)
@@ -79,31 +184,85 @@ def persist_attempt(report_path: Path, assignment_id: str, report: dict[str, Any
     stored["attempt_id"] = attempt_id
     stored["assignment_id"] = assignment_id
     attempt_path = history_dir / "attempts" / f"{attempt_id}.json"
-    if attempt_path.exists():
-        raise ValueError(f"ID tentativo già esistente: {attempt_id}")
-    write_json_atomic(attempt_path, stored)
+    write_base = base_dir or report_path.parents[2]
+    try:
+        write_json_exclusive(attempt_path, stored, base_dir=write_base)
+    except FileExistsError as error:
+        raise ValueError(f"ID tentativo già esistente: {attempt_id}") from error
     assignment_latest_path = history_dir / "latest.json"
-    write_json_atomic(assignment_latest_path, stored)
+    current_latest = (
+        track_assignments.load_report(assignment_latest_path)
+        if confined_regular_file(write_base, assignment_latest_path)
+        else None
+    )
+    if current_latest is None or attempt_sort_key(stored) >= attempt_sort_key(current_latest):
+        write_json_atomic(assignment_latest_path, stored, base_dir=write_base)
     return attempt_path, assignment_latest_path
 
 
-def load_attempts(
+def persist_standard_report(
+    report_path: Path,
+    assignment_id: str,
+    report: dict[str, Any],
+    *,
+    base_dir: Path,
+) -> tuple[Path, Path]:
+    """Persist one attempt and both latest projections under a process lock."""
+
+    history_latest = assignment_history_dir(report_path, assignment_id) / "latest.json"
+    attempt_path: Path | None = None
+    with report_history_lock(report_path, base_dir=base_dir):
+        previous_history = history_latest.read_bytes() if confined_regular_file(base_dir, history_latest) else None
+        previous_legacy = report_path.read_bytes() if confined_regular_file(base_dir, report_path) else None
+        try:
+            attempt_path, history_latest = persist_attempt(
+                report_path,
+                assignment_id,
+                report,
+                base_dir=base_dir,
+            )
+            stored = json.loads(history_latest.read_text(encoding="utf-8"))
+            write_json_atomic(report_path, stored, base_dir=base_dir)
+        except BaseException:
+            if attempt_path is not None:
+                attempt_path.unlink(missing_ok=True)
+            if previous_history is None:
+                history_latest.unlink(missing_ok=True)
+            else:
+                write_bytes_atomic(history_latest, previous_history, base_dir=base_dir)
+            if previous_legacy is None:
+                report_path.unlink(missing_ok=True)
+            else:
+                write_bytes_atomic(report_path, previous_legacy, base_dir=base_dir)
+            raise
+    return attempt_path, history_latest
+
+
+def load_attempt_history(
     report_path: Path,
     assignment_id: str,
     activity_id: str,
     *,
     base_dir: Path | None = None,
-) -> list[dict[str, Any]]:
-    """Load valid immutable attempts for one assignment."""
+) -> dict[str, Any]:
+    """Load a bounded attempt window and disclose when it is truncated."""
 
     attempts_dir = assignment_history_dir(report_path, assignment_id) / "attempts"
     if not attempts_dir.is_dir():
-        return []
+        return {"attempts": [], "count": 0, "truncated": False}
     attempts: list[dict[str, Any]] = []
-    for path in sorted(attempts_dir.glob("attempt-*.json")):
+    total_bytes = 0
+    paths = sorted(attempts_dir.glob("attempt-*.json"), reverse=True)
+    for path in paths[:MAX_ATTEMPTS_LOADED]:
         safe_path = confined_regular_file(base_dir, path) if base_dir is not None else path
         if safe_path is None:
             continue
+        try:
+            total_bytes += safe_path.stat().st_size
+        except OSError:
+            continue
+        if total_bytes > MAX_ATTEMPT_HISTORY_BYTES:
+            break
         try:
             report = track_assignments.load_report(safe_path)
         except (OSError, ValueError, json.JSONDecodeError):
@@ -118,17 +277,74 @@ def load_attempts(
         if not attempt_id or path.name != f"{attempt_id}.json":
             continue
         attempts.append(report)
-    return attempts
+    return {
+        "attempts": attempts,
+        "count": len(paths),
+        "truncated": len(paths) > len(attempts),
+    }
 
 
-def attempt_sort_key(report: dict[str, Any]) -> tuple[str, str]:
+def load_attempts(
+    report_path: Path,
+    assignment_id: str,
+    activity_id: str,
+    *,
+    base_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Load the bounded valid attempt window for one assignment."""
+
+    return load_attempt_history(
+        report_path,
+        assignment_id,
+        activity_id,
+        base_dir=base_dir,
+    )["attempts"]
+
+
+def load_attempt_by_id(
+    report_path: Path,
+    assignment_id: str,
+    activity_id: str,
+    attempt_id: str,
+    *,
+    base_dir: Path | None = None,
+) -> dict[str, Any] | None:
+    """Load one immutable attempt directly without scanning the history."""
+
+    clean_attempt_id = clean_text(attempt_id)
+    if not clean_attempt_id.startswith("attempt-") or Path(clean_attempt_id).name != clean_attempt_id:
+        return None
+    path = assignment_history_dir(report_path, assignment_id) / "attempts" / f"{clean_attempt_id}.json"
+    safe_path = confined_regular_file(base_dir, path) if base_dir is not None else path
+    if safe_path is None:
+        return None
+    try:
+        report = track_assignments.load_report(safe_path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    if report is None:
+        return None
+    if clean_text(report.get("attempt_id")) != clean_attempt_id:
+        return None
+    if clean_text(report.get("assignment_id")) != assignment_id:
+        return None
+    if clean_text(report.get("activity_id")) != activity_id:
+        return None
+    return report
+
+
+def attempt_sort_key(report: dict[str, Any]) -> tuple[float, str]:
     """Return the stable chronological key used for latest selection."""
 
     created_at = clean_text(report.get("submitted_at")) or clean_text(report.get("generated_at"))
-    return created_at, clean_text(report.get("attempt_id"))
+    try:
+        timestamp = datetime.fromisoformat(created_at.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        timestamp = float("-inf")
+    return timestamp, clean_text(report.get("attempt_id"))
 
 
-def best_attempt_sort_key(report: dict[str, Any]) -> tuple[int, float, int, int, str, str]:
+def best_attempt_sort_key(report: dict[str, Any]) -> tuple[int, float, int, int, float, str]:
     """Return a deterministic technical quality key for best selection."""
 
     grading = track_assignments.grading_summary(report)
@@ -175,21 +391,29 @@ def set_final_attempt(report_path: Path, assignment_id: str, activity_id: str, a
     """Select an existing attempt as the final submission."""
 
     clean_attempt_id = clean_text(attempt_id)
-    attempts = load_attempts(report_path, assignment_id, activity_id)
-    selected = next((item for item in attempts if clean_text(item.get("attempt_id")) == clean_attempt_id), None)
+    base_dir = report_path.parents[2]
+    selected = load_attempt_by_id(
+        report_path,
+        assignment_id,
+        activity_id,
+        clean_attempt_id,
+        base_dir=base_dir,
+    )
     if selected is None:
         raise ValueError(f"Tentativo non trovato per la consegna: {clean_attempt_id}")
     output = assignment_history_dir(report_path, assignment_id) / "final.json"
-    write_json_atomic(
-        output,
-        {
-            "schema_version": ATTEMPT_SELECTION_SCHEMA,
-            "assignment_id": assignment_id,
-            "activity_id": activity_id,
-            "attempt_id": clean_attempt_id,
-            "selected_at": datetime.now().astimezone().isoformat(timespec="seconds"),
-        },
-    )
+    with report_history_lock(report_path, base_dir=base_dir):
+        write_json_atomic(
+            output,
+            {
+                "schema_version": ATTEMPT_SELECTION_SCHEMA,
+                "assignment_id": assignment_id,
+                "activity_id": activity_id,
+                "attempt_id": clean_attempt_id,
+                "selected_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+            },
+            base_dir=base_dir,
+        )
     return output
 
 
@@ -219,11 +443,10 @@ def load_final_attempt(
     if clean_text(selection.get("activity_id")) != activity_id:
         return None
     attempt_id = clean_text(selection.get("attempt_id"))
-    return next(
-        (
-            attempt
-            for attempt in load_attempts(report_path, assignment_id, activity_id, base_dir=base_dir)
-            if clean_text(attempt.get("attempt_id")) == attempt_id
-        ),
-        None,
+    return load_attempt_by_id(
+        report_path,
+        assignment_id,
+        activity_id,
+        attempt_id,
+        base_dir=base_dir,
     )

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -84,6 +84,17 @@ def confined_directory(base_dir: Path, candidate: Path) -> Path | None:
     return resolved_candidate if resolved_candidate.is_dir() else None
 
 
+def confined_unlink(base_dir: Path, candidate: Path) -> bool:
+    """Remove a file only when its complete path remains confined."""
+
+    try:
+        safe_candidate = confined_destination(base_dir, candidate)
+    except ValueError:
+        return False
+    safe_candidate.unlink(missing_ok=True)
+    return True
+
+
 def json_bytes(payload: dict[str, Any]) -> bytes:
     """Serialize a JSON object using the repository text contract."""
 
@@ -153,7 +164,7 @@ def write_json_exclusive(path: Path, payload: dict[str, Any], *, base_dir: Path)
         sync_directory(output.parent)
     except BaseException:
         if published:
-            output.unlink(missing_ok=True)
+            confined_unlink(base_dir, output)
         raise
     finally:
         temporary_path.unlink(missing_ok=True)
@@ -219,7 +230,7 @@ def persist_attempt(
         if current_latest is None or attempt_sort_key(stored) >= attempt_sort_key(current_latest):
             write_json_atomic(assignment_latest_path, stored, base_dir=write_base)
     except BaseException:
-        attempt_path.unlink(missing_ok=True)
+        confined_unlink(write_base, attempt_path)
         raise
     return attempt_path, assignment_latest_path
 
@@ -249,13 +260,13 @@ def persist_standard_report(
             write_json_atomic(report_path, stored, base_dir=base_dir)
         except BaseException:
             if attempt_path is not None:
-                attempt_path.unlink(missing_ok=True)
+                confined_unlink(base_dir, attempt_path)
             if previous_history is None:
-                history_latest.unlink(missing_ok=True)
+                confined_unlink(base_dir, history_latest)
             else:
                 write_bytes_atomic(history_latest, previous_history, base_dir=base_dir)
             if previous_legacy is None:
-                report_path.unlink(missing_ok=True)
+                confined_unlink(base_dir, report_path)
             else:
                 write_bytes_atomic(report_path, previous_legacy, base_dir=base_dir)
             raise

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import hashlib
 import heapq
 import json
 import os
-import re
 import tempfile
 import uuid
 from contextlib import contextmanager
@@ -12,12 +10,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
-from scripts import track_assignments
+from scripts import assignment_records, track_assignments
 from scripts.student_identity import confined_regular_file
 
 
 ATTEMPT_SELECTION_SCHEMA = "student_lab_attempt_selection.v1"
-SAFE_KEY_PATTERN = re.compile(r"[^a-z0-9]+")
 MAX_ATTEMPTS_LOADED = 500
 MAX_ATTEMPT_FILES_SCANNED = 5000
 MAX_ATTEMPT_HISTORY_BYTES = 20 * 1024 * 1024
@@ -32,12 +29,7 @@ def clean_text(value: Any) -> str:
 def assignment_storage_key(assignment_id: str) -> str:
     """Return a readable collision-resistant directory name."""
 
-    normalized = clean_text(assignment_id)
-    if not normalized:
-        raise ValueError("assignment_id mancante per lo storico tentativi.")
-    slug = SAFE_KEY_PATTERN.sub("-", normalized.lower()).strip("-")[:48] or "assignment"
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
-    return f"{slug}-{digest}"
+    return assignment_records.assignment_storage_key(assignment_id)
 
 
 def assignment_history_dir(report_path: Path, assignment_id: str) -> Path:

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import heapq
 import json
 import os
 import re
@@ -18,6 +19,7 @@ from scripts.student_identity import confined_regular_file
 ATTEMPT_SELECTION_SCHEMA = "student_lab_attempt_selection.v1"
 SAFE_KEY_PATTERN = re.compile(r"[^a-z0-9]+")
 MAX_ATTEMPTS_LOADED = 500
+MAX_ATTEMPT_FILES_SCANNED = 5000
 MAX_ATTEMPT_HISTORY_BYTES = 20 * 1024 * 1024
 
 
@@ -190,12 +192,12 @@ def persist_attempt(
     except FileExistsError as error:
         raise ValueError(f"ID tentativo già esistente: {attempt_id}") from error
     assignment_latest_path = history_dir / "latest.json"
-    current_latest = (
-        track_assignments.load_report(assignment_latest_path)
-        if confined_regular_file(write_base, assignment_latest_path)
-        else None
-    )
     try:
+        current_latest = (
+            track_assignments.load_report(assignment_latest_path)
+            if confined_regular_file(write_base, assignment_latest_path)
+            else None
+        )
         if current_latest is None or attempt_sort_key(stored) >= attempt_sort_key(current_latest):
             write_json_atomic(assignment_latest_path, stored, base_dir=write_base)
     except BaseException:
@@ -256,8 +258,25 @@ def load_attempt_history(
         return {"attempts": [], "count": 0, "truncated": False}
     attempts: list[dict[str, Any]] = []
     total_bytes = 0
-    paths = sorted(attempts_dir.glob("attempt-*.json"), reverse=True)
-    for path in paths[:MAX_ATTEMPTS_LOADED]:
+    newest_names: list[str] = []
+    scanned_count = 0
+    scan_truncated = False
+    with os.scandir(attempts_dir) as entries:
+        for entry in entries:
+            if not entry.name.startswith("attempt-") or not entry.name.endswith(".json"):
+                continue
+            if not entry.is_file(follow_symlinks=False):
+                continue
+            scanned_count += 1
+            if scanned_count > MAX_ATTEMPT_FILES_SCANNED:
+                scan_truncated = True
+                break
+            if len(newest_names) < MAX_ATTEMPTS_LOADED:
+                heapq.heappush(newest_names, entry.name)
+            elif entry.name > newest_names[0]:
+                heapq.heapreplace(newest_names, entry.name)
+    paths = [attempts_dir / name for name in sorted(newest_names, reverse=True)]
+    for path in paths:
         safe_path = confined_regular_file(base_dir, path) if base_dir is not None else path
         if safe_path is None:
             continue
@@ -283,8 +302,8 @@ def load_attempt_history(
         attempts.append(report)
     return {
         "attempts": attempts,
-        "count": len(paths),
-        "truncated": len(paths) > len(attempts),
+        "count": scanned_count,
+        "truncated": scan_truncated or scanned_count > len(attempts),
     }
 
 

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -14,7 +14,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import grade_activity, student_lab_service
+from scripts import grade_activity, student_lab_attempts, student_lab_service
 from scripts.thebitlab_contracts import normalize_activity
 
 
@@ -640,14 +640,33 @@ def storage_report(root: Path, assignment: dict[str, Any], report: dict[str, Any
 def write_student_report(root: Path, assignment: dict[str, Any], report: dict[str, Any], report_path: Path | None = None) -> Path:
     """Persist a student lab report as JSON."""
 
-    output = report_path or assignment_report_path(root, assignment)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(
-        json.dumps(storage_report(root, assignment, report), ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
-        newline="\n",
-    )
+    standard_output = assignment_report_path(root, assignment)
+    output = report_path or standard_output
+    stored = storage_report(root, assignment, report)
+    if output.resolve(strict=False) == standard_output.resolve(strict=False):
+        assignment_id = clean_text(assignment.get("assignment_id"))
+        _, assignment_latest = student_lab_attempts.persist_attempt(output, assignment_id, stored)
+        stored = json.loads(assignment_latest.read_text(encoding="utf-8"))
+    student_lab_attempts.write_json_atomic(output, stored)
     return output
+
+
+def finalize_report_attempt(root: Path, assignment: dict[str, Any], report_path: Path) -> Path:
+    """Mark the just-written canonical report as the final attempt."""
+
+    standard_output = assignment_report_path(root, assignment)
+    if report_path.resolve(strict=False) != standard_output.resolve(strict=False):
+        raise ValueError("--final richiede il path report standard della consegna.")
+    stored = json.loads(report_path.read_text(encoding="utf-8"))
+    attempt_id = clean_text(stored.get("attempt_id"))
+    if not attempt_id:
+        raise ValueError("Il report salvato non contiene un tentativo selezionabile.")
+    return student_lab_attempts.set_final_attempt(
+        standard_output,
+        clean_text(assignment.get("assignment_id")),
+        clean_text(assignment.get("activity_id")),
+        attempt_id,
+    )
 
 
 def positive_int(value: str) -> int:
@@ -676,6 +695,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout del runner locale.")
     parser.add_argument("--write-report", action="store_true", help="Scrive il report nel path standard dello studente.")
     parser.add_argument("--report", type=Path, help="Path alternativo del report JSON da scrivere.")
+    parser.add_argument(
+        "--final",
+        action="store_true",
+        help="Marca come definitiva l'esecuzione appena salvata; richiede --write-report senza --report.",
+    )
     return parser.parse_args()
 
 
@@ -699,8 +723,17 @@ def main() -> int:
             timeout_seconds=args.timeout,
             docker_image=args.docker_image,
         )
+        if args.final and (not args.write_report or args.report):
+            raise ValueError("--final richiede --write-report e non può essere usato con --report.")
         if args.write_report or args.report:
-            write_student_report(root, assignment, report, args.report.resolve(strict=False) if args.report else None)
+            report_path = write_student_report(
+                root,
+                assignment,
+                report,
+                args.report.resolve(strict=False) if args.report else None,
+            )
+            if args.final:
+                finalize_report_attempt(root, assignment, report_path)
     except ValueError as error:
         print(f"Runner lab non disponibile:\n{error}", file=sys.stderr)
         return 1

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -600,6 +600,10 @@ def load_student_assignment(
 def assignment_report_path(root: Path, assignment: dict[str, Any]) -> Path:
     """Return the default report path for an assignment."""
 
+    repo_path = student_repo_path(root, assignment)
+    activity_id = clean_text(assignment.get("activity_id"))
+    if repo_path is not None and activity_id:
+        return repo_path / "reports" / activity_id / "latest.json"
     report = assignment.get("report") if isinstance(assignment.get("report"), dict) else {}
     report_path_value = clean_text(report.get("path"))
     if not report_path_value:
@@ -645,27 +649,48 @@ def write_student_report(root: Path, assignment: dict[str, Any], report: dict[st
     stored = storage_report(root, assignment, report)
     if output.resolve(strict=False) == standard_output.resolve(strict=False):
         assignment_id = clean_text(assignment.get("assignment_id"))
-        _, assignment_latest = student_lab_attempts.persist_attempt(output, assignment_id, stored)
+        repo_path = student_repo_path(root, assignment)
+        if repo_path is None:
+            raise ValueError("Repository studente non disponibile per lo storico tentativi.")
+        _, assignment_latest = student_lab_attempts.persist_standard_report(
+            output,
+            assignment_id,
+            stored,
+            base_dir=repo_path,
+        )
         stored = json.loads(assignment_latest.read_text(encoding="utf-8"))
-    student_lab_attempts.write_json_atomic(output, stored)
+        report["attempt_id"] = clean_text(stored.get("attempt_id"))
+    else:
+        student_lab_attempts.write_json_atomic(output, stored)
     return output
 
 
-def finalize_report_attempt(root: Path, assignment: dict[str, Any], report_path: Path) -> Path:
+def finalize_report_attempt(
+    root: Path,
+    assignment: dict[str, Any],
+    report_path: Path,
+    attempt_id: str = "",
+) -> Path:
     """Mark the just-written canonical report as the final attempt."""
 
     standard_output = assignment_report_path(root, assignment)
     if report_path.resolve(strict=False) != standard_output.resolve(strict=False):
         raise ValueError("--final richiede il path report standard della consegna.")
-    stored = json.loads(report_path.read_text(encoding="utf-8"))
-    attempt_id = clean_text(stored.get("attempt_id"))
-    if not attempt_id:
+    selected_attempt_id = clean_text(attempt_id)
+    if not selected_attempt_id:
+        assignment_latest = student_lab_attempts.assignment_history_dir(
+            standard_output,
+            clean_text(assignment.get("assignment_id")),
+        ) / "latest.json"
+        stored = json.loads(assignment_latest.read_text(encoding="utf-8"))
+        selected_attempt_id = clean_text(stored.get("attempt_id"))
+    if not selected_attempt_id:
         raise ValueError("Il report salvato non contiene un tentativo selezionabile.")
     return student_lab_attempts.set_final_attempt(
         standard_output,
         clean_text(assignment.get("assignment_id")),
         clean_text(assignment.get("activity_id")),
-        attempt_id,
+        selected_attempt_id,
     )
 
 
@@ -733,7 +758,12 @@ def main() -> int:
                 args.report.resolve(strict=False) if args.report else None,
             )
             if args.final:
-                finalize_report_attempt(root, assignment, report_path)
+                finalize_report_attempt(
+                    root,
+                    assignment,
+                    report_path,
+                    clean_text(report.get("attempt_id")),
+                )
     except ValueError as error:
         print(f"Runner lab non disponibile:\n{error}", file=sys.stderr)
         return 1

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -652,14 +652,14 @@ def write_student_report(root: Path, assignment: dict[str, Any], report: dict[st
         repo_path = student_repo_path(root, assignment)
         if repo_path is None:
             raise ValueError("Repository studente non disponibile per lo storico tentativi.")
-        _, assignment_latest = student_lab_attempts.persist_standard_report(
+        attempt_path, _ = student_lab_attempts.persist_standard_report(
             output,
             assignment_id,
             stored,
             base_dir=repo_path,
         )
-        stored = json.loads(assignment_latest.read_text(encoding="utf-8"))
-        report["attempt_id"] = clean_text(stored.get("attempt_id"))
+        persisted_attempt = json.loads(attempt_path.read_text(encoding="utf-8"))
+        report["attempt_id"] = clean_text(persisted_attempt.get("attempt_id"))
     else:
         student_lab_attempts.write_json_atomic(output, stored)
     return output

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -275,6 +275,7 @@ def build_lab_assignment(
         else None
     )
     report = latest_attempt or legacy_report
+    best_report = legacy_report if attempt_history["count"] == 0 else best_attempt
     effective_report_path = report_path
     if latest_attempt is not None and report_path is not None:
         effective_report_path = student_lab_attempts.assignment_history_dir(report_path, assignment_id) / "latest.json"
@@ -352,7 +353,7 @@ def build_lab_assignment(
             "count": attempt_history["count"] or int(legacy_report is not None),
             "truncated": attempt_history["truncated"],
             "latest": student_lab_attempts.attempt_summary(latest_attempt or legacy_report),
-            "best": student_lab_attempts.attempt_summary(best_attempt or legacy_report),
+            "best": student_lab_attempts.attempt_summary(best_report),
             "final": student_lab_attempts.attempt_summary(final_attempt),
         },
         "grading": grading,

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -14,6 +14,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from scripts import (
     assignment_records,
+    student_lab_attempts,
     student_help_service,
     student_support_policy,
     track_assignments,
@@ -228,9 +229,36 @@ def build_lab_assignment(
     repo_path = target_repo_path(root, target, student_id)
     workspace_path = repo_path / "assignments" / activity_id if repo_path is not None else None
     report_path = repo_path / "reports" / activity_id / "latest.json" if repo_path is not None else None
+    assignment_id = normalized["id"]
     help_log_path = student_help_service.server_help_log_path(root, student_id, normalized["id"])
     safe_report_path = confined_regular_file(repo_path, report_path) if repo_path is not None and report_path else None
-    report = load_report(safe_report_path, activity_id) if safe_report_path is not None else None
+    legacy_report = load_report(safe_report_path, activity_id) if safe_report_path is not None else None
+    attempts = (
+        student_lab_attempts.load_attempts(
+            report_path,
+            assignment_id,
+            activity_id,
+            base_dir=repo_path,
+        )
+        if repo_path is not None and report_path is not None
+        else []
+    )
+    latest_attempt = student_lab_attempts.select_latest_attempt(attempts)
+    best_attempt = student_lab_attempts.select_best_attempt(attempts)
+    final_attempt = (
+        student_lab_attempts.load_final_attempt(
+            report_path,
+            assignment_id,
+            activity_id,
+            base_dir=repo_path,
+        )
+        if repo_path is not None and report_path is not None
+        else None
+    )
+    report = latest_attempt or legacy_report
+    effective_report_path = report_path
+    if latest_attempt is not None and report_path is not None:
+        effective_report_path = student_lab_attempts.assignment_history_dir(report_path, assignment_id) / "latest.json"
     submitted_at = clean_text(report.get("submitted_at")) if report else ""
     status = status_with_report(report, normalized["due_at"], now) if report else status_without_report(normalized["due_at"], now)
     activity = load_activity_summary(
@@ -259,7 +287,7 @@ def build_lab_assignment(
     runner_status = clean_text(report.get("status")) if report and clean_text(report.get("status")) else "not_run"
     runner_backend = clean_text(report.get("backend")) if report and clean_text(report.get("backend")) else "student_lab_service"
     return {
-        "assignment_id": normalized["id"],
+        "assignment_id": assignment_id,
         "activity_id": activity_id,
         "title": activity["title"] or activity_id,
         "student_support_mode": activity.get("student_support_mode", ""),
@@ -290,16 +318,22 @@ def build_lab_assignment(
             "path": (
                 relative_to_root(
                     root,
-                    report_path,
+                    effective_report_path,
                     expose_external_paths=expose_external_paths,
                 )
-                if report_path is not None
+                if effective_report_path is not None
                 else ""
             ),
             "exists": report is not None,
             "submitted_at": submitted_at,
             "commit": report.get("commit") if report else None,
             "tests": report_tests_summary(report),
+        },
+        "attempts": {
+            "count": len(attempts) if attempts else int(legacy_report is not None),
+            "latest": student_lab_attempts.attempt_summary(latest_attempt or legacy_report),
+            "best": student_lab_attempts.attempt_summary(best_attempt or legacy_report),
+            "final": student_lab_attempts.attempt_summary(final_attempt),
         },
         "grading": grading,
         "help": help_log,

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -252,8 +252,18 @@ def build_lab_assignment(
         else {"attempts": [], "count": 0, "truncated": False}
     )
     attempts = attempt_history["attempts"]
-    latest_attempt = student_lab_attempts.select_latest_attempt(attempts)
-    best_attempt = student_lab_attempts.select_best_attempt(attempts)
+    canonical_latest = (
+        student_lab_attempts.load_assignment_latest(
+            report_path,
+            assignment_id,
+            activity_id,
+            base_dir=repo_path,
+        )
+        if repo_path is not None and report_path is not None
+        else None
+    )
+    latest_attempt = canonical_latest or student_lab_attempts.select_latest_attempt(attempts)
+    best_attempt = None if attempt_history["truncated"] else student_lab_attempts.select_best_attempt(attempts)
     final_attempt = (
         student_lab_attempts.load_final_attempt(
             report_path,

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -221,6 +221,7 @@ def build_lab_assignment(
     student_id: str,
     now: str,
     expose_external_paths: bool = False,
+    allow_unscoped_legacy_report: bool = True,
 ) -> dict[str, Any]:
     """Build the student-lab contract for one assignment target."""
 
@@ -237,7 +238,7 @@ def build_lab_assignment(
         legacy_assignment_id = clean_text(legacy_report.get("assignment_id"))
         has_assignment_histories = bool(report_path and (report_path.parent / "assignments").is_dir())
         if (legacy_assignment_id and legacy_assignment_id != assignment_id) or (
-            not legacy_assignment_id and has_assignment_histories
+            not legacy_assignment_id and (has_assignment_histories or not allow_unscoped_legacy_report)
         ):
             legacy_report = None
     attempt_history = (
@@ -398,6 +399,11 @@ def _list_student_lab_assignments(
             f"Identificativo studente ambiguo: {clean_student_id} e associato a repository diversi."
         )
 
+    activity_counts: dict[str, int] = {}
+    for assignment, _, _, _ in selected_assignments:
+        activity_id = clean_text(assignment.get("activity_id"))
+        activity_counts[activity_id] = activity_counts.get(activity_id, 0) + 1
+
     lab_assignments = [
         build_lab_assignment(
             root=root,
@@ -406,6 +412,7 @@ def _list_student_lab_assignments(
             student_id=canonical_student_id,
             now=current_time,
             expose_external_paths=expose_external_paths,
+            allow_unscoped_legacy_report=activity_counts.get(clean_text(assignment.get("activity_id")), 0) == 1,
         )
         for assignment, target, canonical_student_id, _ in selected_assignments
     ]

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -233,16 +233,24 @@ def build_lab_assignment(
     help_log_path = student_help_service.server_help_log_path(root, student_id, normalized["id"])
     safe_report_path = confined_regular_file(repo_path, report_path) if repo_path is not None and report_path else None
     legacy_report = load_report(safe_report_path, activity_id) if safe_report_path is not None else None
-    attempts = (
-        student_lab_attempts.load_attempts(
+    if legacy_report is not None:
+        legacy_assignment_id = clean_text(legacy_report.get("assignment_id"))
+        has_assignment_histories = bool(report_path and (report_path.parent / "assignments").is_dir())
+        if (legacy_assignment_id and legacy_assignment_id != assignment_id) or (
+            not legacy_assignment_id and has_assignment_histories
+        ):
+            legacy_report = None
+    attempt_history = (
+        student_lab_attempts.load_attempt_history(
             report_path,
             assignment_id,
             activity_id,
             base_dir=repo_path,
         )
         if repo_path is not None and report_path is not None
-        else []
+        else {"attempts": [], "count": 0, "truncated": False}
     )
+    attempts = attempt_history["attempts"]
     latest_attempt = student_lab_attempts.select_latest_attempt(attempts)
     best_attempt = student_lab_attempts.select_best_attempt(attempts)
     final_attempt = (
@@ -330,7 +338,8 @@ def build_lab_assignment(
             "tests": report_tests_summary(report),
         },
         "attempts": {
-            "count": len(attempts) if attempts else int(legacy_report is not None),
+            "count": attempt_history["count"] or int(legacy_report is not None),
+            "truncated": attempt_history["truncated"],
             "latest": student_lab_attempts.attempt_summary(latest_attempt or legacy_report),
             "best": student_lab_attempts.attempt_summary(best_attempt or legacy_report),
             "final": student_lab_attempts.attempt_summary(final_attempt),

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -275,7 +275,12 @@ def build_lab_assignment(
         else None
     )
     report = latest_attempt or legacy_report
-    best_report = legacy_report if attempt_history["count"] == 0 else best_attempt
+    if attempt_history["truncated"]:
+        best_report = None
+    elif attempt_history["count"] == 0:
+        best_report = legacy_report
+    else:
+        best_report = best_attempt
     effective_report_path = report_path
     if latest_attempt is not None and report_path is not None:
         effective_report_path = student_lab_attempts.assignment_history_dir(report_path, assignment_id) / "latest.json"

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -471,10 +471,24 @@ def track_assignments(
         else:
             legacy_help_path = student_help_service.help_log_path(target.path, activity_id)
             help_log_path = student_identity.confined_regular_file(target.path, legacy_help_path)
-        safe_report_path = student_identity.confined_regular_file(target.path, report_path)
+        safe_report_path = None
+        if assignment_id:
+            assignment_report_path = (
+                report_path.parent
+                / "assignments"
+                / assignment_records.assignment_storage_key(assignment_id)
+                / "latest.json"
+            )
+            safe_report_path = student_identity.confined_regular_file(target.path, assignment_report_path)
+        if safe_report_path is None:
+            safe_report_path = student_identity.confined_regular_file(target.path, report_path)
         report = load_report(safe_report_path) if safe_report_path is not None else None
         if report is not None:
             validate_report_activity(report, activity_id, report_path)
+            report_assignment_id = clean_metadata(report.get("assignment_id"))
+            if assignment_id and report_assignment_id and report_assignment_id != assignment_id:
+                report = None
+                safe_report_path = None
         relative_report_path = (
             relative_to_root_or_repo(safe_report_path, target.path, server_root)
             if safe_report_path is not None

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -450,15 +450,22 @@ def track_assignments(
     normalized_class_label = clean_metadata(class_label) or normalized_class_id
     normalized_github_team = clean_metadata(github_team) or clean_metadata(normalized_activity.get("github_team"))
     assignment = None
+    same_activity_assignments: list[dict[str, Any]] = []
     if assignment_id and server_root is None:
         raise ValueError("server_root obbligatorio quando assignment_id e specificato.")
     if assignment_id:
+        assignment_storage = assignment_records.JsonAssignmentRecordStorage(server_root)
         try:
-            assignment = assignment_records.JsonAssignmentRecordStorage(server_root).read_assignment(assignment_id)
+            assignment = assignment_storage.read_assignment(assignment_id)
         except FileNotFoundError as error:
             raise ValueError(f"Assegnazione non trovata: {assignment_id}") from error
         if clean_metadata(assignment.get("activity_id")) != activity_id:
             raise ValueError("L'assegnazione richiesta appartiene a un'altra activity.")
+        same_activity_assignments = [
+            candidate
+            for candidate in assignment_storage.list_assignments()
+            if clean_metadata(candidate.get("activity_id")) == activity_id
+        ]
 
     students: list[dict[str, Any]] = []
     for target in targets:
@@ -472,6 +479,7 @@ def track_assignments(
             legacy_help_path = student_help_service.help_log_path(target.path, activity_id)
             help_log_path = student_identity.confined_regular_file(target.path, legacy_help_path)
         safe_report_path = None
+        uses_assignment_report = False
         if assignment_id:
             assignment_report_path = (
                 report_path.parent
@@ -480,6 +488,7 @@ def track_assignments(
                 / "latest.json"
             )
             safe_report_path = student_identity.confined_regular_file(target.path, assignment_report_path)
+            uses_assignment_report = safe_report_path is not None
         if safe_report_path is None:
             safe_report_path = student_identity.confined_regular_file(target.path, report_path)
         report = load_report(safe_report_path) if safe_report_path is not None else None
@@ -489,6 +498,17 @@ def track_assignments(
             if assignment_id and report_assignment_id and report_assignment_id != assignment_id:
                 report = None
                 safe_report_path = None
+            elif assignment_id and not report_assignment_id and not uses_assignment_report:
+                matching_assignment_count = 0
+                for candidate in same_activity_assignments:
+                    try:
+                        assignment_student_id(target, candidate, server_root)
+                    except ValueError:
+                        continue
+                    matching_assignment_count += 1
+                if matching_assignment_count != 1:
+                    report = None
+                    safe_report_path = None
         relative_report_path = (
             relative_to_root_or_repo(safe_report_path, target.path, server_root)
             if safe_report_path is not None

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts import student_lab_attempts
+
+
+ASSIGNMENT_ID = "assignment-python-somma-rossi-2026"
+ACTIVITY_ID = "python-somma"
+
+
+def report(*, attempt_id: str, passed: bool, tests_passed: int, tests_total: int, submitted_at: str) -> dict:
+    """Return one persisted runner report used by history tests."""
+
+    return {
+        "schema_version": "student_lab_run.v1",
+        "attempt_id": attempt_id,
+        "assignment_id": ASSIGNMENT_ID,
+        "activity_id": ACTIVITY_ID,
+        "student_id": "rossi-mario",
+        "status": "passed" if passed else "failed",
+        "passed": passed,
+        "submitted_at": submitted_at,
+        "summary": {"passed": tests_passed, "total": tests_total},
+        "tests": [],
+    }
+
+
+def write_attempt(report_path, payload: dict) -> None:
+    """Write one attempt in the canonical test directory."""
+
+    history_dir = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID)
+    path = history_dir / "attempts" / f"{payload['attempt_id']}.json"
+    student_lab_attempts.write_json_atomic(path, payload)
+
+
+def test_assignment_storage_key_is_stable_and_filesystem_safe() -> None:
+    first = student_lab_attempts.assignment_storage_key("Consegna / ../ Rossi")
+    second = student_lab_attempts.assignment_storage_key("Consegna / ../ Rossi")
+
+    assert first == second
+    assert "/" not in first
+    assert "\\" not in first
+    assert ".." not in first
+    assert first.endswith("-1e7d85554a1f")
+
+
+def test_load_attempts_isolates_assignment_and_activity(tmp_path) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    valid = report(
+        attempt_id="attempt-valid",
+        passed=True,
+        tests_passed=2,
+        tests_total=2,
+        submitted_at="2026-10-18T12:00:00+02:00",
+    )
+    write_attempt(report_path, valid)
+    wrong_assignment = {**valid, "attempt_id": "attempt-wrong-assignment", "assignment_id": "other"}
+    write_attempt(report_path, wrong_assignment)
+    wrong_activity = {**valid, "attempt_id": "attempt-wrong-activity", "activity_id": "other"}
+    write_attempt(report_path, wrong_activity)
+
+    attempts = student_lab_attempts.load_attempts(report_path, ASSIGNMENT_ID, ACTIVITY_ID)
+
+    assert attempts == [valid]
+
+
+def test_load_attempts_skips_corrupt_and_oversized_reports(tmp_path) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    attempts_dir = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID) / "attempts"
+    attempts_dir.mkdir(parents=True)
+    (attempts_dir / "attempt-corrupt.json").write_text("{", encoding="utf-8")
+    (attempts_dir / "attempt-large.json").write_text("x" * (2 * 1024 * 1024 + 1), encoding="utf-8")
+
+    assert student_lab_attempts.load_attempts(report_path, ASSIGNMENT_ID, ACTIVITY_ID) == []
+
+
+def test_best_attempt_prefers_complete_result_and_latest_breaks_ties() -> None:
+    partial = report(
+        attempt_id="attempt-1",
+        passed=False,
+        tests_passed=3,
+        tests_total=4,
+        submitted_at="2026-10-18T10:00:00+02:00",
+    )
+    complete_old = report(
+        attempt_id="attempt-2",
+        passed=True,
+        tests_passed=2,
+        tests_total=2,
+        submitted_at="2026-10-18T11:00:00+02:00",
+    )
+    complete_new = report(
+        attempt_id="attempt-3",
+        passed=True,
+        tests_passed=2,
+        tests_total=2,
+        submitted_at="2026-10-18T12:00:00+02:00",
+    )
+
+    assert student_lab_attempts.select_best_attempt([partial, complete_new, complete_old]) == complete_new
+    assert student_lab_attempts.select_latest_attempt([partial, complete_new, complete_old]) == complete_new
+
+
+def test_final_attempt_remains_selected_after_a_new_attempt(tmp_path) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    selected = report(
+        attempt_id="attempt-selected",
+        passed=True,
+        tests_passed=2,
+        tests_total=2,
+        submitted_at="2026-10-18T11:00:00+02:00",
+    )
+    newer = report(
+        attempt_id="attempt-newer",
+        passed=False,
+        tests_passed=1,
+        tests_total=2,
+        submitted_at="2026-10-18T12:00:00+02:00",
+    )
+    write_attempt(report_path, selected)
+    student_lab_attempts.set_final_attempt(report_path, ASSIGNMENT_ID, ACTIVITY_ID, "attempt-selected")
+    write_attempt(report_path, newer)
+
+    assert student_lab_attempts.load_final_attempt(report_path, ASSIGNMENT_ID, ACTIVITY_ID) == selected
+    assert student_lab_attempts.select_latest_attempt(
+        student_lab_attempts.load_attempts(report_path, ASSIGNMENT_ID, ACTIVITY_ID)
+    ) == newer
+
+
+def test_set_final_attempt_rejects_unknown_id_without_changing_selection(tmp_path) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    selected = report(
+        attempt_id="attempt-selected",
+        passed=True,
+        tests_passed=2,
+        tests_total=2,
+        submitted_at="2026-10-18T11:00:00+02:00",
+    )
+    write_attempt(report_path, selected)
+    final_path = student_lab_attempts.set_final_attempt(
+        report_path,
+        ASSIGNMENT_ID,
+        ACTIVITY_ID,
+        "attempt-selected",
+    )
+    original = json.loads(final_path.read_text(encoding="utf-8"))
+
+    with pytest.raises(ValueError, match="Tentativo non trovato"):
+        student_lab_attempts.set_final_attempt(report_path, ASSIGNMENT_ID, ACTIVITY_ID, "../unknown")
+
+    assert json.loads(final_path.read_text(encoding="utf-8")) == original

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -181,6 +181,38 @@ def test_persist_standard_report_rolls_back_when_legacy_latest_fails(tmp_path, m
     assert not report_path.exists()
 
 
+def test_persist_attempt_rolls_back_when_assignment_latest_fails(tmp_path, monkeypatch) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    history_latest = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID) / "latest.json"
+    original_write = student_lab_attempts.write_json_atomic
+
+    def fail_assignment_latest(path, payload, **kwargs):
+        if path == history_latest:
+            raise OSError("assignment latest failed")
+        return original_write(path, payload, **kwargs)
+
+    monkeypatch.setattr(student_lab_attempts, "write_json_atomic", fail_assignment_latest)
+
+    with pytest.raises(OSError, match="assignment latest failed"):
+        student_lab_attempts.persist_standard_report(
+            report_path,
+            ASSIGNMENT_ID,
+            report(
+                attempt_id="ignored",
+                passed=True,
+                tests_passed=1,
+                tests_total=1,
+                submitted_at="2026-10-18T10:00:00+02:00",
+            ),
+            base_dir=tmp_path,
+        )
+
+    history_dir = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID)
+    assert list((history_dir / "attempts").glob("attempt-*.json")) == []
+    assert not history_latest.exists()
+    assert not report_path.exists()
+
+
 def test_persist_standard_report_rejects_symlinked_history_parent(tmp_path) -> None:
     report_path = tmp_path / "repo" / "reports" / ACTIVITY_ID / "latest.json"
     external = tmp_path / "external"

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -147,6 +147,32 @@ def test_persist_attempt_never_replaces_an_existing_attempt(tmp_path, monkeypatc
     assert attempt_path.read_bytes() == original_bytes
 
 
+def test_exclusive_attempt_is_removed_when_directory_sync_fails(tmp_path, monkeypatch) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    monkeypatch.setattr(student_lab_attempts, "new_attempt_id", lambda: "attempt-sync-failure")
+    monkeypatch.setattr(
+        student_lab_attempts,
+        "sync_directory",
+        lambda path: (_ for _ in ()).throw(OSError("sync failed")),
+    )
+
+    with pytest.raises(OSError, match="sync failed"):
+        student_lab_attempts.persist_attempt(
+            report_path,
+            ASSIGNMENT_ID,
+            report(
+                attempt_id="ignored",
+                passed=True,
+                tests_passed=1,
+                tests_total=1,
+                submitted_at="2026-10-18T10:00:00+02:00",
+            ),
+        )
+
+    history_dir = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID)
+    assert not (history_dir / "attempts" / "attempt-sync-failure.json").exists()
+
+
 def test_persist_standard_report_rolls_back_when_legacy_latest_fails(tmp_path, monkeypatch) -> None:
     report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
     original_write = student_lab_attempts.write_json_atomic
@@ -304,9 +330,56 @@ def test_load_attempts_caps_directory_scan(tmp_path, monkeypatch) -> None:
 
     history = student_lab_attempts.load_attempt_history(report_path, ASSIGNMENT_ID, ACTIVITY_ID)
 
-    assert history["count"] == 3
+    assert history["count"] == 2
     assert history["truncated"] is True
     assert len(history["attempts"]) == 2
+
+
+def test_load_attempts_counts_unrelated_entries_toward_scan_limit(tmp_path, monkeypatch) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    attempts_dir = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID) / "attempts"
+    attempts_dir.mkdir(parents=True)
+    for index in range(4):
+        (attempts_dir / f"noise-{index}.txt").write_text("noise", encoding="utf-8")
+    monkeypatch.setattr(student_lab_attempts, "MAX_ATTEMPT_FILES_SCANNED", 2)
+
+    history = student_lab_attempts.load_attempt_history(report_path, ASSIGNMENT_ID, ACTIVITY_ID)
+
+    assert history == {"attempts": [], "count": 0, "truncated": True}
+
+
+def test_assignment_latest_remains_available_when_history_scan_is_truncated(tmp_path, monkeypatch) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    older = report(
+        attempt_id="attempt-2",
+        passed=False,
+        tests_passed=0,
+        tests_total=1,
+        submitted_at="2026-10-18T10:00:00+02:00",
+    )
+    latest = report(
+        attempt_id="attempt-9",
+        passed=True,
+        tests_passed=1,
+        tests_total=1,
+        submitted_at="2026-10-18T12:00:00+02:00",
+    )
+    write_attempt(report_path, older)
+    write_attempt(report_path, latest)
+    history_latest = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID) / "latest.json"
+    student_lab_attempts.write_json_atomic(history_latest, latest)
+    monkeypatch.setattr(student_lab_attempts, "MAX_ATTEMPT_FILES_SCANNED", 1)
+
+    history = student_lab_attempts.load_attempt_history(report_path, ASSIGNMENT_ID, ACTIVITY_ID)
+    canonical = student_lab_attempts.load_assignment_latest(
+        report_path,
+        ASSIGNMENT_ID,
+        ACTIVITY_ID,
+        base_dir=tmp_path,
+    )
+
+    assert history["truncated"] is True
+    assert canonical == latest
 
 
 def test_final_attempt_remains_selected_after_a_new_attempt(tmp_path) -> None:

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -104,6 +104,131 @@ def test_best_attempt_prefers_complete_result_and_latest_breaks_ties() -> None:
     assert student_lab_attempts.select_latest_attempt([partial, complete_new, complete_old]) == complete_new
 
 
+def test_latest_attempt_compares_timezone_offsets_in_utc() -> None:
+    earlier = report(
+        attempt_id="attempt-earlier",
+        passed=True,
+        tests_passed=1,
+        tests_total=1,
+        submitted_at="2026-10-18T12:00:00+02:00",
+    )
+    later = report(
+        attempt_id="attempt-later",
+        passed=True,
+        tests_passed=1,
+        tests_total=1,
+        submitted_at="2026-10-18T11:30:00+00:00",
+    )
+
+    assert student_lab_attempts.select_latest_attempt([later, earlier]) == later
+
+
+def test_persist_attempt_never_replaces_an_existing_attempt(tmp_path, monkeypatch) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    monkeypatch.setattr(student_lab_attempts, "new_attempt_id", lambda: "attempt-fixed")
+    original = report(
+        attempt_id="ignored",
+        passed=False,
+        tests_passed=0,
+        tests_total=1,
+        submitted_at="2026-10-18T10:00:00+02:00",
+    )
+    student_lab_attempts.persist_attempt(report_path, ASSIGNMENT_ID, original)
+    attempt_path = (
+        student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID)
+        / "attempts"
+        / "attempt-fixed.json"
+    )
+    original_bytes = attempt_path.read_bytes()
+
+    with pytest.raises(ValueError, match="ID tentativo già esistente"):
+        student_lab_attempts.persist_attempt(report_path, ASSIGNMENT_ID, {**original, "passed": True})
+
+    assert attempt_path.read_bytes() == original_bytes
+
+
+def test_persist_standard_report_rolls_back_when_legacy_latest_fails(tmp_path, monkeypatch) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    original_write = student_lab_attempts.write_json_atomic
+    failed = False
+
+    def fail_legacy_once(path, payload, **kwargs):
+        nonlocal failed
+        if path == report_path and not failed:
+            failed = True
+            raise OSError("legacy write failed")
+        return original_write(path, payload, **kwargs)
+
+    monkeypatch.setattr(student_lab_attempts, "write_json_atomic", fail_legacy_once)
+
+    with pytest.raises(OSError, match="legacy write failed"):
+        student_lab_attempts.persist_standard_report(
+            report_path,
+            ASSIGNMENT_ID,
+            report(
+                attempt_id="ignored",
+                passed=True,
+                tests_passed=1,
+                tests_total=1,
+                submitted_at="2026-10-18T10:00:00+02:00",
+            ),
+            base_dir=tmp_path,
+        )
+
+    history_dir = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID)
+    assert list((history_dir / "attempts").glob("attempt-*.json")) == []
+    assert not (history_dir / "latest.json").exists()
+    assert not report_path.exists()
+
+
+def test_persist_standard_report_rejects_symlinked_history_parent(tmp_path) -> None:
+    report_path = tmp_path / "repo" / "reports" / ACTIVITY_ID / "latest.json"
+    external = tmp_path / "external"
+    external.mkdir()
+    report_path.parent.mkdir(parents=True)
+    assignments_link = report_path.parent / "assignments"
+    try:
+        assignments_link.symlink_to(external, target_is_directory=True)
+    except OSError:
+        pytest.skip("Creazione symlink non disponibile su questa piattaforma.")
+
+    with pytest.raises(ValueError, match="collegamento simbolico"):
+        student_lab_attempts.persist_standard_report(
+            report_path,
+            ASSIGNMENT_ID,
+            report(
+                attempt_id="ignored",
+                passed=True,
+                tests_passed=1,
+                tests_total=1,
+                submitted_at="2026-10-18T10:00:00+02:00",
+            ),
+            base_dir=tmp_path / "repo",
+        )
+
+    assert list(external.iterdir()) == []
+
+
+def test_load_attempts_caps_number_of_reports(tmp_path, monkeypatch) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    for index in range(3):
+        write_attempt(
+            report_path,
+            report(
+                attempt_id=f"attempt-{index}",
+                passed=True,
+                tests_passed=1,
+                tests_total=1,
+                submitted_at=f"2026-10-18T1{index}:00:00+02:00",
+            ),
+        )
+    monkeypatch.setattr(student_lab_attempts, "MAX_ATTEMPTS_LOADED", 2)
+
+    attempts = student_lab_attempts.load_attempts(report_path, ASSIGNMENT_ID, ACTIVITY_ID)
+
+    assert [item["attempt_id"] for item in attempts] == ["attempt-2", "attempt-1"]
+
+
 def test_final_attempt_remains_selected_after_a_new_attempt(tmp_path) -> None:
     report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
     selected = report(

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -213,6 +213,32 @@ def test_persist_attempt_rolls_back_when_assignment_latest_fails(tmp_path, monke
     assert not report_path.exists()
 
 
+def test_persist_attempt_rolls_back_when_existing_latest_is_corrupt(tmp_path) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    history_latest = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID) / "latest.json"
+    history_latest.parent.mkdir(parents=True)
+    history_latest.write_text("{", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        student_lab_attempts.persist_standard_report(
+            report_path,
+            ASSIGNMENT_ID,
+            report(
+                attempt_id="ignored",
+                passed=True,
+                tests_passed=1,
+                tests_total=1,
+                submitted_at="2026-10-18T10:00:00+02:00",
+            ),
+            base_dir=tmp_path,
+        )
+
+    history_dir = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID)
+    assert list((history_dir / "attempts").glob("attempt-*.json")) == []
+    assert history_latest.read_text(encoding="utf-8") == "{"
+    assert not report_path.exists()
+
+
 def test_persist_standard_report_rejects_symlinked_history_parent(tmp_path) -> None:
     report_path = tmp_path / "repo" / "reports" / ACTIVITY_ID / "latest.json"
     external = tmp_path / "external"
@@ -259,6 +285,28 @@ def test_load_attempts_caps_number_of_reports(tmp_path, monkeypatch) -> None:
     attempts = student_lab_attempts.load_attempts(report_path, ASSIGNMENT_ID, ACTIVITY_ID)
 
     assert [item["attempt_id"] for item in attempts] == ["attempt-2", "attempt-1"]
+
+
+def test_load_attempts_caps_directory_scan(tmp_path, monkeypatch) -> None:
+    report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
+    for index in range(4):
+        write_attempt(
+            report_path,
+            report(
+                attempt_id=f"attempt-{index}",
+                passed=True,
+                tests_passed=1,
+                tests_total=1,
+                submitted_at=f"2026-10-18T1{index}:00:00+02:00",
+            ),
+        )
+    monkeypatch.setattr(student_lab_attempts, "MAX_ATTEMPT_FILES_SCANNED", 2)
+
+    history = student_lab_attempts.load_attempt_history(report_path, ASSIGNMENT_ID, ACTIVITY_ID)
+
+    assert history["count"] == 3
+    assert history["truncated"] is True
+    assert len(history["attempts"]) == 2
 
 
 def test_final_attempt_remains_selected_after_a_new_attempt(tmp_path) -> None:

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -293,6 +293,31 @@ def test_persist_standard_report_rejects_symlinked_history_parent(tmp_path) -> N
     assert list(external.iterdir()) == []
 
 
+def test_load_attempt_history_rejects_symlinked_attempts_directory(tmp_path) -> None:
+    report_path = tmp_path / "repo" / "reports" / ACTIVITY_ID / "latest.json"
+    external = tmp_path / "external"
+    external.mkdir()
+    external_attempt = external / "attempt-external.json"
+    external_attempt.write_text("not-json", encoding="utf-8")
+    history_dir = student_lab_attempts.assignment_history_dir(report_path, ASSIGNMENT_ID)
+    history_dir.mkdir(parents=True)
+    attempts_link = history_dir / "attempts"
+    try:
+        attempts_link.symlink_to(external, target_is_directory=True)
+    except OSError:
+        pytest.skip("Creazione symlink non disponibile su questa piattaforma.")
+
+    history = student_lab_attempts.load_attempt_history(
+        report_path,
+        ASSIGNMENT_ID,
+        ACTIVITY_ID,
+        base_dir=tmp_path / "repo",
+    )
+
+    assert history == {"attempts": [], "count": 0, "truncated": False}
+    assert external_attempt.read_text(encoding="utf-8") == "not-json"
+
+
 def test_load_attempts_caps_number_of_reports(tmp_path, monkeypatch) -> None:
     report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
     for index in range(3):

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -269,6 +269,13 @@ def test_persist_standard_report_rejects_symlinked_history_parent(tmp_path) -> N
     report_path = tmp_path / "repo" / "reports" / ACTIVITY_ID / "latest.json"
     external = tmp_path / "external"
     external.mkdir()
+    external_history = (
+        external
+        / student_lab_attempts.assignment_storage_key(ASSIGNMENT_ID)
+        / "latest.json"
+    )
+    external_history.parent.mkdir()
+    external_history.write_text("external-data", encoding="utf-8")
     report_path.parent.mkdir(parents=True)
     assignments_link = report_path.parent / "assignments"
     try:
@@ -290,7 +297,7 @@ def test_persist_standard_report_rejects_symlinked_history_parent(tmp_path) -> N
             base_dir=tmp_path / "repo",
         )
 
-    assert list(external.iterdir()) == []
+    assert external_history.read_text(encoding="utf-8") == "external-data"
 
 
 def test_load_attempt_history_rejects_symlinked_attempts_directory(tmp_path) -> None:

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -294,6 +294,37 @@ def test_write_student_report_keeps_attempts_when_runs_share_the_same_second(tmp
     assert latest["attempt_id"] == "attempt-20261018T100000000000Z-22222222"
 
 
+def test_second_run_reuses_activity_report_root_after_service_reload(tmp_path) -> None:
+    write_assignment(tmp_path, write_activity(tmp_path))
+    write_python_workspace(
+        tmp_path,
+        source="def somma(a, b):\n    return a + b\n",
+        test_source="from main import somma\n\ndef test_somma():\n    assert somma(2, 3) == 5\n",
+    )
+    first_assignment = student_lab_runner.load_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        now="2026-10-18T12:00:00+02:00",
+    )
+    first_report = student_lab_runner.run_local_assignment(first_assignment, root=tmp_path)
+    report_path = student_lab_runner.write_student_report(tmp_path, first_assignment, first_report)
+    reloaded_assignment = student_lab_runner.load_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        now="2026-10-18T12:05:00+02:00",
+    )
+    second_report = student_lab_runner.run_local_assignment(reloaded_assignment, root=tmp_path)
+
+    second_path = student_lab_runner.write_student_report(tmp_path, reloaded_assignment, second_report)
+
+    history_dir = student_lab_attempts.assignment_history_dir(report_path, first_assignment["assignment_id"])
+    assert second_path == report_path
+    assert len(list((history_dir / "attempts").glob("attempt-*.json"))) == 2
+    assert not (history_dir / "assignments").exists()
+
+
 def test_write_student_report_custom_path_does_not_create_attempt_history(tmp_path) -> None:
     write_assignment(tmp_path, write_activity(tmp_path))
     write_python_workspace(

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -6,7 +6,7 @@ import subprocess
 
 import pytest
 
-from scripts import assignment_records, student_lab_runner, student_lab_service
+from scripts import assignment_records, student_lab_attempts, student_lab_runner, student_lab_service
 
 
 def write_activity(root, activity_id: str = "python-base-somma-001", **overrides) -> str:
@@ -172,6 +172,12 @@ def test_write_student_report_persists_latest_json_and_service_reads_it(tmp_path
     assert stored["activity_id"] == "python-base-somma-001"
     assert stored["submitted_at"] == report["generated_at"]
     assert stored["source"] == "assignments/python-base-somma-001/main.py"
+    assert stored["attempt_id"].startswith("attempt-")
+    history_dir = student_lab_attempts.assignment_history_dir(report_path, assignment["assignment_id"])
+    attempt_paths = list((history_dir / "attempts").glob("attempt-*.json"))
+    assert len(attempt_paths) == 1
+    assert json.loads(attempt_paths[0].read_text(encoding="utf-8")) == stored
+    assert json.loads((history_dir / "latest.json").read_text(encoding="utf-8")) == stored
 
     payload = student_lab_service.student_lab_payload(
         root=tmp_path,
@@ -187,6 +193,10 @@ def test_write_student_report_persists_latest_json_and_service_reads_it(tmp_path
     assert assignment_payload["grading"]["status"] == "graded_passed"
     assert assignment_payload["grading"]["tests_passed"] == 1
     assert assignment_payload["grading"]["tests_total"] == 1
+    assert assignment_payload["attempts"]["count"] == 1
+    assert assignment_payload["attempts"]["latest"]["id"] == stored["attempt_id"]
+    assert assignment_payload["attempts"]["best"]["id"] == stored["attempt_id"]
+    assert assignment_payload["attempts"]["final"] is None
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node non disponibile nell'ambiente di test")
@@ -248,6 +258,119 @@ def test_sql_assignment_flows_from_runner_to_service_grading(tmp_path) -> None:
     assert assignment_payload["grading"]["status"] == "graded_passed"
     assert assignment_payload["grading"]["tests_passed"] == 1
     assert assignment_payload["grading"]["tests_total"] == 1
+
+
+def test_write_student_report_keeps_attempts_when_runs_share_the_same_second(tmp_path, monkeypatch) -> None:
+    write_assignment(tmp_path, write_activity(tmp_path))
+    write_python_workspace(
+        tmp_path,
+        source="def somma(a, b):\n    return a + b\n",
+        test_source="from main import somma\n\ndef test_somma():\n    assert somma(2, 3) == 5\n",
+    )
+    assignment = student_lab_runner.load_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        now="2026-10-18T12:00:00+02:00",
+    )
+    report = student_lab_runner.run_local_assignment(assignment, root=tmp_path)
+    ids = iter(
+        [
+            "attempt-20261018T100000000000Z-11111111",
+            "attempt-20261018T100000000000Z-22222222",
+        ]
+    )
+    monkeypatch.setattr(student_lab_attempts, "new_attempt_id", lambda: next(ids))
+
+    report_path = student_lab_runner.write_student_report(tmp_path, assignment, report)
+    student_lab_runner.write_student_report(tmp_path, assignment, report)
+
+    history_dir = student_lab_attempts.assignment_history_dir(report_path, assignment["assignment_id"])
+    assert sorted(path.name for path in (history_dir / "attempts").glob("attempt-*.json")) == [
+        "attempt-20261018T100000000000Z-11111111.json",
+        "attempt-20261018T100000000000Z-22222222.json",
+    ]
+    latest = json.loads(report_path.read_text(encoding="utf-8"))
+    assert latest["attempt_id"] == "attempt-20261018T100000000000Z-22222222"
+
+
+def test_write_student_report_custom_path_does_not_create_attempt_history(tmp_path) -> None:
+    write_assignment(tmp_path, write_activity(tmp_path))
+    write_python_workspace(
+        tmp_path,
+        source="def somma(a, b):\n    return a + b\n",
+        test_source="from main import somma\n\ndef test_somma():\n    assert somma(2, 3) == 5\n",
+    )
+    assignment = student_lab_runner.load_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        now="2026-10-18T12:00:00+02:00",
+    )
+    report = student_lab_runner.run_local_assignment(assignment, root=tmp_path)
+    custom_path = tmp_path / "exports" / "report.json"
+
+    written = student_lab_runner.write_student_report(tmp_path, assignment, report, custom_path)
+
+    assert written == custom_path
+    assert custom_path.is_file()
+    assert "attempt_id" not in json.loads(custom_path.read_text(encoding="utf-8"))
+    assert list(custom_path.parent.glob("attempt-*.json")) == []
+
+
+def test_finalize_report_attempt_selects_current_attempt(tmp_path) -> None:
+    write_assignment(tmp_path, write_activity(tmp_path))
+    write_python_workspace(
+        tmp_path,
+        source="def somma(a, b):\n    return a + b\n",
+        test_source="from main import somma\n\ndef test_somma():\n    assert somma(2, 3) == 5\n",
+    )
+    assignment = student_lab_runner.load_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id="python-base-somma-001",
+        now="2026-10-18T12:00:00+02:00",
+    )
+    report = student_lab_runner.run_local_assignment(assignment, root=tmp_path)
+    report_path = student_lab_runner.write_student_report(tmp_path, assignment, report)
+
+    final_path = student_lab_runner.finalize_report_attempt(tmp_path, assignment, report_path)
+
+    final = json.loads(final_path.read_text(encoding="utf-8"))
+    latest = json.loads(report_path.read_text(encoding="utf-8"))
+    assert final["attempt_id"] == latest["attempt_id"]
+    payload = student_lab_service.student_lab_payload(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-20T12:00:00+02:00",
+    )
+    assert payload["assignments"][0]["attempts"]["final"]["id"] == latest["attempt_id"]
+
+
+def test_finalize_report_attempt_rejects_custom_report_path(tmp_path) -> None:
+    assignment = {"report": {"path": "reports/activity/latest.json"}}
+
+    with pytest.raises(ValueError, match="path report standard"):
+        student_lab_runner.finalize_report_attempt(
+            tmp_path,
+            assignment,
+            tmp_path / "exports" / "report.json",
+        )
+
+
+def test_write_json_atomic_removes_temporary_file_after_replace_failure(tmp_path, monkeypatch) -> None:
+    output = tmp_path / "latest.json"
+
+    def fail_replace(source, destination):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(student_lab_attempts.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        student_lab_attempts.write_json_atomic(output, {"status": "passed"})
+
+    assert not output.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
 
 
 def test_run_student_assignment_reports_python_pytest_failure(tmp_path) -> None:

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -746,6 +746,44 @@ def test_student_lab_uses_existing_report_and_grading_summary(tmp_path) -> None:
     }
 
 
+def test_student_lab_does_not_claim_best_when_attempt_history_is_truncated(tmp_path, monkeypatch) -> None:
+    write_assignment(tmp_path, sample_assignment(tmp_path))
+    repo = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario"
+    report_path = repo / "reports" / "python-base-somma-001" / "latest.json"
+    report_path.parent.mkdir(parents=True)
+    report_path.write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "status": "failed",
+                "passed": False,
+                "submitted_at": "2026-10-18T18:00:00+02:00",
+                "summary": {"passed": 1, "total": 2},
+                "tests": [
+                    {"name": "positivo", "status": "passed", "passed": True},
+                    {"name": "negativo", "status": "failed", "passed": False},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        student_lab_attempts,
+        "load_attempt_history",
+        lambda *args, **kwargs: {"attempts": [], "count": 501, "truncated": True},
+    )
+
+    assignment = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-20T12:00:00+02:00",
+    )[0]
+
+    assert assignment["attempts"]["truncated"] is True
+    assert assignment["attempts"]["latest"]["status"] == "failed"
+    assert assignment["attempts"]["best"] is None
+
+
 def test_student_lab_keeps_attempt_history_separate_for_repeated_activity(tmp_path) -> None:
     first = sample_assignment(
         tmp_path,

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -725,6 +725,7 @@ def test_student_lab_uses_existing_report_and_grading_summary(tmp_path) -> None:
     ]
     assert assignment["attempts"] == {
         "count": 1,
+        "truncated": False,
         "latest": {
             "id": "",
             "submitted_at": "2026-10-18T18:00:00+02:00",
@@ -810,6 +811,57 @@ def test_student_lab_keeps_attempt_history_separate_for_repeated_activity(tmp_pa
     assert by_id[second["id"]]["grading"]["tests_passed"] == 2
     assert by_id[second["id"]]["attempts"]["count"] == 1
     assert by_id[first["id"]]["attempts"]["latest"]["id"] != by_id[second["id"]]["attempts"]["latest"]["id"]
+
+
+def test_student_lab_does_not_reuse_legacy_latest_for_another_assignment(tmp_path) -> None:
+    first = sample_assignment(
+        tmp_path,
+        assignment_id="assignment-somma-primo",
+        assigned_at="2026-10-01T09:00:00+02:00",
+        due_at="2026-10-08T23:59:00+02:00",
+    )
+    second = sample_assignment(
+        tmp_path,
+        assignment_id="assignment-somma-secondo",
+        assigned_at="2026-10-12T09:00:00+02:00",
+        due_at="2026-10-19T23:59:00+02:00",
+    )
+    write_assignment(tmp_path, first)
+    write_assignment(tmp_path, second)
+    report_path = (
+        tmp_path
+        / "examples"
+        / "assignment_tracking"
+        / "student_repos"
+        / "rossi-mario"
+        / "reports"
+        / "python-base-somma-001"
+        / "latest.json"
+    )
+    first_report = {
+        "schema_version": "student_lab_run.v1",
+        "assignment_id": first["id"],
+        "activity_id": "python-base-somma-001",
+        "student_id": "rossi-mario",
+        "status": "passed",
+        "passed": True,
+        "submitted_at": "2026-10-08T18:00:00+02:00",
+        "summary": {"passed": 1, "total": 1},
+        "tests": [{"name": "somma", "status": "passed", "passed": True}],
+    }
+    student_lab_attempts.persist_attempt(report_path, first["id"], first_report)
+    student_lab_attempts.write_json_atomic(report_path, first_report)
+
+    assignments = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-20T12:00:00+02:00",
+    )
+
+    by_id = {item["assignment_id"]: item for item in assignments}
+    assert by_id[first["id"]]["submitted"] is True
+    assert by_id[second["id"]]["submitted"] is False
+    assert by_id[second["id"]]["attempts"]["count"] == 0
 
 
 def test_student_lab_exposes_saved_failed_test_messages(tmp_path) -> None:

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -9,6 +9,7 @@ from scripts import (
     student_help_auth,
     student_help_service,
     student_identity,
+    student_lab_attempts,
     student_lab_service,
     student_support_policy,
 )
@@ -722,6 +723,93 @@ def test_student_lab_uses_existing_report_and_grading_summary(tmp_path) -> None:
         {"name": "somma positiva", "passed": True, "status": "passed"},
         {"name": "somma negativa", "passed": True, "status": "passed"},
     ]
+    assert assignment["attempts"] == {
+        "count": 1,
+        "latest": {
+            "id": "",
+            "submitted_at": "2026-10-18T18:00:00+02:00",
+            "status": "passed",
+            "passed": True,
+            "tests_passed": 2,
+            "tests_total": 2,
+        },
+        "best": {
+            "id": "",
+            "submitted_at": "2026-10-18T18:00:00+02:00",
+            "status": "passed",
+            "passed": True,
+            "tests_passed": 2,
+            "tests_total": 2,
+        },
+        "final": None,
+    }
+
+
+def test_student_lab_keeps_attempt_history_separate_for_repeated_activity(tmp_path) -> None:
+    first = sample_assignment(
+        tmp_path,
+        assignment_id="assignment-somma-primo",
+        assigned_at="2026-10-01T09:00:00+02:00",
+        due_at="2026-10-08T23:59:00+02:00",
+    )
+    second = sample_assignment(
+        tmp_path,
+        assignment_id="assignment-somma-secondo",
+        assigned_at="2026-10-12T09:00:00+02:00",
+        due_at="2026-10-19T23:59:00+02:00",
+    )
+    write_assignment(tmp_path, first)
+    write_assignment(tmp_path, second)
+    report_path = (
+        tmp_path
+        / "examples"
+        / "assignment_tracking"
+        / "student_repos"
+        / "rossi-mario"
+        / "reports"
+        / "python-base-somma-001"
+        / "latest.json"
+    )
+    first_report = {
+        "schema_version": "student_lab_run.v1",
+        "activity_id": "python-base-somma-001",
+        "student_id": "rossi-mario",
+        "status": "failed",
+        "passed": False,
+        "submitted_at": "2026-10-08T18:00:00+02:00",
+        "summary": {"passed": 1, "total": 2},
+        "tests": [
+            {"name": "positivo", "status": "passed", "passed": True},
+            {"name": "negativo", "status": "failed", "passed": False},
+        ],
+    }
+    second_report = {
+        **first_report,
+        "status": "passed",
+        "passed": True,
+        "submitted_at": "2026-10-18T18:00:00+02:00",
+        "summary": {"passed": 2, "total": 2},
+        "tests": [
+            {"name": "positivo", "status": "passed", "passed": True},
+            {"name": "negativo", "status": "passed", "passed": True},
+        ],
+    }
+    student_lab_attempts.persist_attempt(report_path, first["id"], first_report)
+    student_lab_attempts.persist_attempt(report_path, second["id"], second_report)
+    student_lab_attempts.write_json_atomic(report_path, second_report)
+
+    assignments = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-20T12:00:00+02:00",
+    )
+
+    by_id = {item["assignment_id"]: item for item in assignments}
+    assert by_id[first["id"]]["grading"]["tests_passed"] == 1
+    assert by_id[first["id"]]["attempts"]["count"] == 1
+    assert by_id[second["id"]]["grading"]["tests_passed"] == 2
+    assert by_id[second["id"]]["attempts"]["count"] == 1
+    assert by_id[first["id"]]["attempts"]["latest"]["id"] != by_id[second["id"]]["attempts"]["latest"]["id"]
 
 
 def test_student_lab_exposes_saved_failed_test_messages(tmp_path) -> None:

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -770,7 +770,7 @@ def test_student_lab_does_not_claim_best_when_attempt_history_is_truncated(tmp_p
     monkeypatch.setattr(
         student_lab_attempts,
         "load_attempt_history",
-        lambda *args, **kwargs: {"attempts": [], "count": 501, "truncated": True},
+        lambda *args, **kwargs: {"attempts": [], "count": 0, "truncated": True},
     )
 
     assignment = student_lab_service.list_student_lab_assignments(

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -864,6 +864,55 @@ def test_student_lab_does_not_reuse_legacy_latest_for_another_assignment(tmp_pat
     assert by_id[second["id"]]["attempts"]["count"] == 0
 
 
+def test_student_lab_does_not_guess_unscoped_legacy_report_for_repeated_activity(tmp_path) -> None:
+    first = sample_assignment(
+        tmp_path,
+        assignment_id="assignment-somma-primo",
+        assigned_at="2026-10-01T09:00:00+02:00",
+        due_at="2026-10-08T23:59:00+02:00",
+    )
+    second = sample_assignment(
+        tmp_path,
+        assignment_id="assignment-somma-secondo",
+        assigned_at="2026-10-12T09:00:00+02:00",
+        due_at="2026-10-19T23:59:00+02:00",
+    )
+    write_assignment(tmp_path, first)
+    write_assignment(tmp_path, second)
+    report_path = (
+        tmp_path
+        / "examples"
+        / "assignment_tracking"
+        / "student_repos"
+        / "rossi-mario"
+        / "reports"
+        / "python-base-somma-001"
+        / "latest.json"
+    )
+    student_lab_attempts.write_json_atomic(
+        report_path,
+        {
+            "schema_version": "student_lab_run.v1",
+            "activity_id": "python-base-somma-001",
+            "student_id": "rossi-mario",
+            "status": "passed",
+            "passed": True,
+            "submitted_at": "2026-10-08T18:00:00+02:00",
+            "summary": {"passed": 1, "total": 1},
+            "tests": [{"name": "somma", "status": "passed", "passed": True}],
+        },
+    )
+
+    assignments = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+        now="2026-10-20T12:00:00+02:00",
+    )
+
+    assert all(item["submitted"] is False for item in assignments)
+    assert all(item["attempts"]["count"] == 0 for item in assignments)
+
+
 def test_student_lab_exposes_saved_failed_test_messages(tmp_path) -> None:
     write_assignment(tmp_path, sample_assignment(tmp_path))
     repo = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario"

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -792,6 +792,90 @@ def test_track_assignments_uses_stable_assignment_student_id_for_server_help(tmp
     assert help_summary["path"].startswith("teacher-help-events/student_id-")
 
 
+def test_track_assignments_reads_assignment_specific_report(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    first_id = "assignment-somma-primo"
+    second_id = "assignment-somma-secondo"
+    storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
+    for assignment_id, assigned_at in (
+        (first_id, "2026-10-01T09:00:00+02:00"),
+        (second_id, "2026-10-12T09:00:00+02:00"),
+    ):
+        storage.write_assignment(
+            assignment_records.build_assignment_record(
+                assignment_id=assignment_id,
+                activity_id="python-base-somma-001",
+                activity_path=str(activity_path.relative_to(tmp_path)),
+                target_type="student",
+                assigned_at=assigned_at,
+                due_at="2026-10-21T08:00:00+02:00",
+                targets=[
+                    {
+                        "student_id": "rossi-mario",
+                        "repo_ref": student.repo,
+                        "path": str(student.path.relative_to(tmp_path)),
+                    }
+                ],
+            )
+        )
+    report_root = student.path / "reports" / "python-base-somma-001"
+    for assignment_id, passed in ((first_id, False), (second_id, True)):
+        path = (
+            report_root
+            / "assignments"
+            / assignment_records.assignment_storage_key(assignment_id)
+            / "latest.json"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "activity_id": "python-base-somma-001",
+                    "assignment_id": assignment_id,
+                    "status": "passed" if passed else "failed",
+                    "passed": passed,
+                    "submitted_at": "2026-10-20T08:00:00+02:00",
+                    "tests": [{"name": "somma", "status": "passed" if passed else "failed", "passed": passed}],
+                }
+            ),
+            encoding="utf-8",
+        )
+    (report_root / "latest.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "assignment_id": second_id,
+                "status": "passed",
+                "passed": True,
+                "submitted_at": "2026-10-20T08:00:00+02:00",
+                "tests": [{"name": "somma", "status": "passed", "passed": True}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    first_index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=first_id,
+        server_root=tmp_path,
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+    )
+    second_index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=second_id,
+        server_root=tmp_path,
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+    )
+
+    assert first_index["students"][0]["grading"]["status"] == "graded_failed"
+    assert second_index["students"][0]["grading"]["status"] == "graded_passed"
+
+
 def test_track_assignments_uses_canonical_legacy_identity_for_server_help(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "Mario Rossi")

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -876,6 +876,63 @@ def test_track_assignments_reads_assignment_specific_report(tmp_path) -> None:
     assert second_index["students"][0]["grading"]["status"] == "graded_passed"
 
 
+def test_track_assignments_rejects_unscoped_legacy_report_for_repeated_activity(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    first_id = "assignment-somma-primo"
+    second_id = "assignment-somma-secondo"
+    storage = assignment_records.JsonAssignmentRecordStorage(tmp_path)
+    for assignment_id, assigned_at in (
+        (first_id, "2026-10-01T09:00:00+02:00"),
+        (second_id, "2026-10-12T09:00:00+02:00"),
+    ):
+        storage.write_assignment(
+            assignment_records.build_assignment_record(
+                assignment_id=assignment_id,
+                activity_id="python-base-somma-001",
+                activity_path=str(activity_path.relative_to(tmp_path)),
+                target_type="student",
+                assigned_at=assigned_at,
+                due_at="2026-10-21T08:00:00+02:00",
+                targets=[
+                    {
+                        "student_id": "rossi-mario",
+                        "repo_ref": student.repo,
+                        "path": str(student.path.relative_to(tmp_path)),
+                    }
+                ],
+            )
+        )
+    legacy_report = student.path / "reports" / "python-base-somma-001" / "latest.json"
+    legacy_report.parent.mkdir(parents=True)
+    legacy_report.write_text(
+        json.dumps(
+            {
+                "activity_id": "python-base-somma-001",
+                "status": "passed",
+                "passed": True,
+                "submitted_at": "2026-10-20T08:00:00+02:00",
+                "tests": [{"name": "somma", "status": "passed", "passed": True}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=first_id,
+        server_root=tmp_path,
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+    )
+
+    row = index["students"][0]
+    assert row["submitted"] is False
+    assert row["grading"]["status"] == "not_graded"
+    assert row["report_path"] is None
+
+
 def test_track_assignments_uses_canonical_legacy_identity_for_server_help(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "Mario Rossi")


### PR DESCRIPTION
## Sintesi

- conserva ogni esecuzione del runner come tentativo immutabile separato per `assignment_id`;
- mantiene `reports/<activity_id>/latest.json` compatibile con dashboard e registro esistenti;
- espone nel servizio conteggio, ultimo tentativo, miglior risultato e tentativo definitivo;
- permette di marcare esplicitamente come definitiva l'esecuzione appena salvata con `--write-report --final`;
- protegge scritture e letture con lock multipiattaforma, path confinement, rollback, limiti e caricamento diretto di `latest`/`final`;
- documenta differenza tra `latest`, `best` e `final` e i limiti dello storico locale.

Closes #500

## Contratto retrocompatibile

`latest.json` al livello activity resta disponibile. Il nuovo storico canonico è:

```text
reports/<activity_id>/
  latest.json
  assignments/<assignment-key>/
    latest.json
    final.json
    attempts/attempt-*.json
```

I report legacy senza `assignment_id` restano leggibili quando l'activity compare in una sola consegna; non vengono attribuiti arbitrariamente quando la stessa activity è assegnata più volte.

## Verifica

- `python -m pytest -q tests/test_student_lab_attempts.py tests/test_student_lab_runner.py tests/test_student_lab_service.py`
- `python -m pytest -q`
- suite completa al 100%, con soli skip già previsti dall'ambiente
- review pre-PR Sol medium pulita dopo i fix di hardening