### PR TITLE
Add student-friendly Windows installation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,12 @@ virtualizzazione hardware e connessione. Docker richiede almeno 4 GiB di RAM e
 8 GiB liberi; una VM richiede almeno 8 GiB di RAM e 20 GiB liberi. Se una
 risorsa obbligatoria manca, nessun componente viene modificato.
 
+Gli errori destinati agli studenti hanno un codice stabile, un titolo rosso e
+istruzioni semplici in giallo. Ogni messaggio spiega cosa è successo, cosa fare
+e quale codice comunicare al docente, per esempio `E03` quando la
+virtualizzazione è disabilitata. I dettagli tecnici restano separati e non è
+mai richiesto a uno studente di modificare da solo BIOS, antivirus o file Git.
+
 #### Aggiornare su Windows
 
 Lo stesso bootstrap può essere rilanciato in sicurezza. È disponibile anche il

--- a/installer/README.md
+++ b/installer/README.md
@@ -21,6 +21,20 @@ Prima di qualsiasi scrittura, il preflight verifica:
 Le misure non disponibili producono un avviso; una misura sotto soglia blocca
 il piano prima del primo comando di installazione.
 
+## Messaggi per gli studenti
+
+Gli errori mostrati dalla procedura usano un catalogo stabile:
+
+- titolo `ERRORE Exx` in rosso;
+- spiegazione e azioni in giallo;
+- codice breve da comunicare al docente;
+- dettaglio tecnico separato.
+
+Il catalogo Python è in `installer/student_errors.py`. Gli script PowerShell
+usano la stessa convenzione durante bootstrap, aggiornamento e disinstallazione.
+Gli studenti non vengono invitati a disattivare protezioni o modificare da soli
+il BIOS; il caso `E03` chiede espressamente l'aiuto di un adulto o del docente.
+
 ## Bootstrap monocomando
 
 Su macOS Apple Silicon:

