### PR TITLE
Integrate remote grading reports into assignment tracking

### DIFF
--- a/.github/workflows/grade-student-assignment.yml
+++ b/.github/workflows/grade-student-assignment.yml
@@ -98,13 +98,13 @@ jobs:
           PY
 
       - name: Checkout trusted TheBitLab source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           path: thebitlab
           persist-credentials: false
 
       - name: Checkout exact student commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: ${{ inputs.student_repo }}
           ref: ${{ inputs.student_head_sha }}
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload authoritative grading report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ runner.temp }}/thebitlab-report/report.json

--- a/.github/workflows/grade-student-assignment.yml
+++ b/.github/workflows/grade-student-assignment.yml
@@ -1,0 +1,124 @@
+name: Grade student assignment
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      student_repo:
+        description: "Repository studente owner/repo"
+        required: true
+      student_head_sha:
+        description: "SHA completo del commit studente"
+        required: true
+      assignment_id:
+        description: "Identificativo stabile dell'assegnazione"
+        required: true
+      student_id:
+        description: "Identificativo stabile dello studente"
+        required: true
+      activity_id:
+        description: "Identificativo stabile dell'attivita"
+        required: true
+      activity_path:
+        description: "Path della activity JSON nel repository studente"
+        required: true
+      source_path:
+        description: "Path del sorgente nel repository studente"
+        required: true
+      language:
+        description: "Linguaggio della consegna"
+        required: true
+        type: choice
+        options:
+          - assembly
+          - c
+          - cpp
+          - go
+          - html
+          - java
+          - javascript
+          - nodejs
+          - php
+          - python
+          - sql
+      artifact_name:
+        description: "Nome artifact concordato con il binding docente"
+        required: true
+
+jobs:
+  grade:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      STUDENT_REPO: ${{ inputs.student_repo }}
+      STUDENT_HEAD_SHA: ${{ inputs.student_head_sha }}
+      ASSIGNMENT_ID: ${{ inputs.assignment_id }}
+      STUDENT_ID: ${{ inputs.student_id }}
+      ACTIVITY_ID: ${{ inputs.activity_id }}
+      ACTIVITY_PATH: ${{ inputs.activity_path }}
+      SOURCE_PATH: ${{ inputs.source_path }}
+      LANGUAGE: ${{ inputs.language }}
+      ARTIFACT_NAME: ${{ inputs.artifact_name }}
+    steps:
+      - name: Validate trusted grading inputs
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import PurePosixPath
+          import re
+
+          slug = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+          repo = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+          sha = re.compile(r"^[0-9a-fA-F]{40}$")
+
+          if not repo.fullmatch(os.environ["STUDENT_REPO"]):
+              raise SystemExit("student_repo non valido")
+          if not sha.fullmatch(os.environ["STUDENT_HEAD_SHA"]):
+              raise SystemExit("student_head_sha non valido")
+          for name in ("ASSIGNMENT_ID", "STUDENT_ID", "ACTIVITY_ID", "ARTIFACT_NAME"):
+              if not slug.fullmatch(os.environ[name]):
+                  raise SystemExit(f"{name.lower()} non valido")
+          for name in ("ACTIVITY_PATH", "SOURCE_PATH"):
+              path = PurePosixPath(os.environ[name])
+              if path.is_absolute() or ".." in path.parts or not path.parts:
+                  raise SystemExit(f"{name.lower()} non valido")
+          PY
+
+      - name: Checkout trusted TheBitLab source
+        uses: actions/checkout@v4
+        with:
+          path: thebitlab
+
+      - name: Checkout exact student commit
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.student_repo }}
+          ref: ${{ inputs.student_head_sha }}
+          path: student-work
+
+      - name: Build grading Docker image
+        run: docker build -t thebitlab-assignment-runner -f thebitlab/docker/assignment-runner/Dockerfile thebitlab
+
+      - name: Run deterministic grading
+        run: |
+          mkdir -p "$RUNNER_TEMP/thebitlab-report"
+          python thebitlab/scripts/grade_activity.py \
+            --activity "student-work/$ACTIVITY_PATH" \
+            --source "student-work/$SOURCE_PATH" \
+            --language "$LANGUAGE" \
+            --assignment-id "$ASSIGNMENT_ID" \
+            --student-id "$STUDENT_ID" \
+            --commit "$STUDENT_HEAD_SHA" \
+            --docker \
+            --report "$RUNNER_TEMP/thebitlab-report/report.json"
+
+      - name: Upload authoritative grading report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ runner.temp }}/thebitlab-report/report.json
+          if-no-files-found: error

--- a/.github/workflows/grade-student-assignment.yml
+++ b/.github/workflows/grade-student-assignment.yml
@@ -22,7 +22,7 @@ on:
         description: "Identificativo stabile dell'attivita"
         required: true
       activity_path:
-        description: "Path della activity JSON nel repository studente"
+        description: "Path della activity JSON fidata nel repository TheBitLab"
         required: true
       source_path:
         description: "Path del sorgente nel repository studente"
@@ -91,6 +91,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: thebitlab
+          persist-credentials: false
 
       - name: Checkout exact student commit
         uses: actions/checkout@v4
@@ -98,6 +99,8 @@ jobs:
           repository: ${{ inputs.student_repo }}
           ref: ${{ inputs.student_head_sha }}
           path: student-work
+          token: ${{ secrets.THEBITLAB_STUDENT_REPO_TOKEN || github.token }}
+          persist-credentials: false
 
       - name: Build grading Docker image
         run: docker build -t thebitlab-assignment-runner -f thebitlab/docker/assignment-runner/Dockerfile thebitlab
@@ -106,12 +109,16 @@ jobs:
         run: |
           mkdir -p "$RUNNER_TEMP/thebitlab-report"
           python thebitlab/scripts/grade_activity.py \
-            --activity "student-work/$ACTIVITY_PATH" \
+            --activity "thebitlab/$ACTIVITY_PATH" \
             --source "student-work/$SOURCE_PATH" \
             --language "$LANGUAGE" \
             --assignment-id "$ASSIGNMENT_ID" \
             --student-id "$STUDENT_ID" \
             --commit "$STUDENT_HEAD_SHA" \
+            --submitted-at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --source-repo-path "$SOURCE_PATH" \
+            --activity-root "thebitlab" \
+            --source-root "student-work" \
             --docker \
             --report "$RUNNER_TEMP/thebitlab-report/report.json"
 

--- a/.github/workflows/grade-student-assignment.yml
+++ b/.github/workflows/grade-student-assignment.yml
@@ -18,6 +18,9 @@ on:
       student_id:
         description: "Identificativo stabile dello studente"
         required: true
+      submitted_at:
+        description: "Timestamp ISO-8601 di consegna registrato dal docente"
+        required: true
       activity_id:
         description: "Identificativo stabile dell'attivita"
         required: true
@@ -56,6 +59,7 @@ jobs:
       STUDENT_HEAD_SHA: ${{ inputs.student_head_sha }}
       ASSIGNMENT_ID: ${{ inputs.assignment_id }}
       STUDENT_ID: ${{ inputs.student_id }}
+      SUBMITTED_AT: ${{ inputs.submitted_at }}
       ACTIVITY_ID: ${{ inputs.activity_id }}
       ACTIVITY_PATH: ${{ inputs.activity_path }}
       SOURCE_PATH: ${{ inputs.source_path }}
@@ -69,6 +73,7 @@ jobs:
           import os
           from pathlib import PurePosixPath
           import re
+          from datetime import datetime
 
           slug = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
           repo = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
@@ -81,6 +86,11 @@ jobs:
           for name in ("ASSIGNMENT_ID", "STUDENT_ID", "ACTIVITY_ID", "ARTIFACT_NAME"):
               if not slug.fullmatch(os.environ[name]):
                   raise SystemExit(f"{name.lower()} non valido")
+          submitted_at = datetime.fromisoformat(
+              os.environ["SUBMITTED_AT"].replace("Z", "+00:00")
+          )
+          if submitted_at.tzinfo is None:
+              raise SystemExit("submitted_at deve includere il fuso orario")
           for name in ("ACTIVITY_PATH", "SOURCE_PATH"):
               path = PurePosixPath(os.environ[name])
               if path.is_absolute() or ".." in path.parts or not path.parts:
@@ -115,7 +125,7 @@ jobs:
             --assignment-id "$ASSIGNMENT_ID" \
             --student-id "$STUDENT_ID" \
             --commit "$STUDENT_HEAD_SHA" \
-            --submitted-at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --submitted-at "$SUBMITTED_AT" \
             --source-repo-path "$SOURCE_PATH" \
             --activity-root "thebitlab" \
             --source-root "student-work" \

--- a/.github/workflows/student-template-smoke.yml
+++ b/.github/workflows/student-template-smoke.yml
@@ -67,6 +67,9 @@ jobs:
             --activity "$RUNNER_TEMP/student-work/assignments/c-base-somma-001/activity.json" \
             --source "$RUNNER_TEMP/student-work/assignments/c-base-somma-001/main.c" \
             --language c \
+            --assignment-id "assignment-smoke-001" \
+            --student-id "studente-smoke-001" \
+            --commit "${GITHUB_SHA}" \
             --docker \
             --report "$RUNNER_TEMP/thebitlab-report/report.json"
           python - <<'PY'
@@ -77,4 +80,7 @@ jobs:
           report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "thebitlab-report" / "report.json").read_text(encoding="utf-8"))
           assert report["passed"] is True
           assert report["status"] == "passed"
+          assert report["assignment_id"] == "assignment-smoke-001"
+          assert report["student_id"] == "studente-smoke-001"
+          assert report["commit"] == os.environ["GITHUB_SHA"]
           PY

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ teacher-reports/**/*.json
 tmp/
 activities/drafts/*.json
 teacher-assignments/*.json
+teacher-grading-bindings.json
 examples/assignment_tracking/student_repos/*/assignments/*/
 examples/assignment_tracking/student_repos/*/reports/*/
 examples/assignment_tracking/student_repos/*/help/

--- a/doc/ASSIGNMENT_SANDBOX.md
+++ b/doc/ASSIGNMENT_SANDBOX.md
@@ -87,7 +87,8 @@ Limiti noti:
 - applica limiti iniziali di memoria, CPU e numero processi, ma non ha ancora una policy configurabile per classe, linguaggio o difficolta dell'esercizio;
 - non gestisce ancora quote su file generati;
 - non isola in modo fine tutti i linguaggi futuri;
-- non integra ancora GitHub Actions dedicate alle consegne studenti;
+- integra un workflow GitHub Actions docente per il grading remoto, ma richiede ancora il collaudo
+  live e gli hardening tracciati in #515 e #516;
 - non sostituisce una futura policy completa di sicurezza.
 
 ## Regola di sicurezza

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -342,6 +342,12 @@ studente viene letto soltanto il sorgente allo SHA esatto. Il workflow riceve `s
 dal binding docente anziche usare l'ora di avvio del grading, e conserva nel report il path
 repository del sorgente.
 
+`verified_remote` attesta oggi identita, provenienza e integrita del report rispetto al binding
+docente. Non attesta ancora un ambiente anti-cheating o una toolchain bit-per-bit riproducibile:
+l'isolamento dei test riservati e tracciato in #515, mentre il pin completo della toolchain e
+tracciato in #516. Fino alla loro chiusura, il risultato automatico resta soggetto alla revisione
+docente e non deve essere pubblicato come voto definitivo senza controllo.
+
 Per repository studenti privati, il secret `THEBITLAB_STUDENT_REPO_TOKEN` deve contenere un
 token GitHub App o PAT di sola lettura limitato ai repository necessari. La credenziale viene
 usata soltanto dal checkout con `persist-credentials: false`; il runner Docker esegue il codice

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -519,9 +519,9 @@ Il flusso e pensato in tre livelli:
 
 | Livello | Responsabilita |
 |---|---|
-| Core Python | Funzioni riusabili da test, CLI e futura GUI |
+| Core Python | Funzioni riusabili da test, CLI e dashboard |
 | CLI | Wrapper operativo per docente, CI e debug |
-| GUI futura | Form e bottoni che chiamano lo stesso core, senza duplicare logica |
+| Dashboard docente | Form e bottoni che chiamano lo stesso core, senza duplicare logica |
 
 Se la classe ha molti repository, puoi usare un file di target:
 
@@ -544,7 +544,8 @@ Le righe vuote e le righe che iniziano con `#` vengono ignorate.
 
 Come per lo scaffold singolo, `--force` aggiorna i metadati della consegna, ma non sovrascrive il sorgente dello studente. Per rigenerare anche il sorgente serve `--overwrite-source`.
 
-Nella GUI futura il docente non dovra ricordare questi comandi: selezionera activity, classe/team GitHub e repository studenti; il server locale chiamera lo stesso core usato dalla CLI.
+Nella dashboard il docente seleziona activity, classe/team GitHub e repository studenti; il server locale
+chiama lo stesso core usato dalla CLI.
 
 ## Registro consegne con scadenza, voti e AI placeholder
 
@@ -573,7 +574,7 @@ La CLI `track_assignments.py` non carica automaticamente `teacher-grading-bindin
 strumento locale per debug e compatibilita. La precedenza remota fail-closed e attiva nella generazione
 tramite server/GUI; l'eventuale composizione remota da CLI richiedera opzioni esplicite dedicate.
 
-Il registro prodotto e pensato per la futura GUI docente.
+Il registro prodotto alimenta la dashboard docente e la vista studente.
 
 Per ogni studente contiene:
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -301,9 +301,17 @@ Prima di accettare un report remoto, l'adapter verifica:
 - repository docente, nome artifact, SHA del workflow e workflow run della provenienza.
 
 Il producer autorevole e `.github/workflows/grade-student-assignment.yml`, eseguito nel
-repository docente. Il workflow effettua il checkout dello SHA studente esatto e usa il
-runner Docker senza segreti. Il workflow presente nel template del repository studente e
-solo un'anteprima e i suoi artifact non devono essere configurati come autorevoli.
+repository docente. Activity e test arrivano dal checkout docente immutabile; dal repository
+studente viene letto soltanto il sorgente allo SHA esatto. Il workflow registra come
+`submitted_at` il momento di ricezione da parte del grading docente e conserva nel report il
+path repository del sorgente.
+
+Per repository studenti privati, il secret `THEBITLAB_STUDENT_REPO_TOKEN` deve contenere un
+token GitHub App o PAT di sola lettura limitato ai repository necessari. La credenziale viene
+usata soltanto dal checkout con `persist-credentials: false`; il runner Docker esegue il codice
+senza rete e senza segreti. Per repository pubblici il workflow puo usare il `GITHUB_TOKEN`.
+Il workflow presente nel template del repository studente e solo un'anteprima e i suoi
+artifact non devono essere configurati come autorevoli.
 
 Il registro conserva separatamente i dati del report e quelli attestati dall'applicazione:
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -612,7 +612,7 @@ Esempio ridotto:
 }
 ```
 
-Il registro legge report locali con questa priorita:
+Quando non esiste un binding remoto, il registro legge report locali con questa priorita:
 
 ```text
 reports/<activity_id>/assignments/<assignment-key>/final.json
@@ -620,9 +620,9 @@ reports/<activity_id>/assignments/<assignment-key>/latest.json
 reports/<activity_id>/latest.json
 ```
 
-`final.json` seleziona il tentativo immutabile autorevole; i due `latest.json` sono fallback provvisori scoped e
-legacy. In futuro la stessa struttura potra essere alimentata scaricando gli artifact GitHub Actions dei repository
-studenti.
+`final.json` seleziona il tentativo locale; i due `latest.json` sono fallback provvisori scoped e
+legacy. Quando esiste un binding remoto, il server acquisisce invece l'artifact GitHub Actions verificato
+e non usa questi fallback locali in caso di errore.
 
 ## Dashboard consegne docente
 
@@ -846,7 +846,7 @@ Per il flusso consegne restano aperti soprattutto:
 
 1. pagina GUI per creare, modificare, duplicare e assegnare activity a classi/team;
 2. gestione classi da GitHub Team, con sincronizzazione studenti;
-3. download artifact GitHub Actions e collegamento automatico al registro consegne;
+3. gestione dei binding GitHub Actions dalla dashboard e collaudo E2E con artifact reale;
 4. modalita studente e feedback assistito;
 5. supporto completo a consegne multi-file, fixture e directory di progetto;
 6. archiviazione e cancellazione sicura di registri, activity e assegnazioni;

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -277,8 +277,8 @@ scripts/thebitlab_tracking_reports.py
 ```
 
 `ArtifactTrackingReportSource` combina la porta `GradingArtifactSource` con binding forniti da una
-sorgente docente fidata. Ogni binding identifica assignment, studente, repository, artifact, SHA completo
-e workflow run autorizzata. Questi dati descrivono una singola esecuzione: non fanno parte dell'activity,
+sorgente docente fidata. Ogni binding distingue repository e SHA dello studente da repository, SHA e run
+del workflow docente protetto, oltre a identificare assignment, studente e artifact. Questi dati descrivono una singola esecuzione: non fanno parte dell'activity,
 del target iniziale o di dati controllati dallo studente.
 
 `track_assignments()` accetta una `TrackingReportSource` opzionale. La precedenza e:
@@ -296,9 +296,14 @@ comportamento locale precedente rimane invariato.
 
 Prima di accettare un report remoto, l'adapter verifica:
 
-- `activity_id` e `assignment_id`;
-- commit completo uguale allo SHA autorizzato;
-- repository, nome artifact, SHA e workflow run della provenienza.
+- `activity_id`, `assignment_id` e `student_id`;
+- commit studente completo uguale allo SHA autorizzato;
+- repository docente, nome artifact, SHA del workflow e workflow run della provenienza.
+
+Il producer autorevole e `.github/workflows/grade-student-assignment.yml`, eseguito nel
+repository docente. Il workflow effettua il checkout dello SHA studente esatto e usa il
+runner Docker senza segreti. Il workflow presente nel template del repository studente e
+solo un'anteprima e i suoi artifact non devono essere configurati come autorevoli.
 
 Il registro conserva separatamente i dati del report e quelli attestati dall'applicazione:
 
@@ -310,10 +315,11 @@ Il registro conserva separatamente i dati del report e quelli attestati dall'app
     "report_provenance": {
       "source": "github_actions",
       "repository": "TheBitPoets/rossi-mario",
+      "artifact_repository": "TheBitPoets/2cornot2c",
       "artifact_id": 123,
       "artifact_name": "grading-assignment-001",
       "workflow_run_id": 456,
-      "head_sha": "0123456789abcdef0123456789abcdef01234567"
+      "head_sha": "fedcba9876543210fedcba9876543210fedcba98"
     },
     "report_error": null
   }
@@ -338,6 +344,9 @@ Esempio:
   "passed": false,
   "status": "failed",
   "activity_id": "c-base-somma-001",
+  "assignment_id": "assignment-c-base-somma-001-3a",
+  "student_id": "rossi-mario",
+  "commit": "0123456789abcdef0123456789abcdef01234567",
   "language": "c",
   "summary": {
     "passed": 1,

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -289,8 +289,10 @@ del target iniziale o di dati controllati dallo studente.
 4. report locale legacy.
 
 Quando un binding remoto esiste ma acquisizione o validazione falliscono, il tracking non usa
-silenziosamente un report locale. La riga resta `not_graded` e registra `remote_error`, autorita ed errore
-di raccolta. Se non esiste alcun binding, il comportamento locale precedente rimane invariato.
+silenziosamente un report locale. La riga resta `not_graded`, usa lo stato `submission_unknown` invece di
+classificare lo studente come mancante e registra `remote_error`, autorita `remote_configured` ed errore di
+raccolta. `verified_remote` e riservato ai report acquisiti e validati. Se non esiste alcun binding, il
+comportamento locale precedente rimane invariato.
 
 Prima di accettare un report remoto, l'adapter verifica:
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -300,9 +300,30 @@ Il server carica i binding docente da `teacher-grading-bindings.json`, ignorato 
 ```json
 {
   "schema_version": "thebitlab_grading_bindings.v1",
-  "bindings": []
+  "bindings": [
+    {
+      "activity_id": "python-base-somma-001",
+      "assignment_id": "assignment-3a-somma-001",
+      "student_id": "rossi-mario",
+      "student_repo_ref": "TheBitPoets/rossi-mario",
+      "workflow_repo_ref": "TheBitPoets/2cornot2c",
+      "artifact_name": "grading-assignment-3a-somma-001-rossi-mario",
+      "expected_student_head_sha": "0123456789abcdef0123456789abcdef01234567",
+      "expected_workflow_head_sha": "89abcdef0123456789abcdef0123456789abcdef",
+      "expected_submitted_at": "2026-10-20T08:00:00+02:00",
+      "expected_workflow_run_id": 123456789,
+      "final": false
+    }
+  ]
 }
 ```
+
+I valori `activity_id`, `assignment_id`, `student_id`, repository studente e timestamp provengono
+dall'assegnazione e dalla consegna registrate dal docente. `workflow_repo_ref` e lo SHA del workflow
+identificano il repository docente e il commit immutabile che ha eseguito il grading. Il nome artifact
+deve coincidere con l'input del workflow; il run ID e il numero visibile nell'URL della relativa
+esecuzione GitHub Actions. Gli SHA devono essere completi, di 40 caratteri. `final: false` mantiene il
+voto provvisorio fino alla revisione docente.
 
 Quando la lista contiene binding, il token di sola lettura per acquisire gli artifact deve essere
 configurato in `THEBITLAB_GRADING_GITHUB_TOKEN`, tramite ambiente oppure `.secrets/ai.secret`.

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -268,9 +268,58 @@ SHA e workflow run legano il report alla revisione e all'esecuzione scelte dal d
 deve comunque usare un workflow protetto o verificato: affidare al repository dello studente anche la scelta
 della run renderebbe la provenienza insufficiente per una valutazione automaticamente attendibile.
 
-Questa fase non modifica ancora il registro docente. L'integrazione successiva usera la porta
-`GradingArtifactSource` per alimentare la raccolta dei report senza inserire chiamate GitHub dentro la
-logica di tracking.
+### Integrazione nel tracking docente
+
+L'adapter applicativo vive in:
+
+```text
+scripts/thebitlab_tracking_reports.py
+```
+
+`ArtifactTrackingReportSource` combina la porta `GradingArtifactSource` con binding forniti da una
+sorgente docente fidata. Ogni binding identifica assignment, studente, repository, artifact, SHA completo
+e workflow run autorizzata. Questi dati descrivono una singola esecuzione: non fanno parte dell'activity,
+del target iniziale o di dati controllati dallo studente.
+
+`track_assignments()` accetta una `TrackingReportSource` opzionale. La precedenza e:
+
+1. tentativo `final` gia selezionato dal docente;
+2. report remoto configurato per assignment e studente;
+3. report locale assignment-scoped;
+4. report locale legacy.
+
+Quando un binding remoto esiste ma acquisizione o validazione falliscono, il tracking non usa
+silenziosamente un report locale. La riga resta `not_graded` e registra `remote_error`, autorita ed errore
+di raccolta. Se non esiste alcun binding, il comportamento locale precedente rimane invariato.
+
+Prima di accettare un report remoto, l'adapter verifica:
+
+- `activity_id` e `assignment_id`;
+- commit completo uguale allo SHA autorizzato;
+- repository, nome artifact, SHA e workflow run della provenienza.
+
+Il registro conserva separatamente i dati del report e quelli attestati dall'applicazione:
+
+```json
+{
+  "submission": {
+    "report_selection": "github_actions_artifact",
+    "report_authority": "verified_remote",
+    "report_provenance": {
+      "source": "github_actions",
+      "repository": "TheBitPoets/rossi-mario",
+      "artifact_id": 123,
+      "artifact_name": "grading-assignment-001",
+      "workflow_run_id": 456,
+      "head_sha": "0123456789abcdef0123456789abcdef01234567"
+    },
+    "report_error": null
+  }
+}
+```
+
+In questa fase i binding sono iniettati a runtime. Il passo successivo e salvarli in record separati lato
+docente e comporre adapter, token e storage nel server o nella CLI.
 
 ## Report
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -295,6 +295,20 @@ classificare lo studente come mancante e registra `remote_error`, autorita `remo
 raccolta. `verified_remote` e riservato ai report acquisiti e validati. Se non esiste alcun binding, il
 comportamento locale precedente rimane invariato.
 
