### PR TITLE
Acquisire report di grading dagli artifact GitHub Actions

### DIFF
--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -248,10 +248,12 @@ scripts/thebitlab_grading_artifacts.py
 ```
 
 `GitHubActionsArtifactSource` riceve dal chiamante un riferimento `owner/repository`, il nome esatto
-dell'artifact, lo SHA completo atteso della consegna e un token GitHub mantenuto fuori dal repository. Il servizio:
+dell'artifact, lo SHA completo atteso della consegna, l'ID della workflow run attesa e un token GitHub
+mantenuto fuori dal repository. L'ID deve provenire da una sorgente docente fidata che abbia gia
+identificato la run del workflow autorizzato. Il servizio:
 
 1. interroga l'API GitHub Actions con paginazione limitata;
-2. considera solo artifact con nome esatto, non scaduti, legati allo SHA atteso e con metadati validi;
+2. considera solo artifact con nome esatto, non scaduti, legati allo SHA e alla workflow run attesi;
 3. sceglie il piu recente usando un timestamp timezone-aware;
 4. richiede il redirect firmato con autenticazione;
 5. scarica il file firmato senza inoltrare il token;
@@ -262,9 +264,9 @@ dell'artifact, lo SHA completo atteso della consegna e un token GitHub mantenuto
 La provenienza comprende repository, ID artifact, workflow run, SHA, data, URL API e digest dichiarato. Non
 contiene token o URL firmati temporanei.
 
-Lo SHA lega il report alla revisione consegnata, ma non dimostra da solo che il workflow sia fidato. Il flusso
-autorevole deve usare un workflow protetto o verificato dal docente; un workflow modificabile liberamente dallo
-studente produce soltanto un report remoto con provenienza, non una valutazione automaticamente attendibile.
+SHA e workflow run legano il report alla revisione e all'esecuzione scelte dal docente. Il flusso autorevole
+deve comunque usare un workflow protetto o verificato: affidare al repository dello studente anche la scelta
+della run renderebbe la provenienza insufficiente per una valutazione automaticamente attendibile.
 
 Questa fase non modifica ancora il registro docente. L'integrazione successiva usera la porta
 `GradingArtifactSource` per alimentare la raccolta dei report senza inserire chiamate GitHub dentro la

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -252,7 +252,7 @@ dell'artifact, lo SHA completo atteso della consegna, l'ID della workflow run at
 mantenuto fuori dal repository. L'ID deve provenire da una sorgente docente fidata che abbia gia
 identificato la run del workflow autorizzato. Il servizio:
 
-1. interroga l'API GitHub Actions con paginazione limitata;
+1. interroga l'endpoint artifact della sola workflow run attesa con paginazione limitata;
 2. considera solo artifact con nome esatto, non scaduti, legati allo SHA e alla workflow run attesi;
 3. sceglie il piu recente usando un timestamp timezone-aware;
 4. richiede il redirect firmato con autenticazione;

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -248,10 +248,10 @@ scripts/thebitlab_grading_artifacts.py
 ```
 
 `GitHubActionsArtifactSource` riceve dal chiamante un riferimento `owner/repository`, il nome esatto
-dell'artifact e un token GitHub mantenuto fuori dal repository. Il servizio:
+dell'artifact, lo SHA completo atteso della consegna e un token GitHub mantenuto fuori dal repository. Il servizio:
 
 1. interroga l'API GitHub Actions con paginazione limitata;
-2. considera solo artifact con nome esatto, non scaduti e con metadati validi;
+2. considera solo artifact con nome esatto, non scaduti, legati allo SHA atteso e con metadati validi;
 3. sceglie il piu recente usando un timestamp timezone-aware;
 4. richiede il redirect firmato con autenticazione;
 5. scarica il file firmato senza inoltrare il token;
@@ -259,8 +259,12 @@ dell'artifact e un token GitHub mantenuto fuori dal repository. Il servizio:
 7. rifiuta ZIP traversal, link simbolici, report multipli e JSON non valido;
 8. restituisce separatamente report e provenienza GitHub.
 
-La provenienza comprende repository, ID artifact, workflow run, data, URL API e digest dichiarato. Non
+La provenienza comprende repository, ID artifact, workflow run, SHA, data, URL API e digest dichiarato. Non
 contiene token o URL firmati temporanei.
+
+Lo SHA lega il report alla revisione consegnata, ma non dimostra da solo che il workflow sia fidato. Il flusso
+autorevole deve usare un workflow protetto o verificato dal docente; un workflow modificabile liberamente dallo
+studente produce soltanto un report remoto con provenienza, non una valutazione automaticamente attendibile.
 
 Questa fase non modifica ancora il registro docente. L'integrazione successiva usera la porta
 `GradingArtifactSource` per alimentare la raccolta dei report senza inserire chiamate GitHub dentro la

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -239,6 +239,33 @@ Il job di grading non deve committare file nel repository studente, perche per f
 
 La fase feedback puo leggere il report e generare spiegazioni, ma non deve eseguire codice studente.
 
+### Acquisizione degli artifact GitHub Actions
+
+Il primo adapter applicativo vive in:
+
+```text
+scripts/thebitlab_grading_artifacts.py
+```
+
+`GitHubActionsArtifactSource` riceve dal chiamante un riferimento `owner/repository`, il nome esatto
+dell'artifact e un token GitHub mantenuto fuori dal repository. Il servizio:
+
+1. interroga l'API GitHub Actions con paginazione limitata;
+2. considera solo artifact con nome esatto, non scaduti e con metadati validi;
+3. sceglie il piu recente usando un timestamp timezone-aware;
+4. richiede il redirect firmato con autenticazione;
+5. scarica il file firmato senza inoltrare il token;
+6. applica limiti a elenco, archivio e `report.json`;
+7. rifiuta ZIP traversal, link simbolici, report multipli e JSON non valido;
+8. restituisce separatamente report e provenienza GitHub.
+
+La provenienza comprende repository, ID artifact, workflow run, data, URL API e digest dichiarato. Non
+contiene token o URL firmati temporanei.
+
+Questa fase non modifica ancora il registro docente. L'integrazione successiva usera la porta
+`GradingArtifactSource` per alimentare la raccolta dei report senza inserire chiamate GitHub dentro la
+logica di tracking.
+
 ## Report
 
 Il report deterministico minimo e quello prodotto da:

