### PR TITLE
Supporta i tentativi su volumi Windows exFAT

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -103,6 +103,10 @@ Le scritture JSON usano file temporanei, replace atomico e sincronizzazione dell
 Su Windows il replace resta atomico, ma Python non espone un equivalente portabile del `fsync` della directory:
 il journal consente il recupero dopo un arresto del processo, mentre non garantisce la persistenza assoluta in caso
 di interruzione dell'alimentazione nel brevissimo intervallo successivo al replace.
+I tentativi immutabili usano hard link quando disponibili. Su Windows, anche i volumi exFAT sono supportati tramite
+rename atomico senza sostituzione. Su Linux, un filesystem privo di hard link richiede una libc che esponga
+`renameat2` (glibc 2.28 o successiva); in assenza del wrapper il salvataggio fallisce esplicitamente senza rischiare
+di sovrascrivere un tentativo esistente.
 
 In un secondo terminale:
 

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -5,7 +5,6 @@ import errno
 import heapq
 import json
 import os
-import platform
 import sys
 import tempfile
 import uuid
@@ -156,62 +155,29 @@ def hard_link_is_unsupported(error: OSError) -> bool:
     return False
 
 
-def linux_renameat2_syscall_number() -> int | None:
-    """Return the renameat2 syscall number for supported Linux architectures."""
-
-    machine = platform.machine().lower()
-    return {
-        "x86_64": 316,
-        "amd64": 316,
-        "i386": 353,
-        "i686": 353,
-        "aarch64": 276,
-        "arm64": 276,
-        "armv6l": 382,
-        "armv7l": 382,
-        "ppc64": 357,
-        "ppc64le": 357,
-        "s390x": 347,
-        "riscv64": 276,
-    }.get(machine)
-
-
 def linux_rename_no_replace(
     temporary_path: Path,
     output: Path,
     *,
     libc: Any | None = None,
 ) -> None:
-    """Call renameat2 with RENAME_NOREPLACE through libc or its syscall entry."""
+    """Call libc renameat2 with RENAME_NOREPLACE."""
 
     libc = libc or ctypes.CDLL(None, use_errno=True)
     source_bytes = os.fsencode(temporary_path)
     output_bytes = os.fsencode(output)
     renameat2 = getattr(libc, "renameat2", None)
-    if renameat2 is not None:
-        renameat2.argtypes = [
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_uint,
-        ]
-        renameat2.restype = ctypes.c_int
-        result = renameat2(-100, source_bytes, -100, output_bytes, 1)
-    else:
-        syscall_number = linux_renameat2_syscall_number()
-        syscall = getattr(libc, "syscall", None)
-        if syscall_number is None or syscall is None:
-            raise OSError(errno.ENOSYS, "renameat2 is not available", output)
-        syscall.restype = ctypes.c_long
-        result = syscall(
-            ctypes.c_long(syscall_number),
-            ctypes.c_int(-100),
-            ctypes.c_char_p(source_bytes),
-            ctypes.c_int(-100),
-            ctypes.c_char_p(output_bytes),
-            ctypes.c_uint(1),
-        )
+    if renameat2 is None:
+        raise OSError(errno.ENOSYS, "libc renameat2 is not available", output)
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(-100, source_bytes, -100, output_bytes, 1)
     if result != 0:
         error_code = ctypes.get_errno()
         raise OSError(error_code, os.strerror(error_code), output)

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import ctypes
 import errno
 import heapq
 import json
 import os
+import sys
 import tempfile
 import uuid
 from contextlib import contextmanager