+Il server carica i binding docente da `teacher-grading-bindings.json`, ignorato da Git, con schema:
+
+```json
+{
+  "schema_version": "thebitlab_grading_bindings.v1",
+  "bindings": []
+}
+```
+
+Quando la lista contiene binding, il token di sola lettura per acquisire gli artifact deve essere
+configurato in `THEBITLAB_GRADING_GITHUB_TOKEN`, tramite ambiente oppure `.secrets/ai.secret`.
+Se il file contiene binding ma il token manca, la generazione del registro si interrompe invece di
+ricadere sui report locali.
+
 Prima di accettare un report remoto, l'adapter verifica:
 
 - `activity_id`, `assignment_id` e `student_id`;

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -349,8 +349,9 @@ Il registro conserva separatamente i dati del report e quelli attestati dall'app
 }
 ```
 
-In questa fase i binding sono iniettati a runtime. Il passo successivo e salvarli in record separati lato
-docente e comporre adapter, token e storage nel server o nella CLI.
+Il server compone adapter, token e binding persistiti quando genera il registro. La gestione dei binding
+tramite dashboard docente resta un passo successivo; fino ad allora il file JSON viene amministrato
+esplicitamente sulla macchina docente.
 
 ## Report
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -348,6 +348,10 @@ l'isolamento dei test riservati e tracciato in #515, mentre il pin completo dell
 tracciato in #516. Fino alla loro chiusura, il risultato automatico resta soggetto alla revisione
 docente e non deve essere pubblicato come voto definitivo senza controllo.
 
+La preview dei file locali viene disabilitata per i report remoti: un checkout locale potrebbe
+contenere file modificati, non tracciati o ignorati diversi dal commit valutato. Una futura preview
+remota dovra leggere i blob direttamente dallo SHA attestato.
+
 Per repository studenti privati, il secret `THEBITLAB_STUDENT_REPO_TOKEN` deve contenere un
 token GitHub App o PAT di sola lettura limitato ai repository necessari. La credenziale viene
 usata soltanto dal checkout con `persist-credentials: false`; il runner Docker esegue il codice

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -278,7 +278,8 @@ scripts/thebitlab_tracking_reports.py
 
 `ArtifactTrackingReportSource` combina la porta `GradingArtifactSource` con binding forniti da una
 sorgente docente fidata. Ogni binding distingue repository e SHA dello studente da repository, SHA e run
-del workflow docente protetto, oltre a identificare assignment, studente e artifact. Questi dati descrivono una singola esecuzione: non fanno parte dell'activity,
+del workflow docente protetto, oltre a identificare assignment, studente, artifact e timestamp
+di consegna registrato. Questi dati descrivono una singola esecuzione: non fanno parte dell'activity,
 del target iniziale o di dati controllati dallo studente.
 
 `track_assignments()` accetta una `TrackingReportSource` opzionale. La precedenza e:
@@ -302,9 +303,9 @@ Prima di accettare un report remoto, l'adapter verifica:
 
 Il producer autorevole e `.github/workflows/grade-student-assignment.yml`, eseguito nel
 repository docente. Activity e test arrivano dal checkout docente immutabile; dal repository
-studente viene letto soltanto il sorgente allo SHA esatto. Il workflow registra come
-`submitted_at` il momento di ricezione da parte del grading docente e conserva nel report il
-path repository del sorgente.
+studente viene letto soltanto il sorgente allo SHA esatto. Il workflow riceve `submitted_at`
+dal binding docente anziche usare l'ora di avvio del grading, e conserva nel report il path
+repository del sorgente.
 
 Per repository studenti privati, il secret `THEBITLAB_STUDENT_REPO_TOKEN` deve contenere un
 token GitHub App o PAT di sola lettura limitato ai repository necessari. La credenziale viene

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -86,8 +86,10 @@ feedback/c-base-somma-001/
 ```
 
 Il file `latest.json` al livello activity rappresenta l'ultimo esito noto e mantiene la compatibilita con i lettori
-legacy e con lo stato operativo della dashboard studente. Un registro collegato a una vera assegnazione preferisce
-invece il tentativo `final` valido oppure il `latest.json` specifico dell'assegnazione come fallback provvisorio.
+legacy e con lo stato operativo della dashboard studente. Senza un binding remoto, un registro collegato a una vera
+assegnazione preferisce il tentativo `final` valido oppure il `latest.json` specifico dell'assegnazione come fallback
+provvisorio. Con un binding remoto usa invece soltanto l'artifact verificato e resta `submission_unknown` se
+l'acquisizione fallisce.
 
 I file `attempt-*.json` sono immutabili e conservano la storia tecnica della singola assegnazione. Il `latest.json`
 interno identifica l'ultimo tentativo di quella consegna, mentre `final.json` contiene solo il riferimento al
@@ -574,7 +576,7 @@ Per ogni studente contiene:
 | Campo | Significato |
 |---|---|
 | `assigned` | Lo studente era tra i destinatari della consegna |
-| `submitted` | Esiste un report locale valido e coerente con l'activity corrente |
+| `submitted` | Esiste un report valido, remoto verificato quando configurato oppure locale in assenza di binding |
 | `status` | Stato sintetico: `missing`, `submitted_on_time`, `submitted_late`, `not_graded`, ecc. |
 | `due_at` | Scadenza della consegna |
 | `submission` | Dati della consegna: sorgente, data invio, commit se disponibile |
@@ -714,14 +716,14 @@ Quando clicchi `Crea registro consegne`, il server locale:
 
 1. legge la activity;
 2. costruisce i target studenti;
-3. per ogni assegnazione cerca prima un tentativo `final` valido;
-4. se il definitivo non esiste, usa il `latest.json` specifico dell'assegnazione o il report legacy come risultato
-   provvisorio;
-5. se una selezione finale esiste ma non e valida, espone `invalid_final` senza attribuire un grading diverso;
-6. calcola stato consegna, ritardi e grading disponibile;
-7. registra in `submission.report_selection` la provenienza e in `grading.provisional` se l'esito non e definitivo;
-8. salva il JSON in `teacher-reports`;
-9. carica subito il risultato nella dashboard.
+3. per ogni assegnazione cerca prima un binding remoto e, se configurato, acquisisce l'artifact verificato;
+4. se il binding remoto fallisce, espone `submission_unknown` senza usare fallback locali;
+5. solo senza binding remoto cerca un tentativo `final`, poi `latest.json` assignment-scoped o legacy;
+6. se una selezione finale locale esiste ma non e valida, espone `invalid_final` senza attribuire un grading diverso;
+7. calcola stato consegna, ritardi e grading disponibile;
+8. registra in `submission.report_selection` la provenienza e in `grading.provisional` se l'esito non e definitivo;
+9. salva il JSON in `teacher-reports`;
+10. carica subito il risultato nella dashboard.
 
 Il file in `teacher-reports` e uno snapshot. Se lo studente cambia il tentativo finale, usa nuovamente
 `Crea registro consegne` per aggiornare la vista docente.

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -88,8 +88,8 @@ feedback/c-base-somma-001/
 Il file `latest.json` al livello activity rappresenta l'ultimo esito noto e mantiene la compatibilita con i lettori
 legacy e con lo stato operativo della dashboard studente. Senza un binding remoto, un registro collegato a una vera
 assegnazione preferisce il tentativo `final` valido oppure il `latest.json` specifico dell'assegnazione come fallback
-provvisorio. Con un binding remoto usa invece soltanto l'artifact verificato e resta `submission_unknown` se
-l'acquisizione fallisce.
+provvisorio. Quando il registro viene generato dal server/GUI, un binding remoto usa invece soltanto l'artifact
+verificato e resta `submission_unknown` se l'acquisizione fallisce.
 
 I file `attempt-*.json` sono immutabili e conservano la storia tecnica della singola assegnazione. Il `latest.json`
 interno identifica l'ultimo tentativo di quella consegna, mentre `final.json` contiene solo il riferimento al
@@ -488,10 +488,11 @@ TheBitLab potra automatizzare:
 - assegnazione activity a una classe;
 - apertura issue o PR per consegna;
 - commit/push assistito;
-- lettura stato GitHub Actions;
-- download artifact report;
 - generazione dashboard classe;
 - feedback AI assisted da report deterministico.
+
+La lettura della workflow run GitHub Actions e il download verificato dell'artifact report sono
+gia disponibili nel flusso server tramite binding docente.
 
 ## Assegnare una activity a repository studenti
 
@@ -568,6 +569,9 @@ python scripts/track_assignments.py \
 `--assignment-id` collega il registro alla consegna salvata e permette di leggere gli aiuti dal relativo storage docente.
 `--server-root` indica la root dati del server; nella normale esecuzione dalla root del progetto il valore predefinito è già corretto.
 Senza `--assignment-id` la CLI mantiene la lettura legacy per i registri storici.
+La CLI `track_assignments.py` non carica automaticamente `teacher-grading-bindings.json`: resta uno
+strumento locale per debug e compatibilita. La precedenza remota fail-closed e attiva nella generazione
+tramite server/GUI; l'eventuale composizione remota da CLI richiedera opzioni esplicite dedicate.
 
 Il registro prodotto e pensato per la futura GUI docente.
 

--- a/doc/ASSIGNMENT_SUBMISSIONS.md
+++ b/doc/ASSIGNMENT_SUBMISSIONS.md
@@ -284,8 +284,8 @@ del target iniziale o di dati controllati dallo studente.
 
 `track_assignments()` accetta una `TrackingReportSource` opzionale. La precedenza e:
 
-1. tentativo `final` gia selezionato dal docente;
-2. report remoto configurato per assignment e studente;
+1. report remoto configurato per assignment e studente;
+2. tentativo `final` locale, soltanto quando non esiste un binding remoto;
 3. report locale assignment-scoped;
 4. report locale legacy.
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -58,8 +58,10 @@ from scripts import (
     student_help_codex_adapter,
     student_help_service,
     student_lab_service,
+    thebitlab_grading_artifacts,
     thebitlab_services,
     thebitlab_storage,
+    thebitlab_tracking_reports,
     track_assignments,
     validate_activity,
 )
@@ -71,6 +73,7 @@ COURSE_DESIGNS_DIR = ROOT / "doc" / "course_designs"
 SCHOOL_CALENDARS_DIR = ROOT / "doc" / "calendars"
 TEACHER_REPORTS_DIR = ROOT / "teacher-reports"
 TEACHER_ASSIGNMENTS_DIR = ROOT / "teacher-assignments"
+GRADING_BINDINGS_PATH = ROOT / "teacher-grading-bindings.json"
 ACTIVITY_DIRS = [ROOT / "activities", ROOT / "examples" / "assignment_tracking"]
 COURSE_PLAN_MD_PATH = ROOT / "doc" / "PERCORSO_DIDATTICO.md"
 README_PATH = ROOT / "README.md"
@@ -393,6 +396,7 @@ def configure_data_root(root: Path) -> Path:
     global SCHOOL_CALENDARS_DIR
     global TEACHER_REPORTS_DIR
     global TEACHER_ASSIGNMENTS_DIR
+    global GRADING_BINDINGS_PATH
     global ACTIVITY_DIRS
     global COURSE_PLAN_MD_PATH
     global README_PATH
@@ -406,6 +410,7 @@ def configure_data_root(root: Path) -> Path:
     SCHOOL_CALENDARS_DIR = ROOT / "doc" / "calendars"
     TEACHER_REPORTS_DIR = ROOT / "teacher-reports"
     TEACHER_ASSIGNMENTS_DIR = ROOT / "teacher-assignments"
+    GRADING_BINDINGS_PATH = ROOT / "teacher-grading-bindings.json"
     ACTIVITY_DIRS = [ROOT / "activities", ROOT / "examples" / "assignment_tracking"]
     COURSE_PLAN_MD_PATH = ROOT / "doc" / "PERCORSO_DIDATTICO.md"
     README_PATH = ROOT / "README.md"
@@ -444,6 +449,26 @@ def assignment_record_storage() -> assignment_records.JsonAssignmentRecordStorag
     """Return the JSON storage adapter for explicit assignment records."""
 
     return assignment_records.JsonAssignmentRecordStorage(ROOT, TEACHER_ASSIGNMENTS_DIR)
+
+
+def grading_tracking_report_source() -> thebitlab_tracking_reports.TrackingReportSource | None:
+    """Compose the production remote report adapter when bindings exist."""
+
+    bindings = thebitlab_tracking_reports.load_trusted_grading_bindings(
+        GRADING_BINDINGS_PATH,
+    )
+    if not bindings:
+        return None
+    token = secret_value("THEBITLAB_GRADING_GITHUB_TOKEN").strip()
+    if not token:
+        raise ValueError(
+            "THEBITLAB_GRADING_GITHUB_TOKEN obbligatorio quando esistono binding grading remoti."
+        )
+    artifact_source = thebitlab_grading_artifacts.GitHubActionsArtifactSource(token)
+    return thebitlab_tracking_reports.ArtifactTrackingReportSource(
+        artifact_source,
+        bindings,
+    )
 
 
 def assignment_record_operation_id(
@@ -1830,6 +1855,7 @@ def generate_assignment_report(payload: dict) -> dict:
             github_team=payload.get("github_team") or None,
             assignment_id=canonical_assignment_id or None,
             server_root=ROOT if canonical_assignment_id else None,
+            report_source=grading_tracking_report_source() if canonical_assignment_id else None,
         )
         with assignment_operation_lock(assignment_report_operation_id(storage, output_name)):
             if output_path.is_file():

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -584,8 +584,36 @@ def path_inside_workspace(path: Path, workspace: Path, label: str) -> str:
         raise ValueError(f"{label} deve trovarsi dentro il workspace montato: {workspace}") from error
 
 
-def prepare_docker_workspace(activity: Path, source: Path, root: Path) -> tuple[Path, Path, Path]:
+def confined_regular_input(path: Path, root: Path, label: str) -> Path:
+    """Resolve one input without following links outside its authorized root."""
+
+    resolved_root = root.resolve(strict=True)
+    resolved = path.resolve(strict=True)
+    try:
+        relative = resolved.relative_to(resolved_root)
+    except ValueError as error:
+        raise ValueError(f"{label} deve trovarsi dentro {resolved_root}.") from error
+    candidate = resolved_root
+    for part in relative.parts:
+        candidate = candidate / part
+        if candidate.is_symlink():
+            raise ValueError(f"{label} non puo essere un collegamento simbolico.")
+    if not resolved.is_file():
+        raise ValueError(f"{label} deve essere un file regolare.")
+    return resolved
+
+
+def prepare_docker_workspace(
+    activity: Path,
+    source: Path,
+    root: Path,
+    *,
+    activity_root: Path | None = None,
+    source_root: Path | None = None,
+) -> tuple[Path, Path, Path]:
     """Create a minimal Docker workspace with only grading inputs."""
+    safe_activity = confined_regular_input(activity, activity_root or activity.parent, "activity")
+    safe_source = confined_regular_input(source, source_root or source.parent, "source")
     workspace = root / "workspace"
     scripts_dir = workspace / "scripts"
     activity_dir = workspace / "activity"
@@ -599,8 +627,8 @@ def prepare_docker_workspace(activity: Path, source: Path, root: Path) -> tuple[
     source_copy = source_dir / source.name
 
     shutil.copy2(Path(__file__).resolve(), script_copy)
-    shutil.copy2(activity.resolve(), activity_copy)
-    shutil.copy2(source.resolve(), source_copy)
+    shutil.copy2(safe_activity, activity_copy)
+    shutil.copy2(safe_source, source_copy)
 
     return workspace, activity_copy, source_copy
 
@@ -667,7 +695,13 @@ def run_docker_grading(args: argparse.Namespace) -> int:
     with tempfile.TemporaryDirectory(prefix="thebitlab-docker-") as temp_dir:
         temp_root = Path(temp_dir)
         try:
-            workspace, activity, source = prepare_docker_workspace(args.activity, args.source, temp_root)
+            workspace, activity, source = prepare_docker_workspace(
+                args.activity,
+                args.source,
+                temp_root,
+                activity_root=getattr(args, "activity_root", None),
+                source_root=getattr(args, "source_root", None),
+            )
             docker_timeout = docker_timeout_seconds(load_activity(activity), args.timeout, args.language)
             command = docker_command(
                 activity=activity,
@@ -690,40 +724,39 @@ def run_docker_grading(args: argparse.Namespace) -> int:
             print("Docker non trovato. Installa Docker oppure esegui senza --docker.")
             return 1
 
-        if args.report:
-            try:
-                report = json.loads(result.stdout)
-            except json.JSONDecodeError:
-                print("Sandbox Docker non ha prodotto un report JSON valido.")
-                if result.stdout:
-                    print(result.stdout)
-                if result.stderr:
-                    print(result.stderr)
-                return 1
-            if not has_minimal_report_shape(report):
-                print("Sandbox Docker non ha prodotto un report di grading valido.")
-                if result.stderr:
-                    print(result.stderr)
-                return 1
-            if result.returncode != 0 and report.get("passed") is True:
-                print("Sandbox Docker ha prodotto un report incoerente con l'esito del container.")
-                if result.stderr:
-                    print(result.stderr)
-                return 1
-            report = with_report_metadata(
-                report,
-                assignment_id=getattr(args, "assignment_id", None),
-                student_id=getattr(args, "student_id", None),
-                commit=getattr(args, "commit", None),
-            )
-            write_report(report, args.report)
-            if result.stderr:
-                print(result.stderr)
-        else:
+        try:
+            report = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            print("Sandbox Docker non ha prodotto un report JSON valido.")
             if result.stdout:
                 print(result.stdout)
             if result.stderr:
                 print(result.stderr)
+            return 1
+        if not has_minimal_report_shape(report):
+            print("Sandbox Docker non ha prodotto un report di grading valido.")
+            if result.stderr:
+                print(result.stderr)
+            return 1
+        if result.returncode != 0 and report.get("passed") is True:
+            print("Sandbox Docker ha prodotto un report incoerente con l'esito del container.")
+            if result.stderr:
+                print(result.stderr)
+            return 1
+        report = with_report_metadata(
+            report,
+            assignment_id=getattr(args, "assignment_id", None),
+            student_id=getattr(args, "student_id", None),
+            commit=getattr(args, "commit", None),
+            submitted_at=getattr(args, "submitted_at", None),
+            source_repo_path=getattr(args, "source_repo_path", None),
+        )
+        if args.report:
+            write_report(report, args.report)
+        else:
+            print(json.dumps(report, ensure_ascii=False, indent=2))
+        if result.stderr:
+            print(result.stderr)
         return result.returncode
 
 
@@ -744,6 +777,8 @@ def with_report_metadata(
     assignment_id: str | None = None,
     student_id: str | None = None,
     commit: str | None = None,
+    submitted_at: str | None = None,
+    source_repo_path: str | None = None,
 ) -> dict[str, Any]:
     """Return a report enriched with explicit remote-tracking identities."""
 
@@ -752,6 +787,8 @@ def with_report_metadata(
         ("assignment_id", assignment_id),
         ("student_id", student_id),
         ("commit", commit),
+        ("submitted_at", submitted_at),
+        ("source", source_repo_path),
     ):
         clean = str(value or "").strip()
         if clean:
@@ -768,6 +805,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assignment-id", help="Identificativo assegnazione da includere nel report.")
     parser.add_argument("--student-id", help="Identificativo studente da includere nel report.")
     parser.add_argument("--commit", help="SHA del commit studente da includere nel report.")
+    parser.add_argument("--submitted-at", help="Timestamp ISO-8601 di ricezione della consegna.")
+    parser.add_argument("--source-repo-path", help="Path del sorgente nel repository studente.")
+    parser.add_argument("--activity-root", type=Path, help="Root autorizzata per la activity.")
+    parser.add_argument("--source-root", type=Path, help="Root autorizzata per il sorgente.")
     parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout compilazione/esecuzione.")
     parser.add_argument("--docker", action="store_true", help="Esegue il grading dentro la sandbox Docker.")
     parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE, help="Immagine Docker da usare con --docker.")
@@ -785,6 +826,8 @@ def main() -> int:
         assignment_id=args.assignment_id,
         student_id=args.student_id,
         commit=args.commit,
+        submitted_at=args.submitted_at,
+        source_repo_path=args.source_repo_path,
     )
 
     if args.report:

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -820,9 +820,19 @@ def main() -> int:
     if args.docker:
         return run_docker_grading(args)
 
-    activity = load_activity(args.activity)
+    activity_path = (
+        confined_regular_input(args.activity, args.activity_root, "activity")
+        if args.activity_root
+        else args.activity
+    )
+    source_path = (
+        confined_regular_input(args.source, args.source_root, "source")
+        if args.source_root
+        else args.source
+    )
+    activity = load_activity(activity_path)
     report = with_report_metadata(
-        grade_activity(activity, args.source, timeout_seconds=args.timeout, language=args.language),
+        grade_activity(activity, source_path, timeout_seconds=args.timeout, language=args.language),
         assignment_id=args.assignment_id,
         student_id=args.student_id,
         commit=args.commit,

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -756,7 +756,7 @@ def run_docker_grading(args: argparse.Namespace) -> int:
         else:
             print(json.dumps(report, ensure_ascii=False, indent=2))
         if result.stderr:
-            print(result.stderr)
+            print(result.stderr, file=sys.stderr)
         return result.returncode
 
 

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -710,6 +710,12 @@ def run_docker_grading(args: argparse.Namespace) -> int:
                 if result.stderr:
                     print(result.stderr)
                 return 1
+            report = with_report_metadata(
+                report,
+                assignment_id=getattr(args, "assignment_id", None),
+                student_id=getattr(args, "student_id", None),
+                commit=getattr(args, "commit", None),
+            )
             write_report(report, args.report)
             if result.stderr:
                 print(result.stderr)
@@ -732,12 +738,36 @@ def positive_int(value: str) -> int:
     return number
 
 
+def with_report_metadata(
+    report: dict[str, Any],
+    *,
+    assignment_id: str | None = None,
+    student_id: str | None = None,
+    commit: str | None = None,
+) -> dict[str, Any]:
+    """Return a report enriched with explicit remote-tracking identities."""
+
+    enriched = dict(report)
+    for key, value in (
+        ("assignment_id", assignment_id),
+        ("student_id", student_id),
+        ("commit", commit),
+    ):
+        clean = str(value or "").strip()
+        if clean:
+            enriched[key] = clean
+    return enriched
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Corregge in modo deterministico una consegna TheBitLab.")
     parser.add_argument("--activity", type=Path, required=True, help="Scheda attivita JSON con test_cases.")
     parser.add_argument("--source", type=Path, required=True, help="File sorgente da correggere.")
     parser.add_argument("--language", choices=sorted(SUPPORTED_LANGUAGES), help="Linguaggio da usare, se diverso dalla scheda.")
     parser.add_argument("--report", type=Path, help="Percorso report JSON da scrivere.")
+    parser.add_argument("--assignment-id", help="Identificativo assegnazione da includere nel report.")
+    parser.add_argument("--student-id", help="Identificativo studente da includere nel report.")
+    parser.add_argument("--commit", help="SHA del commit studente da includere nel report.")
     parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout compilazione/esecuzione.")
     parser.add_argument("--docker", action="store_true", help="Esegue il grading dentro la sandbox Docker.")
     parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE, help="Immagine Docker da usare con --docker.")
@@ -750,7 +780,12 @@ def main() -> int:
         return run_docker_grading(args)
 
     activity = load_activity(args.activity)
-    report = grade_activity(activity, args.source, timeout_seconds=args.timeout, language=args.language)
+    report = with_report_metadata(
+        grade_activity(activity, args.source, timeout_seconds=args.timeout, language=args.language),
+        assignment_id=args.assignment_id,
+        student_id=args.student_id,
+        commit=args.commit,
+    )
 
     if args.report:
         write_report(report, args.report)

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -215,6 +215,8 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
     if normalized["status"] == "submission_unknown":
         normalized["submitted"] = None
     normalized["late"] = bool_value(payload.get("late", False))
+    if normalized["status"] == "submission_unknown":
+        normalized["late"] = False
     submission = payload.get("submission") if isinstance(payload.get("submission"), dict) else {}
     grading = payload.get("grading") if isinstance(payload.get("grading"), dict) else {}
     ai_feedback = payload.get("ai_feedback") if isinstance(payload.get("ai_feedback"), dict) else {}

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -212,6 +212,8 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
     submitted = payload.get("submitted", False)
     normalized["submitted"] = None if submitted is None else bool_value(submitted)
     normalized["status"] = first_text(payload, "status")
+    if normalized["status"] == "submission_unknown":
+        normalized["submitted"] = None
     normalized["late"] = bool_value(payload.get("late", False))
     submission = payload.get("submission") if isinstance(payload.get("submission"), dict) else {}
     grading = payload.get("grading") if isinstance(payload.get("grading"), dict) else {}

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -209,7 +209,8 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
     normalized["student_id"] = first_text(payload, "student_id") or normalized["student"]
     normalized["repo"] = first_text(payload, "repo")
     normalized["repo_path"] = first_text(payload, "repo_path")
-    normalized["submitted"] = bool_value(payload.get("submitted", False))
+    submitted = payload.get("submitted", False)
+    normalized["submitted"] = None if submitted is None else bool_value(submitted)
     normalized["status"] = first_text(payload, "status")
     normalized["late"] = bool_value(payload.get("late", False))
     submission = payload.get("submission") if isinstance(payload.get("submission"), dict) else {}
@@ -228,6 +229,11 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
         normalized_submission["final_selected"] = False
         normalized_grading["provisional"] = True
     elif report_selection == "invalid_final":
+        normalized_submission["final_selected"] = False
+        normalized_grading["provisional"] = False
+    elif report_selection == "github_actions_artifact":
+        normalized_submission["final_selected"] = False
+    elif report_selection == "remote_error":
         normalized_submission["final_selected"] = False
         normalized_grading["provisional"] = False
     elif report_selection is not None:

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -212,8 +212,9 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
     submitted = payload.get("submitted", False)
     normalized["submitted"] = None if submitted is None else bool_value(submitted)
     normalized["status"] = first_text(payload, "status")
-    if normalized["status"] == "submission_unknown":
+    if normalized["submitted"] is None or normalized["status"] == "submission_unknown":
         normalized["submitted"] = None
