### PR TITLE
feat: aggiungere sessioni HTTP e autorizzazione

### DIFF
--- a/doc/architecture/auth-application-services.md
+++ b/doc/architecture/auth-application-services.md
@@ -2,7 +2,7 @@
 
 ## Scopo
 
-Questo documento descrive il livello applicativo tra provider federati, dominio identity e storage SQLite. Gli endpoint HTTP, i cookie e gli SDK Google/GitHub restano adapter successivi.
+Questo documento descrive il livello applicativo tra provider federati, dominio identity e storage SQLite. Il boundary provider-independent per cookie, CSRF e ruoli è descritto in `http-session-authorization.md`; route concrete e SDK Google/GitHub restano adapter successivi.
 
 ## Dipendenze
 
@@ -48,7 +48,7 @@ Una sessione revocata o appartenente a un account disabilitato fallisce chiusa. 
 
 La disabilitazione di un account revoca atomicamente le sue sessioni e rimuove pairing ancora autorizzati, impedendo che una successiva riabilitazione faccia rivivere credenziali precedenti. Gli aggiornamenti utente richiedono `created_at` immutabile, un nuovo `updated_at` strettamente successivo e l'`expected_updated_at` della revisione letta. Il compare-and-swap impedisce a uno snapshot stale di riattivare l'account anche se prova a presentare un timestamp futuro.
 
-Il ruolo `pending` puo possedere una sessione per completare onboarding, ma l'autorizzazione HTTP futura deve impedirgli l'accesso ai dati applicativi.
+Il ruolo `pending` puo possedere una sessione per completare onboarding, ma `HttpSessionAuthBoundary.authorize_application` lo esclude dalle policy sui dati applicativi.
 
 ## Pairing TUI
 
@@ -79,7 +79,7 @@ I messaggi non includono credenziali raw. Gli errori storage condivisi sono defi
 ## Fuori scope
 
 - Google OIDC e GitHub OAuth reali;
-- cookie, CSRF, middleware e autorizzazione route;
+- integrazione del boundary HTTP nelle route e nelle dashboard concrete;
 - rate limiting distribuito;
 - emissione atomica di una sessione TUI dopo il consumo;
 - UI e browser E2E.

--- a/doc/architecture/http-session-authorization.md
+++ b/doc/architecture/http-session-authorization.md
@@ -14,7 +14,7 @@ La policy di produzione predefinita emette:
 __Host-thebitlab_session=<bearer>; Path=/; HttpOnly; Secure; SameSite=Lax; ...
 ```
 
-Il cookie non usa `Domain`. Il prefisso `__Host-`, `Secure` e `Path=/` impediscono shadowing da sottodomini o path. `Max-Age` ed `Expires` seguono la scadenza assoluta della sessione, entro il limite HTTP configurato (24 ore per default, massimo 31 giorni). Risultati service malformati, sessioni non correlate o durate oltre policy falliscono con 503.
+Il cookie non usa `Domain`. Il prefisso `__Host-`, `Secure` e `Path=/` impediscono shadowing da sottodomini o path. `Max-Age` ed `Expires` seguono la scadenza assoluta della sessione, entro il limite HTTP configurato (24 ore per default, massimo 31 giorni). Risultati service malformati, account non attivi, sessioni revocate/non correlate o durate anche minimamente oltre policy falliscono con 503.
 
 Per HTTP locale esiste soltanto `SessionCookiePolicy.loopback_development()`, con nome senza prefisso `__Host-` e opt-in esplicito. L'adapter di rete deve consentirla esclusivamente quando il bind host è loopback. LAN e produzione richiedono HTTPS.
 
@@ -30,7 +30,7 @@ L'adapter concreto deve concatenare in modo deterministico eventuali header `Coo
 
 ## Login completion e fixation
 
-`establish_session` riceve soltanto un ID interno già autenticato. Se il browser presenta una sessione esistente, questa viene revocata prima di emettere il nuovo bearer. Il bearer nuovo proviene dal generatore di `SessionService`, non da input client.
+`establish_session` riceve soltanto un ID interno già autenticato. Se il browser presenta una sessione esistente, questa viene revocata prima di emettere il nuovo bearer; cookie estranei vengono ignorati. Il risultato di revoca deve essere un booleano e la sessione emessa/autenticata deve appartenere esattamente al `user_id` trusted richiesto. Il bearer nuovo proviene dal generatore di `SessionService`, non da input client.
 
 La risposta `EstablishedHttpSession` espone il valore soltanto attraverso `set_cookie`, escluso dal `repr`. Prima di costruire l'header, il boundary accetta soltanto bearer nella grammatica cookie base64url; un generatore incompatibile viene revocato e non può iniettare attributi. Database ed errori contengono esclusivamente digest.
 

--- a/doc/architecture/http-session-authorization.md
+++ b/doc/architecture/http-session-authorization.md
@@ -1,0 +1,74 @@
+# Boundary HTTP per sessioni e autorizzazione
+
+## Scopo
+
+`thebitlab_http_auth.py` traduce richieste HTTP in operazioni di `SessionService`. Rimane indipendente da `course_board_server.py`, Google OIDC e GitHub. Il callback OIDC futuro sarà l'unico adapter pubblico autorizzato a chiamare `establish_session(user_id)` dopo che `FederatedIdentityService` avrà risolto l'identità.
+
+Non deve esistere un endpoint di produzione che accetti direttamente un `user_id` scelto dal client. Provider fake ed eventuali route di test restano esclusivamente nei test.
+
+## Cookie
+
+La policy di produzione predefinita emette:
+
+```text
+__Host-thebitlab_session=<bearer>; Path=/; HttpOnly; Secure; SameSite=Lax; ...
+```
+
+Il cookie non usa `Domain`. Il prefisso `__Host-`, `Secure` e `Path=/` impediscono shadowing da sottodomini o path. `Max-Age` ed `Expires` seguono la scadenza assoluta della sessione.
+
+Per HTTP locale esiste soltanto `SessionCookiePolicy.loopback_development()`, con nome senza prefisso `__Host-` e opt-in esplicito. L'adapter di rete deve consentirla esclusivamente quando il bind host è loopback. LAN e produzione richiedono HTTPS.
+
+Il parser:
+
+- impone un limite in byte all'header;
+- rifiuta controlli, sintassi invalida, token vuoti o sovradimensionati;
+- richiede esattamente un cookie sessione;
+- rifiuta cookie sessione duplicati invece di scegliere first/last wins.
+
+L'adapter concreto deve concatenare in modo deterministico eventuali header `Cookie` multipli con `; ` prima del boundary, così i duplicati rimangono rilevabili.
+
+## Login completion e fixation
+
+`establish_session` riceve soltanto un ID interno già autenticato. Se il browser presenta una sessione esistente, questa viene revocata prima di emettere il nuovo bearer. Il bearer nuovo proviene dal generatore di `SessionService`, non da input client.
+
+La risposta `EstablishedHttpSession` espone il valore soltanto attraverso `set_cookie`, escluso dal `repr`. Database ed errori contengono esclusivamente digest.
+
+## Autenticazione e CSRF
+
+Ogni richiesta autenticata passa per `SessionService.authenticate`, che controlla digest, scadenza, revoca, account attivo e revisione utente con CAS. Ruoli cambiati vengono quindi riletti prima dell'autorizzazione.
+
+Il token CSRF è:
+
+```text
+base64url(HMAC-SHA256(secret_esterno, "thebitlab-csrf-v1\0" || bearer))
+```
+
+Non viene persistito, è legato alla sessione e viene confrontato in constant time. `POST`, `PUT`, `PATCH` e `DELETE` lo richiedono automaticamente. `GET`, `HEAD` e `OPTIONS` non richiedono CSRF. Metodi diversi falliscono chiusi. Il frontend futuro leggerà il token dalla risposta JSON di login/session refresh e lo invierà in un header dedicato, mai in URL.
+
+Il secret CSRF contiene almeno 32 byte, proviene da ambiente/secret store ed è distinto dal pepper pairing.
+
+## Autorizzazione
+
+`authenticate` permette anche a `pending` di raggiungere future route di onboarding. `authorize_application` accetta soltanto policy non vuote composte da `admin`, `teacher` e `student`: `pending` non può essere autorizzato ai dati applicativi per errore di configurazione.
+
+Errori pubblici stabili:
+
+- `400 bad_auth_request`;
+- `401 authentication_required`;
+- `403 authorization_denied`;
+- `403 csrf_rejected`;
+- `405 auth_method_not_allowed`.
+
+I messaggi non includono cookie, bearer o token CSRF.
+
+## Logout
+
+Il logout è esclusivamente `POST`. Per una sessione valida richiede CSRF, revoca il bearer server-side e restituisce sempre un cookie scaduto. Una sessione già scaduta, revocata o disabilitata produce comunque il cookie di cancellazione senza rivelare lo stato precedente.
+
+## Fuori scope
+
+- route concrete nel Course Board e protezione dashboard;
+- callback Google OIDC e verifica `state`/`nonce`/PKCE;
+- account linking GitHub;
+- pairing TUI via browser;
+- TLS termination e rate limiting distribuito.

--- a/doc/architecture/http-session-authorization.md
+++ b/doc/architecture/http-session-authorization.md
@@ -31,7 +31,7 @@ L'adapter concreto deve concatenare in modo deterministico eventuali header `Coo
 
 `establish_session` riceve soltanto un ID interno già autenticato. Se il browser presenta una sessione esistente, questa viene revocata prima di emettere il nuovo bearer. Il bearer nuovo proviene dal generatore di `SessionService`, non da input client.
 
-La risposta `EstablishedHttpSession` espone il valore soltanto attraverso `set_cookie`, escluso dal `repr`. Database ed errori contengono esclusivamente digest.
+La risposta `EstablishedHttpSession` espone il valore soltanto attraverso `set_cookie`, escluso dal `repr`. Prima di costruire l'header, il boundary accetta soltanto bearer nella grammatica cookie base64url; un generatore incompatibile viene revocato e non può iniettare attributi. Database ed errori contengono esclusivamente digest.
 
 ## Autenticazione e CSRF
 
@@ -57,9 +57,10 @@ Errori pubblici stabili:
 - `401 authentication_required`;
 - `403 authorization_denied`;
 - `403 csrf_rejected`;
-- `405 auth_method_not_allowed`.
+- `405 auth_method_not_allowed`;
+- `503 authentication_unavailable` per errori concorrenti, storage o inattesi sanitizzati.
 
-I messaggi non includono cookie, bearer o token CSRF.
+I messaggi non includono cookie, bearer, token CSRF o dettagli dell'adapter storage.
 
 ## Logout
 

--- a/doc/architecture/http-session-authorization.md
+++ b/doc/architecture/http-session-authorization.md
@@ -20,7 +20,8 @@ Per HTTP locale esiste soltanto `SessionCookiePolicy.loopback_development()`, co
 
 Il parser:
 
-- impone un limite in byte all'header;
+- limita il nome cookie e impone un limite in byte all'header;
+- rifiuta e revoca prima dell'emissione bearer il cui `name=value` non potrebbe rientrare nello stesso limite;
 - rifiuta controlli, sintassi invalida, token vuoti o sovradimensionati;
 - richiede esattamente un cookie sessione;
 - rifiuta cookie sessione duplicati invece di scegliere first/last wins;