--- a/scripts/thebitlab_grading_artifacts.py
+++ b/scripts/thebitlab_grading_artifacts.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from io import BytesIO
+import json
+from pathlib import PurePosixPath
+import stat
+from typing import Any, Mapping, Protocol
+import urllib.error
+import urllib.parse
+import urllib.request
+from zipfile import BadZipFile, ZipFile
+
+from scripts.thebitlab_repository_providers import normalize_github_repo_ref
+
+
+GITHUB_API_ROOT = "https://api.github.com"
+GITHUB_API_VERSION = "2022-11-28"
+MAX_ARTIFACT_LIST_BYTES = 2 * 1024 * 1024
+MAX_ARTIFACT_ARCHIVE_BYTES = 4 * 1024 * 1024
+MAX_GRADING_REPORT_BYTES = 2 * 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 32
+MAX_ARTIFACT_LIST_PAGES = 10
+ARTIFACTS_PER_PAGE = 100
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+class GradingArtifactError(RuntimeError):
+    """Raised when a remote grading artifact cannot be acquired safely."""
+
+
+@dataclass(frozen=True)
+class HttpResponse:
+    status: int
+    headers: Mapping[str, str]
+    body: bytes
+
+
+class HttpTransport(Protocol):
+    """Bounded HTTP transport used by remote grading artifact adapters."""
+
+    def request(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        timeout: float,
+        max_bytes: int,
+        follow_redirects: bool,
+    ) -> HttpResponse:
+        """Return one bounded HTTP response."""
+
+
+@dataclass(frozen=True)
+class GradingArtifactProvenance:
+    repository: str
+    artifact_id: int
+    artifact_name: str
+    workflow_run_id: int
+    created_at: str
+    archive_download_url: str
+    digest: str
+
+
+@dataclass(frozen=True)
+class AcquiredGradingReport:
+    report: dict[str, Any]
+    provenance: GradingArtifactProvenance
+
+
+class GradingArtifactSource(Protocol):
+    """Port for retrieving one authoritative grading report."""
+
+    def acquire_latest_report(self, repo_ref: str, artifact_name: str) -> AcquiredGradingReport:
+        """Return the latest valid report artifact for one repository."""
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ANN201
+        return None
+
+
+class _HttpsOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ANN201
+        if urllib.parse.urlparse(newurl).scheme.lower() != "https":
+            raise GradingArtifactError("Redirect artifact non sicuro: e richiesto HTTPS.")
+        redirected = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if redirected is not None:
+            redirected.remove_header("Authorization")
+        return redirected
+
+
+class UrllibHttpTransport:
+    """Standard-library HTTP transport with bounded reads and safe redirects."""
+
+    def request(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        timeout: float,
+        max_bytes: int,
+        follow_redirects: bool,
+    ) -> HttpResponse:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme.lower() != "https":
+            raise GradingArtifactError("Richiesta artifact non sicura: e richiesto HTTPS.")
+        opener = urllib.request.build_opener(
+            _HttpsOnlyRedirectHandler() if follow_redirects else _NoRedirectHandler()
+        )
+        request = urllib.request.Request(url, headers=dict(headers), method="GET")
+        try:
+            with opener.open(request, timeout=timeout) as response:
+                return _bounded_response(response, max_bytes)
+        except urllib.error.HTTPError as error:
+            if not follow_redirects and error.code in {301, 302, 303, 307, 308}:
+                return HttpResponse(
+                    status=error.code,
+                    headers=dict(error.headers.items()),
+                    body=_read_bounded(error, max_bytes),
+                )
+            detail = _read_bounded(error, min(max_bytes, 16 * 1024)).decode("utf-8", errors="replace")
+            raise GradingArtifactError(f"GitHub ha risposto HTTP {error.code}: {detail[:500]}") from error
+        except urllib.error.URLError as error:
+            raise GradingArtifactError(f"Connessione GitHub non riuscita: {error.reason}") from error
+        except TimeoutError as error:
+            raise GradingArtifactError("Connessione GitHub scaduta per timeout.") from error
+
+
+class GitHubActionsArtifactSource:
+    """Acquire deterministic grading reports from GitHub Actions artifacts."""
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        transport: HttpTransport | None = None,
+        timeout: float = REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
+        clean_token = token.strip()
+        if not clean_token:
+            raise ValueError("Token GitHub mancante.")
+        self._token = clean_token
+        self.transport = transport or UrllibHttpTransport()
+        self.timeout = timeout
+
+    def acquire_latest_report(self, repo_ref: str, artifact_name: str) -> AcquiredGradingReport:
+        owner, repo = normalize_github_repo_ref(repo_ref)
+        clean_name = _safe_artifact_name(artifact_name)
+        repository = f"{owner}/{repo}"
+        artifact = self._latest_artifact(owner, repo, clean_name)
+        archive_url = (
+            f"{GITHUB_API_ROOT}/repos/{urllib.parse.quote(owner, safe='')}/"
+            f"{urllib.parse.quote(repo, safe='')}/actions/artifacts/{artifact['id']}/zip"
+        )
+        redirect = self.transport.request(
+            archive_url,
+            headers=self._github_headers("application/vnd.github+json"),
+            timeout=self.timeout,
+            max_bytes=16 * 1024,
+            follow_redirects=False,
+        )
+        if redirect.status not in {301, 302, 303, 307, 308}:
+            raise GradingArtifactError(
+                f"Download artifact inatteso: GitHub ha risposto HTTP {redirect.status} senza redirect."
+            )
+        signed_url = _safe_signed_download_url(_header_value(redirect.headers, "location"))
+        archive = self.transport.request(
+            signed_url,
+            headers={
+                "Accept": "application/zip",
+                "User-Agent": "TheBitLab-grading-artifact-client",
+            },
+            timeout=self.timeout,
+            max_bytes=MAX_ARTIFACT_ARCHIVE_BYTES,
+            follow_redirects=True,
+        )
+        if archive.status != 200:
+            raise GradingArtifactError(f"Download artifact fallito: HTTP {archive.status}.")
+        report = _report_from_archive(archive.body)
+        workflow_run = artifact.get("workflow_run") if isinstance(artifact.get("workflow_run"), dict) else {}
+        return AcquiredGradingReport(
+            report=report,
+            provenance=GradingArtifactProvenance(
+                repository=repository,
+                artifact_id=artifact["id"],
+                artifact_name=clean_name,
+                workflow_run_id=workflow_run["id"],
+                created_at=artifact.get("created_at", ""),
+                archive_download_url=archive_url,
+                digest=artifact.get("digest", "") if isinstance(artifact.get("digest"), str) else "",
+            ),
+        )
+
+    def _latest_artifact(self, owner: str, repo: str, artifact_name: str) -> dict[str, Any]:
+        candidates: list[dict[str, Any]] = []
+        for page in range(1, MAX_ARTIFACT_LIST_PAGES + 1):
+            artifacts = self._artifact_page(owner, repo, artifact_name, page)
+            candidates.extend(
+                artifact
+                for artifact in artifacts
+                if _valid_artifact_candidate(artifact, artifact_name)
+            )
+            if len(artifacts) < ARTIFACTS_PER_PAGE:
+                break
+        else:
+            raise GradingArtifactError(
+                f"Troppi artifact omonimi: superato il limite di {MAX_ARTIFACT_LIST_PAGES} pagine."
+            )
+        if not candidates:
+            raise GradingArtifactError(f"Artifact di grading non trovato o scaduto: {artifact_name}")
+        return max(candidates, key=lambda artifact: (_artifact_created_at(artifact), artifact["id"]))
+
+    def _artifact_page(
+        self,
+        owner: str,
+        repo: str,
+        artifact_name: str,
+        page: int,
+    ) -> list[Any]:
+        query = urllib.parse.urlencode(
+            {
+                "name": artifact_name,
+                "per_page": ARTIFACTS_PER_PAGE,
+                "page": page,
+            }
+        )
+        url = (
+            f"{GITHUB_API_ROOT}/repos/{urllib.parse.quote(owner, safe='')}/"
+            f"{urllib.parse.quote(repo, safe='')}/actions/artifacts?{query}"
+        )
+        response = self.transport.request(
+            url,
+            headers=self._github_headers("application/vnd.github+json"),
+            timeout=self.timeout,
+            max_bytes=MAX_ARTIFACT_LIST_BYTES,
+            follow_redirects=True,
+        )
+        if response.status != 200:
+            raise GradingArtifactError(f"Elenco artifact non disponibile: HTTP {response.status}.")
+        payload = _json_object(response.body, "elenco artifact")
+        artifacts = payload.get("artifacts")
+        if not isinstance(artifacts, list):
+            raise GradingArtifactError("Risposta GitHub non valida: artifacts deve essere una lista.")
+        return artifacts
+
+    def _github_headers(self, accept: str) -> dict[str, str]:
+        return {
+            "Accept": accept,
+            "Authorization": f"Bearer {self._token}",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+            "User-Agent": "TheBitLab-grading-artifact-client",
+        }
+
+
+def _bounded_response(response, max_bytes: int) -> HttpResponse:  # noqa: ANN001
+    status = response.status if hasattr(response, "status") else response.getcode()
+    return HttpResponse(
+        status=status,
+        headers=dict(response.headers.items()),
+        body=_read_bounded(response, max_bytes),
+    )
+
+
+def _read_bounded(stream, max_bytes: int) -> bytes:  # noqa: ANN001
+    if max_bytes < 0:
+        raise ValueError("Limite risposta HTTP non valido.")
+    content_length = stream.headers.get("Content-Length") if getattr(stream, "headers", None) else None
+    if content_length:
+        try:
+            declared_size = int(content_length)
+        except ValueError as error:
+            raise GradingArtifactError("Content-Length GitHub non valido.") from error
+        if declared_size < 0:
+            raise GradingArtifactError("Content-Length GitHub non valido.")
+        if declared_size > max_bytes:
+            raise GradingArtifactError(f"Risposta GitHub troppo grande: supera {max_bytes} byte.")
+    body = stream.read(max_bytes + 1)
+    if len(body) > max_bytes:
+        raise GradingArtifactError(f"Risposta GitHub troppo grande: supera {max_bytes} byte.")
+    return body
+
+
+def _safe_artifact_name(value: str) -> str:
+    clean = value.strip()
+    if not clean:
+        raise ValueError("Nome artifact mancante.")
+    if len(clean) > 256 or any(ord(character) < 32 for character in clean):
+        raise ValueError("Nome artifact non valido.")
+    return clean
+
+
+def _safe_signed_download_url(value: str) -> str:
+    clean = value.strip()
+    parsed = urllib.parse.urlparse(clean)
+    if parsed.scheme.lower() != "https" or not parsed.netloc or parsed.username or parsed.password:
+        raise GradingArtifactError("Redirect download artifact non valido o non sicuro.")
+    return clean
+
+
+def _header_value(headers: Mapping[str, str], name: str) -> str:
+    wanted = name.lower()
+    for key, value in headers.items():
+        if key.lower() == wanted:
+            return value
+    return ""
+
+
+def _json_object(data: bytes, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise GradingArtifactError(f"JSON {label} non valido.") from error
+    if not isinstance(payload, dict):
+        raise GradingArtifactError(f"JSON {label} non valido: e richiesto un oggetto.")
+    return payload
+
+
+def _valid_artifact_candidate(value: Any, artifact_name: str) -> bool:
+    if not isinstance(value, dict) or value.get("name") != artifact_name or value.get("expired") is not False:
+        return False
+    artifact_id = value.get("id")
+    size_in_bytes = value.get("size_in_bytes")
+    workflow_run = value.get("workflow_run")
+    workflow_run_id = workflow_run.get("id") if isinstance(workflow_run, dict) else None
+    return (
+        isinstance(artifact_id, int)
+        and not isinstance(artifact_id, bool)
+        and artifact_id > 0
+        and isinstance(size_in_bytes, int)
+        and not isinstance(size_in_bytes, bool)
+        and 0 <= size_in_bytes <= MAX_ARTIFACT_ARCHIVE_BYTES
+        and isinstance(workflow_run_id, int)
+        and not isinstance(workflow_run_id, bool)
+        and workflow_run_id > 0
+        and _artifact_created_at(value) is not None
+    )
+
+
+def _artifact_created_at(value: Mapping[str, Any]) -> datetime | None:
+    created_at = value.get("created_at")
+    if not isinstance(created_at, str) or not created_at.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(created_at.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else None
+
+
+def _report_from_archive(data: bytes) -> dict[str, Any]:
+    try:
+        with ZipFile(BytesIO(data)) as archive:
+            members = archive.infolist()
+            if len(members) > MAX_ARCHIVE_MEMBERS:
+                raise GradingArtifactError(
+                    f"Artifact non valido: contiene piu di {MAX_ARCHIVE_MEMBERS} file."
+                )
+            if any(not _safe_archive_member(member) for member in members):
+                raise GradingArtifactError("Artifact non valido: contiene path non sicuri o link simbolici.")
+            reports = [member for member in members if not member.is_dir() and member.filename == "report.json"]
+            if len(reports) != 1:
+                raise GradingArtifactError("Artifact non valido: e richiesto un solo report.json alla radice.")
+            report_info = reports[0]
+            if report_info.flag_bits & 0x1:
+                raise GradingArtifactError("Artifact non valido: report.json e cifrato.")
+            if report_info.file_size > MAX_GRADING_REPORT_BYTES:
+                raise GradingArtifactError(
+                    f"Report grading troppo grande: supera {MAX_GRADING_REPORT_BYTES} byte."
+                )
+            with archive.open(report_info) as report_stream:
+                report_bytes = report_stream.read(MAX_GRADING_REPORT_BYTES + 1)
+    except BadZipFile as error:
+        raise GradingArtifactError("Artifact di grading non e un archivio ZIP valido.") from error
+    if len(report_bytes) > MAX_GRADING_REPORT_BYTES:
+        raise GradingArtifactError(f"Report grading troppo grande: supera {MAX_GRADING_REPORT_BYTES} byte.")
+    return _json_object(report_bytes, "report grading")
+
+
+def _safe_archive_member(member) -> bool:  # noqa: ANN001
+    filename = member.filename
+    path = PurePosixPath(filename)
+    mode = member.external_attr >> 16
+    return bool(
+        filename
+        and "\\" not in filename
+        and not path.is_absolute()
+        and ".." not in path.parts
+        and all(":" not in part for part in path.parts)
+        and not stat.S_ISLNK(mode)
+    )

--- a/scripts/thebitlab_grading_artifacts.py
+++ b/scripts/thebitlab_grading_artifacts.py
@@ -216,8 +216,25 @@ class GitHubActionsArtifactSource:
         expected_head_sha: str,
     ) -> dict[str, Any]:
         candidates: list[dict[str, Any]] = []
-        for page in range(1, MAX_ARTIFACT_LIST_PAGES + 1):
-            artifacts = self._artifact_page(owner, repo, artifact_name, page)
+        total_count: int | None = None
+        fetched_count = 0
+        page = 1
+        while True:
+            artifacts, page_total_count = self._artifact_page(owner, repo, artifact_name, page)
+            if total_count is None:
+                total_count = page_total_count
+                if total_count > MAX_ARTIFACT_LIST_PAGES * ARTIFACTS_PER_PAGE:
+                    raise GradingArtifactError(
+                        f"Troppi artifact omonimi: superato il limite di "
+                        f"{MAX_ARTIFACT_LIST_PAGES * ARTIFACTS_PER_PAGE}."
+                    )
+            elif page_total_count != total_count:
+                raise GradingArtifactError(
+                    "Elenco artifact GitHub cambiato durante la paginazione."
+                )
+            fetched_count += len(artifacts)
+            if fetched_count > total_count:
+                raise GradingArtifactError("Paginazione artifact GitHub non coerente.")
             for artifact in artifacts:
                 candidate = _artifact_candidate_for_commit(
                     artifact,
@@ -226,12 +243,11 @@ class GitHubActionsArtifactSource:
                 )
                 if candidate is not None:
                     candidates.append(candidate)
-            if len(artifacts) < ARTIFACTS_PER_PAGE:
+            if fetched_count == total_count:
                 break
-        else:
-            raise GradingArtifactError(
-                f"Troppi artifact omonimi: superato il limite di {MAX_ARTIFACT_LIST_PAGES} pagine."
-            )
+            if len(artifacts) < ARTIFACTS_PER_PAGE or page >= MAX_ARTIFACT_LIST_PAGES:
+                raise GradingArtifactError("Paginazione artifact GitHub incompleta.")
+            page += 1
         if not candidates:
             raise GradingArtifactError(
                 f"Artifact di grading non trovato o scaduto per il commit {expected_head_sha}: {artifact_name}"
@@ -244,7 +260,7 @@ class GitHubActionsArtifactSource:
         repo: str,
         artifact_name: str,
         page: int,
-    ) -> list[Any]:
+    ) -> tuple[list[Any], int]:
         query = urllib.parse.urlencode(
             {
                 "name": artifact_name,
@@ -269,7 +285,14 @@ class GitHubActionsArtifactSource:
         artifacts = payload.get("artifacts")
         if not isinstance(artifacts, list):
             raise GradingArtifactError("Risposta GitHub non valida: artifacts deve essere una lista.")
-        return artifacts
+        total_count = payload.get("total_count")
+        if (
+            not isinstance(total_count, int)
+            or isinstance(total_count, bool)
+            or total_count < 0
+        ):
+            raise GradingArtifactError("Risposta GitHub non valida: total_count non valido.")
+        return artifacts, total_count
 
     def _github_headers(self, accept: str) -> dict[str, str]:
         return {

--- a/scripts/thebitlab_grading_artifacts.py
+++ b/scripts/thebitlab_grading_artifacts.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO
 import json
+import lzma
 from pathlib import PurePosixPath
 import re
 import stat
@@ -484,9 +485,16 @@ def _report_from_archive(data: bytes) -> dict[str, Any]:
         raise GradingArtifactError(
             "Artifact di grading usa un metodo di compressione ZIP non supportato."
         ) from error
-    except zlib.error as error:
+    except (
+        EOFError,
+        OSError,
+        UnicodeDecodeError,
+        ValueError,
+        lzma.LZMAError,
+        zlib.error,
+    ) as error:
         raise GradingArtifactError(
-            "Artifact di grading contiene dati compressi non validi."
+            "Artifact di grading contiene dati ZIP corrotti."
         ) from error
     if len(report_bytes) > MAX_GRADING_REPORT_BYTES:
         raise GradingArtifactError(f"Report grading troppo grande: supera {MAX_GRADING_REPORT_BYTES} byte.")

--- a/scripts/thebitlab_grading_artifacts.py
+++ b/scripts/thebitlab_grading_artifacts.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from io import BytesIO
 import json
 from pathlib import PurePosixPath
+import re
 import stat
 from typing import Any, Mapping, Protocol
 import urllib.error
@@ -24,6 +25,7 @@ MAX_ARCHIVE_MEMBERS = 32
 MAX_ARTIFACT_LIST_PAGES = 10
 ARTIFACTS_PER_PAGE = 100
 REQUEST_TIMEOUT_SECONDS = 30
+GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
 
 class GradingArtifactError(RuntimeError):
@@ -58,6 +60,7 @@ class GradingArtifactProvenance:
     artifact_id: int
     artifact_name: str
     workflow_run_id: int
+    head_sha: str
     created_at: str
     archive_download_url: str
     digest: str
@@ -72,7 +75,12 @@ class AcquiredGradingReport:
 class GradingArtifactSource(Protocol):
     """Port for retrieving one authoritative grading report."""
 
-    def acquire_latest_report(self, repo_ref: str, artifact_name: str) -> AcquiredGradingReport:
+    def acquire_latest_report(
+        self,
+        repo_ref: str,
+        artifact_name: str,
+        expected_head_sha: str,
+    ) -> AcquiredGradingReport:
         """Return the latest valid report artifact for one repository."""
 
 
@@ -145,11 +153,17 @@ class GitHubActionsArtifactSource:
         self.transport = transport or UrllibHttpTransport()
         self.timeout = timeout
 
-    def acquire_latest_report(self, repo_ref: str, artifact_name: str) -> AcquiredGradingReport:
+    def acquire_latest_report(
+        self,
+        repo_ref: str,
+        artifact_name: str,
+        expected_head_sha: str,
+    ) -> AcquiredGradingReport:
         owner, repo = normalize_github_repo_ref(repo_ref)
         clean_name = _safe_artifact_name(artifact_name)
+        clean_head_sha = _safe_head_sha(expected_head_sha)
         repository = f"{owner}/{repo}"
-        artifact = self._latest_artifact(owner, repo, clean_name)
+        artifact = self._latest_artifact(owner, repo, clean_name, clean_head_sha)
         archive_url = (
             f"{GITHUB_API_ROOT}/repos/{urllib.parse.quote(owner, safe='')}/"
             f"{urllib.parse.quote(repo, safe='')}/actions/artifacts/{artifact['id']}/zip"
@@ -187,20 +201,27 @@ class GitHubActionsArtifactSource:
                 artifact_id=artifact["id"],
                 artifact_name=clean_name,
                 workflow_run_id=workflow_run["id"],
+                head_sha=clean_head_sha,
                 created_at=artifact.get("created_at", ""),
                 archive_download_url=archive_url,
                 digest=artifact.get("digest", "") if isinstance(artifact.get("digest"), str) else "",
             ),
         )
 
-    def _latest_artifact(self, owner: str, repo: str, artifact_name: str) -> dict[str, Any]:
+    def _latest_artifact(
+        self,
+        owner: str,
+        repo: str,
+        artifact_name: str,
+        expected_head_sha: str,
+    ) -> dict[str, Any]:
         candidates: list[dict[str, Any]] = []
         for page in range(1, MAX_ARTIFACT_LIST_PAGES + 1):
             artifacts = self._artifact_page(owner, repo, artifact_name, page)
             candidates.extend(
                 artifact
                 for artifact in artifacts
-                if _valid_artifact_candidate(artifact, artifact_name)
+                if _valid_artifact_candidate(artifact, artifact_name, expected_head_sha)
             )
             if len(artifacts) < ARTIFACTS_PER_PAGE:
                 break
@@ -209,7 +230,9 @@ class GitHubActionsArtifactSource:
                 f"Troppi artifact omonimi: superato il limite di {MAX_ARTIFACT_LIST_PAGES} pagine."
             )
         if not candidates:
-            raise GradingArtifactError(f"Artifact di grading non trovato o scaduto: {artifact_name}")
+            raise GradingArtifactError(
+                f"Artifact di grading non trovato o scaduto per il commit {expected_head_sha}: {artifact_name}"
+            )
         return max(candidates, key=lambda artifact: (_artifact_created_at(artifact), artifact["id"]))
 
     def _artifact_page(
@@ -291,6 +314,13 @@ def _safe_artifact_name(value: str) -> str:
     return clean
 
 
+def _safe_head_sha(value: str) -> str:
+    clean = value.strip()
+    if not GIT_SHA_RE.fullmatch(clean):
+        raise ValueError("SHA commit atteso non valido: sono richiesti 40 caratteri esadecimali.")
+    return clean.lower()
+
+
 def _safe_signed_download_url(value: str) -> str:
     clean = value.strip()
     parsed = urllib.parse.urlparse(clean)
@@ -317,13 +347,14 @@ def _json_object(data: bytes, label: str) -> dict[str, Any]:
     return payload
 
 
-def _valid_artifact_candidate(value: Any, artifact_name: str) -> bool:
+def _valid_artifact_candidate(value: Any, artifact_name: str, expected_head_sha: str) -> bool:
     if not isinstance(value, dict) or value.get("name") != artifact_name or value.get("expired") is not False:
         return False
     artifact_id = value.get("id")
     size_in_bytes = value.get("size_in_bytes")
     workflow_run = value.get("workflow_run")
     workflow_run_id = workflow_run.get("id") if isinstance(workflow_run, dict) else None
+    head_sha = workflow_run.get("head_sha") if isinstance(workflow_run, dict) else None
     return (
         isinstance(artifact_id, int)
         and not isinstance(artifact_id, bool)
@@ -334,6 +365,8 @@ def _valid_artifact_candidate(value: Any, artifact_name: str) -> bool:
         and isinstance(workflow_run_id, int)
         and not isinstance(workflow_run_id, bool)
         and workflow_run_id > 0
+        and isinstance(head_sha, str)
+        and head_sha.lower() == expected_head_sha
         and _artifact_created_at(value) is not None
     )
 

--- a/scripts/thebitlab_grading_artifacts.py
+++ b/scripts/thebitlab_grading_artifacts.py
@@ -429,6 +429,10 @@ def _report_from_archive(data: bytes) -> dict[str, Any]:
                 report_bytes = report_stream.read(MAX_GRADING_REPORT_BYTES + 1)
     except BadZipFile as error:
         raise GradingArtifactError("Artifact di grading non e un archivio ZIP valido.") from error
+    except NotImplementedError as error:
+        raise GradingArtifactError(
+            "Artifact di grading usa un metodo di compressione ZIP non supportato."
+        ) from error
     if len(report_bytes) > MAX_GRADING_REPORT_BYTES:
         raise GradingArtifactError(f"Report grading troppo grande: supera {MAX_GRADING_REPORT_BYTES} byte.")
     return _json_object(report_bytes, "report grading")

--- a/scripts/thebitlab_grading_artifacts.py
+++ b/scripts/thebitlab_grading_artifacts.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping, Protocol
 import urllib.error
 import urllib.parse
 import urllib.request
+import zlib
 from zipfile import BadZipFile, ZipFile
 
 from scripts.thebitlab_repository_providers import normalize_github_repo_ref
@@ -482,6 +483,10 @@ def _report_from_archive(data: bytes) -> dict[str, Any]:
     except NotImplementedError as error:
         raise GradingArtifactError(
             "Artifact di grading usa un metodo di compressione ZIP non supportato."
+        ) from error
+    except zlib.error as error:
+        raise GradingArtifactError(
+            "Artifact di grading contiene dati compressi non validi."
         ) from error
     if len(report_bytes) > MAX_GRADING_REPORT_BYTES:
         raise GradingArtifactError(f"Report grading troppo grande: supera {MAX_GRADING_REPORT_BYTES} byte.")

--- a/scripts/thebitlab_grading_artifacts.py
+++ b/scripts/thebitlab_grading_artifacts.py
@@ -230,7 +230,13 @@ class GitHubActionsArtifactSource:
         fetched_count = 0
         page = 1
         while True:
-            artifacts, page_total_count = self._artifact_page(owner, repo, artifact_name, page)
+            artifacts, page_total_count = self._artifact_page(
+                owner,
+                repo,
+                artifact_name,
+                expected_workflow_run_id,
+                page,
+            )
             if total_count is None:
                 total_count = page_total_count
                 if total_count > MAX_ARTIFACT_LIST_PAGES * ARTIFACTS_PER_PAGE:
@@ -270,6 +276,7 @@ class GitHubActionsArtifactSource:
         owner: str,
         repo: str,
         artifact_name: str,
+        workflow_run_id: int,
         page: int,
     ) -> tuple[list[Any], int]:
         query = urllib.parse.urlencode(
@@ -281,7 +288,7 @@ class GitHubActionsArtifactSource:
         )
         url = (
             f"{GITHUB_API_ROOT}/repos/{urllib.parse.quote(owner, safe='')}/"
-            f"{urllib.parse.quote(repo, safe='')}/actions/artifacts?{query}"
+            f"{urllib.parse.quote(repo, safe='')}/actions/runs/{workflow_run_id}/artifacts?{query}"
         )
         response = self.transport.request(
             url,

--- a/scripts/thebitlab_grading_artifacts.py
+++ b/scripts/thebitlab_grading_artifacts.py
@@ -80,6 +80,7 @@ class GradingArtifactSource(Protocol):
         repo_ref: str,
         artifact_name: str,
         expected_head_sha: str,
+        expected_workflow_run_id: int,
     ) -> AcquiredGradingReport:
         """Return the latest valid report artifact for one repository."""
 
@@ -158,12 +159,20 @@ class GitHubActionsArtifactSource:
         repo_ref: str,
         artifact_name: str,
         expected_head_sha: str,
+        expected_workflow_run_id: int,
     ) -> AcquiredGradingReport:
         owner, repo = normalize_github_repo_ref(repo_ref)
         clean_name = _safe_artifact_name(artifact_name)
         clean_head_sha = _safe_head_sha(expected_head_sha)