+        normalized["status"] = "submission_unknown"
     normalized["late"] = bool_value(payload.get("late", False))
     if normalized["status"] == "submission_unknown":
         normalized["late"] = False

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -246,7 +246,7 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
         normalized_grading["provisional"] = False
     else:
         normalized_submission["final_selected"] = False
-        normalized_grading["provisional"] = normalized["submitted"]
+        normalized_grading["provisional"] = bool(normalized["submitted"])
     normalized["submission"] = normalized_submission
     normalized["grading"] = normalized_grading
     normalized["ai_feedback"] = normalize_ai_feedback(ai_feedback)

--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -146,6 +146,7 @@ class AssignmentOverviewService:
                 submission = student.get("submission") if isinstance(student.get("submission"), dict) else {}
                 grading = student.get("grading") if isinstance(student.get("grading"), dict) else {}
                 ai_feedback = student.get("ai_feedback") if isinstance(student.get("ai_feedback"), dict) else {}
+                submitted = student.get("submitted", False)
                 rows.append(
                     {
                         "report_name": report["name"],
@@ -162,7 +163,7 @@ class AssignmentOverviewService:
                         "student": student.get("student", ""),
                         "repo": student.get("repo", ""),
                         "status": student.get("status", ""),
-                        "submitted": bool(student.get("submitted", False)),
+                        "submitted": None if submitted is None else bool(submitted),
                         "late": bool(student.get("late", False)),
                         "submitted_at": submission.get("submitted_at"),
                         "commit": submission.get("commit"),
@@ -201,6 +202,7 @@ class AssignmentOverviewService:
                 submission = student.get("submission") if isinstance(student.get("submission"), dict) else {}
                 grading = student.get("grading") if isinstance(student.get("grading"), dict) else {}
                 ai_feedback = student.get("ai_feedback") if isinstance(student.get("ai_feedback"), dict) else {}
+                submitted = student.get("submitted", False)
                 assignments.append(
                     {
                         "report_name": report["name"],
@@ -213,7 +215,7 @@ class AssignmentOverviewService:
                         "assigned_at": payload.get("assigned_at") or "",
                         "due_at": payload.get("due_at") or "",
                         "status": student.get("status", ""),
-                        "submitted": bool(student.get("submitted", False)),
+                        "submitted": None if submitted is None else bool(submitted),
                         "late": bool(student.get("late", False)),
                         "repo": student.get("repo", ""),
                         "repo_github_url": student.get("repo_github_url", ""),

--- a/scripts/thebitlab_sqlite_index.py
+++ b/scripts/thebitlab_sqlite_index.py
@@ -330,10 +330,14 @@ def _migrate_nullable_submitted(connection: sqlite3.Connection) -> None:
     if table is None:
         return
     submitted_column = next(
-        (row for row in connection.execute("PRAGMA table_info(submissions)") if row["name"] == "submitted"),
+        (
+            row
+            for row in connection.execute("PRAGMA table_info(submissions)")
+            if row[1] == "submitted"
+        ),
         None,
     )
-    if submitted_column is None or not submitted_column["notnull"]:
+    if submitted_column is None or not submitted_column[3]:
         return
 
     connection.commit()

--- a/scripts/thebitlab_sqlite_index.py
+++ b/scripts/thebitlab_sqlite_index.py
@@ -9,7 +9,7 @@ from typing import Any
 from scripts.thebitlab_storage_ports import AssignmentStorage
 
 
-SCHEMA_VERSION = "0001_assignment_index"
+SCHEMA_VERSION = "0002_nullable_submission_state"
 
 
 def connect_assignment_index(db_path: Path) -> sqlite3.Connection:
@@ -25,6 +25,7 @@ def connect_assignment_index(db_path: Path) -> sqlite3.Connection:
 def initialize_assignment_index(connection: sqlite3.Connection) -> None:
     """Create the minimal SQLite schema for the assignment overview spike."""
 
+    _migrate_nullable_submitted(connection)
     connection.executescript(
         """
         CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -71,7 +72,7 @@ def initialize_assignment_index(connection: sqlite3.Connection) -> None:
           student_id TEXT NOT NULL,
           register_id TEXT REFERENCES registers(id),
           status TEXT NOT NULL DEFAULT '',
-          submitted INTEGER NOT NULL DEFAULT 0,
+          submitted INTEGER,
           submitted_at TEXT,
           late INTEGER NOT NULL DEFAULT 0,
           repo_ref TEXT,
@@ -190,7 +191,7 @@ def rebuild_assignment_index_from_storage(storage: AssignmentStorage, db_path: P
                         str(student.get("student", "")),
                         register_id,
                         str(student.get("status", "")),
-                        _to_int_bool(student.get("submitted", False)),
+                        _to_optional_int_bool(student.get("submitted", False)),
                         submission.get("submitted_at"),
                         _to_int_bool(student.get("late", False)),
                         student.get("repo"),
@@ -264,7 +265,7 @@ def list_assignment_index_rows(db_path: Path) -> list[dict[str, Any]]:
         {
             **{key: row[key] for key in row.keys() if key != "commit_sha"},
             "commit": row["commit_sha"],
-            "submitted": bool(row["submitted"]),
+            "submitted": None if row["submitted"] is None else bool(row["submitted"]),
             "late": bool(row["late"]),
         }
         for row in rows
@@ -312,3 +313,73 @@ def _to_int_bool(value: Any) -> int:
     if isinstance(value, str):
         return 1 if value.strip().lower() in {"1", "true", "yes", "si"} else 0
     return 1 if bool(value) else 0
+
+
+def _to_optional_int_bool(value: Any) -> int | None:
+    if value is None:
+        return None
+    return _to_int_bool(value)
+
+
+def _migrate_nullable_submitted(connection: sqlite3.Connection) -> None:
+    """Preserve derived rows while removing the legacy NOT NULL constraint."""
+
+    table = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='submissions'"
+    ).fetchone()
+    if table is None:
+        return
+    submitted_column = next(
+        (row for row in connection.execute("PRAGMA table_info(submissions)") if row["name"] == "submitted"),
+        None,
+    )
+    if submitted_column is None or not submitted_column["notnull"]:
+        return
+
+    connection.commit()
+    connection.execute("PRAGMA foreign_keys = OFF")
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE submissions_nullable (
+              id TEXT PRIMARY KEY,
+              assignment_id TEXT NOT NULL REFERENCES assignments(id),
+              student_id TEXT NOT NULL,
+              register_id TEXT REFERENCES registers(id),
+              status TEXT NOT NULL DEFAULT '',
+              submitted INTEGER,
+              submitted_at TEXT,
+              late INTEGER NOT NULL DEFAULT 0,
+              repo_ref TEXT,
+              commit_sha TEXT,
+              source_path TEXT,
+              updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              payload_json TEXT,
+              UNIQUE (assignment_id, student_id)
+            );
+            INSERT INTO submissions_nullable
+            SELECT * FROM submissions;
+
+            CREATE TABLE grading_results_nullable (
+              id TEXT PRIMARY KEY,
+              submission_id TEXT NOT NULL REFERENCES submissions_nullable(id),
+              status TEXT NOT NULL DEFAULT '',
+              tests_passed INTEGER,
+              tests_total INTEGER,
+              score REAL,
+              teacher_grade REAL,
+              graded_at TEXT,
+              payload_json TEXT
+            );
+            INSERT INTO grading_results_nullable
+            SELECT * FROM grading_results;
+
+            DROP TABLE grading_results;
+            DROP TABLE submissions;
+            ALTER TABLE submissions_nullable RENAME TO submissions;
+            ALTER TABLE grading_results_nullable RENAME TO grading_results;
+            """
+        )
+        connection.commit()
+    finally:
+        connection.execute("PRAGMA foreign_keys = ON")

--- a/scripts/thebitlab_sqlite_index.py
+++ b/scripts/thebitlab_sqlite_index.py
@@ -345,6 +345,10 @@ def _migrate_nullable_submitted(connection: sqlite3.Connection) -> None:
     try:
         connection.executescript(
             """
+            BEGIN IMMEDIATE;
+            DROP TABLE IF EXISTS grading_results_nullable;
+            DROP TABLE IF EXISTS submissions_nullable;
+
             CREATE TABLE submissions_nullable (
               id TEXT PRIMARY KEY,
               assignment_id TEXT NOT NULL REFERENCES assignments(id),
@@ -382,8 +386,12 @@ def _migrate_nullable_submitted(connection: sqlite3.Connection) -> None:
             DROP TABLE submissions;
             ALTER TABLE submissions_nullable RENAME TO submissions;
             ALTER TABLE grading_results_nullable RENAME TO grading_results;
+            COMMIT;
             """
         )
-        connection.commit()
+    except Exception:
+        if connection.in_transaction:
+            connection.rollback()
+        raise
     finally:
         connection.execute("PRAGMA foreign_keys = ON")

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -521,7 +521,22 @@ class JsonAssignmentStorage:
             students = payload.get("students", []) if isinstance(payload.get("students"), list) else []
             submitted = sum(1 for student in students if isinstance(student, dict) and student.get("submitted"))
             late = sum(1 for student in students if isinstance(student, dict) and student.get("submitted") and student.get("late"))
-            not_submitted = sum(1 for student in students if isinstance(student, dict) and not student.get("submitted"))
+            unknown = sum(
+                1
+                for student in students
+                if isinstance(student, dict)
+                and (
+                    student.get("submitted") is None
+                    or student.get("status") == "submission_unknown"
+                )
+            )
+            not_submitted = sum(
+                1
+                for student in students
+                if isinstance(student, dict)
+                and student.get("submitted") is False
+                and student.get("status") != "submission_unknown"
+            )
             reports.append(
                 {
                     "name": str(path.relative_to(self.teacher_reports_dir)).replace("\\", "/"),
@@ -536,6 +551,7 @@ class JsonAssignmentStorage:
                     "submitted": submitted,
                     "late": late,
                     "not_submitted": not_submitted,
+                    "unknown": unknown,
                     "updated_at": datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds"),
                 }
             )

--- a/scripts/thebitlab_tracking_reports.py
+++ b/scripts/thebitlab_tracking_reports.py
@@ -33,9 +33,11 @@ class TrustedGradingBinding:
     activity_id: str
     assignment_id: str
     student_id: str
-    repo_ref: str
+    student_repo_ref: str
+    workflow_repo_ref: str
     artifact_name: str
-    expected_head_sha: str
+    expected_student_head_sha: str
+    expected_workflow_head_sha: str
     expected_workflow_run_id: int
     final: bool = False
 
@@ -136,9 +138,9 @@ class ArtifactTrackingReportSource:
         try:
             _validate_request(request, binding)
             acquired = self.artifact_source.acquire_latest_report(
-                binding.repo_ref,
+                binding.workflow_repo_ref,
                 binding.artifact_name,
-                binding.expected_head_sha,
+                binding.expected_workflow_head_sha,
                 binding.expected_workflow_run_id,
             )
             _validate_acquired_report(acquired.report, acquired.provenance, binding)
@@ -156,10 +158,7 @@ class ArtifactTrackingReportSource:
             selection="github_actions_artifact",
             authority="verified_remote",
             provisional=not binding.final,
-            provenance={
-                "source": "github_actions",
-                **asdict(acquired.provenance),
-            },
+            provenance=_tracking_provenance(acquired.provenance, binding),
         )
 
 
@@ -174,11 +173,25 @@ def _validated_binding(binding: TrustedGradingBinding) -> TrustedGradingBinding:
     activity_id = _required_text(binding.activity_id, "activity_id")
     assignment_id = _required_text(binding.assignment_id, "assignment_id")
     student_id = _required_text(binding.student_id, "student_id")
-    owner, repo = normalize_github_repo_ref(_required_text(binding.repo_ref, "repo_ref"))
+    student_owner, student_repo = normalize_github_repo_ref(
+        _required_text(binding.student_repo_ref, "student_repo_ref")
+    )
+    workflow_owner, workflow_repo = normalize_github_repo_ref(
+        _required_text(binding.workflow_repo_ref, "workflow_repo_ref")
+    )
     artifact_name = _required_text(binding.artifact_name, "artifact_name")
-    head_sha = _required_text(binding.expected_head_sha, "expected_head_sha").lower()
-    if not GIT_SHA_RE.fullmatch(head_sha):
-        raise ValueError("expected_head_sha deve contenere 40 caratteri esadecimali.")
+    student_head_sha = _required_text(
+        binding.expected_student_head_sha,
+        "expected_student_head_sha",
+    ).lower()
+    workflow_head_sha = _required_text(
+        binding.expected_workflow_head_sha,
+        "expected_workflow_head_sha",
+    ).lower()
+    if not GIT_SHA_RE.fullmatch(student_head_sha):
+        raise ValueError("expected_student_head_sha deve contenere 40 caratteri esadecimali.")
+    if not GIT_SHA_RE.fullmatch(workflow_head_sha):
+        raise ValueError("expected_workflow_head_sha deve contenere 40 caratteri esadecimali.")
     run_id = binding.expected_workflow_run_id
     if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id <= 0:
         raise ValueError("expected_workflow_run_id non valido.")
@@ -188,9 +201,11 @@ def _validated_binding(binding: TrustedGradingBinding) -> TrustedGradingBinding:
         activity_id=activity_id,
         assignment_id=assignment_id,
         student_id=student_id,
-        repo_ref=f"{owner}/{repo}",
+        student_repo_ref=f"{student_owner}/{student_repo}",
+        workflow_repo_ref=f"{workflow_owner}/{workflow_repo}",
         artifact_name=artifact_name,
-        expected_head_sha=head_sha,
+        expected_student_head_sha=student_head_sha,
+        expected_workflow_head_sha=workflow_head_sha,
         expected_workflow_run_id=run_id,
         final=binding.final,
     )
@@ -215,7 +230,7 @@ def _validate_request(
     request_repo = str(request.repo_ref or "").strip()
     if request_repo:
         owner, repo = normalize_github_repo_ref(request_repo)
-        if f"{owner}/{repo}".lower() != binding.repo_ref.lower():
+        if f"{owner}/{repo}".lower() != binding.student_repo_ref.lower():
             raise ValueError("Binding grading non coerente con il repository.")
 
 
@@ -230,13 +245,24 @@ def _validate_acquired_report(report, provenance, binding: TrustedGradingBinding
     if report_student_id != binding.student_id:
         raise ValueError("Report remoto riferito a uno studente diverso.")
     commit = str(report.get("commit", "")).strip().lower()
-    if commit != binding.expected_head_sha:
+    if commit != binding.expected_student_head_sha:
         raise ValueError("Commit del report remoto diverso dallo SHA autorizzato.")
-    if provenance.repository.lower() != binding.repo_ref.lower():
+    if provenance.repository.lower() != binding.workflow_repo_ref.lower():
         raise ValueError("Provenienza remota riferita a un repository diverso.")
-    if provenance.head_sha.lower() != binding.expected_head_sha:
+    if provenance.head_sha.lower() != binding.expected_workflow_head_sha:
         raise ValueError("Provenienza remota riferita a uno SHA diverso.")
     if provenance.workflow_run_id != binding.expected_workflow_run_id:
         raise ValueError("Provenienza remota riferita a una workflow run diversa.")
     if provenance.artifact_name != binding.artifact_name:
         raise ValueError("Provenienza remota riferita a un artifact diverso.")
+
+
+def _tracking_provenance(provenance, binding: TrustedGradingBinding) -> dict[str, Any]:  # noqa: ANN001
+    artifact_provenance = asdict(provenance)
+    artifact_repository = artifact_provenance.pop("repository")
+    return {
+        "source": "github_actions",
+        "repository": binding.student_repo_ref,
+        "artifact_repository": artifact_repository,
+        **artifact_provenance,
+    }

--- a/scripts/thebitlab_tracking_reports.py
+++ b/scripts/thebitlab_tracking_reports.py
@@ -60,6 +60,42 @@ class TrackingReportSource(Protocol):
         """Resolve a report or state that no remote binding is configured."""
 
 
+def canonical_tracking_report_result(result: TrackingReportResult) -> TrackingReportResult:
+    """Normalize untrusted adapter output into a fail-closed tracking state."""
+
+    if not result.configured:
+        return TrackingReportResult(configured=False)
+    if result.report is None:
+        return TrackingReportResult(
+            configured=True,
+            selection="remote_error",
+            authority="remote_configured",
+            provisional=False,
+            error=result.error or "Risultato sorgente remota non valido.",
+        )
+    if (
+        result.selection != "github_actions_artifact"
+        or result.authority != "verified_remote"
+        or not isinstance(result.provenance, dict)
+        or not result.provenance
+    ):
+        return TrackingReportResult(
+            configured=True,
+            selection="remote_error",
+            authority="remote_configured",
+            provisional=False,
+            error=result.error or "Provenienza del report remoto non verificabile.",
+        )
+    return TrackingReportResult(
+        configured=True,
+        report=result.report,
+        selection="github_actions_artifact",
+        authority="verified_remote",
+        provisional=bool(result.provisional),
+        provenance=dict(result.provenance),
+    )
+
+
 class ArtifactTrackingReportSource:
     """Resolve teacher-bound reports through a grading artifact source."""
 

--- a/scripts/thebitlab_tracking_reports.py
+++ b/scripts/thebitlab_tracking_reports.py
@@ -1,0 +1,185 @@
+"""Application adapter for authoritative remote grading reports."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+from typing import Any, Iterable, Protocol
+
+from scripts.thebitlab_grading_artifacts import (
+    GradingArtifactError,
+    GradingArtifactSource,
+)
+from scripts.thebitlab_repository_providers import normalize_github_repo_ref
+
+
+GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+@dataclass(frozen=True)
+class TrackingReportRequest:
+    """Identity of one student report requested by assignment tracking."""
+
+    activity_id: str
+    assignment_id: str
+    student_id: str
+    repo_ref: str
+
+
+@dataclass(frozen=True)
+class TrustedGradingBinding:
+    """Teacher-controlled binding to one trusted GitHub Actions run."""
+
+    activity_id: str
+    assignment_id: str
+    student_id: str
+    repo_ref: str
+    artifact_name: str
+    expected_head_sha: str
+    expected_workflow_run_id: int
+    final: bool = False
+
+
+@dataclass(frozen=True)
+class TrackingReportResult:
+    """Remote report resolution without transport-specific exceptions."""
+
+    configured: bool
+    report: dict[str, Any] | None = None
+    selection: str | None = None
+    authority: str | None = None
+    provisional: bool = False
+    provenance: dict[str, Any] | None = None
+    error: str | None = None
+
+
+class TrackingReportSource(Protocol):
+    """Port consumed by assignment tracking for optional remote reports."""
+
+    def resolve(self, request: TrackingReportRequest) -> TrackingReportResult:
+        """Resolve a report or state that no remote binding is configured."""
+
+
+class ArtifactTrackingReportSource:
+    """Resolve teacher-bound reports through a grading artifact source."""
+
+    def __init__(
+        self,
+        artifact_source: GradingArtifactSource,
+        bindings: Iterable[TrustedGradingBinding],
+    ) -> None:
+        self.artifact_source = artifact_source
+        self._bindings: dict[tuple[str, str], TrustedGradingBinding] = {}
+        for binding in bindings:
+            clean = _validated_binding(binding)
+            key = (clean.assignment_id, clean.student_id)
+            if key in self._bindings:
+                raise ValueError(
+                    f"Binding grading duplicato per assignment {key[0]} e studente {key[1]}."
+                )
+            self._bindings[key] = clean
+
+    def resolve(self, request: TrackingReportRequest) -> TrackingReportResult:
+        binding = self._bindings.get((request.assignment_id, request.student_id))
+        if binding is None:
+            return TrackingReportResult(configured=False)
+        try:
+            _validate_request(request, binding)
+            acquired = self.artifact_source.acquire_latest_report(
+                binding.repo_ref,
+                binding.artifact_name,
+                binding.expected_head_sha,
+                binding.expected_workflow_run_id,
+            )
+            _validate_acquired_report(acquired.report, acquired.provenance, binding)
+        except (GradingArtifactError, ValueError) as error:
+            return TrackingReportResult(
+                configured=True,
+                selection="remote_error",
+                authority="verified_remote",
+                provisional=not binding.final,
+                error=str(error),
+            )
+        return TrackingReportResult(
+            configured=True,
+            report=acquired.report,
+            selection="github_actions_artifact",
+            authority="verified_remote",
+            provisional=not binding.final,
+            provenance={
+                "source": "github_actions",
+                **asdict(acquired.provenance),
+            },
+        )
+
+
+def _required_text(value: str, field_name: str) -> str:
+    clean = str(value or "").strip()
+    if not clean:
+        raise ValueError(f"{field_name} obbligatorio nel binding grading.")
+    return clean
+
+
+def _validated_binding(binding: TrustedGradingBinding) -> TrustedGradingBinding:
+    activity_id = _required_text(binding.activity_id, "activity_id")
+    assignment_id = _required_text(binding.assignment_id, "assignment_id")
+    student_id = _required_text(binding.student_id, "student_id")
+    owner, repo = normalize_github_repo_ref(_required_text(binding.repo_ref, "repo_ref"))
+    artifact_name = _required_text(binding.artifact_name, "artifact_name")
+    head_sha = _required_text(binding.expected_head_sha, "expected_head_sha").lower()
+    if not GIT_SHA_RE.fullmatch(head_sha):
+        raise ValueError("expected_head_sha deve contenere 40 caratteri esadecimali.")
+    run_id = binding.expected_workflow_run_id
+    if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id <= 0:
+        raise ValueError("expected_workflow_run_id non valido.")
+    if not isinstance(binding.final, bool):
+        raise ValueError("final deve essere booleano.")
+    return TrustedGradingBinding(
+        activity_id=activity_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        repo_ref=f"{owner}/{repo}",
+        artifact_name=artifact_name,
+        expected_head_sha=head_sha,
+        expected_workflow_run_id=run_id,
+        final=binding.final,
+    )
+
+
+def _validate_request(
+    request: TrackingReportRequest,
+    binding: TrustedGradingBinding,
+) -> None:
+    owner, repo = normalize_github_repo_ref(request.repo_ref)
+    expected = (
+        binding.activity_id,
+        binding.assignment_id,
+        binding.student_id,
+        binding.repo_ref.lower(),
+    )
+    actual = (
+        request.activity_id,
+        request.assignment_id,
+        request.student_id,
+        f"{owner}/{repo}".lower(),
+    )
+    if actual != expected:
+        raise ValueError("Binding grading non coerente con assignment, studente o repository.")
+
+
+def _validate_acquired_report(report, provenance, binding: TrustedGradingBinding) -> None:  # noqa: ANN001
+    if report.get("activity_id") != binding.activity_id:
+        raise ValueError("Report remoto riferito a una activity diversa.")
+    if report.get("assignment_id") != binding.assignment_id:
+        raise ValueError("Report remoto riferito a un'assegnazione diversa.")
+    commit = str(report.get("commit", "")).strip().lower()
+    if commit != binding.expected_head_sha:
+        raise ValueError("Commit del report remoto diverso dallo SHA autorizzato.")
+    if provenance.repository.lower() != binding.repo_ref.lower():
+        raise ValueError("Provenienza remota riferita a un repository diverso.")
+    if provenance.head_sha.lower() != binding.expected_head_sha:
+        raise ValueError("Provenienza remota riferita a uno SHA diverso.")
+    if provenance.workflow_run_id != binding.expected_workflow_run_id:
+        raise ValueError("Provenienza remota riferita a una workflow run diversa.")
+    if provenance.artifact_name != binding.artifact_name:
+        raise ValueError("Provenienza remota riferita a un artifact diverso.")

--- a/scripts/thebitlab_tracking_reports.py
+++ b/scripts/thebitlab_tracking_reports.py
@@ -225,7 +225,9 @@ def _validate_acquired_report(report, provenance, binding: TrustedGradingBinding
     if report.get("assignment_id") != binding.assignment_id:
         raise ValueError("Report remoto riferito a un'assegnazione diversa.")
     report_student_id = str(report.get("student_id", "") or "").strip()
-    if report_student_id and report_student_id != binding.student_id:
+    if not report_student_id:
+        raise ValueError("Report remoto privo dell'identificativo studente.")
+    if report_student_id != binding.student_id:
         raise ValueError("Report remoto riferito a uno studente diverso.")
     commit = str(report.get("commit", "")).strip().lower()
     if commit != binding.expected_head_sha:

--- a/scripts/thebitlab_tracking_reports.py
+++ b/scripts/thebitlab_tracking_reports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from datetime import datetime
 import re
 from typing import Any, Iterable, Protocol
 
@@ -38,6 +39,7 @@ class TrustedGradingBinding:
     artifact_name: str
     expected_student_head_sha: str
     expected_workflow_head_sha: str
+    expected_submitted_at: str
     expected_workflow_run_id: int
     final: bool = False
 
@@ -192,6 +194,10 @@ def _validated_binding(binding: TrustedGradingBinding) -> TrustedGradingBinding:
         raise ValueError("expected_student_head_sha deve contenere 40 caratteri esadecimali.")
     if not GIT_SHA_RE.fullmatch(workflow_head_sha):
         raise ValueError("expected_workflow_head_sha deve contenere 40 caratteri esadecimali.")
+    submitted_at = _required_timestamp(
+        binding.expected_submitted_at,
+        "expected_submitted_at",
+    )
     run_id = binding.expected_workflow_run_id
     if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id <= 0:
         raise ValueError("expected_workflow_run_id non valido.")
@@ -206,6 +212,7 @@ def _validated_binding(binding: TrustedGradingBinding) -> TrustedGradingBinding:
         artifact_name=artifact_name,
         expected_student_head_sha=student_head_sha,
         expected_workflow_head_sha=workflow_head_sha,
+        expected_submitted_at=submitted_at,
         expected_workflow_run_id=run_id,
         final=binding.final,
     )
@@ -247,6 +254,8 @@ def _validate_acquired_report(report, provenance, binding: TrustedGradingBinding
     commit = str(report.get("commit", "")).strip().lower()
     if commit != binding.expected_student_head_sha:
         raise ValueError("Commit del report remoto diverso dallo SHA autorizzato.")
+    if str(report.get("submitted_at", "") or "").strip() != binding.expected_submitted_at:
+        raise ValueError("Timestamp di consegna del report remoto diverso da quello autorizzato.")
     if provenance.repository.lower() != binding.workflow_repo_ref.lower():
         raise ValueError("Provenienza remota riferita a un repository diverso.")
     if provenance.head_sha.lower() != binding.expected_workflow_head_sha:
@@ -266,3 +275,14 @@ def _tracking_provenance(provenance, binding: TrustedGradingBinding) -> dict[str
         "artifact_repository": artifact_repository,
         **artifact_provenance,
     }
+
+
+def _required_timestamp(value: str, field_name: str) -> str:
+    clean = _required_text(value, field_name)
+    try:
+        parsed = datetime.fromisoformat(clean.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{field_name} deve essere un timestamp ISO-8601 valido.") from error
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} deve includere il fuso orario.")
+    return clean

--- a/scripts/thebitlab_tracking_reports.py
+++ b/scripts/thebitlab_tracking_reports.py
@@ -86,13 +86,27 @@ def canonical_tracking_report_result(result: TrackingReportResult) -> TrackingRe
             provisional=False,
             error=result.error or "Provenienza del report remoto non verificabile.",
         )
+    try:
+        owner, repo = normalize_github_repo_ref(
+            str(result.provenance.get("repository", "") or "")
+        )
+    except ValueError:
+        return TrackingReportResult(
+            configured=True,
+            selection="remote_error",
+            authority="remote_configured",
+            provisional=False,
+            error=result.error or "Repository del report remoto non verificabile.",
+        )
+    provenance = dict(result.provenance)
+    provenance["repository"] = f"{owner}/{repo}"
     return TrackingReportResult(
         configured=True,
         report=result.report,
         selection="github_actions_artifact",
         authority="verified_remote",
         provisional=bool(result.provisional),
-        provenance=dict(result.provenance),
+        provenance=provenance,
     )
 
 

--- a/scripts/thebitlab_tracking_reports.py
+++ b/scripts/thebitlab_tracking_reports.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from datetime import datetime
+import json
+from pathlib import Path
 import re
 from typing import Any, Iterable, Protocol
 
@@ -55,6 +57,34 @@ class TrackingReportResult:
     provisional: bool = False
     provenance: dict[str, Any] | None = None
     error: str | None = None
+
+
+def load_trusted_grading_bindings(path: Path) -> list[TrustedGradingBinding]:
+    """Load teacher-controlled remote grading bindings from JSON."""
+
+    if not path.is_file():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Binding grading non leggibili: {path}") from error
+    if not isinstance(payload, dict):
+        raise ValueError("Il file dei binding grading deve contenere un oggetto JSON.")
+    if payload.get("schema_version") != "thebitlab_grading_bindings.v1":
+        raise ValueError("Versione schema binding grading non supportata.")
+    entries = payload.get("bindings")
+    if not isinstance(entries, list):
+        raise ValueError("bindings deve essere una lista.")
+    bindings: list[TrustedGradingBinding] = []
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Binding grading {index + 1} non valido.")
+        try:
+            binding = TrustedGradingBinding(**entry)
+        except TypeError as error:
+            raise ValueError(f"Campi binding grading {index + 1} non validi.") from error
+        bindings.append(_validated_binding(binding))
+    return bindings
 
 
 class TrackingReportSource(Protocol):
@@ -201,6 +231,8 @@ def _validated_binding(binding: TrustedGradingBinding) -> TrustedGradingBinding:
     run_id = binding.expected_workflow_run_id
     if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id <= 0:
         raise ValueError("expected_workflow_run_id non valido.")
+    if not isinstance(binding.final, bool):
+        raise ValueError("final deve essere booleano.")
     if not isinstance(binding.final, bool):
         raise ValueError("final deve essere booleano.")
     return TrustedGradingBinding(

--- a/scripts/thebitlab_tracking_reports.py
+++ b/scripts/thebitlab_tracking_reports.py
@@ -96,7 +96,7 @@ class ArtifactTrackingReportSource:
             return TrackingReportResult(
                 configured=True,
                 selection="remote_error",
-                authority="verified_remote",
+                authority="remote_configured",
                 provisional=not binding.final,
                 error=str(error),
             )
@@ -150,21 +150,23 @@ def _validate_request(
     request: TrackingReportRequest,
     binding: TrustedGradingBinding,
 ) -> None:
-    owner, repo = normalize_github_repo_ref(request.repo_ref)
     expected = (
         binding.activity_id,
         binding.assignment_id,
         binding.student_id,
-        binding.repo_ref.lower(),
     )
     actual = (
         request.activity_id,
         request.assignment_id,
         request.student_id,
-        f"{owner}/{repo}".lower(),
     )
     if actual != expected:
-        raise ValueError("Binding grading non coerente con assignment, studente o repository.")
+        raise ValueError("Binding grading non coerente con assignment o studente.")
+    request_repo = str(request.repo_ref or "").strip()
+    if request_repo:
+        owner, repo = normalize_github_repo_ref(request_repo)
+        if f"{owner}/{repo}".lower() != binding.repo_ref.lower():
+            raise ValueError("Binding grading non coerente con il repository.")
 
 
 def _validate_acquired_report(report, provenance, binding: TrustedGradingBinding) -> None:  # noqa: ANN001

--- a/scripts/thebitlab_tracking_reports.py
+++ b/scripts/thebitlab_tracking_reports.py
@@ -210,6 +210,9 @@ def _validate_acquired_report(report, provenance, binding: TrustedGradingBinding
         raise ValueError("Report remoto riferito a una activity diversa.")
     if report.get("assignment_id") != binding.assignment_id:
         raise ValueError("Report remoto riferito a un'assegnazione diversa.")
+    report_student_id = str(report.get("student_id", "") or "").strip()
+    if report_student_id and report_student_id != binding.student_id:
+        raise ValueError("Report remoto riferito a uno studente diverso.")
     commit = str(report.get("commit", "")).strip().lower()
     if commit != binding.expected_head_sha:
         raise ValueError("Commit del report remoto diverso dallo SHA autorizzato.")

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -594,6 +594,13 @@ def track_assignments(
                         uses_assignment_report = True
                         report = remote_report_result.report
                         report_selection = remote_report_result.selection
+                        if report is not None:
+                            repository_ref = str(
+                                (remote_report_result.provenance or {}).get("repository", "")
+                            )
+                            repo_url = github_url_from_remote(repository_ref)
+                        elif not repository_ref:
+                            repo_url = None
                 if remote_report_result is None or not remote_report_result.configured:
                     assignment_report_path = (
                         report_path.parent

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -9,7 +9,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from scripts import assignment_records, assign_activity, create_submission_scaffold, student_help_service
+from scripts import (
+    assignment_records,
+    assign_activity,
+    create_submission_scaffold,
+    student_help_service,
+    thebitlab_tracking_reports,
+)
 from scripts import student_identity
 from scripts.thebitlab_contracts import (
     legacy_activity_validation_payload,
@@ -474,6 +480,7 @@ def track_assignments(
     github_team: str | None = None,
     assignment_id: str | None = None,
     server_root: Path | None = None,
+    report_source: thebitlab_tracking_reports.TrackingReportSource | None = None,
 ) -> dict[str, Any]:
     """Build a teacher-facing tracking index for one activity."""
     activity = create_submission_scaffold.load_activity(activity_path)
@@ -523,6 +530,7 @@ def track_assignments(
         uses_assignment_report = False
         report = None
         report_selection = None
+        remote_report_result = None
         if assignment_id:
             report, safe_report_path, final_selection_exists = selected_final_report(
                 target,
@@ -537,15 +545,34 @@ def track_assignments(
                 uses_assignment_report = True
                 report_selection = "invalid_final"
             else:
-                assignment_report_path = (
-                    report_path.parent
-                    / "assignments"
-                    / assignment_records.assignment_storage_key(assignment_id)
-                    / "latest.json"
-                )
-                safe_report_path = student_identity.confined_regular_file(target.path, assignment_report_path)
-                uses_assignment_report = safe_report_path is not None
-        if report is None and report_selection != "invalid_final":
+                if report_source is not None:
+                    remote_report_result = report_source.resolve(
+                        thebitlab_tracking_reports.TrackingReportRequest(
+                            activity_id=activity_id,
+                            assignment_id=assignment_id,
+                            student_id=stable_student_id,
+                            repo_ref=target.repo,
+                        )
+                    )
+                    if remote_report_result.configured:
+                        uses_assignment_report = True
+                        report = remote_report_result.report
+                        report_selection = remote_report_result.selection or (
+                            "github_actions_artifact" if report is not None else "remote_error"
+                        )
+                if remote_report_result is None or not remote_report_result.configured:
+                    assignment_report_path = (
+                        report_path.parent
+                        / "assignments"
+                        / assignment_records.assignment_storage_key(assignment_id)
+                        / "latest.json"
+                    )
+                    safe_report_path = student_identity.confined_regular_file(
+                        target.path,
+                        assignment_report_path,
+                    )
+                    uses_assignment_report = safe_report_path is not None
+        if report is None and report_selection not in {"invalid_final", "remote_error"}:
             if safe_report_path is None:
                 safe_report_path = student_identity.confined_regular_file(target.path, report_path)
             report = load_report(safe_report_path) if safe_report_path is not None else None
@@ -591,7 +618,10 @@ def track_assignments(
             help["path"] = relative_to_root_or_repo(help_log_path, target.path) if help_log_path else ""
         help["activity_id"] = activity_id
         grading = grading_summary(report)
-        grading["provisional"] = report is not None and report_selection != "final"
+        if remote_report_result is not None and remote_report_result.configured and report is not None:
+            grading["provisional"] = remote_report_result.provisional
+        else:
+            grading["provisional"] = report is not None and report_selection != "final"
         source_file_path = report_source_path(target, report.get("source")) if report else None
         source_path = relative_to_repo(source_file_path, target.path) if source_file_path is not None else None
         submitted = report is not None
@@ -626,6 +656,21 @@ def track_assignments(
                     "report_schema_version": report.get("schema_version") if report else None,
                     "report_status": report.get("status") if report else None,
                     "report_selection": report_selection,
+                    "report_authority": (
+                        remote_report_result.authority
+                        if remote_report_result is not None and remote_report_result.configured
+                        else ("local" if report is not None else None)
+                    ),
+                    "report_provenance": (
+                        remote_report_result.provenance
+                        if remote_report_result is not None and remote_report_result.configured
+                        else None
+                    ),
+                    "report_error": (
+                        remote_report_result.error
+                        if remote_report_result is not None and remote_report_result.configured
+                        else None
+                    ),
                     "attempt_id": report.get("attempt_id") if report else None,
                     "final_selected": report_selection == "final",
                 },

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -140,6 +140,12 @@ def local_repo_path(path: Path, server_root: Path | None) -> str:
 
 def git_stdout(args: list[str], cwd: Path) -> str:
     """Run a small git query and return stdout, or an empty string."""
+    return git_stdout_optional(args, cwd) or ""
+
+
+def git_stdout_optional(args: list[str], cwd: Path) -> str | None:
+    """Run a small git query while preserving command failure."""
+
     try:
         completed = subprocess.run(
             args,
@@ -150,9 +156,9 @@ def git_stdout(args: list[str], cwd: Path) -> str:
             timeout=5,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return ""
+        return None
     if completed.returncode:
-        return ""
+        return None
     return completed.stdout.strip()
 
 
@@ -179,7 +185,15 @@ def checkout_matches_commit(target: TrackingTarget, commit: str | None) -> bool:
     clean_commit = str(commit or "").strip().lower()
     if not re.fullmatch(r"[0-9a-f]{40}", clean_commit):
         return False
-    return git_stdout(["git", "rev-parse", "HEAD"], target.path).lower() == clean_commit
+    head = git_stdout_optional(["git", "rev-parse", "HEAD"], target.path)
+    head_matches = head is not None and head.lower() == clean_commit
+    if not head_matches:
+        return False
+    status = git_stdout_optional(
+        ["git", "status", "--porcelain", "--untracked-files=normal"],
+        target.path,
+    )
+    return status == ""
 
 
 def github_repo_url(target: TrackingTarget) -> str | None:

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -140,7 +140,17 @@ def local_repo_path(path: Path, server_root: Path | None) -> str:
 
 def git_stdout(args: list[str], cwd: Path) -> str:
     """Run a small git query and return stdout, or an empty string."""
-    completed = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False, timeout=5)
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
     if completed.returncode:
         return ""
     return completed.stdout.strip()
@@ -161,6 +171,15 @@ def git_root(path: Path) -> Path | None:
     """Return the git root that contains path, if available."""
     output = git_stdout(["git", "rev-parse", "--show-toplevel"], path)
     return Path(output).resolve() if output else None
+
+
+def checkout_matches_commit(target: TrackingTarget, commit: str | None) -> bool:
+    """Return whether the local checkout is exactly the report commit."""
+
+    clean_commit = str(commit or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{40}", clean_commit):
+        return False
+    return git_stdout(["git", "rev-parse", "HEAD"], target.path).lower() == clean_commit
 
 
 def github_repo_url(target: TrackingTarget) -> str | None:
@@ -663,7 +682,20 @@ def track_assignments(
             grading["provisional"] = remote_report_result.provisional
         else:
             grading["provisional"] = report is not None and report_selection != "final"
-        source_file_path = report_source_path(target, report.get("source")) if report else None
+        remote_report = (
+            remote_report_result is not None
+            and remote_report_result.configured
+            and report is not None
+        )
+        local_preview_allowed = (
+            not remote_report
+            or checkout_matches_commit(target, report.get("commit"))
+        )
+        source_file_path = (
+            report_source_path(target, report.get("source"))
+            if report and local_preview_allowed
+            else None
+        )
         source_path = relative_to_repo(source_file_path, target.path) if source_file_path is not None else None
         remote_report_error = (
             remote_report_result is not None
@@ -697,7 +729,14 @@ def track_assignments(
                 "submission": {
                     "source_path": source_path,
                     "source_github_url": github_file_url(target, repo_url, str(source_file_path) if source_file_path else None, report.get("commit") if report else None),
-                    "files": submission_files(target, activity_id, report, repo_url),
+                    "files": (
+                        submission_files(target, activity_id, report, repo_url)
+                        if local_preview_allowed
+                        else []
+                    ),
+                    "local_preview_status": (
+                        "available" if local_preview_allowed else "commit_mismatch"
+                    ),
                     "submitted_at": submitted_at,
                     "commit": report.get("commit") if report else None,
                     "report_path": relative_report_path,

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -547,15 +547,17 @@ def track_assignments(
 
     students: list[dict[str, Any]] = []
     for target in targets:
-        repo_url = github_repo_url(target)
         report_path = default_report_path(target, activity_id)
         stable_student_id = student_identity.legacy_display_student_id(target.student)
+        repository_ref = target.repo
         if assignment_id and server_root is not None:
             stable_student_id = assignment_student_id(target, assignment, server_root)
+            repository_ref = assignment_repository_ref(target, assignment, server_root)
             help_log_path = student_help_service.server_help_log_path(server_root, stable_student_id, assignment_id)
         else:
             legacy_help_path = student_help_service.help_log_path(target.path, activity_id)
             help_log_path = student_identity.confined_regular_file(target.path, legacy_help_path)
+        repo_url = github_url_from_remote(repository_ref) or github_repo_url(target)
         safe_report_path = None
         uses_assignment_report = False
         report = None
@@ -576,24 +578,22 @@ def track_assignments(
                 report_selection = "invalid_final"
             else:
                 if report_source is not None:
-                    remote_report_result = report_source.resolve(
-                        thebitlab_tracking_reports.TrackingReportRequest(
-                            activity_id=activity_id,
-                            assignment_id=assignment_id,
-                            student_id=stable_student_id,
-                            repo_ref=assignment_repository_ref(
-                                target,
-                                assignment,
-                                server_root,
-                            ),
+                    remote_report_result = (
+                        thebitlab_tracking_reports.canonical_tracking_report_result(
+                            report_source.resolve(
+                                thebitlab_tracking_reports.TrackingReportRequest(
+                                    activity_id=activity_id,
+                                    assignment_id=assignment_id,
+                                    student_id=stable_student_id,
+                                    repo_ref=repository_ref,
+                                )
+                            )
                         )
                     )
                     if remote_report_result.configured:
                         uses_assignment_report = True
                         report = remote_report_result.report
-                        report_selection = remote_report_result.selection or (
-                            "github_actions_artifact" if report is not None else "remote_error"
-                        )
+                        report_selection = remote_report_result.selection
                 if remote_report_result is None or not remote_report_result.configured:
                     assignment_report_path = (
                         report_path.parent
@@ -678,7 +678,7 @@ def track_assignments(
             {
                 "student": target.student,
                 "student_id": stable_student_id,
-                "repo": target.repo,
+                "repo": repository_ref,
                 "repo_path": local_repo_path(target.path, server_root),
                 "repo_github_url": repo_url,
                 "assigned": True,

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -27,6 +27,7 @@ from scripts.thebitlab_technical_services import grading_dict_from_grade_activit
 
 
 NO_DUE_DATE_STATUS = "no_due_date"
+SUBMISSION_UNKNOWN_STATUS = "submission_unknown"
 EXCLUDED_SUBMISSION_DIRS = {".git", "__pycache__", ".pytest_cache", "node_modules", "bin", "build", "dist"}
 EXCLUDED_SUBMISSION_SUFFIXES = {".pyc", ".pyo", ".o", ".obj", ".exe", ".dll", ".so", ".dylib", ".class"}
 GITHUB_RE = re.compile(r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^/\s]+?)(?:\.git)?/?$")
@@ -431,15 +432,15 @@ def selected_final_report(
     return report, safe_path, True
 
 
-def assignment_student_id(
+def assignment_target_record(
     target: TrackingTarget,
     assignment: dict[str, Any] | None,
     server_root: Path,
-) -> str:
-    """Resolve the stable student id recorded for a tracking target."""
+) -> dict[str, Any] | None:
+    """Return the assignment target matching one local tracking target."""
 
     if assignment is None:
-        return target.student
+        return None
     target_path = target.path.resolve()
     target_repo = clean_metadata(target.repo)
     for assignment_target in assignment.get("targets", []):
@@ -461,11 +462,40 @@ def assignment_student_id(
         if target_repo and clean_metadata(assignment_target.get("repo_ref")) == target_repo:
             matches_target = True
         if matches_target:
-            student_id = student_identity.target_student_id(assignment_target)
-            return student_id or target.student
+            return assignment_target
     raise ValueError(
         f"Il target {target.student} non appartiene all'assegnazione richiesta."
     )
+
+
+def assignment_student_id(
+    target: TrackingTarget,
+    assignment: dict[str, Any] | None,
+    server_root: Path,
+) -> str:
+    """Resolve the stable student id recorded for a tracking target."""
+
+    assignment_target = assignment_target_record(target, assignment, server_root)
+    if assignment_target is None:
+        return target.student
+    student_id = student_identity.target_student_id(assignment_target)
+    return student_id or target.student
+
+
+def assignment_repository_ref(
+    target: TrackingTarget,
+    assignment: dict[str, Any] | None,
+    server_root: Path,
+) -> str:
+    """Resolve the GitHub repository recorded by the teacher assignment."""
+
+    assignment_target = assignment_target_record(target, assignment, server_root)
+    if assignment_target is not None:
+        repo_ref = clean_metadata(assignment_target.get("repo_ref"))
+        if repo_ref:
+            return repo_ref
+    target_repo = clean_metadata(target.repo)
+    return target_repo if OWNER_REPO_RE.fullmatch(target_repo) else ""
 
 
 def track_assignments(
@@ -551,7 +581,11 @@ def track_assignments(
                             activity_id=activity_id,
                             assignment_id=assignment_id,
                             student_id=stable_student_id,
-                            repo_ref=target.repo,
+                            repo_ref=assignment_repository_ref(
+                                target,
+                                assignment,
+                                server_root,
+                            ),
                         )
                     )
                     if remote_report_result.configured:
@@ -624,14 +658,22 @@ def track_assignments(
             grading["provisional"] = report is not None and report_selection != "final"
         source_file_path = report_source_path(target, report.get("source")) if report else None
         source_path = relative_to_repo(source_file_path, target.path) if source_file_path is not None else None
-        submitted = report is not None
-        submitted_at = report.get("submitted_at") if report else None
-        status, late = submission_status(
-            submitted=submitted,
-            submitted_at=submitted_at,
-            due_at=normalized_due_at,
-            now=normalized_now,
+        remote_report_error = (
+            remote_report_result is not None
+            and remote_report_result.configured
+            and report is None
         )
+        submitted = None if remote_report_error else report is not None
+        submitted_at = report.get("submitted_at") if report else None
+        if remote_report_error:
+            status, late = SUBMISSION_UNKNOWN_STATUS, False
+        else:
+            status, late = submission_status(
+                submitted=bool(submitted),
+                submitted_at=submitted_at,
+                due_at=normalized_due_at,
+                now=normalized_now,
+            )
         students.append(
             {
                 "student": target.student,

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -564,44 +564,44 @@ def track_assignments(
         report_selection = None
         remote_report_result = None
         if assignment_id:
-            report, safe_report_path, final_selection_exists = selected_final_report(
-                target,
-                report_path,
-                assignment_id,
-                activity_id,
-            )
-            if report is not None:
-                uses_assignment_report = True
-                report_selection = "final"
-            elif final_selection_exists:
-                uses_assignment_report = True
-                report_selection = "invalid_final"
-            else:
-                if report_source is not None:
-                    remote_report_result = (
-                        thebitlab_tracking_reports.canonical_tracking_report_result(
-                            report_source.resolve(
-                                thebitlab_tracking_reports.TrackingReportRequest(
-                                    activity_id=activity_id,
-                                    assignment_id=assignment_id,
-                                    student_id=stable_student_id,
-                                    repo_ref=repository_ref,
-                                )
+            if report_source is not None:
+                remote_report_result = (
+                    thebitlab_tracking_reports.canonical_tracking_report_result(
+                        report_source.resolve(
+                            thebitlab_tracking_reports.TrackingReportRequest(
+                                activity_id=activity_id,
+                                assignment_id=assignment_id,
+                                student_id=stable_student_id,
+                                repo_ref=repository_ref,
                             )
                         )
                     )
-                    if remote_report_result.configured:
-                        uses_assignment_report = True
-                        report = remote_report_result.report
-                        report_selection = remote_report_result.selection
-                        if report is not None:
-                            repository_ref = str(
-                                (remote_report_result.provenance or {}).get("repository", "")
-                            )
-                            repo_url = github_url_from_remote(repository_ref)
-                        elif not repository_ref:
-                            repo_url = None
-                if remote_report_result is None or not remote_report_result.configured:
+                )
+            if remote_report_result is not None and remote_report_result.configured:
+                uses_assignment_report = True
+                report = remote_report_result.report
+                report_selection = remote_report_result.selection
+                if report is not None:
+                    repository_ref = str(
+                        (remote_report_result.provenance or {}).get("repository", "")
+                    )
+                    repo_url = github_url_from_remote(repository_ref)
+                elif not repository_ref:
+                    repo_url = None
+            else:
+                report, safe_report_path, final_selection_exists = selected_final_report(
+                    target,
+                    report_path,
+                    assignment_id,
+                    activity_id,
+                )
+                if report is not None:
+                    uses_assignment_report = True
+                    report_selection = "final"
+                elif final_selection_exists:
+                    uses_assignment_report = True
+                    report_selection = "invalid_final"
+                else:
                     assignment_report_path = (
                         report_path.parent
                         / "assignments"

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -140,12 +140,6 @@ def local_repo_path(path: Path, server_root: Path | None) -> str:
 
 def git_stdout(args: list[str], cwd: Path) -> str:
     """Run a small git query and return stdout, or an empty string."""
-    return git_stdout_optional(args, cwd) or ""
-
-
-def git_stdout_optional(args: list[str], cwd: Path) -> str | None:
-    """Run a small git query while preserving command failure."""
-
     try:
         completed = subprocess.run(
             args,
@@ -156,9 +150,9 @@ def git_stdout_optional(args: list[str], cwd: Path) -> str | None:
             timeout=5,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return None
+        return ""
     if completed.returncode:
-        return None
+        return ""
     return completed.stdout.strip()
 
 
@@ -177,23 +171,6 @@ def git_root(path: Path) -> Path | None:
     """Return the git root that contains path, if available."""
     output = git_stdout(["git", "rev-parse", "--show-toplevel"], path)
     return Path(output).resolve() if output else None
-
-
-def checkout_matches_commit(target: TrackingTarget, commit: str | None) -> bool:
-    """Return whether the local checkout is exactly the report commit."""
-
-    clean_commit = str(commit or "").strip().lower()
-    if not re.fullmatch(r"[0-9a-f]{40}", clean_commit):
-        return False
-    head = git_stdout_optional(["git", "rev-parse", "HEAD"], target.path)
-    head_matches = head is not None and head.lower() == clean_commit
-    if not head_matches:
-        return False
-    status = git_stdout_optional(
-        ["git", "status", "--porcelain", "--untracked-files=normal"],
-        target.path,
-    )
-    return status == ""
 
 
 def github_repo_url(target: TrackingTarget) -> str | None:
@@ -701,10 +678,7 @@ def track_assignments(
             and remote_report_result.configured
             and report is not None
         )
-        local_preview_allowed = (
-            not remote_report
-            or checkout_matches_commit(target, report.get("commit"))
-        )
+        local_preview_allowed = not remote_report
         source_file_path = (
             report_source_path(target, report.get("source"))
             if report and local_preview_allowed
@@ -749,7 +723,7 @@ def track_assignments(
                         else []
                     ),
                     "local_preview_status": (
-                        "available" if local_preview_allowed else "commit_mismatch"
+                        "available" if local_preview_allowed else "remote_commit_only"
                     ),
                     "submitted_at": submitted_at,
                     "commit": report.get("commit") if report else None,

--- a/templates/student-repository/.github/workflows/thebitlab-grading.yml
+++ b/templates/student-repository/.github/workflows/thebitlab-grading.yml
@@ -10,6 +10,12 @@ on:
         description: "Identificativo stabile dell'attivita"
         required: true
         default: "c-base-somma-001"
+      assignment_id:
+        description: "Identificativo stabile dell'assegnazione"
+        required: true
+      student_id:
+        description: "Identificativo stabile dello studente"
+        required: true
       activity_path:
         description: "Path della activity JSON nel repository studente"
         required: true
@@ -54,6 +60,9 @@ jobs:
             --activity "student-work/${{ inputs.activity_path }}" \
             --source "student-work/${{ inputs.source_path }}" \
             --language "${{ inputs.language }}" \
+            --assignment-id "${{ inputs.assignment_id }}" \
+            --student-id "${{ inputs.student_id }}" \
+            --commit "${{ github.sha }}" \
             --docker \
             --report "$RUNNER_TEMP/thebitlab-report/report.json"
 

--- a/templates/student-repository/.github/workflows/thebitlab-grading.yml
+++ b/templates/student-repository/.github/workflows/thebitlab-grading.yml
@@ -1,4 +1,4 @@
-name: TheBitLab grading
+name: TheBitLab local grading preview
 
 permissions:
   contents: read
@@ -54,14 +54,20 @@ jobs:
         run: docker build -t thebitlab-assignment-runner -f thebitlab/docker/assignment-runner/Dockerfile thebitlab
 
       - name: Run deterministic grading
+        env:
+          ACTIVITY_PATH: ${{ inputs.activity_path }}
+          SOURCE_PATH: ${{ inputs.source_path }}
+          LANGUAGE: ${{ inputs.language }}
+          ASSIGNMENT_ID: ${{ inputs.assignment_id }}
+          STUDENT_ID: ${{ inputs.student_id }}
         run: |
           mkdir -p "$RUNNER_TEMP/thebitlab-report"
           python thebitlab/scripts/grade_activity.py \
-            --activity "student-work/${{ inputs.activity_path }}" \
-            --source "student-work/${{ inputs.source_path }}" \
-            --language "${{ inputs.language }}" \
-            --assignment-id "${{ inputs.assignment_id }}" \
-            --student-id "${{ inputs.student_id }}" \
+            --activity "student-work/$ACTIVITY_PATH" \
+            --source "student-work/$SOURCE_PATH" \
+            --language "$LANGUAGE" \
+            --assignment-id "$ASSIGNMENT_ID" \
+            --student-id "$STUDENT_ID" \
             --commit "${{ github.sha }}" \
             --docker \
             --report "$RUNNER_TEMP/thebitlab-report/report.json"

--- a/templates/student-repository/README.md
+++ b/templates/student-repository/README.md
@@ -91,7 +91,9 @@ Il workflow di anteprima:
 
 Questo artifact non viene usato come fonte autorevole dal registro docente. Il
 docente avvia il workflow protetto nel repository TheBitLab, fissando repository e
-SHA della consegna, identita dello studente e assegnazione.
+SHA della consegna, identita dello studente e assegnazione. Activity e test usati
+per il voto provengono dal repository docente: dal repository studente viene letto
+soltanto il sorgente consegnato.
 
 Il nome dell'artifact contiene activity e linguaggio, per esempio:
 

--- a/templates/student-repository/README.md
+++ b/templates/student-repository/README.md
@@ -64,12 +64,18 @@ Richiede questi input:
 | Input | Esempio |
 |---|---|
 | `activity_id` | `c-base-somma-001` |
+| `assignment_id` | `assignment-c-base-somma-001-3a` |
+| `student_id` | `rossi-mario` |
 | `activity_path` | `assignments/c-base-somma-001/activity.json` |
 | `source_path` | `assignments/c-base-somma-001/main.c` |
 | `language` | `c` |
 | `thebitlab_ref` | `main`, oppure tag/commit indicato dal docente |
 
 `activity_id` deve essere scritto come slug sicuro: usa lettere minuscole, numeri e trattini. Evita spazi, slash e caratteri speciali.
+
+`assignment_id` e `student_id` devono coincidere con i valori comunicati dal docente:
+entrano nel report autorevole e impediscono di attribuire il grading alla consegna o allo
+studente sbagliati.
 
 Il workflow:
 

--- a/templates/student-repository/README.md
+++ b/templates/student-repository/README.md
@@ -25,7 +25,10 @@ feedback/
 | `feedback/` | Feedback del docente o feedback AI assisted approvato |
 | `.github/workflows/` | Workflow GitHub Actions per il grading |
 
-Il report autorevole e quello prodotto dalla GitHub Action come artifact. I file in `reports/` servono solo come copie locali o appunti.
+Il workflow nel repository studente produce solo un'anteprima tecnica. Il report
+autorevole viene prodotto dal workflow protetto `Grade student assignment` nel
+repository docente TheBitLab. I file in `reports/` servono solo come copie locali
+o appunti.
 
 ## Come consegnare un esercizio
 
@@ -34,8 +37,8 @@ Per l'MVP, il flusso consigliato e:
 1. Crea o apri la cartella dell'attivita in `assignments/<activity_id>/`.
 2. Scrivi il file indicato nel README della consegna, per esempio `main.c` per C o `main.py` per Python.
 3. Fai commit e push su `main`.
-4. Avvia o controlla la GitHub Action di grading.
-5. Leggi il report prodotto come artifact.
+4. Avvia la GitHub Action locale se vuoi un'anteprima.
+5. Attendi il grading autorevole avviato dal docente sul commit consegnato.
 
 Esempio:
 
@@ -47,12 +50,13 @@ Il docente puo generare questa cartella con lo script TheBitLab di scaffold cons
 
 ## Grading manuale da GitHub Actions
 
-Il workflow `TheBitLab grading` puo essere avviato manualmente dalla scheda Actions.
+Il workflow `TheBitLab local grading preview` puo essere avviato manualmente dalla
+scheda Actions per controllare il codice prima della correzione docente.
 
 Passi da seguire su GitHub:
 
 1. Apri la scheda **Actions** del repository.
-2. Clicca sul workflow **TheBitLab grading**.
+2. Clicca sul workflow **TheBitLab local grading preview**.
 3. Clicca su **Run workflow**.
 4. Compila i campi richiesti.
 5. Clicca sul pulsante verde **Run workflow**.
@@ -74,16 +78,20 @@ Richiede questi input:
 `activity_id` deve essere scritto come slug sicuro: usa lettere minuscole, numeri e trattini. Evita spazi, slash e caratteri speciali.
 
 `assignment_id` e `student_id` devono coincidere con i valori comunicati dal docente:
-entrano nel report autorevole e impediscono di attribuire il grading alla consegna o allo
-studente sbagliati.
+entrano nel report di anteprima. Il workflow docente li verifica nuovamente rispetto
+al binding autorevole.
 
-Il workflow:
+Il workflow di anteprima:
 
 1. scarica questo repository studente;
 2. scarica il repository sorgente `TheBitPoets/2cornot2c`;
 3. costruisce l'immagine Docker del runner;
 4. esegue il grading in sandbox;
-5. carica il report come artifact.
+5. carica un report di anteprima come artifact.
+
+Questo artifact non viene usato come fonte autorevole dal registro docente. Il
+docente avvia il workflow protetto nel repository TheBitLab, fissando repository e
+SHA della consegna, identita dello studente e assegnazione.
 
 Il nome dell'artifact contiene activity e linguaggio, per esempio:
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -553,6 +553,21 @@ def test_report_selection_badges_distinguish_final_provisional_and_invalid() -> 
           grading: { provisional: true },
         }).compactLabel, "PROV");
         assert.equal(tested.reportSelectionState({
+          submitted: true,
+          submission: { report_selection: "github_actions_artifact" },
+          grading: { provisional: true },
+        }).label, "Remoto verificato");
+        assert.equal(tested.reportSelectionState({
+          submitted: true,
+          submission: { report_selection: "github_actions_artifact" },
+          grading: { provisional: false },
+        }).compactLabel, "REM");
+        assert.equal(tested.reportSelectionState({
+          submitted: null,
+          submission: { report_selection: "remote_error" },
+          grading: { provisional: false },
+        }).label, "Grading remoto non disponibile");
+        assert.equal(tested.reportSelectionState({
           submitted: false,
           submission: { report_selection: "invalid_final" },
           grading: { provisional: false },

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -389,6 +389,9 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         filteredOverviewRows,
         focusOverviewClassFromReport,
         summaryCounts,
+        reportCounts,
+        reportOutcome,
+        coverageReportCounts,
         renderStudentsSummaryCards,
         activeStudentFilterLabel,
         reportSelectionState,
@@ -2926,14 +2929,16 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           { status: "submitted", submitted: true, late: false, grading: { status: "graded_passed", score: 8 } },
           { status: "submitted_late", submitted: true, late: true, grading: { status: "graded_failed", teacher_grade: 5 } },
           { status: "submitted", submitted: true, late: false, grading: { status: "graded_passed", teacher_grade: "" } },
+          { status: "submission_unknown", submitted: null, late: false, grading: {} },
         ]);
         tested.state.report = { class_id: "3A-TPSI", class_label: "3A TPSI", activity_id: "somma", title: "Somma base" };
         tested.state.reportName = "demo-3a/somma.json";
         tested.state.filter = "late";
         assert.equal(JSON.stringify(counts), JSON.stringify({
-          total: 5,
+          total: 6,
           pending: 1,
           missing: 1,
+          unknown: 1,
           submitted: 3,
           late: 1,
           passed: 2,
@@ -2944,16 +2949,17 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           helpAiMissingUsage: 0,
           helpDenied: 0,
           averageGrade: 6.5,
-          missingGrades: 3,
+          missingGrades: 4,
         }));
         assert.equal(JSON.stringify(tested.compactStudentsSummaryItems(counts)), JSON.stringify([
           ["Classe", "3A TPSI"],
           ["Activity", "Somma base"],
           ["Registro", "demo-3a/somma.json"],
           ["Filtri", "In ritardo"],
-          ["Studenti", 5],
+          ["Studenti", 6],
           ["Consegnati", 3],
           ["Mancanti", 1],
+          ["Da verificare", 1],
           ["Ritardo", 1],
           ["KO", 1],
         ]));
@@ -2962,15 +2968,16 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
           ["Activity", "Somma base"],
           ["Registro", "demo-3a/somma.json"],
           ["Filtri", "In ritardo"],
-          ["Studenti", 5],
+          ["Studenti", 6],
           ["Consegnati", 3],
           ["Mancanti", 1],
+          ["Da verificare", 1],
           ["Ritardo", 1],
           ["Pending", 1],
           ["Grading OK", 2],
           ["Grading KO", 1],
           ["Media voto", "6.5"],
-          ["Voti mancanti", 3],
+          ["Voti mancanti", 4],
           ["Aiuti", 0],
           ["Aiuti AI", 0],
           ["Token AI dichiarati", 0],
@@ -2979,6 +2986,29 @@ def test_students_summary_counts_include_grading_and_grades() -> None:
         ]));
         tested.state.filter = "all";
         assert.equal(tested.activeStudentFilterLabel(), "nessuno");
+        """
+    )
+
+
+def test_report_coverage_counts_unknown_submissions_separately() -> None:
+    run_dashboard_js(
+        """
+        const report = {
+          students: [
+            { status: "submitted", submitted: true, late: false },
+            { status: "missing", submitted: false, late: false },
+            { status: "submission_unknown", submitted: null, late: false },
+          ],
+        };
+        assert.equal(JSON.stringify(tested.reportCounts(report)), JSON.stringify({
+          total: 3,
+          submitted: 1,
+          missing: 1,
+          unknown: 1,
+          late: 0,
+        }));
+        assert.equal(tested.reportOutcome(report).label, "1 da verificare");
+        assert.match(tested.coverageReportCounts(report), /1 da verificare/);
         """
     )
 

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -3009,6 +3009,10 @@ def test_report_coverage_counts_unknown_submissions_separately() -> None:
         }));
         assert.equal(tested.reportOutcome(report).label, "1 da verificare");
         assert.match(tested.coverageReportCounts(report), /1 da verificare/);
