### PR TITLE
refactor: isolare il runner Docker dietro ExecutionService

### DIFF
--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -99,16 +99,18 @@ Le prossime implementazioni concrete devono preservare questi casi:
 
 ## Evoluzione prevista
 
-1. Collegare il runner Docker reale a `ExecutionService`.
-2. Spostare la logica di `grade_activity.py` dietro `GradingService`.
-3. Aggiungere un `AiFeedbackService` mockabile per feedback docente/studente.
-4. Salvare i risultati nei registri e, in futuro, nell'indice SQLite senza cambiare la GUI.
+1. [x] Collegare il runner Docker reale a `ExecutionService`.
+2. [ ] Spostare la logica di `grade_activity.py` dietro `GradingService`.
+3. [x] Aggiungere un `AiFeedbackService` mockabile per feedback docente/studente.
+4. [ ] Salvare i risultati nei registri e, in futuro, nell'indice SQLite senza cambiare la GUI.
 
 ## Bridge con i report esistenti
 
 Durante la transizione, i report prodotti da `scripts/grade_activity.py` vengono convertiti nel contratto tecnico con `grading_dict_from_grade_activity_report()`. Questo permette al tracking delle consegne di usare `GradingService` senza cambiare subito il formato dei report gia prodotti.
 
 `GradeActivityExecutionService` espone inoltre `grade_activity.py` dietro la porta `ExecutionService`: i chiamanti passano `activity_path` e `source_path` nei metadati della richiesta e ricevono un `ExecutionResult`, senza dipendere dal formato legacy del report.
+
+`DockerGradeActivityExecutionService` implementa la stessa porta sopra il runner Docker autorevole. Normalizza runner assente, timeout e errori di protocollo, mentre `student_lab_runner.py` si limita a costruire la richiesta tecnica e serializzare il risultato nel contratto pubblico `student_lab_run.v1`. Durante la transizione, `ExecutionResult.metadata.runner_report` conserva una copia difensiva del report del runner per non perdere campi di toolchain o dettagli gia consumati dalle dashboard.
 
 `DeterministicAiFeedbackService` fornisce una prima implementazione mockabile di `AiFeedbackService`: genera bozze di feedback a partire dal `GradingResult` senza chiamare provider esterni. Serve per stabilizzare flussi, test e dashboard prima di collegare un adapter AI reale.
 

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -15,6 +15,11 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from scripts import grade_activity, student_lab_attempts, student_lab_service
 from scripts.thebitlab_contracts import normalize_activity
+from scripts.thebitlab_technical_services import (
+    DockerGradeActivityExecutionService,
+    ExecutionRequest,
+    ExecutionService,
+)
 
 
 DEFAULT_TIMEOUT_SECONDS = 5
@@ -332,8 +337,9 @@ def run_docker_runner(
     timeout_seconds: int,
     language: str = "c",
     docker_image: str = DEFAULT_DOCKER_IMAGE,
+    execution_service: ExecutionService | None = None,
 ) -> dict[str, Any]:
-    """Run a supported assignment through the authoritative Docker harness."""
+    """Run a supported assignment through the Docker ExecutionService port."""
 
     if not source.is_file():
         return error_report(
@@ -344,44 +350,45 @@ def run_docker_runner(
             error=f"Sorgente non trovato: {source}",
             backend="docker",
         )
-    try:
-        report, _worker_stderr = grade_activity.grade_activity_in_docker(
-            activity_path,
-            source,
+    service = execution_service or DockerGradeActivityExecutionService()
+    execution = service.run(
+        ExecutionRequest(
+            activity_id=clean_text(assignment.get("activity_id")),
+            student_id=clean_text(assignment.get("student_id")),
+            files={source.name: str(source)},
+            language=language,
             timeout_seconds=timeout_seconds,
-            language=language,
-            image=docker_image,
+            metadata={
+                "activity_path": activity_path,
+                "source_path": source,
+                "docker_image": docker_image,
+            },
         )
-    except subprocess.TimeoutExpired as error:
-        return error_report(
-            assignment,
-            language=language,
-            source=source,
-            status="docker-timeout",
-            error=f"Timeout Docker dopo {error.timeout} secondi.",
-            backend="docker",
-        )
-    except FileNotFoundError:
-        return error_report(
-            assignment,
-            language=language,
-            source=source,
-            status="docker-not-found",
-            error="Docker non trovato. Installa Docker oppure usa --backend local.",
-            backend="docker",
-        )
-    except (OSError, ValueError) as error:
-        return error_report(
-            assignment,
-            language=language,
-            source=source,
-            status="docker-setup-error",
-            error=str(error),
-            backend="docker",
-        )
-    wrapped = wrap_runner_report(assignment, source, report, language)
-    wrapped["backend"] = "docker"
-    return wrapped
+    )
+    runner_report = execution.metadata.get("runner_report")
+    if isinstance(runner_report, dict):
+        wrapped = wrap_runner_report(assignment, source, runner_report, language)
+        wrapped["backend"] = "docker"
+        return wrapped
+
+    detail = execution.detail
+    if execution.status == "timeout":
+        status = "docker-timeout"
+    elif execution.status == "runner_unavailable":
+        status = "docker-not-found"
+    elif execution.status == "invalid_payload":
+        status = "docker-setup-error"
+    else:
+        status = "docker-setup-error"
+        detail = "ExecutionService Docker senza report compatibile."
+    return error_report(
+        assignment,
+        language=language,
+        source=source,
+        status=status,
+        error=detail or "ExecutionService Docker non disponibile.",
+        backend="docker",
+    )
 
 
 def run_local_assignment(

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -499,7 +499,7 @@ def _grade_activity_report_validation_error(value: Any) -> str:
         expected_status = "passed" if expected_passed else "failed"
         if value["passed"] != expected_passed or value["status"] != expected_status:
             return "Il report Docker contiene esito e status complessivi incoerenti."
-    elif value["passed"]:
+    elif value["passed"] or value["status"] == "passed":
         return "Il report Docker senza test non puo risultare superato."
     summary = value.get("summary")
     if tests and not isinstance(summary, dict):

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -1,6 +1,8 @@
 ﻿from __future__ import annotations
 
+import copy
 import json
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Protocol
@@ -60,6 +62,7 @@ class ExecutionResult:
     stderr: str = ""
     duration_ms: int | None = None
     detail: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -228,6 +231,66 @@ class GradeActivityExecutionService:
             language=request.language,
         )
         return execution_result_from_grade_activity_report(report)
+
+
+class DockerGradeActivityExecutionService:
+    """ExecutionService adapter backed by the authoritative Docker runner."""
+
+    def run(self, request: ExecutionRequest) -> ExecutionResult:
+        """Run grade_activity in Docker and normalize infrastructure failures."""
+
+        from scripts import grade_activity
+
+        activity_path = request.metadata.get("activity_path")
+        source_path = request.metadata.get("source_path")
+        docker_image = str(request.metadata.get("docker_image") or grade_activity.DEFAULT_DOCKER_IMAGE)
+        if not activity_path or not source_path:
+            return ExecutionResult(
+                status="invalid_payload",
+                detail="ExecutionRequest.metadata deve includere activity_path e source_path.",
+            )
+
+        try:
+            report, worker_stderr = grade_activity.grade_activity_in_docker(
+                Path(str(activity_path)),
+                Path(str(source_path)),
+                timeout_seconds=request.timeout_seconds,
+                language=request.language,
+                image=docker_image,
+            )
+        except subprocess.TimeoutExpired as error:
+            return ExecutionResult(
+                status="timeout",
+                detail=f"Timeout Docker dopo {error.timeout} secondi.",
+            )
+        except FileNotFoundError:
+            return ExecutionResult(
+                status="runner_unavailable",
+                detail="Docker non trovato. Installa Docker oppure usa --backend local.",
+            )
+        except (OSError, ValueError) as error:
+            return ExecutionResult(status="invalid_payload", detail=str(error))
+
+        if not isinstance(report, dict):
+            return ExecutionResult(
+                status="invalid_payload",
+                detail="Il runner Docker non ha restituito un report JSON valido.",
+            )
+        result = execution_result_from_grade_activity_report(report)
+        return ExecutionResult(
+            status=result.status,
+            tests=result.tests,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            duration_ms=result.duration_ms,
+            detail=result.detail,
+            metadata={
+                "backend": "docker",
+                "docker_image": docker_image,
+                "runner_report": copy.deepcopy(report),
+                "worker_stderr": str(worker_stderr or ""),
+            },
+        )
 
 
 class DeterministicAiFeedbackService:

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -271,11 +271,9 @@ class DockerGradeActivityExecutionService:
         except (OSError, ValueError) as error:
             return ExecutionResult(status="invalid_payload", detail=str(error))
 
-        if not isinstance(report, dict):
-            return ExecutionResult(
-                status="invalid_payload",
-                detail="Il runner Docker non ha restituito un report JSON valido.",
-            )
+        report_error = _grade_activity_report_validation_error(report)
+        if report_error:
+            return ExecutionResult(status="invalid_payload", detail=report_error)
         result = execution_result_from_grade_activity_report(report)
         return ExecutionResult(
             status=result.status,
@@ -467,6 +465,63 @@ def ai_feedback_result_from_payload(payload: str | dict[str, Any]) -> AiFeedback
         approved_by_teacher=False,
         detail=detail,
     )
+
+
+def _grade_activity_report_validation_error(value: Any) -> str:
+    """Return an error for a malformed trusted-host grading report."""
+
+    if not isinstance(value, dict):
+        return "Il runner Docker non ha restituito un report JSON valido."
+    try:
+        json.dumps(value, allow_nan=False)
+    except (TypeError, ValueError):
+        return "Il runner Docker ha restituito un report non serializzabile in JSON."
+    if not isinstance(value.get("passed"), bool):
+        return "Il report Docker contiene un campo passed non valido."
+    if not isinstance(value.get("status"), str) or not value["status"].strip():
+        return "Il report Docker contiene un campo status non valido."
+    tests = value.get("tests")
+    if not isinstance(tests, list):
+        return "Il report Docker contiene un campo tests non valido."
+    for test in tests:
+        if not isinstance(test, dict):
+            return "Il report Docker contiene un test non valido."
+        if not isinstance(test.get("name"), str) or not test["name"].strip():
+            return "Il report Docker contiene un test senza nome valido."
+        if not isinstance(test.get("passed"), bool):
+            return "Il report Docker contiene un esito test non valido."
+        if not isinstance(test.get("status"), str) or not test["status"].strip():
+            return "Il report Docker contiene uno status test non valido."
+        if test["passed"] != (test["status"] == "passed"):
+            return "Il report Docker contiene esito e status test incoerenti."
+    if tests:
+        expected_passed = all(test["passed"] for test in tests)
+        expected_status = "passed" if expected_passed else "failed"
+        if value["passed"] != expected_passed or value["status"] != expected_status:
+            return "Il report Docker contiene esito e status complessivi incoerenti."
+    elif value["passed"]:
+        return "Il report Docker senza test non puo risultare superato."
+    summary = value.get("summary")
+    if tests and not isinstance(summary, dict):
+        return "Il report Docker con test non contiene un riepilogo valido."
+    if summary is not None:
+        if not isinstance(summary, dict):
+            return "Il report Docker contiene un riepilogo non valido."
+        passed = summary.get("passed")
+        total = summary.get("total")
+        valid_counts = (
+            isinstance(passed, int)
+            and not isinstance(passed, bool)
+            and isinstance(total, int)
+            and not isinstance(total, bool)
+            and 0 <= passed <= total
+        )
+        if not valid_counts or total != len(tests) or passed != sum(test["passed"] for test in tests):
+            return "Il report Docker contiene conteggi riepilogo incoerenti."
+    for key in ("activity_id", "language", "source", "toolchain_version", "toolchain_reference"):
+        if key in value and value[key] is not None and not isinstance(value[key], str):
+            return f"Il report Docker contiene un campo {key} non valido."
+    return ""
 
 
 def execution_result_from_payload(payload: str | dict[str, Any]) -> ExecutionResult:

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -836,7 +836,19 @@ def test_run_docker_assignment_rejects_worker_protocol_error(monkeypatch, tmp_pa
     assert report["passed"] is False
 
 
-def test_run_docker_assignment_rejects_structurally_invalid_report(monkeypatch, tmp_path) -> None:
+@pytest.mark.parametrize(
+    ("runner_report", "detail"),
+    [
+        ({"passed": "yes", "status": 42, "tests": "bad"}, "campo passed non valido"),
+        ({"passed": False, "status": "passed", "tests": []}, "senza test non puo risultare superato"),
+    ],
+)
+def test_run_docker_assignment_rejects_structurally_invalid_report(
+    monkeypatch,
+    tmp_path,
+    runner_report,
+    detail,
+) -> None:
     activity_id = "c-base-somma-001"
     activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")
     write_assignment(tmp_path, activity_path, activity_id=activity_id)
@@ -847,7 +859,7 @@ def test_run_docker_assignment_rejects_structurally_invalid_report(monkeypatch, 
     monkeypatch.setattr(
         student_lab_runner.grade_activity,
         "grade_activity_in_docker",
-        lambda *args, **kwargs: ({"passed": "yes", "status": 42, "tests": "bad"}, ""),
+        lambda *args, **kwargs: (runner_report, ""),
     )
 
     report = student_lab_runner.run_student_assignment(
@@ -861,7 +873,7 @@ def test_run_docker_assignment_rejects_structurally_invalid_report(monkeypatch, 
     assert report["status"] == "docker-setup-error"
     assert report["passed"] is False
     assert isinstance(report["tests"], list)
-    assert "campo passed non valido" in report["error"]
+    assert detail in report["error"]
 
 
 def test_run_docker_assignment_supports_python(monkeypatch, tmp_path) -> None:

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -836,6 +836,34 @@ def test_run_docker_assignment_rejects_worker_protocol_error(monkeypatch, tmp_pa
     assert report["passed"] is False
 
 
+def test_run_docker_assignment_rejects_structurally_invalid_report(monkeypatch, tmp_path) -> None:
+    activity_id = "c-base-somma-001"
+    activity_path = write_activity(tmp_path, activity_id=activity_id, language="c", source_name="main.c")
+    write_assignment(tmp_path, activity_path, activity_id=activity_id)
+    workspace = tmp_path / "examples" / "assignment_tracking" / "student_repos" / "rossi-mario" / "assignments" / activity_id
+    workspace.mkdir(parents=True)
+    (workspace / "main.c").write_text("int main(void){ return 0; }\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        student_lab_runner.grade_activity,
+        "grade_activity_in_docker",
+        lambda *args, **kwargs: ({"passed": "yes", "status": 42, "tests": "bad"}, ""),
+    )
+
+    report = student_lab_runner.run_student_assignment(
+        root=tmp_path,
+        student_id="rossi-mario",
+        activity_id=activity_id,
+        backend="docker",
+    )
+
+    assert report["backend"] == "docker"
+    assert report["status"] == "docker-setup-error"
+    assert report["passed"] is False
+    assert isinstance(report["tests"], list)
+    assert "campo passed non valido" in report["error"]
+
+
 def test_run_docker_assignment_supports_python(monkeypatch, tmp_path) -> None:
     activity_path = write_activity(tmp_path, language="python", source_name="main.py")
     write_assignment(tmp_path, activity_path)

--- a/tests/test_student_lab_runner.py
+++ b/tests/test_student_lab_runner.py
@@ -7,6 +7,7 @@ import subprocess
 import pytest
 
 from scripts import assignment_records, student_lab_attempts, student_lab_runner, student_lab_service
+from scripts.thebitlab_technical_services import ExecutionResult
 
 
 def write_activity(root, activity_id: str = "python-base-somma-001", **overrides) -> str:
@@ -687,6 +688,54 @@ def test_run_docker_assignment_wraps_container_report(monkeypatch, tmp_path) -> 
     assert report["status"] == "passed"
     assert report["passed"] is True
     assert report["summary"] == {"passed": 1, "total": 1}
+
+
+def test_run_docker_runner_uses_execution_service_and_preserves_returned_report(tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.c"
+    activity_path.write_text("{}", encoding="utf-8")
+    source_path.write_text("int main(void){return 0;}", encoding="utf-8")
+    captured = {}
+
+    class FakeExecutionService:
+        def run(self, request):
+            captured["request"] = request
+            return ExecutionResult(
+                status="timeout",
+                detail="timeout interno",
+                metadata={
+                    "runner_report": {
+                        "passed": False,
+                        "status": "timeout",
+                        "summary": {"passed": 0, "total": 0},
+                        "tests": [],
+                        "toolchain_version": "2026.07.1",
+                    }
+                },
+            )
+
+    report = student_lab_runner.run_docker_runner(
+        {
+            "assignment_id": "assignment-1",
+            "activity_id": "activity-1",
+            "student_id": "rossi-mario",
+        },
+        activity_path=activity_path,
+        source=source_path,
+        timeout_seconds=11,
+        language="c",
+        docker_image="runner@sha256:test",
+        execution_service=FakeExecutionService(),
+    )
+
+    request = captured["request"]
+    assert request.activity_id == "activity-1"
+    assert request.student_id == "rossi-mario"
+    assert request.timeout_seconds == 11
+    assert request.metadata["docker_image"] == "runner@sha256:test"
+    assert report["backend"] == "docker"
+    assert report["status"] == "timeout"
+    assert report["toolchain_version"] == "2026.07.1"
 
 
 def test_run_docker_assignment_adds_c_failure_message(monkeypatch, tmp_path) -> None:

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -336,6 +336,7 @@ def test_docker_execution_service_runs_authoritative_runner(monkeypatch, tmp_pat
         "passed": True,
         "status": "passed",
         "tests": [{"name": "base", "passed": True, "status": "passed"}],
+        "summary": {"passed": 1, "total": 1},
         "toolchain_version": "2026.07.1",
     }
 
@@ -447,13 +448,34 @@ def test_docker_execution_service_rejects_runner_protocol_errors(monkeypatch, tm
     assert result.detail == detail
 
 
-def test_docker_execution_service_rejects_non_object_report(monkeypatch, tmp_path) -> None:
+@pytest.mark.parametrize(
+    ("runner_report", "detail"),
+    [
+        ([], "report JSON valido"),
+        ({"passed": "yes", "status": 42, "tests": "bad"}, "campo passed non valido"),
+        (
+            {
+                "passed": True,
+                "status": "passed",
+                "tests": [{"name": "base", "passed": True, "status": "passed"}],
+                "summary": {"passed": 0, "total": 1},
+            },
+            "conteggi riepilogo incoerenti",
+        ),
+    ],
+)
+def test_docker_execution_service_rejects_malformed_reports(
+    monkeypatch,
+    tmp_path,
+    runner_report,
+    detail,
+) -> None:
     from scripts import grade_activity
 
     monkeypatch.setattr(
         grade_activity,
         "grade_activity_in_docker",
-        lambda *args, **kwargs: ([], ""),
+        lambda *args, **kwargs: (runner_report, ""),
     )
     result = DockerGradeActivityExecutionService().run(
         ExecutionRequest(
@@ -466,7 +488,8 @@ def test_docker_execution_service_rejects_non_object_report(monkeypatch, tmp_pat
     )
 
     assert result.status == "invalid_payload"
-    assert "report JSON valido" in result.detail
+    assert detail in result.detail
+    assert "runner_report" not in result.metadata
 
 
 def test_deterministic_ai_feedback_summarizes_passed_grading() -> None:

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -453,6 +453,7 @@ def test_docker_execution_service_rejects_runner_protocol_errors(monkeypatch, tm
     [
         ([], "report JSON valido"),
         ({"passed": "yes", "status": 42, "tests": "bad"}, "campo passed non valido"),
+        ({"passed": False, "status": "passed", "tests": []}, "senza test non puo risultare superato"),
         (
             {
                 "passed": True,

--- a/tests/test_thebitlab_technical_services.py
+++ b/tests/test_thebitlab_technical_services.py
@@ -1,11 +1,14 @@
 ﻿from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from scripts.thebitlab_technical_services import (
     AiFeedbackRequest,
     DeterministicGradingService,
     DeterministicAiFeedbackService,
+    DockerGradeActivityExecutionService,
     ExecutionResult,
     ExecutionRequest,
     GradeActivityExecutionService,
@@ -322,6 +325,148 @@ def test_grade_activity_execution_service_returns_invalid_payload_for_bad_activi
 
     assert result.status == "invalid_payload"
     assert "Activity non caricata" in result.detail
+
+
+def test_docker_execution_service_runs_authoritative_runner(monkeypatch, tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.c"
+    source_path.write_text("int main(void){return 0;}", encoding="utf-8")
+    runner_report = {
+        "activity_id": "c-base-somma-001",
+        "passed": True,
+        "status": "passed",
+        "tests": [{"name": "base", "passed": True, "status": "passed"}],
+        "toolchain_version": "2026.07.1",
+    }
+
+    from scripts import grade_activity
+
+    def fake_docker_runner(activity, source, *, timeout_seconds, language, image):
+        assert activity == activity_path
+        assert source == source_path
+        assert timeout_seconds == 7
+        assert language == "c"
+        assert image == "runner@sha256:test"
+        return runner_report, "worker note"
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", fake_docker_runner)
+    result = DockerGradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="c-base-somma-001",
+            student_id="rossi-mario",
+            files={"main.c": str(source_path)},
+            language="c",
+            timeout_seconds=7,
+            metadata={
+                "activity_path": activity_path,
+                "source_path": source_path,
+                "docker_image": "runner@sha256:test",
+            },
+        )
+    )
+
+    assert result.status == "passed"
+    assert result.tests == [RunnerTestResult("base", True)]
+    assert result.metadata["backend"] == "docker"
+    assert result.metadata["docker_image"] == "runner@sha256:test"
+    assert result.metadata["worker_stderr"] == "worker note"
+    assert result.metadata["runner_report"] == runner_report
+    assert result.metadata["runner_report"] is not runner_report
+
+
+def test_docker_execution_service_reports_missing_runner(monkeypatch, tmp_path) -> None:
+    from scripts import grade_activity
+
+    monkeypatch.setattr(
+        grade_activity,
+        "grade_activity_in_docker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    result = DockerGradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="activity",
+            student_id="student",
+            files={},
+            language="c",
+            metadata={"activity_path": tmp_path / "activity.json", "source_path": tmp_path / "main.c"},
+        )
+    )
+
+    assert result.status == "runner_unavailable"
+    assert "Docker non trovato" in result.detail
+
+
+def test_docker_execution_service_reports_timeout(monkeypatch, tmp_path) -> None:
+    from scripts import grade_activity
+
+    monkeypatch.setattr(
+        grade_activity,
+        "grade_activity_in_docker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired("docker", 9)),
+    )
+    result = DockerGradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="activity",
+            student_id="student",
+            files={},
+            language="c",
+            metadata={"activity_path": tmp_path / "activity.json", "source_path": tmp_path / "main.c"},
+        )
+    )
+
+    assert result.status == "timeout"
+    assert result.detail == "Timeout Docker dopo 9 secondi."
+
+
+@pytest.mark.parametrize(
+    ("failure", "detail"),
+    [
+        (ValueError("report worker incoerente"), "report worker incoerente"),
+        (OSError("errore setup Docker"), "errore setup Docker"),
+    ],
+)
+def test_docker_execution_service_rejects_runner_protocol_errors(monkeypatch, tmp_path, failure, detail) -> None:
+    from scripts import grade_activity
+
+    monkeypatch.setattr(
+        grade_activity,
+        "grade_activity_in_docker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(failure),
+    )
+    result = DockerGradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="activity",
+            student_id="student",
+            files={},
+            language="c",
+            metadata={"activity_path": tmp_path / "activity.json", "source_path": tmp_path / "main.c"},
+        )
+    )
+
+    assert result.status == "invalid_payload"
+    assert result.detail == detail
+
+
+def test_docker_execution_service_rejects_non_object_report(monkeypatch, tmp_path) -> None:
+    from scripts import grade_activity
+
+    monkeypatch.setattr(
+        grade_activity,
+        "grade_activity_in_docker",
+        lambda *args, **kwargs: ([], ""),
+    )
+    result = DockerGradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="activity",
+            student_id="student",
+            files={},
+            language="c",
+            metadata={"activity_path": tmp_path / "activity.json", "source_path": tmp_path / "main.c"},
+        )
+    )
+
+    assert result.status == "invalid_payload"
+    assert "report JSON valido" in result.detail
 
 
 def test_deterministic_ai_feedback_summarizes_passed_grading() -> None:


### PR DESCRIPTION
## Sintesi
- aggiunge DockerGradeActivityExecutionService sopra il runner Docker autorevole
- instrada student_lab_runner attraverso la porta ExecutionService
- normalizza runner assente, timeout e payload/protocollo non valido
- conserva una copia difensiva del report per mantenere student_lab_run.v1 e metadati toolchain
- aggiorna documentazione architetturale e test di compatibilità

## Verifica
- python -m pytest tests/test_thebitlab_technical_services.py tests/test_student_lab_runner.py -q
- python -m pytest tests -q
- python -m py_compile scripts/thebitlab_technical_services.py scripts/student_lab_runner.py
- git diff --check
- smoke demo locale su root tmp isolata

Closes #533