### PR TITLE
feat: lock authoritative grading to published toolchain digest

### DIFF
--- a/.github/workflows/grade-student-assignment.yml
+++ b/.github/workflows/grade-student-assignment.yml
@@ -46,6 +46,9 @@ on:
           - php
           - python
           - sql
+      toolchain_digest:
+        description: "Digest atteso della toolchain (opzionale; se fornito deve corrispondere al lock)"
+        required: false
       artifact_name:
         description: "Nome artifact concordato con il binding docente"
         required: true
@@ -112,11 +115,42 @@ jobs:
           token: ${{ secrets.THEBITLAB_STUDENT_REPO_TOKEN || github.token }}
           persist-credentials: false
 
-      - name: Build grading Docker image
-        run: >-
-          python thebitlab/scripts/build_assignment_runner.py
-          --source-revision "$GITHUB_SHA"
-          --metadata "$RUNNER_TEMP/toolchain-build.json"
+      - name: Load and verify authoritative toolchain lock
+        id: toolchain
+        env:
+          EXPECTED_DIGEST: ${{ inputs.toolchain_digest }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts import toolchain_lock
+
+          lock = toolchain_lock.load_lock(
+              Path("thebitlab/docker/assignment-runner/toolchain.lock.json")
+          )
+          reference = toolchain_lock.immutable_reference(lock)
+          expected = os.environ.get("EXPECTED_DIGEST", "").strip()
+          if expected and expected != lock["digest"]:
+              raise SystemExit(
+                  f"Binding docente {expected} non corrisponde al lock {lock['digest']}."
+              )
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"reference={reference}\n")
+              output.write(f"version={lock['version']}\n")
+              output.write(f"digest={lock['digest']}\n")
+          print(f"Toolchain bloccata: {reference}")
+          PY
+
+      - name: Pull pinned runner image
+        run: |
+          docker pull "${{ steps.toolchain.outputs.reference }}"
+          pulled_id=$(docker image inspect --format '{{.Id}}' "${{ steps.toolchain.outputs.reference }}")
+          if [ "$pulled_id" != "${{ steps.toolchain.outputs.digest }}" ]; then
+            echo "Digest dell'immagine scaricata $pulled_id diverso dal lock ${{ steps.toolchain.outputs.digest }}"
+            exit 1
+          fi
 
       - name: Run deterministic grading
         run: |
@@ -133,6 +167,9 @@ jobs:
             --activity-root "thebitlab" \
             --source-root "student-work" \
             --docker \
+            --docker-image "${{ steps.toolchain.outputs.reference }}" \
+            --toolchain-version "${{ steps.toolchain.outputs.version }}" \
+            --toolchain-reference "${{ steps.toolchain.outputs.reference }}" \
             --report "$RUNNER_TEMP/thebitlab-report/report.json"
 
       - name: Upload authoritative grading report

--- a/doc/ASSIGNMENT_SANDBOX.md
+++ b/doc/ASSIGNMENT_SANDBOX.md
@@ -75,11 +75,41 @@ Per un aggiornamento intenzionale:
 2. incrementa sempre `version`;
 3. apri una PR e attendi build e smoke test;
 4. dopo il merge, recupera il digest dall'artifact o dal summary del workflow di pubblicazione;
-5. aggiorna tramite PR il lock del grading autorevole.
+5. aggiorna `docker/assignment-runner/toolchain.lock.json` con il nuovo `immutable_reference`
+   (e la `source_revision` del merge) tramite PR;
+6. il workflow `grade-student-assignment.yml` carichera esattamente quel digest da GHCR e lo
+   registrera nel report di grading.
 
