### PR TITLE
fix #528: persist structured Codex fallback details

### DIFF
--- a/scripts/student_help_provider.py
+++ b/scripts/student_help_provider.py
@@ -28,7 +28,7 @@ class StudentHelpResponse:
     provider_label: str
     message: str
     usage: dict[str, int]
-    detail: str = ""
+    detail: str | dict[str, str] = ""
 
     def to_dict(self) -> dict[str, Any]:
         """Return the stable response payload used at integration boundaries."""
@@ -40,7 +40,7 @@ class StudentHelpResponse:
             "provider_label": self.provider_label,
             "message": self.message,
             "usage": dict(self.usage),
-            "detail": self.detail,
+            "detail": dict(self.detail) if isinstance(self.detail, dict) else self.detail,
         }
 
 

--- a/scripts/student_help_service.py
+++ b/scripts/student_help_service.py
@@ -26,6 +26,9 @@ HELP_EVENT_SCHEMA_VERSION = "student_help_event.v1"
 PENDING_PROVIDER_MAX_AGE = timedelta(minutes=5)
 MAX_HELP_EVENTS_PER_ASSIGNMENT = 40
 MAX_PROVIDER_MESSAGE_CHARS = 8_000
+MAX_PROVIDER_DETAIL_CHARS = 16_000
+MAX_PROVIDER_DETAIL_FIELDS = 16
+MAX_PROVIDER_DETAIL_KEY_CHARS = 64
 PROVIDER_ERROR_DETAIL = "Il provider non ha potuto completare la richiesta. Riprova più tardi o avvisa il docente."
 _HELP_LOG_LOCKS: dict[str, threading.Lock] = {}
 _HELP_LOG_LOCKS_GUARD = threading.Lock()
@@ -200,8 +203,7 @@ def provider_response_payload(response: Any) -> dict[str, Any]:
         raise ValueError("Messaggio risposta provider non valido.")
     if len(message) > MAX_PROVIDER_MESSAGE_CHARS:
         raise ValueError("Messaggio risposta provider troppo grande.")
-    if not isinstance(detail, str):
-        raise ValueError("Dettaglio risposta provider non valido.")
+    normalized_detail = normalized_provider_detail(detail)
     usage = payload.get("usage")
     if not isinstance(usage, dict):
         raise ValueError("Contatori uso provider non validi.")
@@ -221,9 +223,36 @@ def provider_response_payload(response: Any) -> dict[str, Any]:
         "provider_label": provider_label.strip(),
         "message": "" if status == "error" else message.strip(),
         "usage": normalized_usage,
-        "detail": PROVIDER_ERROR_DETAIL if status == "error" else detail.strip(),
+        "detail": PROVIDER_ERROR_DETAIL if status == "error" else normalized_detail,
     }
 
+
+def normalized_provider_detail(value: Any) -> str | dict[str, str]:
+    """Return a bounded JSON-safe provider diagnostic detail."""
+
+    if isinstance(value, str):
+        if len(value) > MAX_PROVIDER_DETAIL_CHARS:
+            raise ValueError("Dettaglio risposta provider troppo grande.")
+        return value.strip()
+    if not isinstance(value, dict) or len(value) > MAX_PROVIDER_DETAIL_FIELDS:
+        raise ValueError("Dettaglio risposta provider non valido.")
+    normalized: dict[str, str] = {}
+    total_chars = 0
+    for key, item in value.items():
+        if (
+            not isinstance(key, str)
+            or not key.strip()
+            or len(key.strip()) > MAX_PROVIDER_DETAIL_KEY_CHARS
+            or not isinstance(item, str)
+        ):
+            raise ValueError("Dettaglio risposta provider non valido.")
+        clean_key = key.strip()
+        clean_item = item.strip()
+        total_chars += len(clean_key) + len(clean_item)
+        if total_chars > MAX_PROVIDER_DETAIL_CHARS:
+            raise ValueError("Dettaglio risposta provider troppo grande.")
+        normalized[clean_key] = clean_item
+    return normalized
 
 def ai_events_used(events: list[dict[str, Any]]) -> int:
     return sum(

--- a/tests/test_student_help_service.py
+++ b/tests/test_student_help_service.py
@@ -144,6 +144,21 @@ class StructuredErrorHelpProvider:
     )
 
 
