### PR TITLE
Mostra lo storico tentativi nella dashboard studente

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -456,8 +456,8 @@ Il grading attuale e una base, ma il flusso reale richiede altri passi.
 7. Scaricare artifact/report GitHub Actions e collegarli ai registri.
 8. Garantire che i job che eseguono codice studente non abbiano segreti.
 9. Estendere il backend gia introdotto per i tentativi (`Attempt`) separati dalla consegna finale (`Submission`):
-   - mostrare lo storico nella GUI/TUI; la TUI espone gia conteggio, ultimo, migliore, definitivo e lista compatta,
-     mentre resta da aggiungere la vista web;
+   - mostrare lo storico nella GUI/TUI; TUI e dashboard studente espongono conteggio, ultimo, migliore, definitivo
+     e lista compatta recente;
    - permettere allo studente e al docente di selezionare il tentativo definitivo secondo policy; la selezione
      studente e disponibile nella TUI tramite servizio locale o API autenticata, mentre resta da progettare
      l'eventuale override docente;

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -127,14 +127,15 @@ La schermata annotata e stata catturata sulla dashboard reale usando la root `tm
 <strong>7.</strong> Verifica stato completata/consegnata, non mancante.<br>
 <strong>8.</strong> Controlla scadenza e indicazione del grading.<br><br>
 
-<strong style="color:#168a45">Step 9-12 - Verde: dettaglio e test</strong><br>
+<strong style="color:#168a45">Step 9-13 - Verde: dettaglio, test e tentativi</strong><br>
 <strong>9.</strong> Apri <code>Dettaglio</code> o <code>Apri consegna</code>.<br>
 <strong>10.</strong> Verifica workspace e file, inclusi <code>main.py</code> e <code>tests/test_main.py</code> quando disponibili.<br>
 <strong>11.</strong> Chiudi il modal e apri il pannello <code>Lab</code>.<br>
-<strong>12.</strong> Controlla report, ultimo tentativo e risultato <code>2/2</code>.<br><br>
+<strong>12.</strong> Controlla report, riepilogo tentativi e risultato <code>2/2</code>.<br>
+<strong>13.</strong> Clicca <code>Tentativi</code> e verifica nel modal data, esito, test e tentativo definitivo.<br><br>
 
-<strong style="color:#c87800">Step 13 - Arancione: aiuti e feedback</strong><br>
-<strong>13.</strong> Verifica <code>Aiuti tracciati</code> e che il feedback AI non approvato non venga mostrato come definitivo.
+<strong style="color:#c87800">Step 14 - Arancione: aiuti e feedback</strong><br>
+<strong>14.</strong> Verifica <code>Aiuti tracciati</code> e che il feedback AI non approvato non venga mostrato come definitivo.
 
 </td>
 </tr>
@@ -147,7 +148,7 @@ La schermata annotata e stata catturata sulla dashboard reale usando la root `tm
 </details>
 
 <details>
-<summary>Evidenza Step 9-12: pannello Lab con workspace, report e test</summary>
+<summary>Evidenza Step 9-13: pannello Lab con workspace, report, test e accesso ai tentativi</summary>
 
 ![Pannello Lab con workspace, report e test](images/dashboard-guides/scenario-1-studente-lab.png)
 </details>
@@ -194,8 +195,10 @@ Il secondo comando resta attivo nel terminale. Usa un browser separato per la pr
 9. Apri `Dettaglio` o `Apri consegna` nella riga della demo.
 10. Nel dettaglio verifica che il workspace risulti presente e che siano elencati i file dell'attivita, inclusi `main.py` e `tests/test_main.py` quando disponibili.
 11. Chiudi il modal, torna alla vista della consegna e apri il pannello `Lab`.
-12. Controlla il report, l'ultimo tentativo e il risultato dei test.
-13. Verifica che gli aiuti tracciati siano valorizzati e che un eventuale feedback AI non approvato dal docente non venga mostrato come feedback definitivo.
+12. Controlla il report, il riepilogo con conteggio, ultimo, migliore e definitivo, e il risultato dei test.
+13. Clicca `Tentativi`. Nel modal verifica che ogni elemento mostri data, esito, test superati e identificativo;
+    il tentativo scelto deve avere il badge `Definitivo`. Chiudi il modal e controlla che nessun dato sia cambiato.
+14. Verifica che gli aiuti tracciati siano valorizzati e che un eventuale feedback AI non approvato dal docente non venga mostrato come feedback definitivo.
 
 ### Risultato atteso
 
@@ -203,7 +206,8 @@ Il secondo comando resta attivo nel terminale. Usa un browser separato per la pr
 - Il workspace risulta presente.
 - Il report risulta presente.
 - I test risultano passati: `2/2`.