+        assert.equal(
+          tested.reportOutcome({ ...report, due_at: "2020-01-01T00:00:00Z" }).label,
+          "1 mancanti",
+        );
         """
     )
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -28,6 +28,11 @@ from scripts.student_help_provider import StudentHelpResponse
 def isolated_process_lock_dir(tmp_path, monkeypatch) -> None:
     lock_dir = tmp_path.parent / f"{tmp_path.name}-process-locks"
     monkeypatch.setenv("THEBITLAB_LOCK_DIR", str(lock_dir))
+    monkeypatch.setattr(
+        course_board_server,
+        "GRADING_BINDINGS_PATH",
+        tmp_path / "teacher-grading-bindings.json",
+    )
 
 
 def test_server_bind_rejects_clear_text_network_exposure_by_default() -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -2345,6 +2345,78 @@ def test_generate_assignment_report_preserves_assignment_id(tmp_path, monkeypatc
     assert saved_payload["assignment_id"] == "assignment-python-base-somma-001-3a"
 
 
+def test_grading_tracking_report_source_composes_persisted_bindings(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    binding_path = tmp_path / "teacher-grading-bindings.json"
+    binding_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "thebitlab_grading_bindings.v1",
+                "bindings": [
+                    {
+                        "activity_id": "activity-001",
+                        "assignment_id": "assignment-001",
+                        "student_id": "rossi-mario",
+                        "student_repo_ref": "TheBitPoets/rossi-mario",
+                        "workflow_repo_ref": "TheBitPoets/2cornot2c",
+                        "artifact_name": "grading-assignment-001",
+                        "expected_student_head_sha": "a" * 40,
+                        "expected_workflow_head_sha": "b" * 40,
+                        "expected_submitted_at": "2026-10-20T08:00:00+02:00",
+                        "expected_workflow_run_id": 900,
+                        "final": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(course_board_server, "GRADING_BINDINGS_PATH", binding_path)
+    monkeypatch.setenv("THEBITLAB_GRADING_GITHUB_TOKEN", "github-secret")
+
+    source = course_board_server.grading_tracking_report_source()
+
+    assert isinstance(source, course_board_server.thebitlab_tracking_reports.ArtifactTrackingReportSource)
+
+
+def test_grading_tracking_report_source_requires_token_for_configured_bindings(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    binding_path = tmp_path / "teacher-grading-bindings.json"
+    binding_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "thebitlab_grading_bindings.v1",
+                "bindings": [
+                    {
+                        "activity_id": "activity-001",
+                        "assignment_id": "assignment-001",
+                        "student_id": "rossi-mario",
+                        "student_repo_ref": "TheBitPoets/rossi-mario",
+                        "workflow_repo_ref": "TheBitPoets/2cornot2c",
+                        "artifact_name": "grading-assignment-001",
+                        "expected_student_head_sha": "a" * 40,
+                        "expected_workflow_head_sha": "b" * 40,
+                        "expected_submitted_at": "2026-10-20T08:00:00+02:00",
+                        "expected_workflow_run_id": 900,
+                        "final": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(course_board_server, "GRADING_BINDINGS_PATH", binding_path)
+    monkeypatch.delenv("THEBITLAB_GRADING_GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(course_board_server, "read_secret_env", lambda: {})
+
+    with pytest.raises(ValueError, match="THEBITLAB_GRADING_GITHUB_TOKEN"):
+        course_board_server.grading_tracking_report_source()
+
+
 def test_regenerated_report_preserves_reviewed_ai_feedback() -> None:
     approved = {
         "status": "approved",

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -723,6 +723,50 @@ def test_run_docker_grading_enriches_stdout_report(monkeypatch, tmp_path, capsys
     assert report["source"] == "assignments/activity-001/main.c"
 
 
+def test_main_applies_authorized_roots_without_docker(monkeypatch, tmp_path) -> None:
+    teacher_root = tmp_path / "teacher"
+    student_root = tmp_path / "student"
+    outside = tmp_path / "outside"
+    teacher_root.mkdir()
+    student_root.mkdir()
+    outside.mkdir()
+    activity_path = teacher_root / "activity.json"
+    source_path = outside / "main.py"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "id": "activity-001",
+                "linguaggio": "python",
+                "test_cases": [{"expected_stdout": "1\n"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    source_path.write_text("print(1)\n", encoding="utf-8")
+    monkeypatch.setattr(
+        grade_activity,
+        "parse_args",
+        lambda: argparse.Namespace(
+            activity=activity_path,
+            source=source_path,
+            activity_root=teacher_root,
+            source_root=student_root,
+            language="python",
+            timeout=5,
+            docker=False,
+            report=None,
+            assignment_id=None,
+            student_id=None,
+            commit=None,
+            submitted_at=None,
+            source_repo_path=None,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="source deve trovarsi dentro"):
+        grade_activity.main()
+
+
 def test_docker_command_requires_paths_inside_workspace(tmp_path) -> None:
     outside = tmp_path.parent / "outside.c"
     outside.write_text("int main(void){return 0;}", encoding="utf-8")

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -710,12 +710,14 @@ def test_run_docker_grading_enriches_stdout_report(monkeypatch, tmp_path, capsys
     class Result:
         returncode = 0
         stdout = json.dumps({"passed": True, "status": "passed"})
-        stderr = ""
+        stderr = "warning docker"
 
     monkeypatch.setattr(grade_activity.subprocess, "run", lambda *args, **kwargs: Result())
 
     assert grade_activity.run_docker_grading(Args()) == 0
-    report = json.loads(capsys.readouterr().out)
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert captured.err.strip() == "warning docker"
     assert report["assignment_id"] == "assignment-001"
     assert report["student_id"] == "rossi-mario"
     assert report["commit"] == "a" * 40

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -356,6 +356,22 @@ def test_positive_int_rejects_zero() -> None:
         raise AssertionError("positive_int should reject zero")
 
 
+def test_report_metadata_enriches_remote_tracking_identity() -> None:
+    original = {"activity_id": "activity-001", "status": "passed"}
+
+    enriched = grade_activity.with_report_metadata(
+        original,
+        assignment_id=" assignment-001 ",
+        student_id=" rossi-mario ",
+        commit="a" * 40,
+    )
+
+    assert original == {"activity_id": "activity-001", "status": "passed"}
+    assert enriched["assignment_id"] == "assignment-001"
+    assert enriched["student_id"] == "rossi-mario"
+    assert enriched["commit"] == "a" * 40
+
+
 def test_docker_command_uses_read_only_workspace(tmp_path) -> None:
     activity_path = tmp_path / "activity.json"
     source_path = tmp_path / "main.c"

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -364,12 +364,16 @@ def test_report_metadata_enriches_remote_tracking_identity() -> None:
         assignment_id=" assignment-001 ",
         student_id=" rossi-mario ",
         commit="a" * 40,
+        submitted_at="2026-07-24T18:00:00Z",
+        source_repo_path="assignments/activity-001/main.py",
     )
 
     assert original == {"activity_id": "activity-001", "status": "passed"}
     assert enriched["assignment_id"] == "assignment-001"
     assert enriched["student_id"] == "rossi-mario"
     assert enriched["commit"] == "a" * 40
+    assert enriched["submitted_at"] == "2026-07-24T18:00:00Z"
+    assert enriched["source"] == "assignments/activity-001/main.py"
 
 
 def test_docker_command_uses_read_only_workspace(tmp_path) -> None:
@@ -429,6 +433,53 @@ def test_prepare_docker_workspace_copies_only_runner_inputs(tmp_path) -> None:
     assert copied_activity == workspace / "activity" / "activity.json"
     assert copied_source == workspace / "source" / "main.c"
     assert not (workspace / ".secret").exists()
+
+
+def test_prepare_docker_workspace_rejects_input_outside_authorized_root(tmp_path) -> None:
+    teacher_root = tmp_path / "teacher"
+    student_root = tmp_path / "student"
+    outside = tmp_path / "outside"
+    teacher_root.mkdir()
+    student_root.mkdir()
+    outside.mkdir()
+    activity_path = teacher_root / "activity.json"
+    source_path = outside / "main.py"
+    activity_path.write_text("{}", encoding="utf-8")
+    source_path.write_text("print(1)\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="source deve trovarsi dentro"):
+        grade_activity.prepare_docker_workspace(
+            activity_path,
+            source_path,
+            tmp_path / "docker",
+            activity_root=teacher_root,
+            source_root=student_root,
+        )
+
+
+def test_prepare_docker_workspace_rejects_symlink_escaping_source_root(tmp_path) -> None:
+    teacher_root = tmp_path / "teacher"
+    student_root = tmp_path / "student"
+    teacher_root.mkdir()
+    student_root.mkdir()
+    activity_path = teacher_root / "activity.json"
+    outside = tmp_path / "secret.py"
+    linked_source = student_root / "main.py"
+    activity_path.write_text("{}", encoding="utf-8")
+    outside.write_text("print('secret')\n", encoding="utf-8")
+    try:
+        linked_source.symlink_to(outside)
+    except OSError:
+        pytest.skip("Creazione symlink non consentita su questa piattaforma.")
+
+    with pytest.raises(ValueError, match="source deve trovarsi dentro"):
+        grade_activity.prepare_docker_workspace(
+            activity_path,
+            linked_source,
+            tmp_path / "docker",
+            activity_root=teacher_root,
+            source_root=student_root,
+        )
 
 
 def test_run_docker_grading_reports_missing_docker(monkeypatch, tmp_path) -> None:
@@ -637,6 +688,39 @@ def test_run_docker_grading_writes_report_on_host(monkeypatch, tmp_path) -> None
 
     assert grade_activity.run_docker_grading(Args()) == 0
     assert json.loads(Args.report.read_text(encoding="utf-8")) == {"passed": True, "status": "passed"}
+
+
+def test_run_docker_grading_enriches_stdout_report(monkeypatch, tmp_path, capsys) -> None:
+    class Args:
+        activity = tmp_path / "activity.json"
+        source = tmp_path / "main.c"
+        report = None
+        language = "c"
+        timeout = 5
+        docker_image = "thebitlab-assignment-runner"
+        assignment_id = "assignment-001"
+        student_id = "rossi-mario"
+        commit = "a" * 40
+        submitted_at = "2026-07-24T18:00:00Z"
+        source_repo_path = "assignments/activity-001/main.c"
+
+    Args.activity.write_text("{}", encoding="utf-8")
+    Args.source.write_text("int main(void){return 0;}", encoding="utf-8")
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps({"passed": True, "status": "passed"})
+        stderr = ""
+
+    monkeypatch.setattr(grade_activity.subprocess, "run", lambda *args, **kwargs: Result())
+
+    assert grade_activity.run_docker_grading(Args()) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["assignment_id"] == "assignment-001"
+    assert report["student_id"] == "rossi-mario"
+    assert report["commit"] == "a" * 40
+    assert report["submitted_at"] == "2026-07-24T18:00:00Z"
+    assert report["source"] == "assignments/activity-001/main.c"
 
 
 def test_docker_command_requires_paths_inside_workspace(tmp_path) -> None:

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+def test_trusted_grading_workflow_separates_student_and_workflow_commits() -> None:
+    source = Path(".github/workflows/grade-student-assignment.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Checkout trusted TheBitLab source" in source
+    assert "Checkout exact student commit" in source
+    assert "ref: ${{ inputs.student_head_sha }}" in source
+    assert '--commit "$STUDENT_HEAD_SHA"' in source
+    assert '--assignment-id "$ASSIGNMENT_ID"' in source
+    assert '--student-id "$STUDENT_ID"' in source
+    assert "Upload authoritative grading report" in source
+
+
+def test_student_preview_workflow_does_not_interpolate_inputs_in_shell() -> None:
+    source = Path(
+        "templates/student-repository/.github/workflows/thebitlab-grading.yml"
+    ).read_text(encoding="utf-8")
+    run_block = source.split("      - name: Run deterministic grading", maxsplit=1)[1]
+    run_block = run_block.split("      - name: Upload grading report", maxsplit=1)[0]
+
+    assert "env:" in run_block
+    assert '--activity "student-work/$ACTIVITY_PATH"' in run_block
+    assert '--source "student-work/$SOURCE_PATH"' in run_block
+    assert '--assignment-id "$ASSIGNMENT_ID"' in run_block
+    assert '${{ inputs.activity_path }}' not in run_block.split("        run: |", maxsplit=1)[1]
+    assert '${{ inputs.assignment_id }}' not in run_block.split("        run: |", maxsplit=1)[1]

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -6,6 +6,10 @@ def test_trusted_grading_workflow_separates_student_and_workflow_commits() -> No
         encoding="utf-8"
     )
 
+    assert "actions/checkout@v4" not in source
+    assert "actions/upload-artifact@v4" not in source
+    assert source.count("actions/checkout@11d5960a326750d5838078e36cf38b85af677262") == 2
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in source
     assert "Checkout trusted TheBitLab source" in source
     assert "Checkout exact student commit" in source
     assert "ref: ${{ inputs.student_head_sha }}" in source

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -9,7 +9,15 @@ def test_trusted_grading_workflow_separates_student_and_workflow_commits() -> No
     assert "Checkout trusted TheBitLab source" in source
     assert "Checkout exact student commit" in source
     assert "ref: ${{ inputs.student_head_sha }}" in source
+    assert "THEBITLAB_STUDENT_REPO_TOKEN || github.token" in source
+    assert source.count("persist-credentials: false") == 2
+    assert '--activity "thebitlab/$ACTIVITY_PATH"' in source
+    assert '--source "student-work/$SOURCE_PATH"' in source
     assert '--commit "$STUDENT_HEAD_SHA"' in source
+    assert '--submitted-at "$(date -u' in source
+    assert '--source-repo-path "$SOURCE_PATH"' in source
+    assert '--activity-root "thebitlab"' in source
+    assert '--source-root "student-work"' in source
     assert '--assignment-id "$ASSIGNMENT_ID"' in source
     assert '--student-id "$STUDENT_ID"' in source
     assert "Upload authoritative grading report" in source

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -14,7 +14,8 @@ def test_trusted_grading_workflow_separates_student_and_workflow_commits() -> No
     assert '--activity "thebitlab/$ACTIVITY_PATH"' in source
     assert '--source "student-work/$SOURCE_PATH"' in source
     assert '--commit "$STUDENT_HEAD_SHA"' in source
-    assert '--submitted-at "$(date -u' in source
+    assert "submitted_at:" in source
+    assert '--submitted-at "$SUBMITTED_AT"' in source
     assert '--source-repo-path "$SOURCE_PATH"' in source
     assert '--activity-root "thebitlab"' in source
     assert '--source-root "student-work"' in source

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -134,6 +134,7 @@ def run_student_dashboard_js(assertions: str) -> None:
         uniqueStudentsFromOverview,
         populateStudentOptions,
         statusBadge,
+        labStatusBadge,
         gradingBadge,
         gradeValue,
         setCurrentCourseDesign: (design) => {{ currentCourseDesign = design; }},
@@ -454,6 +455,8 @@ def test_student_dashboard_hides_unapproved_feedback_payloads() -> None:
         assert.doesNotMatch(empty, /Bozza/);
         assert.equal(tested.gradeValue({ teacher_grade: null, score: 6 }), 6);
         assert.match(tested.statusBadge({ status: "missing", submitted: false, late: false }), /Mancante/);
+        assert.match(tested.statusBadge({ status: "submission_unknown", submitted: null }), /Consegna da verificare/);
+        assert.match(tested.labStatusBadge({ status: "submission_unknown", submitted: null }), /Report da verificare/);
         assert.match(tested.gradingBadge({ status: "graded_failed" }), /Test falliti/);
         """
     )