+        clean_workflow_run_id = _safe_workflow_run_id(expected_workflow_run_id)
         repository = f"{owner}/{repo}"
-        artifact = self._latest_artifact(owner, repo, clean_name, clean_head_sha)
+        artifact = self._latest_artifact(
+            owner,
+            repo,
+            clean_name,
+            clean_head_sha,
+            clean_workflow_run_id,
+        )
         archive_url = (
             f"{GITHUB_API_ROOT}/repos/{urllib.parse.quote(owner, safe='')}/"
             f"{urllib.parse.quote(repo, safe='')}/actions/artifacts/{artifact['id']}/zip"
@@ -214,6 +223,7 @@ class GitHubActionsArtifactSource:
         repo: str,
         artifact_name: str,
         expected_head_sha: str,
+        expected_workflow_run_id: int,
     ) -> dict[str, Any]:
         candidates: list[dict[str, Any]] = []
         total_count: int | None = None
@@ -240,6 +250,7 @@ class GitHubActionsArtifactSource:
                     artifact,
                     artifact_name,
                     expected_head_sha,
+                    expected_workflow_run_id,
                 )
                 if candidate is not None:
                     candidates.append(candidate)
@@ -347,6 +358,12 @@ def _safe_head_sha(value: str) -> str:
     return clean.lower()
 
 