--- a/doc/architecture/http-session-authorization.md
+++ b/doc/architecture/http-session-authorization.md
@@ -14,7 +14,7 @@ La policy di produzione predefinita emette:
 __Host-thebitlab_session=<bearer>; Path=/; HttpOnly; Secure; SameSite=Lax; ...
 ```
 
-Il cookie non usa `Domain`. Il prefisso `__Host-`, `Secure` e `Path=/` impediscono shadowing da sottodomini o path. `Expires` segue la scadenza assoluta della sessione; `Max-Age` usa la durata residua al momento della risposta, entro il limite HTTP configurato (24 ore per default, massimo 31 giorni). Il clock del boundary è iniettato e deve essere coerente con quello di `SessionService`. Risultati service malformati, account non attivi, sessioni revocate/non correlate o durate anche minimamente oltre policy falliscono con 503.
+Il cookie non usa `Domain`. Il prefisso `__Host-`, `Secure` e `Path=/` impediscono shadowing da sottodomini o path. `Expires` segue la scadenza assoluta della sessione; `Max-Age` usa la durata residua al momento della risposta. Una durata residua inferiore a un secondo viene revocata e rifiutata invece di emettere `Max-Age=0`; il valore accettato resta entro il limite HTTP configurato (24 ore per default, massimo 31 giorni). Il clock del boundary è iniettato e deve essere coerente con quello di `SessionService`. Risultati service malformati, account non attivi, sessioni revocate/non correlate o durate anche minimamente oltre policy falliscono con 503.
 
 Per HTTP locale esiste soltanto `SessionCookiePolicy.loopback_development()`, con nome senza prefisso `__Host-` e opt-in esplicito. L'adapter di rete deve consentirla esclusivamente quando il bind host è loopback. LAN e produzione richiedono HTTPS.
 

--- a/doc/architecture/http-session-authorization.md
+++ b/doc/architecture/http-session-authorization.md
@@ -14,7 +14,7 @@ La policy di produzione predefinita emette:
 __Host-thebitlab_session=<bearer>; Path=/; HttpOnly; Secure; SameSite=Lax; ...
 ```
 
-Il cookie non usa `Domain`. Il prefisso `__Host-`, `Secure` e `Path=/` impediscono shadowing da sottodomini o path. `Max-Age` ed `Expires` seguono la scadenza assoluta della sessione.
+Il cookie non usa `Domain`. Il prefisso `__Host-`, `Secure` e `Path=/` impediscono shadowing da sottodomini o path. `Max-Age` ed `Expires` seguono la scadenza assoluta della sessione, entro il limite HTTP configurato (24 ore per default, massimo 31 giorni). Risultati service malformati, sessioni non correlate o durate oltre policy falliscono con 503.
 
 Per HTTP locale esiste soltanto `SessionCookiePolicy.loopback_development()`, con nome senza prefisso `__Host-` e opt-in esplicito. L'adapter di rete deve consentirla esclusivamente quando il bind host è loopback. LAN e produzione richiedono HTTPS.
 
@@ -23,7 +23,8 @@ Il parser:
 - impone un limite in byte all'header;
 - rifiuta controlli, sintassi invalida, token vuoti o sovradimensionati;
 - richiede esattamente un cookie sessione;
-- rifiuta cookie sessione duplicati invece di scegliere first/last wins.
+- rifiuta cookie sessione duplicati invece di scegliere first/last wins;
+- accetta la forma RFC quoted sia per il bearer base64url sia per cookie estranei.
 
 L'adapter concreto deve concatenare in modo deterministico eventuali header `Cookie` multipli con `; ` prima del boundary, così i duplicati rimangono rilevabili.
 

--- a/doc/architecture/http-session-authorization.md
+++ b/doc/architecture/http-session-authorization.md
@@ -14,7 +14,7 @@ La policy di produzione predefinita emette:
 __Host-thebitlab_session=<bearer>; Path=/; HttpOnly; Secure; SameSite=Lax; ...
 ```
 
-Il cookie non usa `Domain`. Il prefisso `__Host-`, `Secure` e `Path=/` impediscono shadowing da sottodomini o path. `Max-Age` ed `Expires` seguono la scadenza assoluta della sessione, entro il limite HTTP configurato (24 ore per default, massimo 31 giorni). Risultati service malformati, account non attivi, sessioni revocate/non correlate o durate anche minimamente oltre policy falliscono con 503.
+Il cookie non usa `Domain`. Il prefisso `__Host-`, `Secure` e `Path=/` impediscono shadowing da sottodomini o path. `Expires` segue la scadenza assoluta della sessione; `Max-Age` usa la durata residua al momento della risposta, entro il limite HTTP configurato (24 ore per default, massimo 31 giorni). Il clock del boundary è iniettato e deve essere coerente con quello di `SessionService`. Risultati service malformati, account non attivi, sessioni revocate/non correlate o durate anche minimamente oltre policy falliscono con 503.
 
 Per HTTP locale esiste soltanto `SessionCookiePolicy.loopback_development()`, con nome senza prefisso `__Host-` e opt-in esplicito. L'adapter di rete deve consentirla esclusivamente quando il bind host è loopback. LAN e produzione richiedono HTTPS.
 
@@ -36,7 +36,7 @@ La risposta `EstablishedHttpSession` espone il valore soltanto attraverso `set_c
 
 ## Autenticazione e CSRF
 