@@ -567,10 +570,17 @@ def test_student_dashboard_summarizes_next_open_due_date() -> None:
           status: "assigned",
           submitted: false,
         };
+        const unknown = {
+          activity_id: "remote-unknown",
+          due_at: "2026-10-17T23:59:00+02:00",
+          status: "submission_unknown",
+          submitted: null,
+        };
 
-        assert.equal(tested.nextOpenAssignment([submitted, openLater, openSooner, sameDeadline]).activity_id, "c-array-001");
-        assert.equal(tested.nextOpenDueAt([submitted, openLater, openSooner, sameDeadline]), "2026-10-18T23:59:00+02:00");
-        tested.renderDashboard({ student_id: "rossi-mario", assignments: [submitted, openLater, openSooner, sameDeadline] });
+        assert.equal(tested.nextOpenAssignment([submitted, unknown, openLater, openSooner, sameDeadline]).activity_id, "c-array-001");
+        assert.equal(tested.nextOpenDueAt([submitted, unknown, openLater, openSooner, sameDeadline]), "2026-10-18T23:59:00+02:00");
+        tested.renderDashboard({ student_id: "rossi-mario", assignments: [submitted, unknown, openLater, openSooner, sameDeadline] });
+        assert.match(tested.els.summary.innerHTML, /<strong>Da verificare<\\/strong>\\s*<span>1<\\/span>/);
         assert.match(tested.els.summary.innerHTML, /<strong>Prossima attivita<\\/strong>\\s*<span>c-array-001<\\/span>/);
         assert.match(tested.els.summary.innerHTML, /<strong>Prossima scadenza<\\/strong>\\s*<span>18\\/10\\/26, 23:59<\\/span>/);
         assert.match(tested.els.assignments.innerHTML, /Prossima scadenza/);