+def _safe_workflow_run_id(value: int) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError("ID workflow run attesa non valido.")
+    return value
+
+
 def _safe_signed_download_url(value: str) -> str:
     clean = value.strip()
     parsed = urllib.parse.urlparse(clean)
@@ -377,6 +394,7 @@ def _artifact_candidate_for_commit(
     value: Any,
     artifact_name: str,
     expected_head_sha: str,
+    expected_workflow_run_id: int,
 ) -> dict[str, Any] | None:
     if not isinstance(value, dict) or value.get("name") != artifact_name:
         return None
@@ -390,10 +408,18 @@ def _artifact_candidate_for_commit(
         raise GradingArtifactError("Artifact di grading non valido: workflow_run.head_sha non valido.")
     if head_sha.lower() != expected_head_sha:
         return None
+    workflow_run_id = workflow_run.get("id")
+    if (
+        not isinstance(workflow_run_id, int)
+        or isinstance(workflow_run_id, bool)
+        or workflow_run_id <= 0
+    ):
+        raise GradingArtifactError("Artifact di grading non valido: workflow_run.id non valido.")
+    if workflow_run_id != expected_workflow_run_id:
+        return None
 
     artifact_id = value.get("id")
     size_in_bytes = value.get("size_in_bytes")
-    workflow_run_id = workflow_run.get("id")
     if not isinstance(artifact_id, int) or isinstance(artifact_id, bool) or artifact_id <= 0:
         raise GradingArtifactError("Artifact di grading non valido: id non valido.")
     if (
@@ -406,12 +432,6 @@ def _artifact_candidate_for_commit(
         raise GradingArtifactError(
             f"Artifact di grading troppo grande: supera {MAX_ARTIFACT_ARCHIVE_BYTES} byte."
         )
-    if (
-        not isinstance(workflow_run_id, int)
-        or isinstance(workflow_run_id, bool)
-        or workflow_run_id <= 0
-    ):
-        raise GradingArtifactError("Artifact di grading non valido: workflow_run.id non valido.")
     if _artifact_created_at(value) is None:
         raise GradingArtifactError("Artifact di grading non valido: created_at non valido.")
     return value

--- a/scripts/thebitlab_grading_artifacts.py
+++ b/scripts/thebitlab_grading_artifacts.py
@@ -218,11 +218,14 @@ class GitHubActionsArtifactSource:
         candidates: list[dict[str, Any]] = []
         for page in range(1, MAX_ARTIFACT_LIST_PAGES + 1):
             artifacts = self._artifact_page(owner, repo, artifact_name, page)
-            candidates.extend(
-                artifact
-                for artifact in artifacts
-                if _valid_artifact_candidate(artifact, artifact_name, expected_head_sha)
-            )
+            for artifact in artifacts:
+                candidate = _artifact_candidate_for_commit(
+                    artifact,
+                    artifact_name,
+                    expected_head_sha,
+                )
+                if candidate is not None:
+                    candidates.append(candidate)
             if len(artifacts) < ARTIFACTS_PER_PAGE:
                 break
         else:
@@ -347,28 +350,48 @@ def _json_object(data: bytes, label: str) -> dict[str, Any]:
     return payload
 
 
-def _valid_artifact_candidate(value: Any, artifact_name: str, expected_head_sha: str) -> bool:
-    if not isinstance(value, dict) or value.get("name") != artifact_name or value.get("expired") is not False:
-        return False
+def _artifact_candidate_for_commit(
+    value: Any,
+    artifact_name: str,
+    expected_head_sha: str,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict) or value.get("name") != artifact_name:
+        return None
+    if value.get("expired") is not False:
+        return None
+    workflow_run = value.get("workflow_run")
+    if not isinstance(workflow_run, dict):
+        raise GradingArtifactError("Artifact di grading non valido: workflow_run mancante.")
+    head_sha = workflow_run.get("head_sha")
+    if not isinstance(head_sha, str) or not GIT_SHA_RE.fullmatch(head_sha):
+        raise GradingArtifactError("Artifact di grading non valido: workflow_run.head_sha non valido.")
+    if head_sha.lower() != expected_head_sha:
+        return None
+
     artifact_id = value.get("id")
     size_in_bytes = value.get("size_in_bytes")
-    workflow_run = value.get("workflow_run")
-    workflow_run_id = workflow_run.get("id") if isinstance(workflow_run, dict) else None
-    head_sha = workflow_run.get("head_sha") if isinstance(workflow_run, dict) else None
-    return (
-        isinstance(artifact_id, int)
-        and not isinstance(artifact_id, bool)
-        and artifact_id > 0
-        and isinstance(size_in_bytes, int)
-        and not isinstance(size_in_bytes, bool)
-        and 0 <= size_in_bytes <= MAX_ARTIFACT_ARCHIVE_BYTES
-        and isinstance(workflow_run_id, int)
-        and not isinstance(workflow_run_id, bool)
-        and workflow_run_id > 0
-        and isinstance(head_sha, str)
-        and head_sha.lower() == expected_head_sha
-        and _artifact_created_at(value) is not None
-    )
+    workflow_run_id = workflow_run.get("id")
+    if not isinstance(artifact_id, int) or isinstance(artifact_id, bool) or artifact_id <= 0:
+        raise GradingArtifactError("Artifact di grading non valido: id non valido.")
+    if (
+        not isinstance(size_in_bytes, int)
+        or isinstance(size_in_bytes, bool)
+        or size_in_bytes < 0
+    ):
+        raise GradingArtifactError("Artifact di grading non valido: size_in_bytes non valido.")
+    if size_in_bytes > MAX_ARTIFACT_ARCHIVE_BYTES:
+        raise GradingArtifactError(
+            f"Artifact di grading troppo grande: supera {MAX_ARTIFACT_ARCHIVE_BYTES} byte."
+        )
+    if (
+        not isinstance(workflow_run_id, int)
+        or isinstance(workflow_run_id, bool)
+        or workflow_run_id <= 0
+    ):
+        raise GradingArtifactError("Artifact di grading non valido: workflow_run.id non valido.")
+    if _artifact_created_at(value) is None:
+        raise GradingArtifactError("Artifact di grading non valido: created_at non valido.")
+    return value
 
 
 def _artifact_created_at(value: Mapping[str, Any]) -> datetime | None:

--- a/tests/test_thebitlab_grading_artifacts.py
+++ b/tests/test_thebitlab_grading_artifacts.py
@@ -318,6 +318,33 @@ def test_github_source_ignores_newer_artifact_from_another_commit() -> None:
     assert acquired.provenance.head_sha == TEST_SHA
 
 
+def test_github_source_does_not_fall_back_when_newer_matching_artifact_is_unsafe() -> None:
+    older = candidate(30, created_at="2026-07-24T10:00:00Z")
+    newer_oversized = {
+        **candidate(31, created_at="2026-07-24T12:00:00Z"),
+        "size_in_bytes": artifacts.MAX_ARTIFACT_ARCHIVE_BYTES + 1,
+    }
+    source = artifacts.GitHubActionsArtifactSource(
+        "github-secret",
+        transport=FakeTransport(
+            [
+                artifacts.HttpResponse(
+                    200,
+                    {},
+                    artifact_payload([older, newer_oversized]),
+                )
+            ]
+        ),
+    )
+
+    with pytest.raises(artifacts.GradingArtifactError, match="troppo grande"):
+        source.acquire_latest_report(
+            "TheBitPoets/rossi-mario",
+            "thebitlab-demo-python-report",
+            TEST_SHA,
+        )
+
+
 class FakeBoundedStream(BytesIO):
     def __init__(self, content: bytes, content_length: str | None = None) -> None:
         super().__init__(content)

--- a/tests/test_thebitlab_grading_artifacts.py
+++ b/tests/test_thebitlab_grading_artifacts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 import json
-from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+from zipfile import ZIP_BZIP2, ZIP_DEFLATED, ZIP_LZMA, ZipFile, ZipInfo
 
 import pytest
 
@@ -52,9 +52,9 @@ def zip_bytes_with_unsupported_compression() -> bytes:
     return bytes(data)
 
 
-def corrupted_deflate_zip_bytes() -> bytes:
+def corrupted_compressed_zip_bytes(compression: int, mutation_offset: int = 0) -> bytes:
     stream = BytesIO()
-    with ZipFile(stream, "w", compression=ZIP_DEFLATED) as archive:
+    with ZipFile(stream, "w", compression=compression) as archive:
         archive.writestr("report.json", b'{"data":"' + b"a" * 1024 + b'"}')
     data = bytearray(stream.getvalue())
     local_header = data.find(b"PK\x03\x04")
@@ -62,7 +62,7 @@ def corrupted_deflate_zip_bytes() -> bytes:
     filename_length = int.from_bytes(data[local_header + 26 : local_header + 28], "little")
     extra_length = int.from_bytes(data[local_header + 28 : local_header + 30], "little")
     payload_start = local_header + 30 + filename_length + extra_length
-    data[payload_start] ^= 0xFF
+    data[payload_start + mutation_offset] ^= 0xFF
     return bytes(data)
 
 
@@ -379,9 +379,22 @@ def test_report_archive_normalizes_unsupported_compression_error() -> None:
         artifacts._report_from_archive(zip_bytes_with_unsupported_compression())
 
 
-def test_report_archive_normalizes_corrupt_deflate_error() -> None:
-    with pytest.raises(artifacts.GradingArtifactError, match="dati compressi non validi"):
-        artifacts._report_from_archive(corrupted_deflate_zip_bytes())
+@pytest.mark.parametrize(
+    ("compression", "mutation_offset"),
+    [
+        (ZIP_DEFLATED, 0),
+        (ZIP_BZIP2, 0),
+        (ZIP_LZMA, 4),
+    ],
+)
+def test_report_archive_normalizes_corrupt_compression_errors(
+    compression: int,
+    mutation_offset: int,
+) -> None:
+    with pytest.raises(artifacts.GradingArtifactError, match="dati ZIP corrotti"):
+        artifacts._report_from_archive(
+            corrupted_compressed_zip_bytes(compression, mutation_offset)
+        )
 
 
 def test_source_validates_token_repository_and_artifact_name() -> None:

--- a/tests/test_thebitlab_grading_artifacts.py
+++ b/tests/test_thebitlab_grading_artifacts.py
@@ -11,6 +11,7 @@ from scripts import thebitlab_grading_artifacts as artifacts
 
 TEST_SHA = "a" * 40
 OTHER_SHA = "b" * 40
+TEST_WORKFLOW_RUN_ID = 900
 
 
 class FakeTransport:
@@ -114,6 +115,7 @@ def test_github_source_acquires_latest_exact_non_expired_report() -> None:
         "TheBitPoets/rossi-mario",
         "thebitlab-demo-python-report",
         TEST_SHA,
+        913,
     )
 
     assert acquired.report == report
@@ -155,6 +157,7 @@ def test_github_source_rejects_missing_expired_or_different_artifact(payload: by
             "TheBitPoets/rossi-mario",
             "thebitlab-demo-python-report",
             TEST_SHA,
+            TEST_WORKFLOW_RUN_ID,
         )
 
 
@@ -180,6 +183,7 @@ def test_github_source_rejects_invalid_list_payload_and_candidates() -> None:
                 "TheBitPoets/rossi-mario",
                 "thebitlab-demo-python-report",
                 TEST_SHA,
+                TEST_WORKFLOW_RUN_ID,
             )
 
 
@@ -205,6 +209,7 @@ def test_github_source_paginates_before_selecting_latest_artifact() -> None:
         "TheBitPoets/rossi-mario",
         "thebitlab-demo-python-report",
         TEST_SHA,
+        9500,
     )
 
     assert acquired.provenance.artifact_id == 500
