### PR TITLE
Use final attempts in teacher registers

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -464,13 +464,17 @@ Esempio ridotto:
 }
 ```
 
-Per ora il registro legge report locali nel path:
+Il registro legge report locali con questa priorita:
 
 ```text
+reports/<activity_id>/assignments/<assignment-key>/final.json
+reports/<activity_id>/assignments/<assignment-key>/latest.json
 reports/<activity_id>/latest.json
 ```
 
-In futuro la stessa struttura potra essere alimentata scaricando gli artifact GitHub Actions dei repository studenti.
+`final.json` seleziona il tentativo immutabile autorevole; i due `latest.json` sono fallback provvisori scoped e
+legacy. In futuro la stessa struttura potra essere alimentata scaricando gli artifact GitHub Actions dei repository
+studenti.
 
 ## Dashboard consegne docente
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -85,8 +85,9 @@ feedback/c-base-somma-001/
   latest.md
 ```
 
-Il file `latest.json` al livello activity rappresenta l'ultimo esito noto e mantiene la compatibilita con registro e
-dashboard esistenti.
+Il file `latest.json` al livello activity rappresenta l'ultimo esito noto e mantiene la compatibilita con i lettori
+legacy e con lo stato operativo della dashboard studente. Un registro collegato a una vera assegnazione preferisce
+invece il tentativo `final` valido oppure il `latest.json` specifico dell'assegnazione come fallback provvisorio.
 
 I file `attempt-*.json` sono immutabili e conservano la storia tecnica della singola assegnazione. Il `latest.json`
 interno identifica l'ultimo tentativo di quella consegna, mentre `final.json` contiene solo il riferimento al
@@ -561,10 +562,17 @@ Quando clicchi `Crea registro consegne`, il server locale:
 
 1. legge la activity;
 2. costruisce i target studenti;
-3. cerca per ogni studente `reports/<activity_id>/latest.json`;
-4. calcola stato consegna, ritardi e grading disponibile;
-5. salva il JSON in `teacher-reports`;
-6. carica subito il risultato nella dashboard.
+3. per ogni assegnazione cerca prima un tentativo `final` valido;
+4. se il definitivo non esiste, usa il `latest.json` specifico dell'assegnazione o il report legacy come risultato
+   provvisorio;
+5. se una selezione finale esiste ma non e valida, espone `invalid_final` senza attribuire un grading diverso;
+6. calcola stato consegna, ritardi e grading disponibile;
+7. registra in `submission.report_selection` la provenienza e in `grading.provisional` se l'esito non e definitivo;
+8. salva il JSON in `teacher-reports`;
+9. carica subito il risultato nella dashboard.
+
+Il file in `teacher-reports` e uno snapshot. Se lo studente cambia il tentativo finale, usa nuovamente
+`Crea registro consegne` per aggiornare la vista docente.
 
 ### Classe demo per provare il flusso
 

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -397,20 +397,30 @@ Il report salvato usa lo schema `student_lab_run.v1` e mantiene separati:
 - metadati di collegamento: `assignment_id`, `activity_id`, `student_id`, `language`, `source`, `backend`, `submitted_at`;
 - feedback AI: non presente in questo report, per evitare di mescolare esecuzione deterministica e suggerimenti generativi.
 
-Il registro docente legge lo stesso `reports/<activity_id>/latest.json` usato dal lab studente.
-Quando il report esiste, il registro salva nella `submission` anche:
+Il registro docente collegato a un'assegnazione usa il tentativo `final` valido quando presente. Se lo studente non
+ha ancora scelto un definitivo, usa il `latest.json` specifico dell'assegnazione come risultato provvisorio; i dati
+precedenti al modello dei tentativi possono ancora usare il `latest.json` legacy dell'activity. Una selezione finale
+presente ma non valida produce `invalid_final` e non viene sostituita silenziosamente con un altro grading.
+
+Quando il report viene accettato, il registro salva nella `submission` anche:
 
 - `report_path`: path relativo del report letto;
 - `report_backend`: backend che ha prodotto il report, per esempio `local` o `docker`;
 - `report_schema_version`: versione dello schema del report;
 - `report_status`: stato tecnico del report originale.