--- a/installer/student_errors.py
+++ b/installer/student_errors.py
@@ -1,0 +1,193 @@
+"""Messaggi semplici e stabili mostrati agli studenti dall'installer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import sys
+
+
+@dataclass(frozen=True, slots=True)
+class StudentError:
+    code: str
+    title: str
+    explanation: str
+    actions: tuple[str, ...]
+
+    def lines(self, technical: str = "") -> tuple[str, ...]:
+        result = [
+            f"ERRORE {self.code} - {self.title}",
+            f"COSA SIGNIFICA: {self.explanation}",
+            "COSA DEVI FARE:",
+        ]
+        result.extend(
+            f"COSA FARE {index}: {action}"
+            for index, action in enumerate(self.actions, 1)
+        )
+        result.append(f"CODICE DA COMUNICARE AL DOCENTE: {self.code}")
+        if technical:
+            result.append(f"Dettagli tecnici: {technical[:240]}")
+        return tuple(result)
+
+
+ERRORS = {
+    "memory": StudentError(
+        "E02",
+        "Il computer non ha abbastanza memoria RAM",
+        "La RAM e lo spazio di lavoro temporaneo del computer.",
+        ("Chiudi gli altri programmi e riprova.", "Comunica E02 al docente."),
+    ),
+    "virtualization": StudentError(
+        "E03",
+        "La virtualizzazione del computer e disabilitata",
+        "Docker e le VM ne hanno bisogno. Non hai rotto nulla.",
+        (
+            "Apri Gestione attivita, Prestazioni, CPU.",
+            "Non cambiare il BIOS da solo: chiedi a un adulto o al docente.",
+        ),
+    ),
+    "disk": StudentError(
+        "E05",
+        "Non c'e abbastanza spazio libero sul disco",
+        "Serve spazio per conservare programmi ed esercizi.",
+        (
+            "Svuota il Cestino o sposta file personali.",
+            "Non cancellare file che non riconosci e poi riprova.",
+        ),
+    ),
+    "resources": StudentError(
+        "E06",
+        "Il controllo delle risorse non e riuscito",
+        "RAM, disco o virtualizzazione non rispettano i requisiti.",
+        ("Leggi i dettagli qui sotto.", "Comunica E06 al docente."),
+    ),
+    "network": StudentError(
+        "E07",
+        "Non riesco a collegarmi al server di download",
+        "La procedura ha bisogno di Internet.",
+        (
+            "Controlla con il browser che Internet funzioni.",
+            "Non disattivare l'antivirus; riprova o comunica E07.",
+        ),
+    ),
+    "winget": StudentError(
+        "E08",
+        "Il programma di installazione di Windows non e disponibile",
+        "winget e lo strumento ufficiale usato da Windows.",
+        (
+            "Aggiorna App Installer dal Microsoft Store.",
+            "Riapri PowerShell e rilancia il comando.",
+        ),
+    ),
+    "docker": StudentError(
+        "E17",
+        "Docker Desktop non e installato",
+        "Docker avvia l'ambiente Linux leggero.",
+        ("Conferma l'installazione dal menu.", "Accetta la richiesta di Windows."),
+    ),
+    "docker-engine": StudentError(
+        "E19",
+        "Docker Desktop e installato ma non e acceso",
+        "Il programma e presente, ma il suo motore non e ancora pronto.",
+        (
+            "Avvia Docker Desktop dal menu Start.",
+            "Completa WSL 2, accetta le condizioni e riavvia se richiesto.",
+            "Attendi che Docker sia pronto e rilancia l'installer.",
+        ),
+    ),
+    "student-image": StudentError(
+        "E21",
+        "Non riesco a scaricare l'ambiente Linux",
+        "Docker funziona, ma il download non e completo.",
+        (
+            "Lascia Docker Desktop aperto e controlla Internet.",
+            "Rilancia l'installer: non perderai quanto gia scaricato.",
+        ),
+    ),
+    "student-security": StudentError(
+        "E22",
+        "L'ambiente Linux non supera il controllo di sicurezza",
+        "Per sicurezza non verra avviato nulla e il tuo lavoro resta intatto.",
+        ("Non scaricare immagini alternative.", "Comunica E22 al docente."),
+    ),
+    "docker-command": StudentError(
+        "E23",
+        "PowerShell non riesce a trovare Docker",
+        "Docker puo essere appena stato installato e Windows non lo vede ancora.",
+        (
+            "Chiudi PowerShell e avvia Docker Desktop.",
+            "Apri un nuovo PowerShell; se serve, riavvia Windows.",
+        ),
+    ),
+    "container": StudentError(
+        "E24",
+        "L'ambiente Linux non e riuscito ad avviarsi",
+        "Il tuo lavoro non e stato cancellato.",
+        (
+            "Controlla che Docker Desktop sia aperto e pronto.",
+            "Riprova; se ricompare, comunica E24 al docente.",
+        ),
+    ),
+    "terminal": StudentError(
+        "E16",
+        "Questo terminale non puo mostrare il menu",
+        "Serve un terminale interattivo.",
+        ("Apri PowerShell o Windows Terminal.", "Rilancia lo stesso comando."),
+    ),
+}
+
+
+def resource_error(detail: str) -> StudentError:
+    blocked = next(
+        (
+            part
+            for part in detail.split(";")
+            if part.strip().lower().startswith("blocked")
+        ),
+        detail,
+    )
+    lowered = blocked.lower()
+    if "virtualizzazione" in lowered:
+        return ERRORS["virtualization"]
+    if "ram " in lowered:
+        return ERRORS["memory"]
+    if "disco " in lowered:
+        return ERRORS["disk"]
+    return ERRORS["resources"]
+
+
+def for_check(key: str, detail: str) -> StudentError:
+    if key == "resources":
+        return resource_error(detail)
+    return ERRORS.get(
+        key,
+        StudentError(
+            "E09",
+            "Un componente necessario non e disponibile",
+            "La procedura si e fermata senza cancellare il tuo lavoro.",
+            ("Rilancia l'installer.", "Se ricompare, comunica E09 al docente."),
+        ),
+    )
+
+
+def for_step(key: str) -> StudentError:
+    if key == "docker":
+        return StudentError(
+            "E18",
+            "Windows non e riuscito a installare Docker Desktop",
+            "L'installazione e stata interrotta o non autorizzata.",
+            (
+                "Controlla se Windows aspetta una conferma.",
+                "Riavvia e rilancia il comando; se ricompare comunica E18.",
+            ),
+        )
+    return for_check(key, "")
+
+
+def print_error(error: StudentError, technical: str = "") -> None:
+    """Stampa rosso/giallo quando il terminale lo consente."""
+
+    color = sys.stdout.isatty()
+    for line in error.lines(technical):
+        escape = "\x1b[31m" if line.startswith("ERRORE ") else "\x1b[33m"
+        reset = "\x1b[0m" if color else ""
+        print(f"{escape if color else ''}{line}{reset}")

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -26,6 +26,7 @@ from installer.model import Host, Provider
 from installer.platforms import detect_host
 from installer.plans import install_plan, supported_providers
 from installer.resources import order_by_recommendation, total_memory_bytes
+from installer.student_errors import ERRORS, for_check, for_step
 
 
 @dataclass(slots=True)
@@ -84,7 +85,31 @@ def build_screen(state: State):
 def frame(state: State, width: int, height: int, *, color: bool) -> list[str]:
     """Renderizza un frame deterministico."""
 
-    return render_lines(build_screen(state), width, height, color=color)
+    rows = render_lines(build_screen(state), width, height, color=color)
+    if not color:
+        return rows
+    return [_paint_guidance(row) for row in rows]
+
+
+def _paint_guidance(row: str) -> str:
+    """Colora dopo il layout, senza alterare i calcoli di larghezza uTUI."""
+
+    markers = (
+        ("ERRORE E", "\x1b[31m"),
+        ("COSA SIGNIFICA:", "\x1b[33m"),
+        ("COSA DEVI FARE:", "\x1b[33m"),
+        ("COSA FARE ", "\x1b[33m"),
+        ("CODICE DA COMUNICARE", "\x1b[33m"),
+    )
+    for marker, escape in markers:
+        start = row.find(marker)
+        if start < 0:
+            continue
+        end = row.rfind("│")
+        if end <= start:
+            end = len(row)
+        return f"{row[:start]}{escape}{row[start:end]}\x1b[0m{row[end:]}"
+    return row
 
 
 def refresh_report(state: State) -> None:
@@ -92,10 +117,16 @@ def refresh_report(state: State) -> None:
 
     provider = state.providers[state.active_index]
     results = diagnose(install_plan(state.host, provider))
-    state.report = tuple(
-        f"[{'OK' if result.ok else 'MANCA'}] {result.check.label}: {result.detail}"
-        for result in results
-    )
+    report: list[str] = []
+    for result in results:
+        if not result.ok and result.check.key in {"resources", "network"}:
+            report.extend(for_check(result.check.key, result.detail).lines(result.detail))
+        else:
+            report.append(
+                f"[{'OK' if result.ok else 'MANCA'}] "
+                f"{result.check.label}: {result.detail}"
+            )
+    state.report = tuple(report)
 
 
 def request_confirmation(state: State) -> None:
@@ -121,10 +152,20 @@ def apply_selected(state: State) -> None:
         log_path=Path.home() / ".2cornot2c" / "installer.jsonl",
     )
     state.confirmation_pending = False
-    state.report = tuple(
-        f"[{result.status.upper()}] {result.label}: {result.detail}"
-        for result in results
-    ) or ("Nessun passo necessario.",)
+    report: list[str] = []
+    for result in results:
+        if result.status in {"failed", "blocked"}:
+            error = (
+                for_step(result.key)
+                if result.status == "failed"
+                else for_check(result.key, result.detail)
+            )
+            report.extend(error.lines(result.detail))
+        else:
+            report.append(
+                f"[{result.status.upper()}] {result.label}: {result.detail}"
+            )
+    state.report = tuple(report) or ("Nessun passo necessario.",)
     if (
         provider is Provider.DOCKER
         and results
@@ -192,7 +233,8 @@ def main() -> int:
                 if state.running and changed:
                     present(frame(state, size.width, size.height, color=color))
     except UnsupportedOperation as error:
-        print(f"Terminale interattivo non disponibile: {error}", file=sys.stderr)
+        for line in ERRORS["terminal"].lines(str(error)):
+            print(line, file=sys.stderr)
         return 2
     finally:
         print()

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -26,9 +26,30 @@ if (Test-Path $StatePath) {
 }
 
 function Stop-WithMessage {
-    param([string]$Message)
+    param(
+        [string]$Code,
+        [string]$Title,
+        [string]$Explanation,
+        [string[]]$Actions = @(),
+        [string]$Technical = ""
+    )
     Write-Host ""
-    Write-Host "ERRORE: $Message" -ForegroundColor Red
+    Write-Host "ERRORE $Code - $Title" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "COSA SIGNIFICA" -ForegroundColor Yellow
+    Write-Host $Explanation -ForegroundColor Yellow
+    if ($Actions.Count -gt 0) {
+        Write-Host ""
+        Write-Host "COSA DEVI FARE" -ForegroundColor Yellow
+        for ($Index = 0; $Index -lt $Actions.Count; $Index++) {
+            Write-Host "$($Index + 1). $($Actions[$Index])" -ForegroundColor Yellow
+        }
+    }
+    Write-Host ""
+    Write-Host "Se chiedi aiuto, comunica questo codice: $Code" -ForegroundColor Yellow
+    if ($Technical) {
+        Write-Host "Dettagli tecnici: $Technical" -ForegroundColor DarkGray
+    }
     exit 1
 }
 
@@ -37,7 +58,13 @@ function Install-WingetPackage {
     winget install --id $Id --exact --silent `
         --accept-package-agreements --accept-source-agreements
     if ($LASTEXITCODE -ne 0) {
-        Stop-WithMessage "Installazione non riuscita: $Id"
+        Stop-WithMessage "E09" "Installazione di $Id non riuscita" `
+            "Windows ha interrotto o rifiutato l'installazione. Non devi ricominciare da zero." `
+            @(
+                "Controlla se Windows aspetta una conferma e scegli Si."
+                "Rilancia lo stesso comando: i componenti presenti saranno saltati."
+                "Se ricompare, comunica E09 al docente."
+            ) "winget exit code $LASTEXITCODE"
     }
     if (-not $InstalledByBootstrap.Contains($Id)) {
         $InstalledByBootstrap.Add($Id)
@@ -65,10 +92,21 @@ function Test-HostResources {
             1
         )
     } catch {
-        Stop-WithMessage "Impossibile misurare la RAM: $($_.Exception.Message)"
+        Stop-WithMessage "E06" "Non riesco a controllare la memoria del computer" `
+            "Windows non ha permesso alla procedura di leggere la RAM. Non e stato modificato nulla." `
+            @(
+                "Chiudi PowerShell e riaprilo."
+                "Rilancia lo stesso comando."
+                "Se ricompare, comunica E06 al docente."
+            ) $_.Exception.Message
     }
     if ($MemoryGiB -lt 4) {
-        Stop-WithMessage "RAM insufficiente: $MemoryGiB GiB; minimo 4 GiB."
+        Stop-WithMessage "E02" "Il computer non ha abbastanza memoria RAM" `
+            "La RAM e lo spazio di lavoro temporaneo del computer. Docker richiede almeno 4 GiB." `
+            @(
+                "Chiudi gli altri programmi e riprova."
+                "Se l'errore rimane, comunica E02 al docente."
+            ) "RAM trovata: $MemoryGiB GiB; necessaria: 4 GiB"
     }
 
     $FullInstallDir = [IO.Path]::GetFullPath($InstallDir)
@@ -77,21 +115,32 @@ function Test-HostResources {
     $Drive = Get-PSDrive -Name $DriveName
     $FreeGiB = [math]::Round([double]$Drive.Free / 1GB, 1)
     if ($FreeGiB -lt 3) {
-        Stop-WithMessage (
-            "Spazio insufficiente per il bootstrap: $FreeGiB GiB; minimo 3 GiB."
-        )
+        Stop-WithMessage "E05" "Non c'e abbastanza spazio libero sul disco" `
+            "Il disco conserva programmi ed esercizi. Per iniziare servono almeno 3 GiB liberi; Docker ne richiedera 8 e una VM 20." `
+            @(
+                "Svuota il Cestino o sposta file personali su un altro disco."
+                "Non cancellare file che non riconosci."
+                "Rilancia il comando."
+            ) "Spazio disponibile: $FreeGiB GiB; necessario ora: 3 GiB"
     }
 
     try {
         $Virtualization = Get-CimInstance Win32_Processor |
             Select-Object -First 1 -ExpandProperty VirtualizationFirmwareEnabled
         if ($Virtualization -eq $false) {
-            Stop-WithMessage (
-                "Virtualizzazione hardware disabilitata. Abilitala nel BIOS/UEFI."
-            )
+            Stop-WithMessage "E03" "La virtualizzazione del computer e disabilitata" `
+                "Docker e le macchine virtuali hanno bisogno di questa funzione. Il computer probabilmente la possiede, ma e spenta. Non hai rotto nulla." `
+                @(
+                    "Premi Ctrl+Maiusc+Esc, apri Prestazioni e poi CPU."
+                    "Controlla se accanto a Virtualizzazione compare Disabilitata."
+                    "Non cambiare il BIOS da solo: chiedi a un adulto o al docente e comunica E03 e il modello del computer."
+                )
         }
     } catch {
-        Write-Warning "Virtualizzazione non verificabile automaticamente."
+        Write-Host "AVVISO W04 - Virtualizzazione non verificabile automaticamente." `
+            -ForegroundColor Yellow
+        Write-Host "Puoi continuare. Se Docker non parte, comunica W04 al docente." `
+            -ForegroundColor Yellow
     }
 
     try {
@@ -99,7 +148,13 @@ function Test-HostResources {
             "https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/README.md" |
             Out-Null
     } catch {
-        Stop-WithMessage "GitHub non raggiungibile. Controlla la connessione."
+        Stop-WithMessage "E07" "Non riesco a collegarmi al server di download" `
+            "La procedura ha bisogno di Internet. L'antivirus o la rete potrebbero bloccare GitHub." `
+            @(
+                "Controlla con il browser che Internet funzioni."
+                "Non disattivare l'antivirus."
+                "Riprova; se ricompare, comunica E07 al docente."
+            ) $_.Exception.Message
     }
 
     Write-Host "RAM: $MemoryGiB GiB"
@@ -112,10 +167,21 @@ function Test-HostResources {
 }
 
 if (-not [Environment]::Is64BitOperatingSystem) {
-    Stop-WithMessage "È richiesto Windows 10/11 a 64 bit."
+    Stop-WithMessage "E01" "Serve Windows 10 o Windows 11 a 64 bit" `
+        "Questo computer usa una versione di Windows non compatibile. Non hai sbagliato nulla." `
+        @(
+            "Apri Impostazioni, Sistema, Informazioni."
+            "Fai una foto della voce Tipo sistema e mostrala al docente."
+        )
 }
 if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
-    Stop-WithMessage "Windows Package Manager (winget) non è disponibile."
+    Stop-WithMessage "E08" "Il programma di installazione di Windows non e disponibile" `
+        "winget e lo strumento ufficiale che Windows usa per installare le applicazioni." `
+        @(
+            "Apri Microsoft Store."
+            "Cerca App Installer di Microsoft e installalo o aggiornalo."
+            "Chiudi e riapri PowerShell, poi rilancia il comando."
+        )
 }
 
 Write-Host "Bootstrap ambiente didattico 2cornot2c"
@@ -140,24 +206,44 @@ $env:Path = @(
 ) -join [IO.Path]::PathSeparator
 
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Stop-WithMessage "Git non è disponibile. Riavvia Windows e riprova."
+    Stop-WithMessage "E10" "Git e installato ma Windows non riesce ancora a trovarlo" `
+        "A volte Windows riconosce un nuovo programma solamente dopo un riavvio." `
+        @("Riavvia Windows."; "Riapri PowerShell e rilancia lo stesso comando.")
 }
 if (-not (Get-Command py -ErrorAction SilentlyContinue)) {
-    Stop-WithMessage "Python Launcher non è disponibile. Riavvia Windows e riprova."
+    Stop-WithMessage "E10" "Python e installato ma Windows non riesce ancora a trovarlo" `
+        "A volte Windows riconosce un nuovo programma solamente dopo un riavvio." `
+        @("Riavvia Windows."; "Riapri PowerShell e rilancia lo stesso comando.")
 }
 
 Write-Host "[2/4] Preparazione repository..."
 if (Test-Path (Join-Path $InstallDir ".git")) {
     git -C $InstallDir pull --ff-only
     if ($LASTEXITCODE -ne 0) {
-        Stop-WithMessage "Aggiornamento repository non riuscito."
+        Stop-WithMessage "E13" "Non posso aggiornare il progetto in sicurezza" `
+            "La rete potrebbe essere assente oppure alcuni file potrebbero essere stati modificati. Ho fermato tutto per non perdere il tuo lavoro." `
+            @(
+                "Non cancellare la cartella e non usare comandi Git trovati su Internet."
+                "Controlla Internet."
+                "Se l'errore rimane, comunica E13 al docente."
+            ) "git pull exit code $LASTEXITCODE"
     }
 } elseif (Test-Path $InstallDir) {
-    Stop-WithMessage "La directory esiste ma non è un repository Git: $InstallDir"
+    Stop-WithMessage "E11" "La cartella 2cornot2c e gia occupata" `
+        "La cartella esiste ma non contiene il nostro ambiente. Per sicurezza non verra modificata o cancellata." `
+        @(
+            "Rinomina la cartella in 2cornot2c-vecchia oppure chiedi al docente di controllarla."
+            "Rilancia il comando."
+        ) $InstallDir
 } else {
     git clone $RepositoryUrl $InstallDir
     if ($LASTEXITCODE -ne 0) {
-        Stop-WithMessage "Clone repository non riuscito."
+        Stop-WithMessage "E12" "Non sono riuscito a scaricare l'ambiente 2cornot2c" `
+            "Il download e stato interrotto. Non cancellare manualmente una cartella rimasta incompleta." `
+            @(
+                "Controlla Internet e riprova."
+                "Se ricompare, comunica E12 al docente."
+            ) "git clone exit code $LASTEXITCODE"
     }
 }
 
@@ -165,13 +251,22 @@ Write-Host "[3/4] Preparazione interfaccia guidata..."
 $VenvDir = Join-Path $InstallDir ".installer-venv"
 & py -3.12 -m venv $VenvDir
 if ($LASTEXITCODE -ne 0) {
-    Stop-WithMessage "Creazione ambiente Python non riuscita."
+    Stop-WithMessage "E14" "Non sono riuscito a preparare l'interfaccia guidata" `
+        "Il progetto e stato scaricato, ma Python non ha preparato il menu. Il lavoro gia svolto non e perso." `
+        @("Riavvia Windows."; "Rilancia lo stesso comando."; "Se ricompare, comunica E14 al docente.") `
+        "venv exit code $LASTEXITCODE"
 }
 $VenvPython = Join-Path $VenvDir "Scripts\python.exe"
 & $VenvPython -m pip install --disable-pip-version-check `
     -r (Join-Path $InstallDir "requirements-utui.txt")
 if ($LASTEXITCODE -ne 0) {
-    Stop-WithMessage "Installazione uTUI non riuscita."
+    Stop-WithMessage "E15" "Non sono riuscito a installare il menu guidato" `
+        "Python funziona, ma non ha scaricato un componente del menu." `
+        @(
+            "Controlla Internet."
+            "Rilancia lo stesso comando."
+            "Se ricompare, comunica E15 al docente."
+        ) "pip exit code $LASTEXITCODE"
 }
 
 Write-Host "[4/4] Avvio procedura guidata..."

--- a/scripts/student_dev_shell.py
+++ b/scripts/student_dev_shell.py
@@ -15,6 +15,8 @@ except ModuleNotFoundError:  # Esecuzione diretta: python scripts/student_dev_sh
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     from installer import student_dev
 
+from installer.student_errors import ERRORS, print_error
+
 
 def image_reference() -> str:
     """Restituisce il riferimento GHCR immutabile verificato."""
@@ -80,16 +82,19 @@ def main(argv: list[str] | None = None) -> int:
     try:
         command = docker_command(workspace=args.workspace, memory=args.memory)
     except (OSError, ValueError, student_dev.StudentDevLockError) as error:
-        print(f"Ambiente student-dev non disponibile: {error}")
+        print_error(ERRORS["student-security"], str(error))
         return 1
     if args.print_command:
         print(shlex.join(command))
         return 0
     try:
-        return subprocess.run(command, check=False).returncode
+        returncode = subprocess.run(command, check=False).returncode
     except FileNotFoundError:
-        print("Docker non è installato o non è disponibile nel PATH.")
+        print_error(ERRORS["docker-command"])
         return 1
+    if returncode != 0:
+        print_error(ERRORS["container"], f"docker exit code {returncode}")
+    return returncode
 
 
 if __name__ == "__main__":

--- a/scripts/uninstall-classroom-windows.ps1
+++ b/scripts/uninstall-classroom-windows.ps1
@@ -17,9 +17,26 @@ $InstallDir = if ($env:CLASSROOM_INSTALL_DIR) {
 }
 
 function Stop-WithMessage {
-    param([string]$Message)
+    param(
+        [string]$Code,
+        [string]$Title,
+        [string]$Explanation,
+        [string[]]$Actions = @(),
+        [string]$Technical = ""
+    )
     Write-Host ""
-    Write-Host "ERRORE: $Message" -ForegroundColor Red
+    Write-Host "ERRORE $Code - $Title" -ForegroundColor Red
+    Write-Host "COSA SIGNIFICA" -ForegroundColor Yellow
+    Write-Host $Explanation -ForegroundColor Yellow
+    Write-Host "COSA DEVI FARE" -ForegroundColor Yellow
+    for ($Index = 0; $Index -lt $Actions.Count; $Index++) {
+        Write-Host "$($Index + 1). $($Actions[$Index])" -ForegroundColor Yellow
+    }
+    Write-Host "Se chiedi aiuto, comunica questo codice: $Code" `
+        -ForegroundColor Yellow
+    if ($Technical) {
+        Write-Host "Dettagli tecnici: $Technical" -ForegroundColor DarkGray
+    }
     exit 1
 }
 
@@ -28,28 +45,41 @@ function Test-SafeInstallDirectory {
     $HomePath = [IO.Path]::GetFullPath($HOME).TrimEnd('\')
     $RootPath = [IO.Path]::GetPathRoot($FullPath).TrimEnd('\')
     if (-not $FullPath -or $FullPath -eq $HomePath -or $FullPath -eq $RootPath) {
-        Stop-WithMessage "Directory di installazione non sicura: $FullPath"
+        Stop-WithMessage "E26" "La cartella indicata non e sicura" `
+            "Non sono certo che sia la cartella 2cornot2c, quindi non cancellero nulla." `
+            @("Non rimuovere file manualmente."; "Comunica E26 al docente.") $FullPath
     }
     if (Test-Path $FullPath) {
         if (-not (Test-Path (Join-Path $FullPath ".git"))) {
-            Stop-WithMessage "La directory non è un clone Git: $FullPath"
+            Stop-WithMessage "E26" "La cartella indicata non e sicura" `
+                "La cartella non contiene i segni che identificano il progetto. Nessun file e stato cancellato." `
+                @("Non rimuovere file manualmente."; "Comunica E26 al docente.") $FullPath
         }
         if (Get-Command git -ErrorAction SilentlyContinue) {
             $Origin = git -C $FullPath remote get-url origin 2>$null
             if ($LASTEXITCODE -ne 0 -or $Origin -notmatch "TheBitPoets/2cornot2c") {
-                Stop-WithMessage "Repository inatteso: $FullPath"
+                Stop-WithMessage "E27" "La cartella appartiene a un progetto diverso" `
+                    "Per sicurezza la disinstallazione si e fermata e non ha cancellato nulla." `
+                    @("Non rimuovere la cartella manualmente."; "Comunica E27 al docente.") $FullPath
             }
         }
         if (Test-Path (Join-Path $FullPath ".vagrant")) {
-            Stop-WithMessage (
-                "È presente una VM VirtualBox. Non verrà rimossa automaticamente. " +
-                "Spegni e rimuovi prima la VM con la procedura guidata."
-            )
+            Stop-WithMessage "E28" "C'e ancora una macchina virtuale VirtualBox" `
+                "La VM puo contenere file. Per evitare perdite non verra eliminata automaticamente." `
+                @(
+                    "Non cancellare la VM manualmente."
+                    "Chiedi al docente come salvarla o rimuoverla."
+                    "Poi ripeti la disinstallazione."
+                )
         }
         if (Test-Path (Join-Path $FullPath ".vagrant-vmware")) {
-            Stop-WithMessage (
-                "È presente una VM VMware. Non verrà rimossa automaticamente."
-            )
+            Stop-WithMessage "E28" "C'e ancora una macchina virtuale VMware" `
+                "La VM puo contenere file. Per evitare perdite non verra eliminata automaticamente." `
+                @(
+                    "Non cancellare la VM manualmente."
+                    "Chiedi al docente come salvarla o rimuoverla."
+                    "Poi ripeti la disinstallazione."
+                )
         }
     }
     return $FullPath
@@ -126,7 +156,13 @@ function Backup-StudentWork {
                 $Prefix,
                 [StringComparison]::OrdinalIgnoreCase
             )) {
-                Stop-WithMessage "Percorso non sicuro nel repository: $RelativePath"
+                Stop-WithMessage "E29" "Non riesco a salvare tutti i tuoi file" `
+                    "La copia di sicurezza non puo essere completata. La disinstallazione e stata fermata." `
+                    @(
+                        "Non cancellare il progetto."
+                        "Controlla lo spazio libero."
+                        "Comunica E29 al docente."
+                    ) $RelativePath
             }
             $Destination = Join-Path $Backup $RelativePath
             New-Item -ItemType Directory -Force `
@@ -169,7 +205,17 @@ if ($Confirmation -ne "DISINSTALLA") {
     exit 2
 }
 
-$BackupPath = Backup-StudentWork $SafeInstallDir
+try {
+    $BackupPath = Backup-StudentWork $SafeInstallDir
+} catch {
+    Stop-WithMessage "E29" "Non sono riuscito a salvare i tuoi esercizi" `
+        "La copia di sicurezza non e completa. La disinstallazione e stata fermata." `
+        @(
+            "Non cancellare il progetto."
+            "Controlla lo spazio libero sul disco."
+            "Comunica E29 al docente."
+        ) $_.Exception.Message
+}
 if ($BackupPath) {
     Write-Host "Backup creato: $BackupPath"
 }

--- a/scripts/update-classroom-windows.ps1
+++ b/scripts/update-classroom-windows.ps1
@@ -12,8 +12,21 @@ Write-Host "La procedura conserva esercizi e configurazioni locali."
 try {
     $Bootstrap = Invoke-RestMethod -TimeoutSec 30 $BootstrapUrl
 } catch {
-    Write-Host "ERRORE: impossibile scaricare il bootstrap aggiornato." `
+    Write-Host "ERRORE E25 - Non riesco a scaricare l'aggiornamento" `
         -ForegroundColor Red
+    Write-Host "COSA SIGNIFICA" -ForegroundColor Yellow
+    Write-Host (
+        "Il collegamento e stato interrotto. L'ambiente gia installato " +
+        "non e stato modificato e puoi continuare a usarlo."
+    ) -ForegroundColor Yellow
+    Write-Host "COSA DEVI FARE" -ForegroundColor Yellow
+    Write-Host "1. Controlla con il browser che Internet funzioni." `
+        -ForegroundColor Yellow
+    Write-Host "2. Riprova piu tardi." -ForegroundColor Yellow
+    Write-Host "3. Se ricompare, comunica E25 al docente." `
+        -ForegroundColor Yellow
+    Write-Host "Dettagli tecnici: $($_.Exception.Message)" `
+        -ForegroundColor DarkGray
     exit 1
 }
 

--- a/tests/test_student_errors.py
+++ b/tests/test_student_errors.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from installer.student_errors import ERRORS, for_check, for_step, resource_error
+from installer.tui import _paint_guidance
+
+
+def test_every_student_error_has_actionable_structure_and_unique_code() -> None:
+    errors = tuple(ERRORS.values())
+
+    assert len({error.code for error in errors}) == len(errors)
+    for error in errors:
+        lines = error.lines("detail")
+        assert lines[0].startswith(f"ERRORE {error.code} - ")
+        assert any(line.startswith("COSA SIGNIFICA:") for line in lines)
+        assert any(line.startswith("COSA FARE 1:") for line in lines)
+        assert f"CODICE DA COMUNICARE AL DOCENTE: {error.code}" in lines
+        assert lines[-1] == "Dettagli tecnici: detail"
+
+
+def test_resource_error_uses_only_blocked_measurement() -> None:
+    assert (
+        resource_error(
+            "BLOCKED RAM 3.0 GiB; OK disco libero 30 GiB; "
+            "OK virtualizzazione disponibile"
+        ).code
+        == "E02"
+    )
+    assert (
+        resource_error(
+            "OK RAM 8 GiB; BLOCKED disco libero 4 GiB; "
+            "OK virtualizzazione disponibile"
+        ).code
+        == "E05"
+    )
+    assert (
+        resource_error(
+            "OK RAM 8 GiB; OK disco libero 30 GiB; "
+            "BLOCKED virtualizzazione hardware disabilitata"
+        ).code
+        == "E03"
+    )
+
+
+def test_docker_errors_are_specific() -> None:
+    assert for_check("network", "").code == "E07"
+    assert for_check("docker-engine", "").code == "E19"
+    assert for_check("student-image", "").code == "E21"
+    assert for_step("docker").code == "E18"
+
+
+def test_tui_paints_error_red_and_explanation_yellow_after_layout() -> None:
+    assert "\x1b[31mERRORE E03" in _paint_guidance(
+        "│ ERRORE E03 - Virtualizzazione disabilitata │"
+    )
+    assert "\x1b[33mCOSA SIGNIFICA:" in _paint_guidance(
+        "│ COSA SIGNIFICA: Non hai rotto nulla. │"
+    )
+
+
+def test_windows_scripts_render_error_and_explanation_colors() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    for name in (
+        "bootstrap-classroom-windows.ps1",
+        "update-classroom-windows.ps1",
+        "uninstall-classroom-windows.ps1",
+    ):
+        source = (root / "scripts" / name).read_text(encoding="utf-8")
+        assert "ForegroundColor Red" in source
+        assert "ForegroundColor Yellow" in source
+        assert "COSA SIGNIFICA" in source


### PR DESCRIPTION
## Cosa cambia

- introduce un catalogo centrale di errori con codici stabili;
- mostra il titolo dell'errore in rosso e spiegazioni/azioni in giallo;
- traduce i problemi di risorse, rete, winget, Docker e container in istruzioni semplici;
- migliora bootstrap, aggiornamento e disinstallazione Windows;
- impedisce di indirizzare uno studente da solo nel BIOS nel caso E03;
- blocca la disinstallazione con E29 se il backup degli esercizi non riesce;
- mantiene separati i dettagli tecnici utili al docente;
- documenta la convenzione e aggiunge test di struttura, mapping e colori.

## Perché

Gli studenti devono riuscire a capire cosa è successo e quale azione sicura compiere senza interpretare output di PowerShell, Git, winget o Docker. Un codice breve permette inoltre di chiedere assistenza al docente senza trascrivere messaggi complessi.

## Impatto sul collaudo Windows

Il primo caso osservato, virtualizzazione disabilitata, diventa `E03`: spiega cosa significa, come verificarla in Gestione attività e chiede esplicitamente l'aiuto di un adulto o del docente per BIOS/UEFI.

## Verifiche

- 48 test mirati superati;
- compilazione di tutti i moduli Python modificati;
- `git diff --check`;
- la CI Windows valida con il parser AST tutti gli script `*classroom-windows.ps1`.