@@ -239,6 +244,7 @@ def test_github_source_accepts_exact_pagination_safety_limit() -> None:
         "TheBitPoets/rossi-mario",
         "thebitlab-demo-python-report",
         TEST_SHA,
+        TEST_WORKFLOW_RUN_ID,
     )
 
     assert acquired.provenance.artifact_id == total_count
@@ -263,6 +269,7 @@ def test_github_source_fails_when_pagination_safety_limit_is_exceeded() -> None:
             "TheBitPoets/rossi-mario",
             "thebitlab-demo-python-report",
             TEST_SHA,
+            TEST_WORKFLOW_RUN_ID,
         )
 
 
@@ -284,6 +291,7 @@ def test_github_source_rejects_invalid_total_count(total_count: object) -> None:
             "TheBitPoets/rossi-mario",
             "thebitlab-demo-python-report",
             TEST_SHA,
+            TEST_WORKFLOW_RUN_ID,
         )
 
 
@@ -312,6 +320,7 @@ def test_github_source_rejects_unsafe_download_redirect(location: str) -> None:
             "TheBitPoets/rossi-mario",
             "thebitlab-demo-python-report",
             TEST_SHA,
+            TEST_WORKFLOW_RUN_ID,
         )
 
 
@@ -361,14 +370,26 @@ def test_source_validates_token_repository_and_artifact_name() -> None:
 
     source = artifacts.GitHubActionsArtifactSource("github-secret", transport=FakeTransport([]))
     with pytest.raises(ValueError, match="Repository GitHub"):
-        source.acquire_latest_report("not-a-repo", "report", TEST_SHA)
+        source.acquire_latest_report("not-a-repo", "report", TEST_SHA, TEST_WORKFLOW_RUN_ID)
     with pytest.raises(ValueError, match="Nome artifact"):
-        source.acquire_latest_report("TheBitPoets/rossi-mario", " ", TEST_SHA)
+        source.acquire_latest_report(
+            "TheBitPoets/rossi-mario",
+            " ",
+            TEST_SHA,
+            TEST_WORKFLOW_RUN_ID,
+        )
     with pytest.raises(ValueError, match="SHA commit"):