+- `report_selection`: provenienza `final`, `latest`, `legacy` o lo stato `invalid_final`;
+- `attempt_id` e `final_selected`: identita del tentativo e conferma della scelta definitiva.
+
+`grading.provisional` distingue il fallback dall'esito definitivo. Il registro resta uno snapshot: dopo una nuova
+scelta finale deve essere rigenerato per riflettere la decisione corrente.
 
 Quando il registro è collegato a un'assegnazione, il docente legge lo stesso log server-side
 `teacher-help-events/student_id-<sha256>/assignment_id-<sha256>/events.json` e aggiunge a ogni studente il riepilogo `help`.
 La dashboard docente può così mostrare numero di richieste, richieste AI, richieste bloccate, token dichiarati e prompt
 inviati dallo studente per quella consegna. Il riepilogo del registro somma gli stessi token per la classe corrente.
 
-In questo modo dashboard docente, dashboard studente e TUI leggono lo stesso risultato senza ricalcolare grading o stato in modi divergenti.
+In questo modo il risultato operativo piu recente resta visibile allo studente, mentre il registro docente conserva
+il grading del tentativo scelto come definitivo.
 
 Le prossime PR dovranno completare questo contratto con:
 

--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -198,8 +198,12 @@ pulsante `Tentativi` apre lo storico recente con data, esito e numero di test su
 resta un'azione esplicita della TUI autenticata tramite il comando `t`: consultare la dashboard non modifica dati.
 La GUI mostra al massimo 20 elementi e segnala quando il servizio restituisce uno storico parziale.
 
-La dashboard e il registro continuano a usare il report `latest` per stato e grading finche il flusso docente non
-introdurra una decisione esplicita basata su `final`.
+La dashboard studente usa `latest` per mostrare lo stato operativo dell'ultima esecuzione. Il registro docente usa
+invece il tentativo `final` quando lo studente ne ha selezionato uno valido; in assenza di una selezione definitiva
+continua a usare `latest` come fallback compatibile. Il campo `submission.report_selection` del registro dichiara
+esplicitamente se il report letto e `final`, `latest` o `legacy`; `invalid_final` segnala invece una selezione
+presente ma non valida, che non viene sostituita silenziosamente con un grading diverso. `grading.provisional`
+resta vero finche il registro sta usando un report non definitivo.
 
 Per usare la sandbox Docker minima sulle consegne C, Python, JavaScript/Node.js o SQL:
 

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -209,7 +209,15 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
     submission = payload.get("submission") if isinstance(payload.get("submission"), dict) else {}
     grading = payload.get("grading") if isinstance(payload.get("grading"), dict) else {}
     ai_feedback = payload.get("ai_feedback") if isinstance(payload.get("ai_feedback"), dict) else {}
-    normalized["submission"] = normalize_submission(submission)
-    normalized["grading"] = normalize_grading(grading)
+    normalized_submission = normalize_submission(submission)
+    normalized_grading = normalize_grading(grading)
+    if "provisional" not in grading:
+        normalized_grading["provisional"] = (
+            normalized["submitted"]
+            and normalized_submission.get("report_selection") != "final"
+            and not normalized_submission.get("final_selected")
+        )
+    normalized["submission"] = normalized_submission
+    normalized["grading"] = normalized_grading
     normalized["ai_feedback"] = normalize_ai_feedback(ai_feedback)
     return normalized

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -133,6 +133,7 @@ def normalize_grading(payload: dict[str, Any]) -> dict[str, Any]:
     normalized.setdefault("failed_test_details", [])
     normalized.setdefault("score", None)
     normalized.setdefault("teacher_grade", None)
+    normalized["provisional"] = bool_value(payload.get("provisional", False))
     return normalized
 
 