-Ogni richiesta autenticata passa per `SessionService.authenticate`, che controlla digest, scadenza, revoca, account attivo e revisione utente con CAS. Ruoli cambiati vengono quindi riletti prima dell'autorizzazione.
+Ogni richiesta autenticata passa per `SessionService.authenticate`, che controlla digest, scadenza, revoca, account attivo e revisione utente con CAS. Il boundary verifica inoltre strutturalmente `created_at <= now < expires_at`, `now >= last_seen_at`, revoca e account attivo prima di fidarsi del risultato adapter. Ruoli cambiati vengono quindi riletti prima dell'autorizzazione.
 
 Il token CSRF è:
 

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -1,0 +1,412 @@
+"""Provider-independent HTTP session, cookie, CSRF, and role boundary."""
+
+from __future__ import annotations
+
+import base64
+import hmac
+import re
+from dataclasses import dataclass, field
+from datetime import timezone
+from email.utils import format_datetime
+from typing import Collection
+
+from scripts.thebitlab_auth_services import (
+    AuthApplicationError,
+    AuthenticatedSession,
+    IssuedSession,
+    SessionService,
+)
+
+_COOKIE_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_COOKIE_VALUE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_OTHER_COOKIE_VALUE_RE = re.compile(r'^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*$')
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+_UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+_APPLICATION_ROLES = frozenset({"admin", "teacher", "student"})
+_MAX_SESSION_TOKEN_CHARS = 1024
+
+
+class HttpAuthError(RuntimeError):
+    """Stable, credential-free error suitable for mapping to an HTTP response."""
+
+    status_code = 500
+    error_code = "http_auth_error"
+    public_message = "Errore autenticazione HTTP."
+
+    def __init__(self) -> None:
+        super().__init__(self.public_message)
+
+
+class HttpBadRequestError(HttpAuthError):
+    status_code = 400
+    error_code = "bad_auth_request"
+    public_message = "Richiesta di autenticazione non valida."
+
+
+class HttpAuthenticationRequiredError(HttpAuthError):
+    status_code = 401
+    error_code = "authentication_required"
+    public_message = "Autenticazione richiesta."
+
+
+class HttpAuthorizationDeniedError(HttpAuthError):
+    status_code = 403
+    error_code = "authorization_denied"
+    public_message = "Accesso non autorizzato."
+
+
+class HttpCsrfRejectedError(HttpAuthError):
+    status_code = 403
+    error_code = "csrf_rejected"
+    public_message = "Protezione CSRF non valida."
+
+
+class HttpMethodNotAllowedError(HttpAuthError):
+    status_code = 405
+    error_code = "auth_method_not_allowed"
+    public_message = "Metodo HTTP non supportato."
+
+
+@dataclass(frozen=True)
+class SessionCookiePolicy:
+    """Cookie policy; insecure HTTP requires an explicit loopback-only opt-in."""
+
+    name: str = "__Host-thebitlab_session"
+    secure: bool = True
+    same_site: str = "Lax"
+    allow_insecure_loopback: bool = False
+    max_cookie_header_bytes: int = 4096
+
+    def __post_init__(self) -> None:
+        if type(self.name) is not str or not _COOKIE_NAME_RE.fullmatch(self.name):
+            raise ValueError("Nome cookie sessione non valido.")
+        if type(self.secure) is not bool or type(self.allow_insecure_loopback) is not bool:
+            raise ValueError("Flag sicurezza cookie non validi.")
+        if type(self.same_site) is not str or self.same_site not in {"Strict", "Lax", "None"}:
+            raise ValueError("SameSite non valido.")
+        if self.same_site == "None" and not self.secure:
+            raise ValueError("SameSite=None richiede Secure.")
+        if self.name.startswith(("__Host-", "__Secure-")) and not self.secure:
+            raise ValueError("Un cookie con prefisso sicuro richiede Secure.")
+        if not self.secure and not self.allow_insecure_loopback:
+            raise ValueError("HTTP senza Secure richiede opt-in loopback esplicito.")
+        if (
+            type(self.max_cookie_header_bytes) is not int
+            or not 256 <= self.max_cookie_header_bytes <= 65536
+        ):
+            raise ValueError("Limite header Cookie non valido.")
+
+    @classmethod
+    def loopback_development(cls) -> "SessionCookiePolicy":
+        return cls(
+            name="thebitlab_session",
+            secure=False,
+            allow_insecure_loopback=True,
+        )
+
+
+@dataclass(frozen=True)
+class HttpAuthRequest:
+    method: str
+    cookie_header: str | None = field(default=None, repr=False, compare=False)
+    csrf_token: str | None = field(default=None, repr=False, compare=False)
+
+
+@dataclass(frozen=True)
+class HttpAuthContext:
+    authenticated: AuthenticatedSession
+    csrf_token: str = field(repr=False, compare=False)
+
+    @property
+    def user(self):
+        return self.authenticated.user
+
+    @property
+    def session(self):
+        return self.authenticated.session
+
+
+@dataclass(frozen=True)
+class EstablishedHttpSession:
+    context: HttpAuthContext
+    set_cookie: str = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True)
+class LogoutHttpResult:
+    revoked: bool
+    set_cookie: str = field(repr=False, compare=False)
+
+
+class HttpSessionAuthBoundary:
+    """Translate HTTP cookie/CSRF inputs to the provider-independent session service."""
+
+    def __init__(
+        self,
+        sessions: SessionService,
+        *,
+        csrf_secret: bytes,
+        cookie_policy: SessionCookiePolicy = SessionCookiePolicy(),
+    ) -> None:
+        candidate_secret = csrf_secret
+        csrf_secret = None
+        invalid_secret = type(candidate_secret) is not bytes or len(candidate_secret) < 32
+        if invalid_secret:
+            candidate_secret = None
+            raise ValueError("Il secret CSRF deve contenere almeno 32 byte.")
+        self.sessions = sessions
+        self.cookie_policy = cookie_policy
+        self._csrf_secret = candidate_secret
+        candidate_secret = None
+
+    def establish_session(
+        self, user_id: str, *, existing_cookie_header: str | None = None
+    ) -> EstablishedHttpSession:
+        """Rotate any browser session, then issue one for an already-resolved user."""
+        if existing_cookie_header:
+            try:
+                existing = self._extract_bearer(existing_cookie_header)
+            finally:
+                existing_cookie_header = None
+            try:
+                self.sessions.revoke(existing)
+            except AuthApplicationError:
+                pass
+            finally:
+                existing = None
+        issued = self.sessions.issue(user_id)
+        try:
+            return self._established_result(issued)
+        finally:
+            issued = None
+
+    def authenticate(self, request: HttpAuthRequest) -> HttpAuthContext:
+        try:
+            method, cookie_header, supplied_csrf = self._request_values(request)
+        finally:
+            request = None
+        bearer = None
+        auth_failed = False
+        authenticated = None
+        csrf_token = None
+        context = None
+        try:
+            bearer = self._extract_bearer(cookie_header)
+            cookie_header = None
+            try:
+                authenticated = self.sessions.authenticate(bearer)
+            except AuthApplicationError:
+                auth_failed = True
+            if not auth_failed and authenticated is not None:
+                csrf_token = self._csrf_token(bearer)
+                if method in _UNSAFE_METHODS:
+                    self._validate_csrf(bearer, supplied_csrf)
+                context = HttpAuthContext(authenticated, csrf_token)
+        finally:
+            bearer = None
+            cookie_header = None
+            supplied_csrf = None
+            csrf_token = None
+        if auth_failed or context is None:
+            raise HttpAuthenticationRequiredError()
+        return context
+
+    def authorize_application(
+        self, request: HttpAuthRequest, *, allowed_roles: Collection[str]
+    ) -> HttpAuthContext:
+        normalized_roles = self._application_roles(allowed_roles)
+        try:
+            context = self.authenticate(request)
+        finally:
+            request = None
+        if context.user.role not in normalized_roles:
+            context = None
+            raise HttpAuthorizationDeniedError()
+        return context
+
+    def logout(self, request: HttpAuthRequest) -> LogoutHttpResult:
+        try:
+            method, cookie_header, supplied_csrf = self._request_values(request)
+        finally:
+            request = None
+        if method != "POST":
+            cookie_header = None
+            supplied_csrf = None
+            raise HttpMethodNotAllowedError()
+        bearer = None
+        authenticated = None
+        auth_failed = False
+        try:
+            bearer = self._extract_bearer(cookie_header)
+            cookie_header = None
+            try:
+                authenticated = self.sessions.authenticate(bearer)
+            except AuthApplicationError:
+                auth_failed = True
+            if auth_failed:
+                return LogoutHttpResult(False, self._clear_cookie())
+            self._validate_csrf(bearer, supplied_csrf)
+            return LogoutHttpResult(self.sessions.revoke(bearer), self._clear_cookie())
+        finally:
+            bearer = None
+            authenticated = None
+            cookie_header = None
+            supplied_csrf = None
+
+    def _established_result(self, issued: IssuedSession) -> EstablishedHttpSession:
+        bearer = issued.bearer_token
+        authenticated = None
+        failed = False
+        try:
+            try:
+                authenticated = self.sessions.authenticate(bearer)
+            except AuthApplicationError:
+                failed = True
+            if failed or authenticated is None:
+                try:
+                    self.sessions.revoke(bearer)
+                except AuthApplicationError:
+                    pass
+                raise HttpAuthenticationRequiredError()
+            csrf_token = self._csrf_token(bearer)
+            set_cookie = self._session_cookie(bearer, issued)
+            return EstablishedHttpSession(
+                HttpAuthContext(authenticated, csrf_token),
+                set_cookie,
+            )
+        finally:
+            bearer = None
+            issued = None
+
+    @staticmethod
+    def _request_values(request: HttpAuthRequest) -> tuple[str, str | None, str | None]:
+        if type(request) is not HttpAuthRequest:
+            request = None
+            raise HttpBadRequestError()
+        method = request.method
+        cookie_header = request.cookie_header
+        csrf_token = request.csrf_token
+        request = None
+        if type(method) is not str:
+            cookie_header = None
+            csrf_token = None
+            raise HttpBadRequestError()
+        method = method.strip().upper()
+        if method not in _SAFE_METHODS | _UNSAFE_METHODS:
+            cookie_header = None
+            csrf_token = None
+            raise HttpMethodNotAllowedError()
+        return method, cookie_header, csrf_token
+
+    def _extract_bearer(self, cookie_header: str | None) -> str:
+        parse_failed = False
+        bearer = None
+        matches = None
+        segment = None
+        name = None
+        value = None
+        try:
+            if type(cookie_header) is not str:
+                parse_failed = True
+            elif len(cookie_header.encode("utf-8")) > self.cookie_policy.max_cookie_header_bytes:
+                parse_failed = True
+            elif any(ord(character) < 0x20 or ord(character) == 0x7F for character in cookie_header):
+                parse_failed = True
+            else:
+                matches: list[str] = []
+                for segment in cookie_header.split(";"):
+                    segment = segment.strip()
+                    if not segment or "=" not in segment:
+                        parse_failed = True
+                        break
+                    name, value = (part.strip() for part in segment.split("=", 1))
+                    if not _COOKIE_NAME_RE.fullmatch(name):
+                        parse_failed = True
+                        break
+                    if name == self.cookie_policy.name:
+                        matches.append(value)
+                    elif not _OTHER_COOKIE_VALUE_RE.fullmatch(value):
+                        parse_failed = True
+                        break
+                if len(matches) != 1:
+                    parse_failed = True
+                else:
+                    bearer = matches[0]
+                    if (
+                        not bearer
+                        or len(bearer) > _MAX_SESSION_TOKEN_CHARS
+                        or not _COOKIE_VALUE_RE.fullmatch(bearer)
+                    ):
+                        parse_failed = True
+        except (UnicodeError, ValueError):
+            parse_failed = True
+        finally:
+            cookie_header = None
+            matches = None
+            segment = None
+            name = None
+            value = None
+        if parse_failed or bearer is None:
+            bearer = None
+            raise HttpAuthenticationRequiredError()
+        return bearer
+
+    def _validate_csrf(self, bearer: str, supplied_token: str | None) -> None:
+        invalid = False
+        try:
+            expected = self._csrf_token(bearer)
+            invalid = (
+                type(supplied_token) is not str
+                or len(supplied_token) != len(expected)
+                or not hmac.compare_digest(supplied_token, expected)
+            )
+        finally:
+            bearer = None
+            supplied_token = None
+            expected = None
+        if invalid:
+            raise HttpCsrfRejectedError()
+
+    def _csrf_token(self, bearer: str) -> str:
+        digest = hmac.digest(self._csrf_secret, b"thebitlab-csrf-v1\0" + bearer.encode(), "sha256")
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    def _session_cookie(self, bearer: str, issued: IssuedSession) -> str:
+        expires = format_datetime(issued.session.expires_at.astimezone(timezone.utc), usegmt=True)
+        max_age = max(
+            0,
+            int((issued.session.expires_at - issued.session.created_at).total_seconds()),
+        )
+        attributes = [
+            f"{self.cookie_policy.name}={bearer}",
+            "Path=/",
+            "HttpOnly",
+            f"SameSite={self.cookie_policy.same_site}",
+            f"Max-Age={max_age}",
+            f"Expires={expires}",
+        ]
+        if self.cookie_policy.secure:
+            attributes.insert(3, "Secure")
+        return "; ".join(attributes)
+
+    def _clear_cookie(self) -> str:
+        attributes = [
+            f"{self.cookie_policy.name}=",
+            "Path=/",
+            "HttpOnly",
+            f"SameSite={self.cookie_policy.same_site}",
+            "Max-Age=0",
+            "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+        ]
+        if self.cookie_policy.secure:
+            attributes.insert(3, "Secure")
+        return "; ".join(attributes)
+
+    @staticmethod
+    def _application_roles(allowed_roles: Collection[str]) -> frozenset[str]:
+        if isinstance(allowed_roles, (str, bytes)):
+            raise ValueError("I ruoli autorizzati devono essere una collezione.")
+        roles = frozenset(allowed_roles)
+        if not roles or not roles <= _APPLICATION_ROLES:
+            raise ValueError("Policy ruoli applicativi non valida.")
+        return roles

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -426,9 +426,8 @@ class HttpSessionAuthBoundary:
             and hmac.compare_digest(session.token_digest, session_token_digest(bearer))
         )
 
-    @staticmethod
     def _authenticated_is_valid(
-        authenticated: object, bearer: str, now: datetime
+        self, authenticated: object, bearer: str, now: datetime
     ) -> bool:
         if (
             type(authenticated) is not AuthenticatedSession
@@ -440,6 +439,8 @@ class HttpSessionAuthBoundary:
             or now < authenticated.session.created_at
             or now < authenticated.session.last_seen_at
             or now >= authenticated.session.expires_at
+            or authenticated.session.expires_at - authenticated.session.created_at
+            > timedelta(seconds=self.cookie_policy.max_session_age_seconds)
         ):
             return False
         try:

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -90,7 +90,11 @@ class SessionCookiePolicy:
     max_session_age_seconds: int = 86400
 
     def __post_init__(self) -> None:
-        if type(self.name) is not str or not _COOKIE_NAME_RE.fullmatch(self.name):
+        if (
+            type(self.name) is not str
+            or len(self.name) > 128
+            or not _COOKIE_NAME_RE.fullmatch(self.name)
+        ):
             raise ValueError("Nome cookie sessione non valido.")
         if type(self.secure) is not bool or type(self.allow_insecure_loopback) is not bool:
             raise ValueError("Flag sicurezza cookie non validi.")
@@ -419,8 +423,12 @@ class HttpSessionAuthBoundary:
             return False
         session = issued.session
         duration = session.expires_at - session.created_at
+        cookie_pair_bytes = len(
+            f"{self.cookie_policy.name}={bearer}".encode("utf-8")
+        )
         return (
-            session.revoked_at is None
+            cookie_pair_bytes <= self.cookie_policy.max_cookie_header_bytes
+            and session.revoked_at is None
             and duration.total_seconds() > 0
             and duration <= timedelta(seconds=self.cookie_policy.max_session_age_seconds)
             and hmac.compare_digest(session.token_digest, session_token_digest(bearer))

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -601,11 +601,11 @@ class HttpSessionAuthBoundary:
     ) -> str:
         if response_time is None:
             raise ValueError("Clock HTTP non valido.")
+        remaining = issued.session.expires_at - response_time
+        if remaining < timedelta(seconds=1):
+            raise ValueError("Durata residua sessione HTTP non rappresentabile.")
         expires = format_datetime(issued.session.expires_at.astimezone(timezone.utc), usegmt=True)