-        source.acquire_latest_report("TheBitPoets/rossi-mario", "report", "abc123")
+        source.acquire_latest_report(
+            "TheBitPoets/rossi-mario",
+            "report",
+            "abc123",
+            TEST_WORKFLOW_RUN_ID,
+        )
+    with pytest.raises(ValueError, match="workflow run"):
+        source.acquire_latest_report("TheBitPoets/rossi-mario", "report", TEST_SHA, True)
 
 
-def test_github_source_ignores_newer_artifact_from_another_commit() -> None:
+def test_github_source_ignores_newer_artifacts_from_other_commit_or_run() -> None:
     expected = candidate(20, created_at="2026-07-24T10:00:00Z", workflow_run_id=920)
     unrelated = candidate(
         21,
@@ -376,9 +397,18 @@ def test_github_source_ignores_newer_artifact_from_another_commit() -> None:
         workflow_run_id=921,
         head_sha=OTHER_SHA,
     )
+    competing_run = candidate(
+        22,
+        created_at="2026-07-24T13:00:00Z",
+        workflow_run_id=922,
+    )
     transport = FakeTransport(
         [
-            artifacts.HttpResponse(200, {}, artifact_payload([expected, unrelated])),
+            artifacts.HttpResponse(
+                200,
+                {},
+                artifact_payload([expected, unrelated, competing_run]),
+            ),
             artifacts.HttpResponse(302, {"Location": "https://signed.example.test/report.zip"}, b""),
             artifacts.HttpResponse(200, {}, zip_bytes([("report.json", b'{"status":"passed"}')])),
         ]
@@ -391,6 +421,7 @@ def test_github_source_ignores_newer_artifact_from_another_commit() -> None:
         "TheBitPoets/rossi-mario",
         "thebitlab-demo-python-report",
         TEST_SHA,
+        920,
     )
 
     assert acquired.provenance.artifact_id == 20
@@ -421,6 +452,7 @@ def test_github_source_does_not_fall_back_when_newer_matching_artifact_is_unsafe
             "TheBitPoets/rossi-mario",
             "thebitlab-demo-python-report",
             TEST_SHA,
+            TEST_WORKFLOW_RUN_ID,
         )
 
 

--- a/tests/test_thebitlab_grading_artifacts.py
+++ b/tests/test_thebitlab_grading_artifacts.py
@@ -39,6 +39,18 @@ def zip_bytes(files: list[tuple[str, bytes]]) -> bytes:
     return stream.getvalue()
 
 
+def zip_bytes_with_unsupported_compression() -> bytes:
+    data = bytearray(zip_bytes([("report.json", b"{}")]))
+    local_header = data.find(b"PK\x03\x04")
+    central_header = data.find(b"PK\x01\x02")
+    assert local_header >= 0
+    assert central_header >= 0
+    unsupported_method = (99).to_bytes(2, "little")
+    data[local_header + 8 : local_header + 10] = unsupported_method
+    data[central_header + 10 : central_header + 12] = unsupported_method
+    return bytes(data)
+
+
 def artifact_payload(items: list[dict[str, object]]) -> bytes:
     return json.dumps({"artifacts": items}).encode("utf-8")
 
@@ -274,6 +286,11 @@ def test_report_archive_rejects_symbolic_link_and_too_many_members() -> None:
     )
     with pytest.raises(artifacts.GradingArtifactError, match="piu di"):
         artifacts._report_from_archive(crowded)
+
+
+def test_report_archive_normalizes_unsupported_compression_error() -> None:
+    with pytest.raises(artifacts.GradingArtifactError, match="compressione ZIP non supportato"):
+        artifacts._report_from_archive(zip_bytes_with_unsupported_compression())
 
 
 def test_source_validates_token_repository_and_artifact_name() -> None:

--- a/tests/test_thebitlab_grading_artifacts.py
+++ b/tests/test_thebitlab_grading_artifacts.py
@@ -51,8 +51,17 @@ def zip_bytes_with_unsupported_compression() -> bytes:
     return bytes(data)
 
 
-def artifact_payload(items: list[dict[str, object]]) -> bytes:
-    return json.dumps({"artifacts": items}).encode("utf-8")
+def artifact_payload(
+    items: list[dict[str, object]],
+    *,
+    total_count: int | None = None,
+) -> bytes:
+    return json.dumps(
+        {
+            "total_count": len(items) if total_count is None else total_count,
+            "artifacts": items,
+        }
+    ).encode("utf-8")
 
 
 def candidate(
@@ -182,8 +191,8 @@ def test_github_source_paginates_before_selecting_latest_artifact() -> None:
     latest = candidate(500, created_at="2026-07-24T14:00:00Z", workflow_run_id=9500)
     transport = FakeTransport(
         [
-            artifacts.HttpResponse(200, {}, artifact_payload(first_page)),
-            artifacts.HttpResponse(200, {}, artifact_payload([latest])),
+            artifacts.HttpResponse(200, {}, artifact_payload(first_page, total_count=101)),
+            artifacts.HttpResponse(200, {}, artifact_payload([latest], total_count=101)),
             artifacts.HttpResponse(302, {"Location": "https://signed.example.test/report.zip"}, b""),
             artifacts.HttpResponse(200, {}, zip_bytes([("report.json", b'{"status":"passed"}')])),
         ]
@@ -203,21 +212,74 @@ def test_github_source_paginates_before_selecting_latest_artifact() -> None:
     assert "page=2" in transport.calls[1]["url"]
 
 
-def test_github_source_fails_when_pagination_safety_limit_is_reached() -> None:
+def test_github_source_accepts_exact_pagination_safety_limit() -> None:
+    total_count = artifacts.MAX_ARTIFACT_LIST_PAGES * artifacts.ARTIFACTS_PER_PAGE
+    pages = [
+        artifact_payload(
+            [
+                candidate(page * artifacts.ARTIFACTS_PER_PAGE + index + 1)
+                for index in range(artifacts.ARTIFACTS_PER_PAGE)
+            ],
+            total_count=total_count,
+        )
+        for page in range(artifacts.MAX_ARTIFACT_LIST_PAGES)
+    ]
+    transport = FakeTransport(
+        [
+            *[artifacts.HttpResponse(200, {}, payload) for payload in pages],
+            artifacts.HttpResponse(302, {"Location": "https://signed.example.test/report.zip"}, b""),
+            artifacts.HttpResponse(200, {}, zip_bytes([("report.json", b'{"status":"passed"}')])),
+        ]
+    )
+
+    acquired = artifacts.GitHubActionsArtifactSource(
+        "github-secret",
+        transport=transport,
+    ).acquire_latest_report(
+        "TheBitPoets/rossi-mario",
+        "thebitlab-demo-python-report",
+        TEST_SHA,
+    )
+
+    assert acquired.provenance.artifact_id == total_count
+    assert len(transport.calls) == artifacts.MAX_ARTIFACT_LIST_PAGES + 2
+
+
+def test_github_source_fails_when_pagination_safety_limit_is_exceeded() -> None:
+    total_count = artifacts.MAX_ARTIFACT_LIST_PAGES * artifacts.ARTIFACTS_PER_PAGE + 1
     full_page = artifact_payload(
-        [candidate(index + 1) for index in range(artifacts.ARTIFACTS_PER_PAGE)]
+        [candidate(index + 1) for index in range(artifacts.ARTIFACTS_PER_PAGE)],
+        total_count=total_count,
     )
     source = artifacts.GitHubActionsArtifactSource(
         "github-secret",
         transport=FakeTransport(
-            [
-                artifacts.HttpResponse(200, {}, full_page)
-                for _ in range(artifacts.MAX_ARTIFACT_LIST_PAGES)
-            ]
+            [artifacts.HttpResponse(200, {}, full_page)]
         ),
     )
 
     with pytest.raises(artifacts.GradingArtifactError, match="Troppi artifact"):
+        source.acquire_latest_report(
+            "TheBitPoets/rossi-mario",
+            "thebitlab-demo-python-report",
+            TEST_SHA,
+        )
+
+
+@pytest.mark.parametrize("total_count", [None, -1, True, "1"])
+def test_github_source_rejects_invalid_total_count(total_count: object) -> None:
+    payload = json.dumps(
+        {
+            **({} if total_count is None else {"total_count": total_count}),
+            "artifacts": [],
+        }
+    ).encode("utf-8")
+    source = artifacts.GitHubActionsArtifactSource(
+        "github-secret",
+        transport=FakeTransport([artifacts.HttpResponse(200, {}, payload)]),
+    )
+
+    with pytest.raises(artifacts.GradingArtifactError, match="total_count"):
         source.acquire_latest_report(
             "TheBitPoets/rossi-mario",
             "thebitlab-demo-python-report",

--- a/tests/test_thebitlab_grading_artifacts.py
+++ b/tests/test_thebitlab_grading_artifacts.py
@@ -129,6 +129,7 @@ def test_github_source_acquires_latest_exact_non_expired_report() -> None:
         archive_download_url="https://api.github.com/repos/TheBitPoets/rossi-mario/actions/artifacts/13/zip",
         digest="sha256:digest-13",
     )
+    assert "/actions/runs/913/artifacts?" in transport.calls[0]["url"]
     assert "name=thebitlab-demo-python-report" in transport.calls[0]["url"]
     assert transport.calls[0]["headers"]["Authorization"] == "Bearer github-secret"
     assert transport.calls[1]["headers"]["Authorization"] == "Bearer github-secret"

--- a/tests/test_thebitlab_grading_artifacts.py
+++ b/tests/test_thebitlab_grading_artifacts.py
@@ -9,6 +9,10 @@ import pytest
 from scripts import thebitlab_grading_artifacts as artifacts
 
 
+TEST_SHA = "a" * 40
+OTHER_SHA = "b" * 40
+
+
 class FakeTransport:
     def __init__(self, responses: list[artifacts.HttpResponse]) -> None:
         self.responses = list(responses)
@@ -46,6 +50,7 @@ def candidate(
     expired: bool = False,
     created_at: str = "2026-07-24T10:00:00Z",
     workflow_run_id: int = 900,
+    head_sha: str = TEST_SHA,
 ) -> dict[str, object]:
     return {
         "id": artifact_id,
@@ -54,7 +59,7 @@ def candidate(
         "created_at": created_at,
         "size_in_bytes": 1024,
         "digest": f"sha256:digest-{artifact_id}",
-        "workflow_run": {"id": workflow_run_id},
+        "workflow_run": {"id": workflow_run_id, "head_sha": head_sha},
     }
 
 
@@ -84,7 +89,11 @@ def test_github_source_acquires_latest_exact_non_expired_report() -> None:
     )
     source = artifacts.GitHubActionsArtifactSource("github-secret", transport=transport)
 
-    acquired = source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+    acquired = source.acquire_latest_report(
+        "TheBitPoets/rossi-mario",
+        "thebitlab-demo-python-report",
+        TEST_SHA,
+    )
 
     assert acquired.report == report
     assert acquired.provenance == artifacts.GradingArtifactProvenance(
@@ -92,6 +101,7 @@ def test_github_source_acquires_latest_exact_non_expired_report() -> None:
         artifact_id=13,
         artifact_name="thebitlab-demo-python-report",
         workflow_run_id=913,
+        head_sha=TEST_SHA,
         created_at="2026-07-24T11:00:00Z",
         archive_download_url="https://api.github.com/repos/TheBitPoets/rossi-mario/actions/artifacts/13/zip",
         digest="sha256:digest-13",
@@ -120,7 +130,11 @@ def test_github_source_rejects_missing_expired_or_different_artifact(payload: by
     )
 
     with pytest.raises(artifacts.GradingArtifactError, match="non trovato o scaduto"):
-        source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+        source.acquire_latest_report(
+            "TheBitPoets/rossi-mario",
+            "thebitlab-demo-python-report",
+            TEST_SHA,
+        )
 
 
 def test_github_source_rejects_invalid_list_payload_and_candidates() -> None:
@@ -141,7 +155,11 @@ def test_github_source_rejects_invalid_list_payload_and_candidates() -> None:
             transport=FakeTransport([artifacts.HttpResponse(200, {}, payload)]),
         )
         with pytest.raises(artifacts.GradingArtifactError):
-            source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+            source.acquire_latest_report(
+                "TheBitPoets/rossi-mario",
+                "thebitlab-demo-python-report",
+                TEST_SHA,
+            )
 
 
 def test_github_source_paginates_before_selecting_latest_artifact() -> None:
@@ -162,7 +180,11 @@ def test_github_source_paginates_before_selecting_latest_artifact() -> None:
     acquired = artifacts.GitHubActionsArtifactSource(
         "github-secret",
         transport=transport,
-    ).acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+    ).acquire_latest_report(
+        "TheBitPoets/rossi-mario",
+        "thebitlab-demo-python-report",
+        TEST_SHA,
+    )
 
     assert acquired.provenance.artifact_id == 500
     assert "page=1" in transport.calls[0]["url"]
@@ -184,7 +206,11 @@ def test_github_source_fails_when_pagination_safety_limit_is_reached() -> None:
     )
 
     with pytest.raises(artifacts.GradingArtifactError, match="Troppi artifact"):
