### PR TITLE
Add reproducible classroom environments and student-dev

### DIFF
--- a/.github/workflows/publish-student-dev.yml
+++ b/.github/workflows/publish-student-dev.yml
@@ -1,0 +1,39 @@
+name: Publish student development image
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Enable multiarch emulation
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Configure Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Authenticate to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate student-dev configuration
+        run: python scripts/build_student_dev.py --check
+
+      - name: Build and publish AMD64 and ARM64
+        run: >-
+          python scripts/build_student_dev.py
+          --publish
+          --source-revision "$GITHUB_SHA"

--- a/.github/workflows/student-dev-docker.yml
+++ b/.github/workflows/student-dev-docker.yml
@@ -1,0 +1,73 @@
+name: Build student development Docker image
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "docker/student-dev/**"
+      - "scripts/build_student_dev.py"
+      - "tests/test_build_student_dev.py"
+      - ".github/workflows/student-dev-docker.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docker/student-dev/**"
+      - "scripts/build_student_dev.py"
+      - "tests/test_build_student_dev.py"
+      - ".github/workflows/student-dev-docker.yml"
+
+jobs:
+  docker-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            tag: test-amd64
+            machine: x86_64
+          - platform: linux/arm64
+            tag: test-arm64
+            machine: aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Enable multiarch emulation
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Validate student-dev configuration
+        run: python scripts/build_student_dev.py --check
+
+      - name: Build student-dev image
+        run: >-
+          python scripts/build_student_dev.py
+          --platform "${{ matrix.platform }}"
+          --tag "2cornot2c-student-dev:${{ matrix.tag }}"
+
+      - name: Smoke test toolchain
+        run: |
+          docker run --rm \
+            --platform "${{ matrix.platform }}" \
+            "2cornot2c-student-dev:${{ matrix.tag }}" \
+            sh -eu -c '
+              test "$(id -u)" = 1000
+              test "$(id -un)" = student
+              test "$(uname -m)" = "${{ matrix.machine }}"
+              printf "int main(void){return 0;}\n" > /tmp/hello.c
+              gcc -Wall -Wextra -Werror /tmp/hello.c -o /tmp/hello
+              /tmp/hello
+              gdb --version
+              git --version
+              make --version
+              python3 --version
+              node --version
+              sqlite3 --version
+              vim --version
+            '

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .vagrant
 .vagrant-vmware/
 packer/acceptance/.vagrant-*/
+.installer-venv/
 packer/output/
 packer/packer_cache/
 packer/*.box

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .vagrant-vmware/
 packer/acceptance/.vagrant-*/
 .installer-venv/