-Per il rollback non si ricostruisce l'immagine: si ripristina nel lock un digest GHCR precedente
-ancora conservato. Le versioni pubblicate non devono essere eliminate finche esistono report o lock
-che le referenziano.
+Per il rollback non si ricostruisce l'immagine: si ripristina nel lock `toolchain.lock.json`
+un digest GHCR precedente ancora conservato e si mergia la PR. Il workflow autorevole iniziera
+immediatamente a usare il vecchio digest. Le versioni pubblicate non devono essere eliminate
+finché esistono report o lock che le referenziano.
+
+## Lock autorevole
+
+Il file `docker/assignment-runner/toolchain.lock.json` contiene l'unico riferimento immutabile
+che il workflow `grade-student-assignment.yml` e autorizzato a eseguire:
+
+```json
+{
+  "schema_version": "thebitlab.grading-toolchain-lock.v1",
+  "version": "2026.07.1",
+  "platform": "linux/amd64",
+  "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
+  "source_revision": "bd102146a684a9b06835204ec1b7f668f7655a03",
+  "immutable_reference": "ghcr.io/thebitpoets/2cornot2c-assignment-runner@sha256:..."
+}
+```
+
+Il workflow autorevole:
+
+- valida il lock con `scripts/toolchain_lock.py`;
+- se il docente fornisce un `toolchain_digest` in input, lo confronta con il lock e fallisce
+  chiuso in caso di disallineamento;
+- esegue `docker pull` solo del riferimento `@sha256:` autorizzato;
+- verifica che l'immagine scaricata abbia esattamente il digest del lock;
+- passa il riferimento a `grade_activity.py`, che lo registra nei campi
+  `toolchain_version` e `toolchain_reference` del report.
 
 ## Uso
 

--- a/docker/assignment-runner/toolchain.lock.json
+++ b/docker/assignment-runner/toolchain.lock.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "thebitlab.grading-toolchain-lock.v1",
+  "version": "2026.07.1",
+  "platform": "linux/amd64",
+  "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
+  "source_revision": "bd102146a684a9b06835204ec1b7f668f7655a03",
+  "immutable_reference": "ghcr.io/thebitpoets/2cornot2c-assignment-runner@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+}

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -1228,6 +1228,8 @@ def run_docker_grading(args: argparse.Namespace) -> int:
         commit=getattr(args, "commit", None),
         submitted_at=getattr(args, "submitted_at", None),
         source_repo_path=getattr(args, "source_repo_path", None),
+        toolchain_version=getattr(args, "toolchain_version", None),
+        toolchain_reference=getattr(args, "toolchain_reference", None),
     )
     if args.report:
         write_report(report, args.report)
@@ -1255,6 +1257,8 @@ def with_report_metadata(
     commit: str | None = None,
     submitted_at: str | None = None,
     source_repo_path: str | None = None,
+    toolchain_version: str | None = None,
+    toolchain_reference: str | None = None,
 ) -> dict[str, Any]:
     """Return a report enriched with explicit remote-tracking identities."""
 
@@ -1265,6 +1269,8 @@ def with_report_metadata(
         ("commit", commit),
         ("submitted_at", submitted_at),
         ("source", source_repo_path),
+        ("toolchain_version", toolchain_version),
+        ("toolchain_reference", toolchain_reference),
     ):
         clean = str(value or "").strip()
         if clean:
@@ -1289,6 +1295,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--docker", action="store_true", help="Esegue il grading dentro la sandbox Docker.")
     parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE, help="Immagine Docker da usare con --docker.")
+    parser.add_argument("--toolchain-version", help="Versione della toolchain usata per il grading.")
+    parser.add_argument("--toolchain-reference", help="Riferimento immutabile della toolchain usata per il grading.")
     return parser.parse_args()
 
 