+class StructuredReadyHelpProvider:
+    def respond(self, request):
+        return StudentHelpResponse(
+            status="ready",
+            provider="codex-local-fallback",
+            provider_label="Guida locale dopo errore Codex",
+            message="Controlla una sola ipotesi alla volta.",
+            usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            detail={
+                "codex_error": "Codex exec non riuscito.",
+                "codex_error_type": "CodexStudentHelpProcessError",
+            },
+        )
+
+
 def test_provider_response_normalizes_total_tokens() -> None:
     response = StudentHelpResponse(
         status="ready",
@@ -156,6 +171,19 @@ def test_provider_response_normalizes_total_tokens() -> None:
     payload = student_help_service.provider_response_payload(response)
 
     assert payload["usage"] == {"input_tokens": 3, "output_tokens": 7, "total_tokens": 10}
+
+
+def test_provider_response_preserves_bounded_structured_detail() -> None:
+    response = StructuredReadyHelpProvider().respond(None)
+
+    payload = student_help_service.provider_response_payload(response)
+
+    assert payload["provider"] == "codex-local-fallback"
+    assert payload["detail"] == {
+        "codex_error": "Codex exec non riuscito.",
+        "codex_error_type": "CodexStudentHelpProcessError",
+    }
+
 
 
 def test_evaluate_help_request_denies_ai_when_policy_does_not_allow_it() -> None:
@@ -519,6 +547,30 @@ def test_record_help_request_sanitizes_structured_provider_errors(tmp_path) -> N
     assert "Stack trace remoto" not in persisted_text
     assert "segreto-strutturato" not in persisted_text
     assert "Errore remoto" not in persisted_text
+
+
+def test_record_help_request_persists_structured_ready_detail(tmp_path) -> None:
+    repo = tmp_path / "student-repo"
+
+    event = student_help_service.record_help_request(
+        repo_path=repo,
+        activity_id="python-base-somma-001",
+        support_policy=student_support_policy.support_policy("ai-assisted"),
+        help_type="ai",
+        prompt="Conserva il dettaglio del fallback.",
+        provider=StructuredReadyHelpProvider(),
+    )
+
+    persisted = json.loads(
+        (repo / "help" / "python-base-somma-001" / "events.json").read_text(encoding="utf-8")
+    )["events"][0]
+
+    assert event["response"]["provider"] == "codex-local-fallback"
+    assert persisted["response"]["detail"]["codex_error"] == "Codex exec non riuscito."
+    assert (
+        persisted["response"]["detail"]["codex_error_type"]
+        == "CodexStudentHelpProcessError"
+    )
 
 
 def test_record_help_request_blocks_ai_when_budget_is_exhausted(tmp_path) -> None:


### PR DESCRIPTION
## Cosa cambia

- consente a `StudentHelpResponse.detail` di contenere diagnostica strutturata oltre alle stringhe;
- valida e limita dimensione, numero e forma dei campi diagnostici prima della persistenza;
- conserva `codex_error` e `codex_error_type` negli eventi del fallback Codex;
- mantiene la sanitizzazione generica per le risposte con `status="error"`.

## Causa root

Il fallback Codex introdotto da `8f3a758` produceva un oggetto `detail`, ma `student_help_service.provider_response_payload()` accettava soltanto stringhe. La validazione sollevava `ValueError` e trasformava il fallback in `StudentHelpProviderRouter / Provider aiuto non disponibile`, perdendo dettaglio e warning.

## Impatto

La TUI mostra nuovamente la guida locale dopo errore Codex e l'evento persistito mantiene il motivo reale del fallback in forma strutturata e limitata.

Closes #528

## Verifica

- `python -m pytest tests/test_student_help_provider.py tests/test_student_help_service.py tests/test_student_help_codex_adapter.py tests/test_course_board_server.py -q`
- 183 passati, 1 skip previsto
- verifica TUI end-to-end: `provider=codex-local-fallback`, `codex_error_type=CodexStudentHelpProcessError`, dettaglio completo persistito
- `git diff --check`