-- L'ultimo tentativo e valorizzato.
+- Ultimo e migliore sono valorizzati; il definitivo compare solo se e stato scelto esplicitamente.
+- Il modal `Tentativi` mostra lo storico recente in sola lettura senza controlli di modifica.
 - Gli aiuti tracciati sono valorizzati.
 - Il feedback AI non approvato dal docente non viene mostrato allo studente come feedback definitivo.
 

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -189,6 +189,11 @@ python scripts/student_lab_runner.py --student-id rossi-mario --assignment-id <a
 - `best` e il risultato tecnico migliore, calcolato dai test con spareggio sul tentativo piu recente;
 - `final` e soltanto il tentativo scelto esplicitamente come definitivo e non cambia quando lo studente riprova.
 
+Nel pannello `Lab`, la dashboard studente mostra in sola lettura conteggio, ultimo, migliore e definitivo. Il
+pulsante `Tentativi` apre lo storico recente con data, esito e numero di test superati. La scelta del definitivo
+resta un'azione esplicita della TUI autenticata tramite il comando `t`: consultare la dashboard non modifica dati.
+La GUI mostra al massimo 20 elementi e segnala quando il servizio restituisce uno storico parziale.
+
 La dashboard e il registro continuano a usare il report `latest` per stato e grading finche il flusso docente non
 introdurra una decisione esplicita basata su `final`.
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -361,6 +361,19 @@ def test_student_dashboard_attempt_history_handles_empty_and_truncated_data() ->
         assert.equal((truncated.match(/<li class=/g) || []).length, 20);
         assert.match(truncated, /storico disponibile e parziale/);
         assert.match(truncated, /Sono mostrati i 20 tentativi piu recenti/);
+
+        const withOlderFinal = tested.renderAttemptHistory({
+          attempts: {
+            count: 22,
+            truncated: false,
+            final: items[20],
+            items,
+          },
+        });
+        assert.equal((withOlderFinal.match(/<li class=/g) || []).length, 20);
+        assert.match(withOlderFinal, /attempt-021/);
+        assert.match(withOlderFinal, /19 tentativi piu recenti e il tentativo definitivo/);
+        assert.equal((withOlderFinal.match(/Definitivo/g) || []).length, 2);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -421,6 +421,27 @@ def test_student_dashboard_attempt_history_handles_empty_and_truncated_data() ->
         assert.match(withOlderFinal, /attempt-021/);
         assert.match(withOlderFinal, /19 tentativi piu recenti e il tentativo definitivo/);
         assert.equal((withOlderFinal.match(/Definitivo/g) || []).length, 2);
+
+        const standaloneFinal = {
+          id: "attempt-final-outside-window",
+          status: "failed",
+          passed: false,
+          tests_passed: 1,
+          tests_total: 2,
+          submitted_at: "2026-10-10T10:00:00+02:00",
+        };
+        const withStandaloneFinal = tested.renderAttemptHistory({
+          attempts: {
+            count: 501,
+            truncated: true,
+            final: standaloneFinal,
+            items: items.slice(0, 20),
+          },
+        });
+        assert.equal((withStandaloneFinal.match(/<li class=/g) || []).length, 20);
+        assert.match(withStandaloneFinal, /attempt-final-outside-window/);
+        assert.match(withStandaloneFinal, /19 tentativi piu recenti e il tentativo definitivo/);
+        assert.equal((withStandaloneFinal.match(/Definitivo/g) || []).length, 2);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 import textwrap
+from pathlib import Path
 
 
 def run_student_dashboard_js(assertions: str) -> None:
@@ -76,6 +77,10 @@ def run_student_dashboard_js(assertions: str) -> None:
         renderCoursePath,
         renderFeedback,
         renderStudentLab,
+        renderAttemptSummary,
+        renderAttemptHistory,
+        openAttemptHistory,
+        closeAttemptHistory,
         renderAssignment,
         renderAssignmentDetail,
         renderAssignmentFiles,
