### PR TITLE
fix: trigger publish workflow on publisher and workflow file changes

### DIFF
--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -9,8 +9,10 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/publish-assignment-runner.yml"
       - "docker/assignment-runner/**"
       - "scripts/build_assignment_runner.py"
+      - "scripts/publish_assignment_runner.py"
       - "scripts/grade_activity.py"
 
 concurrency:

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -82,7 +82,7 @@ def test_publish_workflow_only_publishes_reviewed_main_toolchains() -> None:
     assert "gunzip" in source
     assert ":latest" not in source
     assert source.count("tests/test_student_lab_runner_docker.py") == 1
-    assert '".github/workflows/publish-assignment-runner.yml"' not in source
+    assert '".github/workflows/publish-assignment-runner.yml"' in source
     assert "actions/checkout@v4" not in source
     assert "actions/upload-artifact@v4" not in source
     assert "actions/checkout@11d5960a326750d5838078e36cf38b85af677262" in source


### PR DESCRIPTION
The publish workflow did not trigger automatically when `scripts/publish_assignment_runner.py` or `.github/workflows/publish-assignment-runner.yml` changed. This caused fixes like #523 to require a manual `workflow_dispatch` on main.

Add both paths to the push filter so every publisher change is validated and published automatically.