@@ -144,12 +146,45 @@ def write_json_atomic(path: Path, payload: dict[str, Any], *, base_dir: Path | N
 
 
 def hard_link_is_unsupported(error: OSError) -> bool:
-    """Return whether an exclusive hard-link publish needs the portable fallback."""
+    """Return whether the current platform can try an atomic no-replace rename."""
 
-    return getattr(error, "winerror", None) in {1, 50} or error.errno in {
-        errno.ENOTSUP,
-        errno.EOPNOTSUPP,
-    }
+    if os.name == "nt":
+        return getattr(error, "winerror", None) in {1, 50}
+    if sys.platform.startswith("linux"):
+        return error.errno in {errno.EPERM, errno.ENOTSUP, errno.EOPNOTSUPP}
+    return False
+
+
+def rename_no_replace(temporary_path: Path, output: Path) -> None:
+    """Atomically rename without replacing an existing path on Windows or Linux."""
+
+    if os.name == "nt":
+        os.rename(temporary_path, output)
+        return
+    if not sys.platform.startswith("linux"):
+        raise OSError(errno.ENOTSUP, "Atomic no-replace rename is not supported", output)
+
+    renameat2 = getattr(ctypes.CDLL(None, use_errno=True), "renameat2", None)
+    if renameat2 is None:
+        raise OSError(errno.ENOSYS, "renameat2 is not available", output)
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(
+        -100,
+        os.fsencode(temporary_path),
+        -100,
+        os.fsencode(output),
+        1,
+    )
+    if result != 0:
+        error_code = ctypes.get_errno()
+        raise OSError(error_code, os.strerror(error_code), output)
 
 
 def publish_exclusive(temporary_path: Path, output: Path) -> None:
@@ -164,20 +199,7 @@ def publish_exclusive(temporary_path: Path, output: Path) -> None:
         if not hard_link_is_unsupported(error):
             raise
 
-    reserved = False
-    descriptor: int | None = None
-    try:
-        descriptor = os.open(output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        reserved = True
-        os.close(descriptor)
-        descriptor = None
-        os.replace(temporary_path, output)
-    except BaseException:
-        if descriptor is not None:
-            os.close(descriptor)
-        if reserved:
-            output.unlink(missing_ok=True)
-        raise
+    rename_no_replace(temporary_path, output)
 
 
 def write_json_exclusive(path: Path, payload: dict[str, Any], *, base_dir: Path) -> None:

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -5,6 +5,7 @@ import errno
 import heapq
 import json
 import os
+import platform
 import sys
 import tempfile
 import uuid
@@ -155,6 +156,67 @@ def hard_link_is_unsupported(error: OSError) -> bool:
     return False
 
 
+def linux_renameat2_syscall_number() -> int | None:
+    """Return the renameat2 syscall number for supported Linux architectures."""
+
+    machine = platform.machine().lower()
+    return {
+        "x86_64": 316,
+        "amd64": 316,
+        "i386": 353,
+        "i686": 353,
+        "aarch64": 276,
+        "arm64": 276,
+        "armv6l": 382,
+        "armv7l": 382,
+        "ppc64": 357,
+        "ppc64le": 357,
+        "s390x": 347,
+        "riscv64": 276,
+    }.get(machine)
+
+
+def linux_rename_no_replace(
+    temporary_path: Path,
+    output: Path,
+    *,
+    libc: Any | None = None,
+) -> None:
+    """Call renameat2 with RENAME_NOREPLACE through libc or its syscall entry."""
+
+    libc = libc or ctypes.CDLL(None, use_errno=True)
+    source_bytes = os.fsencode(temporary_path)
+    output_bytes = os.fsencode(output)
+    renameat2 = getattr(libc, "renameat2", None)
+    if renameat2 is not None:
+        renameat2.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        renameat2.restype = ctypes.c_int
+        result = renameat2(-100, source_bytes, -100, output_bytes, 1)
+    else:
+        syscall_number = linux_renameat2_syscall_number()
+        syscall = getattr(libc, "syscall", None)
+        if syscall_number is None or syscall is None:
+            raise OSError(errno.ENOSYS, "renameat2 is not available", output)
+        syscall.restype = ctypes.c_long
+        result = syscall(
+            ctypes.c_long(syscall_number),
+            ctypes.c_int(-100),
+            ctypes.c_char_p(source_bytes),
+            ctypes.c_int(-100),
+            ctypes.c_char_p(output_bytes),
+            ctypes.c_uint(1),
+        )
+    if result != 0:
+        error_code = ctypes.get_errno()
+        raise OSError(error_code, os.strerror(error_code), output)
+
+
 def rename_no_replace(temporary_path: Path, output: Path) -> None:
     """Atomically rename without replacing an existing path on Windows or Linux."""
 
@@ -163,28 +225,7 @@ def rename_no_replace(temporary_path: Path, output: Path) -> None:
         return
     if not sys.platform.startswith("linux"):
         raise OSError(errno.ENOTSUP, "Atomic no-replace rename is not supported", output)
-
-    renameat2 = getattr(ctypes.CDLL(None, use_errno=True), "renameat2", None)
-    if renameat2 is None:
-        raise OSError(errno.ENOSYS, "renameat2 is not available", output)
-    renameat2.argtypes = [
-        ctypes.c_int,
-        ctypes.c_char_p,
-        ctypes.c_int,
-        ctypes.c_char_p,
-        ctypes.c_uint,
-    ]
-    renameat2.restype = ctypes.c_int
-    result = renameat2(
-        -100,
-        os.fsencode(temporary_path),
-        -100,
-        os.fsencode(output),
-        1,
-    )
-    if result != 0:
-        error_code = ctypes.get_errno()
-        raise OSError(error_code, os.strerror(error_code), output)
+    linux_rename_no_replace(temporary_path, output)
 
 
 def publish_exclusive(temporary_path: Path, output: Path) -> None:

--- a/scripts/student_lab_attempts.py
+++ b/scripts/student_lab_attempts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import heapq
 import json
 import os
@@ -142,6 +143,43 @@ def write_json_atomic(path: Path, payload: dict[str, Any], *, base_dir: Path | N
     write_bytes_atomic(path, json_bytes(payload), base_dir=base_dir)
 
 
+def hard_link_is_unsupported(error: OSError) -> bool:
+    """Return whether an exclusive hard-link publish needs the portable fallback."""
+
+    return getattr(error, "winerror", None) in {1, 50} or error.errno in {
+        errno.ENOTSUP,
+        errno.EOPNOTSUPP,
+    }
+
+
+def publish_exclusive(temporary_path: Path, output: Path) -> None:
+    """Publish a complete file without replacing an existing destination."""
+
+    try:
+        os.link(temporary_path, output)
+        return
+    except FileExistsError:
+        raise
+    except OSError as error:
+        if not hard_link_is_unsupported(error):
+            raise
+
+    reserved = False
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        reserved = True
+        os.close(descriptor)
+        descriptor = None
+        os.replace(temporary_path, output)
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        if reserved:
+            output.unlink(missing_ok=True)
+        raise
+
+
 def write_json_exclusive(path: Path, payload: dict[str, Any], *, base_dir: Path) -> None:
     """Publish an immutable JSON file without replacing an existing attempt."""
 
@@ -159,7 +197,7 @@ def write_json_exclusive(path: Path, payload: dict[str, Any], *, base_dir: Path)
             stream.write(json_bytes(payload))
             stream.flush()
             os.fsync(stream.fileno())
-        os.link(temporary_path, output)
+        publish_exclusive(temporary_path, output)
         published = True
         sync_directory(output.parent)
     except BaseException:

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import errno
 import json
+import os
 
 import pytest
 
@@ -152,8 +154,9 @@ def test_exclusive_write_falls_back_when_hard_links_are_unsupported(tmp_path, mo
     payload = {"attempt_id": "attempt-exfat", "passed": True}
 
     def unsupported_link(source, destination):
-        error = OSError("hard links unsupported")
-        error.winerror = 1
+        error = OSError(errno.EPERM, "hard links unsupported")
+        if os.name == "nt":
+            error.winerror = 1
         raise error
 
     monkeypatch.setattr(student_lab_attempts.os, "link", unsupported_link)
@@ -170,7 +173,7 @@ def test_exclusive_write_does_not_mask_unrelated_link_errors(tmp_path, monkeypat
     output = tmp_path / "attempt.json"
 
     def denied_link(source, destination):
-        raise PermissionError("link denied")
+        raise OSError(errno.EACCES, "link denied")
 
     monkeypatch.setattr(student_lab_attempts.os, "link", denied_link)
 
@@ -182,6 +185,33 @@ def test_exclusive_write_does_not_mask_unrelated_link_errors(tmp_path, monkeypat
         )
 
     assert not output.exists()
+
+
+def test_exclusive_fallback_failure_leaves_no_placeholder(tmp_path, monkeypatch) -> None:
+    output = tmp_path / "attempt.json"
+
+    def unsupported_link(source, destination):
+        error = OSError(errno.EPERM, "hard links unsupported")
+        if os.name == "nt":
+            error.winerror = 1
+        raise error
+
+    monkeypatch.setattr(student_lab_attempts.os, "link", unsupported_link)
+    monkeypatch.setattr(
+        student_lab_attempts,
+        "rename_no_replace",
+        lambda source, destination: (_ for _ in ()).throw(OSError("publish failed")),
+    )
+
+    with pytest.raises(OSError, match="publish failed"):
+        student_lab_attempts.write_json_exclusive(
+            output,
+            {"attempt_id": "attempt-failed"},
+            base_dir=tmp_path,
+        )
+
+    assert not output.exists()
+    assert list(tmp_path.glob(".*.tmp")) == []
 
 
 def test_exclusive_attempt_is_removed_when_directory_sync_fails(tmp_path, monkeypatch) -> None:

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -169,6 +169,32 @@ def test_exclusive_write_falls_back_when_hard_links_are_unsupported(tmp_path, mo
     assert json.loads(output.read_text(encoding="utf-8")) == payload
 
 
+def test_linux_no_replace_uses_syscall_when_libc_wrapper_is_missing(tmp_path, monkeypatch) -> None:
+    calls = []
+
+    class FakeSyscall:
+        restype = None
+
+        def __call__(self, *args):
+            calls.append(args)
+            return 0
+
+    class FakeLibc:
+        syscall = FakeSyscall()
+
+    monkeypatch.setattr(student_lab_attempts.platform, "machine", lambda: "x86_64")
+    source = tmp_path / "attempt.tmp"
+    output = tmp_path / "attempt.json"
+
+    student_lab_attempts.linux_rename_no_replace(source, output, libc=FakeLibc())
+
+    assert calls
+    assert calls[0][0].value == 316
+    assert calls[0][-1].value == 1
+    assert calls[0][2].value == os.fsencode(source)
+    assert calls[0][4].value == os.fsencode(output)
+
+
 def test_exclusive_write_does_not_mask_unrelated_link_errors(tmp_path, monkeypatch) -> None:
     output = tmp_path / "attempt.json"
 

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -147,6 +147,43 @@ def test_persist_attempt_never_replaces_an_existing_attempt(tmp_path, monkeypatc
     assert attempt_path.read_bytes() == original_bytes
 
 
+def test_exclusive_write_falls_back_when_hard_links_are_unsupported(tmp_path, monkeypatch) -> None:
+    output = tmp_path / "attempt.json"
+    payload = {"attempt_id": "attempt-exfat", "passed": True}
+
+    def unsupported_link(source, destination):
+        error = OSError("hard links unsupported")
+        error.winerror = 1
+        raise error
+
+    monkeypatch.setattr(student_lab_attempts.os, "link", unsupported_link)
+
+    student_lab_attempts.write_json_exclusive(output, payload, base_dir=tmp_path)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == payload
+    with pytest.raises(FileExistsError):
+        student_lab_attempts.write_json_exclusive(output, {**payload, "passed": False}, base_dir=tmp_path)
+    assert json.loads(output.read_text(encoding="utf-8")) == payload
+
+
+def test_exclusive_write_does_not_mask_unrelated_link_errors(tmp_path, monkeypatch) -> None:
+    output = tmp_path / "attempt.json"
+
+    def denied_link(source, destination):
+        raise PermissionError("link denied")
+
+    monkeypatch.setattr(student_lab_attempts.os, "link", denied_link)
+
+    with pytest.raises(PermissionError, match="link denied"):
+        student_lab_attempts.write_json_exclusive(
+            output,
+            {"attempt_id": "attempt-denied"},
+            base_dir=tmp_path,
+        )
+
+    assert not output.exists()
+
+
 def test_exclusive_attempt_is_removed_when_directory_sync_fails(tmp_path, monkeypatch) -> None:
     report_path = tmp_path / "reports" / ACTIVITY_ID / "latest.json"
     monkeypatch.setattr(student_lab_attempts, "new_attempt_id", lambda: "attempt-sync-failure")

--- a/tests/test_student_lab_attempts.py
+++ b/tests/test_student_lab_attempts.py
@@ -169,30 +169,17 @@ def test_exclusive_write_falls_back_when_hard_links_are_unsupported(tmp_path, mo
     assert json.loads(output.read_text(encoding="utf-8")) == payload
 
 
-def test_linux_no_replace_uses_syscall_when_libc_wrapper_is_missing(tmp_path, monkeypatch) -> None:
-    calls = []
-
-    class FakeSyscall:
-        restype = None
-
-        def __call__(self, *args):
-            calls.append(args)
-            return 0
-
+def test_linux_no_replace_fails_safely_when_libc_wrapper_is_missing(tmp_path) -> None:
     class FakeLibc:
-        syscall = FakeSyscall()
+        pass
 
-    monkeypatch.setattr(student_lab_attempts.platform, "machine", lambda: "x86_64")
-    source = tmp_path / "attempt.tmp"
-    output = tmp_path / "attempt.json"
-
-    student_lab_attempts.linux_rename_no_replace(source, output, libc=FakeLibc())
-
-    assert calls
-    assert calls[0][0].value == 316
-    assert calls[0][-1].value == 1
-    assert calls[0][2].value == os.fsencode(source)
-    assert calls[0][4].value == os.fsencode(output)
+    with pytest.raises(OSError) as raised:
+        student_lab_attempts.linux_rename_no_replace(
+            tmp_path / "attempt.tmp",
+            tmp_path / "attempt.json",
+            libc=FakeLibc(),
+        )
+    assert raised.value.errno == errno.ENOSYS
 
 
 def test_exclusive_write_does_not_mask_unrelated_link_errors(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Closes #506
Part of #288

## Problema
La pubblicazione immutabile dei tentativi usa hard link. Su Windows exFAT `os.link()` fallisce con `WinError 1`, impedendo setup demo e runner con `--write-report`.

## Correzione
- conserva hard link come percorso principale;
- per filesystem che dichiarano hard link non supportati, riserva il nome finale con creazione esclusiva e pubblica il temporaneo completo con replace;
- non sostituisce mai un tentativo gia esistente;
- non nasconde errori di permesso o altri errori non correlati.

## Verifica
- `python -m pytest -q tests/test_student_lab_attempts.py tests/test_student_lab_runner.py tests/test_student_lab_demo_setup.py`
- setup demo reale su volume Windows exFAT;
- seconda esecuzione runner reale con `--write-report --final` sulla stessa root.