@@ -121,6 +126,15 @@ def run_student_dashboard_js(assertions: str) -> None:
     }});
     """
     subprocess.run(["node", "-e", textwrap.dedent(script)], check=True)
+
+
+def test_student_dashboard_declares_attempt_history_dialog() -> None:
+    source = Path("tools/student_dashboard.html").read_text(encoding="utf-8")
+
+    assert 'id="attemptHistoryModal"' in source
+    assert 'aria-labelledby="attemptHistoryTitle"' in source
+    assert 'id="attemptHistoryBody"' in source
+    assert 'id="attemptHistoryClose"' in source
 
 
 def test_student_dashboard_renders_summary_and_assignment_card() -> None:
@@ -182,6 +196,35 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
               report: { path: "examples/assignment_tracking/student_repos/rossi-mario/reports/python-base-somma-001/latest.json", exists: true, submitted_at: "2026-10-18T18:22:10+02:00" },
               grading: { status: "graded_passed", tests_passed: 2, tests_total: 2, failed_tests: [] },
               runner: { backend: "local" },
+              attempts: {
+                count: 2,
+                truncated: false,
+                latest: {
+                  id: "attempt-002",
+                  status: "passed",
+                  passed: true,
+                  tests_passed: 2,
+                  tests_total: 2,
+                  submitted_at: "2026-10-18T18:22:10+02:00",
+                },
+                best: {
+                  id: "attempt-002",
+                  status: "passed",
+                  passed: true,
+                  tests_passed: 2,
+                  tests_total: 2,
+                  submitted_at: "2026-10-18T18:22:10+02:00",
+                },
+                final: {
+                  id: "attempt-001",
+                  status: "failed",
+                  passed: false,
+                  tests_passed: 1,
+                  tests_total: 2,
+                  submitted_at: "2026-10-18T17:10:00+02:00",
+                },
+                items: [],
+              },
             }],
           },
           assignments: [assignment, { activity_id: "python-loop-001", status: "missing", submitted: false, late: false }],
@@ -211,7 +254,113 @@ def test_student_dashboard_renders_summary_and_assignment_card() -> None:
         assert.match(tested.els.studentLab.innerHTML, /soluzioni complete/);
         assert.match(tested.els.studentLab.innerHTML, /Aiuti tracciati: 2/);
         assert.match(tested.els.studentLab.innerHTML, /Bloccati: 1/);
+        assert.match(tested.els.studentLab.innerHTML, /<strong>Tentativi<\\/strong>2/);
+        assert.match(tested.els.studentLab.innerHTML, /<strong>Ultimo<\\/strong>Superato .* 2\\/2 test/);
+        assert.match(tested.els.studentLab.innerHTML, /<strong>Definitivo<\\/strong>Non superato .* 1\\/2 test/);
+        assert.match(tested.els.studentLab.innerHTML, /data-attempt-history-index="0"/);
         assert.match(tested.els.studentLabStatus.textContent, /1 consegne lab · 1 report salvati/);
+        """
+    )
+
+
+def test_student_dashboard_opens_readonly_attempt_history() -> None:
+    run_student_dashboard_js(
+        """
+        const attempts = {
+          count: 2,
+          truncated: false,
+          latest: {
+            id: "attempt-002",
+            status: "passed",
+            passed: true,
+            tests_passed: 2,
+            tests_total: 2,
+            submitted_at: "2026-10-18T18:22:10+02:00",
+          },
+          best: {
+            id: "attempt-002",
+            status: "passed",
+            passed: true,
+            tests_passed: 2,
+            tests_total: 2,
+            submitted_at: "2026-10-18T18:22:10+02:00",
+          },
+          final: {
+            id: "attempt-001",
+            status: "failed",
+            passed: false,
+            tests_passed: 1,
+            tests_total: 2,
+            submitted_at: "2026-10-18T17:10:00+02:00",
+          },
+          items: [
+            {
+              id: "attempt-002",
+              status: "passed",
+              passed: true,
+              tests_passed: 2,
+              tests_total: 2,
+              submitted_at: "2026-10-18T18:22:10+02:00",
+            },
+            {
+              id: "attempt-001",
+              status: "failed",
+              passed: false,
+              tests_passed: 1,
+              tests_total: 2,
+              submitted_at: "2026-10-18T17:10:00+02:00",
+            },
+          ],
+        };
+        tested.renderDashboard({
+          student_id: "rossi-mario",
+          assignments: [],
+          lab: {
+            assignments: [{
+              activity_id: "python-base-somma-001",
+              title: "Somma in Python",
+              attempts,
+            }],
+          },
+        });
+
+        tested.openAttemptHistory(0);
+
+        assert.equal(tested.els.attemptHistoryModal.hidden, false);
+        assert.equal(tested.els.attemptHistoryTitle.textContent, "Somma in Python");
+        assert.match(tested.els.attemptHistoryBody.innerHTML, /attemptPassed/);
+        assert.match(tested.els.attemptHistoryBody.innerHTML, /attemptFailed/);
+        assert.match(tested.els.attemptHistoryBody.innerHTML, /attempt-002/);
+        assert.match(tested.els.attemptHistoryBody.innerHTML, /attempt-001/);
+        assert.equal((tested.els.attemptHistoryBody.innerHTML.match(/Definitivo/g) || []).length, 2);
+        assert.doesNotMatch(tested.els.attemptHistoryBody.innerHTML, /<button/);
+
+        tested.closeAttemptHistory();
+        assert.equal(tested.els.attemptHistoryModal.hidden, true);
+        """
+    )
+
+
+def test_student_dashboard_attempt_history_handles_empty_and_truncated_data() -> None:
+    run_student_dashboard_js(
+        """
+        const empty = tested.renderAttemptHistory({ attempts: { count: 0, items: [] } });
+        assert.match(empty, /Nessun tentativo salvato/);
+
+        const items = Array.from({ length: 22 }, (_, index) => ({
+          id: `attempt-${String(index + 1).padStart(3, "0")}`,
+          status: index % 2 === 0 ? "passed" : "failed",
+          passed: index % 2 === 0,
+          tests_passed: index % 2 === 0 ? 2 : 1,
+          tests_total: 2,
+          submitted_at: `2026-10-18T${String(index % 20).padStart(2, "0")}:00:00+02:00`,
+        }));
+        const truncated = tested.renderAttemptHistory({
+          attempts: { count: 22, truncated: true, items },
+        });
+        assert.equal((truncated.match(/<li class=/g) || []).length, 20);
+        assert.match(truncated, /storico disponibile e parziale/);
+        assert.match(truncated, /Sono mostrati i 20 tentativi piu recenti/);
         """
     )
 

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -18,6 +18,8 @@ def run_student_dashboard_js(assertions: str) -> None:
         this.textContent = "";
         this.innerHTML = "";
         this.disabled = false;
