### PR TITLE
fix: pass validated runner image to publish job

### DIFF
--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -49,6 +49,21 @@ jobs:
           print(f"image_id={metadata['local_image_id']}")
           PY
 
+      - name: Stage validated runner toolchain
+        run: |
+          mkdir -p "$RUNNER_TEMP/runner-toolchain"
+          docker save thebitlab-assignment-runner \
+            | gzip > "$RUNNER_TEMP/runner-toolchain/runner-image.tar.gz"
+          cp "$RUNNER_TEMP/toolchain-build.json" \
+            "$RUNNER_TEMP/runner-toolchain/toolchain-build.json"
+
+      - name: Upload validated runner toolchain
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runner-toolchain
+          path: ${{ runner.temp }}/runner-toolchain
+          if-no-files-found: error
+
       - name: Install smoke test dependencies
         run: python -m pip install -r requirements-dev.txt
 
@@ -71,33 +86,23 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build pinned runner
-        run: >-
-          python scripts/build_assignment_runner.py
-          --source-revision "$GITHUB_SHA"
-          --metadata "$RUNNER_TEMP/toolchain-build.json"
+      - name: Download validated runner toolchain
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: runner-toolchain
+          path: ${{ runner.temp }}/runner-toolchain
 
-      - name: Verify rebuilt image matches the validated digest
+      - name: Load validated runner image and verify digest
         env:
           VALIDATED_IMAGE_ID: ${{ needs.validate.outputs.image_id }}
         run: |
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          metadata = json.loads(
-              Path(os.environ["RUNNER_TEMP"], "toolchain-build.json").read_text(encoding="utf-8")
-          )
-          rebuilt = metadata["local_image_id"]
-          validated = os.environ["VALIDATED_IMAGE_ID"]
-          if rebuilt != validated:
-              raise SystemExit(
-                  f"L'immagine ricostruita {rebuilt} non corrisponde "
-                  f"all'immagine validata {validated}: build non riproducibile."
-              )
-          print(f"Digest riprodotto dalla build di pubblicazione: {rebuilt}")
-          PY
+          gunzip < "$RUNNER_TEMP/runner-toolchain/runner-image.tar.gz" | docker load
+          loaded_id=$(docker image inspect --format '{{.Id}}' thebitlab-assignment-runner)
+          if [ "$loaded_id" != "$VALIDATED_IMAGE_ID" ]; then
+            echo "L'immagine caricata $loaded_id non corrisponde all'immagine validata $VALIDATED_IMAGE_ID"
+            exit 1
+          fi
+          echo "Immagine validata caricata: $loaded_id"
 
       - name: Authenticate to GHCR
         run: echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
@@ -106,7 +111,7 @@ jobs:
         id: publish
         run: >-
           python scripts/publish_assignment_runner.py
-          --metadata "$RUNNER_TEMP/toolchain-build.json"
+          --metadata "$RUNNER_TEMP/runner-toolchain/toolchain-build.json"
           --release "$RUNNER_TEMP/toolchain-release.json"
           --github-output "$GITHUB_OUTPUT"
 

--- a/doc/ASSIGNMENT_SANDBOX.md
+++ b/doc/ASSIGNMENT_SANDBOX.md
@@ -62,8 +62,8 @@ manualmente. Prima della pubblicazione:
 1. costruisce l'immagine dal manifest con timestamp fissati a `SOURCE_DATE_EPOCH` (derivato dallo
    snapshot Debian), cosi il digest e riproducibile tra runner diversi;
 2. esegue gli smoke test Docker reali;
-3. ricostruisce l'immagine nel job di pubblicazione e fallisce in modo chiuso se il digest non
-   riproduce esattamente quello validato;
+3. salva l'immagine validata come artifact e la ricarica nel job di pubblicazione, verificando
+   che il digest caricato corrisponda esattamente a quello validato;
 4. pubblica su GHCR un tag di versione e un tag legato al commit;
 5. non pubblica mai `latest`;
 6. rifiuta di sovrascrivere una versione gia esistente;

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -66,6 +66,11 @@ def test_publish_workflow_only_publishes_reviewed_main_toolchains() -> None:
     assert "docker login ghcr.io" in source
     assert "image_id: ${{ steps.image-digest.outputs.image_id }}" in source
     assert "VALIDATED_IMAGE_ID: ${{ needs.validate.outputs.image_id }}" in source
+    assert "actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16" in source
+    assert "runner-toolchain" in source
+    assert "docker save" in source
+    assert "docker load" in source
+    assert "gunzip" in source
     assert ":latest" not in source
     assert source.count("tests/test_student_lab_runner_docker.py") == 1
     assert '".github/workflows/publish-assignment-runner.yml"' not in source


### PR DESCRIPTION
After merging #522, the first main-branch `Publish assignment runner toolchain` run failed closed at the digest-reproduction step:\n\n- validated image ID: `sha256:8cf61e81...`\n- rebuilt image ID: `sha256:8e62f2e9...`\n\nCross-runner Docker builds are not bit-identical even with `SOURCE_DATE_EPOCH` (layer timestamps from `useradd`, `WORKDIR`, apt caches, etc.). This PR replaces the rebuild with an artifact handoff:\n\n- `validate` saves the smoke-tested image with `docker save | gzip` and the build metadata, then uploads both as the `runner-toolchain` artifact.\n- `publish` downloads the artifact, `docker load`s the image, and verifies its digest matches `needs.validate.outputs.image_id` before any GHCR authentication.\n\nThis guarantees the exact bytes exercised in smoke tests are the bytes pushed to GHCR, without giving the unprivileged `validate` job package-write authority.\n\nCloses the publication blocker for #521.