### PR TITLE
build reproducible low-memory classroom environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 *~
 .vagrant
 .vagrant-vmware/
+packer/acceptance/.vagrant-*/
+packer/output/
+packer/packer_cache/
+packer/*.box
 *.log
 __pycache__/
 *.py[cod]

--- a/doc/architecture/classroom-environments.md
+++ b/doc/architecture/classroom-environments.md
@@ -1,0 +1,103 @@
+# Ambienti didattici riproducibili
+
+## Obiettivo
+
+Fornire agli studenti un solo percorso supportato per sistema operativo:
+
+| Host | Architettura guest | Provider | Artefatto |
+| --- | --- | --- | --- |
+| Windows 10/11 | amd64 | VirtualBox | box Vagrant Packer |
+| macOS Apple Silicon | arm64 | VMware Fusion | box Vagrant Packer |
+
+VirtualBox su macOS resta un fallback per il docente. L'ambiente Docker
+interattivo sarà una milestone separata e non sostituirà il runner di grading.
+
+## Prima iterazione
+
+La prima iterazione usa come input la box multiarch `bento/ubuntu-24.04`.
+Questo mantiene i Guest Tools specifici del provider già collaudati e permette
+di concentrarsi su desktop minimale, toolchain, consumi e test. La versione
+della box sorgente è fissata.
+
+Packer esegue lo stesso provisioning sui due provider e produce artefatti
+distinti:
+
+- `2cornot2c-ubuntu-24.04-virtualbox-amd64.box`;
+- `2cornot2c-ubuntu-24.04-vmware-arm64.box`.
+
+Una futura iterazione potrà sostituire Bento con installazioni da ISO Ubuntu
+senza cambiare gli script di provisioning o i criteri di accettazione.
+
+## Contenuto della box
+
+- Ubuntu 24.04;
+- Xorg, LightDM e componenti XFCE selezionati senza il metapacchetto completo;
+- login automatico dell'utente `vagrant`;
+- GCC, GDB, Make, Git e Vim;
+- VirtualBox Guest Additions oppure `open-vm-tools-desktop`;
+- zram configurata;
+- script di selezione della risoluzione VMware;
+- health check locale.
+
+## Responsabilità residue di Vagrant
+
+Il Vagrantfile del corso continua a gestire:
+
+- CPU e memoria della VM;
+- cartelle condivise `lab` e `lab2`;
+- clipboard e drag-and-drop;
+- piccole correzioni compatibili con box già distribuite;
+- health check dopo l'avvio.
+
+Le installazioni costose e stabili devono invece passare progressivamente dal
+provisioning Vagrant alla box Packer.
+
+## Criteri di accettazione
+
+Una box può essere pubblicata solo se:
+
+1. il login grafico automatico arriva a una sessione utilizzabile;
+2. GCC, GDB, Make, Git e Vim sono disponibili;
+3. i Guest Tools del provider sono attivi;
+4. `lab` e `lab2` possono essere montate da Vagrant;
+5. tutti i laboratori C compilabili superano il controllo previsto dal repo;
+6. la VM funziona con 2048 MB di RAM e due CPU;
+7. il consumo a riposo viene registrato dopo almeno 60 secondi dal login;
+8. la box e il suo checksum SHA-256 vengono pubblicati insieme;
+9. la versione Ubuntu, della box sorgente e della toolchain sono tracciate.
+
+Il target sperimentale è 1536 MB; non è un requisito di pubblicazione finché
+desktop, compilazione e GDB non risultano stabili.
+
+### Prima misura VMware arm64
+
+La box costruita localmente il 27 luglio 2026 ha superato l'avvio con sessione
+XFCE e cartelle condivise sia a 2048 MB sia a 1536 MB:
+
+| RAM assegnata | RAM usata dopo l'avvio | RAM disponibile | zram usata |
+| ---: | ---: | ---: | ---: |
+| 2048 MB | 386 MB | 1569 MB | 0 MB |
+| 1536 MB | 408 MB | 1045 MB | 0 MB |
+
+Le misure sono indicative e precedono il carico dei laboratori. Il profilo
+1536 MB resta sperimentale finché compilazione, GDB e sessioni prolungate non
+superano gli stessi acceptance test del profilo da 2048 MB.
+
+## Vincoli di build
+
+- VMware arm64 viene costruita e testata su un Mac Apple Silicon.
+- VirtualBox amd64 deve essere costruita su Windows o Linux amd64 con
+  virtualizzazione hardware disponibile.
+- I normali runner GitHub hosted non sono considerati idonei alle build
+  annidate; servirà un runner self-hosted oppure una macchina di build.
+- I file in `packer/output` sono artefatti locali e non entrano in Git.
+
+## Versionamento
+
+Le box seguono SemVer. Un cambio di Ubuntu o incompatibile incrementa la
+versione major; nuovi strumenti incrementano la minor; correzioni a
+configurazione e provisioning incrementano la patch.
+
+Il Vagrantfile degli studenti deve fissare una versione approvata. Una nuova
+box non modifica automaticamente VM già create: l'installer dovrà proporre
+backup delle cartelle condivise e ricreazione controllata.

--- a/doc/architecture/student-docker-environment.md
+++ b/doc/architecture/student-docker-environment.md
@@ -1,0 +1,41 @@
+# Ambiente Docker leggero per gli studenti
+
+## Prima iterazione
+
+La prima soluzione Docker non introduce subito una seconda immagine. Avvia una
+shell usando l'esatto riferimento immutabile del runner di grading:
+
+```bash
+python -m scripts.student_docker_shell --workspace lab
+```
+
+Questo garantisce subito le stesse versioni di GCC, Python, Node.js e SQLite
+usate per correggere gli esercizi. Il workspace scelto è l'unica directory
+scrivibile persistente.
+
+Il container:
+
+- usa 512 MB di RAM e una CPU;
+- gira come utente non root;
+- non ha rete;
+- elimina tutte le capability Linux;
+- usa root filesystem in sola lettura;
+- limita processi e privilegi;
+- viene eliminato all'uscita.
+
+È possibile vedere il comando senza eseguirlo:
+
+```bash
+python -m scripts.student_docker_shell --workspace lab --print-command
+```
+
+## Limiti intenzionali
+
+Il runner corrente è pubblicato soltanto per `linux/amd64`. Su Windows amd64
+Docker lo esegue nativamente; su Apple Silicon richiede emulazione e non è
+ancora il percorso raccomandato per poca RAM.
+
+La shell contiene la toolchain del grading ma non ancora editor, Make e GDB.
+La seconda iterazione produrrà un'immagine `student-dev` multiarch derivata
+dallo stesso manifest riproducibile, aggiungendo soltanto gli strumenti
+interattivi. Il runner autorevole resterà separato e più piccolo.

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,33 @@
+# Installer guidato
+
+Il codice in questa directory prepara il percorso unico per installare
+l'ambiente didattico:
+
+- macOS Apple Silicon: VMware Fusion raccomandato, VirtualBox opzionale;
+- Windows amd64: VirtualBox;
+- modalità Docker: verrà proposta separatamente dopo la diagnosi della RAM.
+
+La logica di rilevamento, i controlli e i piani non dipendono dalla UI.
+`utui` si occupa esclusivamente di rendering e input da terminale.
+
+## Stato attuale
+
+La prima fetta implementa rilevamento, scelta provider e diagnosi read-only:
+
+```bash
+python -m installer.main
+python -m installer.main --provider virtualbox
+```
+
+L'interfaccia usa la revisione uTUI fissata in `installer/plans.py`. In un
+ambiente di sviluppo:
+
+```bash
+python -m pip install \
+  "git+https://github.com/TheBitPoets/utui.git@c38ec96c865f9ee4d2f20abaf63482d7930050fa"
+python -m installer.tui
+```
+
+La modalità di installazione con effetti sul sistema non è ancora esposta:
+verrà aggiunta soltanto insieme a conferma, ripresa dopo errore, log e
+diagnostica finale.

--- a/installer/README.md
+++ b/installer/README.md
@@ -19,12 +19,11 @@ python -m installer.main
 python -m installer.main --provider virtualbox
 ```
 
-L'interfaccia usa la revisione uTUI fissata in `installer/plans.py`. In un
-ambiente di sviluppo:
+L'interfaccia usa la revisione uTUI fissata nell'unica fonte autorevole
+`requirements-utui.txt`. In un ambiente di sviluppo:
 
 ```bash
-python -m pip install \
-  "git+https://github.com/TheBitPoets/utui.git@c38ec96c865f9ee4d2f20abaf63482d7930050fa"
+python -m pip install -r requirements-utui.txt
 python -m installer.tui
 ```
 

--- a/installer/__init__.py
+++ b/installer/__init__.py
@@ -1,0 +1,1 @@
+"""Installer guidato dell'ambiente didattico 2cornot2c."""

--- a/installer/diagnostics.py
+++ b/installer/diagnostics.py
@@ -1,0 +1,50 @@
+"""Esecuzione read-only dei controlli di installazione."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import subprocess
+
+from installer.model import Check, InstallPlan
+
+
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    """Esito serializzabile di un controllo."""
+
+    check: Check
+    ok: bool
+    detail: str
+
+
+def run_check(check: Check) -> CheckResult:
+    """Esegue un singolo controllo senza shell e ne limita l'output."""
+
+    result = subprocess.run(
+        check.command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    combined_output = f"{result.stdout}\n{result.stderr}".strip()
+    output = combined_output.splitlines()
+    detail = output[0][:160] if output else f"exit code {result.returncode}"
+    ok = result.returncode == 0
+    if check.expected_text:
+        ok = ok and check.expected_text in combined_output
+        if not ok and result.returncode == 0:
+            detail = f"non trovato: {check.expected_text}"
+    return CheckResult(check, ok, detail)
+
+
+def diagnose(plan: InstallPlan) -> tuple[CheckResult, ...]:
+    """Esegue tutti i controlli continuando dopo componenti assenti."""
+
+    results = []
+    for check in plan.checks:
+        try:
+            results.append(run_check(check))
+        except (FileNotFoundError, subprocess.TimeoutExpired) as error:
+            results.append(CheckResult(check, False, type(error).__name__))
+    return tuple(results)

--- a/installer/main.py
+++ b/installer/main.py
@@ -1,0 +1,53 @@
+"""Entry point iniziale dell'installer; uTUI verrà collegata sopra questo core."""
+
+from __future__ import annotations
+
+import argparse
+
+from installer.diagnostics import diagnose
+from installer.model import Provider
+from installer.platforms import detect_host
+from installer.plans import install_plan, supported_providers
+
+
+def parser() -> argparse.ArgumentParser:
+    """Crea il parser CLI usato anche dal futuro bootstrap."""
+
+    result = argparse.ArgumentParser(description="Prepara l'ambiente 2cornot2c")
+    result.add_argument(
+        "--provider",
+        choices=[provider.value for provider in Provider],
+        help="provider desiderato; se omesso usa quello raccomandato",
+    )
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Mostra una diagnosi sicura e il piano ancora da applicare."""
+
+    args = parser().parse_args(argv)
+    host = detect_host()
+    providers = supported_providers(host)
+    provider = Provider(args.provider) if args.provider else providers[0]
+    plan = install_plan(host, provider)
+
+    print(f"Host: {host.value}")
+    print(f"Provider: {provider.value}")
+    print("\nDiagnosi:")
+    results = diagnose(plan)
+    for result in results:
+        marker = "OK" if result.ok else "MANCA"
+        print(f"[{marker:5}] {result.check.label}: {result.detail}")
+
+    missing = {result.check.key for result in results if not result.ok}
+    print("\nPiano:")
+    for step in plan.steps:
+        marker = "da eseguire" if step.key in missing else "già presente"
+        print(f"- {step.label}: {marker}")
+        if step.manual and step.key in missing and step.detail:
+            print(f"  {step.detail}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/installer/model.py
+++ b/installer/model.py
@@ -1,0 +1,51 @@
+"""Modello indipendente dalla UI per diagnosi e installazione dell'ambiente."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Host(str, Enum):
+    """Host supportati dall'installer."""
+
+    MACOS_ARM64 = "macos-arm64"
+    WINDOWS_AMD64 = "windows-amd64"
+
+
+class Provider(str, Enum):
+    """Provider VM selezionabili."""
+
+    VMWARE = "vmware_desktop"
+    VIRTUALBOX = "virtualbox"
+
+
+@dataclass(frozen=True, slots=True)
+class Check:
+    """Un controllo diagnostico senza effetti collaterali."""
+
+    key: str
+    label: str
+    command: tuple[str, ...]
+    expected_text: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Step:
+    """Un passo di installazione idempotente."""
+
+    key: str
+    label: str
+    command: tuple[str, ...] | None
+    manual: bool = False
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class InstallPlan:
+    """Piano completo per una combinazione host/provider."""
+
+    host: Host
+    provider: Provider
+    checks: tuple[Check, ...]
+    steps: tuple[Step, ...]

--- a/installer/plans.py
+++ b/installer/plans.py
@@ -1,0 +1,126 @@
+"""Piani supportati dall'installer, separati dalla presentazione uTUI."""
+
+from __future__ import annotations
+
+from installer.model import Check, Host, InstallPlan, Provider, Step
+
+
+UTUI_REVISION = "c38ec96c865f9ee4d2f20abaf63482d7930050fa"
+
+
+def supported_providers(host: Host) -> tuple[Provider, ...]:
+    """Restituisce solo i provider ufficialmente supportati per l'host."""
+
+    if host is Host.MACOS_ARM64:
+        return (Provider.VMWARE, Provider.VIRTUALBOX)
+    if host is Host.WINDOWS_AMD64:
+        return (Provider.VIRTUALBOX,)
+    raise ValueError(f"Host non supportato: {host}")
+
+
+def install_plan(host: Host, provider: Provider) -> InstallPlan:
+    """Costruisce il piano deterministico per host e provider."""
+
+    if provider not in supported_providers(host):
+        raise ValueError(f"{provider.value} non è supportato su {host.value}")
+
+    if host is Host.MACOS_ARM64:
+        return _macos_plan(provider)
+    return _windows_plan()
+
+
+def _macos_plan(provider: Provider) -> InstallPlan:
+    checks = [
+        Check("brew", "Homebrew", ("brew", "--version")),
+        Check("git", "Git", ("git", "--version")),
+        Check("vagrant", "Vagrant", ("vagrant", "--version")),
+    ]
+    steps = [
+        Step("brew", "Installa Homebrew", None, manual=True),
+        Step("git", "Installa Git", ("brew", "install", "git")),
+        Step("vagrant", "Installa Vagrant", ("brew", "install", "--cask", "vagrant")),
+    ]
+
+    if provider is Provider.VMWARE:
+        checks.extend(
+            [
+                Check(
+                    "fusion",
+                    "VMware Fusion",
+                    ("test", "-d", "/Applications/VMware Fusion.app"),
+                ),
+                Check(
+                    "vmware-utility",
+                    "Vagrant VMware Utility",
+                    ("test", "-x", "/opt/vagrant-vmware-desktop/bin/vagrant-vmware-utility"),
+                ),
+                Check(
+                    "vmware-plugin",
+                    "Plugin Vagrant VMware",
+                    ("vagrant", "plugin", "list"),
+                    "vagrant-vmware-desktop",
+                ),
+            ]
+        )
+        steps.extend(
+            [
+                Step(
+                    "fusion",
+                    "Installa VMware Fusion",
+                    None,
+                    manual=True,
+                    detail="Broadcom richiede login e accettazione della licenza.",
+                ),
+                Step(
+                    "vmware-utility",
+                    "Installa Vagrant VMware Utility",
+                    ("brew", "install", "--cask", "vagrant-vmware-utility"),
+                ),
+                Step(
+                    "vmware-plugin",
+                    "Installa plugin Vagrant VMware",
+                    ("vagrant", "plugin", "install", "vagrant-vmware-desktop"),
+                ),
+            ]
+        )
+    else:
+        checks.append(Check("virtualbox", "VirtualBox", ("VBoxManage", "--version")))
+        steps.append(
+            Step(
+                "virtualbox",
+                "Installa VirtualBox",
+                ("brew", "install", "--cask", "virtualbox"),
+            )
+        )
+
+    return InstallPlan(Host.MACOS_ARM64, provider, tuple(checks), tuple(steps))
+
+
+def _windows_plan() -> InstallPlan:
+    return InstallPlan(
+        Host.WINDOWS_AMD64,
+        Provider.VIRTUALBOX,
+        (
+            Check("winget", "Windows Package Manager", ("winget", "--version")),
+            Check("git", "Git", ("git", "--version")),
+            Check("vagrant", "Vagrant", ("vagrant", "--version")),
+            Check("virtualbox", "VirtualBox", ("VBoxManage.exe", "--version")),
+        ),
+        (
+            Step(
+                "git",
+                "Installa Git",
+                ("winget", "install", "--id", "Git.Git", "--exact"),
+            ),
+            Step(
+                "vagrant",
+                "Installa Vagrant",
+                ("winget", "install", "--id", "Hashicorp.Vagrant", "--exact"),
+            ),
+            Step(
+                "virtualbox",
+                "Installa VirtualBox",
+                ("winget", "install", "--id", "Oracle.VirtualBox", "--exact"),
+            ),
+        ),
+    )

--- a/installer/plans.py
+++ b/installer/plans.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from installer.model import Check, Host, InstallPlan, Provider, Step
 
 
-UTUI_REVISION = "c38ec96c865f9ee4d2f20abaf63482d7930050fa"
-
-
 def supported_providers(host: Host) -> tuple[Provider, ...]:
     """Restituisce solo i provider ufficialmente supportati per l'host."""
 

--- a/installer/platforms.py
+++ b/installer/platforms.py
@@ -1,0 +1,23 @@
+"""Rilevamento conservativo dell'host."""
+
+from __future__ import annotations
+
+import platform
+
+from installer.model import Host
+
+
+def detect_host(system: str | None = None, machine: str | None = None) -> Host:
+    """Rileva l'host o fallisce senza proporre combinazioni non collaudate."""
+
+    detected_system = platform.system() if system is None else system
+    detected_machine = platform.machine() if machine is None else machine
+    normalized_machine = detected_machine.lower()
+
+    if detected_system == "Darwin" and normalized_machine in {"arm64", "aarch64"}:
+        return Host.MACOS_ARM64
+    if detected_system == "Windows" and normalized_machine in {"amd64", "x86_64"}:
+        return Host.WINDOWS_AMD64
+    raise RuntimeError(
+        f"Host non supportato: sistema={detected_system}, architettura={detected_machine}"
+    )

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -1,0 +1,133 @@
+"""Interfaccia uTUI sottile sopra il core dell'installer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import UnsupportedOperation
+import sys
+
+from utui import (
+    Key,
+    KeyReader,
+    Label,
+    ListView,
+    Panel,
+    ResizeWatcher,
+    Row,
+    get_terminal_size,
+    render_lines,
+    supports_color,
+)
+
+from installer.diagnostics import diagnose
+from installer.model import Host, Provider
+from installer.platforms import detect_host
+from installer.plans import install_plan, supported_providers
+
+
+@dataclass(slots=True)
+class State:
+    """Stato posseduto dall'applicazione, non dalla libreria grafica."""
+
+    host: Host
+    providers: tuple[Provider, ...]
+    active_index: int = 0
+    report: tuple[str, ...] = ("Premi Invio per eseguire la diagnosi.",)
+    running: bool = True
+
+
+def build_screen(state: State):
+    """Costruisce la schermata senza I/O o mutazioni."""
+
+    provider_labels = tuple(
+        "VMware Fusion (raccomandato)"
+        if provider is Provider.VMWARE
+        else "VirtualBox"
+        for provider in state.providers
+    )
+    choices = Panel(
+        ListView(provider_labels, active_index=state.active_index, focused=True),
+        title=f"Ambiente 2cornot2c - {state.host.value}",
+        min_width=38,
+    )
+    report = Panel(
+        Label("\n".join(state.report)),
+        title="Diagnosi",
+        min_width=38,
+    )
+    commands = Panel(
+        Label("Su/Giu oppure k/j: scegli\nInvio: controlla\nq/Esc: esci"),
+        title="Comandi",
+        min_width=28,
+    )
+    return Row((choices, report, commands), gap=1)
+
+
+def frame(state: State, width: int, height: int, *, color: bool) -> list[str]:
+    """Renderizza un frame deterministico."""
+
+    return render_lines(build_screen(state), width, height, color=color)
+
+
+def refresh_report(state: State) -> None:
+    """Esegue la diagnosi del provider selezionato e aggiorna solo lo stato."""
+
+    provider = state.providers[state.active_index]
+    results = diagnose(install_plan(state.host, provider))
+    state.report = tuple(
+        f"[{'OK' if result.ok else 'MANCA'}] {result.check.label}"
+        for result in results
+    )
+
+
+def present(rows: list[str]) -> None:
+    """Sostituisce il frame visibile."""
+
+    sys.stdout.write("\x1b[2J\x1b[H")
+    sys.stdout.write("\n".join(rows))
+    sys.stdout.flush()
+
+
+def main() -> int:
+    """Esegue il menu interattivo mantenendo l'event loop nel consumer."""
+
+    host = detect_host()
+    state = State(host, supported_providers(host))
+    watcher = ResizeWatcher()
+    color = supports_color()
+
+    try:
+        with KeyReader() as reader:
+            size = watcher.poll() or get_terminal_size()
+            present(frame(state, size.width, size.height, color=color))
+            while state.running:
+                event = reader.read(timeout=0.05)
+                resized = watcher.poll()
+                changed = resized is not None
+                if resized is not None:
+                    size = resized
+                if event is not None:
+                    character = event.character if event.key is Key.CHARACTER else ""
+                    if event.key is Key.UP or character == "k":
+                        state.active_index = max(0, state.active_index - 1)
+                    elif event.key is Key.DOWN or character == "j":
+                        state.active_index = min(
+                            len(state.providers) - 1, state.active_index + 1
+                        )
+                    elif event.key is Key.ENTER:
+                        refresh_report(state)
+                    elif event.key is Key.ESCAPE or character == "q":
+                        state.running = False
+                    changed = True
+                if state.running and changed:
+                    present(frame(state, size.width, size.height, color=color))
+    except UnsupportedOperation as error:
+        print(f"Terminale interattivo non disponibile: {error}", file=sys.stderr)
+        return 2
+    finally:
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,76 @@
+# Box Packer per l'ambiente didattico
+
+Questa directory produce box Vagrant specializzate partendo dalla box Bento
+Ubuntu 24.04 fissata in `classroom.pkr.hcl`.
+
+## Prerequisiti
+
+- Packer 1.11 o successivo;
+- Vagrant;
+- il provider da costruire;
+- spazio libero sufficiente per box sorgente, VM temporanea e artefatto.
+
+Inizializza i plugin:
+
+```bash
+cd packer
+packer init classroom.pkr.hcl
+```
+
+Scarica una volta la box sorgente per il provider scelto:
+
+```bash
+vagrant box add bento/ubuntu-24.04 \
+  --box-version 202510.26.0 \
+  --provider vmware_desktop
+```
+
+Per VirtualBox sostituisci `vmware_desktop` con `virtualbox`. Packer riusa la
+box locale: questo evita download duplicati e rende esplicito quale input
+viene usato.
+
+Valida la configurazione:
+
+```bash
+packer fmt -check .
+packer validate classroom.pkr.hcl
+```
+
+## Build VMware arm64 su Apple Silicon
+
+```bash
+packer build -only=classroom.vagrant.vmware-arm64 classroom.pkr.hcl
+```
+
+## Build VirtualBox amd64
+
+Il comando seguente deve essere eseguito su Windows o Linux amd64:
+
+```bash
+packer build -only=classroom.vagrant.virtualbox-amd64 classroom.pkr.hcl
+```
+
+Gli artefatti vengono scritti sotto `packer/output/` e sono ignorati da Git.
+
+## Test minimo
+
+Dopo la build VMware:
+
+```bash
+./acceptance/test-box.sh vmware_desktop output/vmware-arm64/package.box
+```
+
+Su una macchina amd64, dopo la build VirtualBox:
+
+```bash
+./acceptance/test-box.sh virtualbox output/virtualbox-amd64/package.box
+```
+
+Il test avvia la box con 2048 MB e due CPU, esegue l'health check installato
+nella VM e verifica zram, memoria, sessione grafica e cartelle condivise.
+Il profilo sperimentale da 1536 MB si prova con:
+
+```bash
+CLASSROOM_MEMORY_MB=1536 \
+  ./acceptance/test-box.sh vmware_desktop output/vmware-arm64/package.box
+```

--- a/packer/acceptance/Vagrantfile
+++ b/packer/acceptance/Vagrantfile
@@ -1,0 +1,22 @@
+Vagrant.configure("2") do |config|
+  memory_mb = Integer(ENV.fetch("CLASSROOM_MEMORY_MB", "2048"))
+
+  config.vm.box = ENV.fetch("CLASSROOM_BOX_NAME", "2cornot2c/acceptance")
+  config.vm.boot_timeout = 300
+  config.vm.synced_folder ENV.fetch("CLASSROOM_REPO_ROOT"), "/home/vagrant/2cornot2c",
+    disabled: false
+
+  config.vm.provider "vmware_desktop" do |provider|
+    provider.gui = true
+    provider.vmx["memsize"] = memory_mb.to_s
+    provider.vmx["numvcpus"] = "2"
+  end
+
+  config.vm.provider "virtualbox" do |provider|
+    provider.gui = true
+    provider.memory = memory_mb
+    provider.cpus = 2
+    provider.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+    provider.customize ["modifyvm", :id, "--drag-and-drop", "bidirectional"]
+  end
+end

--- a/packer/acceptance/test-box.sh
+++ b/packer/acceptance/test-box.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider="${1:?Uso: $0 <vmware_desktop|virtualbox> <file.box>}"
+box_file="${2:?Uso: $0 <vmware_desktop|virtualbox> <file.box>}"
+
+case "$provider" in
+  vmware_desktop|virtualbox) ;;
+  *)
+    echo "Provider non supportato: $provider" >&2
+    exit 2
+    ;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+box_file="$(cd "$(dirname "$box_file")" && pwd)/$(basename "$box_file")"
+box_name="2cornot2c/acceptance-${provider}"
+dotfile_path=".vagrant-${provider}"
+
+test -f "$box_file"
+
+vagrant box add "$box_name" "$box_file" --provider "$provider" --force
+
+export CLASSROOM_BOX_NAME="$box_name"
+export CLASSROOM_REPO_ROOT="$repo_root"
+export CLASSROOM_MEMORY_MB="${CLASSROOM_MEMORY_MB:-2048}"
+export VAGRANT_DOTFILE_PATH="$dotfile_path"
+
+cd "$script_dir"
+vagrant up --provider "$provider"
+vagrant ssh -c '
+  set -eu
+  sudo /usr/local/bin/2cornot2c-health-check
+  test "$(stat -c %a /home/vagrant/2cornot2c)" != ""
+  test -x /home/vagrant/cambia-risoluzione.sh || test "'"$provider"'" = virtualbox
+  systemctl is-active --quiet display-manager
+  pgrep -u vagrant -x xfce4-session >/dev/null
+  swapon --show --noheadings | grep -q zram
+  free -m
+  gcc --version | head -n 1
+  vmtoolsd --version 2>/dev/null || VBoxControl --version
+'
+
+echo "Acceptance test superato per $provider."

--- a/packer/classroom.pkr.hcl
+++ b/packer/classroom.pkr.hcl
@@ -1,0 +1,66 @@
+packer {
+  required_version = ">= 1.11.0"
+
+  required_plugins {
+    vagrant = {
+      version = "~> 1.1"
+      source  = "github.com/hashicorp/vagrant"
+    }
+  }
+}
+
+variable "source_box" {
+  type    = string
+  default = "bento/ubuntu-24.04"
+}
+
+variable "source_box_version" {
+  type    = string
+  default = "202510.26.0"
+}
+
+variable "output_root" {
+  type    = string
+  default = "output"
+}
+
+source "vagrant" "virtualbox-amd64" {
+  communicator = "ssh"
+  source_path  = var.source_box
+  box_version  = var.source_box_version
+  skip_add     = true
+  provider     = "virtualbox"
+  output_dir   = "${var.output_root}/virtualbox-amd64"
+}
+
+source "vagrant" "vmware-arm64" {
+  communicator = "ssh"
+  source_path  = var.source_box
+  box_version  = var.source_box_version
+  skip_add     = true
+  provider     = "vmware_desktop"
+  output_dir   = "${var.output_root}/vmware-arm64"
+}
+
+build {
+  name = "classroom"
+  sources = [
+    "source.vagrant.virtualbox-amd64",
+    "source.vagrant.vmware-arm64",
+  ]
+
+  provisioner "file" {
+    source      = "../scripts/change-resolution.sh"
+    destination = "/tmp/change-resolution.sh"
+  }
+
+  provisioner "shell" {
+    scripts = [
+      "provision/toolchain.sh",
+      "provision/desktop-xfce-minimal.sh",
+      "provision/classroom.sh",
+      "provision/cleanup.sh",
+    ]
+    execute_command = "chmod +x '{{ .Path }}'; echo 'vagrant' | sudo -S -E '{{ .Path }}'"
+  }
+}

--- a/packer/classroom.pkr.hcl
+++ b/packer/classroom.pkr.hcl
@@ -50,16 +50,16 @@ build {
   ]
 
   provisioner "file" {
-    source      = "../scripts/change-resolution.sh"
+    source      = "${path.root}/../scripts/change-resolution.sh"
     destination = "/tmp/change-resolution.sh"
   }
 
   provisioner "shell" {
     scripts = [
-      "provision/toolchain.sh",
-      "provision/desktop-xfce-minimal.sh",
-      "provision/classroom.sh",
-      "provision/cleanup.sh",
+      "${path.root}/provision/toolchain.sh",
+      "${path.root}/provision/desktop-xfce-minimal.sh",
+      "${path.root}/provision/classroom.sh",
+      "${path.root}/provision/cleanup.sh",
     ]
     execute_command = "chmod +x '{{ .Path }}'; echo 'vagrant' | sudo -S -E '{{ .Path }}'"
   }

--- a/packer/provision/classroom.sh
+++ b/packer/provision/classroom.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "vagrant:vagrant" | chpasswd
+
+install -d -m 0755 /opt/2cornot2c
+
+if command -v vmtoolsd >/dev/null 2>&1 && [ -f /tmp/change-resolution.sh ]; then
+  sed 's/\r$//' /tmp/change-resolution.sh > /home/vagrant/cambia-risoluzione.sh
+  chown vagrant:vagrant /home/vagrant/cambia-risoluzione.sh
+  chmod 0755 /home/vagrant/cambia-risoluzione.sh
+fi
+rm -f /tmp/change-resolution.sh
+
+cat > /usr/local/bin/2cornot2c-health-check <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command -v gcc >/dev/null
+command -v gdb >/dev/null
+command -v make >/dev/null
+command -v git >/dev/null
+command -v vim >/dev/null
+test -f /etc/lightdm/lightdm.conf.d/50-vagrant-autologin.conf
+systemctl is-enabled --quiet lightdm
+
+if command -v VBoxControl >/dev/null 2>&1; then
+  systemctl is-enabled --quiet vboxadd-service
+elif command -v vmtoolsd >/dev/null 2>&1; then
+  test -x /usr/bin/vmtoolsd
+else
+  echo "Guest Tools del provider non trovati." >&2
+  exit 1
+fi
+EOF
+chmod 0755 /usr/local/bin/2cornot2c-health-check
+
+/usr/local/bin/2cornot2c-health-check

--- a/packer/provision/cleanup.sh
+++ b/packer/provision/cleanup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+rm -rf /tmp/* /var/tmp/*
+rm -f /home/vagrant/.bash_history
+find /var/log -type f -exec truncate -s 0 {} \;
+
+sync

--- a/packer/provision/desktop-xfce-minimal.sh
+++ b/packer/provision/desktop-xfce-minimal.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get install -y --no-install-recommends \
+  dbus-x11 \
+  fonts-dejavu-core \
+  lightdm \
+  lightdm-gtk-greeter \
+  policykit-1 \
+  thunar \
+  xfce4-panel \
+  xfce4-session \
+  xfce4-settings \
+  xfce4-terminal \
+  xfdesktop4 \
+  xfwm4 \
+  xinit \
+  xserver-xorg-core \
+  xserver-xorg-input-all \
+  xserver-xorg-video-all \
+  x11-xserver-utils \
+  zram-tools
+
+if command -v vmtoolsd >/dev/null 2>&1; then
+  apt-get install -y --no-install-recommends open-vm-tools-desktop
+fi
+
+install -d -m 0755 /etc/lightdm/lightdm.conf.d
+cat > /etc/lightdm/lightdm.conf.d/50-vagrant-autologin.conf <<'EOF'
+[Seat:*]
+autologin-user=vagrant
+autologin-user-timeout=0
+user-session=xfce
+EOF
+
+usermod -aG nopasswdlogin vagrant
+systemctl enable lightdm
+systemctl set-default graphical.target
+
+cat > /etc/default/zramswap <<'EOF'
+ALGO=zstd
+PERCENT=25
+PRIORITY=100
+EOF
+systemctl enable zramswap
+
+install -d -o vagrant -g vagrant -m 0700 /home/vagrant/.config/xfce4/xfconf/xfce-perchannel-xml
+cat > /home/vagrant/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="xsettings" version="1.0">
+  <property name="Xft" type="empty">
+    <property name="DPI" type="int" value="120"/>
+  </property>
+  <property name="Gtk" type="empty">
+    <property name="FontName" type="string" value="Sans 11"/>
+  </property>
+</channel>
+EOF
+chown -R vagrant:vagrant /home/vagrant/.config

--- a/packer/provision/toolchain.sh
+++ b/packer/provision/toolchain.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  gdb \
+  git \
+  make \
+  vim

--- a/scripts/student_docker_shell.py
+++ b/scripts/student_docker_shell.py
@@ -1,0 +1,99 @@
+"""Avvia una shell didattica leggera dalla toolchain bloccata del grading."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shlex
+import subprocess
+
+from scripts import toolchain_lock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LOCK = ROOT / "docker" / "assignment-runner" / "toolchain.lock.json"
+
+
+def docker_command(
+    *,
+    workspace: Path,
+    lock_path: Path = DEFAULT_LOCK,
+    memory: str = "512m",
+    interactive: bool = True,
+) -> list[str]:
+    """Costruisce il comando senza shell usando l'immagine immutabile del grading."""
+
+    resolved_workspace = workspace.expanduser().resolve(strict=True)
+    if not resolved_workspace.is_dir():
+        raise ValueError("Il workspace Docker deve essere una directory.")
+    lock = toolchain_lock.load_lock(lock_path)
+
+    command = ["docker", "run", "--rm"]
+    if interactive:
+        command.append("-it")
+    command.extend(
+        [
+            "--platform",
+            lock["platform"],
+            "--network",
+            "none",
+            "--read-only",
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges",
+            "--memory",
+            memory,
+            "--cpus",
+            "1",
+            "--pids-limit",
+            "256",
+            "--user",
+            "runner",
+            "--mount",
+            f"type=bind,source={resolved_workspace},target=/workspace",
+            "--workdir",
+            "/workspace",
+            "--tmpfs",
+            "/tmp:rw,noexec,nosuid,size=64m",
+            "--entrypoint",
+            "/bin/sh",
+            toolchain_lock.immutable_reference(lock),
+        ]
+    )
+    return command
+
+
+def parser() -> argparse.ArgumentParser:
+    """Crea il parser della shell Docker studente."""
+
+    result = argparse.ArgumentParser(
+        description="Shell C/Python/Node/SQLite con la toolchain esatta del grading."
+    )
+    result.add_argument("--workspace", type=Path, default=Path.cwd())
+    result.add_argument("--memory", default="512m")
+    result.add_argument("--print-command", action="store_true")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Stampa oppure esegue la shell interattiva."""
+
+    args = parser().parse_args(argv)
+    try:
+        command = docker_command(workspace=args.workspace, memory=args.memory)
+    except (OSError, ValueError, toolchain_lock.ToolchainLockError) as error:
+        print(f"Ambiente Docker non disponibile: {error}")
+        return 1
+    if args.print_command:
+        print(shlex.join(command))
+        return 0
+    try:
+        return subprocess.run(command, check=False).returncode
+    except FileNotFoundError:
+        print("Docker non è installato o non è disponibile nel PATH.")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from installer.diagnostics import run_check
+from installer.model import Check
+from installer.model import Host, Provider
+from installer.platforms import detect_host
+from installer.plans import install_plan, supported_providers
+
+
+def test_detects_supported_hosts() -> None:
+    assert detect_host("Darwin", "arm64") is Host.MACOS_ARM64
+    assert detect_host("Windows", "AMD64") is Host.WINDOWS_AMD64
+
+
+def test_rejects_unsupported_host() -> None:
+    with pytest.raises(RuntimeError, match="Host non supportato"):
+        detect_host("Linux", "x86_64")
+
+
+def test_mac_supports_choice_but_windows_has_one_path() -> None:
+    assert supported_providers(Host.MACOS_ARM64) == (
+        Provider.VMWARE,
+        Provider.VIRTUALBOX,
+    )
+    assert supported_providers(Host.WINDOWS_AMD64) == (Provider.VIRTUALBOX,)
+
+
+def test_windows_rejects_vmware() -> None:
+    with pytest.raises(ValueError, match="non è supportato"):
+        install_plan(Host.WINDOWS_AMD64, Provider.VMWARE)
+
+
+def test_plans_are_provider_specific() -> None:
+    vmware = install_plan(Host.MACOS_ARM64, Provider.VMWARE)
+    virtualbox = install_plan(Host.MACOS_ARM64, Provider.VIRTUALBOX)
+
+    assert any(step.key == "fusion" for step in vmware.steps)
+    assert not any(step.key == "virtualbox" for step in vmware.steps)
+    assert any(step.key == "virtualbox" for step in virtualbox.steps)
+
+
+def test_check_can_require_semantic_output() -> None:
+    result = run_check(
+        Check(
+            "python",
+            "Python",
+            ("python3", "-c", "print('installed plugins')"),
+            "vagrant-vmware-desktop",
+        )
+    )
+
+    assert result.ok is False
+    assert result.detail == "non trovato: vagrant-vmware-desktop"
+
+
+def test_tui_frame_lists_supported_provider() -> None:
+    pytest.importorskip("utui")
+    from installer.tui import State, frame
+
+    rows = frame(
+        State(Host.WINDOWS_AMD64, (Provider.VIRTUALBOX,)),
+        100,
+        12,
+        color=False,
+    )
+
+    rendered = "\n".join(rows)
+    assert "VirtualBox" in rendered
+    assert "VMware Fusion" not in rendered

--- a/tests/test_student_docker_shell.py
+++ b/tests/test_student_docker_shell.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.student_docker_shell import docker_command
+
+
+REFERENCE = (
+    "ghcr.io/thebitpoets/2cornot2c-assignment-runner"
+    "@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+)
+
+
+def write_lock(path: Path) -> Path:
+    lock = path / "toolchain.lock.json"
+    lock.write_text(
+        json.dumps(
+            {
+                "schema_version": "thebitlab.grading-toolchain-lock.v1",
+                "version": "2026.07.1",
+                "platform": "linux/amd64",
+                "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
+                "source_revision": "bd102146a684a9b06835204ec1b7f668f7655a03",
+                "immutable_reference": REFERENCE,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return lock
+
+
+def test_shell_reuses_locked_grading_image(tmp_path: Path) -> None:
+    workspace = tmp_path / "lab"
+    workspace.mkdir()
+
+    command = docker_command(
+        workspace=workspace,
+        lock_path=write_lock(tmp_path),
+        interactive=False,
+    )
+
+    assert command[:3] == ["docker", "run", "--rm"]
+    assert "--network" in command
+    assert command[command.index("--network") + 1] == "none"
+    assert "--read-only" in command
+    assert "--cap-drop" in command
+    assert "--user" in command
+    assert command[command.index("--user") + 1] == "runner"
+    assert command[-1] == REFERENCE
+
+
+def test_shell_has_small_default_memory_limit(tmp_path: Path) -> None:
+    workspace = tmp_path / "lab"
+    workspace.mkdir()
+
+    command = docker_command(
+        workspace=workspace,
+        lock_path=write_lock(tmp_path),
+        interactive=False,
+    )
+
+    assert command[command.index("--memory") + 1] == "512m"


### PR DESCRIPTION
## Cosa cambia

- aggiunge una configurazione Packer condivisa per box Ubuntu 24.04 VMware ARM64 e VirtualBox AMD64;
- prepara un desktop XFCE minimale con LightDM, toolchain didattica, Guest Tools, zram e health check;
- aggiunge un acceptance test provider-specifico a 2048 MB e un profilo sperimentale a 1536 MB;
- introduce il core dell'installer guidato con rilevamento host/provider, diagnosi read-only e interfaccia uTUI;
- aggiunge una shell Docker studente da 512 MB basata sul riferimento immutabile del runner di grading;
- documenta architettura, limiti, misure RAM e percorso di evoluzione multiarch.

## Perché

L'ambiente attuale dipende da provisioning Vagrant costoso e da procedure manuali difficili da supportare per studenti con poca RAM. Questa PR crea la prima base riproducibile per distribuire immagini già pronte, diagnosticare i prerequisiti e offrire un fallback Docker coerente con la toolchain di grading.

## Impatto

La box VMware ARM64 è stata costruita e avviata realmente su Apple Silicon. Con XFCE attivo sono stati osservati circa 386–408 MB usati, sia con 2048 MB sia con 1536 MB assegnati. La configurazione esistente degli studenti non viene ancora commutata automaticamente sulle nuove box: pubblicazione degli artefatti, bootstrap monocomando e validazione Windows resteranno tranche successive.

## Verifiche

- build Packer VMware ARM64 completata in 3m33s;
- acceptance VMware con sessione XFCE, cartella condivisa, zram, GCC e VMware Tools;
- profili RAM 2048 MB e 1536 MB avviati senza uso swap;
- `packer fmt -check packer`;
- `packer validate packer/classroom.pkr.hcl` dalla root e dalla directory `packer`;
- `bash -n` sugli script di provisioning e acceptance;
- `ruby -c packer/acceptance/Vagrantfile`;
- 20 test mirati verdi per installer, Docker shell e toolchain lock;
- suite completa locale: 1229 passed, 12 skipped; 17 test preesistenti non eseguibili nel sandbox/macOS Python 3.14 per socket/cache vietati e semantica case-insensitive. La CI Python 3.11/3.12 resta autorevole.

## Limiti noti

- la build VirtualBox AMD64 richiede un host Windows/Linux AMD64 reale;
- l'installer è ancora diagnostico e non applica modifiche di sistema;
- VMware Fusion continua a richiedere login/licenza Broadcom;
- il runner Docker pubblicato è oggi solo `linux/amd64`; il percorso `student-dev` multiarch arriverà separatamente.