-        max_age = max(
-            0,
-            int((issued.session.expires_at - response_time).total_seconds()),
-        )
+        max_age = int(remaining.total_seconds())
         attributes = [
             f"{self.cookie_policy.name}={bearer}",
             "Path=/",

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -6,9 +6,9 @@ import base64
 import hmac
 import re
 from dataclasses import dataclass, field
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
-from typing import Collection
+from typing import Callable, Collection
 
 from scripts.thebitlab_auth_services import (
     AuthenticatedSession,
@@ -164,6 +164,7 @@ class HttpSessionAuthBoundary:
         *,
         csrf_secret: bytes,
         cookie_policy: SessionCookiePolicy = SessionCookiePolicy(),
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
     ) -> None:
         candidate_secret = csrf_secret
         csrf_secret = None
@@ -173,6 +174,7 @@ class HttpSessionAuthBoundary:
             raise ValueError("Il secret CSRF deve contenere almeno 32 byte.")
         self.sessions = sessions
         self.cookie_policy = cookie_policy
+        self.clock = clock
         self._csrf_secret = candidate_secret
         candidate_secret = None
 
@@ -238,10 +240,14 @@ class HttpSessionAuthBoundary:
                 auth_failed = True
             except Exception:
                 unavailable = True
+            now = self._current_time()
             if (
                 not auth_failed
                 and not unavailable
-                and not self._authenticated_is_valid(authenticated, bearer)
+                and (
+                    now is None
+                    or not self._authenticated_is_valid(authenticated, bearer, now)
+                )
             ):
                 unavailable = True
             if not auth_failed and not unavailable:
@@ -298,19 +304,24 @@ class HttpSessionAuthBoundary:
                 unavailable = True
             if auth_failed:
                 result = LogoutHttpResult(False, self._clear_cookie())
-            elif not unavailable and not self._authenticated_is_valid(authenticated, bearer):
-                unavailable = True
-            elif not unavailable:
-                self._validate_csrf(bearer, supplied_csrf)
-                try:
-                    revoked = self.sessions.revoke(bearer)
-                except Exception:
-                    unavailable = True
-                else:
-                    if type(revoked) is not bool:
+            else:
+                if not unavailable:
+                    now = self._current_time()
+                    if now is None or not self._authenticated_is_valid(
+                        authenticated, bearer, now
+                    ):
+                        unavailable = True
+                if not unavailable:
+                    self._validate_csrf(bearer, supplied_csrf)
+                    try:
+                        revoked = self.sessions.revoke(bearer)
+                    except Exception:
                         unavailable = True
                     else:
-                        result = LogoutHttpResult(revoked, self._clear_cookie())
+                        if type(revoked) is not bool:
+                            unavailable = True
+                        else:
+                            result = LogoutHttpResult(revoked, self._clear_cookie())
         finally:
             bearer = None
             authenticated = None
@@ -328,6 +339,7 @@ class HttpSessionAuthBoundary:
         failed = False
         unavailable = False
         result = None
+        response_time = None
         try:
             if type(issued) is not IssuedSession:
                 unavailable = True
@@ -342,6 +354,8 @@ class HttpSessionAuthBoundary:
                     failed = True
                 except Exception:
                     unavailable = True
+            if not failed and not unavailable:
+                response_time = self._current_time()
             if (
                 not failed
                 and not unavailable
@@ -349,13 +363,16 @@ class HttpSessionAuthBoundary:
                     authenticated,
                     issued,
                     bearer,
+                    now=response_time,
                     expected_user_id=expected_user_id,
                 )
             ):
                 unavailable = True
             if not failed and not unavailable:
                 csrf_token = self._csrf_token(bearer)
-                set_cookie = self._session_cookie(bearer, issued)
+                set_cookie = self._session_cookie(
+                    bearer, issued, response_time=response_time
+                )
                 result = EstablishedHttpSession(
                     HttpAuthContext(authenticated, csrf_token),
                     set_cookie,
@@ -370,6 +387,7 @@ class HttpSessionAuthBoundary:
             issued = None
             csrf_token = None
             set_cookie = None
+            response_time = None
         if unavailable:
             raise HttpAuthUnavailableError()
         if failed or result is None:
@@ -388,7 +406,7 @@ class HttpSessionAuthBoundary:
     def _cookie_bearer_is_valid(bearer: object) -> bool:
         return (
             type(bearer) is str
-            and 1 <= len(bearer) <= _MAX_SESSION_TOKEN_CHARS
+            and 32 <= len(bearer) <= _MAX_SESSION_TOKEN_CHARS
             and _COOKIE_VALUE_RE.fullmatch(bearer) is not None
         )
 
@@ -409,7 +427,9 @@ class HttpSessionAuthBoundary:
         )
 
     @staticmethod
-    def _authenticated_is_valid(authenticated: object, bearer: str) -> bool:
+    def _authenticated_is_valid(
+        authenticated: object, bearer: str, now: datetime
+    ) -> bool:
         if (
             type(authenticated) is not AuthenticatedSession
             or type(authenticated.session) is not UserSession
@@ -417,10 +437,17 @@ class HttpSessionAuthBoundary:
             or authenticated.session.user_id != authenticated.user.user_id
             or not authenticated.user.active
             or authenticated.session.revoked_at is not None
+            or now < authenticated.session.created_at
+            or now < authenticated.session.last_seen_at
+            or now >= authenticated.session.expires_at
         ):
             return False
+        try:
+            expected_digest = session_token_digest(bearer)
+        except Exception:
+            return False
         return hmac.compare_digest(
-            authenticated.session.token_digest, session_token_digest(bearer)
+            authenticated.session.token_digest, expected_digest
         )
 
     def _authenticated_matches_issued(
@@ -429,9 +456,10 @@ class HttpSessionAuthBoundary:
         issued: IssuedSession,
         bearer: str,
         *,
+        now: datetime | None,
         expected_user_id: str,
     ) -> bool:
-        if not self._authenticated_is_valid(authenticated, bearer):
+        if now is None or not self._authenticated_is_valid(authenticated, bearer, now):
             return False
         current = authenticated.session
         original = issued.session
@@ -464,6 +492,19 @@ class HttpSessionAuthBoundary:
             csrf_token = None
             raise HttpMethodNotAllowedError()
         return method, cookie_header, csrf_token
+
+    def _current_time(self) -> datetime | None:
+        try:
+            value = self.clock()
+            if (
+                not isinstance(value, datetime)
+                or value.tzinfo is None
+                or value.utcoffset() is None
+            ):
+                return None
+            return value.astimezone(timezone.utc)
+        except Exception:
+            return None
 
     def _extract_bearer(
         self, cookie_header: str | None, *, required: bool = True
@@ -504,7 +545,7 @@ class HttpSessionAuthBoundary:
                 elif len(matches) == 1:
                     bearer = matches[0]
                     if (
-                        not bearer
+                        len(bearer) < 32
                         or len(bearer) > _MAX_SESSION_TOKEN_CHARS
                         or not _COOKIE_VALUE_RE.fullmatch(bearer)
                     ):
@@ -542,11 +583,19 @@ class HttpSessionAuthBoundary:
         digest = hmac.digest(self._csrf_secret, b"thebitlab-csrf-v1\0" + bearer.encode(), "sha256")
         return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
-    def _session_cookie(self, bearer: str, issued: IssuedSession) -> str:
+    def _session_cookie(
+        self,
+        bearer: str,
+        issued: IssuedSession,
+        *,
+        response_time: datetime | None,
+    ) -> str:
+        if response_time is None:
+            raise ValueError("Clock HTTP non valido.")
         expires = format_datetime(issued.session.expires_at.astimezone(timezone.utc), usegmt=True)
         max_age = max(
             0,
-            int((issued.session.expires_at - issued.session.created_at).total_seconds()),
+            int((issued.session.expires_at - response_time).total_seconds()),
         )
         attributes = [
             f"{self.cookie_policy.name}={bearer}",

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -15,8 +15,9 @@ from scripts.thebitlab_auth_services import (
     InvalidCredentialError,
     IssuedSession,
     SessionService,
+    session_token_digest,
 )
-from scripts.thebitlab_identity import AccountDisabledError
+from scripts.thebitlab_identity import AccountDisabledError, UserAccount, UserSession
 
 _COOKIE_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
 _COOKIE_VALUE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -86,6 +87,7 @@ class SessionCookiePolicy:
     same_site: str = "Lax"
     allow_insecure_loopback: bool = False
     max_cookie_header_bytes: int = 4096
+    max_session_age_seconds: int = 86400
 
     def __post_init__(self) -> None:
         if type(self.name) is not str or not _COOKIE_NAME_RE.fullmatch(self.name):
@@ -105,6 +107,11 @@ class SessionCookiePolicy:
             or not 256 <= self.max_cookie_header_bytes <= 65536
         ):
             raise ValueError("Limite header Cookie non valido.")
+        if (
+            type(self.max_session_age_seconds) is not int
+            or not 60 <= self.max_session_age_seconds <= 2678400
+        ):
+            raise ValueError("Durata massima sessione HTTP non valida.")
 
     @classmethod
     def loopback_development(cls) -> "SessionCookiePolicy":
@@ -225,7 +232,13 @@ class HttpSessionAuthBoundary:
                 auth_failed = True
             except Exception:
                 unavailable = True
-            if not auth_failed and not unavailable and authenticated is not None:
+            if (
+                not auth_failed
+                and not unavailable
+                and not self._authenticated_is_valid(authenticated, bearer)
+            ):
+                unavailable = True
+            if not auth_failed and not unavailable:
                 csrf_token = self._csrf_token(bearer)
                 if method in _UNSAFE_METHODS:
                     self._validate_csrf(bearer, supplied_csrf)
@@ -279,6 +292,8 @@ class HttpSessionAuthBoundary:
                 unavailable = True
             if auth_failed:
                 result = LogoutHttpResult(False, self._clear_cookie())
+            elif not unavailable and not self._authenticated_is_valid(authenticated, bearer):
+                unavailable = True
             elif not unavailable:
                 self._validate_csrf(bearer, supplied_csrf)
                 try:
@@ -286,7 +301,10 @@ class HttpSessionAuthBoundary:
                 except Exception:
                     unavailable = True
                 else:
-                    result = LogoutHttpResult(revoked, self._clear_cookie())
+                    if type(revoked) is not bool:
+                        unavailable = True
+                    else:
+                        result = LogoutHttpResult(revoked, self._clear_cookie())
         finally:
             bearer = None
             authenticated = None
@@ -303,17 +321,26 @@ class HttpSessionAuthBoundary:
         unavailable = False
         result = None
         try:
-            bearer = issued.bearer_token
-            if not self._cookie_bearer_is_valid(bearer):
+            if type(issued) is not IssuedSession:
                 unavailable = True
             else:
+                bearer = issued.bearer_token
+            if not unavailable and not self._issued_is_valid(issued, bearer):
+                unavailable = True
+            if not unavailable:
                 try:
                     authenticated = self.sessions.authenticate(bearer)
                 except (InvalidCredentialError, AccountDisabledError):
                     failed = True
                 except Exception:
                     unavailable = True
-            if not failed and not unavailable and authenticated is not None:
+            if (
+                not failed
+                and not unavailable
+                and not self._authenticated_matches_issued(authenticated, issued, bearer)
+            ):
+                unavailable = True
+            if not failed and not unavailable:
                 csrf_token = self._csrf_token(bearer)
                 set_cookie = self._session_cookie(bearer, issued)
                 result = EstablishedHttpSession(
@@ -350,6 +377,49 @@ class HttpSessionAuthBoundary:
             type(bearer) is str
             and 1 <= len(bearer) <= _MAX_SESSION_TOKEN_CHARS
             and _COOKIE_VALUE_RE.fullmatch(bearer) is not None
+        )
+
+    def _issued_is_valid(self, issued: object, bearer: object) -> bool:
+        if (
+            type(issued) is not IssuedSession
+            or type(issued.session) is not UserSession
+            or not self._cookie_bearer_is_valid(bearer)
+        ):
+            return False
+        session = issued.session
+        duration = int((session.expires_at - session.created_at).total_seconds())
+        return (
+            session.revoked_at is None
+            and 1 <= duration <= self.cookie_policy.max_session_age_seconds
+            and hmac.compare_digest(session.token_digest, session_token_digest(bearer))
+        )
+
+    @staticmethod
+    def _authenticated_is_valid(authenticated: object, bearer: str) -> bool:
+        if (
+            type(authenticated) is not AuthenticatedSession
+            or type(authenticated.session) is not UserSession
+            or type(authenticated.user) is not UserAccount
+            or authenticated.session.user_id != authenticated.user.user_id
+        ):
+            return False
+        return hmac.compare_digest(
+            authenticated.session.token_digest, session_token_digest(bearer)
+        )
+
+    def _authenticated_matches_issued(
+        self, authenticated: object, issued: IssuedSession, bearer: str
+    ) -> bool:
+        if not self._authenticated_is_valid(authenticated, bearer):
+            return False
+        current = authenticated.session
+        original = issued.session
+        return (
+            current.session_id == original.session_id
+            and current.user_id == original.user_id
+            and hmac.compare_digest(current.token_digest, original.token_digest)
+            and current.created_at == original.created_at
+            and current.expires_at == original.expires_at
         )
 
     @staticmethod
@@ -398,6 +468,8 @@ class HttpSessionAuthBoundary:
                         parse_failed = True
                         break
                     if name == self.cookie_policy.name:
+                        if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+                            value = value[1:-1]
                         matches.append(value)
                     elif not _OTHER_COOKIE_VALUE_RE.fullmatch(value):
                         parse_failed = True

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -6,7 +6,7 @@ import base64
 import hmac
 import re
 from dataclasses import dataclass, field
-from datetime import timezone
+from datetime import timedelta, timezone
 from email.utils import format_datetime
 from typing import Collection
 
@@ -182,16 +182,22 @@ class HttpSessionAuthBoundary:
         """Rotate any browser session, then issue one for an already-resolved user."""
         if existing_cookie_header:
             try:
-                existing = self._extract_bearer(existing_cookie_header)
+                existing = self._extract_bearer(
+                    existing_cookie_header, required=False
+                )
             finally:
                 existing_cookie_header = None
             rotation_failed = False
-            try:
-                self.sessions.revoke(existing)
-            except Exception:
-                rotation_failed = True
-            finally:
-                existing = None
+            if existing is not None:
+                try:
+                    revoked = self.sessions.revoke(existing)
+                except Exception:
+                    rotation_failed = True
+                else:
+                    if type(revoked) is not bool:
+                        rotation_failed = True
+                finally:
+                    existing = None
             if rotation_failed:
                 raise HttpAuthUnavailableError()
         issue_failed = False
@@ -208,7 +214,7 @@ class HttpSessionAuthBoundary:
         if issue_failed or issued is None:
             raise HttpAuthenticationRequiredError()
         try:
-            return self._established_result(issued)
+            return self._established_result(issued, expected_user_id=user_id)
         finally:
             issued = None
 
@@ -314,7 +320,9 @@ class HttpSessionAuthBoundary:
             raise HttpAuthUnavailableError()
         return result
 
-    def _established_result(self, issued: IssuedSession) -> EstablishedHttpSession:
+    def _established_result(
+        self, issued: IssuedSession, *, expected_user_id: str
+    ) -> EstablishedHttpSession:
         bearer = None
         authenticated = None
         failed = False
@@ -337,7 +345,12 @@ class HttpSessionAuthBoundary:
             if (
                 not failed
                 and not unavailable
-                and not self._authenticated_matches_issued(authenticated, issued, bearer)
+                and not self._authenticated_matches_issued(
+                    authenticated,
+                    issued,
+                    bearer,
+                    expected_user_id=expected_user_id,
+                )
             ):
                 unavailable = True
             if not failed and not unavailable:
@@ -387,10 +400,11 @@ class HttpSessionAuthBoundary:
         ):
             return False
         session = issued.session
