### PR TITLE
Integrate student-dev into the classroom installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Riferimento principale: README.md, sezione "Introduzione" (../README.md#introduz
 Il corso è fondamentalmente pratico, non è richiesto alcun prerequisito e nulla è dato per scontato.
 </p>
 
-Per preparare l'ambiente servono sempre:
+Per la macchina virtuale servono:
 
 - [Git](https://git-scm.com/downloads);
 - [Vagrant](https://developer.hashicorp.com/vagrant/install) 2.4 o successivo.
@@ -408,14 +408,37 @@ La stessa configurazione supporta Windows su processori Intel/AMD e macOS su
 Apple Silicon. La macchina virtuale usa Ubuntu 24.04 e contiene già compilatore,
 debugger e interfaccia grafica.
 
-È inoltre in preparazione `student-dev`, l'alternativa Docker leggera per i
-computer con poca RAM. Usa la stessa Ubuntu 24.04 delle VM ed è costruita
+È disponibile anche `student-dev`, l'alternativa Docker leggera per i computer
+con poca RAM. Usa la stessa Ubuntu 24.04 delle VM ed è costruita
 nativamente per `linux/amd64` (Windows e Mac Intel) e `linux/arm64` (Mac Apple
-Silicon). Il runner di grading resta per ora separato e basato su Debian: verrà
-allineato solo dopo i test di compatibilità, così gli esiti delle consegne non
-cambiano durante la sperimentazione.
+Silicon).
 
 ## Installare l'ambiente di sviluppo
+
+### Procedura guidata consigliata
+
+La procedura misura la RAM e propone VM completa oppure Docker leggero. Installa
+soltanto i componenti mancanti e può essere rilanciata dopo un riavvio o un
+passaggio manuale.
+
+Su macOS Apple Silicon:
+
+```bash
+curl --fail --location \
+  https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/bootstrap-classroom-macos.sh \
+  | bash
+```
+
+Su Windows apri PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/bootstrap-classroom-windows.ps1 | iex
+```
+
+Nel menu usa le frecce per scegliere, `Invio` per controllare e `a`, poi `s`,
+per installare. Su computer con al massimo 8 GiB viene mostrato per primo
+**Docker leggero - 512 MB**; tutte le alternative compatibili restano
+selezionabili.
 
 ### Preparazione automatica del Mac
 
@@ -487,10 +510,15 @@ se richiesta, è `vagrant`.
 senza avviare una VM completa. Richiede Docker Desktop e usa per impostazione
 predefinita al massimo 512 MB di RAM e una CPU.
 
-Dalla cartella in cui vuoi conservare gli esercizi esegui:
+Il bootstrap monocomando descritto in `installer/README.md` misura la RAM e,
+quando il computer ha al massimo 8 GiB, propone per primo **Docker leggero**.
+Installa Docker Desktop, richiede di avviarlo una volta e scarica l'immagine
+pubblica adatta al processore.
+
+Dopo la preparazione, dalla cartella del progetto esegui:
 
 ```bash
-python3 /percorso/di/2cornot2c/scripts/student_dev_shell.py
+python3 scripts/student_dev_shell.py
 ```
 
 Al primo avvio Docker scarica automaticamente da GHCR l'immagine adatta al
@@ -504,9 +532,9 @@ Per scegliere un'altra cartella o aumentare il limite di memoria:
 python3 scripts/student_dev_shell.py --workspace ./lab --memory 768m
 ```
 
-L'immagine pubblica è versionata: lo script non usa implicitamente `latest`,
-quindi una nuova pubblicazione non cambia l'ambiente degli studenti finché non
-aggiorniamo esplicitamente il manifest del progetto.
+Lo script usa il digest immutabile registrato nel progetto, non `latest`: una
+nuova pubblicazione non cambia l'ambiente degli studenti finché non aggiorniamo
+esplicitamente il lock verificato.
 
 ### Cartelle condivise
 

--- a/docker/student-dev/toolchain.lock.json
+++ b/docker/student-dev/toolchain.lock.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "2cornot2c.student-dev-lock.v1",
+  "version": "2026.07.1",
+  "image_repository": "ghcr.io/thebitpoets/2cornot2c-student-dev",
+  "digest": "sha256:4a0bc77ac44df156a277963c51ba9ea1930fd5cfc3077c84ff97c92c4776e19a",
+  "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/installer/README.md
+++ b/installer/README.md
@@ -5,7 +5,8 @@ l'ambiente didattico:
 
 - macOS Apple Silicon: VMware Fusion raccomandato, VirtualBox opzionale;
 - Windows amd64: VirtualBox;
-- modalità Docker: verrà proposta separatamente dopo la diagnosi della RAM.
+- modalità Docker leggera: disponibile su entrambi e raccomandata
+  automaticamente fino a 8 GiB di RAM.
 
 La logica di rilevamento, i controlli e i piani non dipendono dalla UI.
 `utui` si occupa esclusivamente di rendering e input da terminale.
@@ -28,7 +29,15 @@ irm https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/bootstr
 
 Il bootstrap installa soltanto Git e Python 3.12, prepara il repository in
 `~/2cornot2c`, crea `.installer-venv` e avvia uTUI. La procedura guidata
-diagnostica e installa poi Vagrant e il provider selezionato.
+diagnostica e installa poi l'ambiente selezionato:
+
+- VMware Fusion o VirtualBox per una VM grafica completa;
+- Docker Desktop e l'immagine pubblica `student-dev` per il percorso da 512 MB.
+
+Docker Desktop richiede un primo avvio manuale per autorizzazioni, condizioni
+d'uso ed eventuale configurazione WSL 2. La procedura si ferma senza saltare il
+passaggio; dopo aver completato Docker Desktop basta rilanciare lo stesso
+bootstrap, che riprende dal primo componente mancante.
 
 ## Diagnosi
 
@@ -67,9 +76,24 @@ python -m installer.tui
 Nel menu premi `a`, controlla il provider mostrato e premi `s` per confermare.
 `n` o `Esc` annullano senza modifiche.
 
-Questa fase non scarica ancora il repository o la box Packer e non avvia la
-VM. Il bootstrap monocomando aggiungerà questi passi dopo aver fissato URL,
-versione e checksum degli artefatti pubblicati.
+Il percorso Docker scarica già l'immagine Ubuntu multiarch da GHCR usando il
+digest immutabile in `docker/student-dev/toolchain.lock.json`. Al termine:
+
+```bash
+cd ~/2cornot2c
+.installer-venv/bin/python scripts/student_dev_shell.py
+```
+
+Su Windows:
+
+```powershell
+cd "$HOME\2cornot2c"
+& .installer-venv\Scripts\python.exe scripts\student_dev_shell.py
+```
+
+La parte VM non scarica ancora la box Packer reale e non avvia la VM. Questi
+passi verranno attivati dopo aver fissato URL, versione e checksum degli
+artefatti che superano il collaudo VirtualBox AMD64.
 
 Il contratto e il downloader verificato sono implementati in
 `installer/artifacts.py`; manca intenzionalmente il manifest reale finché la

--- a/installer/executor.py
+++ b/installer/executor.py
@@ -79,7 +79,10 @@ def execute_plan(
         result
         for key, result in check_by_key.items()
         if key in missing
-        and (key not in step_by_key or step_by_key[key].manual)
+        and (
+            key not in step_by_key
+            or (step_by_key[key].manual and not step_by_key[key].deferred)
+        )
     ]
     if blockers:
         results = tuple(

--- a/installer/main.py
+++ b/installer/main.py
@@ -10,6 +10,7 @@ from installer.executor import execute_plan
 from installer.model import Provider
 from installer.platforms import detect_host
 from installer.plans import install_plan, supported_providers
+from installer.resources import order_by_recommendation, total_memory_bytes
 
 
 def parser() -> argparse.ArgumentParser:
@@ -19,7 +20,7 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument(
         "--provider",
         choices=[provider.value for provider in Provider],
-        help="provider desiderato; se omesso usa quello raccomandato",
+        help="ambiente desiderato; se omesso usa quello raccomandato",
     )
     result.add_argument(
         "--apply",
@@ -47,12 +48,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.yes and not args.apply:
         parser().error("--yes richiede --apply")
     host = detect_host()
-    providers = supported_providers(host)
+    memory_bytes = total_memory_bytes(host)
+    providers = order_by_recommendation(supported_providers(host), memory_bytes)
     provider = Provider(args.provider) if args.provider else providers[0]
     plan = install_plan(host, provider)
 
     print(f"Host: {host.value}")
-    print(f"Provider: {provider.value}")
+    if memory_bytes is not None:
+        print(f"RAM: {memory_bytes / 1024**3:.1f} GiB")
+    print(f"Ambiente: {provider.value}")
     print("\nDiagnosi:")
     results = diagnose(plan)
     for result in results:

--- a/installer/migration.py
+++ b/installer/migration.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 import subprocess
 
-from installer.model import Provider
+from installer.model import Provider, VM_PROVIDERS
 
 
 CONFIRMATION = "RICREA VM"
@@ -76,6 +76,8 @@ def subprocess_runner(
 def state_directory(provider: Provider) -> str:
     """Mantiene isolati gli stati Vagrant dei due provider."""
 
+    if provider not in VM_PROVIDERS:
+        raise ValueError(f"Provider non VM: {provider.value}")
     return ".vagrant-vmware" if provider is Provider.VMWARE else ".vagrant"
 
 
@@ -171,7 +173,7 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument(
         "--provider",
         required=True,
-        choices=[provider.value for provider in Provider],
+        choices=[provider.value for provider in VM_PROVIDERS],
     )
     result.add_argument("--project", type=Path, default=Path.cwd())
     return result

--- a/installer/model.py
+++ b/installer/model.py
@@ -14,10 +14,14 @@ class Host(str, Enum):
 
 
 class Provider(str, Enum):
-    """Provider VM selezionabili."""
+    """Ambienti selezionabili dall'installer."""
 
     VMWARE = "vmware_desktop"
     VIRTUALBOX = "virtualbox"
+    DOCKER = "docker"
+
+
+VM_PROVIDERS = (Provider.VMWARE, Provider.VIRTUALBOX)
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +43,7 @@ class Step:
     command: tuple[str, ...] | None
     manual: bool = False
     detail: str = ""
+    deferred: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/installer/plans.py
+++ b/installer/plans.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 from installer.model import Check, Host, InstallPlan, Provider, Step
+from installer.student_dev import immutable_reference
 
 
 def supported_providers(host: Host) -> tuple[Provider, ...]:
     """Restituisce solo i provider ufficialmente supportati per l'host."""
 
     if host is Host.MACOS_ARM64:
-        return (Provider.VMWARE, Provider.VIRTUALBOX)
+        return (Provider.VMWARE, Provider.VIRTUALBOX, Provider.DOCKER)
     if host is Host.WINDOWS_AMD64:
-        return (Provider.VIRTUALBOX,)
+        return (Provider.VIRTUALBOX, Provider.DOCKER)
     raise ValueError(f"Host non supportato: {host}")
 
 
@@ -21,6 +22,8 @@ def install_plan(host: Host, provider: Provider) -> InstallPlan:
     if provider not in supported_providers(host):
         raise ValueError(f"{provider.value} non è supportato su {host.value}")
 
+    if provider is Provider.DOCKER:
+        return _docker_plan(host)
     if host is Host.MACOS_ARM64:
         return _macos_plan(provider)
     return _windows_plan()
@@ -119,5 +122,82 @@ def _windows_plan() -> InstallPlan:
                 "Installa VirtualBox",
                 ("winget", "install", "--id", "Oracle.VirtualBox", "--exact"),
             ),
+        ),
+    )
+
+
+def _docker_plan(host: Host) -> InstallPlan:
+    image = immutable_reference()
+    common_checks = (
+        Check("docker", "Docker Desktop", ("docker", "--version")),
+        Check("docker-engine", "Motore Docker avviato", ("docker", "info")),
+        Check(
+            "student-image",
+            "Immagine Ubuntu student-dev",
+            ("docker", "image", "inspect", image),
+        ),
+    )
+    if host is Host.MACOS_ARM64:
+        return InstallPlan(
+            host,
+            Provider.DOCKER,
+            (
+                Check("brew", "Homebrew", ("brew", "--version")),
+                *common_checks,
+            ),
+            (
+                Step("brew", "Installa Homebrew", None, manual=True),
+                Step(
+                    "docker",
+                    "Installa Docker Desktop",
+                    ("brew", "install", "--cask", "docker-desktop"),
+                ),
+                Step(
+                    "docker-engine",
+                    "Avvia Docker Desktop",
+                    None,
+                    manual=True,
+                    detail=(
+                        "Apri Docker Desktop e completa autorizzazioni e condizioni "
+                        "d'uso; poi rilancia l'installer."
+                    ),
+                    deferred=True,
+                ),
+                Step("student-image", "Scarica student-dev", ("docker", "pull", image)),
+            ),
+        )
+    return InstallPlan(
+        host,
+        Provider.DOCKER,
+        (
+            Check("winget", "Windows Package Manager", ("winget", "--version")),
+            *common_checks,
+        ),
+        (
+            Step(
+                "docker",
+                "Installa Docker Desktop",
+                (
+                    "winget",
+                    "install",
+                    "--id",
+                    "Docker.DockerDesktop",
+                    "--exact",
+                    "--accept-package-agreements",
+                    "--accept-source-agreements",
+                ),
+            ),
+            Step(
+                "docker-engine",
+                "Avvia Docker Desktop",
+                None,
+                manual=True,
+                detail=(
+                    "Avvia Docker Desktop, completa la configurazione WSL 2 e "
+                    "riavvia Windows se richiesto; poi rilancia l'installer."
+                ),
+                deferred=True,
+            ),
+            Step("student-image", "Scarica student-dev", ("docker", "pull", image)),
         ),
     )

--- a/installer/resources.py
+++ b/installer/resources.py
@@ -1,0 +1,64 @@
+"""Rilevamento prudente delle risorse usato soltanto per la raccomandazione."""
+
+from __future__ import annotations
+
+import ctypes
+import subprocess
+
+from installer.model import Host, Provider
+
+
+LOW_MEMORY_LIMIT_BYTES = 8 * 1024**3
+
+
+class _MemoryStatusEx(ctypes.Structure):
+    _fields_ = [
+        ("dwLength", ctypes.c_ulong),
+        ("dwMemoryLoad", ctypes.c_ulong),
+        ("ullTotalPhys", ctypes.c_ulonglong),
+        ("ullAvailPhys", ctypes.c_ulonglong),
+        ("ullTotalPageFile", ctypes.c_ulonglong),
+        ("ullAvailPageFile", ctypes.c_ulonglong),
+        ("ullTotalVirtual", ctypes.c_ulonglong),
+        ("ullAvailVirtual", ctypes.c_ulonglong),
+        ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+    ]
+
+
+def total_memory_bytes(host: Host) -> int | None:
+    """Restituisce la RAM fisica o None senza impedire l'installazione."""
+
+    try:
+        if host is Host.MACOS_ARM64:
+            result = subprocess.run(
+                ("sysctl", "-n", "hw.memsize"),
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return int(result.stdout.strip())
+        status = _MemoryStatusEx()
+        status.dwLength = ctypes.sizeof(_MemoryStatusEx)
+        if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+            return int(status.ullTotalPhys)
+    except (AttributeError, OSError, ValueError, subprocess.SubprocessError):
+        return None
+    return None
+
+
+def order_by_recommendation(
+    providers: tuple[Provider, ...],
+    memory_bytes: int | None,
+) -> tuple[Provider, ...]:
+    """Mette Docker per primo soltanto su host con non più di 8 GiB."""
+
+    if (
+        memory_bytes is not None
+        and memory_bytes <= LOW_MEMORY_LIMIT_BYTES
+        and Provider.DOCKER in providers
+    ):
+        return (Provider.DOCKER,) + tuple(
+            provider for provider in providers if provider is not Provider.DOCKER
+        )
+    return providers

--- a/installer/student_dev.py
+++ b/installer/student_dev.py
@@ -1,0 +1,52 @@
+"""Contratto immutabile dell'immagine student-dev pubblicata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LOCK = ROOT / "docker" / "student-dev" / "toolchain.lock.json"
+SCHEMA_VERSION = "2cornot2c.student-dev-lock.v1"
+EXPECTED_KEYS = {
+    "schema_version",
+    "version",
+    "image_repository",
+    "digest",
+    "platforms",
+}
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class StudentDevLockError(ValueError):
+    """Lock student-dev mancante o alterato."""
+
+
+def load_lock(path: Path = DEFAULT_LOCK) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise StudentDevLockError(f"Lock student-dev non leggibile: {path}") from error
+    if not isinstance(payload, dict) or set(payload) != EXPECTED_KEYS:
+        raise StudentDevLockError("Campi lock student-dev non validi.")
+    if payload["schema_version"] != SCHEMA_VERSION:
+        raise StudentDevLockError("Schema lock student-dev non supportato.")
+    if payload["image_repository"] != "ghcr.io/thebitpoets/2cornot2c-student-dev":
+        raise StudentDevLockError("Repository student-dev non autorizzato.")
+    if not isinstance(payload["digest"], str) or not DIGEST_RE.fullmatch(
+        payload["digest"]
+    ):
+        raise StudentDevLockError("Digest student-dev non valido.")
+    if payload["platforms"] != ["linux/amd64", "linux/arm64"]:
+        raise StudentDevLockError("Piattaforme student-dev non valide.")
+    if not isinstance(payload["version"], str) or not payload["version"]:
+        raise StudentDevLockError("Versione student-dev non valida.")
+    return payload
+
+
+def immutable_reference(path: Path = DEFAULT_LOCK) -> str:
+    lock = load_lock(path)
+    return f"{lock['image_repository']}@{lock['digest']}"

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -25,6 +25,7 @@ from installer.executor import execute_plan
 from installer.model import Host, Provider
 from installer.platforms import detect_host
 from installer.plans import install_plan, supported_providers
+from installer.resources import order_by_recommendation, total_memory_bytes
 
 
 @dataclass(slots=True)
@@ -33,6 +34,7 @@ class State:
 
     host: Host
     providers: tuple[Provider, ...]
+    memory_bytes: int | None = None
     active_index: int = 0
     report: tuple[str, ...] = ("Premi Invio per eseguire la diagnosi.",)
     confirmation_pending: bool = False
@@ -42,15 +44,23 @@ class State:
 def build_screen(state: State):
     """Costruisce la schermata senza I/O o mutazioni."""
 
+    names = {
+        Provider.VMWARE: "VM completa - VMware Fusion",
+        Provider.VIRTUALBOX: "VM completa - VirtualBox",
+        Provider.DOCKER: "Docker leggero - 512 MB",
+    }
     provider_labels = tuple(
-        "VMware Fusion (raccomandato)"
-        if provider is Provider.VMWARE
-        else "VirtualBox"
-        for provider in state.providers
+        f"{names[provider]}{' (raccomandato)' if index == 0 else ''}"
+        for index, provider in enumerate(state.providers)
+    )
+    memory_label = (
+        f", RAM {state.memory_bytes / 1024**3:.1f} GiB"
+        if state.memory_bytes is not None
+        else ""
     )
     choices = Panel(
         ListView(provider_labels, active_index=state.active_index, focused=True),
-        title=f"Ambiente 2cornot2c - {state.host.value}",
+        title=f"Ambiente 2cornot2c - {state.host.value}{memory_label}",
         min_width=38,
     )
     report = Panel(
@@ -94,7 +104,7 @@ def request_confirmation(state: State) -> None:
     provider = state.providers[state.active_index]
     state.confirmation_pending = True
     state.report = (
-        f"Provider: {provider.value}",
+        f"Ambiente: {provider.value}",
         "Saranno installati solo i componenti mancanti.",
         "Premi s per confermare oppure n per annullare.",
     )
@@ -115,6 +125,15 @@ def apply_selected(state: State) -> None:
         f"[{result.status.upper()}] {result.label}: {result.detail}"
         for result in results
     ) or ("Nessun passo necessario.",)
+    if (
+        provider is Provider.DOCKER
+        and results
+        and all(result.status in {"skipped", "succeeded"} for result in results)
+    ):
+        state.report += (
+            "Pronto. Esci con q, poi avvia:",
+            "python scripts/student_dev_shell.py",
+        )
 
 
 def present(rows: list[str]) -> None:
@@ -129,7 +148,12 @@ def main() -> int:
     """Esegue il menu interattivo mantenendo l'event loop nel consumer."""
 
     host = detect_host()
-    state = State(host, supported_providers(host))
+    memory_bytes = total_memory_bytes(host)
+    state = State(
+        host,
+        order_by_recommendation(supported_providers(host), memory_bytes),
+        memory_bytes,
+    )
     watcher = ResizeWatcher()
     color = supports_color()
 

--- a/installer/vagrant_box.py
+++ b/installer/vagrant_box.py
@@ -11,7 +11,7 @@ import subprocess
 import tempfile
 
 from installer.artifacts import BoxArtifact, verify_box
-from installer.model import Host, Provider
+from installer.model import Host, Provider, VM_PROVIDERS
 
 
 @dataclass(frozen=True, slots=True)
@@ -122,6 +122,8 @@ def configure_project(project: Path, artifact: BoxArtifact) -> None:
 def launch_command(project: Path, host: Host, provider: Provider) -> tuple[str, ...]:
     """Restituisce il comando supportato per il primo avvio e health check."""
 
+    if provider not in VM_PROVIDERS:
+        raise ValueError(f"Provider non VM: {provider.value}")
     if host is Host.MACOS_ARM64:
         option = "--vmware" if provider is Provider.VMWARE else "--virtualbox"
         return ("bash", str(project / "scripts" / "setup-vm.sh"), option)

--- a/scripts/student_dev_shell.py
+++ b/scripts/student_dev_shell.py
@@ -8,16 +8,18 @@ import shlex
 import subprocess
 
 try:
-    from scripts import build_student_dev
+    from installer import student_dev
 except ModuleNotFoundError:  # Esecuzione diretta: python scripts/student_dev_shell.py
-    import build_student_dev
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from installer import student_dev
 
 
 def image_reference() -> str:
-    """Restituisce il tag versionato dichiarato nel manifest controllato."""
+    """Restituisce il riferimento GHCR immutabile verificato."""
 
-    manifest = build_student_dev.load_manifest()
-    return f"{manifest['image_repository']}:{manifest['version']}"
+    return student_dev.immutable_reference()
 
 
 def docker_command(
@@ -77,7 +79,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser().parse_args(argv)
     try:
         command = docker_command(workspace=args.workspace, memory=args.memory)
-    except (OSError, ValueError, build_student_dev.StudentDevBuildError) as error:
+    except (OSError, ValueError, student_dev.StudentDevLockError) as error:
         print(f"Ambiente student-dev non disponibile: {error}")
         return 1
     if args.print_command:

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -8,6 +8,8 @@ from installer.model import Check
 from installer.model import Host, Provider
 from installer.platforms import detect_host
 from installer.plans import install_plan, supported_providers
+from installer.resources import LOW_MEMORY_LIMIT_BYTES, order_by_recommendation
+from installer.student_dev import immutable_reference, load_lock
 
 
 def test_detects_supported_hosts() -> None:
@@ -20,12 +22,16 @@ def test_rejects_unsupported_host() -> None:
         detect_host("Linux", "x86_64")
 
 
-def test_mac_supports_choice_but_windows_has_one_path() -> None:
+def test_hosts_support_vm_and_lightweight_docker_paths() -> None:
     assert supported_providers(Host.MACOS_ARM64) == (
         Provider.VMWARE,
         Provider.VIRTUALBOX,
+        Provider.DOCKER,
     )
-    assert supported_providers(Host.WINDOWS_AMD64) == (Provider.VIRTUALBOX,)
+    assert supported_providers(Host.WINDOWS_AMD64) == (
+        Provider.VIRTUALBOX,
+        Provider.DOCKER,
+    )
 
 
 def test_windows_rejects_vmware() -> None:
@@ -40,6 +46,36 @@ def test_plans_are_provider_specific() -> None:
     assert any(step.key == "fusion" for step in vmware.steps)
     assert not any(step.key == "virtualbox" for step in vmware.steps)
     assert any(step.key == "virtualbox" for step in virtualbox.steps)
+
+
+def test_low_memory_recommends_docker_without_removing_vm_choices() -> None:
+    providers = supported_providers(Host.WINDOWS_AMD64)
+
+    assert order_by_recommendation(providers, LOW_MEMORY_LIMIT_BYTES)[0] is (
+        Provider.DOCKER
+    )
+    assert order_by_recommendation(providers, LOW_MEMORY_LIMIT_BYTES + 1) == providers
+    assert order_by_recommendation(providers, None) == providers
+
+
+def test_docker_plans_install_desktop_and_pull_immutable_image() -> None:
+    image = immutable_reference()
+    mac = install_plan(Host.MACOS_ARM64, Provider.DOCKER)
+    windows = install_plan(Host.WINDOWS_AMD64, Provider.DOCKER)
+
+    assert ("brew", "install", "--cask", "docker-desktop") in {
+        step.command for step in mac.steps
+    }
+    assert any(
+        step.command
+        and step.command[:5]
+        == ("winget", "install", "--id", "Docker.DockerDesktop", "--exact")
+        for step in windows.steps
+    )
+    assert ("docker", "pull", image) in {step.command for step in mac.steps}
+    assert ("docker", "pull", image) in {step.command for step in windows.steps}
+    assert "@sha256:" in image
+    assert load_lock()["platforms"] == ["linux/amd64", "linux/arm64"]
 
 
 def test_check_can_require_semantic_output() -> None:
@@ -70,6 +106,21 @@ def test_tui_frame_lists_supported_provider() -> None:
     rendered = "\n".join(rows)
     assert "VirtualBox" in rendered
     assert "VMware Fusion" not in rendered
+
+
+def test_tui_marks_first_low_memory_choice_as_recommended() -> None:
+    pytest.importorskip("utui")
+    from installer.tui import State, frame
+
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER, Provider.VIRTUALBOX),
+        8 * 1024**3,
+    )
+    rendered = "\n".join(frame(state, 180, 12, color=False))
+
+    assert "Docker leggero - 512 MB (raccomandato)" in rendered
+    assert "RAM 8.0 GiB" in rendered
 
 
 def test_tui_confirmation_is_explicit_and_cancellable() -> None:
@@ -121,6 +172,30 @@ def test_executor_blocks_manual_prerequisite_before_writes() -> None:
     assert [result.key for result in results] == ["fusion"]
     assert results[0].status == "blocked"
     assert calls == []
+
+
+def test_docker_install_runs_before_deferred_first_start() -> None:
+    plan = install_plan(Host.WINDOWS_AMD64, Provider.DOCKER)
+    calls = []
+
+    results = execute_plan(
+        plan,
+        check_results(
+            plan,
+            missing={"docker", "docker-engine", "student-image"},
+        ),
+        runner=lambda command: (calls.append(command) or (0, "installato")),
+    )
+
+    assert [result.key for result in results] == ["docker", "docker-engine"]
+    assert [result.status for result in results] == ["succeeded", "blocked"]
+    assert calls[0][:5] == (
+        "winget",
+        "install",
+        "--id",
+        "Docker.DockerDesktop",
+        "--exact",
+    )
 
 
 def test_executor_stops_on_first_failed_command() -> None:

--- a/tests/test_classroom_migration.py
+++ b/tests/test_classroom_migration.py
@@ -9,6 +9,7 @@ from installer.migration import (
     MachineState,
     parse_machine_state,
     recreate_machine,
+    state_directory,
     validate_shared_folders,
 )
 from installer.model import Provider
@@ -32,6 +33,11 @@ def test_parse_provider_specific_machine_state() -> None:
 
     assert machine.exists is True
     assert machine.running is False
+
+
+def test_docker_is_not_a_vagrant_migration_provider() -> None:
+    with pytest.raises(ValueError, match="non VM"):
+        state_directory(Provider.DOCKER)
 
 
 def test_recreate_requires_exact_confirmation_before_commands(tmp_path: Path) -> None:

--- a/tests/test_classroom_vagrant_box.py
+++ b/tests/test_classroom_vagrant_box.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
+import pytest
+
 from installer.artifacts import BoxArtifact
 from installer.model import Host, Provider
 from installer.vagrant_box import (
@@ -106,3 +108,5 @@ def test_launch_commands_are_host_specific(tmp_path: Path) -> None:
     assert launch_command(
         tmp_path, Host.WINDOWS_AMD64, Provider.VIRTUALBOX
     )[0] == "powershell.exe"
+    with pytest.raises(ValueError, match="non VM"):
+        launch_command(tmp_path, Host.MACOS_ARM64, Provider.DOCKER)

--- a/tests/test_student_dev_shell.py
+++ b/tests/test_student_dev_shell.py
@@ -5,12 +5,12 @@ import pytest
 from scripts import build_student_dev, student_dev_shell
 
 
-def test_image_reference_is_versioned() -> None:
+def test_image_reference_is_immutable() -> None:
     manifest = build_student_dev.load_manifest()
+    reference = student_dev_shell.image_reference()
 
-    assert student_dev_shell.image_reference() == (
-        f"{manifest['image_repository']}:{manifest['version']}"
-    )
+    assert reference.startswith(f"{manifest['image_repository']}@sha256:")
+    assert ":latest" not in reference
 
 
 def test_docker_command_is_lightweight_non_root_image(tmp_path: Path) -> None:


### PR DESCRIPTION
## Cosa cambia

- aggiunge Docker leggero alle scelte uTUI su macOS Apple Silicon e Windows AMD64
- raccomanda Docker sui computer con non più di 8 GiB di RAM
- installa Docker Desktop con Homebrew o winget e gestisce il primo avvio manuale
- scarica `student-dev` pubblico usando un digest GHCR immutabile
- aggiorna il launcher affinché non usi tag mutabili
- impedisce che Docker venga passato alle operazioni Vagrant e alla migrazione VM
- aggiorna README e guida del bootstrap monocomando

## Perché

Gli studenti con poca RAM devono avere una procedura guidata equivalente alla
VM ma più leggera. La scelta automatica deve restare una raccomandazione:
VirtualBox e VMware continuano a essere selezionabili quando supportati.

Il grading Debian non viene modificato.

## Impatto

Su macOS e Windows il bootstrap esistente apre un menu unico. Se viene scelto
Docker, l'installer installa soltanto i componenti mancanti, si ferma per
autorizzazioni/WSL 2 quando necessario e riprende al lancio successivo. La shell
usa 512 MB e l'immagine pubblicata per AMD64 o ARM64.

## Verifiche

- 39 test mirati Python
- rendering uTUI reale con profilo Windows da 8 GiB
- diagnosi Docker reale su macOS Apple Silicon
- riferimento GHCR anonimo verificato e bloccato al digest
- compilazione Python dei moduli modificati
- validazione sintassi degli script shell
- `git diff --check`
