### PR TITLE
feat: aggiungere adapter Google OpenID Connect

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,6 +16,7 @@ on:
       - "pyproject.toml"
       - "requirements-dev.txt"
       - "requirements-utui.txt"
+      - "requirements-auth.txt"
       - ".github/workflows/quality.yml"
   push:
     branches:
@@ -30,6 +31,7 @@ on:
       - "pyproject.toml"
       - "requirements-dev.txt"
       - "requirements-utui.txt"
+      - "requirements-auth.txt"
       - ".github/workflows/quality.yml"
 
 jobs:
@@ -47,7 +49,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install test dependencies
-        run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt
+        run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt -r requirements-auth.txt
 
       - name: Run Python tests
         run: python -m pytest
@@ -69,7 +71,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install test dependencies
-        run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt
+        run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt -r requirements-auth.txt
 
       - name: Test storage, lab and deletion workflows
         run: >-
@@ -105,7 +107,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install test dependencies
-        run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt
+        run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt -r requirements-auth.txt
 
       - name: Test full suite on minimum Python
         run: python -m pytest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -85,6 +85,7 @@ jobs:
           tests/test_student_lab_demo_setup.py
           tests/test_track_assignments.py
           tests/test_course_board_server.py
+          tests/test_thebitlab_google_oidc.py
 
       - name: Test portable Node.js and SQL runners
         run: >-

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -16,7 +16,10 @@ Installa prima la dipendenza di test:
 
 ```bash
 python -m pip install -r requirements-dev.txt
+python -m pip install -r requirements-auth.txt
 ```
+
+`requirements-auth.txt` installa `google-auth` e le dipendenze crittografiche necessarie ai test del verifier Google OIDC; non ometterlo quando si valida l'intera suite.
 
 I test del renderer opzionale `utui` richiedono Python 3.11 o successivo e la dipendenza fissata:
 

--- a/doc/architecture/auth-application-services.md
+++ b/doc/architecture/auth-application-services.md
@@ -78,7 +78,7 @@ I messaggi non includono credenziali raw. Gli errori storage condivisi sono defi
 
 ## Fuori scope
 
