### PR TITLE
feat: gestisci lo storico tentativi dalla TUI studente

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -456,8 +456,11 @@ Il grading attuale e una base, ma il flusso reale richiede altri passi.
 7. Scaricare artifact/report GitHub Actions e collegarli ai registri.
 8. Garantire che i job che eseguono codice studente non abbiano segreti.
 9. Estendere il backend gia introdotto per i tentativi (`Attempt`) separati dalla consegna finale (`Submission`):
-   - mostrare lo storico nella GUI/TUI;
-   - permettere allo studente e al docente di selezionare il tentativo definitivo secondo policy;
+   - mostrare lo storico nella GUI/TUI; la TUI espone gia conteggio, ultimo, migliore, definitivo e lista compatta,
+     mentre resta da aggiungere la vista web;
+   - permettere allo studente e al docente di selezionare il tentativo definitivo secondo policy; la selezione
+     studente e disponibile nella TUI tramite servizio locale o API autenticata, mentre resta da progettare
+     l'eventuale override docente;
    - usare una fonte autorevole server/GitHub per metriche ufficiali;
    - aggiungere retention, fingerprint di activity/test e analytics senza confondere voto e processo.
 

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -78,6 +78,7 @@ Ogni pannello, modal, vista e comando deve avere almeno uno scenario manuale. Qu
 | TUI studente | Comando `e` | Esegui test e salva report con backend local e docker, poi verifica GUI studente/docente | Test interattivo piu assert su file |
 | TUI studente | Comando `a` | Chiedi aiuto, verifica guida locale e storico, annulla con `b`/invio, valida input non valido | Test interattivo con input finto |
 | TUI studente | Comando `h` | Mostra storico aiuti e torna alla consegna | Test interattivo con input finto |
+| TUI studente | Comando `t` | Mostra tentativi, annulla con `b`/invio e salva una scelta definitiva valida | Test interattivo con input finto e assert su `final.json` |
 | TUI studente | Comando `o` | Apre workspace se presente, mostra errore chiaro se assente | Test con mock apertura |
 | TUI studente | Comandi `b`, `r`, `q` | Torna indietro, ricarica, esce senza perdere stato | Test interattivo con input finto |
 

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -239,9 +239,15 @@ Comandi disponibili nella TUI minima:
 
 Nel dettaglio della consegna i comandi sono divisi in:
 
-- azioni principali: `e` esegue il runner e salva il report, `a` registra una richiesta di aiuto, `o` apre la cartella workspace, `v` apre l'editor;
+- azioni principali: `e` esegue il runner e salva il report, `t` mostra lo storico e seleziona il tentativo
+  definitivo, `a` registra una richiesta di aiuto, `o` apre la cartella workspace, `v` apre l'editor;
 - altri comandi: `h` mostra lo storico aiuti, `b` o invio torna alla lista, `q` esce.
 - navigazione `utui`: `j` scorre i pannelli verso il basso e `k` verso l'alto.
+
+Il comando `t` elenca i tentativi immutabili dal piu recente, evidenzia quello gia scelto come definitivo e accetta
+solo uno dei numeri mostrati. `b` o invio annullano senza modificare lo stato. Quando la TUI usa un bearer token,
+la selezione viene inviata a `POST /api/student-lab/final-attempt`: il server ricava lo studente dal token e valida
+consegna e tentativo sui propri dati. Senza token, la stessa operazione applicativa lavora sulla root locale.
 
 Il comando `v` cerca un editor terminale nell'ordine `micro`, `nvim`, `vim`, `hx`, `nano` (e `notepad` su Windows).
 Per scegliere esplicitamente un editor, imposta `THEBITLAB_EDITOR`, per esempio `micro --clean` o `nvim`.
@@ -281,6 +287,8 @@ Il payload ha schema `student_lab.v1` e contiene:
 - `workspace`: cartella locale `assignments/<activity_id>` in cui lo studente lavora;
 - `activity`: metadati minimi della activity collegata;
 - `report`: report locale `reports/<activity_id>/latest.json`, se esiste;
+- `attempts`: conteggio, indicatore di storico parziale, riepiloghi `latest`, `best`, `final` e lista compatta
+  `items` dei tentativi selezionabili;
 - `grading`: riepilogo deterministico del report, se esiste;
 - `runner`: stato del runner lab nel payload di consultazione.
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -119,6 +119,7 @@ REMOTE_STUDENT_API_ROUTES = frozenset(
         ("GET", "/api/student-lab/assignments"),
         ("GET", "/api/student-lab/help-history"),
         ("POST", "/api/student-lab/help"),
+        ("POST", "/api/student-lab/final-attempt"),
     }
 )
 _ASSIGNMENT_OPERATION_LOCKS: dict[str, dict[str, Any]] = {}