--- a/tests/test_student_dashboard_frontend.py
+++ b/tests/test_student_dashboard_frontend.py
@@ -1030,6 +1030,27 @@ def test_student_dashboard_assignment_detail_modal_renders_selected_assignment()
     )
 
 
+def test_student_dashboard_detail_preserves_unknown_submission_state() -> None:
+    run_student_dashboard_js(
+        """
+        const assignment = {
+          activity_id: "remote-unknown",
+          title: "Report remoto",
+          status: "submission_unknown",
+          submitted: null,
+          grading: {},
+        };
+        const card = tested.renderAssignment(assignment, false, 0);
+        const detail = tested.renderAssignmentDetail(assignment);
+
+        assert.match(card, /Consegna da verificare/);
+        assert.doesNotMatch(card, /Consegna mancante/);
+        assert.match(detail, /<strong>Consegnata<\\/strong>\\s*<span>Da verificare<\\/span>/);
+        assert.doesNotMatch(detail, /<strong>Consegnata<\\/strong>\\s*<span>No<\\/span>/);
+        """
+    )
+
+
 def test_student_dashboard_file_modal_lists_submitted_files_separately() -> None:
     run_student_dashboard_js(
         """

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -165,6 +165,31 @@ def test_normalize_register_student_parses_boolean_strings_conservatively() -> N
     assert other_student["late"] is True
 
 
+def test_normalize_register_student_preserves_remote_tracking_states() -> None:
+    verified = thebitlab_contracts.normalize_register_student(
+        {
+            "student": "rossi-mario",
+            "submitted": True,
+            "submission": {"report_selection": "github_actions_artifact"},
+            "grading": {"provisional": True},
+        }
+    )
+    unavailable = thebitlab_contracts.normalize_register_student(
+        {
+            "student": "bianchi-luca",
+            "submitted": None,
+            "status": "submission_unknown",
+            "submission": {"report_selection": "remote_error"},
+            "grading": {"provisional": True},
+        }
+    )
+
+    assert verified["grading"]["provisional"] is True
+    assert unavailable["submitted"] is None
+    assert unavailable["status"] == "submission_unknown"
+    assert unavailable["grading"]["provisional"] is False
+
+
 def test_normalize_submission_parses_late_string_conservatively() -> None:
     submission = thebitlab_contracts.normalize_submission({"late": "false"})
     other_submission = thebitlab_contracts.normalize_submission({"late": "yes"})

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -183,11 +183,28 @@ def test_normalize_register_student_preserves_remote_tracking_states() -> None:
             "grading": {"provisional": True},
         }
     )
+    contradictory = thebitlab_contracts.normalize_register_student(
+        {
+            "student": "verdi-anna",
+            "submitted": False,
+            "status": "submission_unknown",
+            "submission": {"report_selection": "remote_error"},
+        }
+    )
+    missing_flag = thebitlab_contracts.normalize_register_student(
+        {
+            "student": "neri-giulia",
+            "status": "submission_unknown",
+            "submission": {"report_selection": "remote_error"},
+        }
+    )
 
     assert verified["grading"]["provisional"] is True
     assert unavailable["submitted"] is None
     assert unavailable["status"] == "submission_unknown"
     assert unavailable["grading"]["provisional"] is False
+    assert contradictory["submitted"] is None
+    assert missing_flag["submitted"] is None
 
 
 def test_normalize_submission_parses_late_string_conservatively() -> None:

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -199,6 +199,14 @@ def test_normalize_register_student_preserves_remote_tracking_states() -> None:
             "submission": {"report_selection": "remote_error"},
         }
     )
+    contradictory_null = thebitlab_contracts.normalize_register_student(
+        {
+            "student": "gialli-paolo",
+            "submitted": None,
+            "status": "missing",
+            "late": True,
+        }
+    )
 
     assert verified["grading"]["provisional"] is True
     assert unavailable["submitted"] is None
@@ -207,6 +215,8 @@ def test_normalize_register_student_preserves_remote_tracking_states() -> None:
     assert contradictory["submitted"] is None
     assert contradictory["late"] is False
     assert missing_flag["submitted"] is None
+    assert contradictory_null["status"] == "submission_unknown"
+    assert contradictory_null["late"] is False
 
 
 def test_normalize_submission_parses_late_string_conservatively() -> None:

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -187,6 +187,7 @@ def test_normalize_register_student_preserves_remote_tracking_states() -> None:
         {
             "student": "verdi-anna",
             "submitted": False,
+            "late": True,
             "status": "submission_unknown",
             "submission": {"report_selection": "remote_error"},
         }
@@ -204,6 +205,7 @@ def test_normalize_register_student_preserves_remote_tracking_states() -> None:
     assert unavailable["status"] == "submission_unknown"
     assert unavailable["grading"]["provisional"] is False
     assert contradictory["submitted"] is None
+    assert contradictory["late"] is False
     assert missing_flag["submitted"] is None
 
 

--- a/tests/test_thebitlab_contracts.py
+++ b/tests/test_thebitlab_contracts.py
@@ -217,6 +217,7 @@ def test_normalize_register_student_preserves_remote_tracking_states() -> None:
     assert missing_flag["submitted"] is None
     assert contradictory_null["status"] == "submission_unknown"
     assert contradictory_null["late"] is False
+    assert contradictory_null["grading"]["provisional"] is False
 
 
 def test_normalize_submission_parses_late_string_conservatively() -> None:

--- a/tests/test_thebitlab_services.py
+++ b/tests/test_thebitlab_services.py
@@ -247,6 +247,40 @@ def test_assignment_overview_exposes_canonical_attempt_selection(tmp_path) -> No
     assert rows["non-valido"]["grading_provisional"] is False
 
 
+def test_assignment_views_preserve_unknown_remote_submission_state(tmp_path) -> None:
+    service = assignment_overview_service(tmp_path)
+    reports_dir = tmp_path / "teacher-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "remote.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "activity-remota",
+                "students": [
+                    {
+                        "student": "rossi-mario",
+                        "student_id": "rossi-mario",
+                        "status": "submission_unknown",
+                        "submitted": None,
+                        "submission": {
+                            "report_selection": "remote_error",
+                            "report_authority": "remote_configured",
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    overview = service.assignment_overview()[0]
+    dashboard = service.student_dashboard("rossi-mario")["assignments"][0]
+
+    assert overview["submitted"] is None
+    assert overview["status"] == "submission_unknown"
+    assert dashboard["submitted"] is None
+    assert dashboard["status"] == "submission_unknown"
+
+
 def test_assignment_service_accepts_protocol_compatible_storage(tmp_path) -> None:
     class FakeAssignmentStorage:
         def safe_teacher_report_path(self, name: str) -> Path:

--- a/tests/test_thebitlab_sqlite_index.py
+++ b/tests/test_thebitlab_sqlite_index.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import sqlite3
 
+import pytest
+
 from scripts.thebitlab_services import AssignmentOverviewService
 from scripts.thebitlab_sqlite_index import (
     initialize_assignment_index,
@@ -179,6 +181,70 @@ def test_initialize_assignment_index_migrates_legacy_submitted_constraint(tmp_pa
     assert submitted_column[3] == 0
     assert tuple(submission) == ("rossi-mario", 0)
     assert tuple(grading) == ("submission-1", "not_run")
+
+
+def test_nullable_submission_migration_rolls_back_and_can_retry(tmp_path) -> None:
+    db_path = tmp_path / "legacy-interrupted.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE submissions (
+              id TEXT PRIMARY KEY,
+              assignment_id TEXT NOT NULL,
+              student_id TEXT NOT NULL,
+              register_id TEXT,
+              status TEXT NOT NULL DEFAULT '',
+              submitted INTEGER NOT NULL DEFAULT 0,
+              submitted_at TEXT,
+              late INTEGER NOT NULL DEFAULT 0,
+              repo_ref TEXT,
+              commit_sha TEXT,
+              source_path TEXT,
+              updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              payload_json TEXT,
+              UNIQUE (assignment_id, student_id)
+            );
+            CREATE TABLE grading_results (
+              id TEXT PRIMARY KEY,
+              submission_id TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT '',
+              tests_passed INTEGER,
+              tests_total INTEGER,
+              score REAL,
+              teacher_grade REAL,
+              graded_at TEXT,
+              payload_json TEXT
+            );
+            """
+        )
+
+        def deny_drop(action, _arg1, _arg2, _db_name, _trigger_name):
+            if action == sqlite3.SQLITE_DROP_TABLE:
+                return sqlite3.SQLITE_DENY
+            return sqlite3.SQLITE_OK
+
+        connection.set_authorizer(deny_drop)
+        with pytest.raises(sqlite3.DatabaseError):
+            initialize_assignment_index(connection)
+    finally:
+        connection.close()
+
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE name='submissions'"
+        ).fetchone()
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE name='submissions_nullable'"
+        ).fetchone() is None
+
+        initialize_assignment_index(connection)
+        submitted_column = next(
+            row for row in connection.execute("PRAGMA table_info(submissions)")
+            if row[1] == "submitted"
+        )
+
+    assert submitted_column[3] == 0
 
 
 def test_rebuild_assignment_index_keeps_one_submission_per_student_assignment(tmp_path) -> None:

--- a/tests/test_thebitlab_sqlite_index.py
+++ b/tests/test_thebitlab_sqlite_index.py
@@ -163,13 +163,11 @@ def test_initialize_assignment_index_migrates_legacy_submitted_constraint(tmp_pa
             VALUES ('grading-1', 'submission-1', 'not_run');
             """
         )
-        connection.row_factory = sqlite3.Row
-
         initialize_assignment_index(connection)
 
         submitted_column = next(
             row for row in connection.execute("PRAGMA table_info(submissions)")
-            if row["name"] == "submitted"
+            if row[1] == "submitted"
         )
         submission = connection.execute(
             "SELECT student_id, submitted FROM submissions"
@@ -178,7 +176,7 @@ def test_initialize_assignment_index_migrates_legacy_submitted_constraint(tmp_pa
             "SELECT submission_id, status FROM grading_results"
         ).fetchone()
 
-    assert submitted_column["notnull"] == 0
+    assert submitted_column[3] == 0
     assert tuple(submission) == ("rossi-mario", 0)
     assert tuple(grading) == ("submission-1", "not_run")
 

--- a/tests/test_thebitlab_sqlite_index.py
+++ b/tests/test_thebitlab_sqlite_index.py
@@ -5,6 +5,7 @@ import sqlite3
 
 from scripts.thebitlab_services import AssignmentOverviewService
 from scripts.thebitlab_sqlite_index import (
+    initialize_assignment_index,
     list_assignment_index_rows,
     rebuild_assignment_index_from_storage,
 )
@@ -51,6 +52,14 @@ def test_rebuild_assignment_index_from_storage_matches_assignment_overview(tmp_p
                         "late": False,
                         "grading": {"status": "not_run"},
                     },
+                    {
+                        "student": "verdi-anna",
+                        "repo": "TheBitPoets/verdi-anna",
+                        "status": "submission_unknown",
+                        "submitted": None,
+                        "late": False,
+                        "grading": {"status": "not_graded"},
+                    },
                 ],
             }
         ),
@@ -62,7 +71,7 @@ def test_rebuild_assignment_index_from_storage_matches_assignment_overview(tmp_p
     indexed_rows = list_assignment_index_rows(db_path)
     overview_rows = AssignmentOverviewService(storage).assignment_overview()
 
-    assert counts == {"reports": 1, "assignments": 1, "submissions": 2, "grading_results": 2}
+    assert counts == {"reports": 1, "assignments": 1, "submissions": 3, "grading_results": 3}
     assert len(indexed_rows) == len(overview_rows)
     assert indexed_rows[0] == {
         "report_path": "teacher-reports/activity.json",
@@ -87,6 +96,91 @@ def test_rebuild_assignment_index_from_storage_matches_assignment_overview(tmp_p
     assert indexed_rows[1]["student"] == "rossi-mario"
     assert indexed_rows[1]["submitted"] is True
     assert indexed_rows[1]["grading_status"] == "graded_passed"
+    assert indexed_rows[2]["student"] == "verdi-anna"
+    assert indexed_rows[2]["status"] == "submission_unknown"
+    assert indexed_rows[2]["submitted"] is None
+
+
+def test_initialize_assignment_index_migrates_legacy_submitted_constraint(tmp_path) -> None:
+    db_path = tmp_path / "legacy.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE assignments (
+              id TEXT PRIMARY KEY,
+              activity_id TEXT NOT NULL,
+              class_id TEXT NOT NULL DEFAULT '',
+              assigned_at TEXT,
+              due_at TEXT,
+              status TEXT NOT NULL DEFAULT '',
+              source_path TEXT,
+              created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              payload_json TEXT
+            );
+            CREATE TABLE registers (
+              id TEXT PRIMARY KEY,
+              assignment_id TEXT,
+              class_id TEXT DEFAULT '',
+              report_path TEXT NOT NULL,
+              generated_at TEXT,
+              updated_at TEXT NOT NULL,
+              source_hash TEXT,
+              payload_json TEXT
+            );
+            CREATE TABLE submissions (
+              id TEXT PRIMARY KEY,
+              assignment_id TEXT NOT NULL,
+              student_id TEXT NOT NULL,
+              register_id TEXT,
+              status TEXT NOT NULL DEFAULT '',
+              submitted INTEGER NOT NULL DEFAULT 0,
+              submitted_at TEXT,
+              late INTEGER NOT NULL DEFAULT 0,
+              repo_ref TEXT,
+              commit_sha TEXT,
+              source_path TEXT,
+              updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              payload_json TEXT,
+              UNIQUE (assignment_id, student_id)
+            );
+            CREATE TABLE grading_results (
+              id TEXT PRIMARY KEY,
+              submission_id TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT '',
+              tests_passed INTEGER,
+              tests_total INTEGER,
+              score REAL,
+              teacher_grade REAL,
+              graded_at TEXT,
+              payload_json TEXT
+            );
+            INSERT INTO assignments(id, activity_id) VALUES ('assignment-1', 'activity-1');
+            INSERT INTO submissions(
+              id, assignment_id, student_id, status, submitted, late
+            ) VALUES ('submission-1', 'assignment-1', 'rossi-mario', 'missing', 0, 0);
+            INSERT INTO grading_results(id, submission_id, status)
+            VALUES ('grading-1', 'submission-1', 'not_run');
+            """
+        )
+        connection.row_factory = sqlite3.Row
+
+        initialize_assignment_index(connection)
+
+        submitted_column = next(
+            row for row in connection.execute("PRAGMA table_info(submissions)")
+            if row["name"] == "submitted"
+        )
+        submission = connection.execute(
+            "SELECT student_id, submitted FROM submissions"
+        ).fetchone()
+        grading = connection.execute(
+            "SELECT submission_id, status FROM grading_results"
+        ).fetchone()
+
+    assert submitted_column["notnull"] == 0
+    assert tuple(submission) == ("rossi-mario", 0)
+    assert tuple(grading) == ("submission-1", "not_run")
 
 
 def test_rebuild_assignment_index_keeps_one_submission_per_student_assignment(tmp_path) -> None:

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -594,6 +594,35 @@ def test_assignment_reports_are_listed_with_counts(tmp_path) -> None:
     assert reports[0]["updated_at"]
 
 
