### PR TITLE
fix: mostrare inline gli errori di validazione del percorso

### DIFF
--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -395,7 +395,7 @@ def test_confirmed_navigation_preserves_tab_and_window_intent() -> None:
     )
 
 
-def test_create_course_rejects_invalid_weeks_and_hours() -> None:
+def test_create_course_rejects_invalid_weeks_and_hours_inline() -> None:
     run_course_board_js(
         """
         state.design = { years: [] };
@@ -407,14 +407,37 @@ def test_create_course_rejects_invalid_weeks_and_hours() -> None:
         createYearFromDialog();
         assert.equal(state.design.years.length, 0);
         assert.equal(els.yearWeeksInput["aria-invalid"], "true");
+        assert.equal(els.yearWeeksInput["aria-describedby"], "yearDialogError");
+        assert.equal(els.yearWeeksInput["aria-errormessage"], "yearDialogError");
+        assert.equal(els.yearDialogError.hidden, false);
+        assert.equal(
+          els.yearDialogError.textContent,
+          "Le settimane devono essere un numero intero maggiore di zero.",
+        );
 
         els.yearWeeksInput.value = "10";
         els.yearWeeklyHoursInput.value = "-1";
         createYearFromDialog();
         assert.equal(state.design.years.length, 0);
+        assert.equal(els.yearWeeksInput["aria-invalid"], undefined);
         assert.equal(els.yearWeeklyHoursInput["aria-invalid"], "true");
+        assert.equal(els.yearDialogError.hidden, false);
+        assert.equal(
+          els.yearDialogError.textContent,
+          "Le ore settimanali devono essere maggiori di zero.",
+        );
         """
     )
+
+
+def test_course_dialog_contains_accessible_inline_validation_message() -> None:
+    html = Path("tools/course_board.html").read_text(encoding="utf-8")
+    css = Path("tools/course_board.css").read_text(encoding="utf-8")
+
+    assert 'id="yearDialogError"' in html
+    assert 'class="dialogInlineError"' in html
+    assert 'role="alert"' in html
+    assert ".dialogInlineError" in css
 
 
 def test_dirty_tracking_detects_changes_and_resets_after_save() -> None:

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -341,6 +341,16 @@ input[aria-invalid="true"] {
   box-shadow: 0 0 0 2px rgba(180, 35, 24, .16);
 }
 
+.dialogInlineError {
+  margin: 0;
+  border: 1px solid rgba(180, 35, 24, .35);
+  border-radius: 12px;
+  background: rgba(180, 35, 24, .08);
+  color: #8f1d14;
+  padding: .65rem .75rem;
+  font-weight: 700;
+}
+
 .headingCard::before {
   content: "";
   position: absolute;

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -191,6 +191,8 @@
         </label>
       </div>
 
+      <p id="yearDialogError" class="dialogInlineError" role="alert" hidden></p>
+
       <label class="wideField">
         <span>Obiettivi/descrizione</span>
         <textarea id="yearDescriptionInput" rows="4" placeholder="Obiettivi del percorso, criteri di scelta degli argomenti, focus della materia..."></textarea>

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -49,6 +49,7 @@ const els = {
   yearWeeksInput: document.querySelector("#yearWeeksInput"),
   yearWeeklyHoursInput: document.querySelector("#yearWeeklyHoursInput"),
   yearDescriptionInput: document.querySelector("#yearDescriptionInput"),
+  yearDialogError: document.querySelector("#yearDialogError"),
   paragraphDialog: document.querySelector("#paragraphDialog"),
   paragraphCloseBtn: document.querySelector("#paragraphCloseBtn"),
   paragraphDialogTitle: document.querySelector("#paragraphDialogTitle"),
@@ -1181,7 +1182,7 @@ function createYearFromDialog() {
     return;
   }
   if ((state.design.years || []).some((year) => year.id === id)) {
-    setStatus(`Esiste gia un percorso con ID "${id}".`);
+    showInvalidYearField(els.yearIdInput, `Esiste gia un percorso con ID "${id}".`);
     return;
   }
   state.design.years ||= [];
@@ -1202,11 +1203,19 @@ function clearYearValidation() {
     els.yearWeeklyHoursInput,
   ]) {
     element.removeAttribute("aria-invalid");
+    element.removeAttribute("aria-describedby");
+    element.removeAttribute("aria-errormessage");
   }
+  els.yearDialogError.textContent = "";
+  els.yearDialogError.hidden = true;
 }
 
 function showInvalidYearField(element, message) {
+  els.yearDialogError.textContent = message;
+  els.yearDialogError.hidden = false;
   element.setAttribute("aria-invalid", "true");
+  element.setAttribute("aria-describedby", "yearDialogError");
+  element.setAttribute("aria-errormessage", "yearDialogError");
   element.focus();
   setStatus(message);
 }


### PR DESCRIPTION
## Sintesi
- aggiunge un alert inline accessibile nel dialog di creazione percorso
- collega il campo invalido al messaggio tramite aria-describedby e aria-errormessage
- pulisce messaggio e attributi a ogni nuova validazione
- rende inline anche l'errore per ID percorso duplicato

## Verifica
- python -m pytest tests/test_course_board_frontend.py -q
- python -m pytest tests/test_course_board_server.py tests/test_course_board_frontend.py tests/test_school_calendar_frontend.py -q
- node --check tools/course_board.js
- git diff --check

Closes #531