@@ -315,6 +316,12 @@ def student_help_operation_id(assignment_id: str, student_id: str) -> str:
     return f"help::{assignment_id}::{student_id}"
 
 
+def student_attempt_operation_id(assignment_id: str, student_id: str) -> str:
+    """Return the per-student lock key for final-attempt selection."""
+
+    return f"attempt::{assignment_id}::{student_id}"
+
+
 def unique_student_help_operation_ids(assignment_id: str, student_ids: set[str]) -> list[str]:
     """Return one operation id for each effective lock key."""
 
@@ -358,6 +365,23 @@ def record_student_help(payload: dict[str, Any], *, student_id: str) -> dict[str
         except student_help_service.StudentHelpRequestNotFoundError:
             raise StudentHelpBusyError("Richiesta di aiuto gia in elaborazione per questa consegna.") from None
     return {"ok": True, "event": event}
+
+
+def select_student_final_attempt(payload: dict[str, Any], *, student_id: str) -> dict[str, Any]:
+    """Select one immutable attempt through the authenticated student API."""
+
+    assignment_id = str(payload.get("assignment_id", "")).strip()
+    with assignment_operation_lock(
+        student_attempt_operation_id(assignment_id, student_id),
+    ):
+        assignment = student_lab_service.select_student_final_attempt(
+            root=ROOT,
+            assignments_dir=TEACHER_ASSIGNMENTS_DIR,
+            student_id=student_id,
+            assignment_id=assignment_id,
+            attempt_id=payload.get("attempt_id", ""),
+        )
+    return {"ok": True, "assignment": assignment}
 
 
 def configure_data_root(root: Path) -> Path:
@@ -3414,6 +3438,28 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if self.reject_unauthenticated_teacher_api("POST", parsed.path):
             return
         if self.reject_unsafe_teacher_post(parsed.path):
+            return
+        if parsed.path == "/api/student-lab/final-attempt":
+            student_id = self.authenticated_student_id()
+            if student_id is None:
+                return
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+            except (TypeError, ValueError):
+                self.write_error_json(400, "Content-Length non valido.")
+                return
+            if length < 1 or length > MAX_STUDENT_HELP_REQUEST_BYTES:
+                self.write_error_json(413, "Richiesta troppo grande o vuota.")
+                return
+            try:
+                payload = json.loads(self.rfile.read(length).decode("utf-8"))
+                if not isinstance(payload, dict):
+                    raise ValueError("Il payload della richiesta deve essere un oggetto JSON.")
+                self.write_json(select_student_final_attempt(payload, student_id=student_id))
+            except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+                self.write_error_json(400, str(error))
+            except Exception:  # noqa: BLE001
+                self.write_error_json(500, "Selezione tentativo temporaneamente non disponibile.")
             return
         if parsed.path == "/api/student-lab/help":
             student_id = self.authenticated_student_id()

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -68,6 +68,7 @@ GUIDE_TERM_COLORS = {
 }
 GUIDE_TERM_BOLD_COLOR = "\033[1;37m"
 GUIDE_DESCRIPTION_COLOR = "\033[3;90m"
+MAX_ATTEMPTS_DISPLAYED = 20
 RESET_COLOR = "\033[0m"
 
 
@@ -367,6 +368,79 @@ def render_test_details(report: dict[str, Any], use_color: bool = False) -> list
     return lines
 
 
+def attempt_result_label(attempt: dict[str, Any] | None, use_color: bool = False) -> str:
+    """Return one compact attempt result for summaries and history."""
+
+    if not isinstance(attempt, dict):
+        return "-"
+    passed = attempt.get("tests_passed")
+    total = attempt.get("tests_total")
+    tests = f"{passed}/{total} test" if isinstance(passed, int) and isinstance(total, int) else "test n/d"
+    status = clean_text(attempt.get("status"), "esito n/d")
+    color = (
+        HELP_RESPONSE_COLOR
+        if attempt.get("passed") is True
+        else HELP_ERROR_COLOR
+        if attempt.get("passed") is False
+        else HELP_PROMPT_COLOR
+    )
+    return colorize(
+        f"{status}, {tests}, {compact_datetime(attempt.get('submitted_at'))}",
+        color,
+        use_color,
+    )
+
+
+def selectable_attempts(assignment: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the recent valid attempts exposed by the interactive TUI."""
+
+    attempts = assignment.get("attempts") if isinstance(assignment.get("attempts"), dict) else {}
+    items = attempts.get("items") if isinstance(attempts.get("items"), list) else []
+    return [
+        item
+        for item in items
+        if isinstance(item, dict) and clean_text(item.get("id"), "")
+    ][:MAX_ATTEMPTS_DISPLAYED]
+
+
+def render_attempt_history(assignment: dict[str, Any], use_color: bool = False) -> str:
+    """Render the bounded immutable attempt history for one assignment."""
+
+    attempts = assignment.get("attempts") if isinstance(assignment.get("attempts"), dict) else {}
+    all_items = attempts.get("items") if isinstance(attempts.get("items"), list) else []
+    items = selectable_attempts(assignment)
+    final = attempts.get("final") if isinstance(attempts.get("final"), dict) else {}
+    final_id = clean_text(final.get("id"), "")
+    lines = ["Storico tentativi", section_separator()]
+    if not items:
+        lines.append("Nessun tentativo selezionabile.")
+    for index, raw_attempt in enumerate(items, start=1):
+        attempt = raw_attempt if isinstance(raw_attempt, dict) else {}
+        marker = " [definitivo]" if clean_text(attempt.get("id"), "") == final_id else ""
+        lines.append(
+            f"{index:>2}. {attempt_result_label(attempt, use_color=use_color)}{marker}"
+        )
+        lines.append(f"    ID: {clean_text(attempt.get('id'), '-')}")
+    if attempts.get("truncated") is True:
+        lines.extend(
+            [
+                section_separator(),
+                "Avviso: lo storico mostrato e parziale; i tentativi piu vecchi non sono elencati.",
+            ]
+        )
+    if len(all_items) > len(items):
+        lines.append(
+            f"Sono mostrati solo i {len(items)} tentativi piu recenti su {attempts.get('count') or len(all_items)}."
+        )
+    lines.extend(
+        [
+            section_separator(),
+            "Scegli un numero per indicare il tentativo definitivo; invio o b annulla.",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def render_assignment_detail(
     assignment: dict[str, Any],
     use_color: bool = False,
@@ -378,6 +452,7 @@ def render_assignment_detail(
     workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
     activity = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
     report = assignment.get("report") if isinstance(assignment.get("report"), dict) else {}
+    attempts = assignment.get("attempts") if isinstance(assignment.get("attempts"), dict) else {}
     grading = assignment.get("grading") if isinstance(assignment.get("grading"), dict) else {}
     runner = assignment.get("runner") if isinstance(assignment.get("runner"), dict) else {}
     support_policy = assignment.get("support_policy") if isinstance(assignment.get("support_policy"), dict) else {}
@@ -426,6 +501,33 @@ def render_assignment_detail(
         detail_line("Esiste:", "si" if report.get("exists") else "no"),
         detail_line("Consegnata:", compact_datetime(report.get("submitted_at"))),
         detail_line("Commit:", report.get("commit")),
+        section_separator(),
+        "Tentativi",
+        detail_line("Totale:", attempts.get("count")),
+        detail_line(
+            "Ultimo:",
+            attempt_result_label(
+                attempts.get("latest") if isinstance(attempts.get("latest"), dict) else None,
+                use_color,
+            ),
+            formatted=True,
+        ),
+        detail_line(
+            "Migliore:",
+            attempt_result_label(
+                attempts.get("best") if isinstance(attempts.get("best"), dict) else None,
+                use_color,
+            ),
+            formatted=True,
+        ),
+        detail_line(
+            "Definitivo:",
+            attempt_result_label(
+                attempts.get("final") if isinstance(attempts.get("final"), dict) else None,
+                use_color,
+            ),
+            formatted=True,
+        ),
         *(
             [
                 section_separator(),
@@ -468,6 +570,7 @@ def render_assignment_detail(
         "Azioni principali",
         "  e  Esegui test e salva report",
         "  a  Chiedi aiuto",
+        "  t  Storico e tentativo definitivo",
         "  o  Apri workspace",
         "  v  Apri editor",
         "  l  Modifica layout pannelli",
@@ -585,7 +688,7 @@ def render_utui_detail_commands() -> str:
     return "\n".join(
         (
             "Navigazione: j = scorri giu | k = scorri su | l = modifica layout",
-            "Azioni: e = test/report | a = aiuto | o = workspace | v = editor",
+            "Azioni: e = test/report | t = tentativi | a = aiuto | o = workspace | v = editor",
             "Altri: h = storico aiuti | b/invio = lista | q = esci",
         )
     )
@@ -889,6 +992,56 @@ def fetch_help_history_from_server(
     if not isinstance(payload, dict) or not isinstance(payload.get("events"), list):
         raise ValueError("Il server aiuti ha restituito uno storico non valido.")
     return payload
+
+
+def select_final_attempt_from_server(
+    *,
+    assignment: dict[str, Any],
+    attempt_id: str,
+    server_url: str,
+    server_token: str,
+    allow_insecure_http: bool = False,
+) -> dict[str, Any]:
+    """Select one final attempt through the authenticated student API."""
+
+    assignment_id = clean_text(assignment.get("assignment_id"), "")
+    if not assignment_id:
+        raise ValueError("Identificativo consegna non disponibile.")
+    if not server_token.strip():
+        raise ValueError("Token studente mancante. Imposta THEBITLAB_STUDENT_HELP_TOKEN.")
+    safe_server_url = validated_server_url(server_url, allow_insecure_http)
+    body = json.dumps(
+        {
+            "assignment_id": assignment_id,
+            "attempt_id": clean_text(attempt_id, ""),
+        },
+        ensure_ascii=False,
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"{safe_server_url}/api/student-lab/final-attempt",
+        data=body,
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "Authorization": f"Bearer {server_token.strip()}",
+        },
+        method="POST",
+    )
+    try:
+        with student_api_urlopen(request, timeout=HELP_REQUEST_TIMEOUT_SECONDS) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = _server_error_detail(error.read())
+        raise ValueError(f"Server tentativi: {detail or error.reason}") from error
+    except urllib.error.URLError as error:
+        raise ValueError(f"Server non raggiungibile su {server_url}.") from error
+    except TimeoutError as error:
+        raise ValueError("Il server tentativi non ha risposto entro il tempo previsto.") from error
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise ValueError("Il server tentativi ha restituito una risposta non valida.") from error
+    selected = payload.get("assignment") if isinstance(payload, dict) else None
+    if not isinstance(selected, dict):
+        raise ValueError("Il server tentativi non ha restituito la consegna aggiornata.")
+    return selected
 
 
 def _server_error_detail(body: bytes) -> str:
@@ -1373,6 +1526,52 @@ def run_tui(
                         print_fn(render_help_history(assignment, root=root, use_color=use_color))
                 except ValueError as error:
                     print_fn(f"Storico aiuti non disponibile:\n{error}")
+                input_fn("Premi invio per continuare...")
+                continue
+            if action == "t":
+                print_fn(render_attempt_history(assignment, use_color=use_color))
+                items = selectable_attempts(assignment)
+                choice = input_fn("Tentativo definitivo: ").strip().lower()
+                if choice in {"", "b", "back", "indietro"}:
+                    print_fn("Selezione tentativo annullata.")
+                elif not choice.isdigit() or not 1 <= int(choice) <= len(items):
+                    print_fn("Tentativo non valido. Usa uno dei numeri mostrati, invio o b.")
+                else:
+                    selected_attempt = items[int(choice) - 1]
+                    attempt_id = (
+                        clean_text(selected_attempt.get("id"), "")
+                        if isinstance(selected_attempt, dict)
+                        else ""
+                    )
+                    try:
+                        if server_token.strip():
+                            select_final_attempt_from_server(
+                                assignment=assignment,
+                                attempt_id=attempt_id,
+                                server_url=server_url,
+                                server_token=server_token,
+                                allow_insecure_http=allow_insecure_http,
+                            )
+                        else:
+                            student_lab_service.select_student_final_attempt(
+                                root=root,
+                                student_id=student_id,
+                                assignment_id=selected_assignment_id,
+                                attempt_id=attempt_id,
+                                now=now,
+                            )
+                        payload = load_current_payload(
+                            root=root,
+                            student_id=student_id,
+                            now=now,
+                            server_url=server_url,
+                            server_token=server_token,
+                            allow_insecure_http=allow_insecure_http,
+                        )
+                    except ValueError as error:
+                        print_fn(f"Tentativo definitivo non salvato:\n{error}")
+                    else:
+                        print_fn("Tentativo definitivo salvato.")
                 input_fn("Premi invio per continuare...")
                 continue
             if action == "e":

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -360,6 +360,11 @@ def build_lab_assignment(
             "latest": student_lab_attempts.attempt_summary(latest_attempt or legacy_report),
             "best": student_lab_attempts.attempt_summary(best_report),
             "final": student_lab_attempts.attempt_summary(final_attempt),
+            "items": [
+                summary
+                for attempt in attempts
+                if (summary := student_lab_attempts.attempt_summary(attempt)) is not None
+            ],
         },
         "grading": grading,
         "help": help_log,
@@ -499,6 +504,71 @@ def assignment_repo_path(root: Path, assignment: dict[str, Any]) -> Path | None:
         resolved = resolve_local_path(root, workspace_path)
         return resolved.parents[1] if len(resolved.parents) >= 2 else None
     return None
+
+
+def select_student_final_attempt(
+    *,
+    root: Path,
+    student_id: str,
+    assignment_id: str,
+    attempt_id: str,
+    assignments_dir: Path | None = None,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Select one existing attempt as the student's final submission."""
+
+    clean_assignment_id = clean_text(assignment_id)
+    clean_attempt_id = clean_text(attempt_id)
+    if not clean_assignment_id:
+        raise ValueError("assignment_id obbligatorio.")
+    if not clean_attempt_id:
+        raise ValueError("attempt_id obbligatorio.")
+    assignments = list_student_lab_assignments(
+        root=root,
+        student_id=student_id,
+        assignments_dir=assignments_dir,
+        now=now,
+        expose_external_paths=True,
+    )
+    assignment = next(
+        (
+            item
+            for item in assignments
+            if clean_text(item.get("assignment_id")) == clean_assignment_id
+        ),
+        None,
+    )
+    if assignment is None:
+        raise ValueError("Consegna non trovata per lo studente indicato.")
+    repo_path = assignment_repo_path(root, assignment)
+    activity_id = clean_text(assignment.get("activity_id"))
+    if repo_path is None or not activity_id:
+        raise ValueError("Repository studente non disponibile per selezionare il tentativo.")
+    report_path = repo_path / "reports" / activity_id / "latest.json"
+    student_lab_attempts.set_final_attempt(
+        report_path,
+        clean_assignment_id,
+        activity_id,
+        clean_attempt_id,
+    )
+    refreshed = list_student_lab_assignments(
+        root=root,
+        student_id=student_id,
+        assignments_dir=assignments_dir,
+        now=now,
+        expose_external_paths=True,
+    )
+    selected = next(
+        (
+            item
+            for item in refreshed
+            if clean_text(item.get("assignment_id")) == clean_assignment_id
+        ),
+        None,
+    )
+    if selected is None:
+        raise ValueError("Consegna non disponibile dopo la selezione del tentativo.")
+    return selected
 
 
 def help_provider_context(assignment: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/student_lab_service.py
+++ b/scripts/student_lab_service.py
@@ -556,7 +556,7 @@ def select_student_final_attempt(
         student_id=student_id,
         assignments_dir=assignments_dir,
         now=now,
-        expose_external_paths=True,
+        expose_external_paths=False,
     )
     selected = next(
         (

--- a/scripts/student_lab_utui.py
+++ b/scripts/student_lab_utui.py
@@ -217,6 +217,19 @@ def _grading_status(grading: Mapping[str, Any]) -> str:
     return status
 
 
+def _attempt_text(value: Any) -> str:
+    """Return one compact attempt summary for the report panel."""
+
+    attempt = _mapping(value)
+    if not attempt:
+        return MISSING_VALUE
+    passed = attempt.get("tests_passed")
+    total = attempt.get("tests_total")
+    tests = f"{passed}/{total} test" if isinstance(passed, int) and isinstance(total, int) else "test n/d"
+    status = _text(attempt.get("status"), "esito n/d")
+    return f"{status}, {tests}, {_datetime_text(attempt.get('submitted_at'))}"
+
+
 def _rows(*values: tuple[str, Any]) -> tuple[str, ...]:
     return tuple(f"{label}: {_text(value)}" for label, value in values)
 
@@ -262,6 +275,7 @@ def project_assignment_sections(assignment: Mapping[str, Any]) -> tuple[dict[str
     support = _mapping(assignment.get("support_policy"))
     help_summary = _mapping(assignment.get("help"))
     report = _mapping(assignment.get("report"))
+    attempts = _mapping(assignment.get("attempts"))
     grading = _mapping(assignment.get("grading"))
     runner = _mapping(assignment.get("runner"))
     grade = grading.get("teacher_grade")
@@ -346,6 +360,16 @@ def project_assignment_sections(assignment: Mapping[str, Any]) -> tuple[dict[str
                 ("Esiste", _yes_no(report.get("exists"))),
                 ("Consegnata", _datetime_text(report.get("submitted_at"))),
                 ("Commit", report.get("commit")),
+                *(
+                    (
+                        ("Tentativi", attempts.get("count")),
+                        ("Ultimo", _attempt_text(attempts.get("latest"))),
+                        ("Migliore", _attempt_text(attempts.get("best"))),
+                        ("Definitivo", _attempt_text(attempts.get("final"))),
+                    )
+                    if attempts
+                    else ()
+                ),
             ),
         },
         {

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -3475,6 +3475,97 @@ def test_record_student_help_delegates_only_client_identifiers_to_service(monkey
     }
 
 
+def test_select_student_final_attempt_delegates_authenticated_identity(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(course_board_server, "TEACHER_ASSIGNMENTS_DIR", tmp_path / "teacher-assignments")
+    captured = {}
+
+    def fake_select(**kwargs):
+        captured.update(kwargs)
+        return {"assignment_id": "assignment-001", "attempts": {"final": {"id": "attempt-002"}}}
+
+    monkeypatch.setattr(
+        course_board_server.student_lab_service,
+        "select_student_final_attempt",
+        fake_select,
+    )
+
+    response = course_board_server.select_student_final_attempt(
+        {
+            "student_id": "client-controllato",
+            "assignment_id": "assignment-001",
+            "attempt_id": "attempt-002",
+        },
+        student_id="rossi-mario",
+    )
+
+    assert response["assignment"]["attempts"]["final"]["id"] == "attempt-002"
+    assert captured == {
+        "root": tmp_path,
+        "assignments_dir": tmp_path / "teacher-assignments",
+        "student_id": "rossi-mario",
+        "assignment_id": "assignment-001",
+        "attempt_id": "attempt-002",
+    }
+
+
+def test_final_attempt_http_endpoint_requires_student_token(monkeypatch) -> None:
+    secret = "demo-student-help-secret-for-final-attempt-tests"
+    monkeypatch.setenv("THEBITLAB_STUDENT_HELP_SECRET", secret)
+    token = student_help_auth.create_student_token("rossi-mario", secret)
+    captured = {}
+    monkeypatch.setattr(
+        course_board_server,
+        "select_student_final_attempt",
+        lambda payload, student_id: captured.update(payload=payload, student_id=student_id)
+        or {"ok": True, "assignment": {"assignment_id": payload["assignment_id"]}},
+    )
+    server = course_board_server.BoundedThreadingHTTPServer(
+        ("127.0.0.1", 0), course_board_server.CourseBoardHandler
+    )
+    server.teacher_token = "teacher-dashboard-token-for-final-attempt-tests"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}/api/student-lab/final-attempt"
+    body = json.dumps(
+        {"assignment_id": "assignment-001", "attempt_id": "attempt-002"}
+    ).encode("utf-8")
+    try:
+        unauthorized = urllib.request.Request(
+            url,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as error:
+            urllib.request.urlopen(unauthorized, timeout=5)
+        assert error.value.code == 401
+
+        request = urllib.request.Request(
+            url,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload["ok"] is True
+        assert captured == {
+            "payload": {
+                "assignment_id": "assignment-001",
+                "attempt_id": "attempt-002",
+            },
+            "student_id": "rossi-mario",
+        }
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
 def test_student_help_http_endpoint_records_request_on_server_root(tmp_path, monkeypatch) -> None:
     original_root = course_board_server.ROOT
     student_lab_demo_setup.prepare_demo(tmp_path)

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -66,6 +66,45 @@ def sample_assignment(**overrides):
             "submitted_at": "",
             "commit": None,
         },
+        "attempts": {
+            "count": 2,
+            "truncated": False,
+            "latest": {
+                "id": "attempt-002",
+                "submitted_at": "2026-10-18T18:00:00+02:00",
+                "status": "passed",
+                "passed": True,
+                "tests_passed": 2,
+                "tests_total": 2,
+            },
+            "best": {
+                "id": "attempt-002",
+                "submitted_at": "2026-10-18T18:00:00+02:00",
+                "status": "passed",
+                "passed": True,
+                "tests_passed": 2,
+                "tests_total": 2,
+            },
+            "final": None,
+            "items": [
+                {
+                    "id": "attempt-002",
+                    "submitted_at": "2026-10-18T18:00:00+02:00",
+                    "status": "passed",
+                    "passed": True,
+                    "tests_passed": 2,
+                    "tests_total": 2,
+                },
+                {
+                    "id": "attempt-001",
+                    "submitted_at": "2026-10-17T18:00:00+02:00",
+                    "status": "failed",
+                    "passed": False,
+                    "tests_passed": 1,
+                    "tests_total": 2,
+                },
+            ],
+        },
         "grading": {
             "status": "not_graded",
             "tests_passed": None,
@@ -255,13 +294,52 @@ def test_render_assignment_detail_shows_workspace_report_and_runner() -> None:
     assert "Azioni principali" in rendered
     assert "  e  Esegui test e salva report" in rendered
     assert "  a  Chiedi aiuto" in rendered
+    assert "  t  Storico e tentativo definitivo" in rendered
     assert "  o  Apri workspace" in rendered
     assert "Altri comandi" in rendered
     assert "  h  Storico aiuti" in rendered
+    assert "Tentativi" in rendered
+    assert "Totale:" in rendered
+    assert "passed, 2/2 test, 2026-10-18 18:00" in rendered
     assert "  b  Torna alla lista" in rendered
     assert "  invio  Torna alla lista" in rendered
     assert "  q  Esci" in rendered
     assert "Comandi:" not in rendered
+
+
+def test_render_attempt_history_marks_final_and_truncation() -> None:
+    assignment = sample_assignment()
+    assignment["attempts"]["final"] = assignment["attempts"]["items"][1]
+    assignment["attempts"]["truncated"] = True
+
+    rendered = student_lab_cli.render_attempt_history(assignment)
+
+    assert "Storico tentativi" in rendered
+    assert "1. passed, 2/2 test, 2026-10-18 18:00" in rendered
+    assert "2. failed, 1/2 test, 2026-10-17 18:00 [definitivo]" in rendered
+    assert "storico mostrato e parziale" in rendered
+
+
+def test_render_attempt_history_limits_the_interactive_list() -> None:
+    assignment = sample_assignment()
+    assignment["attempts"]["count"] = 25
+    assignment["attempts"]["items"] = [
+        {
+            "id": f"attempt-{index:03d}",
+            "submitted_at": f"2026-10-{25 - index:02d}T18:00:00+02:00",
+            "status": "passed",
+            "passed": True,
+            "tests_passed": 2,
+            "tests_total": 2,
+        }
+        for index in range(25)
+    ]
+
+    rendered = student_lab_cli.render_attempt_history(assignment)
+
+    assert "20. passed" in rendered
+    assert "21. passed" not in rendered
+    assert "20 tentativi piu recenti su 25" in rendered
 
 
 def test_render_assignment_list_can_color_statuses() -> None:
@@ -1090,6 +1168,73 @@ def test_run_tui_can_show_detail_and_exit(monkeypatch, tmp_path) -> None:
     assert result == 0
     assert any("TheBitLab - lab studente" in output for output in outputs)
     assert any("Dettaglio consegna" in output for output in outputs)
+
+
+def test_run_tui_can_select_a_local_final_attempt(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "t", "2", "", "", "q"])
+    selections = []
+    load_calls = []
+
+    def fake_load(root, student_id, now=None):
+        load_calls.append((root, student_id, now))
+        return payload
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", fake_load)
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_service,
+        "select_student_final_attempt",
+        lambda **kwargs: selections.append(kwargs) or payload["assignments"][0],
+    )
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+    )
+
+    assert result == 0
+    assert len(load_calls) == 2
+    assert selections == [
+        {
+            "root": tmp_path,
+            "student_id": "rossi-mario",
+            "assignment_id": "assignment-python-base-somma-001-demo",
+            "attempt_id": "attempt-001",
+            "now": None,
+        }
+    ]
+    assert any("Storico tentativi" in output for output in outputs)
+    assert any("Tentativo definitivo salvato." in output for output in outputs)
+
+
+def test_run_tui_rejects_an_invalid_attempt_choice(monkeypatch, tmp_path) -> None:
+    payload = sample_payload()
+    outputs = []
+    inputs = iter(["1", "t", "9", "", "", "q"])
+    selections = []
+
+    monkeypatch.setattr(student_lab_cli, "load_payload", lambda root, student_id, now=None: payload)
+    monkeypatch.setattr(
+        student_lab_cli.student_lab_service,
+        "select_student_final_attempt",
+        lambda **kwargs: selections.append(kwargs),
+    )
+
+    result = student_lab_cli.run_tui(
+        student_id="rossi-mario",
+        root=tmp_path,
+        input_fn=lambda prompt: next(inputs),
+        print_fn=outputs.append,
+        clear=False,
+    )
+
+    assert result == 0
+    assert selections == []
+    assert any("Tentativo non valido." in output for output in outputs)
 
 
 def test_run_tui_uses_utui_in_an_interactive_terminal(monkeypatch, tmp_path) -> None:

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -743,6 +743,7 @@ def test_student_lab_uses_existing_report_and_grading_summary(tmp_path) -> None:
             "tests_total": 2,
         },
         "final": None,
+        "items": [],
     }
 
 
@@ -849,6 +850,52 @@ def test_student_lab_keeps_attempt_history_separate_for_repeated_activity(tmp_pa
     assert by_id[second["id"]]["grading"]["tests_passed"] == 2
     assert by_id[second["id"]]["attempts"]["count"] == 1
     assert by_id[first["id"]]["attempts"]["latest"]["id"] != by_id[second["id"]]["attempts"]["latest"]["id"]
+    assert by_id[first["id"]]["attempts"]["items"] == [by_id[first["id"]]["attempts"]["latest"]]
+    assert by_id[second["id"]]["attempts"]["items"] == [by_id[second["id"]]["attempts"]["latest"]]
+
+
+def test_student_can_select_an_existing_attempt_as_final(tmp_path) -> None:
+    assignment = sample_assignment(tmp_path)
+    write_assignment(tmp_path, assignment)
+    report_path = (
+        tmp_path
+        / "examples"
+        / "assignment_tracking"
+        / "student_repos"
+        / "rossi-mario"
+        / "reports"
+        / "python-base-somma-001"
+        / "latest.json"
+    )
+    attempt_path, _ = student_lab_attempts.persist_attempt(
+        report_path,
+        assignment["id"],
+        {
+            "schema_version": "student_lab_run.v1",
+            "activity_id": "python-base-somma-001",
+            "student_id": "rossi-mario",
+            "status": "passed",
+            "passed": True,
+            "submitted_at": "2026-10-18T18:00:00+02:00",
+            "summary": {"passed": 2, "total": 2},
+            "tests": [],
+        },
+    )
+    attempt_id = attempt_path.stem
+
+    selected = student_lab_service.select_student_final_attempt(
+        root=tmp_path,
+        student_id="rossi-mario",
+        assignment_id=assignment["id"],
+        attempt_id=attempt_id,
+    )
+
+    assert selected["attempts"]["final"]["id"] == attempt_id
+    reloaded = student_lab_service.list_student_lab_assignments(
+        root=tmp_path,
+        student_id="rossi-mario",
+    )[0]
+    assert reloaded["attempts"]["final"]["id"] == attempt_id
 
 
 def test_student_lab_does_not_reuse_legacy_latest_for_another_assignment(tmp_path) -> None:

--- a/tests/test_student_lab_service.py
+++ b/tests/test_student_lab_service.py
@@ -898,6 +898,45 @@ def test_student_can_select_an_existing_attempt_as_final(tmp_path) -> None:
     assert reloaded["attempts"]["final"]["id"] == attempt_id
 
 
+def test_final_attempt_selection_does_not_expose_external_paths(tmp_path) -> None:
+    root = tmp_path / "server-root"
+    root.mkdir()
+    external_repo = tmp_path / "external-students" / "rossi-mario"
+    (external_repo / "assignments" / "python-base-somma-001").mkdir(parents=True)
+    assignment = sample_assignment(
+        root,
+        target_type="student",
+        targets=[{"student_id": "rossi-mario", "path": str(external_repo)}],
+    )
+    write_assignment(root, assignment)
+    report_path = external_repo / "reports" / "python-base-somma-001" / "latest.json"
+    attempt_path, _ = student_lab_attempts.persist_attempt(
+        report_path,
+        assignment["id"],
+        {
+            "schema_version": "student_lab_run.v1",
+            "activity_id": "python-base-somma-001",
+            "student_id": "rossi-mario",
+            "status": "passed",
+            "passed": True,
+            "submitted_at": "2026-10-18T18:00:00+02:00",
+            "summary": {"passed": 2, "total": 2},
+            "tests": [],
+        },
+    )
+
+    selected = student_lab_service.select_student_final_attempt(
+        root=root,
+        student_id="rossi-mario",
+        assignment_id=assignment["id"],
+        attempt_id=attempt_path.stem,
+    )
+
+    assert selected["workspace"]["path"] == ""
+    assert selected["report"]["path"] == ""
+    assert str(external_repo) not in json.dumps(selected)
+
+
 def test_student_lab_does_not_reuse_legacy_latest_for_another_assignment(tmp_path) -> None:
     first = sample_assignment(
         tmp_path,

--- a/tests/test_student_lab_utui.py
+++ b/tests/test_student_lab_utui.py
@@ -118,6 +118,36 @@ def test_project_assignment_keeps_missing_sections_visible() -> None:
     assert all(section["rows"] for section in sections)
 
 
+def test_project_assignment_adds_attempt_summaries_to_report_panel() -> None:
+    assignment = {
+        **ASSIGNMENT,
+        "attempts": {
+            "count": 2,
+            "latest": {
+                "status": "passed",
+                "submitted_at": "2026-07-23T18:10:00+02:00",
+                "tests_passed": 2,
+                "tests_total": 2,
+            },
+            "best": {
+                "status": "passed",
+                "submitted_at": "2026-07-23T18:10:00+02:00",
+                "tests_passed": 2,
+                "tests_total": 2,
+            },
+            "final": None,
+        },
+    }
+
+    sections = student_lab_utui.project_assignment_sections(assignment)
+    report_rows = next(section["rows"] for section in sections if section["id"] == "report")
+
+    assert "Tentativi: 2" in report_rows
+    assert "Ultimo: passed, 2/2 test, 23/07/2026 18:10" in report_rows
+    assert "Migliore: passed, 2/2 test, 23/07/2026 18:10" in report_rows
+    assert "Definitivo: -" in report_rows
+
+
 def test_project_assignment_removes_terminal_control_characters() -> None:
     assignment = {
         "title": "Titolo\niniettato\x1b]52;c;SGVsbG8=\x07",


### PR DESCRIPTION
## Sintesi
- espone nel payload studente la lista compatta dei tentativi immutabili
- aggiunge una API autenticata per selezionare il tentativo definitivo
- mostra ultimo, migliore e definitivo nei renderer legacy e uTUI
- aggiunge il comando `t` per consultare lo storico e scegliere il definitivo
- documenta flusso, limiti e scenario manuale

## Sicurezza e coerenza
- l'identita studente deriva sempre dal bearer token lato server
- assignment e attempt vengono rivalidati sui dati autorevoli
- la TUI mostra al massimo i 20 tentativi piu recenti senza eliminare lo storico
- il renderer legacy resta disponibile come fallback

## Test
- `python -m pytest -q tests/test_student_lab_attempts.py tests/test_student_lab_runner.py tests/test_student_lab_service.py tests/test_student_lab_cli.py tests/test_student_lab_utui.py tests/test_course_board_server.py`
- `python -m pytest -q` (`846 passed, 20 skipped`)

Closes #502
Parte di #288