+        this.hidden = false;
+        this.listeners = {{}};
         this.dataset = selector.includes("list")
           ? {{ studentCalendarDisplay: "list" }}
           : selector.includes("calendar")
@@ -29,14 +31,29 @@ def run_student_dashboard_js(assertions: str) -> None:
             if (force) this.classList.values.add(name);
             else this.classList.values.delete(name);
           }},
+          add: (name) => this.classList.values.add(name),
+          remove: (name) => this.classList.values.delete(name),
           contains: (name) => this.classList.values.has(name),
         }};
       }}
-      addEventListener() {{}}
+      addEventListener(type, handler) {{
+        this.listeners[type] = this.listeners[type] || [];
+        this.listeners[type].push(handler);
+      }}
+      dispatchEvent(event) {{
+        event.target ||= this;
+        event.preventDefault ||= () => {{ event.defaultPrevented = true; }};
+        for (const handler of this.listeners[event.type] || []) handler(event);
+      }}
       setAttribute(name, value) {{ this[name] = value; }}
       closest() {{ return this; }}
       querySelector(selector) {{ return elementFor(`${{this.selector}} ${{selector}}`); }}
-      querySelectorAll() {{ return []; }}
+      querySelectorAll(selector) {{
+        return this.selector === "#attemptHistoryModal" && selector.includes("button")
+          ? [elementFor("#attemptHistoryClose")]
+          : [];
+      }}
+      focus() {{ context.document.activeElement = this; }}
     }}
 
     const elements = new Map();
@@ -49,10 +66,21 @@ def run_student_dashboard_js(assertions: str) -> None:
       console,
       URL,
       document: {{
+        body: elementFor("body"),
+        activeElement: null,
+        listeners: {{}},
         querySelector: elementFor,
         querySelectorAll: (selector) => selector === "[data-student-calendar-display]"
           ? [elementFor("[data-student-calendar-display=calendar]"), elementFor("[data-student-calendar-display=list]")]
           : [],
+        addEventListener(type, handler) {{
+          this.listeners[type] = this.listeners[type] || [];
+          this.listeners[type].push(handler);
+        }},
+        dispatchEvent(event) {{
+          event.preventDefault ||= () => {{ event.defaultPrevented = true; }};
+          for (const handler of this.listeners[event.type] || []) handler(event);
+        }},
       }},
       fetchImpl: async () => ({{
         ok: true,
@@ -324,10 +352,15 @@ def test_student_dashboard_opens_readonly_attempt_history() -> None:
           },
         });
 
-        tested.openAttemptHistory(0);
+        const historyButton = elementFor("#attemptHistoryButton");
+        historyButton.dataset.attemptHistoryIndex = "0";
+        historyButton.closest = (selector) => selector === "[data-attempt-history-index]" ? historyButton : null;
+        historyButton.focus();
+        tested.els.studentLab.dispatchEvent({ type: "click", target: historyButton });
 
         assert.equal(tested.els.attemptHistoryModal.hidden, false);
         assert.equal(tested.els.attemptHistoryTitle.textContent, "Somma in Python");
+        assert.equal(context.document.activeElement, tested.els.attemptHistoryClose);
         assert.match(tested.els.attemptHistoryBody.innerHTML, /attemptPassed/);
         assert.match(tested.els.attemptHistoryBody.innerHTML, /attemptFailed/);
         assert.match(tested.els.attemptHistoryBody.innerHTML, /attempt-002/);
@@ -335,8 +368,22 @@ def test_student_dashboard_opens_readonly_attempt_history() -> None:
         assert.equal((tested.els.attemptHistoryBody.innerHTML.match(/Definitivo/g) || []).length, 2);
         assert.doesNotMatch(tested.els.attemptHistoryBody.innerHTML, /<button/);
 