@@ -161,6 +162,9 @@ def normalize_submission(payload: dict[str, Any]) -> dict[str, Any]:
     normalized.setdefault("status", "")
     normalized["late"] = bool_value(payload.get("late", False))
     normalized.setdefault("files", [])
+    normalized.setdefault("attempt_id", None)
+    normalized.setdefault("report_selection", None)
+    normalized["final_selected"] = bool_value(payload.get("final_selected", False))
     return normalized
 
 

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -384,6 +384,41 @@ def clean_metadata(value: str | None) -> str:
     return str(value or "").strip()
 
 
+def selected_final_report(
+    target: TrackingTarget,
+    report_path: Path,
+    assignment_id: str,
+    activity_id: str,
+) -> tuple[dict[str, Any] | None, Path | None, bool]:
+    """Return the valid final report and whether a final selection exists."""
+
+    # Imported lazily because the attempt module reuses report parsing helpers
+    # from this module.
+    from scripts import student_lab_attempts
+
+    final_path = student_lab_attempts.assignment_history_dir(report_path, assignment_id) / "final.json"
+    if student_identity.confined_regular_file(target.path, final_path) is None:
+        return None, None, False
+    report = student_lab_attempts.load_final_attempt(
+        report_path,
+        assignment_id,
+        activity_id,
+        base_dir=target.path,
+    )
+    if report is None:
+        return None, None, True
+    attempt_id = clean_metadata(report.get("attempt_id"))
+    attempt_path = (
+        student_lab_attempts.assignment_history_dir(report_path, assignment_id)
+        / "attempts"
+        / f"{attempt_id}.json"
+    )
+    safe_path = student_identity.confined_regular_file(target.path, attempt_path)
+    if safe_path is None:
+        return None, None, True
+    return report, safe_path, True
+
+
 def assignment_student_id(
     target: TrackingTarget,
     assignment: dict[str, Any] | None,
@@ -480,18 +515,36 @@ def track_assignments(
             help_log_path = student_identity.confined_regular_file(target.path, legacy_help_path)
         safe_report_path = None
         uses_assignment_report = False
+        report = None
+        report_selection = None
         if assignment_id:
-            assignment_report_path = (
-                report_path.parent
-                / "assignments"
-                / assignment_records.assignment_storage_key(assignment_id)
-                / "latest.json"
+            report, safe_report_path, final_selection_exists = selected_final_report(
+                target,
+                report_path,
+                assignment_id,
+                activity_id,
             )
-            safe_report_path = student_identity.confined_regular_file(target.path, assignment_report_path)
-            uses_assignment_report = safe_report_path is not None
-        if safe_report_path is None:
-            safe_report_path = student_identity.confined_regular_file(target.path, report_path)
-        report = load_report(safe_report_path) if safe_report_path is not None else None
+            if report is not None:
+                uses_assignment_report = True
+                report_selection = "final"
+            elif final_selection_exists:
+                uses_assignment_report = True
+                report_selection = "invalid_final"
+            else:
+                assignment_report_path = (
+                    report_path.parent
+                    / "assignments"
+                    / assignment_records.assignment_storage_key(assignment_id)
+                    / "latest.json"
+                )
+                safe_report_path = student_identity.confined_regular_file(target.path, assignment_report_path)
+                uses_assignment_report = safe_report_path is not None
+        if report is None and report_selection != "invalid_final":
+            if safe_report_path is None:
+                safe_report_path = student_identity.confined_regular_file(target.path, report_path)
+            report = load_report(safe_report_path) if safe_report_path is not None else None
+            if report is not None:
+                report_selection = "latest" if uses_assignment_report else "legacy"
         if report is not None:
             validate_report_activity(report, activity_id, report_path)
             report_assignment_id = clean_metadata(report.get("assignment_id"))
@@ -529,6 +582,8 @@ def track_assignments(
         else:
             help["path"] = relative_to_root_or_repo(help_log_path, target.path) if help_log_path else ""
         help["activity_id"] = activity_id
+        grading = grading_summary(report)
+        grading["provisional"] = report is not None and report_selection != "final"
         source_file_path = report_source_path(target, report.get("source")) if report else None
         source_path = relative_to_repo(source_file_path, target.path) if source_file_path is not None else None
         submitted = report is not None
@@ -562,8 +617,11 @@ def track_assignments(
                     "report_backend": report.get("backend") if report else None,
                     "report_schema_version": report.get("schema_version") if report else None,
                     "report_status": report.get("status") if report else None,
+                    "report_selection": report_selection,
+                    "attempt_id": report.get("attempt_id") if report else None,
+                    "final_selected": report_selection == "final",
                 },
-                "grading": grading_summary(report),
+                "grading": grading,
                 "help": help,
                 "ai_feedback": ai_feedback_placeholder(),
                 "report_path": relative_report_path,

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -397,8 +397,14 @@ def selected_final_report(
     from scripts import student_lab_attempts
 
     final_path = student_lab_attempts.assignment_history_dir(report_path, assignment_id) / "final.json"
-    if student_identity.confined_regular_file(target.path, final_path) is None:
+    try:
+        final_path.lstat()
+    except FileNotFoundError:
         return None, None, False
+    except OSError:
+        return None, None, True
+    if student_identity.confined_regular_file(target.path, final_path) is None:
+        return None, None, True
     report = student_lab_attempts.load_final_attempt(
         report_path,
         assignment_id,

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -557,6 +557,7 @@ def track_assignments(
             if assignment_id and report_assignment_id and report_assignment_id != assignment_id:
                 report = None
                 safe_report_path = None
+                report_selection = None
             elif assignment_id and not report_assignment_id and not uses_assignment_report:
                 matching_assignment_count = 0
                 for candidate in same_activity_assignments:
@@ -568,6 +569,7 @@ def track_assignments(
                 if matching_assignment_count != 1:
                     report = None
                     safe_report_path = None
+                    report_selection = None
         relative_report_path = (
             relative_to_root_or_repo(safe_report_path, target.path, server_root)
             if safe_report_path is not None

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -626,6 +626,39 @@ def test_read_assignment_report_normalizes_student_booleans(tmp_path) -> None:
     assert student["ai_feedback"]["approved_by_teacher"] is True
 
 
+def test_assignment_report_reload_marks_legacy_grading_as_provisional(tmp_path) -> None:
+    storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [])
+    storage.write_assignment_report(
+        "attempt-selection.json",
+        {
+            "activity_id": "activity",
+            "students": [
+                {
+                    "student": "rossi-mario",
+                    "submitted": True,
+                    "submission": {},
+                    "grading": {"status": "graded_passed"},
+                },
+                {
+                    "student": "bianchi-luca",
+                    "submitted": True,
+                    "submission": {
+                        "attempt_id": "attempt-final",
+                        "report_selection": "final",
+                        "final_selected": True,
+                    },
+                    "grading": {"status": "graded_failed", "provisional": False},
+                },
+            ],
+        },
+    )
+
+    students = storage.read_assignment_report("attempt-selection.json")["students"]
+
+    assert students[0]["grading"]["provisional"] is True
+    assert students[1]["grading"]["provisional"] is False
+
+
 def test_ai_feedback_demo_report_exposes_teacher_review_states() -> None:
     root = Path(__file__).resolve().parents[1]
     storage = JsonAssignmentStorage(root, root / "teacher-reports", [])

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1035,6 +1035,30 @@ def test_track_assignments_does_not_grade_an_invalid_final_selection(tmp_path) -
     assert row["submission"]["report_path"] is None
 
 
+def test_selected_final_report_rejects_a_non_regular_selection_without_fallback(tmp_path) -> None:
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-somma-directory"
+    report_path = student.path / "reports" / "python-base-somma-001" / "latest.json"
+    final_path = (
+        report_path.parent
+        / "assignments"
+        / assignment_records.assignment_storage_key(assignment_id)
+        / "final.json"
+    )
+    final_path.mkdir(parents=True)
+
+    report, selected_path, selection_exists = track_assignments.selected_final_report(
+        student,
+        report_path,
+        assignment_id,
+        "python-base-somma-001",
+    )
+
+    assert report is None
+    assert selected_path is None
+    assert selection_exists is True
+
+
 def test_track_assignments_rejects_unscoped_legacy_report_for_repeated_activity(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "rossi-mario")

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -90,6 +90,43 @@ def target(tmp_path, name: str) -> track_assignments.TrackingTarget:
     return track_assignments.TrackingTarget(student=name, repo=f"TheBitPoets/{name}", path=root)
 
 
+def write_assignment_record(tmp_path, activity_path, student, assignment_id: str) -> None:
+    """Persist one student assignment used by assignment-scoped report tests."""
+
+    assignment_records.JsonAssignmentRecordStorage(tmp_path).write_assignment(
+        assignment_records.build_assignment_record(
+            assignment_id=assignment_id,
+            activity_id="python-base-somma-001",
+            activity_path=str(activity_path.relative_to(tmp_path)),
+            target_type="student",
+            assigned_at="2026-10-12T09:00:00+02:00",
+            due_at="2026-10-21T08:00:00+02:00",
+            targets=[
+                {
+                    "student_id": "rossi-mario",
+                    "repo_ref": student.repo,
+                    "path": str(student.path.relative_to(tmp_path)),
+                }
+            ],
+        )
+    )
+
+
+def attempt_report(assignment_id: str, attempt_id: str, *, passed: bool, submitted_at: str) -> dict:
+    """Return a compact immutable attempt fixture."""
+
+    return {
+        "activity_id": "python-base-somma-001",
+        "assignment_id": assignment_id,
+        "attempt_id": attempt_id,
+        "status": "passed" if passed else "failed",
+        "passed": passed,
+        "submitted_at": submitted_at,
+        "source": "assignments/python-base-somma-001/main.py",
+        "tests": [{"name": "somma", "status": "passed" if passed else "failed", "passed": passed}],
+    }
+
+
 def test_github_file_path_uses_project_root_for_repo_relative_paths(tmp_path, monkeypatch) -> None:
     project_root = tmp_path / "project"
     source_path = (
@@ -695,6 +732,8 @@ def test_track_assignments_exposes_student_lab_report_metadata(tmp_path) -> None
     assert row["submission"]["report_backend"] == "docker"
     assert row["submission"]["report_schema_version"] == "student_lab_run.v1"
     assert row["submission"]["report_status"] == "passed"
+    assert row["submission"]["report_selection"] == "legacy"
+    assert row["grading"]["provisional"] is True
     assert row["grading"]["status"] == "graded_passed"
 
 
@@ -874,6 +913,126 @@ def test_track_assignments_reads_assignment_specific_report(tmp_path) -> None:
 
     assert first_index["students"][0]["grading"]["status"] == "graded_failed"
     assert second_index["students"][0]["grading"]["status"] == "graded_passed"
+    assert first_index["students"][0]["submission"]["report_selection"] == "latest"
+    assert second_index["students"][0]["submission"]["report_selection"] == "latest"
+    assert first_index["students"][0]["grading"]["provisional"] is True
+    assert second_index["students"][0]["grading"]["provisional"] is True
+
+
+def test_track_assignments_uses_selected_final_attempt_instead_of_latest(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-somma-finale"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    source_path = student.path / "assignments" / "python-base-somma-001" / "main.py"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("print(3)\n", encoding="utf-8")
+    history_dir = (
+        student.path
+        / "reports"
+        / "python-base-somma-001"
+        / "assignments"
+        / assignment_records.assignment_storage_key(assignment_id)
+    )
+    attempts_dir = history_dir / "attempts"
+    attempts_dir.mkdir(parents=True)
+    final_report = attempt_report(
+        assignment_id,
+        "attempt-final",
+        passed=False,
+        submitted_at="2026-10-19T08:00:00+02:00",
+    )
+    latest_report = attempt_report(
+        assignment_id,
+        "attempt-latest",
+        passed=True,
+        submitted_at="2026-10-20T08:00:00+02:00",
+    )
+    (attempts_dir / "attempt-final.json").write_text(json.dumps(final_report), encoding="utf-8")
+    (attempts_dir / "attempt-latest.json").write_text(json.dumps(latest_report), encoding="utf-8")
+    (history_dir / "latest.json").write_text(json.dumps(latest_report), encoding="utf-8")
+    (history_dir / "final.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "student_lab_attempt_selection.v1",
+                "assignment_id": assignment_id,
+                "activity_id": "python-base-somma-001",
+                "attempt_id": "attempt-final",
+                "selected_at": "2026-10-20T08:05:00+02:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+    )
+
+    row = index["students"][0]
+    assert row["grading"]["status"] == "graded_failed"
+    assert row["grading"]["provisional"] is False
+    assert row["submission"]["submitted_at"] == "2026-10-19T08:00:00+02:00"
+    assert row["submission"]["report_selection"] == "final"
+    assert row["submission"]["attempt_id"] == "attempt-final"
+    assert row["submission"]["final_selected"] is True
+    assert row["submission"]["report_path"].endswith("/attempts/attempt-final.json")
+
+
+def test_track_assignments_does_not_grade_an_invalid_final_selection(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-somma-fallback"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    history_dir = (
+        student.path
+        / "reports"
+        / "python-base-somma-001"
+        / "assignments"
+        / assignment_records.assignment_storage_key(assignment_id)
+    )
+    history_dir.mkdir(parents=True)
+    latest_report = attempt_report(
+        assignment_id,
+        "attempt-latest",
+        passed=True,
+        submitted_at="2026-10-20T08:00:00+02:00",
+    )
+    (history_dir / "latest.json").write_text(json.dumps(latest_report), encoding="utf-8")
+    (history_dir / "final.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "student_lab_attempt_selection.v1",
+                "assignment_id": assignment_id,
+                "activity_id": "python-base-somma-001",
+                "attempt_id": "attempt-missing",
+                "selected_at": "2026-10-20T08:05:00+02:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+    )
+
+    row = index["students"][0]
+    assert row["submitted"] is False
+    assert row["grading"]["status"] == "not_graded"
+    assert row["grading"]["provisional"] is False
+    assert row["submission"]["report_selection"] == "invalid_final"
+    assert row["submission"]["attempt_id"] is None
+    assert row["submission"]["final_selected"] is False
+    assert row["submission"]["report_path"] is None
 
 
 def test_track_assignments_rejects_unscoped_legacy_report_for_repeated_activity(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1114,6 +1114,7 @@ def test_track_assignments_rejects_unscoped_legacy_report_for_repeated_activity(
     assert row["submitted"] is False
     assert row["grading"]["status"] == "not_graded"
     assert row["report_path"] is None
+    assert row["submission"]["report_selection"] is None
 
 
 def test_track_assignments_uses_canonical_legacy_identity_for_server_help(tmp_path) -> None:


### PR DESCRIPTION
## Sintesi

- usa il tentativo `final` valido come fonte autorevole per submission e grading nel registro docente;
- mantiene `latest`/legacy come fallback provvisorio solo quando non esiste una selezione finale;
- non ripiega silenziosamente se `final.json` esiste ma non è valido;
- espone `report_selection`, `attempt_id`, `final_selected` e `grading.provisional` nel contratto;
- documenta la distinzione tra stato operativo della dashboard studente e grading del registro.

## Perché

La scelta finale dello studente non deve essere modificata da un tentativo successivo. Il registro deve inoltre rendere esplicito se sta mostrando un risultato definitivo o provvisorio.

## Test

- `python -m pytest -q tests/test_track_assignments.py tests/test_student_lab_attempts.py tests/test_student_lab_service.py tests/test_thebitlab_contracts.py tests/test_data_contract_fixtures.py`
- `python -m pytest -q`

Closes #508
Parent: #288, #292