-- Google OIDC e GitHub OAuth reali;
+- route/browser E2E Google OIDC e GitHub OAuth (l'adapter Google è descritto in `google-oidc-adapter.md`);
 - integrazione del boundary HTTP nelle route e nelle dashboard concrete;
 - rate limiting distribuito;
 - emissione atomica di una sessione TUI dopo il consumo;

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -15,7 +15,7 @@
 - path post-login locale e fisso, mai ricevuto dal callback;
 - TTL flow, età massima ID token, clock skew, timeout e limite risposta.
 
-La dipendenza di produzione è dichiarata in `requirements-auth.txt` come `google-auth[requests]`. `GoogleOfficialIdTokenVerifier` usa la libreria ufficiale per firma RS256, certificati Google, issuer, audience e scadenze. Il livello applicativo ripete fail-closed i controlli essenziali su issuer, audience/azp, exp/iat, nonce, subject ed email verificata.
+La dipendenza di produzione è dichiarata in `requirements-auth.txt` come `google-auth`. `GoogleOfficialIdTokenVerifier` usa la libreria ufficiale per firma RS256, issuer, audience e scadenze. Il recupero certificati passa da `BoundedGoogleCertRequest`, limitato agli endpoint Google noti, senza redirect, con timeout e dimensione derivati dalla config. Il livello applicativo ripete fail-closed i controlli essenziali su issuer, audience/azp, exp/iat, nonce, subject ed email verificata.
 
 ## Avvio authorization flow
 
@@ -37,7 +37,7 @@ State e nonce raw esistono soltanto nella URL consegnata al browser. Lo store co
 
 ## Store one-time
 
-`InMemoryGoogleOidcFlowStore` è protetto da lock e consuma lo state con una singola `pop`: un solo callback concorrente può vincere. La scadenza è esclusiva (`now >= expires_at`). Errori provider con state valido consumano comunque il flow. Il cleanup riceve un cutoff esplicito.
+`InMemoryGoogleOidcFlowStore` è protetto da lock e consuma lo state con una singola `pop`: un solo callback concorrente può vincere. La scadenza è esclusiva (`now >= expires_at`). Errori provider con state valido consumano comunque il flow. Il cleanup riceve un cutoff esplicito; ogni creazione elimina inoltre i flow già scaduti e lo store impone un cap configurabile, evitando crescita non limitata dei verifier raw.
 
 Lo store è adatto al server MVP a processo singolo. Deployment multi-process richiederà uno store transazionale condiviso; non è ammesso usare sticky session come unica garanzia di replay protection.
 

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -1,0 +1,95 @@
+# Adapter Google OpenID Connect
+
+## Scopo
+
+`thebitlab_google_oidc.py` implementa il login Google tramite Authorization Code Flow sopra `FederatedIdentityService` e `HttpSessionAuthBoundary`. Non introduce route nel Course Board: il futuro adapter HTTP tradurrà `/auth/google/login` e `/auth/google/callback` nei contratti qui descritti.
+
+## Configurazione
+
+`GoogleOidcConfig` richiede:
+
+- Google OAuth client ID;
+- client secret proveniente da ambiente o secret store;
+- redirect URI HTTPS esatto registrato nella Google Cloud Console;
+- authorization e token endpoint HTTPS senza credenziali URL o fragment;
+- path post-login locale e fisso, mai ricevuto dal callback;
+- TTL flow, età massima ID token, clock skew, timeout e limite risposta.
+
+La dipendenza di produzione è dichiarata in `requirements-auth.txt` come `google-auth[requests]`. `GoogleOfficialIdTokenVerifier` usa la libreria ufficiale per firma RS256, certificati Google, issuer, audience e scadenze. Il livello applicativo ripete fail-closed i controlli essenziali su issuer, audience/azp, exp/iat, nonce, subject ed email verificata.
+
+## Avvio authorization flow
+
+`begin_login()` genera con CSPRNG:
+
+- `state` di almeno 256 bit;
+- `nonce` di almeno 256 bit;
+- PKCE verifier tra 43 e 128 caratteri.
+
+La authorization request usa:
+
+```text
+response_type=code
+scope=openid email profile
+code_challenge_method=S256
+```
+
+State e nonce raw esistono soltanto nella URL consegnata al browser. Lo store conserva digest SHA-256; il verifier PKCE raw rimane unicamente nella memoria del processo e ha `repr` oscurato.
+
+## Store one-time
+
+`InMemoryGoogleOidcFlowStore` è protetto da lock e consuma lo state con una singola `pop`: un solo callback concorrente può vincere. La scadenza è esclusiva (`now >= expires_at`). Errori provider con state valido consumano comunque il flow. Il cleanup riceve un cutoff esplicito.
+
+Lo store è adatto al server MVP a processo singolo. Deployment multi-process richiederà uno store transazionale condiviso; non è ammesso usare sticky session come unica garanzia di replay protection.
+
+## Callback
+
+Il callback:
+
+1. rifiuta parametri sconosciuti, duplicati, mancanti, sovradimensionati o con controlli;
+2. consuma atomicamente state prima del token exchange;
+3. invia code, redirect URI e PKCE verifier al token endpoint tramite POST form;
+4. non segue redirect, impone HTTPS, timeout e limite risposta;
+5. accetta JSON object senza chiavi duplicate ed estrae soltanto `id_token`;
+6. verifica firma e claim tramite la porta `GoogleIdTokenVerifier`;
+7. confronta il digest del nonce in constant time;
+8. richiede subject stabile, `email_verified is True`, audience/azp e intervalli temporali validi;
+9. crea `FederatedIdentityAssertion(provider="google", ...)`;
+10. risolve/onboarda l'utente e chiede al boundary HTTP di ruotare/emetterne la sessione;
+11. restituisce esclusivamente il redirect path configurato.
+
+Utenti nuovi entrano come `pending`. Identità collegate ad account disabilitati producono un errore distinto e nessuna sessione.
+
+## Segreti
+
+Non vengono persistiti:
+
+- client secret;
+- authorization code;
+- state/nonce raw;
+- PKCE verifier;
+- ID/access/refresh token;
+- cookie sessione raw.
+
+URL/result dataclass escludono i valori sensibili dal `repr`. Transport, verifier e callback eliminano riferimenti locali prima di propagare errori sanitizzati. Access e refresh token eventualmente presenti nella risposta Google vengono ignorati: una futura necessità di refresh token richiederà una decisione separata su cifratura, retention e revoca.
+
+## Errori
+
+La taxonomy distingue:
+
+- configurazione/generatori invalidi;
+- callback provider o parametri invalidi;
+- state sconosciuto, scaduto o replayed;
+- provider/token endpoint indisponibile;
+- ID token/claim rifiutati;
+- identità interna non autorizzata.
+
+I messaggi non includono valori OAuth raw o dettagli backend.
+
+## Fuori scope
+
+- credenziali reali nel repository o CI;
+- route concrete, UI e browser E2E Google;
+- protezione dashboard;
+- persistenza flow multi-process;
+- GitHub linking;
+- TLS termination e deployment pubblico.

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -23,7 +23,8 @@ Gli endpoint authorization e token sono fissati ai valori Google canonici; una c
 
 - `state` di almeno 256 bit;
 - `nonce` di almeno 256 bit;
-- PKCE verifier tra 43 e 128 caratteri.
+- PKCE verifier tra 43 e 128 caratteri;
+- binding browser transazionale di almeno 256 bit.
 
 La authorization request usa:
 
@@ -32,6 +33,8 @@ response_type=code
 scope=openid email profile
 code_challenge_method=S256
 ```
+
+Il binding è inviato soltanto nel cookie one-time `__Host-thebitlab_oidc_txn` con `Secure`, `HttpOnly`, `SameSite=Lax` e `Path=/`; nel flow resta solo il digest. Il callback consuma lo state esclusivamente con il cookie del browser originario e restituisce un cookie di cancellazione, impedendo login CSRF/session swapping.
 
 State e nonce raw esistono soltanto nella URL consegnata al browser. Lo store conserva digest SHA-256; il verifier PKCE raw rimane unicamente nella memoria del processo e ha `repr` oscurato.
 

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -34,7 +34,7 @@ scope=openid email profile
 code_challenge_method=S256
 ```
 
-Il binding è inviato soltanto nel cookie one-time `__Host-thebitlab_oidc_txn` con `Secure`, `HttpOnly`, `SameSite=Lax` e `Path=/`; nel flow resta solo il digest. Il callback consuma lo state esclusivamente con il cookie del browser originario e restituisce un cookie di cancellazione, impedendo login CSRF/session swapping. Dopo un consumo terminale fallito, anche l'errore pubblico espone `clear_transaction_cookie`; un binding errato che non consuma il flow non lo espone.
+Il binding è inviato soltanto nel cookie one-time `__Host-thebitlab_oidc_txn-<state-digest>` con `Secure`, `HttpOnly`, `SameSite=Lax` e `Path=/`; nel flow resta solo il digest. Il callback consuma lo state esclusivamente con il cookie del browser originario e restituisce un cookie di cancellazione, impedendo login CSRF/session swapping. Dopo un consumo terminale fallito, anche l'errore pubblico espone `clear_transaction_cookie`; un binding errato che non consuma il flow non lo espone. Il suffisso derivato dallo state assegna nomi distinti ai flow concorrenti nello stesso browser, evitando sovrascritture tra schede.
 
 State e nonce raw esistono soltanto nella URL consegnata al browser. Lo store conserva digest SHA-256; il verifier PKCE raw rimane unicamente nella memoria del processo e ha `repr` oscurato.
 

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -73,7 +73,7 @@ Non vengono persistiti:
 - ID/access/refresh token;
 - cookie sessione raw.
 
-URL/result dataclass escludono i valori sensibili dal `repr`. Transport, verifier e callback eliminano riferimenti locali prima di propagare errori sanitizzati. Access e refresh token eventualmente presenti nella risposta Google vengono ignorati: una futura necessità di refresh token richiederà una decisione separata su cifratura, retention e revoca.
+URL/result dataclass escludono i valori sensibili dal `repr`. Transport, verifier e callback eliminano riferimenti locali raw prima di propagare errori sanitizzati. Il threat model dei log/traceback copre messaggi, `repr` e serializzazione dei locals; non promette segretezza contro codice con introspezione arbitraria ricorsiva dell'object graph o accesso alla memoria del processo, che può necessariamente raggiungere le credenziali necessarie al token exchange. Access e refresh token eventualmente presenti nella risposta Google vengono ignorati: una futura necessità di refresh token richiederà una decisione separata su cifratura, retention e revoca.
 
 ## Errori
 

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -15,7 +15,7 @@
 - path post-login locale e fisso, mai ricevuto dal callback;
 - TTL flow, età massima ID token, clock skew, timeout e limite risposta.
 
-La dipendenza di produzione è dichiarata in `requirements-auth.txt` come `google-auth`. `GoogleOfficialIdTokenVerifier` usa la libreria ufficiale per firma RS256, issuer, audience e scadenze. Il recupero certificati passa da `BoundedGoogleCertRequest`, limitato agli endpoint Google noti, senza redirect, con timeout e dimensione derivati dalla config. Il livello applicativo ripete fail-closed i controlli essenziali su issuer, audience/azp, exp/iat, nonce, subject ed email verificata.
+La dipendenza di produzione è dichiarata in `requirements-auth.txt` come `google-auth`. `GoogleOfficialIdTokenVerifier` usa la libreria ufficiale per firma RS256, issuer, audience e scadenze. Il recupero certificati passa da `BoundedGoogleCertRequest`, limitato agli endpoint Google noti, senza redirect, con timeout e dimensione derivati dalla config. Un ulteriore adapter accetta solo la risposta X.509 `kid -> PEM` dell'endpoint v1 e rifiuta JWKS, impedendo a `google-auth`/PyJWT di avviare fetch secondarie fuori dal trasporto bounded. Il livello applicativo ripete fail-closed i controlli essenziali su issuer, audience/azp, exp/iat, nonce, subject ed email verificata.
 
 ## Avvio authorization flow
 

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -42,7 +42,7 @@ State e nonce raw esistono soltanto nella URL consegnata al browser. Lo store co
 
 `InMemoryGoogleOidcFlowStore` è protetto da lock e consuma lo state con una singola `pop`: un solo callback concorrente può vincere. La scadenza è esclusiva (`now >= expires_at`). Errori provider con state valido consumano comunque il flow. Il cleanup riceve un cutoff esplicito; ogni creazione elimina inoltre i flow già scaduti e lo store impone un cap configurabile, evitando crescita non limitata dei verifier raw.
 
-Lo store è adatto al server MVP a processo singolo. Deployment multi-process richiederà uno store transazionale condiviso; non è ammesso usare sticky session come unica garanzia di replay protection.
+Lo store è adatto al server MVP a processo singolo. Deployment multi-process richiederà uno store transazionale condiviso; non è ammesso usare sticky session come unica garanzia di replay protection. Il cap limita la memoria ma non sostituisce il controllo abuso: la futura route pubblica deve applicare rate limit per-client e globale, trusted-proxy-aware, prima di `begin_login()`; il requisito è tracciato in #549.
 
 ## Callback
 
@@ -51,7 +51,7 @@ Il callback:
 1. rifiuta parametri sconosciuti, duplicati, mancanti, sovradimensionati o con controlli;
 2. consuma atomicamente state prima del token exchange;
 3. invia code, redirect URI e PKCE verifier al token endpoint tramite POST form;
-4. non segue redirect, impone HTTPS, timeout e limite risposta;
+4. non segue redirect, impone HTTPS, timeout e limite risposta; classifica OAuth 4xx bounded come rejection/configurazione e 5xx/rete come indisponibilità;
 5. accetta JSON object senza chiavi duplicate ed estrae soltanto `id_token`;
 6. verifica firma e claim tramite la porta `GoogleIdTokenVerifier`;
 7. confronta il digest del nonce in constant time;

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -34,7 +34,7 @@ scope=openid email profile
 code_challenge_method=S256
 ```
 
-Il binding è inviato soltanto nel cookie one-time `__Host-thebitlab_oidc_txn` con `Secure`, `HttpOnly`, `SameSite=Lax` e `Path=/`; nel flow resta solo il digest. Il callback consuma lo state esclusivamente con il cookie del browser originario e restituisce un cookie di cancellazione, impedendo login CSRF/session swapping.
+Il binding è inviato soltanto nel cookie one-time `__Host-thebitlab_oidc_txn` con `Secure`, `HttpOnly`, `SameSite=Lax` e `Path=/`; nel flow resta solo il digest. Il callback consuma lo state esclusivamente con il cookie del browser originario e restituisce un cookie di cancellazione, impedendo login CSRF/session swapping. Dopo un consumo terminale fallito, anche l'errore pubblico espone `clear_transaction_cookie`; un binding errato che non consuma il flow non lo espone.
 
 State e nonce raw esistono soltanto nella URL consegnata al browser. Lo store conserva digest SHA-256; il verifier PKCE raw rimane unicamente nella memoria del processo e ha `repr` oscurato.
 

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -15,7 +15,7 @@
 - path post-login locale e fisso, mai ricevuto dal callback;
 - TTL flow, età massima ID token, clock skew, timeout e limite risposta.
 
-La dipendenza di produzione è dichiarata in `requirements-auth.txt` come `google-auth`. `GoogleOfficialIdTokenVerifier` usa la libreria ufficiale per firma RS256, issuer, audience e scadenze. Il recupero certificati passa da `BoundedGoogleCertRequest`, limitato agli endpoint Google noti, senza redirect, con timeout e dimensione derivati dalla config. Un ulteriore adapter accetta solo la risposta X.509 `kid -> PEM` dell'endpoint v1 e rifiuta JWKS, impedendo a `google-auth`/PyJWT di avviare fetch secondarie fuori dal trasporto bounded. Il livello applicativo ripete fail-closed i controlli essenziali su issuer, audience/azp, exp/iat, nonce, subject ed email verificata.
+Gli endpoint authorization e token sono fissati ai valori Google canonici; una configurazione non può redirigere client secret, authorization code o verifier PKCE verso host alternativi. La dipendenza di produzione è dichiarata in `requirements-auth.txt` come `google-auth`. `GoogleOfficialIdTokenVerifier` usa la libreria ufficiale per firma RS256, issuer, audience e scadenze. Il recupero certificati passa da `BoundedGoogleCertRequest`, limitato agli endpoint Google noti, senza redirect, con timeout e dimensione derivati dalla config. Un ulteriore adapter accetta solo la risposta X.509 `kid -> PEM` dell'endpoint v1 e rifiuta JWKS, impedendo a `google-auth`/PyJWT di avviare fetch secondarie fuori dal trasporto bounded. Il livello applicativo ripete fail-closed i controlli essenziali su issuer, audience/azp, exp/iat, nonce, subject ed email verificata.
 
 ## Avvio authorization flow
 

--- a/doc/architecture/http-session-authorization.md
+++ b/doc/architecture/http-session-authorization.md
@@ -2,7 +2,7 @@
 
 ## Scopo
 
-`thebitlab_http_auth.py` traduce richieste HTTP in operazioni di `SessionService`. Rimane indipendente da `course_board_server.py`, Google OIDC e GitHub. Il callback OIDC futuro sarà l'unico adapter pubblico autorizzato a chiamare `establish_session(user_id)` dopo che `FederatedIdentityService` avrà risolto l'identità.
+`thebitlab_http_auth.py` traduce richieste HTTP in operazioni di `SessionService`. Rimane indipendente da `course_board_server.py`, Google OIDC e GitHub. `GoogleOidcLoginService`, descritto in `google-oidc-adapter.md`, è il primo adapter autorizzato a chiamare `establish_session(user_id)` dopo che `FederatedIdentityService` ha risolto l'identità; la route HTTP concreta resta successiva.
 
 Non deve esistere un endpoint di produzione che accetti direttamente un `user_id` scelto dal client. Provider fake ed eventuali route di test restano esclusivamente nei test.
 
@@ -71,7 +71,7 @@ Il logout è esclusivamente `POST`. Per una sessione valida richiede CSRF, revoc
 ## Fuori scope
 
 - route concrete nel Course Board e protezione dashboard;
-- callback Google OIDC e verifica `state`/`nonce`/PKCE;
+- route e browser E2E Google OIDC (il protocol adapter `state`/`nonce`/PKCE è implementato);
 - account linking GitHub;
 - pairing TUI via browser;
 - TLS termination e rate limiting distribuito.

--- a/requirements-auth.txt
+++ b/requirements-auth.txt
@@ -1,0 +1,2 @@
+# Official Google OpenID Connect ID-token verification and HTTPS transport.
+google-auth[requests]>=2.40,<3

--- a/requirements-auth.txt
+++ b/requirements-auth.txt
@@ -1,2 +1,2 @@
 # Official Google OpenID Connect ID-token verification and HTTPS transport.
-google-auth[requests]>=2.40,<3
+google-auth>=2.40,<3

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -37,7 +37,7 @@ _UNRESERVED_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
 _CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{10,512}$")
 _INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 _MAX_CALLBACK_VALUE_CHARS = 8192
-_TRANSACTION_COOKIE_NAME = "__Host-thebitlab_oidc_txn"
+_TRANSACTION_COOKIE_PREFIX = "__Host-thebitlab_oidc_txn-"
 _MAX_COOKIE_HEADER_BYTES = 4096
 _GOOGLE_CERT_ENDPOINTS = frozenset(
     {
@@ -65,6 +65,10 @@ class GoogleOidcCallbackError(GoogleOidcError):
 
 class GoogleOidcStateError(GoogleOidcError):
     """Raised for unknown, expired, duplicate, or replayed state."""
+
+
+class GoogleOidcConsumedStateError(GoogleOidcStateError):
+    """Raised after a terminal state was removed from the flow store."""
 
 
 class GoogleOidcStateConflictError(GoogleOidcStateError):
@@ -377,7 +381,7 @@ class InMemoryGoogleOidcFlowStore:
             raise GoogleOidcStateError("State OIDC sconosciuto o gia usato.")
         if now < flow.created_at or now >= flow.expires_at:
             flow = None
-            raise GoogleOidcStateError("State OIDC scaduto.")
+            raise GoogleOidcConsumedStateError("State OIDC scaduto.")
         return flow
 
     def discard_created_flow(self, state: str, creation_marker: object) -> bool:
@@ -838,7 +842,9 @@ class GoogleOidcLoginService:
                     }
                 )
                 authorization_url = f"{self.config.authorization_endpoint}?{query}"
-                transaction_cookie = self._transaction_cookie(browser_binding)
+                transaction_cookie = self._transaction_cookie(
+                    state, browser_binding
+                )
                 authorization_request = GoogleAuthorizationRequest(
                     authorization_url, transaction_cookie
                 )
@@ -874,22 +880,31 @@ class GoogleOidcLoginService:
             return authorization_request
         raise GoogleOidcConfigurationError("Impossibile generare state OIDC univoco.")
 
-    def _transaction_cookie(self, browser_binding: str) -> str:
+    @staticmethod
+    def _transaction_cookie_name(state: str) -> str:
+        suffix = hashlib.sha256(state.encode("utf-8")).hexdigest()[:24]
+        return _TRANSACTION_COOKIE_PREFIX + suffix
+
+    def _transaction_cookie(self, state: str, browser_binding: str) -> str:
         max_age = math.ceil(self.config.flow_ttl.total_seconds())
+        cookie_name = self._transaction_cookie_name(state)
         return (
-            f"{_TRANSACTION_COOKIE_NAME}={browser_binding}; Path=/; "
+            f"{cookie_name}={browser_binding}; Path=/; "
             f"Max-Age={max_age}; Secure; HttpOnly; SameSite=Lax"
         )
 
     @staticmethod
-    def _clear_transaction_cookie() -> str:
+    def _clear_transaction_cookie(cookie_name: str) -> str:
         return (
-            f"{_TRANSACTION_COOKIE_NAME}=; Path=/; Max-Age=0; "
+            f"{cookie_name}=; Path=/; Max-Age=0; "
             "Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax"
         )
 
-    @staticmethod
-    def _transaction_binding(cookie_header: str | None) -> str:
+    @classmethod
+    def _transaction_binding(
+        cls, cookie_header: str | None, state: str
+    ) -> tuple[str, str]:
+        cookie_name = cls._transaction_cookie_name(state)
         invalid = (
             type(cookie_header) is not str
             or not cookie_header
@@ -903,7 +918,7 @@ class GoogleOidcLoginService:
         if not invalid:
             for part in cookie_header.split(";"):
                 name, separator, value = part.strip().partition("=")
-                if separator and name == _TRANSACTION_COOKIE_NAME:
+                if separator and name == cookie_name:
                     matches.append(value)
         if (
             invalid
@@ -913,11 +928,14 @@ class GoogleOidcLoginService:
         ):
             matches = []
             cookie_header = None
+            part = None
+            name = None
+            value = None
             raise GoogleOidcStateError("Cookie transazione OIDC non valido.")
         binding = matches[0]
         matches = []
         cookie_header = None
-        return binding
+        return binding, cookie_name
 
     def complete_callback(
         self,
@@ -932,6 +950,7 @@ class GoogleOidcLoginService:
         code = None
         state = None
         browser_binding = None
+        transaction_cookie_name = None
         provider_error = False
         assertion = None
         user = None
@@ -940,6 +959,7 @@ class GoogleOidcLoginService:
         expected_error = None
         unexpected_failed = False
         flow_consumed = False
+        clear_cookie_name = None
         try:
             try:
                 code, state, provider_error = self._callback_values(parameters)
@@ -948,10 +968,16 @@ class GoogleOidcLoginService:
             state_failed = False
             state_unavailable = False
             try:
-                browser_binding = self._transaction_binding(existing_cookie_header)
+                browser_binding, transaction_cookie_name = (
+                    self._transaction_binding(existing_cookie_header, state)
+                )
+                clear_cookie_name = transaction_cookie_name
                 flow = self.flows.consume(
                     state, browser_binding, _utc(self.clock())
                 )
+            except GoogleOidcConsumedStateError:
+                flow_consumed = True
+                state_failed = True
             except GoogleOidcStateError:
                 state_failed = True
             except Exception:
@@ -1045,7 +1071,9 @@ class GoogleOidcLoginService:
                     role=session.context.user.role,
                     session=session,
                     redirect_path=self.config.post_login_path,
-                    clear_transaction_cookie=self._clear_transaction_cookie(),
+                    clear_transaction_cookie=self._clear_transaction_cookie(
+                        transaction_cookie_name
+                    ),
                 )
             except Exception:
                 result_failed = True
@@ -1071,6 +1099,7 @@ class GoogleOidcLoginService:
             code = None
             state = None
             browser_binding = None
+            transaction_cookie_name = None
             provider_error = False
             state_failed = False
             state_unavailable = False
@@ -1088,7 +1117,7 @@ class GoogleOidcLoginService:
         if expected_error is not None:
             if flow_consumed:
                 expected_error.clear_transaction_cookie = (
-                    self._clear_transaction_cookie()
+                    self._clear_transaction_cookie(clear_cookie_name)
                 )
             raise expected_error
         if unexpected_failed or result is None:
@@ -1097,7 +1126,7 @@ class GoogleOidcLoginService:
             )
             if flow_consumed:
                 unavailable_error.clear_transaction_cookie = (
-                    self._clear_transaction_cookie()
+                    self._clear_transaction_cookie(clear_cookie_name)
                 )
             raise unavailable_error
         return result

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -766,12 +766,25 @@ class GoogleOidcLoginService:
                 existing_cookie_header=existing_cookie_header,
             )
             existing_cookie_header = None
-            result = GoogleOidcLoginResult(
-                user_id=user.user_id,
-                role=user.role,
-                session=session,
-                redirect_path=self.config.post_login_path,
-            )
+            result_failed = False
+            try:
+                result = GoogleOidcLoginResult(
+                    user_id=session.context.user.user_id,
+                    role=session.context.user.role,
+                    session=session,
+                    redirect_path=self.config.post_login_path,
+                )
+            except Exception:
+                result_failed = True
+            if result_failed or result is None:
+                try:
+                    self.http_sessions.discard_established_session(session)
+                except Exception:
+                    pass
+                session = None
+                raise GoogleOidcProviderUnavailableError(
+                    "Completamento login Google non disponibile."
+                )
         except GoogleOidcError as error:
             expected_error = error
         except Exception:
@@ -787,6 +800,7 @@ class GoogleOidcLoginService:
             provider_error = False
             verification_failed = False
             verification_unavailable = False
+            result_failed = False
             assertion = None
             user = None
             session = None

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -1,0 +1,734 @@
+"""Google OpenID Connect authorization-code adapter with state, nonce, and PKCE."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import math
+import re
+import secrets
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Mapping, Protocol, Sequence
+
+from scripts.thebitlab_auth_services import (
+    AuthApplicationError,
+    FederatedIdentityAssertion,
+    FederatedIdentityService,
+)
+from scripts.thebitlab_http_auth import EstablishedHttpSession, HttpSessionAuthBoundary
+from scripts.thebitlab_identity import IdentityDomainError
+
+_GOOGLE_ISSUERS = frozenset({"accounts.google.com", "https://accounts.google.com"})
+_UNRESERVED_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
+_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{10,512}$")
+_MAX_CALLBACK_VALUE_CHARS = 8192
+
+
+class GoogleOidcError(RuntimeError):
+    """Base credential-free Google OIDC adapter error."""
+
+
+class GoogleOidcConfigurationError(GoogleOidcError):
+    """Raised for invalid server-side OIDC configuration."""
+
+
+class GoogleOidcCallbackError(GoogleOidcError):
+    """Raised for malformed or provider-declined callbacks."""
+
+
+class GoogleOidcStateError(GoogleOidcError):
+    """Raised for unknown, expired, duplicate, or replayed state."""
+
+
+class GoogleOidcProviderUnavailableError(GoogleOidcError):
+    """Raised when Google token or verification infrastructure is unavailable."""
+
+
+class GoogleOidcTokenRejectedError(GoogleOidcError):
+    """Raised when an ID token does not satisfy the OIDC contract."""
+
+
+class GoogleOidcIdentityRejectedError(GoogleOidcError):
+    """Raised when the authenticated Google identity cannot use an account."""
+
+
+@dataclass(frozen=True)
+class GoogleOidcConfig:
+    client_id: str
+    client_secret: str = field(repr=False, compare=False)
+    redirect_uri: str
+    authorization_endpoint: str = "https://accounts.google.com/o/oauth2/v2/auth"
+    token_endpoint: str = "https://oauth2.googleapis.com/token"
+    post_login_path: str = "/"
+    flow_ttl: timedelta = timedelta(minutes=10)
+    id_token_max_age: timedelta = timedelta(minutes=15)
+    clock_skew: timedelta = timedelta(seconds=30)
+    timeout_seconds: float = 10.0
+    max_token_response_bytes: int = 64 * 1024
+
+    def __post_init__(self) -> None:
+        if type(self.client_id) is not str or not _CLIENT_ID_RE.fullmatch(self.client_id):
+            raise GoogleOidcConfigurationError("Google client ID non valido.")
+        if (
+            type(self.client_secret) is not str
+            or not 1 <= len(self.client_secret) <= 2048
+            or not self.client_secret.strip()
+            or any(ord(character) < 0x20 for character in self.client_secret)
+        ):
+            raise GoogleOidcConfigurationError("Google client secret non valido.")
+        for field_name in ("redirect_uri", "authorization_endpoint", "token_endpoint"):
+            value = getattr(self, field_name)
+            parsed = urllib.parse.urlsplit(value) if type(value) is str else None
+            if (
+                parsed is None
+                or parsed.scheme != "https"
+                or not parsed.hostname
+                or parsed.username is not None
+                or parsed.password is not None
+                or parsed.fragment
+                or (field_name != "redirect_uri" and parsed.query)
+            ):
+                raise GoogleOidcConfigurationError(
+                    f"{field_name} deve essere un URL HTTPS assoluto."
+                )
+        if (
+            type(self.post_login_path) is not str
+            or not self.post_login_path.startswith("/")
+            or self.post_login_path.startswith("//")
+            or "\\" in self.post_login_path
+            or any(ord(character) < 0x20 for character in self.post_login_path)
+        ):
+            raise GoogleOidcConfigurationError("Path post-login non valido.")
+        for value, name, maximum in (
+            (self.flow_ttl, "flow_ttl", timedelta(minutes=30)),
+            (self.id_token_max_age, "id_token_max_age", timedelta(hours=1)),
+            (self.clock_skew, "clock_skew", timedelta(minutes=5)),
+        ):
+            if (
+                type(value) is not timedelta
+                or value < timedelta(0)
+                or (name != "clock_skew" and value == timedelta(0))
+                or value > maximum
+            ):
+                raise GoogleOidcConfigurationError(f"{name} non valido.")
+        if (
+            isinstance(self.timeout_seconds, bool)
+            or not isinstance(self.timeout_seconds, (int, float))
+            or not 0 < self.timeout_seconds <= 60
+        ):
+            raise GoogleOidcConfigurationError("Timeout OIDC non valido.")
+        if (
+            type(self.max_token_response_bytes) is not int
+            or not 1024 <= self.max_token_response_bytes <= 1024 * 1024
+        ):
+            raise GoogleOidcConfigurationError("Limite risposta token non valido.")
+
+
+@dataclass(frozen=True)
+class PendingGoogleOidcFlow:
+    state_digest: str
+    nonce_digest: str
+    code_verifier: str = field(repr=False, compare=False)
+    created_at: datetime
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class GoogleAuthorizationRequest:
+    authorization_url: str = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True)
+class GoogleOidcLoginResult:
+    user_id: str
+    role: str
+    session: EstablishedHttpSession
+    redirect_path: str
+
+
+class GoogleTokenTransport(Protocol):
+    def exchange_code(
+        self,
+        *,
+        endpoint: str,
+        form: Mapping[str, str],
+        timeout_seconds: float,
+        max_response_bytes: int,
+    ) -> Mapping[str, object]: ...
+
+
+class GoogleIdTokenVerifier(Protocol):
+    def verify(self, id_token: str, *, audience: str) -> Mapping[str, object]: ...
+
+
+class InMemoryGoogleOidcFlowStore:
+    """Thread-safe one-time flow store; raw verifier exists only in memory."""
+
+    def __init__(self) -> None:
+        self._flows: dict[str, PendingGoogleOidcFlow] = {}
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def state_digest(state: str) -> str:
+        return "sha256:" + hashlib.sha256(state.encode("ascii")).hexdigest()
+
+    @staticmethod
+    def nonce_digest(nonce: str) -> str:
+        return "sha256:" + hashlib.sha256(nonce.encode("ascii")).hexdigest()
+
+    def create(self, state: str, nonce: str, code_verifier: str, now: datetime, ttl: timedelta) -> None:
+        flow = PendingGoogleOidcFlow(
+            state_digest=self.state_digest(state),
+            nonce_digest=self.nonce_digest(nonce),
+            code_verifier=code_verifier,
+            created_at=now,
+            expires_at=now + ttl,
+        )
+        with self._lock:
+            if flow.state_digest in self._flows:
+                raise GoogleOidcStateError("Collisione state OIDC.")
+            self._flows[flow.state_digest] = flow
+
+    def consume(self, state: str, now: datetime) -> PendingGoogleOidcFlow:
+        digest_failed = False
+        try:
+            digest = self.state_digest(state)
+        except Exception:
+            digest_failed = True
+            digest = ""
+        finally:
+            state = None
+        if digest_failed:
+            raise GoogleOidcStateError("State OIDC non valido.")
+        with self._lock:
+            flow = self._flows.pop(digest, None)
+        if flow is None:
+            raise GoogleOidcStateError("State OIDC sconosciuto o gia usato.")
+        if now < flow.created_at or now >= flow.expires_at:
+            flow = None
+            raise GoogleOidcStateError("State OIDC scaduto.")
+        return flow
+
+    def delete_expired(self, cutoff: datetime) -> int:
+        with self._lock:
+            expired = [key for key, flow in self._flows.items() if flow.expires_at <= cutoff]
+            for key in expired:
+                del self._flows[key]
+            return len(expired)
+
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._flows)
+
+
+class UrllibGoogleTokenTransport:
+    """Bounded HTTPS form transport that never follows redirects."""
+
+    class _NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, request, fp, code, msg, headers, newurl):
+            return None
+
+    def __init__(self) -> None:
+        self._opener = urllib.request.build_opener(self._NoRedirect())
+
+    def exchange_code(
+        self,
+        *,
+        endpoint: str,
+        form: Mapping[str, str],
+        timeout_seconds: float,
+        max_response_bytes: int,
+    ) -> Mapping[str, object]:
+        failed = False
+        payload = None
+        request = None
+        response = None
+        response_bytes = None
+        try:
+            payload = urllib.parse.urlencode(form).encode("ascii")
+            form = None
+            request = urllib.request.Request(
+                endpoint,
+                data=payload,
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                method="POST",
+            )
+            with self._opener.open(request, timeout=timeout_seconds) as response:
+                if response.status != 200:
+                    failed = True
+                else:
+                    response_bytes = response.read(max_response_bytes + 1)
+                    if len(response_bytes) > max_response_bytes:
+                        failed = True
+        except Exception:
+            failed = True
+        finally:
+            payload = None
+            request = None
+            response = None
+            form = None
+        if failed or response_bytes is None:
+            response_bytes = None
+            raise GoogleOidcProviderUnavailableError("Token endpoint Google non disponibile.")
+        try:
+            decoded = json.loads(
+                response_bytes.decode("utf-8"),
+                object_pairs_hook=_reject_duplicate_json_keys,
+            )
+        except (UnicodeError, ValueError, TypeError):
+            decoded = None
+        finally:
+            response_bytes = None
+        if type(decoded) is not dict:
+            decoded = None
+            raise GoogleOidcProviderUnavailableError("Risposta token Google non valida.")
+        return decoded
+
+
+class GoogleOfficialIdTokenVerifier:
+    """Production verifier backed by the official google-auth package."""
+
+    def __init__(self, request_adapter=None, *, clock_skew_seconds: int = 30) -> None:
+        if (
+            type(clock_skew_seconds) is not int
+            or not 0 <= clock_skew_seconds <= 300
+        ):
+            raise GoogleOidcConfigurationError("Clock skew verifier non valido.")
+        self._request_adapter = request_adapter
+        self.clock_skew_seconds = clock_skew_seconds
+
+    def verify(self, id_token: str, *, audience: str) -> Mapping[str, object]:
+        failed = False
+        claims = None
+        try:
+            from google.auth.transport.requests import Request
+            from google.oauth2 import id_token as google_id_token
+
+            request_adapter = self._request_adapter or Request()
+            claims = google_id_token.verify_oauth2_token(
+                id_token,
+                request_adapter,
+                audience,
+                clock_skew_in_seconds=self.clock_skew_seconds,
+            )
+        except Exception:
+            failed = True
+        finally:
+            id_token = None
+            audience = None
+            request_adapter = None
+        if failed or type(claims) is not dict:
+            claims = None
+            raise GoogleOidcTokenRejectedError("ID token Google rifiutato.")
+        return claims
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("Chiave JSON duplicata.")
+        result[key] = value
+    return result
+
+
+def _utc(value: datetime) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise GoogleOidcConfigurationError("Clock OIDC senza timezone.")
+    return value.astimezone(timezone.utc)
+
+
+def _generated_credential(value: object, name: str, minimum: int, maximum: int) -> str:
+    invalid = (
+        type(value) is not str
+        or not minimum <= len(value) <= maximum
+        or not _UNRESERVED_RE.fullmatch(value)
+    )
+    if invalid:
+        value = None
+        raise GoogleOidcConfigurationError(f"Generatore {name} non valido.")
+    return value
+
+
+class GoogleOidcLoginService:
+    """Coordinate Google OIDC callback, identity resolution, and HTTP session issue."""
+
+    def __init__(
+        self,
+        config: GoogleOidcConfig,
+        flows: InMemoryGoogleOidcFlowStore,
+        token_transport: GoogleTokenTransport,
+        token_verifier: GoogleIdTokenVerifier,
+        identities: FederatedIdentityService,
+        http_sessions: HttpSessionAuthBoundary,
+        *,
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        state_factory: Callable[[], str] = lambda: secrets.token_urlsafe(32),
+        nonce_factory: Callable[[], str] = lambda: secrets.token_urlsafe(32),
+        verifier_factory: Callable[[], str] = lambda: secrets.token_urlsafe(64),
+    ) -> None:
+        self.config = config
+        self.flows = flows
+        self.token_transport = token_transport
+        self.token_verifier = token_verifier
+        self.identities = identities
+        self.http_sessions = http_sessions
+        self.clock = clock
+        self.state_factory = state_factory
+        self.nonce_factory = nonce_factory
+        self.verifier_factory = verifier_factory
+
+    def begin_login(self) -> GoogleAuthorizationRequest:
+        now = _utc(self.clock())
+        for _attempt in range(5):
+            state = _generated_credential(self.state_factory(), "state", 32, 256)
+            nonce = _generated_credential(self.nonce_factory(), "nonce", 32, 256)
+            verifier = _generated_credential(
+                self.verifier_factory(), "PKCE verifier", 43, 128
+            )
+            try:
+                self.flows.create(state, nonce, verifier, now, self.config.flow_ttl)
+            except GoogleOidcStateError:
+                state = None
+                nonce = None
+                verifier = None
+                continue
+            challenge = base64.urlsafe_b64encode(
+                hashlib.sha256(verifier.encode("ascii")).digest()
+            ).rstrip(b"=").decode("ascii")
+            query = urllib.parse.urlencode(
+                {
+                    "client_id": self.config.client_id,
+                    "redirect_uri": self.config.redirect_uri,
+                    "response_type": "code",
+                    "scope": "openid email profile",
+                    "state": state,
+                    "nonce": nonce,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                }
+            )
+            authorization_url = f"{self.config.authorization_endpoint}?{query}"
+            state = None
+            nonce = None
+            verifier = None
+            challenge = None
+            query = None
+            return GoogleAuthorizationRequest(authorization_url)
+        raise GoogleOidcConfigurationError("Impossibile generare state OIDC univoco.")
+
+    def complete_callback(
+        self,
+        parameters: Mapping[str, Sequence[str]],
+        *,
+        existing_cookie_header: str | None = None,
+    ) -> GoogleOidcLoginResult:
+        flow = None
+        token_response = None
+        id_token = None
+        claims = None
+        code = None
+        state = None
+        provider_error = False
+        assertion = None
+        user = None
+        session = None
+        result = None
+        expected_error = None
+        unexpected_failed = False
+        try:
+            try:
+                code, state, provider_error = self._callback_values(parameters)
+            finally:
+                parameters = None
+            flow = self.flows.consume(state, _utc(self.clock()))
+            state = None
+            if provider_error:
+                provider_error = False
+                raise GoogleOidcCallbackError("Login Google annullato o rifiutato.")
+            token_response = self._exchange(code, flow.code_verifier)
+            code = None
+            id_token = token_response.get("id_token")
+            token_response = None
+            if type(id_token) is not str or not 32 <= len(id_token) <= 32768:
+                raise GoogleOidcTokenRejectedError("ID token Google mancante.")
+            claims = self.token_verifier.verify(
+                id_token, audience=self.config.client_id
+            )
+            assertion = self._assertion_from_claims(claims, flow, id_token)
+            claims = None
+            id_token = None
+            flow = None
+            try:
+                user = self.identities.resolve(assertion)
+            except (AuthApplicationError, IdentityDomainError):
+                raise GoogleOidcIdentityRejectedError(
+                    "Identita Google non autorizzata."
+                ) from None
+            assertion = None
+            session = self.http_sessions.establish_session(
+                user.user_id,
+                existing_cookie_header=existing_cookie_header,
+            )
+            existing_cookie_header = None
+            result = GoogleOidcLoginResult(
+                user_id=user.user_id,
+                role=user.role,
+                session=session,
+                redirect_path=self.config.post_login_path,
+            )
+        except GoogleOidcError as error:
+            expected_error = error
+        except Exception:
+            unexpected_failed = True
+        finally:
+            parameters = None
+            flow = None
+            token_response = None
+            id_token = None
+            claims = None
+            code = None
+            state = None
+            provider_error = False
+            assertion = None
+            user = None
+            session = None
+            existing_cookie_header = None
+        if expected_error is not None:
+            raise expected_error
+        if unexpected_failed or result is None:
+            raise GoogleOidcProviderUnavailableError(
+                "Completamento login Google non disponibile."
+            )
+        return result
+
+    @staticmethod
+    def _callback_values(
+        parameters: Mapping[str, Sequence[str]],
+    ) -> tuple[str, str, bool]:
+        invalid = False
+        code = None
+        state = None
+        provider_error = False
+        try:
+            if not isinstance(parameters, Mapping):
+                invalid = True
+            else:
+                allowed = {"code", "state", "error", "error_description", "scope", "authuser", "prompt", "hd"}
+                if any(type(key) is not str or key not in allowed for key in parameters):
+                    invalid = True
+                for callback_values in parameters.values():
+                    if (
+                        not isinstance(callback_values, Sequence)
+                        or isinstance(callback_values, (str, bytes))
+                        or len(callback_values) != 1
+                        or type(callback_values[0]) is not str
+                        or len(callback_values[0]) > _MAX_CALLBACK_VALUE_CHARS
+                        or any(ord(character) < 0x20 for character in callback_values[0])
+                    ):
+                        invalid = True
+                values = parameters.get("state", ())
+                if (
+                    not isinstance(values, Sequence)
+                    or isinstance(values, (str, bytes))
+                    or len(values) != 1
+                    or type(values[0]) is not str
+                ):
+                    invalid = True
+                else:
+                    state = values[0]
+                error_values = parameters.get("error", ())
+                if error_values:
+                    provider_error = True
+                    if "code" in parameters or not error_values[0]:
+                        invalid = True
+                    if (
+                        not isinstance(error_values, Sequence)
+                        or isinstance(error_values, (str, bytes))
+                        or len(error_values) != 1
+                    ):
+                        invalid = True
+                    code = "provider-error-placeholder"
+                else:
+                    code_values = parameters.get("code", ())
+                    if (
+                        not isinstance(code_values, Sequence)
+                        or isinstance(code_values, (str, bytes))
+                        or len(code_values) != 1
+                        or type(code_values[0]) is not str
+                    ):
+                        invalid = True
+                    else:
+                        code = code_values[0]
+                if (
+                    type(state) is not str
+                    or not 32 <= len(state) <= _MAX_CALLBACK_VALUE_CHARS
+                    or not _UNRESERVED_RE.fullmatch(state)
+                    or type(code) is not str
+                    or not 1 <= len(code) <= _MAX_CALLBACK_VALUE_CHARS
+                    or any(ord(character) < 0x20 for character in code)
+                ):
+                    invalid = True
+        except Exception:
+            invalid = True
+        finally:
+            parameters = None
+            values = None
+            error_values = None
+            code_values = None
+            callback_values = None
+        if invalid:
+            code = None
+            state = None
+            raise GoogleOidcCallbackError("Callback Google non valida.")
+        return code, state, provider_error
+
+    def _exchange(self, code: str, verifier: str) -> Mapping[str, object]:
+        failed = False
+        response = None
+        form = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": self.config.client_id,
+            "client_secret": self.config.client_secret,
+            "redirect_uri": self.config.redirect_uri,
+            "code_verifier": verifier,
+        }
+        try:
+            response = self.token_transport.exchange_code(
+                endpoint=self.config.token_endpoint,
+                form=form,
+                timeout_seconds=float(self.config.timeout_seconds),
+                max_response_bytes=self.config.max_token_response_bytes,
+            )
+        except Exception:
+            failed = True
+        finally:
+            code = None
+            verifier = None
+            form = None
+        if failed or not isinstance(response, Mapping):
+            response = None
+            raise GoogleOidcProviderUnavailableError("Token exchange Google fallito.")
+        return response
+
+    def _assertion_from_claims(
+        self,
+        claims: Mapping[str, object],
+        flow: PendingGoogleOidcFlow,
+        id_token: str,
+    ) -> FederatedIdentityAssertion:
+        invalid = False
+        assertion = None
+        try:
+            if not isinstance(claims, Mapping):
+                invalid = True
+                known = {}
+            else:
+                known = {
+                    key: claims.get(key)
+                    for key in (
+                        "iss", "aud", "azp", "sub", "email", "email_verified",
+                        "name", "nonce", "exp", "iat",
+                    )
+                }
+            now = _utc(self.clock())
+            issuer = known.get("iss")
+            audience = known.get("aud")
+            authorized_party = known.get("azp")
+            subject = known.get("sub")
+            email = known.get("email")
+            email_verified = known.get("email_verified")
+            display_name = known.get("name")
+            nonce = known.get("nonce")
+            expires_at = known.get("exp")
+            issued_at = known.get("iat")
+            if issuer not in _GOOGLE_ISSUERS:
+                invalid = True
+            if type(audience) is str:
+                audience_valid = hmac.compare_digest(audience, self.config.client_id)
+            elif type(audience) is list and all(type(item) is str for item in audience):
+                audience_valid = self.config.client_id in audience
+                if len(audience) > 1 and authorized_party != self.config.client_id:
+                    audience_valid = False
+            else:
+                audience_valid = False
+            if (
+                not audience_valid
+                or (
+                    authorized_party is not None
+                    and authorized_party != self.config.client_id
+                )
+            ):
+                invalid = True
+            if (
+                type(subject) is not str or not subject.strip()
+                or len(subject) > 255
+                or any(ord(character) < 0x21 or ord(character) > 0x7E for character in subject)
+                or type(email) is not str or not email.strip()
+                or any(ord(character) < 0x20 for character in email)
+                or email_verified is not True
+                or type(nonce) is not str
+                or not hmac.compare_digest(
+                    InMemoryGoogleOidcFlowStore.nonce_digest(nonce), flow.nonce_digest
+                )
+            ):
+                invalid = True
+            if type(expires_at) not in {int, float} or type(issued_at) not in {int, float}:
+                invalid = True
+            else:
+                expires_value = float(expires_at)
+                issued_value = float(issued_at)
+                now_timestamp = now.timestamp()
+                skew = self.config.clock_skew.total_seconds()
+                if (
+                    not math.isfinite(expires_value)
+                    or not math.isfinite(issued_value)
+                    or expires_value <= issued_value
+                    or now_timestamp >= expires_value
+                    or issued_value > now_timestamp + skew
+                    or now_timestamp - issued_value
+                    > self.config.id_token_max_age.total_seconds() + skew
+                ):
+                    invalid = True
+            secret_echoes = (subject, email, display_name, nonce)
+            if any(
+                type(value) is str and hmac.compare_digest(value, id_token)
+                for value in secret_echoes
+            ):
+                invalid = True
+            if not invalid:
+                normalized_name = display_name.strip() if type(display_name) is str and display_name.strip() else email.strip()
+                assertion = FederatedIdentityAssertion(
+                    provider="google",
+                    subject=subject.strip(),
+                    display_name=normalized_name,
+                    email=email.strip().lower(),
+                    email_verified=True,
+                )
+        except Exception:
+            invalid = True
+        finally:
+            claims = None
+            flow = None
+            id_token = None
+            known = None
+            nonce = None
+            subject = None
+            email = None
+            display_name = None
+            secret_echoes = None
+        if invalid or assertion is None:
+            assertion = None
+            raise GoogleOidcTokenRejectedError("Claim ID token Google non validi.")
+        return assertion

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -806,8 +806,21 @@ class GoogleOidcLoginService:
                 code, state, provider_error = self._callback_values(parameters)
             finally:
                 parameters = None
-            flow = self.flows.consume(state, _utc(self.clock()))
+            state_failed = False
+            state_unavailable = False
+            try:
+                flow = self.flows.consume(state, _utc(self.clock()))
+            except GoogleOidcStateError:
+                state_failed = True
+            except Exception:
+                state_unavailable = True
             state = None
+            if state_failed:
+                raise GoogleOidcStateError("State OIDC non valido o gia usato.")
+            if state_unavailable or flow is None:
+                raise GoogleOidcProviderUnavailableError(
+                    "Store flow OIDC non disponibile."
+                )
             if provider_error:
                 provider_error = False
                 raise GoogleOidcCallbackError("Login Google annullato o rifiutato.")
@@ -886,6 +899,8 @@ class GoogleOidcLoginService:
             code = None
             state = None
             provider_error = False
+            state_failed = False
+            state_unavailable = False
             verification_failed = False
             verification_unavailable = False
             result_failed = False

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -1002,10 +1002,30 @@ class GoogleOidcLoginService:
                     > self.config.id_token_max_age.total_seconds() + skew
                 ):
                     invalid = True
-            secret_echoes = (subject, email, display_name, nonce)
-            if any(
-                type(value) is str and id_token in value
-                for value in secret_echoes
+            secret_echoes = (
+                issuer,
+                authorized_party,
+                subject,
+                email,
+                email_verified,
+                display_name,
+                nonce,
+                expires_at,
+                issued_at,
+            )
+            if (
+                any(
+                    type(value) is str and id_token in value
+                    for value in secret_echoes
+                )
+                or (
+                    type(audience) is list
+                    and any(
+                        type(value) is str and id_token in value
+                        for value in audience
+                    )
+                )
+                or (type(audience) is str and id_token in audience)
             ):
                 invalid = True
             if not invalid:
@@ -1024,10 +1044,23 @@ class GoogleOidcLoginService:
             flow = None
             id_token = None
             known = None
+            now = None
+            issuer = None
+            audience = None
+            audience_valid = None
+            authorized_party = None
             nonce = None
             subject = None
             email = None
+            email_verified = None
             display_name = None
+            expires_at = None
+            issued_at = None
+            expires_value = None
+            issued_value = None
+            now_timestamp = None
+            skew = None
+            normalized_name = None
             secret_echoes = None
         if invalid or assertion is None:
             assertion = None

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -65,7 +65,7 @@ class GoogleOidcIdentityRejectedError(GoogleOidcError):
     """Raised when the authenticated Google identity cannot use an account."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class GoogleOidcConfig:
     client_id: str
     client_secret: str = field(repr=False, compare=False)
@@ -80,7 +80,52 @@ class GoogleOidcConfig:
     max_token_response_bytes: int = 64 * 1024
     max_cert_response_bytes: int = 256 * 1024
 
-    def __post_init__(self) -> None:
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str,
+        authorization_endpoint: str = "https://accounts.google.com/o/oauth2/v2/auth",
+        token_endpoint: str = "https://oauth2.googleapis.com/token",
+        post_login_path: str = "/",
+        flow_ttl: timedelta = timedelta(minutes=10),
+        id_token_max_age: timedelta = timedelta(minutes=15),
+        clock_skew: timedelta = timedelta(seconds=30),
+        timeout_seconds: float = 10.0,
+        max_token_response_bytes: int = 64 * 1024,
+        max_cert_response_bytes: int = 256 * 1024,
+    ) -> None:
+        candidate_secret = client_secret
+        client_secret = None
+        object.__setattr__(self, "client_id", client_id)
+        object.__setattr__(self, "client_secret", candidate_secret)
+        object.__setattr__(self, "redirect_uri", redirect_uri)
+        object.__setattr__(self, "authorization_endpoint", authorization_endpoint)
+        object.__setattr__(self, "token_endpoint", token_endpoint)
+        object.__setattr__(self, "post_login_path", post_login_path)
+        object.__setattr__(self, "flow_ttl", flow_ttl)
+        object.__setattr__(self, "id_token_max_age", id_token_max_age)
+        object.__setattr__(self, "clock_skew", clock_skew)
+        object.__setattr__(self, "timeout_seconds", timeout_seconds)
+        object.__setattr__(self, "max_token_response_bytes", max_token_response_bytes)
+        object.__setattr__(self, "max_cert_response_bytes", max_cert_response_bytes)
+        validation_error = None
+        unexpected = False
+        try:
+            self._validate()
+        except GoogleOidcConfigurationError as error:
+            validation_error = error
+        except Exception:
+            unexpected = True
+        if validation_error is not None or unexpected:
+            object.__setattr__(self, "client_secret", "")
+            candidate_secret = None
+            if validation_error is not None:
+                raise validation_error
+            raise GoogleOidcConfigurationError("Configurazione Google OIDC non valida.")
+        candidate_secret = None
+
+    def _validate(self) -> None:
         if type(self.client_id) is not str or not _CLIENT_ID_RE.fullmatch(self.client_id):
             raise GoogleOidcConfigurationError("Google client ID non valido.")
         if (
@@ -237,6 +282,20 @@ class InMemoryGoogleOidcFlowStore:
             flow = None
             raise GoogleOidcStateError("State OIDC scaduto.")
         return flow
+
+    def discard(self, state: str) -> bool:
+        digest_failed = False
+        try:
+            digest = self.state_digest(state)
+        except Exception:
+            digest_failed = True
+            digest = ""
+        finally:
+            state = None
+        if digest_failed:
+            return False
+        with self._lock:
+            return self._flows.pop(digest, None) is not None
 
     def delete_expired(self, cutoff: datetime) -> int:
         with self._lock:
@@ -494,34 +553,90 @@ class GoogleOidcLoginService:
     def begin_login(self) -> GoogleAuthorizationRequest:
         now = _utc(self.clock())
         for _attempt in range(5):
-            state = _generated_credential(self.state_factory(), "state", 32, 256)
-            nonce = _generated_credential(self.nonce_factory(), "nonce", 32, 256)
-            verifier = _generated_credential(
-                self.verifier_factory(), "PKCE verifier", 43, 128
-            )
+            state = None
+            nonce = None
+            verifier = None
+            generation_error = None
+            generation_unavailable = False
+            try:
+                state = _generated_credential(self.state_factory(), "state", 32, 256)
+                nonce = _generated_credential(self.nonce_factory(), "nonce", 32, 256)
+                verifier = _generated_credential(
+                    self.verifier_factory(), "PKCE verifier", 43, 128
+                )
+            except GoogleOidcConfigurationError as error:
+                generation_error = error
+            except Exception:
+                generation_unavailable = True
+            if generation_error is not None or generation_unavailable:
+                state = None
+                nonce = None
+                verifier = None
+                if generation_error is not None:
+                    raise generation_error
+                raise GoogleOidcProviderUnavailableError(
+                    "Generatori flow OIDC non disponibili."
+                )
+            collision = False
+            store_failed = False
             try:
                 self.flows.create(state, nonce, verifier, now, self.config.flow_ttl)
             except GoogleOidcStateError:
+                collision = True
+            except Exception:
+                store_failed = True
+            if collision:
                 state = None
                 nonce = None
                 verifier = None
                 continue
-            challenge = base64.urlsafe_b64encode(
-                hashlib.sha256(verifier.encode("ascii")).digest()
-            ).rstrip(b"=").decode("ascii")
-            query = urllib.parse.urlencode(
-                {
-                    "client_id": self.config.client_id,
-                    "redirect_uri": self.config.redirect_uri,
-                    "response_type": "code",
-                    "scope": "openid email profile",
-                    "state": state,
-                    "nonce": nonce,
-                    "code_challenge": challenge,
-                    "code_challenge_method": "S256",
-                }
-            )
-            authorization_url = f"{self.config.authorization_endpoint}?{query}"
+            if store_failed:
+                try:
+                    self.flows.discard(state)
+                except Exception:
+                    pass
+                state = None
+                nonce = None
+                verifier = None
+                raise GoogleOidcProviderUnavailableError(
+                    "Store flow OIDC non disponibile."
+                )
+            build_failed = False
+            authorization_url = None
+            challenge = None
+            query = None
+            try:
+                challenge = base64.urlsafe_b64encode(
+                    hashlib.sha256(verifier.encode("ascii")).digest()
+                ).rstrip(b"=").decode("ascii")
+                query = urllib.parse.urlencode(
+                    {
+                        "client_id": self.config.client_id,
+                        "redirect_uri": self.config.redirect_uri,
+                        "response_type": "code",
+                        "scope": "openid email profile",
+                        "state": state,
+                        "nonce": nonce,
+                        "code_challenge": challenge,
+                        "code_challenge_method": "S256",
+                    }
+                )
+                authorization_url = f"{self.config.authorization_endpoint}?{query}"
+            except Exception:
+                build_failed = True
+            if build_failed or authorization_url is None:
+                try:
+                    self.flows.discard(state)
+                except Exception:
+                    pass
+                state = None
+                nonce = None
+                verifier = None
+                challenge = None
+                query = None
+                raise GoogleOidcProviderUnavailableError(
+                    "Authorization request Google non disponibile."
+                )
             state = None
             nonce = None
             verifier = None

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -50,6 +50,10 @@ _GOOGLE_CERT_ENDPOINTS = frozenset(
 class GoogleOidcError(RuntimeError):
     """Base credential-free Google OIDC adapter error."""
 
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.clear_transaction_cookie: str | None = None
+
 
 class GoogleOidcConfigurationError(GoogleOidcError):
     """Raised for invalid server-side OIDC configuration."""
@@ -935,6 +939,7 @@ class GoogleOidcLoginService:
         result = None
         expected_error = None
         unexpected_failed = False
+        flow_consumed = False
         try:
             try:
                 code, state, provider_error = self._callback_values(parameters)
@@ -959,6 +964,7 @@ class GoogleOidcLoginService:
                 raise GoogleOidcProviderUnavailableError(
                     "Store flow OIDC non disponibile."
                 )
+            flow_consumed = True
             if provider_error:
                 provider_error = False
                 raise GoogleOidcCallbackError("Login Google annullato o rifiutato.")
@@ -1080,11 +1086,20 @@ class GoogleOidcLoginService:
             session = None
             existing_cookie_header = None
         if expected_error is not None:
+            if flow_consumed:
+                expected_error.clear_transaction_cookie = (
+                    self._clear_transaction_cookie()
+                )
             raise expected_error
         if unexpected_failed or result is None:
-            raise GoogleOidcProviderUnavailableError(
+            unavailable_error = GoogleOidcProviderUnavailableError(
                 "Completamento login Google non disponibile."
             )
+            if flow_consumed:
+                unavailable_error.clear_transaction_cookie = (
+                    self._clear_transaction_cookie()
+                )
+            raise unavailable_error
         return result
 
     @staticmethod

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -26,6 +26,8 @@ from scripts.thebitlab_http_auth import EstablishedHttpSession, HttpSessionAuthB
 from scripts.thebitlab_identity import IdentityDomainError
 
 _GOOGLE_ISSUERS = frozenset({"accounts.google.com", "https://accounts.google.com"})
+_GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+_GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 _UNRESERVED_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
 _CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{10,512}$")
 _MAX_CALLBACK_VALUE_CHARS = 8192
@@ -74,8 +76,8 @@ class GoogleOidcConfig:
     client_id: str
     client_secret: str = field(repr=False, compare=False)
     redirect_uri: str
-    authorization_endpoint: str = "https://accounts.google.com/o/oauth2/v2/auth"
-    token_endpoint: str = "https://oauth2.googleapis.com/token"
+    authorization_endpoint: str = _GOOGLE_AUTHORIZATION_ENDPOINT
+    token_endpoint: str = _GOOGLE_TOKEN_ENDPOINT
     post_login_path: str = "/"
     flow_ttl: timedelta = timedelta(minutes=10)
     id_token_max_age: timedelta = timedelta(minutes=15)
@@ -89,8 +91,8 @@ class GoogleOidcConfig:
         client_id: str,
         client_secret: str,
         redirect_uri: str,
-        authorization_endpoint: str = "https://accounts.google.com/o/oauth2/v2/auth",
-        token_endpoint: str = "https://oauth2.googleapis.com/token",
+        authorization_endpoint: str = _GOOGLE_AUTHORIZATION_ENDPOINT,
+        token_endpoint: str = _GOOGLE_TOKEN_ENDPOINT,
         post_login_path: str = "/",
         flow_ttl: timedelta = timedelta(minutes=10),
         id_token_max_age: timedelta = timedelta(minutes=15),
@@ -154,6 +156,13 @@ class GoogleOidcConfig:
                 raise GoogleOidcConfigurationError(
                     f"{field_name} deve essere un URL HTTPS assoluto."
                 )
+        if (
+            self.authorization_endpoint != _GOOGLE_AUTHORIZATION_ENDPOINT
+            or self.token_endpoint != _GOOGLE_TOKEN_ENDPOINT
+        ):
+            raise GoogleOidcConfigurationError(
+                "Endpoint Google OIDC non consentito."
+            )
         if (
             type(self.post_login_path) is not str
             or not self.post_login_path.startswith("/")

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -645,6 +645,7 @@ class GoogleOidcLoginService:
                 )
             build_failed = False
             authorization_url = None
+            authorization_request = None
             challenge = None
             query = None
             try:
@@ -664,9 +665,10 @@ class GoogleOidcLoginService:
                     }
                 )
                 authorization_url = f"{self.config.authorization_endpoint}?{query}"
+                authorization_request = GoogleAuthorizationRequest(authorization_url)
             except Exception:
                 build_failed = True
-            if build_failed or authorization_url is None:
+            if build_failed or authorization_request is None:
                 try:
                     self.flows.discard_created_flow(state, creation_marker)
                 except Exception:
@@ -675,6 +677,8 @@ class GoogleOidcLoginService:
                 nonce = None
                 verifier = None
                 creation_marker = None
+                authorization_url = None
+                authorization_request = None
                 challenge = None
                 query = None
                 raise GoogleOidcProviderUnavailableError(
@@ -684,9 +688,10 @@ class GoogleOidcLoginService:
             nonce = None
             verifier = None
             creation_marker = None
+            authorization_url = None
             challenge = None
             query = None
-            return GoogleAuthorizationRequest(authorization_url)
+            return authorization_request
         raise GoogleOidcConfigurationError("Impossibile generare state OIDC univoco.")
 
     def complete_callback(
@@ -985,7 +990,7 @@ class GoogleOidcLoginService:
                     invalid = True
             secret_echoes = (subject, email, display_name, nonce)
             if any(
-                type(value) is str and hmac.compare_digest(value, id_token)
+                type(value) is str and id_token in value
                 for value in secret_echoes
             ):
                 invalid = True

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -53,6 +53,10 @@ class GoogleOidcStateError(GoogleOidcError):
     """Raised for unknown, expired, duplicate, or replayed state."""
 
 
+class GoogleOidcStateConflictError(GoogleOidcStateError):
+    """Raised before insert when a state collides or the flow store is full."""
+
+
 class GoogleOidcProviderUnavailableError(GoogleOidcError):
     """Raised when Google token or verification infrastructure is unavailable."""
 
@@ -258,9 +262,9 @@ class InMemoryGoogleOidcFlowStore:
                 del self._flows[key]
             if len(self._flows) >= self.max_pending_flows:
                 flow = None
-                raise GoogleOidcStateError("Capacita flow OIDC esaurita.")
+                raise GoogleOidcStateConflictError("Capacita flow OIDC esaurita.")
             if flow.state_digest in self._flows:
-                raise GoogleOidcStateError("Collisione state OIDC.")
+                raise GoogleOidcStateConflictError("Collisione state OIDC.")
             self._flows[flow.state_digest] = flow
 
     def consume(self, state: str, now: datetime) -> PendingGoogleOidcFlow:
@@ -581,7 +585,7 @@ class GoogleOidcLoginService:
             store_failed = False
             try:
                 self.flows.create(state, nonce, verifier, now, self.config.flow_ttl)
-            except GoogleOidcStateError:
+            except GoogleOidcStateConflictError:
                 collision = True
             except Exception:
                 store_failed = True

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -436,6 +436,8 @@ class UrllibGoogleTokenTransport:
         max_response_bytes: int,
     ) -> Mapping[str, object]:
         failed = False
+        rejected = False
+        configuration_failed = False
         payload = None
         request = None
         response = None
@@ -459,6 +461,36 @@ class UrllibGoogleTokenTransport:
                     response_bytes = response.read(max_response_bytes + 1)
                     if len(response_bytes) > max_response_bytes:
                         failed = True
+        except urllib.error.HTTPError as error:
+            status = error.code
+            error_bytes = None
+            if 400 <= status < 500:
+                try:
+                    error_bytes = error.read(max_response_bytes + 1)
+                    decoded_error = json.loads(
+                        error_bytes.decode("utf-8"),
+                        object_pairs_hook=_reject_duplicate_json_keys,
+                    )
+                    oauth_error = (
+                        decoded_error.get("error")
+                        if type(decoded_error) is dict
+                        else None
+                    )
+                    if oauth_error == "invalid_client":
+                        configuration_failed = True
+                    elif type(oauth_error) is str:
+                        rejected = True
+                    else:
+                        failed = True
+                except Exception:
+                    failed = True
+                finally:
+                    error_bytes = None
+                    decoded_error = None
+                    oauth_error = None
+            else:
+                failed = True
+            error = None
         except Exception:
             failed = True
         finally:
@@ -466,6 +498,16 @@ class UrllibGoogleTokenTransport:
             request = None
             response = None
             form = None
+        if configuration_failed:
+            response_bytes = None
+            raise GoogleOidcConfigurationError(
+                "Credenziali client Google rifiutate."
+            )
+        if rejected:
+            response_bytes = None
+            raise GoogleOidcTokenRejectedError(
+                "Authorization code Google rifiutato."
+            )
         if failed or response_bytes is None:
             response_bytes = None
             raise GoogleOidcProviderUnavailableError("Token endpoint Google non disponibile.")
@@ -1214,6 +1256,8 @@ class GoogleOidcLoginService:
 
     def _exchange(self, code: str, verifier: str) -> Mapping[str, object]:
         failed = False
+        rejected = False
+        configuration_failed = False
         response = None
         form = {
             "grant_type": "authorization_code",
@@ -1230,12 +1274,26 @@ class GoogleOidcLoginService:
                 timeout_seconds=float(self.config.timeout_seconds),
                 max_response_bytes=self.config.max_token_response_bytes,
             )
+        except GoogleOidcTokenRejectedError:
+            rejected = True
+        except GoogleOidcConfigurationError:
+            configuration_failed = True
         except Exception:
             failed = True
         finally:
             code = None
             verifier = None
             form = None
+        if configuration_failed:
+            response = None
+            raise GoogleOidcConfigurationError(
+                "Configurazione token Google rifiutata."
+            )
+        if rejected:
+            response = None
+            raise GoogleOidcTokenRejectedError(
+                "Authorization code Google rifiutato."
+            )
         if failed or not isinstance(response, Mapping):
             response = None
             raise GoogleOidcProviderUnavailableError("Token exchange Google fallito.")

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -195,6 +195,7 @@ class PendingGoogleOidcFlow:
     state_digest: str
     nonce_digest: str
     code_verifier: str = field(repr=False, compare=False)
+    creation_marker: object = field(repr=False, compare=False)
     created_at: datetime
     expires_at: datetime
 
@@ -245,11 +246,20 @@ class InMemoryGoogleOidcFlowStore:
     def nonce_digest(nonce: str) -> str:
         return "sha256:" + hashlib.sha256(nonce.encode("ascii")).hexdigest()
 
-    def create(self, state: str, nonce: str, code_verifier: str, now: datetime, ttl: timedelta) -> None:
+    def create(
+        self,
+        state: str,
+        nonce: str,
+        code_verifier: str,
+        creation_marker: object,
+        now: datetime,
+        ttl: timedelta,
+    ) -> None:
         flow = PendingGoogleOidcFlow(
             state_digest=self.state_digest(state),
             nonce_digest=self.nonce_digest(nonce),
             code_verifier=code_verifier,
+            creation_marker=creation_marker,
             created_at=now,
             expires_at=now + ttl,
         )
@@ -286,6 +296,27 @@ class InMemoryGoogleOidcFlowStore:
             flow = None
             raise GoogleOidcStateError("State OIDC scaduto.")
         return flow
+
+    def discard_created_flow(self, state: str, creation_marker: object) -> bool:
+        digest_failed = False
+        try:
+            state_digest = self.state_digest(state)
+        except Exception:
+            digest_failed = True
+            state_digest = ""
+        finally:
+            state = None
+        if digest_failed:
+            creation_marker = None
+            return False
+        with self._lock:
+            flow = self._flows.get(state_digest)
+            matches = flow is not None and flow.creation_marker is creation_marker
+            if matches:
+                del self._flows[state_digest]
+        flow = None
+        creation_marker = None
+        return matches
 
     def discard(self, state: str) -> bool:
         digest_failed = False
@@ -583,17 +614,37 @@ class GoogleOidcLoginService:
                 )
             collision = False
             store_failed = False
+            creation_marker = object()
             try:
-                self.flows.create(state, nonce, verifier, now, self.config.flow_ttl)
+                self.flows.create(
+                    state,
+                    nonce,
+                    verifier,
+                    creation_marker,
+                    now,
+                    self.config.flow_ttl,
+                )
             except GoogleOidcStateConflictError:
                 collision = True
             except Exception:
                 store_failed = True
             if collision:
-                state = None
-                nonce = None
-                verifier = None
-                continue
+                inserted_then_failed = False
+                try:
+                    inserted_then_failed = self.flows.discard_created_flow(
+                        state, creation_marker
+                    )
+                except Exception:
+                    pass
+                if inserted_then_failed:
+                    collision = False
+                    store_failed = True
+                else:
+                    state = None
+                    nonce = None
+                    verifier = None
+                    creation_marker = None
+                    continue
             if store_failed:
                 try:
                     self.flows.discard(state)
@@ -602,6 +653,7 @@ class GoogleOidcLoginService:
                 state = None
                 nonce = None
                 verifier = None
+                creation_marker = None
                 raise GoogleOidcProviderUnavailableError(
                     "Store flow OIDC non disponibile."
                 )
@@ -636,6 +688,7 @@ class GoogleOidcLoginService:
                 state = None
                 nonce = None
                 verifier = None
+                creation_marker = None
                 challenge = None
                 query = None
                 raise GoogleOidcProviderUnavailableError(
@@ -644,6 +697,7 @@ class GoogleOidcLoginService:
             state = None
             nonce = None
             verifier = None
+            creation_marker = None
             challenge = None
             query = None
             return GoogleAuthorizationRequest(authorization_url)
@@ -684,9 +738,27 @@ class GoogleOidcLoginService:
             token_response = None
             if type(id_token) is not str or not 32 <= len(id_token) <= 32768:
                 raise GoogleOidcTokenRejectedError("ID token Google mancante.")
-            claims = self.token_verifier.verify(
-                id_token, audience=self.config.client_id
-            )
+            verification_failed = False
+            verification_unavailable = False
+            try:
+                claims = self.token_verifier.verify(
+                    id_token, audience=self.config.client_id
+                )
+            except GoogleOidcProviderUnavailableError:
+                verification_unavailable = True
+            except Exception:
+                verification_failed = True
+            if verification_failed or verification_unavailable:
+                id_token = None
+                claims = None
+                flow = None
+                if verification_unavailable:
+                    raise GoogleOidcProviderUnavailableError(
+                        "Verifica ID token Google non disponibile."
+                    )
+                raise GoogleOidcTokenRejectedError(
+                    "ID token Google rifiutato."
+                )
             assertion = self._assertion_from_claims(claims, flow, id_token)
             claims = None
             id_token = None
@@ -722,6 +794,8 @@ class GoogleOidcLoginService:
             code = None
             state = None
             provider_error = False
+            verification_failed = False
+            verification_unavailable = False
             assertion = None
             user = None
             session = None

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -499,6 +499,7 @@ class _X509OnlyGoogleCertRequest:
         valid = (
             valid
             and type(decoded) is dict
+            and "keys" not in decoded
             and 1 <= len(decoded) <= 32
             and all(
                 type(key) is str
@@ -649,7 +650,17 @@ class GoogleOidcLoginService:
         self.verifier_factory = verifier_factory
 
     def begin_login(self) -> GoogleAuthorizationRequest:
-        now = _utc(self.clock())
+        now = None
+        clock_failed = False
+        try:
+            now = _utc(self.clock())
+        except Exception:
+            clock_failed = True
+        if clock_failed or now is None:
+            now = None
+            raise GoogleOidcProviderUnavailableError(
+                "Clock flow OIDC non disponibile."
+            )
         for _attempt in range(5):
             state = None
             nonce = None

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -472,16 +472,78 @@ class BoundedGoogleCertRequest:
         return _GoogleAuthCertResponse(status, data, response_headers)
 
 
+class _X509OnlyGoogleCertRequest:
+    """Reject JWKS so google-auth cannot start an independent PyJWT fetch."""
+
+    def __init__(self, delegate, *, max_response_bytes: int) -> None:
+        self.delegate = delegate
+        self.max_response_bytes = max_response_bytes
+
+    def __call__(self, url: str, **kwargs):
+        response = self.delegate(url, **kwargs)
+        data = getattr(response, "data", None)
+        valid = (
+            url == "https://www.googleapis.com/oauth2/v1/certs"
+            and type(data) is bytes
+            and len(data) <= self.max_response_bytes
+        )
+        decoded = None
+        if valid:
+            try:
+                decoded = json.loads(
+                    data.decode("utf-8"),
+                    object_pairs_hook=_reject_duplicate_json_keys,
+                )
+            except (UnicodeError, ValueError, TypeError):
+                valid = False
+        valid = (
+            valid
+            and type(decoded) is dict
+            and 1 <= len(decoded) <= 32
+            and all(
+                type(key) is str
+                and 1 <= len(key) <= 512
+                and type(value) is str
+                and 1 <= len(value) <= 16384
+                and value.startswith("-----BEGIN CERTIFICATE-----")
+                and value.rstrip().endswith("-----END CERTIFICATE-----")
+                for key, value in decoded.items()
+            )
+        )
+        decoded = None
+        data = None
+        if not valid:
+            response = None
+            raise GoogleOidcProviderUnavailableError(
+                "Formato certificati Google non valido."
+            )
+        return response
+
+
 class GoogleOfficialIdTokenVerifier:
     """Production verifier backed by google-auth and a bounded cert transport."""
 
-    def __init__(self, request_adapter=None, *, clock_skew_seconds: int = 30) -> None:
+    def __init__(
+        self,
+        request_adapter=None,
+        *,
+        clock_skew_seconds: int = 30,
+        max_cert_response_bytes: int = 256 * 1024,
+    ) -> None:
         if (
             type(clock_skew_seconds) is not int
             or not 0 <= clock_skew_seconds <= 300
         ):
             raise GoogleOidcConfigurationError("Clock skew verifier non valido.")
-        self._request_adapter = request_adapter or BoundedGoogleCertRequest()
+        if (
+            type(max_cert_response_bytes) is not int
+            or not 4096 <= max_cert_response_bytes <= 1048576
+        ):
+            raise GoogleOidcConfigurationError("Limite certificati non valido.")
+        self._request_adapter = request_adapter or BoundedGoogleCertRequest(
+            max_response_bytes=max_cert_response_bytes
+        )
+        self.max_cert_response_bytes = max_cert_response_bytes
         self.clock_skew_seconds = clock_skew_seconds
 
     @classmethod
@@ -492,6 +554,7 @@ class GoogleOfficialIdTokenVerifier:
                 max_response_bytes=config.max_cert_response_bytes,
             ),
             clock_skew_seconds=int(config.clock_skew.total_seconds()),
+            max_cert_response_bytes=config.max_cert_response_bytes,
         )
 
     def verify(self, id_token: str, *, audience: str) -> Mapping[str, object]:
@@ -501,7 +564,10 @@ class GoogleOfficialIdTokenVerifier:
         try:
             from google.oauth2 import id_token as google_id_token
 
-            request_adapter = self._request_adapter
+            request_adapter = _X509OnlyGoogleCertRequest(
+                self._request_adapter,
+                max_response_bytes=self.max_cert_response_bytes,
+            )
             claims = google_id_token.verify_oauth2_token(
                 id_token,
                 request_adapter,

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -1330,6 +1330,7 @@ class GoogleOidcLoginService:
         id_token: str,
     ) -> FederatedIdentityAssertion:
         invalid = False
+        unavailable = False
         assertion = None
         try:
             if not isinstance(claims, Mapping):
@@ -1343,7 +1344,11 @@ class GoogleOidcLoginService:
                         "name", "nonce", "exp", "iat",
                     )
                 }
-            now = _utc(self.clock())
+            try:
+                now = _utc(self.clock())
+            except Exception:
+                unavailable = True
+                now = None
             issuer = known.get("iss")
             audience = known.get("aud")
             authorized_party = known.get("azp")
@@ -1385,7 +1390,11 @@ class GoogleOidcLoginService:
                 )
             ):
                 invalid = True
-            if type(expires_at) not in {int, float} or type(issued_at) not in {int, float}:
+            if (
+                unavailable
+                or type(expires_at) not in {int, float}
+                or type(issued_at) not in {int, float}
+            ):
                 invalid = True
             else:
                 expires_value = float(expires_at)
@@ -1462,6 +1471,11 @@ class GoogleOidcLoginService:
             skew = None
             normalized_name = None
             secret_echoes = None
+        if unavailable:
+            assertion = None
+            raise GoogleOidcProviderUnavailableError(
+                "Clock verifica claim non disponibile."
+            )
         if invalid or assertion is None:
             assertion = None
             raise GoogleOidcTokenRejectedError("Claim ID token Google non validi.")

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -23,7 +23,11 @@ from scripts.thebitlab_auth_services import (
     FederatedIdentityService,
     OnboardingNotAllowedError,
 )
-from scripts.thebitlab_http_auth import EstablishedHttpSession, HttpSessionAuthBoundary
+from scripts.thebitlab_http_auth import (
+    EstablishedHttpSession,
+    HttpAuthenticationRequiredError,
+    HttpSessionAuthBoundary,
+)
 from scripts.thebitlab_identity import AccountDisabledError, IdentityDomainError
 
 _GOOGLE_ISSUERS = frozenset({"accounts.google.com", "https://accounts.google.com"})
@@ -31,6 +35,7 @@ _GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
 _GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 _UNRESERVED_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
 _CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{10,512}$")
+_INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 _MAX_CALLBACK_VALUE_CHARS = 8192
 _GOOGLE_CERT_ENDPOINTS = frozenset(
     {
@@ -156,6 +161,8 @@ class GoogleOidcConfig:
                 or invalid_port
                 or (port is not None and port < 1)
                 or any(ord(character) <= 0x20 or ord(character) == 0x7F for character in value)
+                or "\\" in value
+                or _INVALID_PERCENT_ESCAPE_RE.search(value) is not None
                 or parsed.scheme != "https"
                 or not parsed.hostname
                 or parsed.username is not None
@@ -893,11 +900,26 @@ class GoogleOidcLoginService:
                 raise GoogleOidcProviderUnavailableError(
                     "Servizio identita non disponibile."
                 )
-            session = self.http_sessions.establish_session(
-                user.user_id,
-                existing_cookie_header=existing_cookie_header,
-            )
+            session_rejected = False
+            session_unavailable = False
+            try:
+                session = self.http_sessions.establish_session(
+                    user.user_id,
+                    existing_cookie_header=existing_cookie_header,
+                )
+            except HttpAuthenticationRequiredError:
+                session_rejected = True
+            except Exception:
+                session_unavailable = True
             existing_cookie_header = None
+            if session_rejected:
+                raise GoogleOidcIdentityRejectedError(
+                    "Identita Google non autorizzata."
+                )
+            if session_unavailable or session is None:
+                raise GoogleOidcProviderUnavailableError(
+                    "Servizio sessioni non disponibile."
+                )
             result_failed = False
             try:
                 result = GoogleOidcLoginResult(
@@ -934,6 +956,8 @@ class GoogleOidcLoginService:
             state_unavailable = False
             identity_rejected = False
             identity_unavailable = False
+            session_rejected = False
+            session_unavailable = False
             verification_failed = False
             verification_unavailable = False
             result_failed = False

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -37,6 +37,8 @@ _UNRESERVED_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
 _CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{10,512}$")
 _INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 _MAX_CALLBACK_VALUE_CHARS = 8192
+_TRANSACTION_COOKIE_NAME = "__Host-thebitlab_oidc_txn"
+_MAX_COOKIE_HEADER_BYTES = 4096
 _GOOGLE_CERT_ENDPOINTS = frozenset(
     {
         "https://www.googleapis.com/oauth2/v1/certs",
@@ -234,6 +236,7 @@ class GoogleOidcConfig:
 class PendingGoogleOidcFlow:
     state_digest: str
     nonce_digest: str
+    browser_digest: str
     code_verifier: str = field(repr=False, compare=False)
     creation_marker: object = field(repr=False, compare=False)
     created_at: datetime
@@ -243,6 +246,7 @@ class PendingGoogleOidcFlow:
 @dataclass(frozen=True)
 class GoogleAuthorizationRequest:
     authorization_url: str = field(repr=False, compare=False)
+    set_cookie: str = field(repr=False, compare=False)
 
 
 @dataclass(frozen=True)
@@ -251,6 +255,7 @@ class GoogleOidcLoginResult:
     role: str
     session: EstablishedHttpSession
     redirect_path: str
+    clear_transaction_cookie: str = field(repr=False, compare=False)
 
 
 class GoogleTokenTransport(Protocol):
@@ -286,11 +291,16 @@ class InMemoryGoogleOidcFlowStore:
     def nonce_digest(nonce: str) -> str:
         return "sha256:" + hashlib.sha256(nonce.encode("ascii")).hexdigest()
 
+    @staticmethod
+    def browser_digest(browser_binding: str) -> str:
+        return "sha256:" + hashlib.sha256(browser_binding.encode("ascii")).hexdigest()
+
     def create(
         self,
         state: str,
         nonce: str,
         code_verifier: str,
+        browser_binding: str,
         creation_marker: object,
         now: datetime,
         ttl: timedelta,
@@ -302,6 +312,7 @@ class InMemoryGoogleOidcFlowStore:
             flow = PendingGoogleOidcFlow(
                 state_digest=self.state_digest(state),
                 nonce_digest=self.nonce_digest(nonce),
+                browser_digest=self.browser_digest(browser_binding),
                 code_verifier=code_verifier,
                 creation_marker=creation_marker,
                 created_at=now,
@@ -325,6 +336,7 @@ class InMemoryGoogleOidcFlowStore:
             state = None
             nonce = None
             code_verifier = None
+            browser_binding = None
             creation_marker = None
             flow = None
         if conflict_message is not None:
@@ -332,20 +344,32 @@ class InMemoryGoogleOidcFlowStore:
                 raise GoogleOidcFlowCapacityError(conflict_message)
             raise GoogleOidcStateConflictError(conflict_message)
 
-    def consume(self, state: str, now: datetime) -> PendingGoogleOidcFlow:
+    def consume(
+        self, state: str, browser_binding: str, now: datetime
+    ) -> PendingGoogleOidcFlow:
         digest_failed = False
         try:
             digest = self.state_digest(state)
+            supplied_browser_digest = self.browser_digest(browser_binding)
         except Exception:
             digest_failed = True
             digest = ""
+            supplied_browser_digest = ""
         finally:
             state = None
+            browser_binding = None
         if digest_failed:
             raise GoogleOidcStateError("State OIDC non valido.")
         with self._lock:
-            flow = self._flows.pop(digest, None)
-        if flow is None:
+            flow = self._flows.get(digest)
+            binding_matches = flow is not None and hmac.compare_digest(
+                flow.browser_digest, supplied_browser_digest
+            )
+            if binding_matches:
+                del self._flows[digest]
+        supplied_browser_digest = None
+        if flow is None or not binding_matches:
+            flow = None
             raise GoogleOidcStateError("State OIDC sconosciuto o gia usato.")
         if now < flow.created_at or now >= flow.expires_at:
             flow = None
@@ -681,6 +705,7 @@ class GoogleOidcLoginService:
         state_factory: Callable[[], str] = lambda: secrets.token_urlsafe(32),
         nonce_factory: Callable[[], str] = lambda: secrets.token_urlsafe(32),
         verifier_factory: Callable[[], str] = lambda: secrets.token_urlsafe(64),
+        browser_binding_factory: Callable[[], str] = lambda: secrets.token_urlsafe(32),
     ) -> None:
         self.config = config
         self.flows = flows
@@ -692,6 +717,7 @@ class GoogleOidcLoginService:
         self.state_factory = state_factory
         self.nonce_factory = nonce_factory
         self.verifier_factory = verifier_factory
+        self.browser_binding_factory = browser_binding_factory
 
     def begin_login(self) -> GoogleAuthorizationRequest:
         now = None
@@ -709,6 +735,7 @@ class GoogleOidcLoginService:
             state = None
             nonce = None
             verifier = None
+            browser_binding = None
             generation_error = None
             generation_unavailable = False
             try:
@@ -716,6 +743,9 @@ class GoogleOidcLoginService:
                 nonce = _generated_credential(self.nonce_factory(), "nonce", 32, 256)
                 verifier = _generated_credential(
                     self.verifier_factory(), "PKCE verifier", 43, 128
+                )
+                browser_binding = _generated_credential(
+                    self.browser_binding_factory(), "browser binding", 32, 256
                 )
             except GoogleOidcConfigurationError as error:
                 generation_error = error
@@ -725,6 +755,7 @@ class GoogleOidcLoginService:
                 state = None
                 nonce = None
                 verifier = None
+                browser_binding = None
                 if generation_error is not None:
                     raise generation_error
                 raise GoogleOidcProviderUnavailableError(
@@ -738,6 +769,7 @@ class GoogleOidcLoginService:
                     state,
                     nonce,
                     verifier,
+                    browser_binding,
                     creation_marker,
                     now,
                     self.config.flow_ttl,
@@ -763,6 +795,7 @@ class GoogleOidcLoginService:
                     state = None
                     nonce = None
                     verifier = None
+                    browser_binding = None
                     creation_marker = None
                     continue
             if store_failed:
@@ -773,6 +806,7 @@ class GoogleOidcLoginService:
                 state = None
                 nonce = None
                 verifier = None
+                browser_binding = None
                 creation_marker = None
                 raise GoogleOidcProviderUnavailableError(
                     "Store flow OIDC non disponibile."
@@ -782,6 +816,7 @@ class GoogleOidcLoginService:
             authorization_request = None
             challenge = None
             query = None
+            transaction_cookie = None
             try:
                 challenge = base64.urlsafe_b64encode(
                     hashlib.sha256(verifier.encode("ascii")).digest()
@@ -799,7 +834,10 @@ class GoogleOidcLoginService:
                     }
                 )
                 authorization_url = f"{self.config.authorization_endpoint}?{query}"
-                authorization_request = GoogleAuthorizationRequest(authorization_url)
+                transaction_cookie = self._transaction_cookie(browser_binding)
+                authorization_request = GoogleAuthorizationRequest(
+                    authorization_url, transaction_cookie
+                )
             except Exception:
                 build_failed = True
             if build_failed or authorization_request is None:
@@ -810,23 +848,72 @@ class GoogleOidcLoginService:
                 state = None
                 nonce = None
                 verifier = None
+                browser_binding = None
                 creation_marker = None
                 authorization_url = None
                 authorization_request = None
                 challenge = None
                 query = None
+                transaction_cookie = None
                 raise GoogleOidcProviderUnavailableError(
                     "Authorization request Google non disponibile."
                 )
             state = None
             nonce = None
             verifier = None
+            browser_binding = None
             creation_marker = None
             authorization_url = None
             challenge = None
             query = None
+            transaction_cookie = None
             return authorization_request
         raise GoogleOidcConfigurationError("Impossibile generare state OIDC univoco.")
+
+    def _transaction_cookie(self, browser_binding: str) -> str:
+        max_age = math.ceil(self.config.flow_ttl.total_seconds())
+        return (
+            f"{_TRANSACTION_COOKIE_NAME}={browser_binding}; Path=/; "
+            f"Max-Age={max_age}; Secure; HttpOnly; SameSite=Lax"
+        )
+
+    @staticmethod
+    def _clear_transaction_cookie() -> str:
+        return (
+            f"{_TRANSACTION_COOKIE_NAME}=; Path=/; Max-Age=0; "
+            "Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax"
+        )
+
+    @staticmethod
+    def _transaction_binding(cookie_header: str | None) -> str:
+        invalid = (
+            type(cookie_header) is not str
+            or not cookie_header
+            or len(cookie_header.encode("utf-8")) > _MAX_COOKIE_HEADER_BYTES
+            or any(
+                ord(character) < 0x20 or ord(character) == 0x7F
+                for character in cookie_header
+            )
+        )
+        matches: list[str] = []
+        if not invalid:
+            for part in cookie_header.split(";"):
+                name, separator, value = part.strip().partition("=")
+                if separator and name == _TRANSACTION_COOKIE_NAME:
+                    matches.append(value)
+        if (
+            invalid
+            or len(matches) != 1
+            or not 32 <= len(matches[0]) <= 256
+            or _UNRESERVED_RE.fullmatch(matches[0]) is None
+        ):
+            matches = []
+            cookie_header = None
+            raise GoogleOidcStateError("Cookie transazione OIDC non valido.")
+        binding = matches[0]
+        matches = []
+        cookie_header = None
+        return binding
 
     def complete_callback(
         self,
@@ -840,6 +927,7 @@ class GoogleOidcLoginService:
         claims = None
         code = None
         state = None
+        browser_binding = None
         provider_error = False
         assertion = None
         user = None
@@ -855,12 +943,16 @@ class GoogleOidcLoginService:
             state_failed = False
             state_unavailable = False
             try:
-                flow = self.flows.consume(state, _utc(self.clock()))
+                browser_binding = self._transaction_binding(existing_cookie_header)
+                flow = self.flows.consume(
+                    state, browser_binding, _utc(self.clock())
+                )
             except GoogleOidcStateError:
                 state_failed = True
             except Exception:
                 state_unavailable = True
             state = None
+            browser_binding = None
             if state_failed:
                 raise GoogleOidcStateError("State OIDC non valido o gia usato.")
             if state_unavailable or flow is None:
@@ -947,6 +1039,7 @@ class GoogleOidcLoginService:
                     role=session.context.user.role,
                     session=session,
                     redirect_path=self.config.post_login_path,
+                    clear_transaction_cookie=self._clear_transaction_cookie(),
                 )
             except Exception:
                 result_failed = True
@@ -971,6 +1064,7 @@ class GoogleOidcLoginService:
             claims = None
             code = None
             state = None
+            browser_binding = None
             provider_error = False
             state_failed = False
             state_unavailable = False

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -653,6 +653,16 @@ class _X509OnlyGoogleCertRequest:
                 for key, value in decoded.items()
             )
         )
+        if valid:
+            try:
+                from cryptography import x509
+
+                for certificate_pem in decoded.values():
+                    x509.load_pem_x509_certificate(certificate_pem.encode("ascii"))
+            except Exception:
+                valid = False
+            finally:
+                certificate_pem = None
         decoded = None
         data = None
         if not valid:
@@ -1405,7 +1415,7 @@ class GoogleOidcLoginService:
                     not math.isfinite(expires_value)
                     or not math.isfinite(issued_value)
                     or expires_value <= issued_value
-                    or now_timestamp >= expires_value
+                    or now_timestamp >= expires_value + skew
                     or issued_value > now_timestamp + skew
                     or now_timestamp - issued_value
                     > self.config.id_token_max_age.total_seconds() + skew

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -230,11 +230,11 @@ class GoogleOidcConfig:
             or not 0 < self.timeout_seconds <= 60
         ):
             raise GoogleOidcConfigurationError("Timeout OIDC non valido.")
-        for value, name in (
-            (self.max_token_response_bytes, "token"),
-            (self.max_cert_response_bytes, "certificati"),
+        for value, name, minimum in (
+            (self.max_token_response_bytes, "token", 1024),
+            (self.max_cert_response_bytes, "certificati", 4096),
         ):
-            if type(value) is not int or not 1024 <= value <= 1024 * 1024:
+            if type(value) is not int or not minimum <= value <= 1024 * 1024:
                 raise GoogleOidcConfigurationError(
                     f"Limite risposta {name} non valido."
                 )
@@ -480,6 +480,7 @@ class UrllibGoogleTokenTransport:
                     )
                     if oauth_error in {
                         "invalid_client",
+                        "invalid_request",
                         "unauthorized_client",
                         "unsupported_grant_type",
                         "invalid_scope",

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -486,7 +486,7 @@ class UrllibGoogleTokenTransport:
                         "invalid_scope",
                     }:
                         configuration_failed = True
-                    elif type(oauth_error) is str:
+                    elif oauth_error == "invalid_grant":
                         rejected = True
                     else:
                         failed = True
@@ -550,6 +550,22 @@ class BoundedGoogleCertRequest:
         timeout_seconds: float = 10.0,
         max_response_bytes: int = 256 * 1024,
     ) -> None:
+        if (
+            isinstance(timeout_seconds, bool)
+            or not isinstance(timeout_seconds, (int, float))
+            or not math.isfinite(float(timeout_seconds))
+            or not 0 < timeout_seconds <= 60
+        ):
+            raise GoogleOidcConfigurationError(
+                "Timeout certificati non valido."
+            )
+        if (
+            type(max_response_bytes) is not int
+            or not 4096 <= max_response_bytes <= 1024 * 1024
+        ):
+            raise GoogleOidcConfigurationError(
+                "Limite certificati non valido."
+            )
         self.timeout_seconds = timeout_seconds
         self.max_response_bytes = max_response_bytes
         self._opener = urllib.request.build_opener(UrllibGoogleTokenTransport._NoRedirect())

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -478,7 +478,12 @@ class UrllibGoogleTokenTransport:
                         if type(decoded_error) is dict
                         else None
                     )
-                    if oauth_error == "invalid_client":
+                    if oauth_error in {
+                        "invalid_client",
+                        "unauthorized_client",
+                        "unsupported_grant_type",
+                        "invalid_scope",
+                    }:
                         configuration_failed = True
                     elif type(oauth_error) is str:
                         rejected = True

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -29,6 +29,12 @@ _GOOGLE_ISSUERS = frozenset({"accounts.google.com", "https://accounts.google.com
 _UNRESERVED_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
 _CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{10,512}$")
 _MAX_CALLBACK_VALUE_CHARS = 8192
+_GOOGLE_CERT_ENDPOINTS = frozenset(
+    {
+        "https://www.googleapis.com/oauth2/v1/certs",
+        "https://www.googleapis.com/oauth2/v3/certs",
+    }
+)
 
 
 class GoogleOidcError(RuntimeError):
@@ -72,6 +78,7 @@ class GoogleOidcConfig:
     clock_skew: timedelta = timedelta(seconds=30)
     timeout_seconds: float = 10.0
     max_token_response_bytes: int = 64 * 1024
+    max_cert_response_bytes: int = 256 * 1024
 
     def __post_init__(self) -> None:
         if type(self.client_id) is not str or not _CLIENT_ID_RE.fullmatch(self.client_id):
@@ -124,11 +131,14 @@ class GoogleOidcConfig:
             or not 0 < self.timeout_seconds <= 60
         ):
             raise GoogleOidcConfigurationError("Timeout OIDC non valido.")
-        if (
-            type(self.max_token_response_bytes) is not int
-            or not 1024 <= self.max_token_response_bytes <= 1024 * 1024
+        for value, name in (
+            (self.max_token_response_bytes, "token"),
+            (self.max_cert_response_bytes, "certificati"),
         ):
-            raise GoogleOidcConfigurationError("Limite risposta token non valido.")
+            if type(value) is not int or not 1024 <= value <= 1024 * 1024:
+                raise GoogleOidcConfigurationError(
+                    f"Limite risposta {name} non valido."
+                )
 
 
 @dataclass(frozen=True)
@@ -171,7 +181,10 @@ class GoogleIdTokenVerifier(Protocol):
 class InMemoryGoogleOidcFlowStore:
     """Thread-safe one-time flow store; raw verifier exists only in memory."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, max_pending_flows: int = 4096) -> None:
+        if type(max_pending_flows) is not int or not 1 <= max_pending_flows <= 100000:
+            raise GoogleOidcConfigurationError("Limite flow OIDC non valido.")
+        self.max_pending_flows = max_pending_flows
         self._flows: dict[str, PendingGoogleOidcFlow] = {}
         self._lock = threading.Lock()
 
@@ -192,6 +205,15 @@ class InMemoryGoogleOidcFlowStore:
             expires_at=now + ttl,
         )
         with self._lock:
+            expired = [
+                key for key, current in self._flows.items()
+                if current.expires_at <= now
+            ]
+            for key in expired:
+                del self._flows[key]
+            if len(self._flows) >= self.max_pending_flows:
+                flow = None
+                raise GoogleOidcStateError("Capacita flow OIDC esaurita.")
             if flow.state_digest in self._flows:
                 raise GoogleOidcStateError("Collisione state OIDC.")
             self._flows[flow.state_digest] = flow
@@ -295,8 +317,72 @@ class UrllibGoogleTokenTransport:
         return decoded
 
 
+class _GoogleAuthCertResponse:
+    def __init__(self, status: int, data: bytes, headers: Mapping[str, str]) -> None:
+        self.status = status
+        self.data = data
+        self.headers = headers
+
+
+class BoundedGoogleCertRequest:
+    """google-auth request adapter with fixed endpoints, bounds, and no redirects."""
+
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = 10.0,
+        max_response_bytes: int = 256 * 1024,
+    ) -> None:
+        self.timeout_seconds = timeout_seconds
+        self.max_response_bytes = max_response_bytes
+        self._opener = urllib.request.build_opener(UrllibGoogleTokenTransport._NoRedirect())
+
+    def __call__(
+        self,
+        url: str,
+        method: str = "GET",
+        body: bytes | None = None,
+        headers: Mapping[str, str] | None = None,
+        **_kwargs,
+    ) -> _GoogleAuthCertResponse:
+        failed = False
+        request = None
+        response = None
+        data = None
+        status = 0
+        response_headers: Mapping[str, str] = {}
+        try:
+            if url not in _GOOGLE_CERT_ENDPOINTS or method != "GET" or body is not None:
+                failed = True
+            else:
+                request = urllib.request.Request(
+                    url,
+                    headers={"Accept": "application/json", **dict(headers or {})},
+                    method="GET",
+                )
+                with self._opener.open(request, timeout=self.timeout_seconds) as response:
+                    status = response.status
+                    data = response.read(self.max_response_bytes + 1)
+                    response_headers = dict(response.headers.items())
+                    if status != 200 or len(data) > self.max_response_bytes:
+                        failed = True
+        except Exception:
+            failed = True
+        finally:
+            request = None
+            response = None
+            body = None
+            headers = None
+        if failed or data is None:
+            data = None
+            raise GoogleOidcProviderUnavailableError(
+                "Certificati Google non disponibili."
+            )
+        return _GoogleAuthCertResponse(status, data, response_headers)
+
+
 class GoogleOfficialIdTokenVerifier:
-    """Production verifier backed by the official google-auth package."""
+    """Production verifier backed by google-auth and a bounded cert transport."""
 
     def __init__(self, request_adapter=None, *, clock_skew_seconds: int = 30) -> None:
         if (
@@ -304,29 +390,46 @@ class GoogleOfficialIdTokenVerifier:
             or not 0 <= clock_skew_seconds <= 300
         ):
             raise GoogleOidcConfigurationError("Clock skew verifier non valido.")
-        self._request_adapter = request_adapter
+        self._request_adapter = request_adapter or BoundedGoogleCertRequest()
         self.clock_skew_seconds = clock_skew_seconds
+
+    @classmethod
+    def from_config(cls, config: GoogleOidcConfig) -> "GoogleOfficialIdTokenVerifier":
+        return cls(
+            BoundedGoogleCertRequest(
+                timeout_seconds=float(config.timeout_seconds),
+                max_response_bytes=config.max_cert_response_bytes,
+            ),
+            clock_skew_seconds=int(config.clock_skew.total_seconds()),
+        )
 
     def verify(self, id_token: str, *, audience: str) -> Mapping[str, object]:
         failed = False
+        unavailable = False
         claims = None
         try:
-            from google.auth.transport.requests import Request
             from google.oauth2 import id_token as google_id_token
 
-            request_adapter = self._request_adapter or Request()
+            request_adapter = self._request_adapter
             claims = google_id_token.verify_oauth2_token(
                 id_token,
                 request_adapter,
                 audience,
                 clock_skew_in_seconds=self.clock_skew_seconds,
             )
+        except GoogleOidcProviderUnavailableError:
+            unavailable = True
         except Exception:
             failed = True
         finally:
             id_token = None
             audience = None
             request_adapter = None
+        if unavailable:
+            claims = None
+            raise GoogleOidcProviderUnavailableError(
+                "Verifica certificati Google non disponibile."
+            )
         if failed or type(claims) is not dict:
             claims = None
             raise GoogleOidcTokenRejectedError("ID token Google rifiutato.")

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -467,6 +467,8 @@ class UrllibGoogleTokenTransport:
             if 400 <= status < 500:
                 try:
                     error_bytes = error.read(max_response_bytes + 1)
+                    if len(error_bytes) > max_response_bytes:
+                        raise ValueError("Risposta OAuth 4xx oltre il limite.")
                     decoded_error = json.loads(
                         error_bytes.decode("utf-8"),
                         object_pairs_hook=_reject_duplicate_json_keys,

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -144,8 +144,15 @@ class GoogleOidcConfig:
         for field_name in ("redirect_uri", "authorization_endpoint", "token_endpoint"):
             value = getattr(self, field_name)
             parsed = urllib.parse.urlsplit(value) if type(value) is str else None
+            invalid_port = False
+            try:
+                port = parsed.port if parsed is not None else None
+            except ValueError:
+                invalid_port = True
+                port = None
             if (
                 parsed is None
+                or invalid_port
                 or parsed.scheme != "https"
                 or not parsed.hostname
                 or parsed.username is not None
@@ -864,13 +871,23 @@ class GoogleOidcLoginService:
             claims = None
             id_token = None
             flow = None
+            identity_rejected = False
+            identity_unavailable = False
             try:
                 user = self.identities.resolve(assertion)
             except (AuthApplicationError, IdentityDomainError):
+                identity_rejected = True
+            except Exception:
+                identity_unavailable = True
+            assertion = None
+            if identity_rejected:
                 raise GoogleOidcIdentityRejectedError(
                     "Identita Google non autorizzata."
-                ) from None
-            assertion = None
+                )
+            if identity_unavailable or user is None:
+                raise GoogleOidcProviderUnavailableError(
+                    "Servizio identita non disponibile."
+                )
             session = self.http_sessions.establish_session(
                 user.user_id,
                 existing_cookie_header=existing_cookie_header,
@@ -910,6 +927,8 @@ class GoogleOidcLoginService:
             provider_error = False
             state_failed = False
             state_unavailable = False
+            identity_rejected = False
+            identity_unavailable = False
             verification_failed = False
             verification_unavailable = False
             result_failed = False

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -21,9 +21,10 @@ from scripts.thebitlab_auth_services import (
     AuthApplicationError,
     FederatedIdentityAssertion,
     FederatedIdentityService,
+    OnboardingNotAllowedError,
 )
 from scripts.thebitlab_http_auth import EstablishedHttpSession, HttpSessionAuthBoundary
-from scripts.thebitlab_identity import IdentityDomainError
+from scripts.thebitlab_identity import AccountDisabledError, IdentityDomainError
 
 _GOOGLE_ISSUERS = frozenset({"accounts.google.com", "https://accounts.google.com"})
 _GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
@@ -153,6 +154,8 @@ class GoogleOidcConfig:
             if (
                 parsed is None
                 or invalid_port
+                or (port is not None and port < 1)
+                or any(ord(character) <= 0x20 or ord(character) == 0x7F for character in value)
                 or parsed.scheme != "https"
                 or not parsed.hostname
                 or parsed.username is not None
@@ -875,8 +878,10 @@ class GoogleOidcLoginService:
             identity_unavailable = False
             try:
                 user = self.identities.resolve(assertion)
-            except (AuthApplicationError, IdentityDomainError):
+            except (OnboardingNotAllowedError, AccountDisabledError):
                 identity_rejected = True
+            except (AuthApplicationError, IdentityDomainError):
+                identity_unavailable = True
             except Exception:
                 identity_unavailable = True
             assertion = None

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -62,7 +62,11 @@ class GoogleOidcStateError(GoogleOidcError):
 
 
 class GoogleOidcStateConflictError(GoogleOidcStateError):
-    """Raised before insert when a state collides or the flow store is full."""
+    """Raised before insert when a generated state collides."""
+
+
+class GoogleOidcFlowCapacityError(GoogleOidcStateConflictError):
+    """Raised before insert when the bounded flow store is full."""
 
 
 class GoogleOidcProviderUnavailableError(GoogleOidcError):
@@ -180,12 +184,22 @@ class GoogleOidcConfig:
             raise GoogleOidcConfigurationError(
                 "Endpoint Google OIDC non consentito."
             )
+        encoded_post_login = (
+            urllib.parse.unquote_to_bytes(self.post_login_path)
+            if type(self.post_login_path) is str
+            else b""
+        )
         if (
             type(self.post_login_path) is not str
             or not self.post_login_path.startswith("/")
             or self.post_login_path.startswith("//")
             or "\\" in self.post_login_path
-            or any(ord(character) < 0x20 for character in self.post_login_path)
+            or _INVALID_PERCENT_ESCAPE_RE.search(self.post_login_path) is not None
+            or any(
+                ord(character) <= 0x20 or ord(character) == 0x7F
+                for character in self.post_login_path
+            )
+            or any(byte < 0x20 or byte == 0x7F for byte in encoded_post_login)
         ):
             raise GoogleOidcConfigurationError("Path post-login non valido.")
         for value, name, maximum in (
@@ -283,6 +297,7 @@ class InMemoryGoogleOidcFlowStore:
     ) -> None:
         flow = None
         conflict_message = None
+        capacity_exhausted = False
         try:
             flow = PendingGoogleOidcFlow(
                 state_digest=self.state_digest(state),
@@ -301,6 +316,7 @@ class InMemoryGoogleOidcFlowStore:
                     del self._flows[key]
                 if len(self._flows) >= self.max_pending_flows:
                     conflict_message = "Capacita flow OIDC esaurita."
+                    capacity_exhausted = True
                 elif flow.state_digest in self._flows:
                     conflict_message = "Collisione state OIDC."
                 else:
@@ -312,6 +328,8 @@ class InMemoryGoogleOidcFlowStore:
             creation_marker = None
             flow = None
         if conflict_message is not None:
+            if capacity_exhausted:
+                raise GoogleOidcFlowCapacityError(conflict_message)
             raise GoogleOidcStateConflictError(conflict_message)
 
     def consume(self, state: str, now: datetime) -> PendingGoogleOidcFlow:
@@ -724,6 +742,8 @@ class GoogleOidcLoginService:
                     now,
                     self.config.flow_ttl,
                 )
+            except GoogleOidcFlowCapacityError:
+                store_failed = True
             except GoogleOidcStateConflictError:
                 collision = True
             except Exception:

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -318,20 +318,6 @@ class InMemoryGoogleOidcFlowStore:
         creation_marker = None
         return matches
 
-    def discard(self, state: str) -> bool:
-        digest_failed = False
-        try:
-            digest = self.state_digest(state)
-        except Exception:
-            digest_failed = True
-            digest = ""
-        finally:
-            state = None
-        if digest_failed:
-            return False
-        with self._lock:
-            return self._flows.pop(digest, None) is not None
-
     def delete_expired(self, cutoff: datetime) -> int:
         with self._lock:
             expired = [key for key, flow in self._flows.items() if flow.expires_at <= cutoff]
@@ -647,7 +633,7 @@ class GoogleOidcLoginService:
                     continue
             if store_failed:
                 try:
-                    self.flows.discard(state)
+                    self.flows.discard_created_flow(state, creation_marker)
                 except Exception:
                     pass
                 state = None
@@ -682,7 +668,7 @@ class GoogleOidcLoginService:
                 build_failed = True
             if build_failed or authorization_url is None:
                 try:
-                    self.flows.discard(state)
+                    self.flows.discard_created_flow(state, creation_marker)
                 except Exception:
                     pass
                 state = None

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -255,27 +255,38 @@ class InMemoryGoogleOidcFlowStore:
         now: datetime,
         ttl: timedelta,
     ) -> None:
-        flow = PendingGoogleOidcFlow(
-            state_digest=self.state_digest(state),
-            nonce_digest=self.nonce_digest(nonce),
-            code_verifier=code_verifier,
-            creation_marker=creation_marker,
-            created_at=now,
-            expires_at=now + ttl,
-        )
-        with self._lock:
-            expired = [
-                key for key, current in self._flows.items()
-                if current.expires_at <= now
-            ]
-            for key in expired:
-                del self._flows[key]
-            if len(self._flows) >= self.max_pending_flows:
-                flow = None
-                raise GoogleOidcStateConflictError("Capacita flow OIDC esaurita.")
-            if flow.state_digest in self._flows:
-                raise GoogleOidcStateConflictError("Collisione state OIDC.")
-            self._flows[flow.state_digest] = flow
+        flow = None
+        conflict_message = None
+        try:
+            flow = PendingGoogleOidcFlow(
+                state_digest=self.state_digest(state),
+                nonce_digest=self.nonce_digest(nonce),
+                code_verifier=code_verifier,
+                creation_marker=creation_marker,
+                created_at=now,
+                expires_at=now + ttl,
+            )
+            with self._lock:
+                expired = [
+                    key for key, current in self._flows.items()
+                    if current.expires_at <= now
+                ]
+                for key in expired:
+                    del self._flows[key]
+                if len(self._flows) >= self.max_pending_flows:
+                    conflict_message = "Capacita flow OIDC esaurita."
+                elif flow.state_digest in self._flows:
+                    conflict_message = "Collisione state OIDC."
+                else:
+                    self._flows[flow.state_digest] = flow
+        finally:
+            state = None
+            nonce = None
+            code_verifier = None
+            creation_marker = None
+            flow = None
+        if conflict_message is not None:
+            raise GoogleOidcStateConflictError(conflict_message)
 
     def consume(self, state: str, now: datetime) -> PendingGoogleOidcFlow:
         digest_failed = False

--- a/scripts/thebitlab_http_auth.py
+++ b/scripts/thebitlab_http_auth.py
@@ -224,6 +224,32 @@ class HttpSessionAuthBoundary:
         finally:
             issued = None
 
+    def discard_established_session(self, established: EstablishedHttpSession) -> bool:
+        """Best-effort cleanup for a session whose HTTP response was not delivered."""
+        bearer = None
+        revoked = False
+        try:
+            if type(established) is not EstablishedHttpSession:
+                return False
+            cookie_pair = established.set_cookie.partition(";")[0]
+            bearer = self._extract_bearer(cookie_pair)
+            session = established.context.session
+            if (
+                type(session) is not UserSession
+                or not hmac.compare_digest(
+                    session.token_digest, session_token_digest(bearer)
+                )
+            ):
+                return False
+            result = self.sessions.revoke(bearer)
+            revoked = result is True
+        except Exception:
+            revoked = False
+        finally:
+            bearer = None
+            established = None
+        return revoked
+
     def authenticate(self, request: HttpAuthRequest) -> HttpAuthContext:
         try:
             method, cookie_header, supplied_csrf = self._request_values(request)

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -414,6 +414,26 @@ def test_callback_replay_and_concurrent_consume_have_one_winner(database_path, c
         service.complete_callback(valid_callback(state))
 
 
+def test_flow_store_state_error_is_normalized(database_path, clock) -> None:
+    service, _storage, _flows, _transport, _verifier = make_service(
+        database_path, clock
+    )
+    state = begin_state(service)
+
+    class RawErrorStore:
+        def consume(self, *_args):
+            raise GoogleOidcStateError("RAW_BACKEND_SECRET")
+
+    service.flows = RawErrorStore()
+    with pytest.raises(GoogleOidcStateError) as captured:
+        service.complete_callback(valid_callback(state))
+    assert "RAW_BACKEND_SECRET" not in str(captured.value)
+    assert "RAW_BACKEND_SECRET" not in traceback_function_locals(
+        captured.value, "complete_callback", "consume"
+    )
+    assert captured.value.__context__ is None
+
+
 def test_flow_creation_auto_cleans_expired_records_and_store_is_bounded(
     database_path, clock
 ) -> None:

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -204,6 +204,9 @@ def test_config_requires_https_fixed_redirect_and_safe_post_login() -> None:
         {"client_secret": "secret\nheader"},
         {"post_login_path": "https://evil.test/"},
         {"post_login_path": "//evil.test/"},
+        {"post_login_path": "/%ZZ"},
+        {"post_login_path": "/ok\x7fSet-Cookie: evil=1"},
+        {"post_login_path": "/%0d%0aLocation:%20https://evil.test/"},
         {"flow_ttl": timedelta(0)},
         {"clock_skew": timedelta(minutes=6)},
     ):
@@ -462,7 +465,7 @@ def test_flow_creation_auto_cleans_expired_records_and_store_is_bounded(
     service.state_factory = lambda: "a" * 43
     begin_state(service)
     service.state_factory = lambda: "b" * 43
-    with pytest.raises(GoogleOidcConfigurationError):
+    with pytest.raises(GoogleOidcProviderUnavailableError):
         service.begin_login()
     assert bounded.pending_count() == 1
 

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -257,8 +257,12 @@ def test_generator_collision_and_invalid_secret_are_sanitized(database_path, clo
     )
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [RuntimeError("store unavailable"), GoogleOidcStateError("post-insert failure")],
+)
 def test_unexpected_flow_store_failure_discards_and_scrubs_credentials(
-    database_path, clock
+    database_path, clock, failure
 ) -> None:
     service, _storage, _flows, _transport, _verifier = make_service(database_path, clock)
     real_store = InMemoryGoogleOidcFlowStore()
@@ -266,7 +270,7 @@ def test_unexpected_flow_store_failure_discards_and_scrubs_credentials(
     class InsertThenFailStore:
         def create(self, state, nonce, verifier, now, ttl):
             real_store.create(state, nonce, verifier, now, ttl)
-            raise RuntimeError("store unavailable")
+            raise failure
 
         def discard(self, state):
             return real_store.discard(state)

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -261,9 +261,8 @@ def test_begin_login_builds_state_nonce_and_pkce_without_persisting_raw_values(
     ).rstrip(b"=").decode()
     assert query["code_challenge"] == [expected_challenge]
     assert CLIENT_SECRET not in started.authorization_url
-    assert started.set_cookie.startswith(
-        f"__Host-thebitlab_oidc_txn={BROWSER_BINDING};"
-    )
+    assert started.set_cookie.startswith("__Host-thebitlab_oidc_txn-")
+    assert f"={BROWSER_BINDING};" in started.set_cookie
     assert "Secure" in started.set_cookie
     assert "HttpOnly" in started.set_cookie
     assert "SameSite=Lax" in started.set_cookie
@@ -408,8 +407,9 @@ def test_valid_callback_onboards_pending_user_and_issues_session_cookie(
 
     assert result.user_id == "internal-user-01"
     assert result.clear_transaction_cookie.startswith(
-        "__Host-thebitlab_oidc_txn=;"
+        "__Host-thebitlab_oidc_txn-"
     )
+    assert "=;" in result.clear_transaction_cookie
     assert "Max-Age=0" in result.clear_transaction_cookie
     assert result.role == "pending"
     assert result.redirect_path == "/dashboard"
@@ -472,7 +472,7 @@ def test_callback_requires_originating_browser_cookie_without_consuming_flow(
 
     for cookie_header in (
         None,
-        "__Host-thebitlab_oidc_txn=" + "x" * 43,
+        service._test_transaction_cookie.split("=", 1)[0] + "=" + "x" * 43,
         service._test_transaction_cookie + "; " + service._test_transaction_cookie,
     ):
         with pytest.raises(GoogleOidcStateError) as rejected:
@@ -486,6 +486,29 @@ def test_callback_requires_originating_browser_cookie_without_consuming_flow(
     result = finish_callback(service, valid_callback(state))
     assert result.user_id == "internal-user-01"
     assert flows.pending_count() == 0
+
+
+def test_concurrent_login_tabs_use_distinct_transaction_cookies(
+    database_path, clock
+) -> None:
+    service, _storage, flows, _transport, _verifier = make_service(
+        database_path, clock
+    )
+    first = service.begin_login()
+    first_state = parse_qs(urlsplit(first.authorization_url).query)["state"][0]
+    service.state_factory = lambda: "z" * 43
+    second = service.begin_login()
+
+    first_pair = first.set_cookie.split(";", 1)[0]
+    second_pair = second.set_cookie.split(";", 1)[0]
+    assert first_pair.split("=", 1)[0] != second_pair.split("=", 1)[0]
+    both_cookies = f"{first_pair}; {second_pair}"
+
+    result = service.complete_callback(
+        valid_callback(first_state), existing_cookie_header=both_cookies
+    )
+    assert result.user_id == "internal-user-01"
+    assert flows.pending_count() == 1
 
 
 def test_flow_store_state_error_is_normalized(database_path, clock) -> None:
@@ -554,8 +577,12 @@ def test_expired_state_is_consumed_and_cleanup_is_explicit(database_path, clock)
     state = begin_state(service)
     clock.value += timedelta(seconds=1)
 
-    with pytest.raises(GoogleOidcStateError):
+    with pytest.raises(GoogleOidcStateError) as expired:
         finish_callback(service, valid_callback(state))
+    assert expired.value.clear_transaction_cookie.startswith(
+        "__Host-thebitlab_oidc_txn-"
+    )
+    assert "=;" in expired.value.clear_transaction_cookie
     assert transport.calls == []
     assert flows.pending_count() == 0
 
@@ -572,8 +599,9 @@ def test_provider_error_consumes_state_and_duplicate_or_unknown_params_fail_clos
     with pytest.raises(GoogleOidcCallbackError) as cancelled:
         finish_callback(service, {"error": ["access_denied"], "state": [state]})
     assert cancelled.value.clear_transaction_cookie.startswith(
-        "__Host-thebitlab_oidc_txn=;"
+        "__Host-thebitlab_oidc_txn-"
     )
+    assert "=;" in cancelled.value.clear_transaction_cookie
     with pytest.raises(GoogleOidcStateError) as replayed:
         finish_callback(service, valid_callback(state))
     assert replayed.value.clear_transaction_cookie is None

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -49,6 +49,7 @@ CSRF_SECRET = b"c" * 32
 STATE = "s" * 43
 NONCE = "n" * 43
 VERIFIER = "v" * 64
+BROWSER_BINDING = "b" * 43
 
 
 class MutableClock:
@@ -161,13 +162,25 @@ def make_service(database_path, clock, *, transport=None, verifier=None, flow_tt
         state_factory=lambda: STATE,
         nonce_factory=lambda: NONCE,
         verifier_factory=lambda: VERIFIER,
+        browser_binding_factory=lambda: BROWSER_BINDING,
     )
     return service, storage, flows, transport, verifier
 
 
 def begin_state(service):
     started = service.begin_login()
+    service._test_transaction_cookie = started.set_cookie.split(";", 1)[0]
     return parse_qs(urlsplit(started.authorization_url).query)["state"][0]
+
+
+def finish_callback(service, parameters, *, existing_cookie_header=None):
+    transaction_cookie = service._test_transaction_cookie
+    cookie_header = transaction_cookie
+    if existing_cookie_header:
+        cookie_header = f"{existing_cookie_header}; {transaction_cookie}"
+    return service.complete_callback(
+        parameters, existing_cookie_header=cookie_header
+    )
 
 
 def valid_callback(state=STATE):
@@ -248,12 +261,20 @@ def test_begin_login_builds_state_nonce_and_pkce_without_persisting_raw_values(
     ).rstrip(b"=").decode()
     assert query["code_challenge"] == [expected_challenge]
     assert CLIENT_SECRET not in started.authorization_url
+    assert started.set_cookie.startswith(
+        f"__Host-thebitlab_oidc_txn={BROWSER_BINDING};"
+    )
+    assert "Secure" in started.set_cookie
+    assert "HttpOnly" in started.set_cookie
+    assert "SameSite=Lax" in started.set_cookie
+    assert BROWSER_BINDING not in repr(started)
 
     assert flows.pending_count() == 1
     with flows._lock:
         pending = next(iter(flows._flows.values()))
     assert pending.state_digest != STATE
     assert pending.nonce_digest != NONCE
+    assert pending.browser_digest != BROWSER_BINDING
     assert STATE not in repr(pending)
     assert NONCE not in repr(pending)
     assert VERIFIER not in repr(pending)
@@ -309,9 +330,17 @@ def test_unexpected_flow_store_failure_discards_and_scrubs_credentials(
     real_store = InMemoryGoogleOidcFlowStore()
 
     class InsertThenFailStore:
-        def create(self, state, nonce, verifier, creation_marker, now, ttl):
+        def create(
+            self, state, nonce, verifier, browser_binding, creation_marker, now, ttl
+        ):
             real_store.create(
-                state, nonce, verifier, creation_marker, now, ttl
+                state,
+                nonce,
+                verifier,
+                browser_binding,
+                creation_marker,
+                now,
+                ttl,
             )
             raise failure
 
@@ -336,7 +365,7 @@ def test_authorization_result_failure_discards_flow_and_scrubs_url(
     )
 
     class FailingAuthorizationRequest:
-        def __init__(self, authorization_url):
+        def __init__(self, authorization_url, set_cookie):
             raise RuntimeError("result unavailable")
 
     monkeypatch.setattr(
@@ -375,9 +404,13 @@ def test_valid_callback_onboards_pending_user_and_issues_session_cookie(
     service, storage, flows, transport, verifier = make_service(database_path, clock)
     state = begin_state(service)
 
-    result = service.complete_callback(valid_callback(state))
+    result = finish_callback(service, valid_callback(state))
 
     assert result.user_id == "internal-user-01"
+    assert result.clear_transaction_cookie.startswith(
+        "__Host-thebitlab_oidc_txn=;"
+    )
+    assert "Max-Age=0" in result.clear_transaction_cookie
     assert result.role == "pending"
     assert result.redirect_path == "/dashboard"
     assert result.session.set_cookie.startswith("__Host-thebitlab_session=")
@@ -414,7 +447,7 @@ def test_callback_replay_and_concurrent_consume_have_one_winner(database_path, c
     state = begin_state(service)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = [executor.submit(service.complete_callback, valid_callback(state)) for _ in range(2)]
+        futures = [executor.submit(finish_callback, service, valid_callback(state)) for _ in range(2)]
     outcomes = []
     for future in futures:
         try:
@@ -426,7 +459,32 @@ def test_callback_replay_and_concurrent_consume_have_one_winner(database_path, c
     assert len(transport.calls) == 1
     assert len(storage.list_users()) == 1
     with pytest.raises(GoogleOidcStateError):
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
+
+
+def test_callback_requires_originating_browser_cookie_without_consuming_flow(
+    database_path, clock
+) -> None:
+    service, _storage, flows, transport, _verifier = make_service(
+        database_path, clock
+    )
+    state = begin_state(service)
+
+    for cookie_header in (
+        None,
+        "__Host-thebitlab_oidc_txn=" + "x" * 43,
+        service._test_transaction_cookie + "; " + service._test_transaction_cookie,
+    ):
+        with pytest.raises(GoogleOidcStateError):
+            service.complete_callback(
+                valid_callback(state), existing_cookie_header=cookie_header
+            )
+        assert flows.pending_count() == 1
+        assert transport.calls == []
+
+    result = finish_callback(service, valid_callback(state))
+    assert result.user_id == "internal-user-01"
+    assert flows.pending_count() == 0
 
 
 def test_flow_store_state_error_is_normalized(database_path, clock) -> None:
@@ -441,7 +499,7 @@ def test_flow_store_state_error_is_normalized(database_path, clock) -> None:
 
     service.flows = RawErrorStore()
     with pytest.raises(GoogleOidcStateError) as captured:
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
     assert "RAW_BACKEND_SECRET" not in str(captured.value)
     assert "RAW_BACKEND_SECRET" not in traceback_function_locals(
         captured.value, "complete_callback", "consume"
@@ -477,6 +535,7 @@ def test_flow_creation_auto_cleans_expired_records_and_store_is_bounded(
             raw_state,
             raw_nonce,
             raw_verifier,
+            BROWSER_BINDING,
             object(),
             clock.value,
             timedelta(minutes=1),
@@ -495,7 +554,7 @@ def test_expired_state_is_consumed_and_cleanup_is_explicit(database_path, clock)
     clock.value += timedelta(seconds=1)
 
     with pytest.raises(GoogleOidcStateError):
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
     assert transport.calls == []
     assert flows.pending_count() == 0
 
@@ -510,9 +569,9 @@ def test_provider_error_consumes_state_and_duplicate_or_unknown_params_fail_clos
     service, _storage, _flows, transport, _verifier = make_service(database_path, clock)
     state = begin_state(service)
     with pytest.raises(GoogleOidcCallbackError):
-        service.complete_callback({"error": ["access_denied"], "state": [state]})
+        finish_callback(service, {"error": ["access_denied"], "state": [state]})
     with pytest.raises(GoogleOidcStateError):
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
     assert transport.calls == []
 
     malformed = (
@@ -526,7 +585,7 @@ def test_provider_error_consumes_state_and_duplicate_or_unknown_params_fail_clos
     )
     for parameters in malformed:
         with pytest.raises(GoogleOidcCallbackError):
-            service.complete_callback(parameters)
+            finish_callback(service, parameters)
 
 
 def test_token_exchange_and_verification_failures_are_sanitized_and_consume_state(
@@ -539,13 +598,13 @@ def test_token_exchange_and_verification_failures_are_sanitized_and_consume_stat
     )
     state = begin_state(service)
     with pytest.raises(GoogleOidcProviderUnavailableError) as exchange_error:
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
     assert "raw-google" not in str(exchange_error.value)
     assert "raw-google" not in traceback_function_locals(
         exchange_error.value, "complete_callback", "_exchange"
     )
     with pytest.raises(GoogleOidcStateError):
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
 
     verifier = FakeIdTokenVerifier(claims(), error=RuntimeError(ID_TOKEN))
     service, _storage, _flows, _transport, _verifier = make_service(
@@ -553,7 +612,7 @@ def test_token_exchange_and_verification_failures_are_sanitized_and_consume_stat
     )
     state = begin_state(service)
     with pytest.raises(GoogleOidcTokenRejectedError) as verify_error:
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
     assert ID_TOKEN not in str(verify_error.value)
     assert ID_TOKEN not in traceback_function_locals(
         verify_error.value, "complete_callback", "verify"
@@ -573,7 +632,7 @@ def test_identity_collaborator_error_is_normalized(database_path, clock) -> None
 
     service.identities = RawIdentityService()
     with pytest.raises(GoogleOidcProviderUnavailableError) as captured:
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
     assert "RAW_IDENTITY_DB_PASSWORD" not in str(captured.value)
     assert "RAW_IDENTITY_DB_PASSWORD" not in traceback_function_locals(
         captured.value, "complete_callback", "resolve"
@@ -603,7 +662,7 @@ def test_disable_race_before_session_is_identity_rejection(database_path, clock)
     service.identities = DisableAfterResolve()
     state = begin_state(service)
     with pytest.raises(GoogleOidcIdentityRejectedError):
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
     sessions = storage.list_user_sessions("internal-user-01")
     assert sessions == []
 
@@ -632,7 +691,7 @@ def test_login_result_uses_current_session_role(database_path, clock) -> None:
 
     service.http_sessions = PromoteBeforeSession()
     state = begin_state(service)
-    result = service.complete_callback(valid_callback(state))
+    result = finish_callback(service, valid_callback(state))
 
     assert result.role == "teacher"
     assert result.user_id == result.session.context.user.user_id
@@ -653,7 +712,7 @@ def test_login_result_construction_failure_revokes_issued_session(
 
     monkeypatch.setattr(google_oidc, "GoogleOidcLoginResult", FailingLoginResult)
     with pytest.raises(GoogleOidcProviderUnavailableError):
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
 
     sessions = storage.list_user_sessions("internal-user-01")
     assert len(sessions) == 1
@@ -698,7 +757,7 @@ def test_wrong_or_unverified_claims_never_create_user(database_path, clock, over
     state = begin_state(service)
 
     with pytest.raises(GoogleOidcTokenRejectedError) as captured:
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
     assert ID_TOKEN not in traceback_function_locals(
         captured.value, "_assertion_from_claims"
     )
@@ -732,20 +791,20 @@ def test_disabled_existing_google_identity_is_rejected_without_session(
     state = begin_state(service)
 
     with pytest.raises(GoogleOidcIdentityRejectedError):
-        service.complete_callback(valid_callback(state))
+        finish_callback(service, valid_callback(state))
     assert storage.list_user_sessions(disabled.user_id) == []
 
 
 def test_existing_google_identity_reuses_internal_user(database_path, clock) -> None:
     service, storage, _flows, _transport, _verifier = make_service(database_path, clock)
     first_state = begin_state(service)
-    first = service.complete_callback(valid_callback(first_state))
+    first = finish_callback(service, valid_callback(first_state))
 
     service.http_sessions.sessions.token_factory = lambda: "B" * 40
     service.http_sessions.sessions.session_id_factory = lambda: "session-02"
     second_state = begin_state(service)
     first_cookie = first.session.set_cookie.split(";", 1)[0]
-    second = service.complete_callback(
+    second = finish_callback(service,
         valid_callback(second_state), existing_cookie_header=first_cookie
     )
 

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import base64
+import io
 import json
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
+from urllib.error import HTTPError
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
@@ -880,6 +882,31 @@ def test_urllib_transport_rejects_duplicate_json_and_bounds_response() -> None:
         transport.exchange_code(
             endpoint="https://oauth2.googleapis.com/token",
             form={"code": "raw-code", "client_secret": CLIENT_SECRET},
+            timeout_seconds=1,
+            max_response_bytes=1024,
+        )
+
+    class ErrorOpener:
+        def __init__(self, oauth_error):
+            self.oauth_error = oauth_error
+
+        def open(self, request, timeout):
+            body = json.dumps({"error": self.oauth_error}).encode()
+            raise HTTPError(request.full_url, 400, "bad request", {}, io.BytesIO(body))
+
+    transport._opener = ErrorOpener("invalid_grant")
+    with pytest.raises(GoogleOidcTokenRejectedError):
+        transport.exchange_code(
+            endpoint="https://oauth2.googleapis.com/token",
+            form={"code": "expired-code"},
+            timeout_seconds=1,
+            max_response_bytes=1024,
+        )
+    transport._opener = ErrorOpener("invalid_client")
+    with pytest.raises(GoogleOidcConfigurationError):
+        transport.exchange_code(
+            endpoint="https://oauth2.googleapis.com/token",
+            form={"client_secret": CLIENT_SECRET},
             timeout_seconds=1,
             max_response_bytes=1024,
         )

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -224,6 +224,7 @@ def test_config_requires_https_fixed_redirect_and_safe_post_login() -> None:
         {"post_login_path": "/%0d%0aLocation:%20https://evil.test/"},
         {"flow_ttl": timedelta(0)},
         {"clock_skew": timedelta(minutes=6)},
+        {"max_cert_response_bytes": 1024},
     ):
         with pytest.raises(GoogleOidcConfigurationError):
             config(**override)
@@ -914,6 +915,7 @@ def test_urllib_transport_rejects_duplicate_json_and_bounds_response() -> None:
 
     for configuration_error in (
         "invalid_client",
+        "invalid_request",
         "unauthorized_client",
         "unsupported_grant_type",
         "invalid_scope",

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -12,7 +12,11 @@ from urllib.parse import parse_qs, urlsplit
 import pytest
 
 import scripts.thebitlab_google_oidc as google_oidc
-from scripts.thebitlab_auth_services import FederatedIdentityService, SessionService
+from scripts.thebitlab_auth_services import (
+    AuthApplicationError,
+    FederatedIdentityService,
+    SessionService,
+)
 from scripts.thebitlab_google_oidc import (
     BoundedGoogleCertRequest,
     GoogleAuthorizationRequest,
@@ -186,6 +190,7 @@ def test_config_requires_https_fixed_redirect_and_safe_post_login() -> None:
 
     for override in (
         {"redirect_uri": "http://lab.example.test/callback"},
+        {"redirect_uri": "https://lab.example.test:bad/callback"},
         {"token_endpoint": "https://user:pass@example.test/token"},
         {"authorization_endpoint": "https://example.test/auth#fragment"},
         {"token_endpoint": "https://example.test/collect"},
@@ -546,6 +551,26 @@ def test_token_exchange_and_verification_failures_are_sanitized_and_consume_stat
         verify_error.value, "complete_callback", "verify"
     )
     assert verify_error.value.__context__ is None
+
+
+def test_identity_collaborator_error_is_normalized(database_path, clock) -> None:
+    service, _storage, _flows, _transport, _verifier = make_service(
+        database_path, clock
+    )
+    state = begin_state(service)
+
+    class RawIdentityService:
+        def resolve(self, _assertion):
+            raise AuthApplicationError("RAW_IDENTITY_DB_PASSWORD")
+
+    service.identities = RawIdentityService()
+    with pytest.raises(GoogleOidcIdentityRejectedError) as captured:
+        service.complete_callback(valid_callback(state))
+    assert "RAW_IDENTITY_DB_PASSWORD" not in str(captured.value)
+    assert "RAW_IDENTITY_DB_PASSWORD" not in traceback_function_locals(
+        captured.value, "complete_callback", "resolve"
+    )
+    assert captured.value.__context__ is None
 
 
 def test_login_result_uses_current_session_role(database_path, clock) -> None:

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -812,6 +812,23 @@ def test_official_google_verifier_validates_rs256_signature_and_sanitizes_failur
     verified = verifier.verify(token, audience=CLIENT_ID)
     assert verified["sub"] == "subject"
 
+    class JwksRequest:
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, *_args, **_kwargs):
+            self.calls += 1
+            response = CertResponse()
+            response.data = json.dumps({"keys": []}).encode()
+            return response
+
+    jwks_request = JwksRequest()
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        GoogleOfficialIdTokenVerifier(jwks_request).verify(
+            token, audience=CLIENT_ID
+        )
+    assert jwks_request.calls == 1
+
     token_parts = token.split(".")
     token_parts[2] = ("A" if token_parts[2][0] != "A" else "B") + token_parts[2][1:]
     tampered = ".".join(token_parts)

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -912,14 +912,20 @@ def test_urllib_transport_rejects_duplicate_json_and_bounds_response() -> None:
             max_response_bytes=1024,
         )
 
-    transport._opener = ErrorOpener("invalid_client")
-    with pytest.raises(GoogleOidcConfigurationError):
-        transport.exchange_code(
-            endpoint="https://oauth2.googleapis.com/token",
-            form={"client_secret": CLIENT_SECRET},
-            timeout_seconds=1,
-            max_response_bytes=1024,
-        )
+    for configuration_error in (
+        "invalid_client",
+        "unauthorized_client",
+        "unsupported_grant_type",
+        "invalid_scope",
+    ):
+        transport._opener = ErrorOpener(configuration_error)
+        with pytest.raises(GoogleOidcConfigurationError):
+            transport.exchange_code(
+                endpoint="https://oauth2.googleapis.com/token",
+                form={"client_secret": CLIENT_SECRET},
+                timeout_seconds=1,
+                max_response_bytes=1024,
+            )
 
     transport._opener = Opener(b"x" * 1025)
     with pytest.raises(GoogleOidcProviderUnavailableError) as oversized:

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -475,10 +475,11 @@ def test_callback_requires_originating_browser_cookie_without_consuming_flow(
         "__Host-thebitlab_oidc_txn=" + "x" * 43,
         service._test_transaction_cookie + "; " + service._test_transaction_cookie,
     ):
-        with pytest.raises(GoogleOidcStateError):
+        with pytest.raises(GoogleOidcStateError) as rejected:
             service.complete_callback(
                 valid_callback(state), existing_cookie_header=cookie_header
             )
+        assert rejected.value.clear_transaction_cookie is None
         assert flows.pending_count() == 1
         assert transport.calls == []
 
@@ -568,10 +569,14 @@ def test_provider_error_consumes_state_and_duplicate_or_unknown_params_fail_clos
 ) -> None:
     service, _storage, _flows, transport, _verifier = make_service(database_path, clock)
     state = begin_state(service)
-    with pytest.raises(GoogleOidcCallbackError):
+    with pytest.raises(GoogleOidcCallbackError) as cancelled:
         finish_callback(service, {"error": ["access_denied"], "state": [state]})
-    with pytest.raises(GoogleOidcStateError):
+    assert cancelled.value.clear_transaction_cookie.startswith(
+        "__Host-thebitlab_oidc_txn=;"
+    )
+    with pytest.raises(GoogleOidcStateError) as replayed:
         finish_callback(service, valid_callback(state))
+    assert replayed.value.clear_transaction_cookie is None
     assert transport.calls == []
 
     malformed = (

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -21,6 +21,7 @@ from scripts.thebitlab_google_oidc import (
     GoogleOidcIdentityRejectedError,
     GoogleOidcLoginService,
     GoogleOidcProviderUnavailableError,
+    GoogleOidcStateConflictError,
     GoogleOidcStateError,
     GoogleOidcTokenRejectedError,
     InMemoryGoogleOidcFlowStore,
@@ -259,7 +260,11 @@ def test_generator_collision_and_invalid_secret_are_sanitized(database_path, clo
 
 @pytest.mark.parametrize(
     "failure",
-    [RuntimeError("store unavailable"), GoogleOidcStateError("post-insert failure")],
+    [
+        RuntimeError("store unavailable"),
+        GoogleOidcStateError("post-insert failure"),
+        GoogleOidcStateConflictError("post-insert conflict"),
+    ],
 )
 def test_unexpected_flow_store_failure_discards_and_scrubs_credentials(
     database_path, clock, failure
@@ -268,9 +273,14 @@ def test_unexpected_flow_store_failure_discards_and_scrubs_credentials(
     real_store = InMemoryGoogleOidcFlowStore()
 
     class InsertThenFailStore:
-        def create(self, state, nonce, verifier, now, ttl):
-            real_store.create(state, nonce, verifier, now, ttl)
+        def create(self, state, nonce, verifier, creation_marker, now, ttl):
+            real_store.create(
+                state, nonce, verifier, creation_marker, now, ttl
+            )
             raise failure
+
+        def discard_created_flow(self, state, creation_marker):
+            return real_store.discard_created_flow(state, creation_marker)
 
         def discard(self, state):
             return real_store.discard(state)
@@ -431,12 +441,13 @@ def test_token_exchange_and_verification_failures_are_sanitized_and_consume_stat
         database_path.parent / "verify.sqlite3", clock, verifier=verifier
     )
     state = begin_state(service)
-    with pytest.raises(GoogleOidcProviderUnavailableError) as verify_error:
+    with pytest.raises(GoogleOidcTokenRejectedError) as verify_error:
         service.complete_callback(valid_callback(state))
     assert ID_TOKEN not in str(verify_error.value)
     assert ID_TOKEN not in traceback_function_locals(
-        verify_error.value, "complete_callback"
+        verify_error.value, "complete_callback", "verify"
     )
+    assert verify_error.value.__context__ is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -282,9 +282,6 @@ def test_unexpected_flow_store_failure_discards_and_scrubs_credentials(
         def discard_created_flow(self, state, creation_marker):
             return real_store.discard_created_flow(state, creation_marker)
 
-        def discard(self, state):
-            return real_store.discard(state)
-
     service.flows = InsertThenFailStore()
     with pytest.raises(GoogleOidcProviderUnavailableError) as captured:
         service.begin_login()
@@ -293,6 +290,25 @@ def test_unexpected_flow_store_failure_discards_and_scrubs_credentials(
     assert STATE not in retained
     assert NONCE not in retained
     assert VERIFIER not in retained
+
+
+def test_preinsert_store_failure_never_discards_existing_flow(database_path, clock) -> None:
+    service, _storage, real_store, _transport, _verifier = make_service(
+        database_path, clock
+    )
+    begin_state(service)
+
+    class FailBeforeInsertStore:
+        def create(self, *_args):
+            raise RuntimeError("pre-insert failure")
+
+        def discard_created_flow(self, state, creation_marker):
+            return real_store.discard_created_flow(state, creation_marker)
+
+    service.flows = FailBeforeInsertStore()
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        service.begin_login()
+    assert real_store.pending_count() == 1
 
 
 def test_valid_callback_onboards_pending_user_and_issues_session_cookie(

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -10,6 +10,7 @@ from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
+import scripts.thebitlab_google_oidc as google_oidc
 from scripts.thebitlab_auth_services import FederatedIdentityService, SessionService
 from scripts.thebitlab_google_oidc import (
     BoundedGoogleCertRequest,
@@ -292,6 +293,28 @@ def test_unexpected_flow_store_failure_discards_and_scrubs_credentials(
     assert VERIFIER not in retained
 
 
+def test_authorization_result_failure_discards_flow_and_scrubs_url(
+    database_path, clock, monkeypatch
+) -> None:
+    service, _storage, flows, _transport, _verifier = make_service(
+        database_path, clock
+    )
+
+    class FailingAuthorizationRequest:
+        def __init__(self, authorization_url):
+            raise RuntimeError("result unavailable")
+
+    monkeypatch.setattr(
+        google_oidc, "GoogleAuthorizationRequest", FailingAuthorizationRequest
+    )
+    with pytest.raises(GoogleOidcProviderUnavailableError) as captured:
+        service.begin_login()
+    assert flows.pending_count() == 0
+    retained = traceback_function_locals(captured.value, "begin_login", "__init__")
+    assert STATE not in retained
+    assert NONCE not in retained
+
+
 def test_preinsert_store_failure_never_discards_existing_flow(database_path, clock) -> None:
     service, _storage, real_store, _transport, _verifier = make_service(
         database_path, clock
@@ -482,6 +505,9 @@ def test_token_exchange_and_verification_failures_are_sanitized_and_consume_stat
         {"iat": int((NOW + timedelta(minutes=2)).timestamp())},
         {"iat": int((NOW - timedelta(hours=1)).timestamp())},
         {"name": ID_TOKEN},
+        {"name": f"prefix-{ID_TOKEN}-suffix"},
+        {"email": f"prefix-{ID_TOKEN}@example.test"},
+        {"sub": f"prefix-{ID_TOKEN}-suffix"},
         {"exp": float("nan")},
         {"iat": float("inf")},
     ],

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -799,7 +799,7 @@ def test_login_result_construction_failure_revokes_issued_session(
         {"email_verified": 1},
         {"sub": ""},
         {"sub": "subject\nlog"},
-        {"exp": int(NOW.timestamp())},
+        {"exp": int((NOW - timedelta(seconds=31)).timestamp())},
         {"exp": ID_TOKEN},
         {"iat": ID_TOKEN},
         {"iat": int((NOW + timedelta(minutes=2)).timestamp())},
@@ -826,6 +826,22 @@ def test_wrong_or_unverified_claims_never_create_user(database_path, clock, over
     )
     assert storage.list_users() == []
     assert storage.list_user_sessions("internal-user-01") == []
+
+
+def test_expiration_within_configured_clock_skew_is_accepted(database_path, clock) -> None:
+    verifier = FakeIdTokenVerifier(
+        claims(
+            iat=int((NOW - timedelta(minutes=1)).timestamp()),
+            exp=int((NOW - timedelta(seconds=10)).timestamp()),
+        )
+    )
+    service, _storage, _flows, _transport, _verifier = make_service(
+        database_path, clock, verifier=verifier
+    )
+    state = begin_state(service)
+
+    result = finish_callback(service, valid_callback(state))
+    assert result.user_id == "internal-user-01"
 
 
 def test_disabled_existing_google_identity_is_rejected_without_session(
@@ -1120,6 +1136,22 @@ def test_official_google_verifier_validates_rs256_signature_and_sanitizes_failur
             token, audience=CLIENT_ID
         )
     assert jwks_request.calls == 1
+
+    class MalformedCertificateRequest:
+        def __call__(self, *_args, **_kwargs):
+            response = CertResponse()
+            response.data = json.dumps(
+                {
+                    "key-1": "-----BEGIN CERTIFICATE-----\n"
+                    "garbage\n-----END CERTIFICATE-----"
+                }
+            ).encode()
+            return response
+
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        GoogleOfficialIdTokenVerifier(MalformedCertificateRequest()).verify(
+            token, audience=CLIENT_ID
+        )
 
     token_parts = token.split(".")
     token_parts[2] = ("A" if token_parts[2][0] != "A" else "B") + token_parts[2][1:]

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -1,0 +1,574 @@
+from __future__ import annotations
+
+import base64
+import json
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from scripts.thebitlab_auth_services import FederatedIdentityService, SessionService
+from scripts.thebitlab_google_oidc import (
+    GoogleAuthorizationRequest,
+    GoogleOfficialIdTokenVerifier,
+    GoogleOidcCallbackError,
+    GoogleOidcConfig,
+    GoogleOidcConfigurationError,
+    GoogleOidcIdentityRejectedError,
+    GoogleOidcLoginService,
+    GoogleOidcProviderUnavailableError,
+    GoogleOidcStateError,
+    GoogleOidcTokenRejectedError,
+    InMemoryGoogleOidcFlowStore,
+    UrllibGoogleTokenTransport,
+)
+from scripts.thebitlab_http_auth import (
+    HttpAuthenticationRequiredError,
+    HttpAuthRequest,
+    HttpSessionAuthBoundary,
+)
+from scripts.thebitlab_identity import ExternalIdentity, UserAccount
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+CLIENT_ID = "client-id-123456.apps.googleusercontent.com"
+CLIENT_SECRET = "raw-google-client-secret"
+ID_TOKEN = "google-id-token-" + "x" * 48
+CSRF_SECRET = b"c" * 32
+STATE = "s" * 43
+NONCE = "n" * 43
+VERIFIER = "v" * 64
+
+
+class MutableClock:
+    def __init__(self, value=NOW):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+
+class FakeTokenTransport:
+    def __init__(self, response=None, error=None):
+        self.response = response or {
+            "id_token": ID_TOKEN,
+            "access_token": "raw-google-access-token",
+            "refresh_token": "raw-google-refresh-token",
+        }
+        self.error = error
+        self.calls = []
+        self.lock = threading.Lock()
+
+    def exchange_code(self, **kwargs):
+        with self.lock:
+            self.calls.append(kwargs)
+        if self.error:
+            raise self.error
+        return dict(self.response)
+
+
+class FakeIdTokenVerifier:
+    def __init__(self, claims=None, error=None):
+        self.claims = claims
+        self.error = error
+        self.calls = []
+
+    def verify(self, id_token, *, audience):
+        self.calls.append((id_token, audience))
+        if self.error:
+            raise self.error
+        return dict(self.claims)
+
+
+def config(**overrides):
+    values = {
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "redirect_uri": "https://lab.example.test/auth/google/callback",
+        "post_login_path": "/dashboard",
+    }
+    values.update(overrides)
+    return GoogleOidcConfig(**values)
+
+
+def claims(**overrides):
+    values = {
+        "iss": "https://accounts.google.com",
+        "aud": CLIENT_ID,
+        "sub": "google-subject-42",
+        "email": "Mario@Example.Test",
+        "email_verified": True,
+        "name": "Mario Rossi",
+        "nonce": NONCE,
+        "iat": int(NOW.timestamp()),
+        "exp": int((NOW + timedelta(minutes=5)).timestamp()),
+    }
+    values.update(overrides)
+    return values
+
+
+@pytest.fixture
+def database_path(tmp_path):
+    return tmp_path / "identity.sqlite3"
+
+
+@pytest.fixture
+def clock():
+    return MutableClock()
+
+
+def make_service(database_path, clock, *, transport=None, verifier=None, flow_ttl=None):
+    storage = SqliteIdentityStorage(database_path)
+    identities = FederatedIdentityService(
+        storage,
+        clock=clock,
+        user_id_factory=lambda: "internal-user-01",
+    )
+    sessions = SessionService(
+        storage,
+        clock=clock,
+        token_factory=lambda: "A" * 40,
+        session_id_factory=lambda: "session-01",
+    )
+    http = HttpSessionAuthBoundary(
+        sessions,
+        csrf_secret=CSRF_SECRET,
+        clock=clock,
+    )
+    selected_config = config(**({"flow_ttl": flow_ttl} if flow_ttl else {}))
+    transport = transport or FakeTokenTransport()
+    verifier = verifier or FakeIdTokenVerifier(claims())
+    flows = InMemoryGoogleOidcFlowStore()
+    service = GoogleOidcLoginService(
+        selected_config,
+        flows,
+        transport,
+        verifier,
+        identities,
+        http,
+        clock=clock,
+        state_factory=lambda: STATE,
+        nonce_factory=lambda: NONCE,
+        verifier_factory=lambda: VERIFIER,
+    )
+    return service, storage, flows, transport, verifier
+
+
+def begin_state(service):
+    started = service.begin_login()
+    return parse_qs(urlsplit(started.authorization_url).query)["state"][0]
+
+
+def valid_callback(state=STATE):
+    return {"code": ["raw-google-authorization-code"], "state": [state]}
+
+
+def traceback_function_locals(error, *names):
+    values = []
+    traceback = error.__traceback__
+    while traceback is not None:
+        if traceback.tb_frame.f_code.co_name in names:
+            values.extend(traceback.tb_frame.f_locals.values())
+        traceback = traceback.tb_next
+    return repr(values)
+
+
+def test_config_requires_https_fixed_redirect_and_safe_post_login() -> None:
+    configured = config()
+    assert CLIENT_SECRET not in repr(configured)
+
+    for override in (
+        {"redirect_uri": "http://lab.example.test/callback"},
+        {"token_endpoint": "https://user:pass@example.test/token"},
+        {"authorization_endpoint": "https://example.test/auth#fragment"},
+        {"token_endpoint": "https://example.test/token?tenant=evil"},
+        {"client_secret": "secret\nheader"},
+        {"post_login_path": "https://evil.test/"},
+        {"post_login_path": "//evil.test/"},
+        {"flow_ttl": timedelta(0)},
+        {"clock_skew": timedelta(minutes=6)},
+    ):
+        with pytest.raises(GoogleOidcConfigurationError):
+            config(**override)
+
+
+def test_begin_login_builds_state_nonce_and_pkce_without_persisting_raw_values(
+    database_path, clock
+) -> None:
+    service, _storage, flows, _transport, _verifier = make_service(database_path, clock)
+
+    started = service.begin_login()
+
+    assert isinstance(started, GoogleAuthorizationRequest)
+    assert started.authorization_url not in repr(started)
+    parsed = urlsplit(started.authorization_url)
+    query = parse_qs(parsed.query)
+    assert parsed.scheme == "https"
+    assert query["client_id"] == [CLIENT_ID]
+    assert query["redirect_uri"] == [service.config.redirect_uri]
+    assert query["response_type"] == ["code"]
+    assert query["scope"] == ["openid email profile"]
+    assert query["state"] == [STATE]
+    assert query["nonce"] == [NONCE]
+    assert query["code_challenge_method"] == ["S256"]
+    expected_challenge = base64.urlsafe_b64encode(
+        __import__("hashlib").sha256(VERIFIER.encode()).digest()
+    ).rstrip(b"=").decode()
+    assert query["code_challenge"] == [expected_challenge]
+    assert CLIENT_SECRET not in started.authorization_url
+
+    assert flows.pending_count() == 1
+    with flows._lock:
+        pending = next(iter(flows._flows.values()))
+    assert pending.state_digest != STATE
+    assert pending.nonce_digest != NONCE
+    assert STATE not in repr(pending)
+    assert NONCE not in repr(pending)
+    assert VERIFIER not in repr(pending)
+
+
+def test_generator_collision_and_invalid_secret_are_sanitized(database_path, clock) -> None:
+    service, _storage, flows, _transport, _verifier = make_service(database_path, clock)
+    begin_state(service)
+
+    with pytest.raises(GoogleOidcConfigurationError):
+        service.begin_login()
+    assert flows.pending_count() == 1
+
+    service.state_factory = lambda: "raw invalid generated state"
+    with pytest.raises(GoogleOidcConfigurationError) as invalid:
+        service.begin_login()
+    assert "raw invalid generated state" not in traceback_function_locals(
+        invalid.value, "begin_login", "_generated_credential"
+    )
+
+
+def test_valid_callback_onboards_pending_user_and_issues_session_cookie(
+    database_path, clock
+) -> None:
+    service, storage, flows, transport, verifier = make_service(database_path, clock)
+    state = begin_state(service)
+
+    result = service.complete_callback(valid_callback(state))
+
+    assert result.user_id == "internal-user-01"
+    assert result.role == "pending"
+    assert result.redirect_path == "/dashboard"
+    assert result.session.set_cookie.startswith("__Host-thebitlab_session=")
+    assert "A" * 40 not in repr(result)
+    identity = storage.read_external_identity("google", "google-subject-42")
+    assert identity is not None
+    assert identity.email == "mario@example.test"
+    assert flows.pending_count() == 0
+    assert verifier.calls == [(ID_TOKEN, CLIENT_ID)]
+    call = transport.calls[0]
+    assert call["endpoint"] == service.config.token_endpoint
+    assert call["form"]["code"] == "raw-google-authorization-code"
+    assert call["form"]["code_verifier"] == VERIFIER
+    assert call["form"]["client_secret"] == CLIENT_SECRET
+
+    with sqlite3.connect(database_path) as connection:
+        dump = "\n".join(connection.iterdump())
+    for raw in (
+        STATE,
+        NONCE,
+        VERIFIER,
+        CLIENT_SECRET,
+        "raw-google-authorization-code",
+        ID_TOKEN,
+        "raw-google-access-token",
+        "raw-google-refresh-token",
+        "A" * 40,
+    ):
+        assert raw not in dump
+
+
+def test_callback_replay_and_concurrent_consume_have_one_winner(database_path, clock) -> None:
+    service, storage, _flows, transport, _verifier = make_service(database_path, clock)
+    state = begin_state(service)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(service.complete_callback, valid_callback(state)) for _ in range(2)]
+    outcomes = []
+    for future in futures:
+        try:
+            outcomes.append(future.result().user_id)
+        except GoogleOidcStateError:
+            outcomes.append("state-error")
+
+    assert sorted(outcomes) == ["internal-user-01", "state-error"]
+    assert len(transport.calls) == 1
+    assert len(storage.list_users()) == 1
+    with pytest.raises(GoogleOidcStateError):
+        service.complete_callback(valid_callback(state))
+
+
+def test_expired_state_is_consumed_and_cleanup_is_explicit(database_path, clock) -> None:
+    service, _storage, flows, transport, _verifier = make_service(
+        database_path, clock, flow_ttl=timedelta(seconds=1)
+    )
+    state = begin_state(service)
+    clock.value += timedelta(seconds=1)
+
+    with pytest.raises(GoogleOidcStateError):
+        service.complete_callback(valid_callback(state))
+    assert transport.calls == []
+    assert flows.pending_count() == 0
+
+    clock.value = NOW
+    begin_state(service)
+    assert flows.delete_expired(NOW + timedelta(seconds=1)) == 1
+
+
+def test_provider_error_consumes_state_and_duplicate_or_unknown_params_fail_closed(
+    database_path, clock
+) -> None:
+    service, _storage, _flows, transport, _verifier = make_service(database_path, clock)
+    state = begin_state(service)
+    with pytest.raises(GoogleOidcCallbackError):
+        service.complete_callback({"error": ["access_denied"], "state": [state]})
+    with pytest.raises(GoogleOidcStateError):
+        service.complete_callback(valid_callback(state))
+    assert transport.calls == []
+
+    malformed = (
+        {"code": ["one", "two"], "state": [STATE]},
+        {"code": ["one"], "state": [STATE, STATE]},
+        {"code": ["one"], "state": [STATE], "evil": ["value"]},
+        {"code": ["one"], "state": [STATE], "scope": ["one", "two"]},
+        {"code": ["one"], "error": ["access_denied"], "state": [STATE]},
+        {"code": ["one"]},
+        {"state": [STATE]},
+    )
+    for parameters in malformed:
+        with pytest.raises(GoogleOidcCallbackError):
+            service.complete_callback(parameters)
+
+
+def test_token_exchange_and_verification_failures_are_sanitized_and_consume_state(
+    database_path, clock
+) -> None:
+    raw_error = RuntimeError("raw-google-authorization-code raw-google-client-secret")
+    transport = FakeTokenTransport(error=raw_error)
+    service, _storage, _flows, _transport, _verifier = make_service(
+        database_path, clock, transport=transport
+    )
+    state = begin_state(service)
+    with pytest.raises(GoogleOidcProviderUnavailableError) as exchange_error:
+        service.complete_callback(valid_callback(state))
+    assert "raw-google" not in str(exchange_error.value)
+    assert "raw-google" not in traceback_function_locals(
+        exchange_error.value, "complete_callback", "_exchange"
+    )
+    with pytest.raises(GoogleOidcStateError):
+        service.complete_callback(valid_callback(state))
+
+    verifier = FakeIdTokenVerifier(claims(), error=RuntimeError(ID_TOKEN))
+    service, _storage, _flows, _transport, _verifier = make_service(
+        database_path.parent / "verify.sqlite3", clock, verifier=verifier
+    )
+    state = begin_state(service)
+    with pytest.raises(GoogleOidcProviderUnavailableError) as verify_error:
+        service.complete_callback(valid_callback(state))
+    assert ID_TOKEN not in str(verify_error.value)
+    assert ID_TOKEN not in traceback_function_locals(
+        verify_error.value, "complete_callback"
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"iss": "https://evil.test"},
+        {"aud": "other-client"},
+        {"aud": [CLIENT_ID, "other"], "azp": "other"},
+        {"aud": CLIENT_ID, "azp": "other"},
+        {"nonce": "wrong-nonce"},
+        {"email_verified": False},
+        {"email_verified": 1},
+        {"sub": ""},
+        {"sub": "subject\nlog"},
+        {"exp": int(NOW.timestamp())},
+        {"iat": int((NOW + timedelta(minutes=2)).timestamp())},
+        {"iat": int((NOW - timedelta(hours=1)).timestamp())},
+        {"name": ID_TOKEN},
+        {"exp": float("nan")},
+        {"iat": float("inf")},
+    ],
+)
+def test_wrong_or_unverified_claims_never_create_user(database_path, clock, overrides) -> None:
+    verifier = FakeIdTokenVerifier(claims(**overrides))
+    service, storage, _flows, _transport, _verifier = make_service(
+        database_path, clock, verifier=verifier
+    )
+    state = begin_state(service)
+
+    with pytest.raises(GoogleOidcTokenRejectedError):
+        service.complete_callback(valid_callback(state))
+    assert storage.list_users() == []
+    assert storage.list_user_sessions("internal-user-01") == []
+
+
+def test_disabled_existing_google_identity_is_rejected_without_session(
+    database_path, clock
+) -> None:
+    service, storage, _flows, _transport, _verifier = make_service(database_path, clock)
+    disabled = UserAccount(
+        "disabled-user",
+        "Mario Rossi",
+        "student",
+        False,
+        NOW,
+        NOW,
+        "mario@example.test",
+    )
+    storage.create_user(disabled)
+    storage.link_external_identity(
+        ExternalIdentity(
+            disabled.user_id,
+            "google",
+            "google-subject-42",
+            NOW,
+            email="mario@example.test",
+        )
+    )
+    state = begin_state(service)
+
+    with pytest.raises(GoogleOidcIdentityRejectedError):
+        service.complete_callback(valid_callback(state))
+    assert storage.list_user_sessions(disabled.user_id) == []
+
+
+def test_existing_google_identity_reuses_internal_user(database_path, clock) -> None:
+    service, storage, _flows, _transport, _verifier = make_service(database_path, clock)
+    first_state = begin_state(service)
+    first = service.complete_callback(valid_callback(first_state))
+
+    service.http_sessions.sessions.token_factory = lambda: "B" * 40
+    service.http_sessions.sessions.session_id_factory = lambda: "session-02"
+    second_state = begin_state(service)
+    first_cookie = first.session.set_cookie.split(";", 1)[0]
+    second = service.complete_callback(
+        valid_callback(second_state), existing_cookie_header=first_cookie
+    )
+
+    assert second.user_id == first.user_id
+    assert len(storage.list_users()) == 1
+    assert len(storage.list_external_identities(first.user_id)) == 1
+    with pytest.raises(HttpAuthenticationRequiredError):
+        service.http_sessions.authenticate(HttpAuthRequest("GET", first_cookie))
+
+
+def test_urllib_transport_rejects_duplicate_json_and_bounds_response() -> None:
+    class Response:
+        status = 200
+
+        def __init__(self, body):
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, limit):
+            return self.body[:limit]
+
+    class Opener:
+        def __init__(self, body):
+            self.body = body
+            self.requests = []
+
+        def open(self, request, timeout):
+            self.requests.append((request, timeout))
+            return Response(self.body)
+
+    transport = UrllibGoogleTokenTransport()
+    opener = Opener(b'{"id_token":"one","id_token":"two"}')
+    transport._opener = opener
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        transport.exchange_code(
+            endpoint="https://oauth2.googleapis.com/token",
+            form={"code": "raw-code", "client_secret": CLIENT_SECRET},
+            timeout_seconds=1,
+            max_response_bytes=1024,
+        )
+
+    transport._opener = Opener(b"x" * 1025)
+    with pytest.raises(GoogleOidcProviderUnavailableError) as oversized:
+        transport.exchange_code(
+            endpoint="https://oauth2.googleapis.com/token",
+            form={"code": "raw-code", "client_secret": CLIENT_SECRET},
+            timeout_seconds=1,
+            max_response_bytes=1024,
+        )
+    assert "raw-code" not in traceback_function_locals(
+        oversized.value, "exchange_code"
+    )
+    assert CLIENT_SECRET not in traceback_function_locals(
+        oversized.value, "exchange_code"
+    )
+
+
+def test_official_google_verifier_validates_rs256_signature_and_sanitizes_failure() -> None:
+    cryptography = pytest.importorskip("cryptography")
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    certificate_name = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, "accounts.google.com")]
+    )
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(certificate_name)
+        .issuer_name(certificate_name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(minutes=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    public_pem = certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def encode(value):
+        return base64.urlsafe_b64encode(json.dumps(value, separators=(",", ":")).encode()).rstrip(b"=").decode()
+
+    header = encode({"alg": "RS256", "kid": "key-1", "typ": "JWT"})
+    payload = encode(
+        {
+            "iss": "accounts.google.com",
+            "aud": CLIENT_ID,
+            "sub": "subject",
+            "iat": int(datetime.now(timezone.utc).timestamp()),
+            "exp": int((datetime.now(timezone.utc) + timedelta(minutes=5)).timestamp()),
+        }
+    )
+    signing_input = f"{header}.{payload}".encode()
+    signature = key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+    token = f"{header}.{payload}." + base64.urlsafe_b64encode(signature).rstrip(b"=").decode()
+
+    class CertResponse:
+        status = 200
+        data = json.dumps({"key-1": public_pem}).encode()
+
+    class CertRequest:
+        def __call__(self, *_args, **_kwargs):
+            return CertResponse()
+
+    verifier = GoogleOfficialIdTokenVerifier(CertRequest())
+    verified = verifier.verify(token, audience=CLIENT_ID)
+    assert verified["sub"] == "subject"
+
+    token_parts = token.split(".")
+    token_parts[2] = ("A" if token_parts[2][0] != "A" else "B") + token_parts[2][1:]
+    tampered = ".".join(token_parts)
+    with pytest.raises(GoogleOidcTokenRejectedError) as rejected:
+        verifier.verify(tampered, audience=CLIENT_ID)
+    assert tampered not in traceback_function_locals(rejected.value, "verify")

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -188,6 +188,8 @@ def test_config_requires_https_fixed_redirect_and_safe_post_login() -> None:
         {"redirect_uri": "http://lab.example.test/callback"},
         {"token_endpoint": "https://user:pass@example.test/token"},
         {"authorization_endpoint": "https://example.test/auth#fragment"},
+        {"token_endpoint": "https://example.test/collect"},
+        {"authorization_endpoint": "https://example.test/auth"},
         {"token_endpoint": "https://example.test/token?tenant=evil"},
         {"client_secret": "secret\nheader"},
         {"post_login_path": "https://evil.test/"},

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -194,6 +194,8 @@ def test_config_requires_https_fixed_redirect_and_safe_post_login() -> None:
         {"redirect_uri": "https://lab.example.test:0/callback"},
         {"redirect_uri": "https://lab.example.test/callback\n"},
         {"redirect_uri": "https://lab.example.test/\x00callback"},
+        {"redirect_uri": r"https://lab.example.test\evil/callback"},
+        {"redirect_uri": "https://lab.example.test/%ZZ/callback"},
         {"token_endpoint": "https://user:pass@example.test/token"},
         {"authorization_endpoint": "https://example.test/auth#fragment"},
         {"token_endpoint": "https://example.test/collect"},
@@ -574,6 +576,33 @@ def test_identity_collaborator_error_is_normalized(database_path, clock) -> None
         captured.value, "complete_callback", "resolve"
     )
     assert captured.value.__context__ is None
+
+
+def test_disable_race_before_session_is_identity_rejection(database_path, clock) -> None:
+    service, storage, _flows, _transport, _verifier = make_service(
+        database_path, clock
+    )
+    identities = service.identities
+
+    class DisableAfterResolve:
+        def resolve(self, assertion):
+            user = identities.resolve(assertion)
+            storage.save_user(
+                replace(
+                    user,
+                    active=False,
+                    updated_at=user.updated_at + timedelta(microseconds=1),
+                ),
+                expected_updated_at=user.updated_at,
+            )
+            return user
+
+    service.identities = DisableAfterResolve()
+    state = begin_state(service)
+    with pytest.raises(GoogleOidcIdentityRejectedError):
+        service.complete_callback(valid_callback(state))
+    sessions = storage.list_user_sessions("internal-user-01")
+    assert sessions == []
 
 
 def test_login_result_uses_current_session_role(database_path, clock) -> None:

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -546,15 +546,22 @@ def test_login_result_construction_failure_revokes_issued_session(
     "overrides",
     [
         {"iss": "https://evil.test"},
+        {"iss": ID_TOKEN},
         {"aud": "other-client"},
+        {"aud": ID_TOKEN},
+        {"aud": [CLIENT_ID, ID_TOKEN], "azp": CLIENT_ID},
         {"aud": [CLIENT_ID, "other"], "azp": "other"},
         {"aud": CLIENT_ID, "azp": "other"},
+        {"azp": ID_TOKEN},
         {"nonce": "wrong-nonce"},
         {"email_verified": False},
+        {"email_verified": ID_TOKEN},
         {"email_verified": 1},
         {"sub": ""},
         {"sub": "subject\nlog"},
         {"exp": int(NOW.timestamp())},
+        {"exp": ID_TOKEN},
+        {"iat": ID_TOKEN},
         {"iat": int((NOW + timedelta(minutes=2)).timestamp())},
         {"iat": int((NOW - timedelta(hours=1)).timestamp())},
         {"name": ID_TOKEN},
@@ -572,8 +579,11 @@ def test_wrong_or_unverified_claims_never_create_user(database_path, clock, over
     )
     state = begin_state(service)
 
-    with pytest.raises(GoogleOidcTokenRejectedError):
+    with pytest.raises(GoogleOidcTokenRejectedError) as captured:
         service.complete_callback(valid_callback(state))
+    assert ID_TOKEN not in traceback_function_locals(
+        captured.value, "_assertion_from_claims"
+    )
     assert storage.list_users() == []
     assert storage.list_user_sessions("internal-user-01") == []
 

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -195,6 +195,16 @@ def test_config_requires_https_fixed_redirect_and_safe_post_login() -> None:
         with pytest.raises(GoogleOidcConfigurationError):
             config(**override)
 
+    with pytest.raises(GoogleOidcConfigurationError) as invalid_secret:
+        GoogleOidcConfig(
+            client_id=CLIENT_ID,
+            client_secret="TOP_SECRET_CONFIG\n",
+            redirect_uri="https://lab.example.test/callback",
+        )
+    assert "TOP_SECRET_CONFIG" not in traceback_function_locals(
+        invalid_secret.value, "__init__", "_validate"
+    )
+
 
 def test_begin_login_builds_state_nonce_and_pkce_without_persisting_raw_values(
     database_path, clock
@@ -245,6 +255,30 @@ def test_generator_collision_and_invalid_secret_are_sanitized(database_path, clo
     assert "raw invalid generated state" not in traceback_function_locals(
         invalid.value, "begin_login", "_generated_credential"
     )
+
+
+def test_unexpected_flow_store_failure_discards_and_scrubs_credentials(
+    database_path, clock
+) -> None:
+    service, _storage, _flows, _transport, _verifier = make_service(database_path, clock)
+    real_store = InMemoryGoogleOidcFlowStore()
+
+    class InsertThenFailStore:
+        def create(self, state, nonce, verifier, now, ttl):
+            real_store.create(state, nonce, verifier, now, ttl)
+            raise RuntimeError("store unavailable")
+
+        def discard(self, state):
+            return real_store.discard(state)
+
+    service.flows = InsertThenFailStore()
+    with pytest.raises(GoogleOidcProviderUnavailableError) as captured:
+        service.begin_login()
+    assert real_store.pending_count() == 0
+    retained = traceback_function_locals(captured.value, "begin_login")
+    assert STATE not in retained
+    assert NONCE not in retained
+    assert VERIFIER not in retained
 
 
 def test_valid_callback_onboards_pending_user_and_issues_session_cookie(

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -301,6 +301,33 @@ def test_begin_login_clock_failure_is_sanitized(database_path, clock) -> None:
     assert flows.pending_count() == 0
 
 
+def test_claim_validation_clock_failure_is_unavailable_and_sanitized(
+    database_path, clock
+) -> None:
+    service, _storage, _flows, _transport, _verifier = make_service(
+        database_path, clock
+    )
+    calls = 0
+
+    def failing_third_clock():
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise RuntimeError("RAW_CLOCK_BACKEND_SECRET")
+        return NOW
+
+    service.clock = failing_third_clock
+    state = begin_state(service)
+    with pytest.raises(GoogleOidcProviderUnavailableError) as captured:
+        finish_callback(service, valid_callback(state))
+    assert captured.value.clear_transaction_cookie is not None
+    assert "RAW_CLOCK_BACKEND_SECRET" not in str(captured.value)
+    assert "RAW_CLOCK_BACKEND_SECRET" not in traceback_function_locals(
+        captured.value, "complete_callback", "_assertion_from_claims"
+    )
+    assert captured.value.__context__ is None
+
+
 def test_generator_collision_and_invalid_secret_are_sanitized(database_path, clock) -> None:
     service, _storage, flows, _transport, _verifier = make_service(database_path, clock)
     begin_state(service)

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -415,6 +415,23 @@ def test_flow_creation_auto_cleans_expired_records_and_store_is_bounded(
         service.begin_login()
     assert bounded.pending_count() == 1
 
+    raw_state = "raw-direct-state"
+    raw_nonce = "raw-direct-nonce"
+    raw_verifier = "raw-direct-pkce-verifier"
+    with pytest.raises(GoogleOidcStateConflictError) as captured:
+        bounded.create(
+            raw_state,
+            raw_nonce,
+            raw_verifier,
+            object(),
+            clock.value,
+            timedelta(minutes=1),
+        )
+    retained = traceback_function_locals(captured.value, "create")
+    assert raw_state not in retained
+    assert raw_nonce not in retained
+    assert raw_verifier not in retained
+
 
 def test_expired_state_is_consumed_and_cleanup_is_explicit(database_path, clock) -> None:
     service, _storage, flows, transport, _verifier = make_service(

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -5,6 +5,7 @@ import json
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlsplit
 
@@ -487,6 +488,58 @@ def test_token_exchange_and_verification_failures_are_sanitized_and_consume_stat
         verify_error.value, "complete_callback", "verify"
     )
     assert verify_error.value.__context__ is None
+
+
+def test_login_result_uses_current_session_role(database_path, clock) -> None:
+    service, storage, _flows, _transport, _verifier = make_service(
+        database_path, clock
+    )
+    boundary = service.http_sessions
+
+    class PromoteBeforeSession:
+        def establish_session(self, user_id, **kwargs):
+            current = storage.read_user(user_id)
+            storage.save_user(
+                replace(
+                    current,
+                    role="teacher",
+                    updated_at=current.updated_at + timedelta(microseconds=1),
+                ),
+                expected_updated_at=current.updated_at,
+            )
+            return boundary.establish_session(user_id, **kwargs)
+
+        def discard_established_session(self, established):
+            return boundary.discard_established_session(established)
+
+    service.http_sessions = PromoteBeforeSession()
+    state = begin_state(service)
+    result = service.complete_callback(valid_callback(state))
+
+    assert result.role == "teacher"
+    assert result.user_id == result.session.context.user.user_id
+    assert result.role == result.session.context.user.role
+
+
+def test_login_result_construction_failure_revokes_issued_session(
+    database_path, clock, monkeypatch
+) -> None:
+    service, storage, _flows, _transport, _verifier = make_service(
+        database_path, clock
+    )
+    state = begin_state(service)
+
+    class FailingLoginResult:
+        def __init__(self, **_kwargs):
+            raise RuntimeError("result unavailable")
+
+    monkeypatch.setattr(google_oidc, "GoogleOidcLoginResult", FailingLoginResult)
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        service.complete_callback(valid_callback(state))
+
+    sessions = storage.list_user_sessions("internal-user-01")
+    assert len(sessions) == 1
+    assert sessions[0].revoked_at is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -904,6 +904,24 @@ def test_urllib_transport_rejects_duplicate_json_and_bounds_response() -> None:
             timeout_seconds=1,
             max_response_bytes=1024,
         )
+    transport._opener = ErrorOpener("temporarily_unavailable")
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        transport.exchange_code(
+            endpoint="https://oauth2.googleapis.com/token",
+            form={"code": "retry-later"},
+            timeout_seconds=1,
+            max_response_bytes=1024,
+        )
+
+    transport._opener = ErrorOpener("unknown_provider_error")
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        transport.exchange_code(
+            endpoint="https://oauth2.googleapis.com/token",
+            form={"code": "unknown"},
+            timeout_seconds=1,
+            max_response_bytes=1024,
+        )
+
     transport._opener = ErrorOpener("invalid_grant", b" " * 1024)
     with pytest.raises(GoogleOidcProviderUnavailableError):
         transport.exchange_code(
@@ -975,7 +993,16 @@ def test_bounded_cert_request_restricts_endpoint_timeout_redirect_and_size() -> 
             self.timeout = timeout
             return Response(self.body)
 
-    request = BoundedGoogleCertRequest(timeout_seconds=1.5, max_response_bytes=1024)
+    for invalid_kwargs in (
+        {"timeout_seconds": 0},
+        {"timeout_seconds": float("nan")},
+        {"max_response_bytes": -1},
+        {"max_response_bytes": 4095},
+    ):
+        with pytest.raises(GoogleOidcConfigurationError):
+            BoundedGoogleCertRequest(**invalid_kwargs)
+
+    request = BoundedGoogleCertRequest(timeout_seconds=1.5, max_response_bytes=4096)
     opener = Opener(b"{}")
     request._opener = opener
     response = request("https://www.googleapis.com/oauth2/v1/certs")
@@ -983,7 +1010,7 @@ def test_bounded_cert_request_restricts_endpoint_timeout_redirect_and_size() -> 
     assert response.data == b"{}"
     assert opener.timeout == 1.5
 
-    request._opener = Opener(b"x" * 1025)
+    request._opener = Opener(b"x" * 4097)
     with pytest.raises(GoogleOidcProviderUnavailableError):
         request("https://www.googleapis.com/oauth2/v1/certs")
     with pytest.raises(GoogleOidcProviderUnavailableError):

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -887,11 +887,12 @@ def test_urllib_transport_rejects_duplicate_json_and_bounds_response() -> None:
         )
 
     class ErrorOpener:
-        def __init__(self, oauth_error):
+        def __init__(self, oauth_error, suffix=b""):
             self.oauth_error = oauth_error
+            self.suffix = suffix
 
         def open(self, request, timeout):
-            body = json.dumps({"error": self.oauth_error}).encode()
+            body = json.dumps({"error": self.oauth_error}).encode() + self.suffix
             raise HTTPError(request.full_url, 400, "bad request", {}, io.BytesIO(body))
 
     transport._opener = ErrorOpener("invalid_grant")
@@ -902,6 +903,15 @@ def test_urllib_transport_rejects_duplicate_json_and_bounds_response() -> None:
             timeout_seconds=1,
             max_response_bytes=1024,
         )
+    transport._opener = ErrorOpener("invalid_grant", b" " * 1024)
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        transport.exchange_code(
+            endpoint="https://oauth2.googleapis.com/token",
+            form={"code": "expired-code"},
+            timeout_seconds=1,
+            max_response_bytes=1024,
+        )
+
     transport._opener = ErrorOpener("invalid_client")
     with pytest.raises(GoogleOidcConfigurationError):
         transport.exchange_code(

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -12,6 +12,7 @@ import pytest
 
 from scripts.thebitlab_auth_services import FederatedIdentityService, SessionService
 from scripts.thebitlab_google_oidc import (
+    BoundedGoogleCertRequest,
     GoogleAuthorizationRequest,
     GoogleOfficialIdTokenVerifier,
     GoogleOidcCallbackError,
@@ -306,6 +307,27 @@ def test_callback_replay_and_concurrent_consume_have_one_winner(database_path, c
         service.complete_callback(valid_callback(state))
 
 
+def test_flow_creation_auto_cleans_expired_records_and_store_is_bounded(
+    database_path, clock
+) -> None:
+    service, _storage, flows, _transport, _verifier = make_service(
+        database_path, clock, flow_ttl=timedelta(seconds=1)
+    )
+    begin_state(service)
+    clock.value += timedelta(seconds=1)
+    begin_state(service)
+    assert flows.pending_count() == 1
+
+    bounded = InMemoryGoogleOidcFlowStore(max_pending_flows=1)
+    service.flows = bounded
+    service.state_factory = lambda: "a" * 43
+    begin_state(service)
+    service.state_factory = lambda: "b" * 43
+    with pytest.raises(GoogleOidcConfigurationError):
+        service.begin_login()
+    assert bounded.pending_count() == 1
+
+
 def test_expired_state_is_consumed_and_cleanup_is_explicit(database_path, clock) -> None:
     service, _storage, flows, transport, _verifier = make_service(
         database_path, clock, flow_ttl=timedelta(seconds=1)
@@ -512,6 +534,59 @@ def test_urllib_transport_rejects_duplicate_json_and_bounds_response() -> None:
     assert CLIENT_SECRET not in traceback_function_locals(
         oversized.value, "exchange_code"
     )
+
+
+def test_bounded_cert_request_restricts_endpoint_timeout_redirect_and_size() -> None:
+    class Headers:
+        def items(self):
+            return [("Content-Type", "application/json")]
+
+    class Response:
+        status = 200
+        headers = Headers()
+
+        def __init__(self, body):
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, limit):
+            return self.body[:limit]
+
+    class Opener:
+        def __init__(self, body):
+            self.body = body
+            self.timeout = None
+
+        def open(self, _request, timeout):
+            self.timeout = timeout
+            return Response(self.body)
+
+    request = BoundedGoogleCertRequest(timeout_seconds=1.5, max_response_bytes=1024)
+    opener = Opener(b"{}")
+    request._opener = opener
+    response = request("https://www.googleapis.com/oauth2/v1/certs")
+    assert response.status == 200
+    assert response.data == b"{}"
+    assert opener.timeout == 1.5
+
+    request._opener = Opener(b"x" * 1025)
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        request("https://www.googleapis.com/oauth2/v1/certs")
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        request("https://evil.test/certs")
+    with pytest.raises(GoogleOidcProviderUnavailableError):
+        request("https://www.googleapis.com/oauth2/v1/certs", method="POST")
+
+    production = GoogleOfficialIdTokenVerifier.from_config(
+        config(timeout_seconds=2, max_cert_response_bytes=4096)
+    )
+    assert production._request_adapter.timeout_seconds == 2
+    assert production._request_adapter.max_response_bytes == 4096
 
 
 def test_official_google_verifier_validates_rs256_signature_and_sanitizes_failure() -> None:

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -13,7 +13,7 @@ import pytest
 
 import scripts.thebitlab_google_oidc as google_oidc
 from scripts.thebitlab_auth_services import (
-    AuthApplicationError,
+    ConcurrentStateChangeError,
     FederatedIdentityService,
     SessionService,
 )
@@ -191,6 +191,9 @@ def test_config_requires_https_fixed_redirect_and_safe_post_login() -> None:
     for override in (
         {"redirect_uri": "http://lab.example.test/callback"},
         {"redirect_uri": "https://lab.example.test:bad/callback"},
+        {"redirect_uri": "https://lab.example.test:0/callback"},
+        {"redirect_uri": "https://lab.example.test/callback\n"},
+        {"redirect_uri": "https://lab.example.test/\x00callback"},
         {"token_endpoint": "https://user:pass@example.test/token"},
         {"authorization_endpoint": "https://example.test/auth#fragment"},
         {"token_endpoint": "https://example.test/collect"},
@@ -561,10 +564,10 @@ def test_identity_collaborator_error_is_normalized(database_path, clock) -> None
 
     class RawIdentityService:
         def resolve(self, _assertion):
-            raise AuthApplicationError("RAW_IDENTITY_DB_PASSWORD")
+            raise ConcurrentStateChangeError("RAW_IDENTITY_DB_PASSWORD")
 
     service.identities = RawIdentityService()
-    with pytest.raises(GoogleOidcIdentityRejectedError) as captured:
+    with pytest.raises(GoogleOidcProviderUnavailableError) as captured:
         service.complete_callback(valid_callback(state))
     assert "RAW_IDENTITY_DB_PASSWORD" not in str(captured.value)
     assert "RAW_IDENTITY_DB_PASSWORD" not in traceback_function_locals(

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -244,6 +244,25 @@ def test_begin_login_builds_state_nonce_and_pkce_without_persisting_raw_values(
     assert VERIFIER not in repr(pending)
 
 
+def test_begin_login_clock_failure_is_sanitized(database_path, clock) -> None:
+    service, _storage, flows, _transport, _verifier = make_service(
+        database_path, clock
+    )
+
+    def failing_clock():
+        raise RuntimeError("RAW_BACKEND_SECRET")
+
+    service.clock = failing_clock
+    with pytest.raises(GoogleOidcProviderUnavailableError) as captured:
+        service.begin_login()
+    assert "RAW_BACKEND_SECRET" not in str(captured.value)
+    assert "RAW_BACKEND_SECRET" not in traceback_function_locals(
+        captured.value, "begin_login", "failing_clock"
+    )
+    assert captured.value.__context__ is None
+    assert flows.pending_count() == 0
+
+
 def test_generator_collision_and_invalid_secret_are_sanitized(database_path, clock) -> None:
     service, _storage, flows, _transport, _verifier = make_service(database_path, clock)
     begin_state(service)
@@ -819,7 +838,7 @@ def test_official_google_verifier_validates_rs256_signature_and_sanitizes_failur
         def __call__(self, *_args, **_kwargs):
             self.calls += 1
             response = CertResponse()
-            response.data = json.dumps({"keys": []}).encode()
+            response.data = json.dumps({"keys": public_pem}).encode()
             return response
 
     jwks_request = JwksRequest()

--- a/tests/test_thebitlab_http_auth.py
+++ b/tests/test_thebitlab_http_auth.py
@@ -14,6 +14,7 @@ from scripts.thebitlab_auth_services import (
     session_token_digest,
 )
 from scripts.thebitlab_http_auth import (
+    EstablishedHttpSession,
     HttpAuthRequest,
     HttpAuthenticationRequiredError,
     HttpAuthorizationDeniedError,
@@ -687,6 +688,24 @@ def test_expiry_disable_and_role_change_are_fail_closed_or_refreshed(storage, cl
         replace(disabled, active=True, updated_at=NOW + timedelta(minutes=4)),
         expected_updated_at=disabled.updated_at,
     )
+    with pytest.raises(HttpAuthenticationRequiredError):
+        boundary.authenticate(request("GET", established))
+
+
+def test_discard_established_session_revokes_only_correlated_session(storage, clock) -> None:
+    storage.create_user(account())
+    boundary = make_boundary(storage, clock)
+    established = boundary.establish_session("user-01")
+
+    malformed = EstablishedHttpSession(
+        established.context,
+        "__Host-thebitlab_session=" + "Z" * 40 + "; Path=/; Secure",
+    )
+    assert boundary.discard_established_session(malformed) is False
+    assert boundary.authenticate(request("GET", established)).user.user_id == "user-01"
+
+    assert boundary.discard_established_session(established) is True
+    assert boundary.discard_established_session(established) is False
     with pytest.raises(HttpAuthenticationRequiredError):
         boundary.authenticate(request("GET", established))
 


### PR DESCRIPTION
## Sintesi
- aggiunge Authorization Code Flow Google con state, nonce, PKCE S256 e binding one-time al browser
- usa cookie transazionali `__Host-`, Secure, HttpOnly e SameSite=Lax distinti per flow/multi-tab
- introduce store flow in-memory bounded, thread-safe, one-time e fail-closed
- scambia il code tramite transport HTTPS bounded senza redirect
- verifica ID token con `google-auth`, certificati X.509 prevalidati e claim fail-closed
- risolve/onboarda utenti e ruota/emette sessioni HTTP usando il ruolo corrente

## Sicurezza
- state, nonce e browser binding conservati solo come digest; PKCE verifier raw solo in memoria
- callback vincolato al browser originario, replay e race con un solo vincitore
- endpoint OAuth Google canonici; nessun fallback JWKS/PyJWKClient non bounded
- code, token e client secret esclusi da persistenza, messaggi, repr e locals raw
- cleanup condizionale dei flow e revoca best-effort delle sessioni non consegnate
- taxonomy distinta per configuration, rejection, identity denial e provider unavailable
- rate limiting della futura route pubblica tracciato separatamente in #549

## Verifica
- 54 test Google OIDC dedicati e 75 OIDC/HTTP mirati verdi
- suite completa: 1267 passed, 37 skipped
- matrice CI Python 3.10–3.13, Windows/Linux e Docker verde
- due review indipendenti consecutive senza finding allo SHA `18cf8db`

Closes #545