+def test_assignment_report_counts_remote_unknown_separately(tmp_path) -> None:
+    storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [])
+    reports_dir = tmp_path / "teacher-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "remote.json").write_text(
+        json.dumps(
+            {
+                "activity_id": "activity",
+                "students": [
+                    {"student": "consegnato", "submitted": True},
+                    {"student": "mancante", "submitted": False, "status": "missing"},
+                    {
+                        "student": "da-verificare",
+                        "submitted": None,
+                        "status": "submission_unknown",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = storage.list_assignment_reports()[0]
+
+    assert report["submitted"] == 1
+    assert report["not_submitted"] == 1
+    assert report["unknown"] == 1
+
+
 def test_read_assignment_report_normalizes_student_booleans(tmp_path) -> None:
     storage = JsonAssignmentStorage(tmp_path, tmp_path / "teacher-reports", [])
     reports_dir = tmp_path / "teacher-reports"
@@ -696,6 +725,19 @@ def test_assignment_report_reload_canonicalizes_attempt_selection_state(tmp_path
                     "submission": {"report_selection": ["final"], "final_selected": True},
                     "grading": {"provisional": True},
                 },
+                {
+                    "student": "remoto-verificato",
+                    "submitted": True,
+                    "submission": {"report_selection": "github_actions_artifact"},
+                    "grading": {"provisional": True},
+                },
+                {
+                    "student": "remoto-non-disponibile",
+                    "submitted": None,
+                    "status": "submission_unknown",
+                    "submission": {"report_selection": "remote_error"},
+                    "grading": {"provisional": True},
+                },
             ],
         },
     )
@@ -714,6 +756,10 @@ def test_assignment_report_reload_canonicalizes_attempt_selection_state(tmp_path
     assert by_student["non-scalare"]["submission"]["report_selection"] == "invalid_value"
     assert by_student["non-scalare"]["submission"]["final_selected"] is False
     assert by_student["non-scalare"]["grading"]["provisional"] is False
+    assert by_student["remoto-verificato"]["grading"]["provisional"] is True
+    assert by_student["remoto-non-disponibile"]["submitted"] is None
+    assert by_student["remoto-non-disponibile"]["status"] == "submission_unknown"
+    assert by_student["remoto-non-disponibile"]["grading"]["provisional"] is False
 
 
 def test_ai_feedback_demo_report_exposes_teacher_review_states() -> None:

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -171,7 +171,7 @@ def test_artifact_tracking_source_fails_closed_on_mismatched_report_or_provenanc
     assert result.configured is True
     assert result.report is None
     assert result.selection == "remote_error"
-    assert result.authority == "verified_remote"
+    assert result.authority == "remote_configured"
     assert result.provisional is False
     assert message in result.error
 
@@ -187,7 +187,23 @@ def test_artifact_tracking_source_normalizes_expected_acquisition_error() -> Non
     assert result.configured is True
     assert result.report is None
     assert result.selection == "remote_error"
+    assert result.authority == "remote_configured"
     assert result.error == "artifact non disponibile"
+
+
+def test_artifact_tracking_source_accepts_missing_runtime_repo_when_binding_is_trusted() -> None:
+    artifact_source = FakeArtifactSource(
+        AcquiredGradingReport(report=report(), provenance=provenance())
+    )
+    source = tracking_reports.ArtifactTrackingReportSource(
+        artifact_source,
+        [binding()],
+    )
+
+    result = source.resolve(request(repo_ref=""))
+
+    assert result.configured is True
+    assert result.authority == "verified_remote"
 
 
 def test_artifact_tracking_source_rejects_duplicate_or_invalid_bindings() -> None:

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from scripts import thebitlab_tracking_reports as tracking_reports
+from scripts.thebitlab_grading_artifacts import (
+    AcquiredGradingReport,
+    GradingArtifactError,
+    GradingArtifactProvenance,
+)
+
+
+HEAD_SHA = "a" * 40
+
+
+class FakeArtifactSource:
+    def __init__(self, acquired=None, error: Exception | None = None) -> None:
+        self.acquired = acquired
+        self.error = error
+        self.calls: list[tuple[object, ...]] = []
+
+    def acquire_latest_report(
+        self,
+        repo_ref,
+        artifact_name,
+        expected_head_sha,
+        expected_workflow_run_id,
+    ):  # noqa: ANN001
+        self.calls.append(
+            (
+                repo_ref,
+                artifact_name,
+                expected_head_sha,
+                expected_workflow_run_id,
+            )
+        )
+        if self.error is not None:
+            raise self.error
+        return self.acquired
+
+
+def binding(**overrides) -> tracking_reports.TrustedGradingBinding:
+    values = {
+        "activity_id": "python-base-somma-001",
+        "assignment_id": "assignment-001",
+        "student_id": "rossi-mario",
+        "repo_ref": "TheBitPoets/rossi-mario",
+        "artifact_name": "grading-assignment-001",
+        "expected_head_sha": HEAD_SHA,
+        "expected_workflow_run_id": 900,
+        "final": False,
+    }
+    values.update(overrides)
+    return tracking_reports.TrustedGradingBinding(**values)
+
+
+def report(**overrides) -> dict:
+    values = {
+        "activity_id": "python-base-somma-001",
+        "assignment_id": "assignment-001",
+        "commit": HEAD_SHA,
+        "status": "passed",
+        "passed": True,
+        "submitted_at": "2026-10-20T08:00:00+02:00",
+        "tests": [{"name": "somma", "status": "passed", "passed": True}],
+    }
+    values.update(overrides)
+    return values
+
+
+def provenance(**overrides) -> GradingArtifactProvenance:
+    values = {
+        "repository": "TheBitPoets/rossi-mario",
+        "artifact_id": 12,
+        "artifact_name": "grading-assignment-001",
+        "workflow_run_id": 900,
+        "head_sha": HEAD_SHA,
+        "created_at": "2026-10-20T08:05:00Z",
+        "archive_download_url": (
+            "https://api.github.com/repos/TheBitPoets/rossi-mario/actions/artifacts/12/zip"
+        ),
+        "digest": "sha256:abc",
+    }
+    values.update(overrides)
+    return GradingArtifactProvenance(**values)
+
+
+def request(**overrides) -> tracking_reports.TrackingReportRequest:
+    values = {
+        "activity_id": "python-base-somma-001",
+        "assignment_id": "assignment-001",
+        "student_id": "rossi-mario",
+        "repo_ref": "TheBitPoets/rossi-mario",
+    }
+    values.update(overrides)
+    return tracking_reports.TrackingReportRequest(**values)
+
+
+def test_artifact_tracking_source_resolves_verified_remote_report() -> None:
+    artifact_source = FakeArtifactSource(
+        AcquiredGradingReport(report=report(), provenance=provenance())
+    )
+    source = tracking_reports.ArtifactTrackingReportSource(
+        artifact_source,
+        [binding()],
+    )
+
+    result = source.resolve(request())
+
+    assert result.configured is True
+    assert result.report == report()
+    assert result.selection == "github_actions_artifact"
+    assert result.authority == "verified_remote"
+    assert result.provisional is True
+    assert result.error is None
+    assert result.provenance["source"] == "github_actions"
+    assert result.provenance["artifact_id"] == 12
+    assert artifact_source.calls == [
+        (
+            "TheBitPoets/rossi-mario",
+            "grading-assignment-001",
+            HEAD_SHA,
+            900,
+        )
+    ]
+
+
+def test_artifact_tracking_source_skips_students_without_binding() -> None:
+    artifact_source = FakeArtifactSource()
+    source = tracking_reports.ArtifactTrackingReportSource(
+        artifact_source,
+        [binding()],
+    )
+
+    result = source.resolve(request(student_id="bianchi-luca"))
+
+    assert result == tracking_reports.TrackingReportResult(configured=False)
+    assert artifact_source.calls == []
+
+
+@pytest.mark.parametrize(
+    ("changed_report", "changed_provenance", "message"),
+    [
+        ({"activity_id": "other"}, {}, "activity diversa"),
+        ({"assignment_id": "other"}, {}, "assegnazione diversa"),
+        ({"commit": "b" * 40}, {}, "Commit"),
+        ({}, {"repository": "TheBitPoets/altro"}, "repository diverso"),
+        ({}, {"head_sha": "b" * 40}, "SHA diverso"),
+        ({}, {"workflow_run_id": 901}, "workflow run diversa"),
+        ({}, {"artifact_name": "altro"}, "artifact diverso"),
+    ],
+)
+def test_artifact_tracking_source_fails_closed_on_mismatched_report_or_provenance(
+    changed_report: dict,
+    changed_provenance: dict,
+    message: str,
+) -> None:
+    acquired = AcquiredGradingReport(
+        report=report(**changed_report),
+        provenance=provenance(**changed_provenance),
+    )
+    source = tracking_reports.ArtifactTrackingReportSource(
+        FakeArtifactSource(acquired),
+        [binding(final=True)],
+    )
+
+    result = source.resolve(request())
+
+    assert result.configured is True
+    assert result.report is None
+    assert result.selection == "remote_error"
+    assert result.authority == "verified_remote"
+    assert result.provisional is False
+    assert message in result.error
+
+
+def test_artifact_tracking_source_normalizes_expected_acquisition_error() -> None:
+    source = tracking_reports.ArtifactTrackingReportSource(
+        FakeArtifactSource(error=GradingArtifactError("artifact non disponibile")),
+        [binding()],
+    )
+
+    result = source.resolve(request())
+
+    assert result.configured is True
+    assert result.report is None
+    assert result.selection == "remote_error"
+    assert result.error == "artifact non disponibile"
+
+
+def test_artifact_tracking_source_rejects_duplicate_or_invalid_bindings() -> None:
+    artifact_source = FakeArtifactSource()
+    with pytest.raises(ValueError, match="duplicato"):
+        tracking_reports.ArtifactTrackingReportSource(
+            artifact_source,
+            [binding(), replace(binding(), final=True)],
+        )
+    with pytest.raises(ValueError, match="40 caratteri"):
+        tracking_reports.ArtifactTrackingReportSource(
+            artifact_source,
+            [binding(expected_head_sha="abc")],
+        )

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -60,6 +60,7 @@ def report(**overrides) -> dict:
     values = {
         "activity_id": "python-base-somma-001",
         "assignment_id": "assignment-001",
+        "student_id": "rossi-mario",
         "commit": HEAD_SHA,
         "status": "passed",
         "passed": True,
@@ -181,6 +182,7 @@ def test_artifact_tracking_source_skips_students_without_binding() -> None:
     [
         ({"activity_id": "other"}, {}, "activity diversa"),
         ({"assignment_id": "other"}, {}, "assegnazione diversa"),
+        ({"student_id": ""}, {}, "privo dell'identificativo studente"),
         ({"student_id": "bianchi-luca"}, {}, "studente diverso"),
         ({"commit": "b" * 40}, {}, "Commit"),
         ({}, {"repository": "TheBitPoets/altro"}, "repository diverso"),

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -98,6 +98,31 @@ def request(**overrides) -> tracking_reports.TrackingReportRequest:
     return tracking_reports.TrackingReportRequest(**values)
 
 
+def test_canonical_tracking_result_rejects_contradictory_remote_states() -> None:
+    missing_report = tracking_reports.canonical_tracking_report_result(
+        tracking_reports.TrackingReportResult(
+            configured=True,
+            selection="github_actions_artifact",
+            authority="verified_remote",
+        )
+    )
+    missing_provenance = tracking_reports.canonical_tracking_report_result(
+        tracking_reports.TrackingReportResult(
+            configured=True,
+            report={"status": "passed"},
+            selection="github_actions_artifact",
+            authority="verified_remote",
+        )
+    )
+
+    assert missing_report.selection == "remote_error"
+    assert missing_report.authority == "remote_configured"
+    assert missing_report.report is None
+    assert missing_provenance.selection == "remote_error"
+    assert missing_provenance.report is None
+    assert "Provenienza" in missing_provenance.error
+
+
 def test_artifact_tracking_source_resolves_verified_remote_report() -> None:
     artifact_source = FakeArtifactSource(
         AcquiredGradingReport(report=report(), provenance=provenance())

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -14,6 +14,7 @@ from scripts.thebitlab_grading_artifacts import (
 
 
 HEAD_SHA = "a" * 40
+WORKFLOW_SHA = "b" * 40
 
 
 class FakeArtifactSource:
@@ -47,9 +48,11 @@ def binding(**overrides) -> tracking_reports.TrustedGradingBinding:
         "activity_id": "python-base-somma-001",
         "assignment_id": "assignment-001",
         "student_id": "rossi-mario",
-        "repo_ref": "TheBitPoets/rossi-mario",
+        "student_repo_ref": "TheBitPoets/rossi-mario",
+        "workflow_repo_ref": "TheBitPoets/2cornot2c",
         "artifact_name": "grading-assignment-001",
-        "expected_head_sha": HEAD_SHA,
+        "expected_student_head_sha": HEAD_SHA,
+        "expected_workflow_head_sha": WORKFLOW_SHA,
         "expected_workflow_run_id": 900,
         "final": False,
     }
@@ -74,14 +77,14 @@ def report(**overrides) -> dict:
 
 def provenance(**overrides) -> GradingArtifactProvenance:
     values = {
-        "repository": "TheBitPoets/rossi-mario",
+        "repository": "TheBitPoets/2cornot2c",
         "artifact_id": 12,
         "artifact_name": "grading-assignment-001",
         "workflow_run_id": 900,
-        "head_sha": HEAD_SHA,
+        "head_sha": WORKFLOW_SHA,
         "created_at": "2026-10-20T08:05:00Z",
         "archive_download_url": (
-            "https://api.github.com/repos/TheBitPoets/rossi-mario/actions/artifacts/12/zip"
+            "https://api.github.com/repos/TheBitPoets/2cornot2c/actions/artifacts/12/zip"
         ),
         "digest": "sha256:abc",
     }
@@ -154,12 +157,14 @@ def test_artifact_tracking_source_resolves_verified_remote_report() -> None:
     assert result.provisional is True
     assert result.error is None
     assert result.provenance["source"] == "github_actions"
+    assert result.provenance["repository"] == "TheBitPoets/rossi-mario"
+    assert result.provenance["artifact_repository"] == "TheBitPoets/2cornot2c"
     assert result.provenance["artifact_id"] == 12
     assert artifact_source.calls == [
         (
-            "TheBitPoets/rossi-mario",
+            "TheBitPoets/2cornot2c",
             "grading-assignment-001",
-            HEAD_SHA,
+            WORKFLOW_SHA,
             900,
         )
     ]
@@ -218,7 +223,7 @@ def test_artifact_tracking_source_skips_students_without_binding() -> None:
         ({"student_id": "bianchi-luca"}, {}, "studente diverso"),
         ({"commit": "b" * 40}, {}, "Commit"),
         ({}, {"repository": "TheBitPoets/altro"}, "repository diverso"),
-        ({}, {"head_sha": "b" * 40}, "SHA diverso"),
+        ({}, {"head_sha": "c" * 40}, "SHA diverso"),
         ({}, {"workflow_run_id": 901}, "workflow run diversa"),
         ({}, {"artifact_name": "altro"}, "artifact diverso"),
     ],
@@ -287,5 +292,5 @@ def test_artifact_tracking_source_rejects_duplicate_or_invalid_bindings() -> Non
     with pytest.raises(ValueError, match="40 caratteri"):
         tracking_reports.ArtifactTrackingReportSource(
             artifact_source,
-            [binding(expected_head_sha="abc")],
+            [binding(expected_student_head_sha="abc")],
         )

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 import pytest
 
 from scripts import thebitlab_tracking_reports as tracking_reports
+from scripts import grade_activity
 from scripts.thebitlab_grading_artifacts import (
     AcquiredGradingReport,
     GradingArtifactError,
@@ -162,6 +163,37 @@ def test_artifact_tracking_source_resolves_verified_remote_report() -> None:
             900,
         )
     ]
+
+
+def test_grader_report_is_accepted_after_workflow_metadata_enrichment(tmp_path) -> None:
+    source_path = tmp_path / "main.py"
+    source_path.write_text("print(5)\n", encoding="utf-8")
+    produced = grade_activity.grade_activity(
+        {
+            "id": "python-base-somma-001",
+            "linguaggio": "python",
+            "test_cases": [{"name": "output", "expected_stdout": "5\n"}],
+        },
+        source_path,
+    )
+    produced = grade_activity.with_report_metadata(
+        produced,
+        assignment_id="assignment-001",
+        student_id="rossi-mario",
+        commit=HEAD_SHA,
+    )
+    source = tracking_reports.ArtifactTrackingReportSource(
+        FakeArtifactSource(
+            AcquiredGradingReport(report=produced, provenance=provenance())
+        ),
+        [binding()],
+    )
+
+    result = source.resolve(request())
+
+    assert result.selection == "github_actions_artifact"
+    assert result.authority == "verified_remote"
+    assert result.report["passed"] is True
 
 
 def test_artifact_tracking_source_skips_students_without_binding() -> None:

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -170,6 +170,7 @@ def test_artifact_tracking_source_skips_students_without_binding() -> None:
     [
         ({"activity_id": "other"}, {}, "activity diversa"),
         ({"assignment_id": "other"}, {}, "assegnazione diversa"),
+        ({"student_id": "bianchi-luca"}, {}, "studente diverso"),
         ({"commit": "b" * 40}, {}, "Commit"),
         ({}, {"repository": "TheBitPoets/altro"}, "repository diverso"),
         ({}, {"head_sha": "b" * 40}, "SHA diverso"),

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -53,6 +53,7 @@ def binding(**overrides) -> tracking_reports.TrustedGradingBinding:
         "artifact_name": "grading-assignment-001",
         "expected_student_head_sha": HEAD_SHA,
         "expected_workflow_head_sha": WORKFLOW_SHA,
+        "expected_submitted_at": "2026-10-20T08:00:00+02:00",
         "expected_workflow_run_id": 900,
         "final": False,
     }
@@ -186,6 +187,7 @@ def test_grader_report_is_accepted_after_workflow_metadata_enrichment(tmp_path) 
         assignment_id="assignment-001",
         student_id="rossi-mario",
         commit=HEAD_SHA,
+        submitted_at="2026-10-20T08:00:00+02:00",
     )
     source = tracking_reports.ArtifactTrackingReportSource(
         FakeArtifactSource(
@@ -222,6 +224,7 @@ def test_artifact_tracking_source_skips_students_without_binding() -> None:
         ({"student_id": ""}, {}, "privo dell'identificativo studente"),
         ({"student_id": "bianchi-luca"}, {}, "studente diverso"),
         ({"commit": "b" * 40}, {}, "Commit"),
+        ({"submitted_at": "2026-10-21T08:00:00+02:00"}, {}, "Timestamp"),
         ({}, {"repository": "TheBitPoets/altro"}, "repository diverso"),
         ({}, {"head_sha": "c" * 40}, "SHA diverso"),
         ({}, {"workflow_run_id": 901}, "workflow run diversa"),
@@ -293,4 +296,9 @@ def test_artifact_tracking_source_rejects_duplicate_or_invalid_bindings() -> Non
         tracking_reports.ArtifactTrackingReportSource(
             artifact_source,
             [binding(expected_student_head_sha="abc")],
+        )
+    with pytest.raises(ValueError, match="fuso orario"):
+        tracking_reports.ArtifactTrackingReportSource(
+            artifact_source,
+            [binding(expected_submitted_at="2026-10-20T08:00:00")],
         )

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -114,6 +114,15 @@ def test_canonical_tracking_result_rejects_contradictory_remote_states() -> None
             authority="verified_remote",
         )
     )
+    invalid_repository = tracking_reports.canonical_tracking_report_result(
+        tracking_reports.TrackingReportResult(
+            configured=True,
+            report={"status": "passed"},
+            selection="github_actions_artifact",
+            authority="verified_remote",
+            provenance={"repository": "not a repository"},
+        )
+    )
 
     assert missing_report.selection == "remote_error"
     assert missing_report.authority == "remote_configured"
@@ -121,6 +130,8 @@ def test_canonical_tracking_result_rejects_contradictory_remote_states() -> None
     assert missing_provenance.selection == "remote_error"
     assert missing_provenance.report is None
     assert "Provenienza" in missing_provenance.error
+    assert invalid_repository.selection == "remote_error"
+    assert "Repository" in invalid_repository.error
 
 
 def test_artifact_tracking_source_resolves_verified_remote_report() -> None:

--- a/tests/test_thebitlab_tracking_reports.py
+++ b/tests/test_thebitlab_tracking_reports.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import asdict, replace
+import json
 
 import pytest
 
@@ -302,3 +303,53 @@ def test_artifact_tracking_source_rejects_duplicate_or_invalid_bindings() -> Non
             artifact_source,
             [binding(expected_submitted_at="2026-10-20T08:00:00")],
         )
+
+
+def test_load_trusted_grading_bindings_reads_teacher_json(tmp_path) -> None:
+    path = tmp_path / "teacher-grading-bindings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "thebitlab_grading_bindings.v1",
+                "bindings": [asdict(binding())],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = tracking_reports.load_trusted_grading_bindings(path)
+
+    assert loaded == [binding()]
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ([], "oggetto JSON"),
+        ({"schema_version": "other", "bindings": []}, "schema"),
+        (
+            {
+                "schema_version": "thebitlab_grading_bindings.v1",
+                "bindings": [{"unexpected": True}],
+            },
+            "Campi",
+        ),
+        (
+            {
+                "schema_version": "thebitlab_grading_bindings.v1",
+                "bindings": [{**asdict(binding()), "final": "false"}],
+            },
+            "booleano",
+        ),
+    ],
+)
+def test_load_trusted_grading_bindings_rejects_invalid_payload(
+    tmp_path,
+    payload,
+    message,
+) -> None:
+    path = tmp_path / "teacher-grading-bindings.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        tracking_reports.load_trusted_grading_bindings(path)

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -91,7 +91,14 @@ def target(tmp_path, name: str) -> track_assignments.TrackingTarget:
     return track_assignments.TrackingTarget(student=name, repo=f"TheBitPoets/{name}", path=root)
 
 
-def write_assignment_record(tmp_path, activity_path, student, assignment_id: str) -> None:
+def write_assignment_record(
+    tmp_path,
+    activity_path,
+    student,
+    assignment_id: str,
+    *,
+    repo_ref: str | None = None,
+) -> None:
     """Persist one student assignment used by assignment-scoped report tests."""
 
     assignment_records.JsonAssignmentRecordStorage(tmp_path).write_assignment(
@@ -105,7 +112,7 @@ def write_assignment_record(tmp_path, activity_path, student, assignment_id: str
             targets=[
                 {
                     "student_id": "rossi-mario",
-                    "repo_ref": student.repo,
+                    "repo_ref": repo_ref or student.repo,
                     "path": str(student.path.relative_to(tmp_path)),
                 }
             ],
@@ -1321,9 +1328,20 @@ class StaticTrackingReportSource:
 
 def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
-    student = target(tmp_path, "rossi-mario")
+    student_path = tmp_path / "rossi-mario"
+    student = track_assignments.TrackingTarget(
+        student="rossi-mario",
+        repo=str(student_path),
+        path=student_path,
+    )
     assignment_id = "assignment-remote"
-    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    write_assignment_record(
+        tmp_path,
+        activity_path,
+        student,
+        assignment_id,
+        repo_ref="TheBitPoets/rossi-mario",
+    )
     remote_report = attempt_report(
         assignment_id,
         "attempt-remote",
@@ -1340,7 +1358,7 @@ def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) 
             provisional=True,
             provenance={
                 "source": "github_actions",
-                "repository": student.repo,
+                "repository": "TheBitPoets/rossi-mario",
                 "artifact_id": 12,
                 "workflow_run_id": 900,
                 "head_sha": "a" * 40,
@@ -1372,7 +1390,7 @@ def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) 
             activity_id="python-base-somma-001",
             assignment_id=assignment_id,
             student_id="rossi-mario",
-            repo_ref=student.repo,
+            repo_ref="TheBitPoets/rossi-mario",
         )
     ]
 
@@ -1387,7 +1405,7 @@ def test_track_assignments_remote_error_does_not_fall_back_to_local_report(tmp_p
         thebitlab_tracking_reports.TrackingReportResult(
             configured=True,
             selection="remote_error",
-            authority="verified_remote",
+            authority="remote_configured",
             provisional=True,
             error="artifact non disponibile",
         )
@@ -1404,10 +1422,11 @@ def test_track_assignments_remote_error_does_not_fall_back_to_local_report(tmp_p
     )
 
     row = index["students"][0]
-    assert row["submitted"] is False
+    assert row["submitted"] is None
+    assert row["status"] == "submission_unknown"
     assert row["grading"]["status"] == "not_graded"
     assert row["submission"]["report_selection"] == "remote_error"
-    assert row["submission"]["report_authority"] == "verified_remote"
+    assert row["submission"]["report_authority"] == "remote_configured"
     assert row["submission"]["report_error"] == "artifact non disponibile"
     assert row["submission"]["report_path"] is None
 
@@ -1431,7 +1450,8 @@ def test_track_assignments_malformed_configured_source_still_fails_closed(tmp_pa
     )
 
     row = index["students"][0]
-    assert row["submitted"] is False
+    assert row["submitted"] is None
+    assert row["status"] == "submission_unknown"
     assert row["submission"]["report_selection"] == "remote_error"
     assert row["submission"]["report_path"] is None
 

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1378,6 +1378,9 @@ def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) 
 
     row = index["students"][0]
     assert row["submitted"] is True
+    assert row["repo"] == "TheBitPoets/rossi-mario"
+    assert row["repo_path"] == "rossi-mario"
+    assert row["repo_github_url"] == "https://github.com/TheBitPoets/rossi-mario"
     assert row["grading"]["status"] == "graded_passed"
     assert row["grading"]["provisional"] is True
     assert row["submission"]["report_selection"] == "github_actions_artifact"