+.classroom-box
+.classroom-provider
 packer/output/
 packer/packer_cache/
 packer/*.box

--- a/README.md
+++ b/README.md
@@ -408,6 +408,13 @@ La stessa configurazione supporta Windows su processori Intel/AMD e macOS su
 Apple Silicon. La macchina virtuale usa Ubuntu 24.04 e contiene già compilatore,
 debugger e interfaccia grafica.
 
+È inoltre in preparazione `student-dev`, l'alternativa Docker leggera per i
+computer con poca RAM. Usa la stessa Ubuntu 24.04 delle VM ed è costruita
+nativamente per `linux/amd64` (Windows e Mac Intel) e `linux/arm64` (Mac Apple
+Silicon). Il runner di grading resta per ora separato e basato su Debian: verrà
+allineato solo dopo i test di compatibilità, così gli esiti delle consegne non
+cambiano durante la sperimentazione.
+
 ## Installare l'ambiente di sviluppo
 
 ### Preparazione automatica del Mac

--- a/README.md
+++ b/README.md
@@ -481,6 +481,33 @@ prova automaticamente un riavvio.
 La sessione grafica accede automaticamente con l'utente `vagrant`; la password,
 se richiesta, è `vagrant`.
 
+### Alternativa Docker per PC con poca RAM
+
+`student-dev` offre la stessa base Ubuntu 24.04 senza interfaccia grafica e
+senza avviare una VM completa. Richiede Docker Desktop e usa per impostazione
+predefinita al massimo 512 MB di RAM e una CPU.
+
+Dalla cartella in cui vuoi conservare gli esercizi esegui:
+
+```bash
+python3 /percorso/di/2cornot2c/scripts/student_dev_shell.py
+```
+
+Al primo avvio Docker scarica automaticamente da GHCR l'immagine adatta al
+processore del computer. La cartella corrente diventa `/workspace` e resta
+salvata sul computer; il resto del container viene eliminato all'uscita. Per
+lasciare la shell usa `exit`.
+
+Per scegliere un'altra cartella o aumentare il limite di memoria:
+
+```bash
+python3 scripts/student_dev_shell.py --workspace ./lab --memory 768m
+```
+
+L'immagine pubblica è versionata: lo script non usa implicitamente `latest`,
+quindi una nuova pubblicazione non cambia l'ambiente degli studenti finché non
+aggiorniamo esplicitamente il manifest del progetto.
+
 ### Cartelle condivise
 
 Le cartelle `lab` e `lab2` del progetto sono disponibili nella VM come `/lab` e

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,18 @@
 
 require "rbconfig"
 
+box_file = File.join(__dir__, ".classroom-box")
+box_name = ENV["CLASSROOM_BOX_NAME"]
+box_name = File.read(box_file, encoding: "UTF-8").strip if box_name.to_s.empty? && File.file?(box_file)
+box_name = "bento/ubuntu-24.04" if box_name.to_s.empty?
+unless box_name.match?(/\A[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+\z/)
+  raise "Nome box non valido in .classroom-box o CLASSROOM_BOX_NAME."
+end
+
+memory_mb = Integer(ENV.fetch("CLASSROOM_MEMORY_MB", "2048"), 10)
+raise "CLASSROOM_MEMORY_MB deve essere tra 1024 e 8192." unless (1024..8192).cover?(memory_mb)
+prebuilt_classroom_box = box_name != "bento/ubuntu-24.04"
+
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
@@ -16,7 +28,7 @@ Vagrant.configure("2") do |config|
   # boxes at https://vagrantcloud.com/search.
   # Bento publishes amd64 and arm64 variants for VirtualBox and VMware, so the
   # same Vagrantfile works on Windows and on Apple Silicon.
-  config.vm.box = "bento/ubuntu-24.04"
+  config.vm.box = box_name
   config.vm.hostname = "2cornot2c"
   config.vm.boot_timeout = 900
 
@@ -88,14 +100,14 @@ Vagrant.configure("2") do |config|
   #  vb.customize ["storageattach", :id, "--storagectl", "IDE Controller", "--port", "1", "--device", "0", "--type", "dvddrive", "--medium", "emptydrive"]
   #
   #   # Customize the amount of memory on the VM:
-    vb.memory = "4096"
+    vb.memory = memory_mb
     vb.cpus = 2
    end
 
    config.vm.provider "vmware_desktop" do |vmware|
      vmware.gui = true
      vmware.allowlist_verified = true
-     vmware.vmx["memsize"] = "4096"
+     vmware.vmx["memsize"] = memory_mb.to_s
      vmware.vmx["numvcpus"] = "2"
    end
   #
@@ -105,7 +117,8 @@ Vagrant.configure("2") do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
   # documentation for more information about their specific syntax and use.
-   config.vm.provision "shell", inline: <<-SHELL
+   unless prebuilt_classroom_box
+     config.vm.provision "shell", inline: <<-SHELL
      export DEBIAN_FRONTEND=noninteractive
      apt-get update
      apt-get install -y gcc gdb vim make build-essential git xfce4 lightdm
@@ -138,9 +151,10 @@ Vagrant.configure("2") do |config|
      systemctl daemon-reload
      systemctl set-default graphical.target
    SHELL
-   config.vm.provision "shell", inline: <<-SHELL
-     if [ -f /etc/X11/Xwrapper.config ]; then
-       sed -i 's/allowed_users=.*$/allowed_users=anybody/' /etc/X11/Xwrapper.config
-     fi
-   SHELL
+     config.vm.provision "shell", inline: <<-SHELL
+       if [ -f /etc/X11/Xwrapper.config ]; then
+         sed -i 's/allowed_users=.*$/allowed_users=anybody/' /etc/X11/Xwrapper.config
+       fi
+     SHELL
+   end
 end

--- a/doc/architecture/classroom-environments.md
+++ b/doc/architecture/classroom-environments.md
@@ -110,3 +110,8 @@ La selezione locale viene salvata in file ignorati da Git:
 Il fallback senza questi file resta `bento/ubuntu-24.04`. La presenza di una
 box Packer disabilita il provisioning legacy, evitando reinstallazioni lente
 e dipendenti dalla rete a ogni ricreazione.
+
+La sostituzione di una VM già presente è un'operazione distinta
+dall'importazione della box. Richiede una conferma testuale non abbreviabile,
+verifica `lab` e `lab2`, arresta prima una macchina attiva e applica
+`vagrant destroy --force` soltanto allo state directory del provider scelto.

--- a/doc/architecture/classroom-environments.md
+++ b/doc/architecture/classroom-environments.md
@@ -101,3 +101,12 @@ configurazione e provisioning incrementano la patch.
 Il Vagrantfile degli studenti deve fissare una versione approvata. Una nuova
 box non modifica automaticamente VM già create: l'installer dovrà proporre
 backup delle cartelle condivise e ricreazione controllata.
+
+La selezione locale viene salvata in file ignorati da Git:
+
+- `.classroom-box`: nome immutabile della box verificata;
+- `.classroom-provider`: provider collaudato per l'host.
+
+Il fallback senza questi file resta `bento/ubuntu-24.04`. La presenza di una
+box Packer disabilita il provisioning legacy, evitando reinstallazioni lente
+e dipendenti dalla rete a ogni ricreazione.

--- a/docker/student-dev/Dockerfile
+++ b/docker/student-dev/Dockerfile
@@ -17,6 +17,8 @@ ARG STUDENT_DEV_VERSION
 ARG SOURCE_REVISION
 
 LABEL org.opencontainers.image.title="2cornot2c student development environment" \
+      org.opencontainers.image.description="Ambiente Ubuntu leggero per i laboratori 2cornot2c" \
+      org.opencontainers.image.source="https://github.com/TheBitPoets/2cornot2c" \
       org.opencontainers.image.version="${STUDENT_DEV_VERSION}" \
       org.opencontainers.image.revision="${SOURCE_REVISION}" \
       io.2cornot2c.student-dev.base-image="${UBUNTU_BASE_IMAGE}" \

--- a/docker/student-dev/Dockerfile
+++ b/docker/student-dev/Dockerfile
@@ -1,0 +1,74 @@
+ARG UBUNTU_BASE_IMAGE=ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+FROM ${UBUNTU_BASE_IMAGE}
+
+ARG UBUNTU_BASE_IMAGE
+ARG UBUNTU_SNAPSHOT
+ARG BUILD_ESSENTIAL_VERSION
+ARG CA_CERTIFICATES_VERSION
+ARG GCC_VERSION
+ARG GDB_VERSION
+ARG GIT_VERSION
+ARG MAKE_VERSION
+ARG NODEJS_VERSION
+ARG PYTHON3_VERSION
+ARG SQLITE3_VERSION
+ARG VIM_TINY_VERSION
+ARG STUDENT_DEV_VERSION
+ARG SOURCE_REVISION
+
+LABEL org.opencontainers.image.title="2cornot2c student development environment" \
+      org.opencontainers.image.version="${STUDENT_DEV_VERSION}" \
+      org.opencontainers.image.revision="${SOURCE_REVISION}" \
+      io.2cornot2c.student-dev.base-image="${UBUNTU_BASE_IMAGE}" \
+      io.2cornot2c.student-dev.ubuntu-snapshot="${UBUNTU_SNAPSHOT}"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ubuntu:24.04-minimal non include ancora il bundle CA. Il primo accesso allo
+# snapshot disabilita soltanto la verifica TLS; firme Release e pacchetti APT
+# restano verificate tramite ubuntu-keyring già presente nell'immagine base.
+RUN printf '%s\n' \
+      'Types: deb' \
+      "URIs: https://snapshot.ubuntu.com/ubuntu/${UBUNTU_SNAPSHOT}" \
+      'Suites: noble noble-updates noble-backports noble-security' \
+      'Components: main universe restricted multiverse' \
+      'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
+      > /etc/apt/sources.list.d/ubuntu.sources \
+    && apt-get \
+      -o Acquire::https::Verify-Peer=false \
+      -o Acquire::https::Verify-Host=false \
+      update \
+    && apt-get \
+      -o Acquire::https::Verify-Peer=false \
+      -o Acquire::https::Verify-Host=false \
+      install -y --no-install-recommends \
+      "build-essential=${BUILD_ESSENTIAL_VERSION}" \
+      "ca-certificates=${CA_CERTIFICATES_VERSION}" \
+      "gcc=${GCC_VERSION}" \
+      "gdb=${GDB_VERSION}" \
+      "git=${GIT_VERSION}" \
+      "make=${MAKE_VERSION}" \
+      "nodejs=${NODEJS_VERSION}" \
+      "python3=${PYTHON3_VERSION}" \
+      "sqlite3=${SQLITE3_VERSION}" \
+      "vim-tiny=${VIM_TINY_VERSION}" \
+    && ln -s /usr/bin/vim.tiny /usr/local/bin/vim \
+    && rm -rf /var/lib/apt/lists/*
+
+# L'immagine Ubuntu ufficiale contiene già l'utente ubuntu (UID/GID 1000).
+# Lo rinominiamo per conservare UID 1000: i file montati dal computer dello
+# studente restano utilizzabili anche su host Linux.
+RUN groupmod --new-name student ubuntu \
+    && usermod --login student \
+      --comment "2cornot2c student" \
+      --home /home/student \
+      --move-home \
+      --shell /bin/bash \
+      ubuntu \
+    && install -d -o student -g student -m 0755 /workspace
+
+ENV HOME=/home/student
+WORKDIR /workspace
+USER student
+
+CMD ["/bin/bash"]

--- a/docker/student-dev/toolchain.json
+++ b/docker/student-dev/toolchain.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "2cornot2c.student-dev-build.v1",
+  "version": "2026.07.1",
+  "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+  ],
+  "image_repository": "ghcr.io/thebitpoets/2cornot2c-student-dev",
+  "base_image": "ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90",
+  "ubuntu_snapshot": "20260713T000000Z",
+  "packages": {
+    "build-essential": "12.10ubuntu1",
+    "ca-certificates": "20260601~24.04.1",
+    "gcc": "4:13.2.0-7ubuntu1",
+    "gdb": "15.1-1ubuntu1~24.04.1",
+    "git": "1:2.43.0-1ubuntu7.3",
+    "make": "4.3-4.1build2",
+    "nodejs": "18.19.1+dfsg-6ubuntu5",
+    "python3": "3.12.3-0ubuntu2.1",
+    "sqlite3": "3.45.1-1ubuntu2.6",
+    "vim-tiny": "2:9.1.0016-1ubuntu7.17"
+  }
+}

--- a/installer/README.md
+++ b/installer/README.md
@@ -70,3 +70,7 @@ Nel menu premi `a`, controlla il provider mostrato e premi `s` per confermare.
 Questa fase non scarica ancora il repository o la box Packer e non avvia la
 VM. Il bootstrap monocomando aggiungerà questi passi dopo aver fissato URL,
 versione e checksum degli artefatti pubblicati.
+
+Il contratto e il downloader verificato sono implementati in
+`installer/artifacts.py`; manca intenzionalmente il manifest reale finché la
+box VirtualBox AMD64 non supera il collaudo Windows.

--- a/installer/README.md
+++ b/installer/README.md
@@ -10,7 +10,7 @@ l'ambiente didattico:
 La logica di rilevamento, i controlli e i piani non dipendono dalla UI.
 `utui` si occupa esclusivamente di rendering e input da terminale.
 
-## Stato attuale
+## Diagnosi
 
 La prima fetta implementa rilevamento, scelta provider e diagnosi read-only:
 
@@ -18,6 +18,23 @@ La prima fetta implementa rilevamento, scelta provider e diagnosi read-only:
 python -m installer.main
 python -m installer.main --provider virtualbox
 ```
+
+## Applicazione del piano
+
+Per applicare i soli componenti mancanti:
+
+```bash
+python -m installer.main --apply
+```
+
+Prima di eseguire comandi viene richiesta la parola `INSTALLA`. Per
+automazioni già supervisionate è disponibile `--apply --yes`.
+
+Ogni passo viene aggiunto a `~/.2cornot2c/installer.jsonl`. Se un comando
+fallisce, l'installer si ferma; al nuovo avvio ripete la diagnosi, salta i
+componenti già presenti e riparte dal primo ancora mancante. I passaggi
+manuali, come login e licenza di VMware Fusion, bloccano il piano prima di
+qualsiasi modifica.
 
 L'interfaccia usa la revisione uTUI fissata nell'unica fonte autorevole
 `requirements-utui.txt`. In un ambiente di sviluppo:
@@ -27,6 +44,6 @@ python -m pip install -r requirements-utui.txt
 python -m installer.tui
 ```
 
-La modalità di installazione con effetti sul sistema non è ancora esposta:
-verrà aggiunta soltanto insieme a conferma, ripresa dopo errore, log e
-diagnostica finale.
+Questa fase non scarica ancora il repository o la box Packer e non avvia la
+VM. Il bootstrap monocomando aggiungerà questi passi dopo aver fissato URL,
+versione e checksum degli artefatti pubblicati.

--- a/installer/README.md
+++ b/installer/README.md
@@ -74,3 +74,15 @@ versione e checksum degli artefatti pubblicati.
 Il contratto e il downloader verificato sono implementati in
 `installer/artifacts.py`; manca intenzionalmente il manifest reale finché la
 box VirtualBox AMD64 non supera il collaudo Windows.
+
+`installer/vagrant_box.py` completa il flusso locale:
+
+1. verifica nuovamente dimensione e SHA-256;
+2. controlla le box installate tramite output machine-readable;
+3. importa soltanto se nome e provider non sono già presenti, senza `--force`;
+4. salva box e provider in `.classroom-box` e `.classroom-provider`;
+5. usa gli script `setup-vm` esistenti per primo avvio e health check.
+
+Quando `.classroom-box` è presente, il `Vagrantfile` salta il provisioning
+legacy perché desktop, toolchain e Guest Tools sono già nella box Packer.
+Senza quel file continua a usare Bento e il provisioning attuale.

--- a/installer/README.md
+++ b/installer/README.md
@@ -10,6 +10,26 @@ l'ambiente didattico:
 La logica di rilevamento, i controlli e i piani non dipendono dalla UI.
 `utui` si occupa esclusivamente di rendering e input da terminale.
 
+## Bootstrap monocomando
+
+Su macOS Apple Silicon:
+
+```bash
+curl --fail --location \
+  https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/bootstrap-classroom-macos.sh \
+  | bash
+```
+
+Su Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/bootstrap-classroom-windows.ps1 | iex
+```
+
+Il bootstrap installa soltanto Git e Python 3.12, prepara il repository in
+`~/2cornot2c`, crea `.installer-venv` e avvia uTUI. La procedura guidata
+diagnostica e installa poi Vagrant e il provider selezionato.
+
 ## Diagnosi
 
 La prima fetta implementa rilevamento, scelta provider e diagnosi read-only:
@@ -43,6 +63,9 @@ L'interfaccia usa la revisione uTUI fissata nell'unica fonte autorevole
 python -m pip install -r requirements-utui.txt
 python -m installer.tui
 ```
+
+Nel menu premi `a`, controlla il provider mostrato e premi `s` per confermare.
+`n` o `Esc` annullano senza modifiche.
 
 Questa fase non scarica ancora il repository o la box Packer e non avvia la
 VM. Il bootstrap monocomando aggiungerà questi passi dopo aver fissato URL,

--- a/installer/README.md
+++ b/installer/README.md
@@ -86,3 +86,23 @@ box VirtualBox AMD64 non supera il collaudo Windows.
 Quando `.classroom-box` è presente, il `Vagrantfile` salta il provisioning
 legacy perché desktop, toolchain e Guest Tools sono già nella box Packer.
 Senza quel file continua a usare Bento e il provisioning attuale.
+
+## VM già esistente
+
+Prima di attivare una nuova box, lo stato del provider può essere controllato
+e migrato esplicitamente:
+
+```bash
+python -m installer.migration --provider vmware_desktop
+```
+
+Su Windows usa `--provider virtualbox`. La procedura:
+
+- non esegue nulla senza la frase esatta `RICREA VM`;
+- controlla che `lab` e `lab2` siano directory interne al progetto;
+- arresta ordinatamente una VM accesa;
+- distrugge soltanto la VM del provider selezionato;
+- non elimina o sposta le cartelle condivise sull'host.
+
+I file salvati esclusivamente dentro la VM non possono essere garantiti e
+vengono segnalati prima della conferma.

--- a/installer/artifacts.py
+++ b/installer/artifacts.py
@@ -1,0 +1,223 @@
+"""Manifest e download verificato delle box didattiche pubblicate."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import tempfile
+from typing import Any, BinaryIO
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+from installer.model import Host, Provider
+
+
+SCHEMA_VERSION = "2cornot2c.classroom-images.v1"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+MAX_BOX_BYTES = 8 * 1024 * 1024 * 1024
+MANIFEST_KEYS = {"schema_version", "release", "artifacts"}
+ARTIFACT_KEYS = {
+    "name",
+    "host",
+    "provider",
+    "architecture",
+    "box_name",
+    "url",
+    "sha256",
+    "size_bytes",
+}
+
+
+class ArtifactError(RuntimeError):
+    """Manifest, download o checksum non valido."""
+
+
+@dataclass(frozen=True, slots=True)
+class BoxArtifact:
+    """Una box provider-specifica descritta dal manifest autorevole."""
+
+    name: str
+    host: Host
+    provider: Provider
+    architecture: str
+    box_name: str
+    url: str
+    sha256: str
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class ImageRelease:
+    """Release immutabile contenente le box supportate."""
+
+    version: str
+    artifacts: tuple[BoxArtifact, ...]
+
+
+def _object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ArtifactError(f"Chiave duplicata nel manifest: {key}")
+        result[key] = value
+    return result
+
+
+def load_release(path: Path) -> ImageRelease:
+    """Carica e valida completamente un manifest locale affidabile."""
+
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_object_without_duplicates,
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ArtifactError(f"Manifest non leggibile: {path}") from error
+    if not isinstance(payload, dict) or set(payload) != MANIFEST_KEYS:
+        raise ArtifactError("Campi del manifest non validi.")
+    if payload["schema_version"] != SCHEMA_VERSION:
+        raise ArtifactError("Schema manifest non supportato.")
+    version = payload["release"]
+    if not isinstance(version, str) or not VERSION_RE.fullmatch(version):
+        raise ArtifactError("Versione release non valida.")
+    raw_artifacts = payload["artifacts"]
+    if not isinstance(raw_artifacts, list) or not raw_artifacts:
+        raise ArtifactError("Il manifest non contiene artefatti.")
+
+    artifacts = tuple(_parse_artifact(item) for item in raw_artifacts)
+    identities = {(item.host, item.provider) for item in artifacts}
+    if len(identities) != len(artifacts):
+        raise ArtifactError("Combinazione host/provider duplicata.")
+    return ImageRelease(version, artifacts)
+
+
+def _parse_artifact(payload: Any) -> BoxArtifact:
+    if not isinstance(payload, dict) or set(payload) != ARTIFACT_KEYS:
+        raise ArtifactError("Campi artefatto non validi.")
+    try:
+        host = Host(payload["host"])
+        provider = Provider(payload["provider"])
+    except (TypeError, ValueError) as error:
+        raise ArtifactError("Host o provider artefatto non valido.") from error
+
+    expected = {
+        (Host.MACOS_ARM64, Provider.VMWARE): "arm64",
+        (Host.WINDOWS_AMD64, Provider.VIRTUALBOX): "amd64",
+    }
+    architecture = payload["architecture"]
+    if expected.get((host, provider)) != architecture:
+        raise ArtifactError("Architettura non coerente con host e provider.")
+    for key in ("name", "box_name"):
+        if not isinstance(payload[key], str) or not payload[key].strip():
+            raise ArtifactError(f"Campo artefatto vuoto: {key}")
+    url = payload["url"]
+    if not isinstance(url, str) or urlparse(url).scheme != "https":
+        raise ArtifactError("La box deve usare un URL HTTPS.")
+    digest = payload["sha256"]
+    if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+        raise ArtifactError("Checksum SHA-256 non valido.")
+    size = payload["size_bytes"]
+    if not isinstance(size, int) or isinstance(size, bool) or not 0 < size <= MAX_BOX_BYTES:
+        raise ArtifactError("Dimensione artefatto non valida.")
+    return BoxArtifact(
+        payload["name"],
+        host,
+        provider,
+        architecture,
+        payload["box_name"],
+        url,
+        digest,
+        size,
+    )
+
+
+def select_artifact(
+    release: ImageRelease, host: Host, provider: Provider
+) -> BoxArtifact:
+    """Seleziona una sola box per la combinazione richiesta."""
+
+    matches = [
+        artifact
+        for artifact in release.artifacts
+        if artifact.host is host and artifact.provider is provider
+    ]
+    if len(matches) != 1:
+        raise ArtifactError(f"Box non disponibile per {host.value}/{provider.value}.")
+    return matches[0]
+
+
+def sha256_file(path: Path) -> tuple[str, int]:
+    """Calcola digest e dimensione leggendo il file a blocchi."""
+
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def verify_box(path: Path, artifact: BoxArtifact) -> None:
+    """Rifiuta file incompleti o diversi dal manifest."""
+
+    digest, size = sha256_file(path)
+    if size != artifact.size_bytes:
+        raise ArtifactError(
+            f"Dimensione box errata: attesi {artifact.size_bytes}, trovati {size} byte."
+        )
+    if digest != artifact.sha256:
+        raise ArtifactError("Checksum SHA-256 della box non corrispondente.")
+
+
+ResponseOpener = Callable[[str], BinaryIO]
+
+
+def download_box(
+    artifact: BoxArtifact,
+    destination: Path,
+    *,
+    opener: ResponseOpener = urlopen,
+) -> Path:
+    """Scarica in streaming e pubblica atomicamente solo una box verificata."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        verify_box(destination, artifact)
+        return destination
+
+    temporary_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            prefix=f".{destination.name}.",
+            suffix=".part",
+            dir=destination.parent,
+            delete=False,
+        ) as output:
+            temporary_name = output.name
+            with opener(artifact.url) as response:
+                final_url = getattr(response, "geturl", lambda: artifact.url)()
+                if urlparse(final_url).scheme != "https":
+                    raise ArtifactError("Il download è stato reindirizzato fuori da HTTPS.")
+                written = 0
+                while chunk := response.read(1024 * 1024):
+                    written += len(chunk)
+                    if written > artifact.size_bytes:
+                        raise ArtifactError("Il download supera la dimensione dichiarata.")
+                    output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        temporary = Path(temporary_name)
+        verify_box(temporary, artifact)
+        temporary.replace(destination)
+        return destination
+    finally:
+        if temporary_name:
+            Path(temporary_name).unlink(missing_ok=True)

--- a/installer/executor.py
+++ b/installer/executor.py
@@ -1,0 +1,121 @@
+"""Esecuzione idempotente e registrata dei piani di installazione."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import subprocess
+
+from installer.diagnostics import CheckResult
+from installer.model import InstallPlan, Step
+
+
+@dataclass(frozen=True, slots=True)
+class StepResult:
+    """Esito di un passo applicato o saltato."""
+
+    key: str
+    label: str
+    status: str
+    detail: str = ""
+
+
+CommandRunner = Callable[[tuple[str, ...]], tuple[int, str]]
+
+
+def subprocess_runner(command: tuple[str, ...]) -> tuple[int, str]:
+    """Esegue un comando senza shell e restituisce output limitato."""
+
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return 127, f"Comando non trovato: {command[0]}"
+    output = f"{completed.stdout}\n{completed.stderr}".strip()
+    return completed.returncode, output[-4000:]
+
+
+def _append_log(path: Path | None, plan: InstallPlan, result: StepResult) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "host": plan.host.value,
+        "provider": plan.provider.value,
+        **asdict(result),
+    }
+    with path.open("a", encoding="utf-8", newline="\n") as stream:
+        stream.write(json.dumps(record, ensure_ascii=False) + "\n")
+        stream.flush()
+
+
+def execute_plan(
+    plan: InstallPlan,
+    checks: tuple[CheckResult, ...],
+    *,
+    runner: CommandRunner = subprocess_runner,
+    log_path: Path | None = None,
+) -> tuple[StepResult, ...]:
+    """Applica i soli passi mancanti, fermandosi al primo errore.
+
+    I prerequisiti o passi manuali mancanti bloccano il piano prima di
+    qualsiasi modifica. Un nuovo avvio riesegue la diagnosi e salta ciò che è
+    già installato, fornendo una ripresa naturale e idempotente.
+    """
+
+    check_by_key = {result.check.key: result for result in checks}
+    step_by_key = {step.key: step for step in plan.steps}
+    missing = {key for key, result in check_by_key.items() if not result.ok}
+
+    blockers = [
+        result
+        for key, result in check_by_key.items()
+        if key in missing
+        and (key not in step_by_key or step_by_key[key].manual)
+    ]
+    if blockers:
+        results = tuple(
+            StepResult(
+                result.check.key,
+                result.check.label,
+                "blocked",
+                step_by_key.get(
+                    result.check.key,
+                    Step(result.check.key, result.check.label, None),
+                ).detail
+                or result.detail,
+            )
+            for result in blockers
+        )
+        for result in results:
+            _append_log(log_path, plan, result)
+        return results
+
+    applied: list[StepResult] = []
+    for step in plan.steps:
+        if step.key not in missing:
+            result = StepResult(step.key, step.label, "skipped", "già presente")
+        elif step.command is None:
+            result = StepResult(step.key, step.label, "blocked", step.detail)
+        else:
+            returncode, output = runner(step.command)
+            detail = output.strip().splitlines()[-1][:300] if output.strip() else ""
+            result = StepResult(
+                step.key,
+                step.label,
+                "succeeded" if returncode == 0 else "failed",
+                detail or f"exit code {returncode}",
+            )
+        applied.append(result)
+        _append_log(log_path, plan, result)
+        if result.status in {"failed", "blocked"}:
+            break
+    return tuple(applied)

--- a/installer/main.py
+++ b/installer/main.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from installer.diagnostics import diagnose
+from installer.executor import execute_plan
 from installer.model import Provider
 from installer.platforms import detect_host
 from installer.plans import install_plan, supported_providers
@@ -19,6 +21,22 @@ def parser() -> argparse.ArgumentParser:
         choices=[provider.value for provider in Provider],
         help="provider desiderato; se omesso usa quello raccomandato",
     )
+    result.add_argument(
+        "--apply",
+        action="store_true",
+        help="applica i passi mancanti dopo una conferma esplicita",
+    )
+    result.add_argument(
+        "--yes",
+        action="store_true",
+        help="conferma non interattiva; valido soltanto insieme a --apply",
+    )
+    result.add_argument(
+        "--log",
+        type=Path,
+        default=Path.home() / ".2cornot2c" / "installer.jsonl",
+        help="registro append-only usato per diagnosi e supporto",
+    )
     return result
 
 
@@ -26,6 +44,8 @@ def main(argv: list[str] | None = None) -> int:
     """Mostra una diagnosi sicura e il piano ancora da applicare."""
 
     args = parser().parse_args(argv)
+    if args.yes and not args.apply:
+        parser().error("--yes richiede --apply")
     host = detect_host()
     providers = supported_providers(host)
     provider = Provider(args.provider) if args.provider else providers[0]
@@ -46,6 +66,23 @@ def main(argv: list[str] | None = None) -> int:
         print(f"- {step.label}: {marker}")
         if step.manual and step.key in missing and step.detail:
             print(f"  {step.detail}")
+    if not args.apply:
+        return 0
+
+    if not args.yes:
+        confirmation = input("\nDigita INSTALLA per applicare il piano: ")
+        if confirmation != "INSTALLA":
+            print("Installazione annullata senza modifiche.")
+            return 2
+
+    print("\nEsecuzione:")
+    applied = execute_plan(plan, results, log_path=args.log)
+    for result in applied:
+        print(f"[{result.status.upper():9}] {result.label}: {result.detail}")
+    if any(result.status in {"failed", "blocked"} for result in applied):
+        print(f"\nInstallazione incompleta. Log: {args.log}")
+        return 1
+    print(f"\nInstallazione completata. Log: {args.log}")
     return 0
 
 

--- a/installer/migration.py
+++ b/installer/migration.py
@@ -1,0 +1,205 @@
+"""Migrazione esplicita e conservativa di una VM Vagrant preesistente."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Mapping
+import csv
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import subprocess
+
+from installer.model import Provider
+
+
+CONFIRMATION = "RICREA VM"
+ABSENT_STATES = {"not_created", "not created", ""}
+RUNNING_STATES = {"running"}
+
+
+@dataclass(frozen=True, slots=True)
+class MachineState:
+    """Stato provider-specifico della VM locale."""
+
+    provider: Provider
+    state: str
+
+    @property
+    def exists(self) -> bool:
+        return self.state not in ABSENT_STATES
+
+    @property
+    def running(self) -> bool:
+        return self.state in RUNNING_STATES
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationResult:
+    """Esito della migrazione distruttiva esplicitamente confermata."""
+
+    status: str
+    detail: str
+
+
+Runner = Callable[
+    [tuple[str, ...], Path, Mapping[str, str] | None],
+    tuple[int, str],
+]
+
+
+def subprocess_runner(
+    command: tuple[str, ...],
+    cwd: Path,
+    environment: Mapping[str, str] | None = None,
+) -> tuple[int, str]:
+    """Esegue un comando Vagrant senza shell."""
+
+    merged_environment = os.environ.copy()
+    if environment:
+        merged_environment.update(environment)
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=merged_environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return 127, f"Comando non trovato: {command[0]}"
+    output = f"{completed.stdout}\n{completed.stderr}".strip()
+    return completed.returncode, output[-8000:]
+
+
+def state_directory(provider: Provider) -> str:
+    """Mantiene isolati gli stati Vagrant dei due provider."""
+
+    return ".vagrant-vmware" if provider is Provider.VMWARE else ".vagrant"
+
+
+def parse_machine_state(machine_output: str, provider: Provider) -> MachineState:
+    """Legge lo stato della macchina `default` dall'output machine-readable."""
+
+    state = ""
+    for row in csv.reader(machine_output.splitlines()):
+        if len(row) >= 4 and row[1] == "default" and row[2] == "state":
+            state = row[3].strip().lower()
+    return MachineState(provider, state)
+
+
+def inspect_machine(
+    project: Path,
+    provider: Provider,
+    *,
+    runner: Runner = subprocess_runner,
+) -> MachineState:
+    """Ispeziona una sola VM senza modificarla."""
+
+    environment = {"VAGRANT_DOTFILE_PATH": state_directory(provider)}
+    returncode, output = runner(
+        ("vagrant", "status", "--machine-readable"),
+        project,
+        environment,
+    )
+    if returncode != 0:
+        raise RuntimeError(output or "Impossibile leggere lo stato Vagrant.")
+    return parse_machine_state(output, provider)
+
+
+def validate_shared_folders(project: Path) -> tuple[Path, Path]:
+    """Verifica che i dati persistenti siano directory interne al progetto."""
+
+    project = project.resolve(strict=True)
+    folders = tuple(project / name for name in ("lab", "lab2"))
+    for folder in folders:
+        if not folder.is_dir():
+            raise RuntimeError(f"Cartella condivisa mancante: {folder}")
+        try:
+            folder.resolve(strict=True).relative_to(project)
+        except ValueError as error:
+            raise RuntimeError(
+                f"Cartella condivisa fuori dal progetto: {folder}"
+            ) from error
+    return folders
+
+
+def recreate_machine(
+    project: Path,
+    machine: MachineState,
+    confirmation: str,
+    *,
+    runner: Runner = subprocess_runner,
+) -> MigrationResult:
+    """Arresta e distrugge soltanto la VM confermata, mai i dati condivisi."""
+
+    if not machine.exists:
+        return MigrationResult("skipped", "nessuna VM preesistente")
+    if confirmation != CONFIRMATION:
+        return MigrationResult(
+            "blocked",
+            f"Conferma non valida: digitare esattamente {CONFIRMATION}",
+        )
+    validate_shared_folders(project)
+    environment = {"VAGRANT_DOTFILE_PATH": state_directory(machine.provider)}
+
+    if machine.running:
+        returncode, output = runner(("vagrant", "halt"), project, environment)
+        if returncode != 0:
+            return MigrationResult("failed", output or "Arresto VM non riuscito.")
+
+    returncode, output = runner(
+        ("vagrant", "destroy", "--force"),
+        project,
+        environment,
+    )
+    if returncode != 0:
+        return MigrationResult("failed", output or "Rimozione VM non riuscita.")
+    return MigrationResult(
+        "succeeded",
+        "VM precedente rimossa; lab e lab2 sono rimaste sull'host",
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    """Crea la CLI esplicita di migrazione."""
+
+    result = argparse.ArgumentParser(
+        description="Prepara la sostituzione controllata di una VM 2cornot2c."
+    )
+    result.add_argument(
+        "--provider",
+        required=True,
+        choices=[provider.value for provider in Provider],
+    )
+    result.add_argument("--project", type=Path, default=Path.cwd())
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Mostra stato e richiede una conferma non abbreviabile."""
+
+    args = parser().parse_args(argv)
+    provider = Provider(args.provider)
+    try:
+        machine = inspect_machine(args.project, provider)
+        validate_shared_folders(args.project)
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"Migrazione non disponibile: {error}")
+        return 1
+    if not machine.exists:
+        print("Nessuna VM preesistente da rimuovere.")
+        return 0
+
+    print(f"VM trovata: provider={provider.value}, stato={machine.state}")
+    print("Saranno conservate soltanto le cartelle host lab e lab2.")
+    print("I file salvati esclusivamente dentro la VM andranno persi.")
+    confirmation = input(f"Digita esattamente {CONFIRMATION}: ")
+    result = recreate_machine(args.project, machine, confirmation)
+    print(f"[{result.status.upper()}] {result.detail}")
+    return 0 if result.status in {"succeeded", "skipped"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from io import UnsupportedOperation
+from pathlib import Path
 import sys
 
 from utui import (
@@ -20,6 +21,7 @@ from utui import (
 )
 
 from installer.diagnostics import diagnose
+from installer.executor import execute_plan
 from installer.model import Host, Provider
 from installer.platforms import detect_host
 from installer.plans import install_plan, supported_providers
@@ -33,6 +35,7 @@ class State:
     providers: tuple[Provider, ...]
     active_index: int = 0
     report: tuple[str, ...] = ("Premi Invio per eseguire la diagnosi.",)
+    confirmation_pending: bool = False
     running: bool = True
 
 
@@ -55,8 +58,13 @@ def build_screen(state: State):
         title="Diagnosi",
         min_width=38,
     )
+    command_text = (
+        "s: conferma installazione\nn/Esc: annulla"
+        if state.confirmation_pending
+        else "Su/Giu oppure k/j: scegli\nInvio: controlla\na: installa\nq/Esc: esci"
+    )
     commands = Panel(
-        Label("Su/Giu oppure k/j: scegli\nInvio: controlla\nq/Esc: esci"),
+        Label(command_text),
         title="Comandi",
         min_width=28,
     )
@@ -75,9 +83,38 @@ def refresh_report(state: State) -> None:
     provider = state.providers[state.active_index]
     results = diagnose(install_plan(state.host, provider))
     state.report = tuple(
-        f"[{'OK' if result.ok else 'MANCA'}] {result.check.label}"
+        f"[{'OK' if result.ok else 'MANCA'}] {result.check.label}: {result.detail}"
         for result in results
     )
+
+
+def request_confirmation(state: State) -> None:
+    """Mostra la conferma senza eseguire modifiche."""
+
+    provider = state.providers[state.active_index]
+    state.confirmation_pending = True
+    state.report = (
+        f"Provider: {provider.value}",
+        "Saranno installati solo i componenti mancanti.",
+        "Premi s per confermare oppure n per annullare.",
+    )
+
+
+def apply_selected(state: State) -> None:
+    """Applica il piano selezionato e mostra un riepilogo compatto."""
+
+    provider = state.providers[state.active_index]
+    plan = install_plan(state.host, provider)
+    results = execute_plan(
+        plan,
+        diagnose(plan),
+        log_path=Path.home() / ".2cornot2c" / "installer.jsonl",
+    )
+    state.confirmation_pending = False
+    state.report = tuple(
+        f"[{result.status.upper()}] {result.label}: {result.detail}"
+        for result in results
+    ) or ("Nessun passo necessario.",)
 
 
 def present(rows: list[str]) -> None:
@@ -116,6 +153,15 @@ def main() -> int:
                         )
                     elif event.key is Key.ENTER:
                         refresh_report(state)
+                    elif character == "a" and not state.confirmation_pending:
+                        request_confirmation(state)
+                    elif character == "s" and state.confirmation_pending:
+                        apply_selected(state)
+                    elif (
+                        character == "n" or event.key is Key.ESCAPE
+                    ) and state.confirmation_pending:
+                        state.confirmation_pending = False
+                        state.report = ("Installazione annullata senza modifiche.",)
                     elif event.key is Key.ESCAPE or character == "q":
                         state.running = False
                     changed = True

--- a/installer/vagrant_box.py
+++ b/installer/vagrant_box.py
@@ -1,0 +1,151 @@
+"""Importazione idempotente della box e configurazione locale del progetto."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import csv
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+from installer.artifacts import BoxArtifact, verify_box
+from installer.model import Host, Provider
+
+
+@dataclass(frozen=True, slots=True)
+class VagrantResult:
+    """Esito di importazione o primo avvio."""
+
+    status: str
+    detail: str
+
+
+Runner = Callable[[tuple[str, ...], Path | None], tuple[int, str]]
+
+
+def subprocess_runner(
+    command: tuple[str, ...], cwd: Path | None = None
+) -> tuple[int, str]:
+    """Esegue Vagrant senza shell conservando un output diagnostico limitato."""
+
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return 127, f"Comando non trovato: {command[0]}"
+    output = f"{completed.stdout}\n{completed.stderr}".strip()
+    return completed.returncode, output[-8000:]
+
+
+def parse_installed_boxes(machine_output: str) -> set[tuple[str, str]]:
+    """Estrae coppie nome/provider dall'output machine-readable di Vagrant."""
+
+    installed: set[tuple[str, str]] = set()
+    current_name = ""
+    for row in csv.reader(machine_output.splitlines()):
+        if len(row) < 4:
+            continue
+        event, data = row[2], row[3]
+        if event == "box-name":
+            current_name = data
+        elif event == "box-provider" and current_name:
+            installed.add((current_name, data))
+            current_name = ""
+    return installed
+
+
+def import_box(
+    artifact: BoxArtifact,
+    box_path: Path,
+    *,
+    runner: Runner = subprocess_runner,
+) -> VagrantResult:
+    """Verifica e importa la box senza forzare o sovrascrivere installazioni."""
+
+    verify_box(box_path, artifact)
+    returncode, output = runner(("vagrant", "box", "list", "--machine-readable"), None)
+    if returncode != 0:
+        return VagrantResult("failed", output or "Impossibile elencare le box Vagrant.")
+    identity = (artifact.box_name, artifact.provider.value)
+    if identity in parse_installed_boxes(output):
+        return VagrantResult("skipped", "box già installata")
+
+    returncode, output = runner(
+        (
+            "vagrant",
+            "box",
+            "add",
+            artifact.box_name,
+            str(box_path),
+            "--provider",
+            artifact.provider.value,
+        ),
+        None,
+    )
+    if returncode != 0:
+        return VagrantResult("failed", output or "Importazione box non riuscita.")
+    return VagrantResult("succeeded", "box verificata e importata")
+
+
+def _atomic_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        Path(temporary_name).replace(path)
+    finally:
+        Path(temporary_name).unlink(missing_ok=True)
+
+
+def configure_project(project: Path, artifact: BoxArtifact) -> None:
+    """Attiva atomicamente box e provider per i successivi comandi Vagrant."""
+
+    project = project.resolve(strict=True)
+    if not (project / "Vagrantfile").is_file():
+        raise ValueError(f"Vagrantfile non trovato in {project}")
+    _atomic_text(project / ".classroom-box", f"{artifact.box_name}\n")
+    _atomic_text(project / ".classroom-provider", f"{artifact.provider.value}\n")
+
+
+def launch_command(project: Path, host: Host, provider: Provider) -> tuple[str, ...]:
+    """Restituisce il comando supportato per il primo avvio e health check."""
+
+    if host is Host.MACOS_ARM64:
+        option = "--vmware" if provider is Provider.VMWARE else "--virtualbox"
+        return ("bash", str(project / "scripts" / "setup-vm.sh"), option)
+    if host is Host.WINDOWS_AMD64 and provider is Provider.VIRTUALBOX:
+        return (
+            "powershell.exe",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(project / "scripts" / "setup-vm.ps1"),
+        )
+    raise ValueError(f"Avvio non supportato: {host.value}/{provider.value}")
+
+
+def launch_classroom(
+    project: Path,
+    host: Host,
+    provider: Provider,
+    *,
+    runner: Runner = subprocess_runner,
+) -> VagrantResult:
+    """Avvia la VM tramite lo script provider-specifico già dotato di health check."""
+
+    returncode, output = runner(launch_command(project, host, provider), project)
+    if returncode != 0:
+        return VagrantResult("failed", output or "Primo avvio non riuscito.")
+    return VagrantResult("succeeded", "VM avviata e verificata")

--- a/packer/README.md
+++ b/packer/README.md
@@ -52,6 +52,25 @@ packer build -only=classroom.vagrant.virtualbox-amd64 classroom.pkr.hcl
 
 Gli artefatti vengono scritti sotto `packer/output/` e sono ignorati da Git.
 
+## Manifest di rilascio
+
+`release-manifest.example.json` descrive il contratto che una release deve
+pubblicare insieme alle box. Per ciascun host contiene:
+
+- provider e architettura;
+- nome Vagrant immutabile che include la versione;
+- URL esclusivamente HTTPS;
+- dimensione esatta;
+- checksum SHA-256.
+
+L'esempio usa deliberatamente `example.invalid` e checksum fittizi: non è un
+manifest installabile. Il manifest reale verrà aggiunto soltanto dopo aver
+costruito e collaudato entrambe le box.
+
+L'installer scarica a blocchi in un file `.part`, controlla dimensione e
+checksum e rinomina atomicamente il file solo dopo la verifica. Una box
+parziale o alterata non viene mai importata in Vagrant.
+
 ## Test minimo
 
 Dopo la build VMware:

--- a/packer/release-manifest.example.json
+++ b/packer/release-manifest.example.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "2cornot2c.classroom-images.v1",
+  "release": "0.1.0",
+  "artifacts": [
+    {
+      "name": "Ubuntu 24.04 VMware ARM64",
+      "host": "macos-arm64",
+      "provider": "vmware_desktop",
+      "architecture": "arm64",
+      "box_name": "2cornot2c/ubuntu-24.04-vmware-arm64-0.1.0",
+      "url": "https://example.invalid/2cornot2c-ubuntu-24.04-vmware-arm64.box",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "size_bytes": 1
+    },
+    {
+      "name": "Ubuntu 24.04 VirtualBox AMD64",
+      "host": "windows-amd64",
+      "provider": "virtualbox",
+      "architecture": "amd64",
+      "box_name": "2cornot2c/ubuntu-24.04-virtualbox-amd64-0.1.0",
+      "url": "https://example.invalid/2cornot2c-ubuntu-24.04-virtualbox-amd64.box",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "size_bytes": 1
+    }
+  ]
+}

--- a/scripts/bootstrap-classroom-macos.sh
+++ b/scripts/bootstrap-classroom-macos.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_url="${CLASSROOM_REPOSITORY_URL:-https://github.com/TheBitPoets/2cornot2c.git}"
+install_dir="${CLASSROOM_INSTALL_DIR:-$HOME/2cornot2c}"
+brew_prefix="/opt/homebrew"
+
+fail() {
+  printf '\nERRORE: %s\n' "$1" >&2
+  exit 1
+}
+
+[ "$(uname -s)" = "Darwin" ] || fail "Questo bootstrap richiede macOS."
+[ "$(uname -m)" = "arm64" ] || fail "Sono supportati soltanto Mac Apple Silicon."
+
+printf 'Bootstrap ambiente didattico 2cornot2c\n'
+printf 'Directory: %s\n\n' "$install_dir"
+
+if ! command -v brew >/dev/null 2>&1; then
+  printf '[1/5] Installazione Homebrew...\n'
+  NONINTERACTIVE=1 /bin/bash -c \
+    "$(curl --fail --silent --show-error --location \
+      https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+if [ -x "$brew_prefix/bin/brew" ]; then
+  eval "$("$brew_prefix/bin/brew" shellenv)"
+fi
+command -v brew >/dev/null 2>&1 || fail "Homebrew non è disponibile."
+
+printf '[2/5] Preparazione Git e Python 3.12...\n'
+brew list --formula git >/dev/null 2>&1 || brew install git
+brew list --formula python@3.12 >/dev/null 2>&1 || brew install python@3.12
+
+printf '[3/5] Preparazione repository...\n'
+if [ -d "$install_dir/.git" ]; then
+  git -C "$install_dir" pull --ff-only
+elif [ -e "$install_dir" ]; then
+  fail "La directory esiste ma non è un repository Git: $install_dir"
+else
+  git clone "$repository_url" "$install_dir"
+fi
+
+printf '[4/5] Preparazione interfaccia guidata...\n'
+python_bin="$brew_prefix/bin/python3.12"
+[ -x "$python_bin" ] || fail "Python 3.12 non è disponibile in $python_bin."
+"$python_bin" -m venv "$install_dir/.installer-venv"
+"$install_dir/.installer-venv/bin/python" -m pip install \
+  --disable-pip-version-check \
+  -r "$install_dir/requirements-utui.txt"
+
+printf '[5/5] Avvio procedura guidata...\n'
+cd "$install_dir"
+exec "$install_dir/.installer-venv/bin/python" -m installer.tui

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -1,0 +1,99 @@
+$ErrorActionPreference = "Stop"
+
+$RepositoryUrl = if ($env:CLASSROOM_REPOSITORY_URL) {
+    $env:CLASSROOM_REPOSITORY_URL
+} else {
+    "https://github.com/TheBitPoets/2cornot2c.git"
+}
+$InstallDir = if ($env:CLASSROOM_INSTALL_DIR) {
+    $env:CLASSROOM_INSTALL_DIR
+} else {
+    Join-Path $HOME "2cornot2c"
+}
+
+function Stop-WithMessage {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "ERRORE: $Message" -ForegroundColor Red
+    exit 1
+}
+
+function Install-WingetPackage {
+    param([string]$Id)
+    winget install --id $Id --exact --silent `
+        --accept-package-agreements --accept-source-agreements
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithMessage "Installazione non riuscita: $Id"
+    }
+}
+
+if (-not [Environment]::Is64BitOperatingSystem) {
+    Stop-WithMessage "È richiesto Windows 10/11 a 64 bit."
+}
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Stop-WithMessage "Windows Package Manager (winget) non è disponibile."
+}
+
+Write-Host "Bootstrap ambiente didattico 2cornot2c"
+Write-Host "Directory: $InstallDir"
+
+Write-Host "[1/4] Preparazione Git e Python 3.12..."
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Install-WingetPackage "Git.Git"
+}
+if (-not (Get-Command py -ErrorAction SilentlyContinue)) {
+    Install-WingetPackage "Python.Python.3.12"
+}
+
+$env:Path = @(
+    "$env:ProgramFiles\Git\cmd"
+    "$env:LOCALAPPDATA\Programs\Python\Launcher"
+    "$env:LOCALAPPDATA\Programs\Python\Python312"
+    "$env:LOCALAPPDATA\Programs\Python\Python312\Scripts"
+    $env:Path
+) -join [IO.Path]::PathSeparator
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Stop-WithMessage "Git non è disponibile. Riavvia Windows e riprova."
+}
+if (-not (Get-Command py -ErrorAction SilentlyContinue)) {
+    Stop-WithMessage "Python Launcher non è disponibile. Riavvia Windows e riprova."
+}
+
+Write-Host "[2/4] Preparazione repository..."
+if (Test-Path (Join-Path $InstallDir ".git")) {
+    git -C $InstallDir pull --ff-only
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithMessage "Aggiornamento repository non riuscito."
+    }
+} elseif (Test-Path $InstallDir) {
+    Stop-WithMessage "La directory esiste ma non è un repository Git: $InstallDir"
+} else {
+    git clone $RepositoryUrl $InstallDir
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithMessage "Clone repository non riuscito."
+    }
+}
+
+Write-Host "[3/4] Preparazione interfaccia guidata..."
+$VenvDir = Join-Path $InstallDir ".installer-venv"
+& py -3.12 -m venv $VenvDir
+if ($LASTEXITCODE -ne 0) {
+    Stop-WithMessage "Creazione ambiente Python non riuscita."
+}
+$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
+& $VenvPython -m pip install --disable-pip-version-check `
+    -r (Join-Path $InstallDir "requirements-utui.txt")
+if ($LASTEXITCODE -ne 0) {
+    Stop-WithMessage "Installazione uTUI non riuscita."
+}
+
+Write-Host "[4/4] Avvio procedura guidata..."
+Push-Location $InstallDir
+try {
+    & $VenvPython -m installer.tui
+    exit $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}

--- a/scripts/build_student_dev.py
+++ b/scripts/build_student_dev.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = ROOT / "docker" / "student-dev" / "toolchain.json"
+DOCKERFILE = ROOT / "docker" / "student-dev" / "Dockerfile"
+DEFAULT_TAG = "2cornot2c-student-dev"
+SCHEMA_VERSION = "2cornot2c.student-dev-build.v1"
+IMAGE_REPOSITORY = "ghcr.io/thebitpoets/2cornot2c-student-dev"
+EXPECTED_PLATFORMS = ["linux/amd64", "linux/arm64"]
+EXPECTED_PACKAGES = {
+    "build-essential",
+    "ca-certificates",
+    "gcc",
+    "gdb",
+    "git",
+    "make",
+    "nodejs",
+    "python3",
+    "sqlite3",
+    "vim-tiny",
+}
+EXPECTED_KEYS = {
+    "schema_version",
+    "version",
+    "platforms",
+    "image_repository",
+    "base_image",
+    "ubuntu_snapshot",
+    "packages",
+}
+VERSION_RE = re.compile(r"^[0-9]{4}\.[0-9]{2}\.[1-9][0-9]*$")
+SNAPSHOT_RE = re.compile(r"^[0-9]{8}T[0-9]{6}Z$")
+BASE_RE = re.compile(r"^ubuntu:24\.04@sha256:[0-9a-f]{64}$")
+PACKAGE_RE = re.compile(r"^[A-Za-z0-9.+:~_-]+$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class StudentDevBuildError(RuntimeError):
+    """Configurazione student-dev non valida."""
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
+    """Carica e valida senza tollerare campi o piattaforme implicite."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise StudentDevBuildError(f"Manifest non leggibile: {path}") from error
+    if not isinstance(payload, dict) or set(payload) != EXPECTED_KEYS:
+        raise StudentDevBuildError("Campi manifest student-dev non validi.")
+    if payload["schema_version"] != SCHEMA_VERSION:
+        raise StudentDevBuildError("Schema student-dev non supportato.")
+    if not isinstance(payload["version"], str) or not VERSION_RE.fullmatch(
+        payload["version"]
+    ):
+        raise StudentDevBuildError("Versione student-dev non valida.")
+    if payload["platforms"] != EXPECTED_PLATFORMS:
+        raise StudentDevBuildError("Piattaforme student-dev non valide.")
+    if payload["image_repository"] != IMAGE_REPOSITORY:
+        raise StudentDevBuildError("Repository student-dev non autorizzato.")
+    if not isinstance(payload["base_image"], str) or not BASE_RE.fullmatch(
+        payload["base_image"]
+    ):
+        raise StudentDevBuildError("Base Ubuntu 24.04 non fissata a digest.")
+    if not isinstance(payload["ubuntu_snapshot"], str) or not SNAPSHOT_RE.fullmatch(
+        payload["ubuntu_snapshot"]
+    ):
+        raise StudentDevBuildError("Snapshot Ubuntu non valido.")
+    packages = payload["packages"]
+    if not isinstance(packages, dict) or set(packages) != EXPECTED_PACKAGES:
+        raise StudentDevBuildError("Pacchetti student-dev mancanti o inattesi.")
+    if any(
+        not isinstance(version, str) or not PACKAGE_RE.fullmatch(version)
+        for version in packages.values()
+    ):
+        raise StudentDevBuildError("Versione pacchetto student-dev non valida.")
+    return payload
+
+
+def build_command(
+    manifest: dict[str, Any],
+    *,
+    platform: str,
+    tag: str,
+    source_revision: str,
+) -> list[str]:
+    """Costruisce il comando per una singola architettura collaudabile."""
+
+    if platform not in manifest["platforms"]:
+        raise StudentDevBuildError(f"Piattaforma non supportata: {platform}")
+    if not tag.strip():
+        raise StudentDevBuildError("Tag locale mancante.")
+    if not SHA_RE.fullmatch(source_revision):
+        raise StudentDevBuildError("Revisione sorgente non valida.")
+    packages = manifest["packages"]
+    arguments = {
+        "UBUNTU_BASE_IMAGE": manifest["base_image"],
+        "UBUNTU_SNAPSHOT": manifest["ubuntu_snapshot"],
+        "BUILD_ESSENTIAL_VERSION": packages["build-essential"],
+        "CA_CERTIFICATES_VERSION": packages["ca-certificates"],
+        "GCC_VERSION": packages["gcc"],
+        "GDB_VERSION": packages["gdb"],
+        "GIT_VERSION": packages["git"],
+        "MAKE_VERSION": packages["make"],
+        "NODEJS_VERSION": packages["nodejs"],
+        "PYTHON3_VERSION": packages["python3"],
+        "SQLITE3_VERSION": packages["sqlite3"],
+        "VIM_TINY_VERSION": packages["vim-tiny"],
+        "STUDENT_DEV_VERSION": manifest["version"],
+        "SOURCE_REVISION": source_revision,
+    }
+    command = [
+        "docker",
+        "build",
+        "--pull=false",
+        "--platform",
+        platform,
+        "--tag",
+        tag,
+        "--file",
+        str(DOCKERFILE),
+    ]
+    for name, value in arguments.items():
+        command.extend(["--build-arg", f"{name}={value}"])
+    command.append(str(ROOT))
+    return command
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Costruisce student-dev Ubuntu.")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--platform", choices=EXPECTED_PLATFORMS)
+    parser.add_argument("--tag", default=DEFAULT_TAG)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    try:
+        manifest = load_manifest(args.manifest)
+        if args.check:
+            print(
+                f"student-dev {manifest['version']} valido per "
+                f"{', '.join(manifest['platforms'])}."
+            )
+            return 0
+        platform = args.platform
+        if platform is None:
+            raise StudentDevBuildError("--platform è richiesto per una build locale.")
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            build_command(
+                manifest,
+                platform=platform,
+                tag=args.tag,
+                source_revision=revision,
+            ),
+            cwd=ROOT,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError, StudentDevBuildError) as error:
+        print(f"Build student-dev non riuscita: {error}")
+        return 1
+    print(f"student-dev costruito come {args.tag} per {platform}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_student_dev.py
+++ b/scripts/build_student_dev.py
@@ -134,12 +134,61 @@ def build_command(
     return command
 
 
+def publish_command(
+    manifest: dict[str, Any],
+    *,
+    source_revision: str,
+) -> list[str]:
+    """Costruisce e pubblica un unico manifest nativo multiarch."""
+
+    packages = manifest["packages"]
+    arguments = {
+        "UBUNTU_BASE_IMAGE": manifest["base_image"],
+        "UBUNTU_SNAPSHOT": manifest["ubuntu_snapshot"],
+        "BUILD_ESSENTIAL_VERSION": packages["build-essential"],
+        "CA_CERTIFICATES_VERSION": packages["ca-certificates"],
+        "GCC_VERSION": packages["gcc"],
+        "GDB_VERSION": packages["gdb"],
+        "GIT_VERSION": packages["git"],
+        "MAKE_VERSION": packages["make"],
+        "NODEJS_VERSION": packages["nodejs"],
+        "PYTHON3_VERSION": packages["python3"],
+        "SQLITE3_VERSION": packages["sqlite3"],
+        "VIM_TINY_VERSION": packages["vim-tiny"],
+        "STUDENT_DEV_VERSION": manifest["version"],
+        "SOURCE_REVISION": source_revision,
+    }
+    if not SHA_RE.fullmatch(source_revision):
+        raise StudentDevBuildError("Revisione sorgente non valida.")
+    repository = manifest["image_repository"]
+    command = [
+        "docker",
+        "buildx",
+        "build",
+        "--pull=false",
+        "--platform",
+        ",".join(manifest["platforms"]),
+        "--tag",
+        f"{repository}:{manifest['version']}",
+        "--tag",
+        f"{repository}:latest",
+        "--file",
+        str(DOCKERFILE),
+    ]
+    for name, value in arguments.items():
+        command.extend(["--build-arg", f"{name}={value}"])
+    command.extend(["--push", str(ROOT)])
+    return command
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Costruisce student-dev Ubuntu.")
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--platform", choices=EXPECTED_PLATFORMS)
     parser.add_argument("--tag", default=DEFAULT_TAG)
     parser.add_argument("--check", action="store_true")
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument("--source-revision")
     args = parser.parse_args()
     try:
         manifest = load_manifest(args.manifest)
@@ -149,30 +198,47 @@ def main() -> int:
                 f"{', '.join(manifest['platforms'])}."
             )
             return 0
+        if args.publish and args.platform is not None:
+            raise StudentDevBuildError("--publish e --platform sono alternativi.")
         platform = args.platform
-        if platform is None:
+        if not args.publish and platform is None:
             raise StudentDevBuildError("--platform è richiesto per una build locale.")
-        revision = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-        subprocess.run(
-            build_command(
-                manifest,
-                platform=platform,
-                tag=args.tag,
-                source_revision=revision,
-            ),
-            cwd=ROOT,
-            check=True,
-        )
+        revision = args.source_revision
+        if revision is None:
+            revision = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        if args.publish:
+            subprocess.run(
+                publish_command(manifest, source_revision=revision),
+                cwd=ROOT,
+                check=True,
+            )
+        else:
+            subprocess.run(
+                build_command(
+                    manifest,
+                    platform=platform,
+                    tag=args.tag,
+                    source_revision=revision,
+                ),
+                cwd=ROOT,
+                check=True,
+            )
     except (OSError, subprocess.CalledProcessError, StudentDevBuildError) as error:
         print(f"Build student-dev non riuscita: {error}")
         return 1
-    print(f"student-dev costruito come {args.tag} per {platform}.")
+    if args.publish:
+        print(
+            f"student-dev {manifest['version']} pubblicato per "
+            f"{', '.join(manifest['platforms'])}."
+        )
+    else:
+        print(f"student-dev costruito come {args.tag} per {platform}.")
     return 0
 
 

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -31,7 +31,13 @@ case "${1:-}" in
 esac
 
 if [ -z "$provider" ]; then
-  if [ "$(uname -s)" = "Darwin" ] && [ -t 0 ]; then
+  if [ -f ".classroom-provider" ]; then
+    provider="$(tr -d '\r\n' < .classroom-provider)"
+    case "$provider" in
+      virtualbox|vmware_desktop) ;;
+      *) fail "Provider non valido in .classroom-provider." ;;
+    esac
+  elif [ "$(uname -s)" = "Darwin" ] && [ -t 0 ]; then
     printf 'Scegli il motore della macchina virtuale:\n'
     printf '  1) VirtualBox (soluzione stabile con finestra scalata)\n'
     printf '  2) VMware Fusion (ridimensionamento dinamico)\n'

--- a/scripts/student_dev_shell.py
+++ b/scripts/student_dev_shell.py
@@ -1,0 +1,94 @@
+"""Avvia la shell Ubuntu leggera e multiarch per lo sviluppo degli studenti."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shlex
+import subprocess
+
+try:
+    from scripts import build_student_dev
+except ModuleNotFoundError:  # Esecuzione diretta: python scripts/student_dev_shell.py
+    import build_student_dev
+
+
+def image_reference() -> str:
+    """Restituisce il tag versionato dichiarato nel manifest controllato."""
+
+    manifest = build_student_dev.load_manifest()
+    return f"{manifest['image_repository']}:{manifest['version']}"
+
+
+def docker_command(
+    *,
+    workspace: Path,
+    memory: str = "512m",
+    interactive: bool = True,
+) -> list[str]:
+    """Costruisce il comando isolato mantenendo scrivibile solo il workspace."""
+
+    resolved_workspace = workspace.expanduser().resolve(strict=True)
+    if not resolved_workspace.is_dir():
+        raise ValueError("Il workspace student-dev deve essere una directory.")
+    command = ["docker", "run", "--rm"]
+    if interactive:
+        command.append("-it")
+    command.extend(
+        [
+            "--init",
+            "--read-only",
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges",
+            "--memory",
+            memory,
+            "--cpus",
+            "1",
+            "--pids-limit",
+            "256",
+            "--mount",
+            f"type=bind,source={resolved_workspace},target=/workspace",
+            "--workdir",
+            "/workspace",
+            "--tmpfs",
+            "/tmp:rw,nosuid,size=64m",
+            "--tmpfs",
+            "/home/student:rw,nosuid,size=32m,uid=1000,gid=1000",
+            image_reference(),
+            "/bin/bash",
+        ]
+    )
+    return command
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Shell Ubuntu student-dev per PC con poca RAM."
+    )
+    result.add_argument("--workspace", type=Path, default=Path.cwd())
+    result.add_argument("--memory", default="512m")
+    result.add_argument("--print-command", action="store_true")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        command = docker_command(workspace=args.workspace, memory=args.memory)
+    except (OSError, ValueError, build_student_dev.StudentDevBuildError) as error:
+        print(f"Ambiente student-dev non disponibile: {error}")
+        return 1
+    if args.print_command:
+        print(shlex.join(command))
+        return 0
+    try:
+        return subprocess.run(command, check=False).returncode
+    except FileNotFoundError:
+        print("Docker non è installato o non è disponibile nel PATH.")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_student_dev.py
+++ b/tests/test_build_student_dev.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import build_student_dev
+
+
+def manifest_payload() -> dict:
+    return json.loads(build_student_dev.DEFAULT_MANIFEST.read_text(encoding="utf-8"))
+
+
+def write_manifest(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "toolchain.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_manifest_is_ubuntu_2404_multiarch() -> None:
+    manifest = build_student_dev.load_manifest()
+
+    assert manifest["platforms"] == ["linux/amd64", "linux/arm64"]
+    assert manifest["base_image"].startswith("ubuntu:24.04@sha256:")
+    assert {"gcc", "gdb", "make", "git", "vim-tiny"} <= set(manifest["packages"])
+
+
+def test_manifest_rejects_missing_architecture(tmp_path: Path) -> None:
+    payload = manifest_payload()
+    payload["platforms"] = ["linux/amd64"]
+
+    with pytest.raises(build_student_dev.StudentDevBuildError, match="Piattaforme"):
+        build_student_dev.load_manifest(write_manifest(tmp_path, payload))
+
+
+def test_build_command_pins_snapshot_packages_and_platform() -> None:
+    manifest = build_student_dev.load_manifest()
+
+    command = build_student_dev.build_command(
+        manifest,
+        platform="linux/arm64",
+        tag="student-dev:test",
+        source_revision="a" * 40,
+    )
+
+    assert command[:5] == [
+        "docker",
+        "build",
+        "--pull=false",
+        "--platform",
+        "linux/arm64",
+    ]
+    joined = "\n".join(command)
+    assert "UBUNTU_SNAPSHOT=20260713T000000Z" in joined
+    assert "GCC_VERSION=4:13.2.0-7ubuntu1" in joined
+    assert manifest["base_image"] in joined
+
+
+def test_build_rejects_unlisted_platform() -> None:
+    with pytest.raises(build_student_dev.StudentDevBuildError, match="Piattaforma"):
+        build_student_dev.build_command(
+            build_student_dev.load_manifest(),
+            platform="linux/ppc64le",
+            tag="test",
+            source_revision="b" * 40,
+        )

--- a/tests/test_build_student_dev.py
+++ b/tests/test_build_student_dev.py
@@ -65,3 +65,24 @@ def test_build_rejects_unlisted_platform() -> None:
             tag="test",
             source_revision="b" * 40,
         )
+
+
+def test_publish_command_uses_versioned_and_latest_multiarch_tags() -> None:
+    manifest = build_student_dev.load_manifest()
+
+    command = build_student_dev.publish_command(
+        manifest,
+        source_revision="c" * 40,
+    )
+
+    assert command[:6] == [
+        "docker",
+        "buildx",
+        "build",
+        "--pull=false",
+        "--platform",
+        "linux/amd64,linux/arm64",
+    ]
+    assert f"{manifest['image_repository']}:{manifest['version']}" in command
+    assert f"{manifest['image_repository']}:latest" in command
+    assert command[-2:] == ["--push", str(build_student_dev.ROOT)]

--- a/tests/test_classroom_artifacts.py
+++ b/tests/test_classroom_artifacts.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import hashlib
+from io import BytesIO
+import json
+from pathlib import Path
+
+import pytest
+
+from installer.artifacts import (
+    ArtifactError,
+    download_box,
+    load_release,
+    select_artifact,
+    verify_box,
+)
+from installer.model import Host, Provider
+
+
+BOX_CONTENT = b"verified classroom box"
+
+
+def manifest_payload() -> dict:
+    return {
+        "schema_version": "2cornot2c.classroom-images.v1",
+        "release": "0.1.0",
+        "artifacts": [
+            {
+                "name": "VMware ARM64",
+                "host": "macos-arm64",
+                "provider": "vmware_desktop",
+                "architecture": "arm64",
+                "box_name": "2cornot2c/test-vmware-0.1.0",
+                "url": "https://downloads.example.test/vmware.box",
+                "sha256": hashlib.sha256(BOX_CONTENT).hexdigest(),
+                "size_bytes": len(BOX_CONTENT),
+            }
+        ],
+    }
+
+
+def write_manifest(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "release.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_manifest_selects_exact_host_provider(tmp_path: Path) -> None:
+    release = load_release(write_manifest(tmp_path, manifest_payload()))
+
+    artifact = select_artifact(release, Host.MACOS_ARM64, Provider.VMWARE)
+
+    assert artifact.architecture == "arm64"
+    assert artifact.size_bytes == len(BOX_CONTENT)
+
+
+def test_manifest_rejects_http_and_wrong_architecture(tmp_path: Path) -> None:
+    payload = manifest_payload()
+    payload["artifacts"][0]["url"] = "http://downloads.example.test/vmware.box"
+    with pytest.raises(ArtifactError, match="HTTPS"):
+        load_release(write_manifest(tmp_path, payload))
+
+    payload = manifest_payload()
+    payload["artifacts"][0]["architecture"] = "amd64"
+    with pytest.raises(ArtifactError, match="Architettura"):
+        load_release(write_manifest(tmp_path, payload))
+
+
+def test_verify_box_rejects_changed_content(tmp_path: Path) -> None:
+    release = load_release(write_manifest(tmp_path, manifest_payload()))
+    artifact = release.artifacts[0]
+    box = tmp_path / "classroom.box"
+    box.write_bytes(b"tampered classroom box")
+
+    with pytest.raises(ArtifactError):
+        verify_box(box, artifact)
+
+
+class FakeResponse(BytesIO):
+    def geturl(self) -> str:
+        return "https://cdn.example.test/classroom.box"
+
+
+def test_download_is_verified_and_atomically_published(tmp_path: Path) -> None:
+    release = load_release(write_manifest(tmp_path, manifest_payload()))
+    destination = tmp_path / "cache" / "classroom.box"
+
+    result = download_box(
+        release.artifacts[0],
+        destination,
+        opener=lambda url: FakeResponse(BOX_CONTENT),
+    )
+
+    assert result == destination
+    assert destination.read_bytes() == BOX_CONTENT
+    assert list(destination.parent.glob("*.part")) == []
+
+
+def test_download_does_not_publish_invalid_file(tmp_path: Path) -> None:
+    release = load_release(write_manifest(tmp_path, manifest_payload()))
+    destination = tmp_path / "classroom.box"
+
+    with pytest.raises(ArtifactError):
+        download_box(
+            release.artifacts[0],
+            destination,
+            opener=lambda url: FakeResponse(b"invalid"),
+        )
+
+    assert not destination.exists()

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -72,6 +72,19 @@ def test_tui_frame_lists_supported_provider() -> None:
     assert "VMware Fusion" not in rendered
 
 
+def test_tui_confirmation_is_explicit_and_cancellable() -> None:
+    pytest.importorskip("utui")
+    from installer.tui import State, frame, request_confirmation
+
+    state = State(Host.WINDOWS_AMD64, (Provider.VIRTUALBOX,))
+    request_confirmation(state)
+    rendered = "\n".join(frame(state, 100, 12, color=False))
+
+    assert state.confirmation_pending is True
+    assert "s: conferma installazione" in rendered
+    assert "Saranno installati solo i componenti mancanti." in state.report
+
+
 def check_results(plan, *, missing: set[str] = set()):
     return tuple(
         CheckResult(check, check.key not in missing, "manca")

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from installer.diagnostics import run_check
+from installer.diagnostics import CheckResult, run_check
+from installer.executor import execute_plan
 from installer.model import Check
 from installer.model import Host, Provider
 from installer.platforms import detect_host
@@ -69,3 +70,56 @@ def test_tui_frame_lists_supported_provider() -> None:
     rendered = "\n".join(rows)
     assert "VirtualBox" in rendered
     assert "VMware Fusion" not in rendered
+
+
+def check_results(plan, *, missing: set[str] = set()):
+    return tuple(
+        CheckResult(check, check.key not in missing, "manca")
+        for check in plan.checks
+    )
+
+
+def test_executor_skips_present_steps_and_applies_only_missing(tmp_path) -> None:
+    plan = install_plan(Host.WINDOWS_AMD64, Provider.VIRTUALBOX)
+    calls = []
+
+    results = execute_plan(
+        plan,
+        check_results(plan, missing={"virtualbox"}),
+        runner=lambda command: (calls.append(command) or (0, "installato")),
+        log_path=tmp_path / "installer.jsonl",
+    )
+
+    assert [result.status for result in results] == ["skipped", "skipped", "succeeded"]
+    assert calls == [("winget", "install", "--id", "Oracle.VirtualBox", "--exact")]
+    assert (tmp_path / "installer.jsonl").read_text(encoding="utf-8").count("\n") == 3
+
+
+def test_executor_blocks_manual_prerequisite_before_writes() -> None:
+    plan = install_plan(Host.MACOS_ARM64, Provider.VMWARE)
+    calls = []
+
+    results = execute_plan(
+        plan,
+        check_results(plan, missing={"fusion", "vmware-plugin"}),
+        runner=lambda command: (calls.append(command) or (0, "")),
+    )
+
+    assert [result.key for result in results] == ["fusion"]
+    assert results[0].status == "blocked"
+    assert calls == []
+
+
+def test_executor_stops_on_first_failed_command() -> None:
+    plan = install_plan(Host.WINDOWS_AMD64, Provider.VIRTUALBOX)
+    calls = []
+
+    results = execute_plan(
+        plan,
+        check_results(plan, missing={"git", "vagrant", "virtualbox"}),
+        runner=lambda command: (calls.append(command) or (9, "errore installazione")),
+    )
+
+    assert len(results) == 1
+    assert results[0].status == "failed"
+    assert len(calls) == 1

--- a/tests/test_classroom_migration.py
+++ b/tests/test_classroom_migration.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.migration import (
+    CONFIRMATION,
+    MachineState,
+    parse_machine_state,
+    recreate_machine,
+    validate_shared_folders,
+)
+from installer.model import Provider
+
+
+def project_with_labs(tmp_path: Path) -> Path:
+    (tmp_path / "lab").mkdir()
+    (tmp_path / "lab2").mkdir()
+    return tmp_path
+
+
+def test_parse_provider_specific_machine_state() -> None:
+    output = "\n".join(
+        [
+            "1,default,metadata,provider,vmware_desktop",
+            "1,default,state,not_running",
+        ]
+    )
+
+    machine = parse_machine_state(output, Provider.VMWARE)
+
+    assert machine.exists is True
+    assert machine.running is False
+
+
+def test_recreate_requires_exact_confirmation_before_commands(tmp_path: Path) -> None:
+    calls = []
+    machine = MachineState(Provider.VIRTUALBOX, "poweroff")
+
+    result = recreate_machine(
+        project_with_labs(tmp_path),
+        machine,
+        "ricrea vm",
+        runner=lambda command, cwd, environment: (
+            calls.append((command, environment)) or (0, "")
+        ),
+    )
+
+    assert result.status == "blocked"
+    assert calls == []
+
+
+def test_running_machine_is_halted_then_destroyed(tmp_path: Path) -> None:
+    calls = []
+    machine = MachineState(Provider.VMWARE, "running")
+
+    result = recreate_machine(
+        project_with_labs(tmp_path),
+        machine,
+        CONFIRMATION,
+        runner=lambda command, cwd, environment: (
+            calls.append((command, environment)) or (0, "")
+        ),
+    )
+
+    assert result.status == "succeeded"
+    assert [call[0] for call in calls] == [
+        ("vagrant", "halt"),
+        ("vagrant", "destroy", "--force"),
+    ]
+    assert all(
+        call[1] == {"VAGRANT_DOTFILE_PATH": ".vagrant-vmware"}
+        for call in calls
+    )
+    assert (tmp_path / "lab").is_dir()
+    assert (tmp_path / "lab2").is_dir()
+
+
+def test_destroy_failure_is_reported(tmp_path: Path) -> None:
+    result = recreate_machine(
+        project_with_labs(tmp_path),
+        MachineState(Provider.VIRTUALBOX, "poweroff"),
+        CONFIRMATION,
+        runner=lambda command, cwd, environment: (3, "destroy failed"),
+    )
+
+    assert result.status == "failed"
+    assert result.detail == "destroy failed"
+
+
+def test_shared_folder_symlink_outside_project_is_rejected(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (project / "lab").symlink_to(outside, target_is_directory=True)
+    (project / "lab2").mkdir()
+
+    with pytest.raises(RuntimeError, match="fuori dal progetto"):
+        validate_shared_folders(project)

--- a/tests/test_classroom_vagrant_box.py
+++ b/tests/test_classroom_vagrant_box.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from installer.artifacts import BoxArtifact
+from installer.model import Host, Provider
+from installer.vagrant_box import (
+    configure_project,
+    import_box,
+    launch_command,
+    parse_installed_boxes,
+)
+
+
+CONTENT = b"classroom box"
+
+
+def artifact() -> BoxArtifact:
+    return BoxArtifact(
+        "VMware ARM64",
+        Host.MACOS_ARM64,
+        Provider.VMWARE,
+        "arm64",
+        "2cornot2c/ubuntu-vmware-0.1.0",
+        "https://downloads.example.test/classroom.box",
+        hashlib.sha256(CONTENT).hexdigest(),
+        len(CONTENT),
+    )
+
+
+def test_parse_installed_boxes_pairs_name_and_provider() -> None:
+    output = "\n".join(
+        [
+            "1,,box-name,2cornot2c/ubuntu-vmware-0.1.0",
+            "1,,box-provider,vmware_desktop",
+            "1,,box-version,0",
+        ]
+    )
+
+    assert parse_installed_boxes(output) == {
+        ("2cornot2c/ubuntu-vmware-0.1.0", "vmware_desktop")
+    }
+
+
+def test_import_skips_exact_installed_box(tmp_path: Path) -> None:
+    box = tmp_path / "classroom.box"
+    box.write_bytes(CONTENT)
+    calls = []
+
+    result = import_box(
+        artifact(),
+        box,
+        runner=lambda command, cwd: (
+            calls.append(command)
+            or (
+                0,
+                "1,,box-name,2cornot2c/ubuntu-vmware-0.1.0\n"
+                "1,,box-provider,vmware_desktop\n",
+            )
+        ),
+    )
+
+    assert result.status == "skipped"
+    assert len(calls) == 1
+
+
+def test_import_does_not_force_overwrite(tmp_path: Path) -> None:
+    box = tmp_path / "classroom.box"
+    box.write_bytes(CONTENT)
+    calls = []
+
+    result = import_box(
+        artifact(),
+        box,
+        runner=lambda command, cwd: (
+            calls.append(command) or (0, "" if len(calls) == 1 else "added")
+        ),
+    )
+
+    assert result.status == "succeeded"
+    assert calls[1][:4] == (
+        "vagrant",
+        "box",
+        "add",
+        "2cornot2c/ubuntu-vmware-0.1.0",
+    )
+    assert "--force" not in calls[1]
+
+
+def test_configure_project_writes_local_selection(tmp_path: Path) -> None:
+    (tmp_path / "Vagrantfile").write_text("", encoding="utf-8")
+
+    configure_project(tmp_path, artifact())
+
+    assert (tmp_path / ".classroom-box").read_text(encoding="utf-8").strip() == (
+        "2cornot2c/ubuntu-vmware-0.1.0"
+    )
+    assert (tmp_path / ".classroom-provider").read_text(encoding="utf-8").strip() == (
+        "vmware_desktop"
+    )
+
+
+def test_launch_commands_are_host_specific(tmp_path: Path) -> None:
+    assert launch_command(tmp_path, Host.MACOS_ARM64, Provider.VMWARE)[-1] == "--vmware"
+    assert launch_command(
+        tmp_path, Host.WINDOWS_AMD64, Provider.VIRTUALBOX
+    )[0] == "powershell.exe"

--- a/tests/test_student_dev_shell.py
+++ b/tests/test_student_dev_shell.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+from scripts import build_student_dev, student_dev_shell
+
+
+def test_image_reference_is_versioned() -> None:
+    manifest = build_student_dev.load_manifest()
+
+    assert student_dev_shell.image_reference() == (
+        f"{manifest['image_repository']}:{manifest['version']}"
+    )
+
+
+def test_docker_command_is_lightweight_non_root_image(tmp_path: Path) -> None:
+    command = student_dev_shell.docker_command(
+        workspace=tmp_path,
+        interactive=False,
+    )
+
+    assert command[:3] == ["docker", "run", "--rm"]
+    assert "-it" not in command
+    assert "--read-only" in command
+    assert ["--memory", "512m"] == command[
+        command.index("--memory") : command.index("--memory") + 2
+    ]
+    assert any(
+        item == f"type=bind,source={tmp_path.resolve()},target=/workspace"
+        for item in command
+    )
+    assert command[-2:] == [student_dev_shell.image_reference(), "/bin/bash"]
+
+
+def test_docker_command_rejects_file_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "main.c"
+    workspace.write_text("", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="directory"):
+        student_dev_shell.docker_command(workspace=workspace)


### PR DESCRIPTION
## Cosa cambia

- completa il bootstrap guidato e ripristinabile dell'ambiente VM Packer/Vagrant
- aggiunge controlli, import e migrazione protetta delle box verificate
- introduce `student-dev` Ubuntu 24.04 per AMD64 e ARM64
- aggiunge build riproducibili da snapshot Ubuntu e CI multiarch
- aggiunge il launcher Docker leggero con limite predefinito di 512 MB
- aggiunge il workflow manuale di pubblicazione su GHCR
- documenta VM e alternativa Docker per computer con poca RAM

## Perché

Gli studenti devono poter preparare un ambiente coerente con un comando guidato
anche su computer con risorse limitate. La variante Docker mantiene la stessa
base Ubuntu 24.04 delle VM e sceglie automaticamente l'architettura del computer.

Il grading Debian non viene modificato.

## Verifiche

- 21 test Python relativi a builder, launcher e lock
- build reale `student-dev` su `linux/arm64`
- build emulata `student-dev` su `linux/amd64`
- smoke test GCC, GDB, Git, Make, Python, Node.js, SQLite e Vim su entrambe
- collaudo launcher con filesystem read-only, workspace scrivibile e 512 MB RAM
- validazione YAML dei workflow
- `git diff --check`

## Dopo il merge

Eseguire manualmente `Publish student development image`, rendere pubblico il
nuovo package GHCR dalle impostazioni e verificare un pull anonimo.