-        duration = int((session.expires_at - session.created_at).total_seconds())
+        duration = session.expires_at - session.created_at
         return (
             session.revoked_at is None
-            and 1 <= duration <= self.cookie_policy.max_session_age_seconds
+            and duration.total_seconds() > 0
+            and duration <= timedelta(seconds=self.cookie_policy.max_session_age_seconds)
             and hmac.compare_digest(session.token_digest, session_token_digest(bearer))
         )
 
@@ -401,6 +415,8 @@ class HttpSessionAuthBoundary:
             or type(authenticated.session) is not UserSession
             or type(authenticated.user) is not UserAccount
             or authenticated.session.user_id != authenticated.user.user_id
+            or not authenticated.user.active
+            or authenticated.session.revoked_at is not None
         ):
             return False
         return hmac.compare_digest(
@@ -408,14 +424,21 @@ class HttpSessionAuthBoundary:
         )
 
     def _authenticated_matches_issued(
-        self, authenticated: object, issued: IssuedSession, bearer: str
+        self,
+        authenticated: object,
+        issued: IssuedSession,
+        bearer: str,
+        *,
+        expected_user_id: str,
     ) -> bool:
         if not self._authenticated_is_valid(authenticated, bearer):
             return False
         current = authenticated.session
         original = issued.session
         return (
-            current.session_id == original.session_id
+            original.user_id == expected_user_id
+            and authenticated.user.user_id == expected_user_id
+            and current.session_id == original.session_id
             and current.user_id == original.user_id
             and hmac.compare_digest(current.token_digest, original.token_digest)
             and current.created_at == original.created_at
@@ -442,7 +465,9 @@ class HttpSessionAuthBoundary:
             raise HttpMethodNotAllowedError()
         return method, cookie_header, csrf_token
 
-    def _extract_bearer(self, cookie_header: str | None) -> str:
+    def _extract_bearer(
+        self, cookie_header: str | None, *, required: bool = True
+    ) -> str | None:
         parse_failed = False
         bearer = None
         matches = None
@@ -474,9 +499,9 @@ class HttpSessionAuthBoundary:
                     elif not _OTHER_COOKIE_VALUE_RE.fullmatch(value):
                         parse_failed = True
                         break
-                if len(matches) != 1:
+                if len(matches) > 1 or (required and len(matches) != 1):
                     parse_failed = True
-                else:
+                elif len(matches) == 1:
                     bearer = matches[0]
                     if (
                         not bearer
@@ -492,7 +517,7 @@ class HttpSessionAuthBoundary:
             segment = None
             name = None
             value = None
-        if parse_failed or bearer is None:
+        if parse_failed or (required and bearer is None):
             bearer = None
             raise HttpAuthenticationRequiredError()
         return bearer

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -11,11 +11,12 @@ from email.utils import format_datetime
 from typing import Collection
 
 from scripts.thebitlab_auth_services import (
-    AuthApplicationError,
     AuthenticatedSession,
+    InvalidCredentialError,
     IssuedSession,
     SessionService,
 )
+from scripts.thebitlab_identity import AccountDisabledError
 
 _COOKIE_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
 _COOKIE_VALUE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -65,6 +66,12 @@ class HttpMethodNotAllowedError(HttpAuthError):
     status_code = 405
     error_code = "auth_method_not_allowed"
     public_message = "Metodo HTTP non supportato."
+
+
+class HttpAuthUnavailableError(HttpAuthError):
+    status_code = 503
+    error_code = "authentication_unavailable"
+    public_message = "Servizio di autenticazione temporaneamente non disponibile."
 
 
 @dataclass(frozen=True)
@@ -168,13 +175,28 @@ class HttpSessionAuthBoundary:
                 existing = self._extract_bearer(existing_cookie_header)
             finally:
                 existing_cookie_header = None
+            rotation_failed = False
             try:
                 self.sessions.revoke(existing)
-            except AuthApplicationError:
-                pass
+            except Exception:
+                rotation_failed = True
             finally:
                 existing = None
-        issued = self.sessions.issue(user_id)
+            if rotation_failed:
+                raise HttpAuthUnavailableError()
+        issue_failed = False
+        unavailable = False
+        issued = None
+        try:
+            issued = self.sessions.issue(user_id)
+        except (InvalidCredentialError, AccountDisabledError):
+            issue_failed = True
+        except Exception:
+            unavailable = True
+        if unavailable:
+            raise HttpAuthUnavailableError()
+        if issue_failed or issued is None:
+            raise HttpAuthenticationRequiredError()
         try:
             return self._established_result(issued)
         finally:
@@ -187,6 +209,7 @@ class HttpSessionAuthBoundary:
             request = None
         bearer = None
         auth_failed = False
+        unavailable = False
         authenticated = None
         csrf_token = None
         context = None
@@ -195,9 +218,11 @@ class HttpSessionAuthBoundary:
             cookie_header = None
             try:
                 authenticated = self.sessions.authenticate(bearer)
-            except AuthApplicationError:
+            except (InvalidCredentialError, AccountDisabledError):
                 auth_failed = True
-            if not auth_failed and authenticated is not None:
+            except Exception:
+                unavailable = True
+            if not auth_failed and not unavailable and authenticated is not None:
                 csrf_token = self._csrf_token(bearer)
                 if method in _UNSAFE_METHODS:
                     self._validate_csrf(bearer, supplied_csrf)
@@ -207,6 +232,8 @@ class HttpSessionAuthBoundary:
             cookie_header = None
             supplied_csrf = None
             csrf_token = None
+        if unavailable:
+            raise HttpAuthUnavailableError()
         if auth_failed or context is None:
             raise HttpAuthenticationRequiredError()
         return context
@@ -236,47 +263,90 @@ class HttpSessionAuthBoundary:
         bearer = None
         authenticated = None
         auth_failed = False
+        unavailable = False
+        result = None
         try:
             bearer = self._extract_bearer(cookie_header)
             cookie_header = None
             try:
                 authenticated = self.sessions.authenticate(bearer)
-            except AuthApplicationError:
+            except (InvalidCredentialError, AccountDisabledError):
                 auth_failed = True
+            except Exception:
+                unavailable = True
             if auth_failed:
-                return LogoutHttpResult(False, self._clear_cookie())
-            self._validate_csrf(bearer, supplied_csrf)
-            return LogoutHttpResult(self.sessions.revoke(bearer), self._clear_cookie())
+                result = LogoutHttpResult(False, self._clear_cookie())
+            elif not unavailable:
+                self._validate_csrf(bearer, supplied_csrf)
+                try:
+                    revoked = self.sessions.revoke(bearer)
+                except Exception:
+                    unavailable = True
+                else:
+                    result = LogoutHttpResult(revoked, self._clear_cookie())
         finally:
             bearer = None
             authenticated = None
             cookie_header = None
             supplied_csrf = None
+        if unavailable or result is None:
+            raise HttpAuthUnavailableError()
+        return result
 
     def _established_result(self, issued: IssuedSession) -> EstablishedHttpSession:
         bearer = issued.bearer_token
         authenticated = None
         failed = False
+        unavailable = False
+        result = None
         try:
-            try:
-                authenticated = self.sessions.authenticate(bearer)
-            except AuthApplicationError:
-                failed = True
-            if failed or authenticated is None:
+            if not self._cookie_bearer_is_valid(bearer):
+                unavailable = True
+            else:
                 try:
-                    self.sessions.revoke(bearer)
-                except AuthApplicationError:
-                    pass
-                raise HttpAuthenticationRequiredError()
-            csrf_token = self._csrf_token(bearer)
-            set_cookie = self._session_cookie(bearer, issued)
-            return EstablishedHttpSession(
-                HttpAuthContext(authenticated, csrf_token),
-                set_cookie,
-            )
+                    authenticated = self.sessions.authenticate(bearer)
+                except (InvalidCredentialError, AccountDisabledError):
+                    failed = True
+                except Exception:
+                    unavailable = True
+            if not failed and not unavailable and authenticated is not None:
+                csrf_token = self._csrf_token(bearer)
+                set_cookie = self._session_cookie(bearer, issued)
+                result = EstablishedHttpSession(
+                    HttpAuthContext(authenticated, csrf_token),
+                    set_cookie,
+                )
+            else:
+                self._best_effort_revoke(bearer)
+        except Exception:
+            self._best_effort_revoke(bearer)
+            unavailable = True
         finally:
             bearer = None
             issued = None
+            csrf_token = None
+            set_cookie = None
+        if unavailable:
+            raise HttpAuthUnavailableError()
+        if failed or result is None:
+            raise HttpAuthenticationRequiredError()
+        return result
+
+    def _best_effort_revoke(self, bearer: str) -> None:
+        try:
+            self.sessions.revoke(bearer)
+        except Exception:
+            pass
+        finally:
+            bearer = None
+
+    @staticmethod
+    def _cookie_bearer_is_valid(bearer: object) -> bool:
+        return (
+            type(bearer) is str
+            and 1 <= len(bearer) <= _MAX_SESSION_TOKEN_CHARS
+            and _COOKIE_VALUE_RE.fullmatch(bearer) is not None
+        )
 
     @staticmethod
     def _request_values(request: HttpAuthRequest) -> tuple[str, str | None, str | None]:

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -20,7 +20,10 @@ from scripts.thebitlab_identity import AccountDisabledError
 
 _COOKIE_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
 _COOKIE_VALUE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
-_OTHER_COOKIE_VALUE_RE = re.compile(r'^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*$')
+_OTHER_COOKIE_VALUE_RE = re.compile(
+    r'^(?:[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*|'
+    r'"[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*")$'
+)
 _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 _UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 _APPLICATION_ROLES = frozenset({"admin", "teacher", "student"})
@@ -294,12 +297,13 @@ class HttpSessionAuthBoundary:
         return result
 
     def _established_result(self, issued: IssuedSession) -> EstablishedHttpSession:
-        bearer = issued.bearer_token
+        bearer = None
         authenticated = None
         failed = False
         unavailable = False
         result = None
         try:
+            bearer = issued.bearer_token
             if not self._cookie_bearer_is_valid(bearer):
                 unavailable = True
             else:

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -7,7 +7,12 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from scripts.thebitlab_auth_services import SessionService
+from scripts.thebitlab_auth_services import (
+    AuthenticatedSession,
+    IssuedSession,
+    SessionService,
+    session_token_digest,
+)
 from scripts.thebitlab_http_auth import (
     HttpAuthRequest,
     HttpAuthenticationRequiredError,
@@ -19,7 +24,7 @@ from scripts.thebitlab_http_auth import (
     HttpSessionAuthBoundary,
     SessionCookiePolicy,
 )
-from scripts.thebitlab_identity import UserAccount
+from scripts.thebitlab_identity import UserAccount, UserSession
 from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
 
 NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
@@ -253,6 +258,79 @@ def test_storage_and_unexpected_failures_are_sanitized_at_http_boundary() -> Non
         assert error.__context__ is None
 
 
+def test_malformed_session_service_results_fail_closed(storage, clock) -> None:
+    storage.create_user(account())
+    real = make_boundary(storage, clock)
+    established = real.establish_session("user-01")
+
+    real.sessions.authenticate = lambda _bearer: object()
+    with pytest.raises(HttpAuthUnavailableError):
+        real.authenticate(request("GET", established))
+
+    real.sessions.authenticate = lambda _bearer: None
+    with pytest.raises(HttpAuthUnavailableError):
+        real.authenticate(request("GET", established))
+
+    valid_session = storage.read_session("session-01")
+    assert valid_session is not None
+    real.sessions.authenticate = lambda _bearer: AuthenticatedSession(
+        valid_session, account()
+    )
+    real.sessions.revoke = lambda _bearer: "not-a-bool"
+    with pytest.raises(HttpAuthUnavailableError):
+        real.logout(
+            request("POST", established, established.context.csrf_token)
+        )
+
+
+def test_issued_and_authenticated_sessions_must_match_and_respect_max_age(clock) -> None:
+    bearer = "A" * 40
+    digest = session_token_digest(bearer)
+    user = account()
+    long_session = UserSession(
+        "long-session",
+        user.user_id,
+        digest,
+        NOW,
+        NOW + timedelta(days=36500),
+        NOW,
+    )
+
+    class LongSessionService:
+        def issue(self, _user_id):
+            return IssuedSession(long_session, bearer)
+
+        def authenticate(self, _bearer):
+            return AuthenticatedSession(long_session, user)
+
+        def revoke(self, _bearer):
+            return True
+
+    boundary = HttpSessionAuthBoundary(LongSessionService(), csrf_secret=CSRF_SECRET)
+    with pytest.raises(HttpAuthUnavailableError):
+        boundary.establish_session("user-01")
+
+    normal_session = replace(
+        long_session,
+        session_id="normal-session",
+        expires_at=NOW + timedelta(hours=8),
+    )
+    other_session = replace(normal_session, session_id="other-session")
+
+    class MismatchedSessionService(LongSessionService):
+        def issue(self, _user_id):
+            return IssuedSession(normal_session, bearer)
+
+        def authenticate(self, _bearer):
+            return AuthenticatedSession(other_session, user)
+
+    mismatch = HttpSessionAuthBoundary(
+        MismatchedSessionService(), csrf_secret=CSRF_SECRET
+    )
+    with pytest.raises(HttpAuthUnavailableError):
+        mismatch.establish_session("user-01")
+
+
 def test_safe_authentication_refreshes_context_and_role_authorization(storage, clock) -> None:
     storage.create_user(account(role="teacher"))
     boundary = make_boundary(storage, clock)
@@ -391,6 +469,10 @@ def test_malformed_duplicate_missing_and_oversized_cookies_fail_closed(storage, 
 
     assert boundary.authenticate(
         HttpAuthRequest("GET", valid + "; padded=a=b==; analytics=\"abc\"")
+    ).user.user_id == "user-01"
+    quoted_session = valid.split("=", 1)[0] + '=\"' + "A" * 40 + '\"'
+    assert boundary.authenticate(
+        HttpAuthRequest("GET", quoted_session)
     ).user.user_id == "user-01"
 
     for header in bad_headers:

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -262,6 +262,8 @@ def test_malformed_session_service_results_fail_closed(storage, clock) -> None:
     storage.create_user(account())
     real = make_boundary(storage, clock)
     established = real.establish_session("user-01")
+    valid_session = storage.read_session("session-01")
+    assert valid_session is not None
 
     real.sessions.authenticate = lambda _bearer: object()
     with pytest.raises(HttpAuthUnavailableError):
@@ -271,8 +273,18 @@ def test_malformed_session_service_results_fail_closed(storage, clock) -> None:
     with pytest.raises(HttpAuthUnavailableError):
         real.authenticate(request("GET", established))
 
-    valid_session = storage.read_session("session-01")
-    assert valid_session is not None
+    real.sessions.authenticate = lambda _bearer: AuthenticatedSession(
+        valid_session, account(active=False)
+    )
+    with pytest.raises(HttpAuthUnavailableError):
+        real.authenticate(request("GET", established))
+
+    real.sessions.authenticate = lambda _bearer: AuthenticatedSession(
+        replace(valid_session, revoked_at=NOW), account()
+    )
+    with pytest.raises(HttpAuthUnavailableError):
+        real.authenticate(request("GET", established))
+
     real.sessions.authenticate = lambda _bearer: AuthenticatedSession(
         valid_session, account()
     )
@@ -292,7 +304,7 @@ def test_issued_and_authenticated_sessions_must_match_and_respect_max_age(clock)
         user.user_id,
         digest,
         NOW,
-        NOW + timedelta(days=36500),
+        NOW + timedelta(days=1, microseconds=1),
         NOW,
     )
 
@@ -329,6 +341,22 @@ def test_issued_and_authenticated_sessions_must_match_and_respect_max_age(clock)
     )
     with pytest.raises(HttpAuthUnavailableError):
         mismatch.establish_session("user-01")
+
+    other_user = replace(user, user_id="other-user")
+    other_session = replace(normal_session, user_id="other-user")
+
+    class WrongOwnerSessionService(LongSessionService):
+        def issue(self, _user_id):
+            return IssuedSession(other_session, bearer)
+
+        def authenticate(self, _bearer):
+            return AuthenticatedSession(other_session, other_user)
+
+    wrong_owner = HttpSessionAuthBoundary(
+        WrongOwnerSessionService(), csrf_secret=CSRF_SECRET
+    )
+    with pytest.raises(HttpAuthUnavailableError):
+        wrong_owner.establish_session("requested-user")
 
 
 def test_safe_authentication_refreshes_context_and_role_authorization(storage, clock) -> None:
@@ -448,6 +476,29 @@ def test_login_completion_rotates_existing_session(storage, clock) -> None:
     with pytest.raises(HttpAuthenticationRequiredError):
         boundary.authenticate(request("GET", first))
     assert boundary.authenticate(request("GET", second)).user.user_id == "user-01"
+
+
+def test_login_completion_ignores_unrelated_cookies_and_validates_rotation_result(
+    storage, clock
+) -> None:
+    storage.create_user(account())
+    boundary = make_boundary(
+        storage,
+        clock,
+        tokens=("A" * 40, "B" * 40),
+        session_ids=("session-01", "session-02"),
+    )
+
+    established = boundary.establish_session(
+        "user-01", existing_cookie_header="analytics=abc"
+    )
+    assert boundary.authenticate(request("GET", established)).user.user_id == "user-01"
+
+    boundary.sessions.revoke = lambda _bearer: "not-a-bool"
+    with pytest.raises(HttpAuthUnavailableError):
+        boundary.establish_session(
+            "user-01", existing_cookie_header=cookie_header(established.set_cookie)
+        )
 
 
 def test_malformed_duplicate_missing_and_oversized_cookies_fail_closed(storage, clock) -> None:

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -93,6 +93,7 @@ def make_boundary(
         sessions,
         csrf_secret=csrf_secret,
         cookie_policy=policy or SessionCookiePolicy(),
+        clock=clock,
     )
 
 
@@ -285,6 +286,20 @@ def test_malformed_session_service_results_fail_closed(storage, clock) -> None:
     with pytest.raises(HttpAuthUnavailableError):
         real.authenticate(request("GET", established))
 
+    expired_session = UserSession(
+        valid_session.session_id,
+        valid_session.user_id,
+        valid_session.token_digest,
+        NOW - timedelta(hours=2),
+        NOW - timedelta(hours=1),
+        NOW - timedelta(hours=2),
+    )
+    real.sessions.authenticate = lambda _bearer: AuthenticatedSession(
+        expired_session, account()
+    )
+    with pytest.raises(HttpAuthUnavailableError):
+        real.authenticate(request("GET", established))
+
     real.sessions.authenticate = lambda _bearer: AuthenticatedSession(
         valid_session, account()
     )
@@ -318,7 +333,9 @@ def test_issued_and_authenticated_sessions_must_match_and_respect_max_age(clock)
         def revoke(self, _bearer):
             return True
 
-    boundary = HttpSessionAuthBoundary(LongSessionService(), csrf_secret=CSRF_SECRET)
+    boundary = HttpSessionAuthBoundary(
+        LongSessionService(), csrf_secret=CSRF_SECRET, clock=clock
+    )
     with pytest.raises(HttpAuthUnavailableError):
         boundary.establish_session("user-01")
 
@@ -337,7 +354,7 @@ def test_issued_and_authenticated_sessions_must_match_and_respect_max_age(clock)
             return AuthenticatedSession(other_session, user)
 
     mismatch = HttpSessionAuthBoundary(
-        MismatchedSessionService(), csrf_secret=CSRF_SECRET
+        MismatchedSessionService(), csrf_secret=CSRF_SECRET, clock=clock
     )
     with pytest.raises(HttpAuthUnavailableError):
         mismatch.establish_session("user-01")
@@ -353,10 +370,44 @@ def test_issued_and_authenticated_sessions_must_match_and_respect_max_age(clock)
             return AuthenticatedSession(other_session, other_user)
 
     wrong_owner = HttpSessionAuthBoundary(
-        WrongOwnerSessionService(), csrf_secret=CSRF_SECRET
+        WrongOwnerSessionService(), csrf_secret=CSRF_SECRET, clock=clock
     )
     with pytest.raises(HttpAuthUnavailableError):
         wrong_owner.establish_session("requested-user")
+
+
+def test_set_cookie_max_age_uses_response_time(clock) -> None:
+    bearer = "A" * 40
+    user = account()
+    session = UserSession(
+        "delayed-session",
+        user.user_id,
+        session_token_digest(bearer),
+        NOW,
+        NOW + timedelta(hours=8),
+        NOW,
+    )
+
+    class DelayedSessionService:
+        def issue(self, _user_id):
+            return IssuedSession(session, bearer)
+
+        def authenticate(self, _bearer):
+            clock.value = NOW + timedelta(hours=1)
+            return AuthenticatedSession(
+                replace(session, last_seen_at=clock.value), user
+            )
+
+        def revoke(self, _bearer):
+            return True
+
+    boundary = HttpSessionAuthBoundary(
+        DelayedSessionService(), csrf_secret=CSRF_SECRET, clock=clock
+    )
+    established = boundary.establish_session("user-01")
+
+    assert "; Max-Age=25200;" in established.set_cookie
+    assert "Tue, 01 Sep 2026 16:00:00 GMT" in established.set_cookie
 
 
 def test_safe_authentication_refreshes_context_and_role_authorization(storage, clock) -> None:
@@ -516,6 +567,7 @@ def test_malformed_duplicate_missing_and_oversized_cookies_fail_closed(storage, 
         valid + "\r\nInjected: yes",
         valid + "; padding=" + "x" * 256,
         "__Host-thebitlab_session=quoted value",
+        "__Host-thebitlab_session=" + "S" * 25,
     ]
 
     assert boundary.authenticate(
@@ -586,7 +638,9 @@ def test_expired_cookie_cannot_authenticate_and_invalid_logout_still_clears(stor
         token_factory=lambda: "A" * 40,
         session_id_factory=lambda: "session-01",
     )
-    boundary = HttpSessionAuthBoundary(sessions, csrf_secret=CSRF_SECRET)
+    boundary = HttpSessionAuthBoundary(
+        sessions, csrf_secret=CSRF_SECRET, clock=clock
+    )
     established = boundary.establish_session("user-01")
     clock.value += timedelta(minutes=5)
 

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -226,11 +226,25 @@ def test_storage_and_unexpected_failures_are_sanitized_at_http_boundary() -> Non
             existing_cookie_header="__Host-thebitlab_session=" + "A" * 40,
         )
 
+    class MalformedIssueSessions(BrokenSessions):
+        def issue(self, _user_id):
+            return object()
+
+        def revoke(self, _bearer):
+            return False
+
+    malformed_boundary = HttpSessionAuthBoundary(
+        MalformedIssueSessions(), csrf_secret=CSRF_SECRET
+    )
+    with pytest.raises(HttpAuthUnavailableError) as malformed_issue:
+        malformed_boundary.establish_session("user-01")
+
     for error in (
         authenticate_error.value,
         logout_error.value,
         issue_error.value,
         rotation_error.value,
+        malformed_issue.value,
     ):
         assert error.status_code == 503
         assert error.error_code == "authentication_unavailable"
@@ -376,7 +390,7 @@ def test_malformed_duplicate_missing_and_oversized_cookies_fail_closed(storage, 
     ]
 
     assert boundary.authenticate(
-        HttpAuthRequest("GET", valid + "; padded=a=b==")
+        HttpAuthRequest("GET", valid + "; padded=a=b==; analytics=\"abc\"")
     ).user.user_id == "user-01"
 
     for header in bad_headers:

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.thebitlab_auth_services import SessionService
+from scripts.thebitlab_http_auth import (
+    HttpAuthRequest,
+    HttpAuthenticationRequiredError,
+    HttpAuthorizationDeniedError,
+    HttpBadRequestError,
+    HttpCsrfRejectedError,
+    HttpMethodNotAllowedError,
+    HttpSessionAuthBoundary,
+    SessionCookiePolicy,
+)
+from scripts.thebitlab_identity import UserAccount
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+CSRF_SECRET = b"c" * 32
+
+
+class MutableClock:
+    def __init__(self, value=NOW):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+
+class SequenceFactory:
+    def __init__(self, *values):
+        self.values = iter(values)
+
+    def __call__(self):
+        return next(self.values)
+
+
+def account(role="student", active=True):
+    return UserAccount(
+        user_id="user-01",
+        display_name="Mario Rossi",
+        role=role,
+        active=active,
+        created_at=NOW,
+        updated_at=NOW,
+        primary_email="mario@example.test",
+    )
+
+
+@pytest.fixture
+def database_path(tmp_path):
+    return tmp_path / "identity.sqlite3"
+
+
+@pytest.fixture
+def storage(database_path):
+    return SqliteIdentityStorage(database_path)
+
+
+@pytest.fixture
+def clock():
+    return MutableClock()
+
+
+def make_boundary(
+    storage,
+    clock,
+    *,
+    tokens=("A" * 40,),
+    session_ids=("session-01",),
+    csrf_secret=CSRF_SECRET,
+    policy=None,
+):
+    sessions = SessionService(
+        storage,
+        clock=clock,
+        token_factory=SequenceFactory(*tokens),
+        session_id_factory=SequenceFactory(*session_ids),
+    )
+    return HttpSessionAuthBoundary(
+        sessions,
+        csrf_secret=csrf_secret,
+        cookie_policy=policy or SessionCookiePolicy(),
+    )
+
+
+def cookie_header(set_cookie):
+    return set_cookie.split(";", 1)[0]
+
+
+def traceback_locals_repr(error, *function_names):
+    values = []
+    traceback = error.__traceback__
+    while traceback is not None:
+        if traceback.tb_frame.f_code.co_name in function_names:
+            values.extend(traceback.tb_frame.f_locals.values())
+        traceback = traceback.tb_next
+    return repr(values)
+
+
+def request(method, established, csrf_token=None):
+    return HttpAuthRequest(
+        method,
+        cookie_header(established.set_cookie),
+        csrf_token,
+    )
+
+
+def test_cookie_policy_is_secure_by_default_and_loopback_is_explicit() -> None:
+    production = SessionCookiePolicy()
+    assert production.name.startswith("__Host-")
+    assert production.secure is True
+
+    development = SessionCookiePolicy.loopback_development()
+    assert development.secure is False
+    assert development.allow_insecure_loopback is True
+    assert not development.name.startswith("__Host-")
+
+    with pytest.raises(ValueError, match="loopback"):
+        SessionCookiePolicy(name="session", secure=False)
+    with pytest.raises(ValueError, match="prefisso sicuro"):
+        SessionCookiePolicy(
+            secure=False,
+            allow_insecure_loopback=True,
+        )
+    with pytest.raises(ValueError, match="SameSite=None"):
+        SessionCookiePolicy(
+            name="session",
+            secure=False,
+            same_site="None",
+            allow_insecure_loopback=True,
+        )
+    with pytest.raises(ValueError, match="32 byte") as invalid_secret:
+        HttpSessionAuthBoundary(object(), csrf_secret=b"raw-short-secret")
+    assert "raw-short-secret" not in traceback_locals_repr(
+        invalid_secret.value, "__init__"
+    )
+
+
+def test_establishes_secure_cookie_and_never_persists_or_reprs_raw_values(
+    storage, database_path, clock
+) -> None:
+    storage.create_user(account())
+    boundary = make_boundary(storage, clock)
+
+    established = boundary.establish_session("user-01")
+
+    header = established.set_cookie
+    assert header.startswith("__Host-thebitlab_session=" + "A" * 40 + ";")
+    assert "; Path=/" in header
+    assert "; HttpOnly" in header
+    assert "; Secure" in header
+    assert "; SameSite=Lax" in header
+    assert "; Max-Age=28800" in header
+    assert "GMT" in header
+    assert "A" * 40 not in repr(established)
+    assert established.context.csrf_token not in repr(established.context)
+    assert established.context.user.user_id == "user-01"
+
+    with sqlite3.connect(database_path) as connection:
+        persisted = connection.execute(
+            "SELECT token_digest FROM sessions WHERE session_id = 'session-01'"
+        ).fetchone()[0]
+    assert "A" * 40 not in persisted
+    assert established.context.csrf_token not in persisted
+
+
+def test_safe_authentication_refreshes_context_and_role_authorization(storage, clock) -> None:
+    storage.create_user(account(role="teacher"))
+    boundary = make_boundary(storage, clock)
+    established = boundary.establish_session("user-01")
+    clock.value += timedelta(minutes=1)
+
+    context = boundary.authenticate(request("GET", established))
+    authorized = boundary.authorize_application(
+        request("HEAD", established), allowed_roles={"teacher", "admin"}
+    )
+
+    assert context.user.role == "teacher"
+    assert context.session.last_seen_at == clock.value
+    assert authorized.user.user_id == "user-01"
+    assert context.csrf_token == established.context.csrf_token
+    with pytest.raises(HttpAuthorizationDeniedError) as denied:
+        boundary.authorize_application(
+            request("GET", established), allowed_roles={"student"}
+        )
+    assert denied.value.status_code == 403
+    assert denied.value.error_code == "authorization_denied"
+
+
+def test_pending_is_authenticated_but_never_an_application_role(storage, clock) -> None:
+    storage.create_user(account(role="pending"))
+    boundary = make_boundary(storage, clock)
+    established = boundary.establish_session("user-01")
+
+    assert boundary.authenticate(request("GET", established)).user.role == "pending"
+    with pytest.raises(ValueError, match="Policy"):
+        boundary.authorize_application(
+            request("GET", established), allowed_roles={"pending"}
+        )
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_application(
+            request("GET", established), allowed_roles={"student"}
+        )
+
+
+def test_unsafe_requests_require_session_bound_csrf(storage, clock) -> None:
+    storage.create_user(account())
+    boundary = make_boundary(storage, clock)
+    established = boundary.establish_session("user-01")
+
+    with pytest.raises(HttpCsrfRejectedError) as missing:
+        boundary.authenticate(request("POST", established))
+    assert missing.value.error_code == "csrf_rejected"
+    with pytest.raises(HttpCsrfRejectedError) as wrong:
+        boundary.authenticate(request("DELETE", established, "raw-wrong-csrf"))
+    assert "raw-wrong-csrf" not in traceback_locals_repr(
+        wrong.value, "authenticate", "_validate_csrf"
+    )
+
+    context = boundary.authenticate(
+        request("PATCH", established, established.context.csrf_token)
+    )
+    assert context.user.user_id == "user-01"
+
+    other = make_boundary(
+        storage,
+        clock,
+        tokens=("B" * 40,),
+        session_ids=("session-02",),
+        csrf_secret=b"d" * 32,
+    )
+    with pytest.raises(HttpCsrfRejectedError):
+        other.authenticate(
+            request("POST", established, established.context.csrf_token)
+        )
+
+
+def test_logout_requires_post_and_csrf_then_revokes_and_clears_cookie(storage, clock) -> None:
+    storage.create_user(account())
+    boundary = make_boundary(storage, clock)
+    established = boundary.establish_session("user-01")
+
+    with pytest.raises(HttpMethodNotAllowedError):
+        boundary.logout(request("GET", established))
+    with pytest.raises(HttpCsrfRejectedError):
+        boundary.logout(request("POST", established, "wrong"))
+
+    result = boundary.logout(
+        request("POST", established, established.context.csrf_token)
+    )
+    assert result.revoked is True
+    assert result.set_cookie.startswith("__Host-thebitlab_session=;")
+    assert "Max-Age=0" in result.set_cookie
+    assert "Expires=Thu, 01 Jan 1970 00:00:00 GMT" in result.set_cookie
+    assert "A" * 40 not in repr(result)
+    with pytest.raises(HttpAuthenticationRequiredError):
+        boundary.authenticate(request("GET", established))
+
+    repeated = boundary.logout(
+        request("POST", established, established.context.csrf_token)
+    )
+    assert repeated.revoked is False
+    assert "Max-Age=0" in repeated.set_cookie
+
+
+def test_login_completion_rotates_existing_session(storage, clock) -> None:
+    storage.create_user(account())
+    boundary = make_boundary(
+        storage,
+        clock,
+        tokens=("A" * 40, "B" * 40),
+        session_ids=("session-01", "session-02"),
+    )
+    first = boundary.establish_session("user-01")
+
+    second = boundary.establish_session(
+        "user-01", existing_cookie_header=cookie_header(first.set_cookie)
+    )
+
+    assert cookie_header(first.set_cookie) != cookie_header(second.set_cookie)
+    with pytest.raises(HttpAuthenticationRequiredError):
+        boundary.authenticate(request("GET", first))
+    assert boundary.authenticate(request("GET", second)).user.user_id == "user-01"
+
+
+def test_malformed_duplicate_missing_and_oversized_cookies_fail_closed(storage, clock) -> None:
+    storage.create_user(account())
+    policy = SessionCookiePolicy(max_cookie_header_bytes=256)
+    boundary = make_boundary(storage, clock, policy=policy)
+    established = boundary.establish_session("user-01")
+    valid = cookie_header(established.set_cookie)
+    bad_headers = [
+        None,
+        "",
+        "unrelated=value",
+        valid + "; " + valid,
+        valid + "; broken",
+        valid + "\r\nInjected: yes",
+        valid + "; padding=" + "x" * 256,
+        "__Host-thebitlab_session=quoted value",
+    ]
+
+    assert boundary.authenticate(
+        HttpAuthRequest("GET", valid + "; padded=a=b==")
+    ).user.user_id == "user-01"
+
+    for header in bad_headers:
+        captured = HttpAuthRequest("GET", header, "csrf-secret-value")
+        if header:
+            assert header not in repr(captured)
+        assert "csrf-secret-value" not in repr(captured)
+        with pytest.raises(HttpAuthenticationRequiredError):
+            boundary.authenticate(captured)
+
+    with pytest.raises(HttpBadRequestError):
+        boundary.authenticate("not-a-request")
+    with pytest.raises(HttpMethodNotAllowedError):
+        boundary.authenticate(HttpAuthRequest("TRACE", valid))
+
+
+def test_expiry_disable_and_role_change_are_fail_closed_or_refreshed(storage, clock) -> None:
+    original = account(role="teacher")
+    storage.create_user(original)
+    boundary = make_boundary(storage, clock)
+    established = boundary.establish_session("user-01")
+
+    changed = replace(
+        original,
+        role="student",
+        updated_at=NOW + timedelta(minutes=1),
+    )
+    storage.save_user(changed, expected_updated_at=original.updated_at)
+    clock.value += timedelta(minutes=2)
+    refreshed = boundary.authenticate(request("GET", established))
+    assert refreshed.user.role == "student"
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_application(
+            request("GET", established), allowed_roles={"teacher"}
+        )
+
+    disabled = replace(
+        changed,
+        active=False,
+        updated_at=NOW + timedelta(minutes=3),
+    )
+    storage.save_user(disabled, expected_updated_at=changed.updated_at)
+    with pytest.raises(HttpAuthenticationRequiredError):
+        boundary.authenticate(request("GET", established))
+
+    storage.save_user(
+        replace(disabled, active=True, updated_at=NOW + timedelta(minutes=4)),
+        expected_updated_at=disabled.updated_at,
+    )
+    with pytest.raises(HttpAuthenticationRequiredError):
+        boundary.authenticate(request("GET", established))
+
+
+def test_expired_cookie_cannot_authenticate_and_invalid_logout_still_clears(storage, clock) -> None:
+    storage.create_user(account())
+    sessions = SessionService(
+        storage,
+        clock=clock,
+        ttl=timedelta(minutes=5),
+        token_factory=lambda: "A" * 40,
+        session_id_factory=lambda: "session-01",
+    )
+    boundary = HttpSessionAuthBoundary(sessions, csrf_secret=CSRF_SECRET)
+    established = boundary.establish_session("user-01")
+    clock.value += timedelta(minutes=5)
+
+    with pytest.raises(HttpAuthenticationRequiredError):
+        boundary.authenticate(request("GET", established))
+    result = boundary.logout(request("POST", established, "anything"))
+    assert result.revoked is False
+    assert "Max-Age=0" in result.set_cookie
+
+
+def test_concurrent_logout_has_at_most_one_revocation_winner(storage, clock) -> None:
+    storage.create_user(account())
+    boundary = make_boundary(storage, clock)
+    established = boundary.establish_session("user-01")
+    logout_request = request("POST", established, established.context.csrf_token)
+
+    def logout():
+        return boundary.logout(logout_request).revoked
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(lambda _index: logout(), range(2)))
+
+    assert outcomes.count(True) <= 1
+    assert outcomes.count(False) >= 1

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -200,6 +200,24 @@ def test_cookie_incompatible_generated_bearer_is_revoked_without_header_injectio
     assert captured.value.status_code == 503
 
 
+def test_generated_cookie_pair_must_fit_request_header_limit(storage, clock) -> None:
+    storage.create_user(account())
+    boundary = make_boundary(
+        storage,
+        clock,
+        tokens=("A" * 300,),
+        session_ids=("session-oversized",),
+        policy=SessionCookiePolicy(max_cookie_header_bytes=256),
+    )
+
+    with pytest.raises(HttpAuthUnavailableError):
+        boundary.establish_session("user-01")
+
+    persisted = storage.read_session("session-oversized")
+    assert persisted is not None
+    assert persisted.revoked_at == NOW
+
+
 def test_storage_and_unexpected_failures_are_sanitized_at_http_boundary() -> None:
     class BrokenSessions:
         def authenticate(self, _bearer):

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -12,6 +12,7 @@ from scripts.thebitlab_http_auth import (
     HttpAuthRequest,
     HttpAuthenticationRequiredError,
     HttpAuthorizationDeniedError,
+    HttpAuthUnavailableError,
     HttpBadRequestError,
     HttpCsrfRejectedError,
     HttpMethodNotAllowedError,
@@ -169,6 +170,73 @@ def test_establishes_secure_cookie_and_never_persists_or_reprs_raw_values(
         ).fetchone()[0]
     assert "A" * 40 not in persisted
     assert established.context.csrf_token not in persisted
+
+
+def test_cookie_incompatible_generated_bearer_is_revoked_without_header_injection(
+    storage, clock
+) -> None:
+    storage.create_user(account())
+    injected = "A" * 32 + "; Domain=attacker.test"
+    boundary = make_boundary(
+        storage,
+        clock,
+        tokens=(injected,),
+        session_ids=("session-injected",),
+    )
+
+    with pytest.raises(HttpAuthUnavailableError) as captured:
+        boundary.establish_session("user-01")
+
+    persisted = storage.read_session("session-injected")
+    assert persisted is not None
+    assert persisted.revoked_at == NOW
+    assert injected not in str(captured.value)
+    assert captured.value.status_code == 503
+
+
+def test_storage_and_unexpected_failures_are_sanitized_at_http_boundary() -> None:
+    class BrokenSessions:
+        def authenticate(self, _bearer):
+            raise RuntimeError("raw storage backend details")
+
+        def issue(self, _user_id):
+            raise RuntimeError("raw storage backend details")
+
+        def revoke(self, _bearer):
+            raise RuntimeError("raw storage backend details")
+
+    boundary = HttpSessionAuthBoundary(BrokenSessions(), csrf_secret=CSRF_SECRET)
+    auth_request = HttpAuthRequest("GET", "__Host-thebitlab_session=" + "A" * 40)
+
+    with pytest.raises(HttpAuthUnavailableError) as authenticate_error:
+        boundary.authenticate(auth_request)
+    with pytest.raises(HttpAuthUnavailableError) as logout_error:
+        boundary.logout(
+            HttpAuthRequest(
+                "POST",
+                "__Host-thebitlab_session=" + "A" * 40,
+                "csrf",
+            )
+        )
+    with pytest.raises(HttpAuthUnavailableError) as issue_error:
+        boundary.establish_session("user-01")
+    with pytest.raises(HttpAuthUnavailableError) as rotation_error:
+        boundary.establish_session(
+            "user-01",
+            existing_cookie_header="__Host-thebitlab_session=" + "A" * 40,
+        )
+
+    for error in (
+        authenticate_error.value,
+        logout_error.value,
+        issue_error.value,
+        rotation_error.value,
+    ):
+        assert error.status_code == 503
+        assert error.error_code == "authentication_unavailable"
+        assert "storage" not in str(error)
+        assert error.__cause__ is None
+        assert error.__context__ is None
 
 
 def test_safe_authentication_refreshes_context_and_role_authorization(storage, clock) -> None:

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -300,6 +300,16 @@ def test_malformed_session_service_results_fail_closed(storage, clock) -> None:
     with pytest.raises(HttpAuthUnavailableError):
         real.authenticate(request("GET", established))
 
+    extended_session = replace(
+        valid_session,
+        expires_at=valid_session.created_at + timedelta(days=4),
+    )
+    real.sessions.authenticate = lambda _bearer: AuthenticatedSession(
+        extended_session, account()
+    )
+    with pytest.raises(HttpAuthUnavailableError):
+        real.authenticate(request("GET", established))
+
     real.sessions.authenticate = lambda _bearer: AuthenticatedSession(
         valid_session, account()
     )

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -438,6 +438,40 @@ def test_set_cookie_max_age_uses_response_time(clock) -> None:
     assert "Tue, 01 Sep 2026 16:00:00 GMT" in established.set_cookie
 
 
+def test_subsecond_remaining_session_is_revoked_instead_of_emitting_deleted_cookie(
+    clock,
+) -> None:
+    bearer = "A" * 40
+    user = account()
+    session = UserSession(
+        "short-session",
+        user.user_id,
+        session_token_digest(bearer),
+        NOW,
+        NOW + timedelta(milliseconds=500),
+        NOW,
+    )
+    revoked = []
+
+    class ShortSessionService:
+        def issue(self, _user_id):
+            return IssuedSession(session, bearer)
+
+        def authenticate(self, _bearer):
+            return AuthenticatedSession(session, user)
+
+        def revoke(self, _bearer):
+            revoked.append(True)
+            return True
+
+    boundary = HttpSessionAuthBoundary(
+        ShortSessionService(), csrf_secret=CSRF_SECRET, clock=clock
+    )
+    with pytest.raises(HttpAuthUnavailableError):
+        boundary.establish_session("user-01")
+    assert revoked == [True]
+
+
 def test_safe_authentication_refreshes_context_and_role_authorization(storage, clock) -> None:
     storage.create_user(account(role="teacher"))
     boundary = make_boundary(storage, clock)


### PR DESCRIPTION
## Sintesi
- aggiunge boundary HTTP provider-independent sopra `SessionService`
- emette e ruota cookie sessione sicuri
- applica CSRF HMAC session-bound alle richieste unsafe
- separa autenticazione da autorizzazione applicativa per ruoli
- esclude `pending` dalle policy sui dati applicativi
- revoca server-side e cancella il cookie al logout
- supporta sviluppo HTTP solo con opt-in loopback esplicito

## Sicurezza e robustezza
- cookie `__Host-`, `HttpOnly`, `Secure`, `SameSite=Lax`, senza `Domain`
- cookie duplicati, malformati, quoted e sovradimensionati gestiti fail-closed
- session rotation contro fixation e correlazione con il `user_id` trusted
- CSRF HMAC legato al bearer, non persistito e confrontato constant-time
- clock iniettato, scadenza esclusiva, durata massima e Max-Age residuo
- output service/storage malformati o inattesi sanitizzati come 503
- bearer e CSRF esclusi da repr/errori e mai persistiti raw

## Verifica
- test HTTP dedicati: 19 passati
- suite completa Python 3.10.7/Windows: 1212 passati, 37 skip previsti
- matrice CI Python 3.11-3.13 Windows/Linux e Docker verde
- `py_compile` e `git diff --check` verdi
- due review indipendenti consecutive senza finding allo SHA `0b1c5ab`

Closes #543