-        tested.closeAttemptHistory();
+        const tabEvent = { type: "keydown", key: "Tab", shiftKey: false };
+        context.document.dispatchEvent(tabEvent);
+        assert.equal(tabEvent.defaultPrevented, true);
+        assert.equal(context.document.activeElement, tested.els.attemptHistoryClose);
+
+        context.document.dispatchEvent({ type: "keydown", key: "Escape" });
         assert.equal(tested.els.attemptHistoryModal.hidden, true);
+        assert.equal(context.document.activeElement, historyButton);
+
+        tested.els.studentLab.dispatchEvent({ type: "click", target: historyButton });
+        tested.els.attemptHistoryModal.dispatchEvent({
+          type: "click",
+          target: tested.els.attemptHistoryModal,
+        });
+        assert.equal(tested.els.attemptHistoryModal.hidden, true);
+        assert.equal(context.document.activeElement, historyButton);
         """
     )
 

--- a/tools/student_dashboard.css
+++ b/tools/student_dashboard.css
@@ -278,6 +278,88 @@ button:hover { transform: translateY(-1px); }
   overflow-wrap: anywhere;
 }
 
+.attemptSummary {
+  display: grid;
+  gap: .55rem;
+  min-width: 0;
+  border-top: 1px solid rgba(17, 17, 17, .12);
+  border-bottom: 1px solid rgba(17, 17, 17, .12);
+  padding: .75rem 0;
+}
+
+.attemptSummaryGrid {
+  display: grid;
+  grid-template-columns: minmax(5rem, .55fr) repeat(3, minmax(10rem, 1fr));
+  gap: .75rem;
+  min-width: 0;
+}
+
+.attemptSummaryGrid span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.attemptSummaryGrid strong {
+  display: block;
+  margin-bottom: .2rem;
+  color: var(--muted);
+  font-size: .72rem;
+}
+
+.studentLabActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.attemptWarning {
+  margin: 0;
+  color: #8b4a00;
+  font-weight: 700;
+}
+
+.attemptHistoryList {
+  display: grid;
+  gap: .65rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.attemptHistoryList li {
+  display: grid;
+  gap: .4rem;
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, .16);
+  border-left-width: .35rem;
+  border-radius: 8px;
+  padding: .8rem;
+  background: #fafafa;
+}
+
+.attemptHistoryList li.attemptPassed {
+  border-left-color: #168a45;
+}
+
+.attemptHistoryList li.attemptFailed {
+  border-left-color: #b42318;
+}
+
+.attemptHistoryList li.attemptUnknown {
+  border-left-color: #8b6a00;
+}
+
+.attemptHistoryList li > div {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+}
+
+.attemptHistoryList code {
+  overflow-wrap: anywhere;
+}
+
 .studentCalendarControls {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -1147,6 +1229,10 @@ button:hover { transform: translateY(-1px); }
   }
 
   .studentCalendarListItem {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .attemptSummaryGrid {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/tools/student_dashboard.html
+++ b/tools/student_dashboard.html
@@ -161,6 +161,19 @@
     </section>
   </div>
 
+  <div id="attemptHistoryModal" class="modalOverlay" hidden>
+    <section class="detailModal attemptHistoryModal" role="dialog" aria-modal="true" aria-labelledby="attemptHistoryTitle">
+      <header class="detailModalHead">
+        <div>
+          <p class="modalEyebrow">Storico tentativi</p>
+          <h2 id="attemptHistoryTitle">Consegna</h2>
+        </div>
+        <button id="attemptHistoryClose" type="button" class="secondaryActionButton">Chiudi</button>
+      </header>
+      <div id="attemptHistoryBody" class="detailModalBody"></div>
+    </section>
+  </div>
+
   <script src="student_dashboard.js"></script>
 </body>
 </html>

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -429,8 +429,9 @@ function renderAttemptHistory(assignment) {
   const allItems = Array.isArray(attempts.items) ? attempts.items : [];
   const finalId = String(attempts.final?.id || "");
   let items = allItems.slice(0, 20);
-  const finalOutsideRecent = finalId
-    ? allItems.find((attempt, index) => index >= 20 && String(attempt.id || "") === finalId)
+  const finalInRecent = finalId && items.some((attempt) => String(attempt.id || "") === finalId);
+  const finalOutsideRecent = finalId && !finalInRecent
+    ? allItems.find((attempt) => String(attempt.id || "") === finalId) || attempts.final
     : null;
   if (finalOutsideRecent) items = [...items.slice(0, 19), finalOutsideRecent];
   if (!items.length) {
@@ -453,9 +454,11 @@ function renderAttemptHistory(assignment) {
         </li>
       `).join("")}
     </ol>
-    ${allItems.length > items.length
+    ${finalOutsideRecent || allItems.length > items.length
       ? `<p class="attemptWarning">${finalOutsideRecent
-        ? "Sono mostrati i 19 tentativi piu recenti e il tentativo definitivo."
+        ? allItems.length >= 20
+          ? "Sono mostrati i 19 tentativi piu recenti e il tentativo definitivo."
+          : `Sono mostrati i ${allItems.length} tentativi recenti e il definitivo conservato separatamente.`
         : `Sono mostrati i ${items.length} tentativi piu recenti.`
       }</p>`
       : ""}

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -49,6 +49,7 @@ let currentStudentCalendarView = {
 let visibleStudentPathIds = null;
 let currentAssignmentFilesIndex = -1;
 let assignmentFilesRequestToken = 0;
+let attemptHistoryInvoker = null;
 
 async function api(path, options = {}) {
   const response = await fetch(path, options);
@@ -461,13 +462,38 @@ function renderAttemptHistory(assignment) {
   `;
 }
 
-function openAttemptHistory(assignmentIndex) {
+function attemptHistoryFocusableElements() {
+  if (!els.attemptHistoryModal?.querySelectorAll) return [];
+  return [...els.attemptHistoryModal.querySelectorAll(
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  )].filter((element) => !element.hidden);
+}
+
+function trapAttemptHistoryFocus(event) {
+  const focusable = attemptHistoryFocusableElements();
+  if (!focusable.length) {
+    event.preventDefault();
+    return;
+  }
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (event.shiftKey && (document.activeElement === first || !focusable.includes(document.activeElement))) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && (document.activeElement === last || !focusable.includes(document.activeElement))) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+function openAttemptHistory(assignmentIndex, invoker = null) {
   const index = Number(assignmentIndex);
   const assignments = Array.isArray(currentDashboardPayload.lab?.assignments)
     ? currentDashboardPayload.lab.assignments
     : [];
   const assignment = assignments[index];
   if (!assignment || !els.attemptHistoryModal || !els.attemptHistoryBody || !els.attemptHistoryTitle) return;
+  attemptHistoryInvoker = invoker || document.activeElement || null;
   els.attemptHistoryTitle.textContent = assignment.title || assignment.activity_id || "Consegna";
   els.attemptHistoryBody.innerHTML = renderAttemptHistory(assignment);
   els.attemptHistoryModal.hidden = false;
@@ -475,10 +501,14 @@ function openAttemptHistory(assignmentIndex) {
   els.attemptHistoryClose?.focus?.();
 }
 
-function closeAttemptHistory() {
+function closeAttemptHistory({ restoreFocus = true } = {}) {
   if (!els.attemptHistoryModal) return;
+  const wasOpen = els.attemptHistoryModal.hidden === false;
+  const invoker = attemptHistoryInvoker;
+  attemptHistoryInvoker = null;
   els.attemptHistoryModal.hidden = true;
   document.body?.classList?.remove("modalOpen");
+  if (restoreFocus && wasOpen) invoker?.focus?.();
 }
 
 function isOpenAssignment(assignment) {
@@ -1602,7 +1632,7 @@ function isNextDeadlineAssignment(assignment, nextAssignment) {
 function renderDashboard(payload) {
   closeAssignmentDetail();
   closeAssignmentFiles();
-  closeAttemptHistory();
+  closeAttemptHistory({ restoreFocus: false });
   const assignments = Array.isArray(payload.assignments) ? payload.assignments : [];
   currentDashboardPayload = { ...payload, assignments };
   const filterValue = els.assignmentFilter?.value || "all";
@@ -1727,7 +1757,7 @@ els.assignments?.addEventListener("click", (event) => {
 els.studentLab?.addEventListener("click", (event) => {
   const historyButton = event.target.closest?.("[data-attempt-history-index]");
   if (!historyButton) return;
-  openAttemptHistory(historyButton.dataset.attemptHistoryIndex);
+  openAttemptHistory(historyButton.dataset.attemptHistoryIndex, historyButton);
 });
 
 els.assignmentDetailClose?.addEventListener("click", closeAssignmentDetail);
@@ -1759,6 +1789,10 @@ els.attemptHistoryModal?.addEventListener("click", (event) => {
 });
 
 document.addEventListener?.("keydown", (event) => {
+  if (event.key === "Tab" && els.attemptHistoryModal?.hidden === false) {
+    trapAttemptHistoryFocus(event);
+    return;
+  }
   if (event.key === "Escape") {
     closeAssignmentDetail();
     closeAssignmentFiles();

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -27,6 +27,10 @@ const els = {
   assignmentFilesTitle: document.querySelector("#assignmentFilesTitle"),
   assignmentFilesBody: document.querySelector("#assignmentFilesBody"),
   assignmentFilesClose: document.querySelector("#assignmentFilesClose"),
+  attemptHistoryModal: document.querySelector("#attemptHistoryModal"),
+  attemptHistoryTitle: document.querySelector("#attemptHistoryTitle"),
+  attemptHistoryBody: document.querySelector("#attemptHistoryBody"),
+  attemptHistoryClose: document.querySelector("#attemptHistoryClose"),
 };
 
 const DEMO_STUDENTS = ["bianchi-luca", "rossi-mario", "verdi-anna", "neri-giulia"];
@@ -317,10 +321,43 @@ function renderSupportPolicy(assignment) {
   `;
 }
 
-function renderLabAssignment(assignment) {
+function attemptOutcomeText(attempt) {
+  if (!attempt || typeof attempt !== "object") return "-";
+  const passed = Number.isInteger(attempt.tests_passed) ? attempt.tests_passed : "-";
+  const total = Number.isInteger(attempt.tests_total) ? attempt.tests_total : "-";
+  const outcome = attempt.passed === true
+    ? "Superato"
+    : attempt.passed === false
+      ? "Non superato"
+      : attempt.status || "Esito non disponibile";
+  return `${outcome} · ${passed}/${total} test`;
+}
+
+function attemptResultText(attempt) {
+  if (!attempt || typeof attempt !== "object") return "-";
+  return `${attemptOutcomeText(attempt)} · ${formatDate(attempt.submitted_at)}`;
+}
+
+function renderAttemptSummary(attempts) {
+  const summary = attempts && typeof attempts === "object" ? attempts : {};
+  return `
+    <section class="attemptSummary">
+      <div class="attemptSummaryGrid">
+        <span><strong>Tentativi</strong>${escapeHtml(summary.count ?? 0)}</span>
+        <span><strong>Ultimo</strong>${escapeHtml(attemptResultText(summary.latest))}</span>
+        <span><strong>Migliore</strong>${escapeHtml(attemptResultText(summary.best))}</span>
+        <span><strong>Definitivo</strong>${escapeHtml(attemptResultText(summary.final))}</span>
+      </div>
+      ${summary.truncated ? '<p class="attemptWarning">Lo storico disponibile e parziale.</p>' : ""}
+    </section>
+  `;
+}
+
+function renderLabAssignment(assignment, assignmentIndex) {
   const grading = assignment.grading || {};
   const workspace = assignment.workspace || {};
   const report = assignment.report || {};
+  const attempts = assignment.attempts || {};
   const failedTests = Array.isArray(grading.failed_tests) ? grading.failed_tests : [];
   return `
     <article class="studentLabCard">
@@ -348,6 +385,10 @@ function renderLabAssignment(assignment) {
         <span>Report: ${escapeHtml(report.path || "-")}</span>
         <span>Backend: ${escapeHtml(assignment.runner?.backend || "-")}</span>
       </p>
+      ${renderAttemptSummary(attempts)}
+      <div class="studentLabActions">
+        <button type="button" class="secondaryActionButton" data-attempt-history-index="${escapeHtml(assignmentIndex)}">Tentativi</button>
+      </div>
       ${renderSupportPolicy(assignment)}
       ${grading.detail ? `<p class="details">${escapeHtml(grading.detail)}</p>` : ""}
       ${failedTests.length ? `<p class="details">Test falliti: ${failedTests.map(escapeHtml).join(", ")}</p>` : ""}
@@ -372,6 +413,64 @@ function renderStudentLab(lab) {
   els.studentLab.innerHTML = assignments.length
     ? assignments.map(renderLabAssignment).join("")
     : '<p class="status">Nessuna consegna lab operativa disponibile per questo studente.</p>';
+}
+
+function attemptTone(attempt) {
+  if (attempt?.passed === true) return "attemptPassed";
+  if (attempt?.passed === false) return "attemptFailed";
+  return "attemptUnknown";
+}
+
+function renderAttemptHistory(assignment) {
+  const attempts = assignment?.attempts && typeof assignment.attempts === "object"
+    ? assignment.attempts
+    : {};
+  const items = Array.isArray(attempts.items) ? attempts.items.slice(0, 20) : [];
+  const finalId = String(attempts.final?.id || "");
+  if (!items.length) {
+    return `
+      ${renderAttemptSummary(attempts)}
+      <p class="emptyFeedback">Nessun tentativo salvato per questa consegna.</p>
+    `;
+  }
+  return `
+    ${renderAttemptSummary(attempts)}
+    <ol class="attemptHistoryList">
+      ${items.map((attempt) => `
+        <li class="${attemptTone(attempt)}">
+          <div>
+            <strong>${escapeHtml(formatDate(attempt.submitted_at))}</strong>
+            ${String(attempt.id || "") === finalId ? badge("Definitivo", "badgeOk") : ""}
+          </div>
+          <span>${escapeHtml(attemptOutcomeText(attempt))}</span>
+          <code>${escapeHtml(attempt.id || "-")}</code>
+        </li>
+      `).join("")}
+    </ol>
+    ${Array.isArray(attempts.items) && attempts.items.length > items.length
+      ? `<p class="attemptWarning">Sono mostrati i ${items.length} tentativi piu recenti.</p>`
+      : ""}
+  `;
+}
+
+function openAttemptHistory(assignmentIndex) {
+  const index = Number(assignmentIndex);
+  const assignments = Array.isArray(currentDashboardPayload.lab?.assignments)
+    ? currentDashboardPayload.lab.assignments
+    : [];
+  const assignment = assignments[index];
+  if (!assignment || !els.attemptHistoryModal || !els.attemptHistoryBody || !els.attemptHistoryTitle) return;
+  els.attemptHistoryTitle.textContent = assignment.title || assignment.activity_id || "Consegna";
+  els.attemptHistoryBody.innerHTML = renderAttemptHistory(assignment);
+  els.attemptHistoryModal.hidden = false;
+  document.body?.classList?.add("modalOpen");
+  els.attemptHistoryClose?.focus?.();
+}
+
+function closeAttemptHistory() {
+  if (!els.attemptHistoryModal) return;
+  els.attemptHistoryModal.hidden = true;
+  document.body?.classList?.remove("modalOpen");
 }
 
 function isOpenAssignment(assignment) {
@@ -1495,6 +1594,7 @@ function isNextDeadlineAssignment(assignment, nextAssignment) {
 function renderDashboard(payload) {
   closeAssignmentDetail();
   closeAssignmentFiles();
+  closeAttemptHistory();
   const assignments = Array.isArray(payload.assignments) ? payload.assignments : [];
   currentDashboardPayload = { ...payload, assignments };
   const filterValue = els.assignmentFilter?.value || "all";
@@ -1616,6 +1716,12 @@ els.assignments?.addEventListener("click", (event) => {
   openAssignmentDetail(detailButton.dataset.detailIndex);
 });
 
+els.studentLab?.addEventListener("click", (event) => {
+  const historyButton = event.target.closest?.("[data-attempt-history-index]");
+  if (!historyButton) return;
+  openAttemptHistory(historyButton.dataset.attemptHistoryIndex);
+});
+
 els.assignmentDetailClose?.addEventListener("click", closeAssignmentDetail);
 
 els.assignmentDetailModal?.addEventListener("click", (event) => {
@@ -1639,10 +1745,16 @@ els.assignmentFilesModal?.addEventListener("click", (event) => {
   }
 });
 
+els.attemptHistoryClose?.addEventListener("click", closeAttemptHistory);
+els.attemptHistoryModal?.addEventListener("click", (event) => {
+  if (event.target === els.attemptHistoryModal) closeAttemptHistory();
+});
+
 document.addEventListener?.("keydown", (event) => {
   if (event.key === "Escape") {
     closeAssignmentDetail();
     closeAssignmentFiles();
+    closeAttemptHistory();
   }
 });
 

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -425,8 +425,13 @@ function renderAttemptHistory(assignment) {
   const attempts = assignment?.attempts && typeof assignment.attempts === "object"
     ? assignment.attempts
     : {};
-  const items = Array.isArray(attempts.items) ? attempts.items.slice(0, 20) : [];
+  const allItems = Array.isArray(attempts.items) ? attempts.items : [];
   const finalId = String(attempts.final?.id || "");
+  let items = allItems.slice(0, 20);
+  const finalOutsideRecent = finalId
+    ? allItems.find((attempt, index) => index >= 20 && String(attempt.id || "") === finalId)
+    : null;
+  if (finalOutsideRecent) items = [...items.slice(0, 19), finalOutsideRecent];
   if (!items.length) {
     return `
       ${renderAttemptSummary(attempts)}
@@ -447,8 +452,11 @@ function renderAttemptHistory(assignment) {
         </li>
       `).join("")}
     </ol>
-    ${Array.isArray(attempts.items) && attempts.items.length > items.length
-      ? `<p class="attemptWarning">Sono mostrati i ${items.length} tentativi piu recenti.</p>`
+    ${allItems.length > items.length
+      ? `<p class="attemptWarning">${finalOutsideRecent
+        ? "Sono mostrati i 19 tentativi piu recenti e il tentativo definitivo."
+        : `Sono mostrati i ${items.length} tentativi piu recenti.`
+      }</p>`
       : ""}
   `;
 }


### PR DESCRIPTION
Closes #504
Part of #288

## Cosa cambia
- mostra nel pannello Lab il riepilogo di conteggio, ultimo, migliore e definitivo;
- apre uno storico recente in un modal read-only con esito, test, data e badge del definitivo;
- gestisce stato vuoto, storico parziale e limite visuale di 20 elementi;
- aggiorna guida lab, roadmap e scenario manuale della dashboard studente.

## Verifica
- `python -m pytest -q tests/test_student_dashboard_frontend.py tests/test_course_board_server.py`
- `python -m pytest -q`
- `git diff --check`

## Nota visuale
Il browser integrato non era disponibile nella sessione di sviluppo. Lo scenario manuale indica il controllo desktop/mobile da completare prima del merge.