@@ -1438,7 +1441,11 @@ def test_track_assignments_malformed_configured_source_still_fails_closed(tmp_pa
     write_assignment_record(tmp_path, activity_path, student, assignment_id)
     write_report(student.path, "2026-10-20T08:00:00+02:00")
     source = StaticTrackingReportSource(
-        thebitlab_tracking_reports.TrackingReportResult(configured=True)
+        thebitlab_tracking_reports.TrackingReportResult(
+            configured=True,
+            selection="github_actions_artifact",
+            authority="verified_remote",
+        )
     )
 
     index = track_assignments.track_assignments(
@@ -1453,6 +1460,45 @@ def test_track_assignments_malformed_configured_source_still_fails_closed(tmp_pa
     assert row["submitted"] is None
     assert row["status"] == "submission_unknown"
     assert row["submission"]["report_selection"] == "remote_error"
+    assert row["submission"]["report_authority"] == "remote_configured"
+    assert row["submission"]["report_error"] == "Risultato sorgente remota non valido."
+    assert row["submission"]["report_path"] is None
+
+
+def test_track_assignments_rejects_remote_report_without_verified_provenance(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-unverified-remote"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    write_report(student.path, "2026-10-20T08:00:00+02:00")
+    source = StaticTrackingReportSource(
+        thebitlab_tracking_reports.TrackingReportResult(
+            configured=True,
+            report=attempt_report(
+                assignment_id,
+                "attempt-unverified",
+                passed=True,
+                submitted_at="2026-10-20T08:00:00+02:00",
+            ),
+            selection="github_actions_artifact",
+            authority="verified_remote",
+        )
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        report_source=source,
+    )
+
+    row = index["students"][0]
+    assert row["submitted"] is None
+    assert row["status"] == "submission_unknown"
+    assert row["grading"]["status"] == "not_graded"
+    assert row["submission"]["report_selection"] == "remote_error"
+    assert row["submission"]["report_authority"] == "remote_configured"
     assert row["submission"]["report_path"] is None
 
 

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1389,7 +1389,7 @@ def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) 
     assert row["submission"]["report_error"] is None
     assert row["submission"]["report_path"] is None
     assert row["submission"]["files"] == []
-    assert row["submission"]["local_preview_status"] == "commit_mismatch"
+    assert row["submission"]["local_preview_status"] == "remote_commit_only"
     assert source.requests == [
         thebitlab_tracking_reports.TrackingReportRequest(
             activity_id="python-base-somma-001",
@@ -1400,10 +1400,7 @@ def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) 
     ]
 
 
-def test_remote_report_allows_local_preview_only_at_verified_commit(
-    tmp_path,
-    monkeypatch,
-) -> None:
+def test_remote_report_never_reads_files_from_local_checkout(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "rossi-mario")
     assignment_id = "assignment-preview"
@@ -1429,12 +1426,6 @@ def test_remote_report_allows_local_preview_only_at_verified_commit(
             provenance={"repository": "TheBitPoets/rossi-mario"},
         )
     )
-    monkeypatch.setattr(
-        track_assignments,
-        "git_stdout_optional",
-        lambda args, cwd: commit if args == ["git", "rev-parse", "HEAD"] else "",
-    )
-
     row = track_assignments.track_assignments(
         activity_path=activity_path,
         targets=[student],
@@ -1443,25 +1434,9 @@ def test_remote_report_allows_local_preview_only_at_verified_commit(
         report_source=source,
     )["students"][0]
 
-    assert row["submission"]["local_preview_status"] == "available"
-    assert row["submission"]["source_path"].endswith("main.py")
-    assert row["submission"]["files"][0]["path"].endswith("main.py")
-
-
-def test_checkout_preview_rejects_dirty_worktree(monkeypatch, tmp_path) -> None:
-    student = target(tmp_path, "rossi-mario")
-    commit = "a" * 40
-
-    def fake_git_stdout(args, _cwd):
-        if args == ["git", "rev-parse", "HEAD"]:
-            return commit
-        if args == ["git", "status", "--porcelain", "--untracked-files=normal"]:
-            return " M assignments/python-base-somma-001/main.py"
-        return ""
-
-    monkeypatch.setattr(track_assignments, "git_stdout_optional", fake_git_stdout)
-
-    assert track_assignments.checkout_matches_commit(student, commit) is False
+    assert row["submission"]["local_preview_status"] == "remote_commit_only"
+    assert row["submission"]["source_path"] is None
+    assert row["submission"]["files"] == []
 
 
 def test_remote_provenance_supplies_missing_assignment_repository(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1431,7 +1431,7 @@ def test_remote_report_allows_local_preview_only_at_verified_commit(
     )
     monkeypatch.setattr(
         track_assignments,
-        "git_stdout",
+        "git_stdout_optional",
         lambda args, cwd: commit if args == ["git", "rev-parse", "HEAD"] else "",
     )
 
@@ -1446,6 +1446,22 @@ def test_remote_report_allows_local_preview_only_at_verified_commit(
     assert row["submission"]["local_preview_status"] == "available"
     assert row["submission"]["source_path"].endswith("main.py")
     assert row["submission"]["files"][0]["path"].endswith("main.py")
+
+
+def test_checkout_preview_rejects_dirty_worktree(monkeypatch, tmp_path) -> None:
+    student = target(tmp_path, "rossi-mario")
+    commit = "a" * 40
+
+    def fake_git_stdout(args, _cwd):
+        if args == ["git", "rev-parse", "HEAD"]:
+            return commit
+        if args == ["git", "status", "--porcelain", "--untracked-files=normal"]:
+            return " M assignments/python-base-somma-001/main.py"
+        return ""
+
+    monkeypatch.setattr(track_assignments, "git_stdout_optional", fake_git_stdout)
+
+    assert track_assignments.checkout_matches_commit(student, commit) is False
 
 
 def test_remote_provenance_supplies_missing_assignment_repository(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1388,6 +1388,8 @@ def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) 
     assert row["submission"]["report_provenance"]["artifact_id"] == 12
     assert row["submission"]["report_error"] is None
     assert row["submission"]["report_path"] is None
+    assert row["submission"]["files"] == []
+    assert row["submission"]["local_preview_status"] == "commit_mismatch"
     assert source.requests == [
         thebitlab_tracking_reports.TrackingReportRequest(
             activity_id="python-base-somma-001",
@@ -1396,6 +1398,54 @@ def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) 
             repo_ref="TheBitPoets/rossi-mario",
         )
     ]
+
+
+def test_remote_report_allows_local_preview_only_at_verified_commit(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-preview"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    source_path = student.path / "assignments" / "python-base-somma-001" / "main.py"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text("print(3)\n", encoding="utf-8")
+    commit = "a" * 40
+    remote_report = attempt_report(
+        assignment_id,
+        "attempt-remote",
+        passed=True,
+        submitted_at="2026-10-20T08:00:00+02:00",
+    )
+    remote_report["commit"] = commit
+    remote_report["source"] = str(source_path)
+    source = StaticTrackingReportSource(
+        thebitlab_tracking_reports.TrackingReportResult(
+            configured=True,
+            report=remote_report,
+            selection="github_actions_artifact",
+            authority="verified_remote",
+            provenance={"repository": "TheBitPoets/rossi-mario"},
+        )
+    )
+    monkeypatch.setattr(
+        track_assignments,
+        "git_stdout",
+        lambda args, cwd: commit if args == ["git", "rev-parse", "HEAD"] else "",
+    )
+
+    row = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        report_source=source,
+    )["students"][0]
+
+    assert row["submission"]["local_preview_status"] == "available"
+    assert row["submission"]["source_path"].endswith("main.py")
+    assert row["submission"]["files"][0]["path"].endswith("main.py")
 
 
 def test_remote_provenance_supplies_missing_assignment_repository(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1570,7 +1570,7 @@ def test_track_assignments_uses_local_report_when_remote_binding_is_absent(tmp_p
     assert row["submission"]["report_error"] is None
 
 
-def test_track_assignments_keeps_teacher_selected_final_before_remote_source(tmp_path) -> None:
+def test_track_assignments_remote_binding_rejects_student_selected_final(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student = target(tmp_path, "rossi-mario")
     assignment_id = "assignment-final-before-remote"
@@ -1624,11 +1624,19 @@ def test_track_assignments_keeps_teacher_selected_final_before_remote_source(tmp
     )
 
     row = index["students"][0]
-    assert row["grading"]["status"] == "graded_failed"
-    assert row["grading"]["provisional"] is False
-    assert row["submission"]["report_selection"] == "final"
-    assert row["submission"]["report_authority"] == "local"
-    assert source.requests == []
+    assert row["submitted"] is None
+    assert row["status"] == "submission_unknown"
+    assert row["grading"]["status"] == "not_graded"
+    assert row["submission"]["report_selection"] == "remote_error"
+    assert row["submission"]["report_authority"] == "remote_configured"
+    assert source.requests == [
+        thebitlab_tracking_reports.TrackingReportRequest(
+            activity_id="python-base-somma-001",
+            assignment_id=assignment_id,
+            student_id="rossi-mario",
+            repo_ref="TheBitPoets/rossi-mario",
+        )
+    ]
 
 
 def test_write_tracking_index_creates_parent_directories(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -112,7 +112,7 @@ def write_assignment_record(
             targets=[
                 {
                     "student_id": "rossi-mario",
-                    "repo_ref": repo_ref or student.repo,
+                    "repo_ref": student.repo if repo_ref is None else repo_ref,
                     "path": str(student.path.relative_to(tmp_path)),
                 }
             ],
@@ -1396,6 +1396,45 @@ def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) 
             repo_ref="TheBitPoets/rossi-mario",
         )
     ]
+
+
+def test_remote_provenance_supplies_missing_assignment_repository(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student_path = tmp_path / "rossi-mario"
+    student = track_assignments.TrackingTarget(
+        student="rossi-mario",
+        repo=str(student_path),
+        path=student_path,
+    )
+    assignment_id = "assignment-remote-repository"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id, repo_ref="")
+    remote_report = attempt_report(
+        assignment_id,
+        "attempt-remote",
+        passed=True,
+        submitted_at="2026-10-20T08:00:00+02:00",
+    )
+    source = StaticTrackingReportSource(
+        thebitlab_tracking_reports.TrackingReportResult(
+            configured=True,
+            report=remote_report,
+            selection="github_actions_artifact",
+            authority="verified_remote",
+            provenance={"repository": "TheBitPoets/rossi-mario"},
+        )
+    )
+
+    row = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        report_source=source,
+    )["students"][0]
+
+    assert source.requests[0].repo_ref == ""
+    assert row["repo"] == "TheBitPoets/rossi-mario"
+    assert row["repo_github_url"] == "https://github.com/TheBitPoets/rossi-mario"
 
 
 def test_track_assignments_remote_error_does_not_fall_back_to_local_report(tmp_path) -> None:

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -15,6 +15,7 @@ from scripts import (
     student_support_policy,
     track_assignments,
 )
+from scripts import thebitlab_tracking_reports
 from scripts.thebitlab_repository_providers import LocalRepositoryProvider, StudentRepository
 
 
@@ -1303,6 +1304,226 @@ def test_track_assignments_rejects_report_without_activity_id(tmp_path) -> None:
         assert "manca activity_id" in str(error)
     else:
         raise AssertionError("track_assignments should reject reports without activity_id")
+
+
+class StaticTrackingReportSource:
+    def __init__(self, result: thebitlab_tracking_reports.TrackingReportResult) -> None:
+        self.result = result
+        self.requests: list[thebitlab_tracking_reports.TrackingReportRequest] = []
+
+    def resolve(
+        self,
+        request: thebitlab_tracking_reports.TrackingReportRequest,
+    ) -> thebitlab_tracking_reports.TrackingReportResult:
+        self.requests.append(request)
+        return self.result
+
+
+def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-remote"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    remote_report = attempt_report(
+        assignment_id,
+        "attempt-remote",
+        passed=True,
+        submitted_at="2026-10-20T08:00:00+02:00",
+    )
+    remote_report["commit"] = "a" * 40
+    source = StaticTrackingReportSource(
+        thebitlab_tracking_reports.TrackingReportResult(
+            configured=True,
+            report=remote_report,
+            selection="github_actions_artifact",
+            authority="verified_remote",
+            provisional=True,
+            provenance={
+                "source": "github_actions",
+                "repository": student.repo,
+                "artifact_id": 12,
+                "workflow_run_id": 900,
+                "head_sha": "a" * 40,
+            },
+        )
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+        report_source=source,
+    )
+
+    row = index["students"][0]
+    assert row["submitted"] is True
+    assert row["grading"]["status"] == "graded_passed"
+    assert row["grading"]["provisional"] is True
+    assert row["submission"]["report_selection"] == "github_actions_artifact"
+    assert row["submission"]["report_authority"] == "verified_remote"
+    assert row["submission"]["report_provenance"]["artifact_id"] == 12
+    assert row["submission"]["report_error"] is None
+    assert row["submission"]["report_path"] is None
+    assert source.requests == [
+        thebitlab_tracking_reports.TrackingReportRequest(
+            activity_id="python-base-somma-001",
+            assignment_id=assignment_id,
+            student_id="rossi-mario",
+            repo_ref=student.repo,
+        )
+    ]
+
+
+def test_track_assignments_remote_error_does_not_fall_back_to_local_report(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-remote-error"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    write_report(student.path, "2026-10-20T08:00:00+02:00")
+    source = StaticTrackingReportSource(
+        thebitlab_tracking_reports.TrackingReportResult(
+            configured=True,
+            selection="remote_error",
+            authority="verified_remote",
+            provisional=True,
+            error="artifact non disponibile",
+        )
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+        report_source=source,
+    )
+
+    row = index["students"][0]
+    assert row["submitted"] is False
+    assert row["grading"]["status"] == "not_graded"
+    assert row["submission"]["report_selection"] == "remote_error"
+    assert row["submission"]["report_authority"] == "verified_remote"
+    assert row["submission"]["report_error"] == "artifact non disponibile"
+    assert row["submission"]["report_path"] is None
+
+
+def test_track_assignments_malformed_configured_source_still_fails_closed(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-malformed-remote"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    write_report(student.path, "2026-10-20T08:00:00+02:00")
+    source = StaticTrackingReportSource(
+        thebitlab_tracking_reports.TrackingReportResult(configured=True)
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        report_source=source,
+    )
+
+    row = index["students"][0]
+    assert row["submitted"] is False
+    assert row["submission"]["report_selection"] == "remote_error"
+    assert row["submission"]["report_path"] is None
+
+
+def test_track_assignments_uses_local_report_when_remote_binding_is_absent(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-local-fallback"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    write_report(student.path, "2026-10-20T08:00:00+02:00")
+    source = StaticTrackingReportSource(
+        thebitlab_tracking_reports.TrackingReportResult(configured=False)
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+        report_source=source,
+    )
+
+    row = index["students"][0]
+    assert row["submitted"] is True
+    assert row["grading"]["status"] == "graded_passed"
+    assert row["submission"]["report_selection"] == "legacy"
+    assert row["submission"]["report_authority"] == "local"
+    assert row["submission"]["report_provenance"] is None
+    assert row["submission"]["report_error"] is None
+
+
+def test_track_assignments_keeps_teacher_selected_final_before_remote_source(tmp_path) -> None:
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    assignment_id = "assignment-final-before-remote"
+    write_assignment_record(tmp_path, activity_path, student, assignment_id)
+    report_path = track_assignments.default_report_path(student, "python-base-somma-001")
+    history_dir = (
+        report_path.parent
+        / "assignments"
+        / assignment_records.assignment_storage_key(assignment_id)
+    )
+    attempts_dir = history_dir / "attempts"
+    attempts_dir.mkdir(parents=True)
+    final_report = attempt_report(
+        assignment_id,
+        "attempt-final",
+        passed=False,
+        submitted_at="2026-10-20T08:00:00+02:00",
+    )
+    (attempts_dir / "attempt-final.json").write_text(
+        json.dumps(final_report),
+        encoding="utf-8",
+    )
+    (history_dir / "final.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "student_lab_attempt_selection.v1",
+                "assignment_id": assignment_id,
+                "activity_id": "python-base-somma-001",
+                "attempt_id": "attempt-final",
+                "selected_at": "2026-10-20T08:05:00+02:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    source = StaticTrackingReportSource(
+        thebitlab_tracking_reports.TrackingReportResult(
+            configured=True,
+            selection="remote_error",
+            error="non deve essere usato",
+        )
+    )
+
+    index = track_assignments.track_assignments(
+        activity_path=activity_path,
+        targets=[student],
+        assignment_id=assignment_id,
+        server_root=tmp_path,
+        due_at="2026-10-21T08:00:00+02:00",
+        now="2026-10-20T09:00:00+02:00",
+        report_source=source,
+    )
+
+    row = index["students"][0]
+    assert row["grading"]["status"] == "graded_failed"
+    assert row["grading"]["provisional"] is False
+    assert row["submission"]["report_selection"] == "final"
+    assert row["submission"]["report_authority"] == "local"
+    assert source.requests == []
 
 
 def test_write_tracking_index_creates_parent_directories(tmp_path) -> None:

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2366,8 +2366,8 @@ function reportOutcome(report) {
   const late = counts.late;
   const submitted = counts.submitted;
   const total = counts.total;
-  if (unknown > 0) return { kind: "warn", label: `${unknown} da verificare` };
   if (expired && notSubmitted > 0) return { kind: "bad", label: `${notSubmitted} mancanti` };
+  if (unknown > 0) return { kind: "warn", label: `${unknown} da verificare` };
   if (late > 0) return { kind: "warn", label: `${late} ritardi` };
   if (total > 0 && submitted === total) return { kind: "ok", label: "tutti in tempo" };
   if (!expired && notSubmitted > 0) return { kind: "muted", label: `${notSubmitted} in corso` };

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2362,9 +2362,11 @@ function reportOutcome(report) {
   const expired = reportIsExpired(report);
   const counts = reportCounts(report);
   const notSubmitted = counts.missing;
+  const unknown = counts.unknown;
   const late = counts.late;
   const submitted = counts.submitted;
   const total = counts.total;
+  if (unknown > 0) return { kind: "warn", label: `${unknown} da verificare` };
   if (expired && notSubmitted > 0) return { kind: "bad", label: `${notSubmitted} mancanti` };
   if (late > 0) return { kind: "warn", label: `${late} ritardi` };
   if (total > 0 && submitted === total) return { kind: "ok", label: "tutti in tempo" };
@@ -2381,7 +2383,7 @@ function reportCounts(report) {
   const students = Array.isArray(report?.students) ? report.students : [];
   const overviewRows = students.length ? [] : reportOverviewRows(report);
   const detailRows = students.length ? students : overviewRows;
-  const hasSummaryCounts = ["submitted", "not_submitted", "late"].some((key) => Object.prototype.hasOwnProperty.call(report || {}, key));
+  const hasSummaryCounts = ["submitted", "not_submitted", "unknown", "late"].some((key) => Object.prototype.hasOwnProperty.call(report || {}, key));
   const total = detailRows.length || Number(report?.students || 0);
   const submitted = detailRows.length
     ? detailRows.filter((student) => student.submitted).length
@@ -2392,10 +2394,14 @@ function reportCounts(report) {
   const late = detailRows.length
     ? detailRows.filter((student) => student.submitted && student.late).length
     : hasSummaryCounts ? Number(report?.late || 0) : 0;
+  const unknown = detailRows.length
+    ? detailRows.filter((student) => student.status === "submission_unknown" || student.submitted == null).length
+    : hasSummaryCounts ? Number(report?.unknown || 0) : 0;
   return {
     total: Number.isFinite(total) ? total : 0,
     submitted: Number.isFinite(submitted) ? submitted : 0,
     missing: Number.isFinite(missing) ? missing : 0,
+    unknown: Number.isFinite(unknown) ? unknown : 0,
     late: Number.isFinite(late) ? late : 0,
   };
 }
@@ -2404,7 +2410,7 @@ function coverageReportCounts(report) {
   const counts = reportCounts(report);
   return `
     <small class="coverageReportCounts">
-      ${escapeHtml(counts.total)} studenti - ${escapeHtml(counts.submitted)} consegnati - ${escapeHtml(counts.missing)} mancanti - ${escapeHtml(counts.late)} in ritardo
+      ${escapeHtml(counts.total)} studenti - ${escapeHtml(counts.submitted)} consegnati - ${escapeHtml(counts.missing)} mancanti - ${escapeHtml(counts.unknown)} da verificare - ${escapeHtml(counts.late)} in ritardo
     </small>
   `;
 }
@@ -4518,6 +4524,7 @@ const SUMMARY_TOOLTIPS = {
   Scadenza: "Data e ora di scadenza del registro consegne selezionato.",
   Consegnati: "Numero di studenti che hanno effettuato una consegna.",
   Mancanti: "Numero di studenti senza consegna registrata.",
+  "Da verificare": "Numero di consegne il cui report remoto non e stato ancora verificato.",
   "In ritardo": "Numero di studenti che hanno consegnato oltre la scadenza.",
   Ritardo: "Numero di studenti che hanno consegnato oltre la scadenza.",
   KO: "Numero di studenti con grading o test falliti.",
@@ -4551,6 +4558,7 @@ function summaryCounts(students) {
     total: students.length,
     pending: students.filter((student) => student.status === "pending").length,
     missing: students.filter((student) => student.status === "missing").length,
+    unknown: students.filter((student) => student.status === "submission_unknown" || student.submitted == null).length,
     submitted: students.filter((student) => student.submitted).length,
     late: students.filter((student) => student.submitted && student.late).length,
     passed: students.filter((student) => student.grading?.status === "graded_passed").length,
@@ -4590,6 +4598,7 @@ function compactStudentsSummaryItems(counts) {
     ["Studenti", counts.total],
     ["Consegnati", counts.submitted],
     ["Mancanti", counts.missing],
+    ["Da verificare", counts.unknown],
     ["Ritardo", counts.late],
     ["KO", counts.failed],
   ];
@@ -4604,6 +4613,7 @@ function detailedStudentsSummaryItems(counts) {
     ["Studenti", counts.total],
     ["Consegnati", counts.submitted],
     ["Mancanti", counts.missing],
+    ["Da verificare", counts.unknown],
     ["Ritardo", counts.late],
     ["Pending", counts.pending],
     ["Grading OK", counts.passed],
@@ -4638,6 +4648,7 @@ function renderSummary(students) {
     ["Studenti", counts.total],
     ["Consegnati", counts.submitted],
     ["Mancanti", counts.missing],
+    ["Da verificare", counts.unknown],
     ["In ritardo", counts.late],
   ];
   els.reportSummary.innerHTML = cards.map(([label, value]) => `

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -51,6 +51,7 @@ const ASSIGNMENT_WIZARD_STEPS = [
 const OVERVIEW_STATUS_ORDER = [
   "missing",
   "pending",
+  "submission_unknown",
   "submitted_late",
   "submitted_unknown_time",
   "submitted_on_time",
@@ -2728,6 +2729,7 @@ function overviewStudents(rows) {
 function matrixCellKind(row) {
   if (!row) return "Empty";
   if (row.status === "missing") return "Bad";
+  if (row.status === "submission_unknown") return "Warn";
   if (row.status === "pending") return "Pending";
   if (row.late) return "Warn";
   if (row.grading_status === "graded_failed") return "Bad";
@@ -2738,6 +2740,7 @@ function matrixCellKind(row) {
 function matrixCellText(row) {
   if (!row) return "-";
   if (row.status === "missing") return "NP";
+  if (row.status === "submission_unknown") return "?";
   if (row.status === "pending") return "...";
   if (row.grading_status === "graded_failed") return "KO";
   if (row.status?.startsWith("submitted")) return row.late ? "RIT" : "OK";
@@ -3849,6 +3852,7 @@ async function generateReport() {
 
 function statusKind(status, late, grading) {
   if (status === "missing") return "bad";
+  if (status === "submission_unknown") return "warn";
   if (status === "pending") return "warn";
   if (late) return "warn";
   if (grading?.status === "graded_failed") return "bad";
@@ -4020,6 +4024,24 @@ function reportSelectionState(value) {
       compactLabel: "PROV",
       kind: "warn",
       tooltip: "Il grading deriva dall'ultimo report disponibile e puo cambiare quando viene scelto il definitivo.",
+    };
+  }
+  if (selection === "github_actions_artifact") {
+    return {
+      label: "Remoto verificato",
+      compactLabel: "REM",
+      kind: provisional === true ? "warn" : "ok",
+      tooltip: provisional === true
+        ? "Il grading arriva da un artifact GitHub Actions verificato, ma non e ancora stato scelto come definitivo."
+        : "Il grading arriva da un artifact GitHub Actions verificato e autorizzato dal docente.",
+    };
+  }
+  if (selection === "remote_error") {
+    return {
+      label: "Grading remoto non disponibile",
+      compactLabel: "ERR",
+      kind: "bad",
+      tooltip: "Il report remoto configurato non e stato acquisito o validato; lo stato della consegna resta da verificare.",
     };
   }
   if (selection != null) {

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -1323,9 +1323,19 @@ function renderFeedback(feedback) {
 }
 
 function actionUnavailableLabel(assignment) {
+  if (assignment.status === "submission_unknown" || assignment.submitted == null) {
+    return "Consegna da verificare";
+  }
   return assignment.status === "missing" || !assignment.submitted
     ? "Consegna mancante"
     : "File consegna non disponibile";
+}
+
+function submittedLabel(assignment) {
+  if (assignment.status === "submission_unknown" || assignment.submitted == null) {
+    return "Da verificare";
+  }
+  return assignment.submitted ? "Si" : "No";
 }
 
 function assignmentOpenAction(assignment, assignmentIndex = -1) {
@@ -1425,7 +1435,7 @@ function renderAssignmentDetail(assignment) {
       <h3>Consegna</h3>
       <div class="detailGrid">
         ${detailItem("Stato", assignment.status || "-")}
-        ${detailItem("Consegnata", assignment.submitted ? "Si" : "No")}
+        ${detailItem("Consegnata", submittedLabel(assignment))}
         ${detailItem("In ritardo", assignment.late ? "Si" : "No")}
         ${detailItem("Consegnato il", formatDate(assignment.submitted_at))}
         ${detailItem("Commit", assignment.commit || "-")}

--- a/tools/student_dashboard.js
+++ b/tools/student_dashboard.js
@@ -255,6 +255,7 @@ function badge(text, kind = "") {
 }
 
 function statusBadge(assignment) {
+  if (assignment.status === "submission_unknown") return badge("Consegna da verificare", "badgeWarn");
   if (assignment.status === "missing") return badge("Mancante", "badgeBad");
   if (assignment.late) return badge("In ritardo", "badgeWarn");
   if (assignment.submitted) return badge("Consegnata", "badgeOk");
@@ -274,6 +275,7 @@ function gradeValue(grading) {
 }
 
 function labStatusBadge(assignment) {
+  if (assignment.status === "submission_unknown") return badge("Report da verificare", "badgeWarn");
   if (assignment.status === "missing") return badge("Mancante", "badgeBad");
   if (assignment.status === "submitted_late") return badge("Report in ritardo", "badgeWarn");
   if (assignment.submitted || assignment.status === "submitted") return badge("Report presente", "badgeOk");
@@ -515,6 +517,7 @@ function closeAttemptHistory({ restoreFocus = true } = {}) {
 }
 
 function isOpenAssignment(assignment) {
+  if (assignment.status === "submission_unknown" || assignment.submitted == null) return false;
   return !assignment.submitted || assignment.status === "missing";
 }
 
@@ -535,6 +538,7 @@ function renderSummary(studentId, assignments) {
   const nextAssignment = nextOpenAssignment(assignments);
   const submitted = assignments.filter((item) => item.submitted).length;
   const missing = assignments.filter((item) => item.status === "missing").length;
+  const unknown = assignments.filter((item) => item.status === "submission_unknown").length;
   const late = assignments.filter((item) => item.late).length;
   const approvedFeedback = assignments.filter((item) => item.approved_feedback).length;
   const cards = [
@@ -543,6 +547,7 @@ function renderSummary(studentId, assignments) {
     ["Consegne", assignments.length],
     ["Consegnate", submitted],
     ["Mancanti", missing],
+    ["Da verificare", unknown],
     ["In ritardo", late],
     ["Feedback", approvedFeedback],
     ["Prossima attivita", nextAssignment ? assignmentTitle(nextAssignment) : "-"],


### PR DESCRIPTION
## Sintesi

- acquisizione e validazione di report GitHub Actions con binding docente;
- integrazione fail-closed nella generazione registri server;
- provenienza e stato tri-state preservati in contratti, storage, SQLite e dashboard;
- workflow docente con input validati, sandbox Docker e Actions fissate a SHA;
- preview locale disabilitata per report remoti;
- documentazione e formato `teacher-grading-bindings.json` aggiornati.

## Verifica

- `python -m pytest -q`
- `git diff --check`
- collaudo manuale GUI positivo
- due round consecutivi di review indipendente senza finding

## Limiti dichiarati

`verified_remote` attesta provenienza e binding. Gli hardening anti-cheat e toolchain riproducibile sono tracciati in #515 e #516.

Closes #514