-        source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+        source.acquire_latest_report(
+            "TheBitPoets/rossi-mario",
+            "thebitlab-demo-python-report",
+            TEST_SHA,
+        )
 
 
 @pytest.mark.parametrize(
@@ -208,7 +234,11 @@ def test_github_source_rejects_unsafe_download_redirect(location: str) -> None:
     )
 
     with pytest.raises(artifacts.GradingArtifactError, match="Redirect"):
-        source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+        source.acquire_latest_report(
+            "TheBitPoets/rossi-mario",
+            "thebitlab-demo-python-report",
+            TEST_SHA,
+        )
 
 
 @pytest.mark.parametrize(
@@ -252,9 +282,40 @@ def test_source_validates_token_repository_and_artifact_name() -> None:
 
     source = artifacts.GitHubActionsArtifactSource("github-secret", transport=FakeTransport([]))
     with pytest.raises(ValueError, match="Repository GitHub"):
-        source.acquire_latest_report("not-a-repo", "report")
+        source.acquire_latest_report("not-a-repo", "report", TEST_SHA)
     with pytest.raises(ValueError, match="Nome artifact"):
-        source.acquire_latest_report("TheBitPoets/rossi-mario", " ")
+        source.acquire_latest_report("TheBitPoets/rossi-mario", " ", TEST_SHA)
+    with pytest.raises(ValueError, match="SHA commit"):
+        source.acquire_latest_report("TheBitPoets/rossi-mario", "report", "abc123")
+
+
+def test_github_source_ignores_newer_artifact_from_another_commit() -> None:
+    expected = candidate(20, created_at="2026-07-24T10:00:00Z", workflow_run_id=920)
+    unrelated = candidate(
+        21,
+        created_at="2026-07-24T12:00:00Z",
+        workflow_run_id=921,
+        head_sha=OTHER_SHA,
+    )
+    transport = FakeTransport(
+        [
+            artifacts.HttpResponse(200, {}, artifact_payload([expected, unrelated])),
+            artifacts.HttpResponse(302, {"Location": "https://signed.example.test/report.zip"}, b""),
+            artifacts.HttpResponse(200, {}, zip_bytes([("report.json", b'{"status":"passed"}')])),
+        ]
+    )
+
+    acquired = artifacts.GitHubActionsArtifactSource(
+        "github-secret",
+        transport=transport,
+    ).acquire_latest_report(
+        "TheBitPoets/rossi-mario",
+        "thebitlab-demo-python-report",
+        TEST_SHA,
+    )
+
+    assert acquired.provenance.artifact_id == 20
+    assert acquired.provenance.head_sha == TEST_SHA
 
 
 class FakeBoundedStream(BytesIO):

--- a/tests/test_thebitlab_grading_artifacts.py
+++ b/tests/test_thebitlab_grading_artifacts.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from io import BytesIO
+import json
+from zipfile import ZipFile, ZipInfo
+
+import pytest
+
+from scripts import thebitlab_grading_artifacts as artifacts
+
+
+class FakeTransport:
+    def __init__(self, responses: list[artifacts.HttpResponse]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, url, *, headers, timeout, max_bytes, follow_redirects):  # noqa: ANN001
+        self.calls.append(
+            {
+                "url": url,
+                "headers": dict(headers),
+                "timeout": timeout,
+                "max_bytes": max_bytes,
+                "follow_redirects": follow_redirects,
+            }
+        )
+        return self.responses.pop(0)
+
+
+def zip_bytes(files: list[tuple[str, bytes]]) -> bytes:
+    stream = BytesIO()
+    with ZipFile(stream, "w") as archive:
+        for name, content in files:
+            archive.writestr(name, content)
+    return stream.getvalue()
+
+
+def artifact_payload(items: list[dict[str, object]]) -> bytes:
+    return json.dumps({"artifacts": items}).encode("utf-8")
+
+
+def candidate(
+    artifact_id: int,
+    *,
+    name: str = "thebitlab-demo-python-report",
+    expired: bool = False,
+    created_at: str = "2026-07-24T10:00:00Z",
+    workflow_run_id: int = 900,
+) -> dict[str, object]:
+    return {
+        "id": artifact_id,
+        "name": name,
+        "expired": expired,
+        "created_at": created_at,
+        "size_in_bytes": 1024,
+        "digest": f"sha256:digest-{artifact_id}",
+        "workflow_run": {"id": workflow_run_id},
+    }
+
+
+def test_github_source_acquires_latest_exact_non_expired_report() -> None:
+    report = {"schema_version": "1.0", "status": "passed", "tests_passed": 2, "tests_total": 2}
+    transport = FakeTransport(
+        [
+            artifacts.HttpResponse(
+                200,
+                {},
+                artifact_payload(
+                    [
+                        candidate(10, created_at="2026-07-24T10:00:00Z", workflow_run_id=910),
+                        candidate(11, expired=True, created_at="2026-07-24T12:00:00Z"),
+                        candidate(12, name="other-report", created_at="2026-07-24T13:00:00Z"),
+                        candidate(13, created_at="2026-07-24T11:00:00Z", workflow_run_id=913),
+                    ]
+                ),
+            ),
+            artifacts.HttpResponse(
+                302,
+                {"Location": "https://signed.example.test/report.zip?signature=secret"},
+                b"",
+            ),
+            artifacts.HttpResponse(200, {"Content-Type": "application/zip"}, zip_bytes([("report.json", json.dumps(report).encode())])),
+        ]
+    )
+    source = artifacts.GitHubActionsArtifactSource("github-secret", transport=transport)
+
+    acquired = source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+
+    assert acquired.report == report
+    assert acquired.provenance == artifacts.GradingArtifactProvenance(
+        repository="TheBitPoets/rossi-mario",
+        artifact_id=13,
+        artifact_name="thebitlab-demo-python-report",
+        workflow_run_id=913,
+        created_at="2026-07-24T11:00:00Z",
+        archive_download_url="https://api.github.com/repos/TheBitPoets/rossi-mario/actions/artifacts/13/zip",
+        digest="sha256:digest-13",
+    )
+    assert "name=thebitlab-demo-python-report" in transport.calls[0]["url"]
+    assert transport.calls[0]["headers"]["Authorization"] == "Bearer github-secret"
+    assert transport.calls[1]["headers"]["Authorization"] == "Bearer github-secret"
+    assert "Authorization" not in transport.calls[2]["headers"]
+    assert transport.calls[1]["follow_redirects"] is False
+    assert transport.calls[2]["follow_redirects"] is True
+    assert transport.calls[2]["max_bytes"] == artifacts.MAX_ARTIFACT_ARCHIVE_BYTES
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        artifact_payload([]),
+        artifact_payload([candidate(1, expired=True)]),
+        artifact_payload([candidate(2, name="similar-report")]),
+    ],
+)
+def test_github_source_rejects_missing_expired_or_different_artifact(payload: bytes) -> None:
+    source = artifacts.GitHubActionsArtifactSource(
+        "github-secret",
+        transport=FakeTransport([artifacts.HttpResponse(200, {}, payload)]),
+    )
+
+    with pytest.raises(artifacts.GradingArtifactError, match="non trovato o scaduto"):
+        source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+
+
+def test_github_source_rejects_invalid_list_payload_and_candidates() -> None:
+    invalid_payloads = [
+        b"[]",
+        b'{"artifacts": "not-a-list"}',
+        artifact_payload([candidate(True)]),
+        artifact_payload([{**candidate(1), "workflow_run": {"id": True}}]),
+        artifact_payload([{**candidate(2), "created_at": 42}]),
+        artifact_payload([{**candidate(3), "created_at": "not-a-date"}]),
+        artifact_payload([{**candidate(4), "created_at": "2026-07-24T10:00:00"}]),
+        artifact_payload([{**candidate(5), "size_in_bytes": artifacts.MAX_ARTIFACT_ARCHIVE_BYTES + 1}]),
+    ]
+
+    for payload in invalid_payloads:
+        source = artifacts.GitHubActionsArtifactSource(
+            "github-secret",
+            transport=FakeTransport([artifacts.HttpResponse(200, {}, payload)]),
+        )
+        with pytest.raises(artifacts.GradingArtifactError):
+            source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+
+
+def test_github_source_paginates_before_selecting_latest_artifact() -> None:
+    first_page = [
+        candidate(index + 1, created_at=f"2026-07-23T{index % 24:02d}:00:00Z")
+        for index in range(artifacts.ARTIFACTS_PER_PAGE)
+    ]
+    latest = candidate(500, created_at="2026-07-24T14:00:00Z", workflow_run_id=9500)
+    transport = FakeTransport(
+        [
+            artifacts.HttpResponse(200, {}, artifact_payload(first_page)),
+            artifacts.HttpResponse(200, {}, artifact_payload([latest])),
+            artifacts.HttpResponse(302, {"Location": "https://signed.example.test/report.zip"}, b""),
+            artifacts.HttpResponse(200, {}, zip_bytes([("report.json", b'{"status":"passed"}')])),
+        ]
+    )
+
+    acquired = artifacts.GitHubActionsArtifactSource(
+        "github-secret",
+        transport=transport,
+    ).acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+
+    assert acquired.provenance.artifact_id == 500
+    assert "page=1" in transport.calls[0]["url"]
+    assert "page=2" in transport.calls[1]["url"]
+
+
+def test_github_source_fails_when_pagination_safety_limit_is_reached() -> None:
+    full_page = artifact_payload(
+        [candidate(index + 1) for index in range(artifacts.ARTIFACTS_PER_PAGE)]
+    )
+    source = artifacts.GitHubActionsArtifactSource(
+        "github-secret",
+        transport=FakeTransport(
+            [
+                artifacts.HttpResponse(200, {}, full_page)
+                for _ in range(artifacts.MAX_ARTIFACT_LIST_PAGES)
+            ]
+        ),
+    )
+
+    with pytest.raises(artifacts.GradingArtifactError, match="Troppi artifact"):
+        source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        "",
+        "http://signed.example.test/report.zip",
+        "https://user:password@signed.example.test/report.zip",
+        "/relative/report.zip",
+    ],
+)
+def test_github_source_rejects_unsafe_download_redirect(location: str) -> None:
+    source = artifacts.GitHubActionsArtifactSource(
+        "github-secret",
+        transport=FakeTransport(
+            [
+                artifacts.HttpResponse(200, {}, artifact_payload([candidate(10)])),
+                artifacts.HttpResponse(302, {"Location": location}, b""),
+            ]
+        ),
+    )
+
+    with pytest.raises(artifacts.GradingArtifactError, match="Redirect"):
+        source.acquire_latest_report("TheBitPoets/rossi-mario", "thebitlab-demo-python-report")
+
+
+@pytest.mark.parametrize(
+    ("archive", "message"),
+    [
+        (b"not-a-zip", "ZIP valido"),
+        (zip_bytes([("nested/report.json", b"{}")]), "un solo report.json"),
+        (zip_bytes([("../report.json", b"{}"), ("report.json", b"{}")]), "path non sicuri"),
+        (zip_bytes([("report.json", b"[]")]), "richiesto un oggetto"),
+        (zip_bytes([("report.json", b"{")]), "JSON report grading non valido"),
+    ],
+)
+def test_report_archive_rejects_invalid_or_unsafe_content(archive: bytes, message: str) -> None:
+    with pytest.raises(artifacts.GradingArtifactError, match=message):
+        artifacts._report_from_archive(archive)
+
+
+def test_report_archive_rejects_symbolic_link_and_too_many_members() -> None:
+    symlink_stream = BytesIO()
+    with ZipFile(symlink_stream, "w") as archive:
+        link = ZipInfo("linked-report")
+        link.create_system = 3
+        link.external_attr = 0o120777 << 16
+        archive.writestr(link, "report.json")
+        archive.writestr("report.json", "{}")
+
+    with pytest.raises(artifacts.GradingArtifactError, match="link simbolici"):
+        artifacts._report_from_archive(symlink_stream.getvalue())
+
+    crowded = zip_bytes(
+        [("report.json", b"{}")]
+        + [(f"extra-{index}.txt", b"x") for index in range(artifacts.MAX_ARCHIVE_MEMBERS)]
+    )
+    with pytest.raises(artifacts.GradingArtifactError, match="piu di"):
+        artifacts._report_from_archive(crowded)
+
+
+def test_source_validates_token_repository_and_artifact_name() -> None:
+    with pytest.raises(ValueError, match="Token"):
+        artifacts.GitHubActionsArtifactSource(" ")
+
+    source = artifacts.GitHubActionsArtifactSource("github-secret", transport=FakeTransport([]))
+    with pytest.raises(ValueError, match="Repository GitHub"):
+        source.acquire_latest_report("not-a-repo", "report")
+    with pytest.raises(ValueError, match="Nome artifact"):
+        source.acquire_latest_report("TheBitPoets/rossi-mario", " ")
+
+
+class FakeBoundedStream(BytesIO):
+    def __init__(self, content: bytes, content_length: str | None = None) -> None:
+        super().__init__(content)
+        self.headers = {} if content_length is None else {"Content-Length": content_length}
+        self.status = 200
+
+
+@pytest.mark.parametrize("content_length", ["-1", "not-a-number"])
+def test_bounded_read_rejects_invalid_content_length(content_length: str) -> None:
+    with pytest.raises(artifacts.GradingArtifactError, match="Content-Length"):
+        artifacts._read_bounded(FakeBoundedStream(b"{}", content_length), 10)
+
+
+def test_bounded_read_rejects_declared_or_actual_oversize() -> None:
+    with pytest.raises(artifacts.GradingArtifactError, match="troppo grande"):
+        artifacts._read_bounded(FakeBoundedStream(b"{}", "11"), 10)
+    with pytest.raises(artifacts.GradingArtifactError, match="troppo grande"):
+        artifacts._read_bounded(FakeBoundedStream(b"x" * 11), 10)
+
+
+def test_urllib_transport_normalizes_timeout(monkeypatch) -> None:
+    class TimeoutOpener:
+        def open(self, request, timeout):  # noqa: ANN001
+            raise TimeoutError("timed out")
+
+    monkeypatch.setattr(
+        artifacts.urllib.request,
+        "build_opener",
+        lambda *handlers: TimeoutOpener(),
+    )
+
+    with pytest.raises(artifacts.GradingArtifactError, match="timeout"):
+        artifacts.UrllibHttpTransport().request(
+            "https://api.github.com/repos/TheBitPoets/rossi-mario/actions/artifacts",
+            headers={},
+            timeout=1,
+            max_bytes=10,
+            follow_redirects=True,
+        )