--- a/scripts/toolchain_lock.py
+++ b/scripts/toolchain_lock.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from scripts.build_assignment_runner import IMAGE_REPOSITORY, VERSION_RE
+
+
+LOCK_SCHEMA_VERSION = "thebitlab.grading-toolchain-lock.v1"
+SUPPORTED_PLATFORMS = {"linux/amd64"}
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+EXPECTED_KEYS = {
+    "schema_version",
+    "version",
+    "platform",
+    "image_repository",
+    "source_revision",
+    "immutable_reference",
+}
+
+
+class ToolchainLockError(RuntimeError):
+    """Raised when the toolchain lock is missing, malformed, or unauthorized."""
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ToolchainLockError(f"Lock toolchain non leggibile: {path}.") from error
+
+
+def _split_reference(reference: str) -> tuple[str, str]:
+    if "@" not in reference:
+        raise ToolchainLockError("Riferimento immutabile mancante di digest.")
+    repository, digest = reference.rsplit("@", 1)
+    if not repository:
+        raise ToolchainLockError("Repository nel riferimento immutabile vuota.")
+    if not DIGEST_RE.fullmatch(digest):
+        raise ToolchainLockError("Digest nel riferimento immutabile non valido.")
+    return repository, digest
+
+
+def load_lock(path: Path) -> dict[str, Any]:
+    """Load and strictly validate the authoritative toolchain lock file."""
+
+    payload = _load_json(path)
+    if not isinstance(payload, dict) or set(payload) != EXPECTED_KEYS:
+        raise ToolchainLockError("Campi del lock toolchain non validi.")
+    if payload["schema_version"] != LOCK_SCHEMA_VERSION:
+        raise ToolchainLockError("Schema lock toolchain non supportato.")
+    if not isinstance(payload["version"], str) or not VERSION_RE.fullmatch(
+        payload["version"]
+    ):
+        raise ToolchainLockError("Versione nel lock toolchain non valida.")
+    if payload["platform"] not in SUPPORTED_PLATFORMS:
+        raise ToolchainLockError("Piattaforma nel lock toolchain non supportata.")
+    if payload["image_repository"] != IMAGE_REPOSITORY:
+        raise ToolchainLockError("Repository nel lock toolchain non autorizzato.")
+    if not isinstance(payload["source_revision"], str) or not SHA_RE.fullmatch(
+        payload["source_revision"]
+    ):
+        raise ToolchainLockError("Revisione sorgente nel lock non valida.")
+    repository, digest = _split_reference(payload["immutable_reference"])
+    if repository != payload["image_repository"]:
+        raise ToolchainLockError("Repository e riferimento immutabile non coerenti.")
+    return {
+        **payload,
+        "digest": digest,
+    }
+
+
+def immutable_reference(lock: dict[str, Any]) -> str:
+    """Return the fully qualified immutable reference from a validated lock."""
+
+    return str(lock["immutable_reference"])

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -438,6 +438,43 @@ def test_docker_command_uses_read_only_workspace(tmp_path) -> None:
     assert "--language" not in command
     assert "--worker" in command
     assert command[command.index("--source") + 1] == "main.c"