--- a/tests/test_thebitlab_grading_artifacts.py
+++ b/tests/test_thebitlab_grading_artifacts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 import json
-from zipfile import ZipFile, ZipInfo
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
 import pytest
 
@@ -49,6 +49,20 @@ def zip_bytes_with_unsupported_compression() -> bytes:
     unsupported_method = (99).to_bytes(2, "little")
     data[local_header + 8 : local_header + 10] = unsupported_method
     data[central_header + 10 : central_header + 12] = unsupported_method
+    return bytes(data)
+
+
+def corrupted_deflate_zip_bytes() -> bytes:
+    stream = BytesIO()
+    with ZipFile(stream, "w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr("report.json", b'{"data":"' + b"a" * 1024 + b'"}')
+    data = bytearray(stream.getvalue())
+    local_header = data.find(b"PK\x03\x04")
+    assert local_header >= 0
+    filename_length = int.from_bytes(data[local_header + 26 : local_header + 28], "little")
+    extra_length = int.from_bytes(data[local_header + 28 : local_header + 30], "little")
+    payload_start = local_header + 30 + filename_length + extra_length
+    data[payload_start] ^= 0xFF
     return bytes(data)
 
 
@@ -363,6 +377,11 @@ def test_report_archive_rejects_symbolic_link_and_too_many_members() -> None:
 def test_report_archive_normalizes_unsupported_compression_error() -> None:
     with pytest.raises(artifacts.GradingArtifactError, match="compressione ZIP non supportato"):
         artifacts._report_from_archive(zip_bytes_with_unsupported_compression())
+
+
+def test_report_archive_normalizes_corrupt_deflate_error() -> None:
+    with pytest.raises(artifacts.GradingArtifactError, match="dati compressi non validi"):
+        artifacts._report_from_archive(corrupted_deflate_zip_bytes())
 
 
 def test_source_validates_token_repository_and_artifact_name() -> None:


### PR DESCRIPTION
$## Sommario\n\n- introduce la porta GradingArtifactSource e l'adapter GitHubActionsArtifactSource\n- acquisisce il report più recente da artifact GitHub Actions omonimi e non scaduti\n- mantiene il token soltanto sulle richieste API GitHub e lo rimuove prima del download firmato\n- applica paginazione e limiti espliciti a elenco, archivio e report\n- rifiuta redirect non HTTPS, ZIP traversal, symlink, report multipli e JSON non valido\n- restituisce report e provenienza GitHub come dati separati\n- documenta il confine con la futura integrazione nel registro\n\n## Verifica\n\n- python -m pytest -q tests/test_thebitlab_grading_artifacts.py tests/test_thebitlab_repository_providers.py\n- python -m pytest -q\n- python -m compileall -q scripts/thebitlab_grading_artifacts.py\n- git diff --check\n\n## Fuori perimetro\n\nQuesta PR non modifica ancora 	rack_assignments, non avvia workflow remoti e non aggiunge controlli GUI.\n\nCloses #512\nRelated to #289\nRelated to #292