+    assert "thebitlab-assignment-runner" in command
+
+
+def test_docker_command_uses_locked_image_reference(tmp_path) -> None:
+    source_path = tmp_path / "main.c"
+    source_path.write_text("int main(void){return 0;}", encoding="utf-8")
+    reference = (
+        "ghcr.io/thebitpoets/2cornot2c-assignment-runner"
+        "@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+    )
+
+    command = grade_activity.docker_command(
+        source=source_path,
+        timeout_seconds=5,
+        image=reference,
+        workspace=tmp_path,
+        cidfile=tmp_path / "container.cid",
+        container_name="thebitlab-grade-test",
+    )
+
+    assert command[command.index("--name") + 1] == "thebitlab-grade-test"
+    assert reference in command
+
+
+def test_report_metadata_includes_toolchain_fields() -> None:
+    report = grade_activity.with_report_metadata(
+        {"passed": True, "status": "passed"},
+        assignment_id="A1",
+        toolchain_version="2026.07.1",
+        toolchain_reference="ghcr.io/thebitpoets/2cornot2c-assignment-runner@sha256:abc",
+    )
+
+    assert report["assignment_id"] == "A1"
+    assert report["toolchain_version"] == "2026.07.1"
+    assert report["toolchain_reference"] == (
+        "ghcr.io/thebitpoets/2cornot2c-assignment-runner@sha256:abc"
+    )
 
 
 def test_remove_docker_container_validates_id_and_forces_cleanup(

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -15,6 +15,16 @@ def test_trusted_grading_workflow_separates_student_and_workflow_commits() -> No
     assert "ref: ${{ inputs.student_head_sha }}" in source
     assert "THEBITLAB_STUDENT_REPO_TOKEN || github.token" in source
     assert source.count("persist-credentials: false") == 2
+    assert "scripts/build_assignment_runner.py" not in source
+    assert "docker build" not in source
+    assert "from scripts import toolchain_lock" in source
+    assert "docker pull" in source
+    assert "steps.toolchain.outputs.reference" in source
+    assert "steps.toolchain.outputs.digest" in source
+    assert "toolchain_digest" in source
+    assert "--docker-image" in source
+    assert "--toolchain-version" in source
+    assert "--toolchain-reference" in source
     assert '--activity "thebitlab/$ACTIVITY_PATH"' in source
     assert '--source "student-work/$SOURCE_PATH"' in source
     assert '--commit "$STUDENT_HEAD_SHA"' in source
@@ -32,7 +42,6 @@ def test_runner_workflows_use_the_validated_toolchain_builder() -> None:
     for path in (
         ".github/workflows/assignment-runner-docker.yml",
         ".github/workflows/student-template-smoke.yml",
-        ".github/workflows/grade-student-assignment.yml",
     ):
         source = Path(path).read_text(encoding="utf-8")
         assert "scripts/build_assignment_runner.py" in source

--- a/tests/test_toolchain_lock.py
+++ b/tests/test_toolchain_lock.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import toolchain_lock
+
+
+def lock_payload() -> dict:
+    return {
+        "schema_version": "thebitlab.grading-toolchain-lock.v1",
+        "version": "2026.07.1",
+        "platform": "linux/amd64",
+        "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
+        "source_revision": "bd102146a684a9b06835204ec1b7f668f7655a03",
+        "immutable_reference": (
+            "ghcr.io/thebitpoets/2cornot2c-assignment-runner"
+            "@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+        ),
+    }
+
+
+def write_lock(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "toolchain.lock.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_load_lock_accepts_checked_in_reference(tmp_path: Path) -> None:
+    lock = toolchain_lock.load_lock(
+        write_lock(tmp_path, lock_payload())
+    )
+
+    assert lock["version"] == "2026.07.1"
+    assert lock["platform"] == "linux/amd64"
+    assert lock["image_repository"] == "ghcr.io/thebitpoets/2cornot2c-assignment-runner"
+    assert lock["digest"] == (
+        "sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+    )
+    assert toolchain_lock.immutable_reference(lock) == lock_payload()["immutable_reference"]
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        ({"schema_version": "other"}, "Schema"),
+        ({"version": "latest"}, "Versione"),
+        ({"platform": "linux/arm64"}, "Piattaforma"),
+        (
+            {"image_repository": "ghcr.io/thebitpoets/other-runner"},
+            "Repository",
+        ),
+        ({"source_revision": "short"}, "Revisione"),
+        ({"immutable_reference": "missing-digest"}, "digest"),
+        (
+            {
+                "immutable_reference": (
+                    "ghcr.io/thebitpoets/other-runner"
+                    "@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+                )
+            },
+            "coerenti",
+        ),
+        ({"immutable_reference": "repo@sha256:notadigest"}, "Digest"),
+    ],
+)
+def test_load_lock_rejects_malformed_or_unauthorized_configuration(
+    tmp_path: Path, change: dict, message: str
+) -> None:
+    payload = lock_payload()
+    payload.update(change)
+
+    with pytest.raises(toolchain_lock.ToolchainLockError, match=message):
+        toolchain_lock.load_lock(write_lock(tmp_path, payload))
+
+
+def test_load_lock_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(toolchain_lock.ToolchainLockError, match="non leggibile"):
+        toolchain_lock.load_lock(tmp_path / "missing.lock.json")
+
+
+def test_load_lock_rejects_extra_or_missing_fields(tmp_path: Path) -> None:
+    payload = lock_payload()
+    payload["extra"] = "value"
+
+    with pytest.raises(toolchain_lock.ToolchainLockError, match="Campi"):
+        toolchain_lock.load_lock(write_lock(tmp_path, payload))
+
+    payload.pop("extra")
+    payload.pop("source_revision")
+
+    with pytest.raises(toolchain_lock.ToolchainLockError, match="Campi"):
+        toolchain_lock.load_lock(write_lock(tmp_path, payload))


### PR DESCRIPTION
Implements #521.

- Adds `docker/assignment-runner/toolchain.lock.json` with the real published OCI reference.
- Adds `scripts/toolchain_lock.py` for strict lock validation (schema, version, platform, repository allowlist, digest format, coherence between repository and reference).
- Updates `.github/workflows/grade-student-assignment.yml` to stop building the runner and instead pull the exact `@sha256:` reference from the lock.
- Optional instructor `toolchain_digest` input: if provided, the workflow compares it to the lock and fails closed on mismatch.
- Verifies the pulled image digest matches the lock before running grading.
- Records `toolchain_version` and `toolchain_reference` in the authoritative grading report.
- Updates docs and adds tests.
