### PR TITLE
feat: map GitHub teams to classes

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -106,6 +106,7 @@ jobs:
           tests/test_course_board_server.py
           tests/test_thebitlab_google_oidc.py
           tests/test_thebitlab_github_oauth.py
+          tests/test_thebitlab_github_team_mapping.py
 
       - name: Test portable Node.js and SQL runners
         run: >-

--- a/doc/architecture/github-team-class-mapping.md
+++ b/doc/architecture/github-team-class-mapping.md
@@ -15,7 +15,7 @@ Solo un account persistito, attivo e con ruolo `admin` può creare, rinominare o
 - chiave numerica `(github, organization_subject, team_subject)`;
 - classe e generazione `created_at` del mapping.
 
-Le generazioni sono conservate in `external_group_mapping_generations`. Delete/relink con clock costante o arretrato produce una generazione monotona e impedisce ABA. Un team non viene mai riassegnato implicitamente a un'altra classe.
+Le generazioni sono conservate in `external_group_mapping_generations` da ogni percorso di scrittura, inclusa la compatibilità storage preesistente. Delete/relink con clock costante o arretrato produce una generazione monotona e impedisce ABA. Un team non viene mai riassegnato implicitamente a un'altra classe.
 
 ## Onboarding pending
 
@@ -23,8 +23,8 @@ La riconciliazione è consentita soltanto quando:
 
 1. l'utente è attivo e ancora `pending`;
 2. esiste esattamente una identità GitHub collegata;
-3. la directory restituisce uno snapshot completo, correlato allo stesso subject numerico e senza duplicati;
-4. esiste esattamente un team mappato nello snapshot;
+3. la directory restituisce uno snapshot completo, fresco, correlato allo stesso subject numerico e senza duplicati;
+4. esiste esattamente un team mappato nello snapshot, ricontrollato atomicamente su tutte le chiavi al commit;
 5. la classe mappata è ancora attiva.
 
 La transazione finale verifica nuovamente revisione utente, generazione dell'identità GitHub, generazione del mapping e revisione classe. Solo allora inserisce la membership `student` e promuove il ruolo interno a `student`. Zero team o più team mappati lasciano l'utente `pending` senza membership parziale. Errori o snapshot incompleti non vengono interpretati come assenza di membership.

--- a/doc/architecture/github-team-class-mapping.md
+++ b/doc/architecture/github-team-class-mapping.md
@@ -13,9 +13,9 @@ Solo un account persistito, attivo e con ruolo `admin` può creare, rinominare o
 - revisione e ruolo dell'admin;
 - classe attiva e sua revisione monotona CAS (anche ogni aggiornamento classe richiede la revisione attesa);
 - chiave numerica `(github, organization_subject, team_subject)`;
-- classe e generazione `created_at` del mapping.
+- classe, generazione immutabile `created_at` e revisione monotona `updated_at` del mapping.
 
-Le generazioni sono conservate in `external_group_mapping_generations` da ogni percorso di scrittura, inclusa la compatibilità storage preesistente; anche rename e delete legacy richiedono la generazione attesa. Delete/relink con clock costante o arretrato produce una generazione monotona e impedisce ABA. Un team non viene mai riassegnato implicitamente a un'altra classe.
+Le generazioni sono conservate in `external_group_mapping_generations` da ogni percorso di scrittura, inclusa la compatibilità storage preesistente, e devono avanzare oltre il massimo storico. Rename e delete richiedono generazione e revisione attese. Delete/relink con clock costante o arretrato produce una generazione monotona e impedisce ABA; rename concorrenti non possono sovrascriversi. Un team non viene mai riassegnato implicitamente a un'altra classe.
 
 ## Onboarding pending
 
@@ -27,7 +27,7 @@ La riconciliazione è consentita soltanto quando:
 4. esiste esattamente un team mappato nello snapshot, ricontrollato atomicamente su tutte le chiavi al commit;
 5. la classe mappata è ancora attiva.
 
-La transazione finale verifica nuovamente revisione utente, generazione dell'identità GitHub, generazione del mapping e revisione classe. Solo allora inserisce la membership `student` e promuove il ruolo interno a `student`. Zero team o più team mappati lasciano l'utente `pending` senza membership parziale. Errori o snapshot incompleti non vengono interpretati come assenza di membership.
+La transazione finale verifica nuovamente revisione utente, generazione dell'identità GitHub, generazione e revisione del mapping e revisione classe. Solo allora inserisce la membership `student` e promuove il ruolo interno a `student`. Zero team o più team mappati lasciano l'utente `pending` senza membership parziale. Errori o snapshot incompleti non vengono interpretati come assenza di membership.
 
 ## Limiti
 

--- a/doc/architecture/github-team-class-mapping.md
+++ b/doc/architecture/github-team-class-mapping.md
@@ -11,11 +11,11 @@ Questo incremento usa una porta e un fake. Il futuro adapter GitHub App dovrà p
 Solo un account persistito, attivo e con ruolo `admin` può creare, rinominare o eliminare un mapping. La transazione SQLite ricontrolla:
 
 - revisione e ruolo dell'admin;
-- classe attiva e sua revisione;
+- classe attiva e sua revisione monotona CAS (anche ogni aggiornamento classe richiede la revisione attesa);
 - chiave numerica `(github, organization_subject, team_subject)`;
 - classe e generazione `created_at` del mapping.
 
-Le generazioni sono conservate in `external_group_mapping_generations` da ogni percorso di scrittura, inclusa la compatibilità storage preesistente. Delete/relink con clock costante o arretrato produce una generazione monotona e impedisce ABA. Un team non viene mai riassegnato implicitamente a un'altra classe.
+Le generazioni sono conservate in `external_group_mapping_generations` da ogni percorso di scrittura, inclusa la compatibilità storage preesistente; anche rename e delete legacy richiedono la generazione attesa. Delete/relink con clock costante o arretrato produce una generazione monotona e impedisce ABA. Un team non viene mai riassegnato implicitamente a un'altra classe.
 
 ## Onboarding pending
 

--- a/doc/architecture/github-team-class-mapping.md
+++ b/doc/architecture/github-team-class-mapping.md
@@ -1,0 +1,38 @@
+# Mapping team GitHub e onboarding classi
+
+## Scopo
+
+`thebitlab_github_team_mapping.py` traduce snapshot completi della directory GitHub in mapping verso classi interne. Il provider non assegna direttamente ruoli o ID TheBitLab: organization e team restano riferimenti esterni numerici e rinominabili.
+
+Questo incremento usa una porta e un fake. Il futuro adapter GitHub App dovrà produrre lo stesso snapshot senza esporre installation token al dominio.
+
+## Mapping amministrativo
+
+Solo un account persistito, attivo e con ruolo `admin` può creare, rinominare o eliminare un mapping. La transazione SQLite ricontrolla:
+
+- revisione e ruolo dell'admin;
+- classe attiva e sua revisione;
+- chiave numerica `(github, organization_subject, team_subject)`;
+- classe e generazione `created_at` del mapping.
+
+Le generazioni sono conservate in `external_group_mapping_generations`. Delete/relink con clock costante o arretrato produce una generazione monotona e impedisce ABA. Un team non viene mai riassegnato implicitamente a un'altra classe.
+
+## Onboarding pending
+
+La riconciliazione è consentita soltanto quando:
+
+1. l'utente è attivo e ancora `pending`;
+2. esiste esattamente una identità GitHub collegata;
+3. la directory restituisce uno snapshot completo, correlato allo stesso subject numerico e senza duplicati;
+4. esiste esattamente un team mappato nello snapshot;
+5. la classe mappata è ancora attiva.
+
+La transazione finale verifica nuovamente revisione utente, generazione dell'identità GitHub, generazione del mapping e revisione classe. Solo allora inserisce la membership `student` e promuove il ruolo interno a `student`. Zero team o più team mappati lasciano l'utente `pending` senza membership parziale. Errori o snapshot incompleti non vengono interpretati come assenza di membership.
+
+## Limiti
+
+- nessuna credenziale GitHub è acquisita o persistita;
+- nessuna sincronizzazione periodica o revoca automatica di studenti già approvati;
+- nessuna route HTTP o UI amministrativa;
+- nessun repository discovery;
+- adapter GitHub App reale e mapping GitLab restano follow-up.

--- a/scripts/thebitlab_github_team_mapping.py
+++ b/scripts/thebitlab_github_team_mapping.py
@@ -182,6 +182,7 @@ class GitHubTeamMappingStorage(Protocol):
         admin_user_id: str,
         expected_admin_updated_at: datetime,
         expected_class_updated_at: datetime,
+        expected_mapping_created_at: datetime | None,
     ) -> None: ...
     def delete_external_group_mapping_for_admin(
         self,
@@ -200,6 +201,9 @@ class GitHubTeamMappingStorage(Protocol):
         expected_identity_linked_at: datetime,
         expected_mapping: ExternalGroupMapping,
         expected_snapshot_group_keys: tuple[tuple[str, str], ...],
+        expected_snapshot_captured_at: datetime,
+        max_snapshot_age: timedelta,
+        future_skew: timedelta,
         expected_class_updated_at: datetime,
     ) -> None: ...
 
@@ -256,6 +260,7 @@ class GitHubTeamClassMappingService:
                     admin_user_id=actor.user_id,
                     expected_admin_updated_at=actor.updated_at,
                     expected_class_updated_at=class_group.updated_at,
+                    expected_mapping_created_at=existing.created_at,
                 )
             except (IdentityStorageConflictError, IdentityStorageNotFoundError) as error:
                 raise GitHubTeamMappingConflictError(
@@ -281,9 +286,15 @@ class GitHubTeamClassMappingService:
                     admin_user_id=actor.user_id,
                     expected_admin_updated_at=actor.updated_at,
                     expected_class_updated_at=class_group.updated_at,
+                    expected_mapping_created_at=None,
                 )
                 return mapping
-            except IdentityStorageMappingGenerationConflictError:
+            except IdentityStorageMappingGenerationConflictError as error:
+                current = self.storage.read_external_group_mapping(*team.provider_key)
+                if current is not None:
+                    raise GitHubTeamMappingConflictError(
+                        "Mapping creato da un'altra operazione."
+                    ) from error
                 candidate = _next_generation(created_at, created_at)
             except (IdentityStorageConflictError, IdentityStorageNotFoundError) as error:
                 raise GitHubTeamMappingConflictError(
@@ -415,6 +426,9 @@ class GitHubPendingOnboardingService:
                     (team.organization_subject, team.team_subject)
                     for team in snapshot.teams
                 ),
+                expected_snapshot_captured_at=snapshot.captured_at,
+                max_snapshot_age=self.max_snapshot_age,
+                future_skew=self.future_skew,
                 expected_class_updated_at=class_group.updated_at,
             )
         except (IdentityStorageConflictError, IdentityStorageNotFoundError) as error:

--- a/scripts/thebitlab_github_team_mapping.py
+++ b/scripts/thebitlab_github_team_mapping.py
@@ -20,7 +20,7 @@ from scripts.thebitlab_identity_ports import (
 )
 
 _MAX_GITHUB_SUBJECT = 9223372036854775807
-_MAX_TEAMS = 1000
+_MAX_TEAMS = 200
 _MAX_ATTEMPTS = 5
 
 
@@ -199,6 +199,7 @@ class GitHubTeamMappingStorage(Protocol):
         expected_identity_subject: str,
         expected_identity_linked_at: datetime,
         expected_mapping: ExternalGroupMapping,
+        expected_snapshot_group_keys: tuple[tuple[str, str], ...],
         expected_class_updated_at: datetime,
     ) -> None: ...
 
@@ -333,10 +334,21 @@ class GitHubPendingOnboardingService:
         directory: GitHubTeamDirectory,
         *,
         clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        max_snapshot_age: timedelta = timedelta(minutes=2),
+        future_skew: timedelta = timedelta(seconds=30),
     ) -> None:
+        if (
+            type(max_snapshot_age) is not timedelta
+            or not timedelta(seconds=1) <= max_snapshot_age <= timedelta(minutes=10)
+            or type(future_skew) is not timedelta
+            or not timedelta(0) <= future_skew <= timedelta(minutes=2)
+        ):
+            raise GitHubTeamDirectoryRejectedError("Policy freschezza snapshot non valida.")
         self.storage = storage
         self.directory = directory
         self.clock = clock
+        self.max_snapshot_age = max_snapshot_age
+        self.future_skew = future_skew
 
     def reconcile(self, user_id: str) -> GitHubPendingOnboardingResult:
         account = self.storage.read_user(_text(user_id, "user_id"))
@@ -354,7 +366,7 @@ class GitHubPendingOnboardingService:
         identity = github_identities[0]
         try:
             snapshot = self.directory.read_complete_memberships(identity.subject)
-        except GitHubTeamDirectoryUnavailableError:
+        except (GitHubTeamDirectoryUnavailableError, GitHubTeamDirectoryRejectedError):
             raise
         except Exception as error:
             raise GitHubTeamDirectoryUnavailableError(
@@ -362,6 +374,13 @@ class GitHubPendingOnboardingService:
             ) from error
         if type(snapshot) is not GitHubTeamMembershipSnapshot or snapshot.user_subject != identity.subject:
             raise GitHubTeamDirectoryRejectedError("Snapshot GitHub non correlato all'utente.")
+        validation_now = _utc(self.clock())
+        if (
+            snapshot.captured_at < identity.linked_at
+            or snapshot.captured_at <= validation_now - self.max_snapshot_age
+            or snapshot.captured_at > validation_now + self.future_skew
+        ):
+            raise GitHubTeamDirectoryRejectedError("Snapshot GitHub non fresco.")
 
         mapped: list[ExternalGroupMapping] = []
         for team in snapshot.teams:
@@ -392,6 +411,10 @@ class GitHubPendingOnboardingService:
                 expected_identity_subject=identity.subject,
                 expected_identity_linked_at=identity.linked_at,
                 expected_mapping=mapping,
+                expected_snapshot_group_keys=tuple(
+                    (team.organization_subject, team.team_subject)
+                    for team in snapshot.teams
+                ),
                 expected_class_updated_at=class_group.updated_at,
             )
         except (IdentityStorageConflictError, IdentityStorageNotFoundError) as error:

--- a/scripts/thebitlab_github_team_mapping.py
+++ b/scripts/thebitlab_github_team_mapping.py
@@ -1,0 +1,401 @@
+"""GitHub team-to-class mapping and deterministic pending-user onboarding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Mapping, Protocol, Sequence
+
+from scripts.thebitlab_identity import (
+    ClassGroup,
+    ClassMembership,
+    ExternalGroupMapping,
+    ExternalIdentity,
+    UserAccount,
+)
+from scripts.thebitlab_identity_ports import (
+    IdentityStorageConflictError,
+    IdentityStorageMappingGenerationConflictError,
+    IdentityStorageNotFoundError,
+)
+
+_MAX_GITHUB_SUBJECT = 9223372036854775807
+_MAX_TEAMS = 1000
+_MAX_ATTEMPTS = 5
+
+
+class GitHubTeamMappingError(RuntimeError):
+    """Base error for team mapping and onboarding."""
+
+
+class GitHubTeamDirectoryUnavailableError(GitHubTeamMappingError):
+    """The external directory could not return an authoritative snapshot."""
+
+
+class GitHubTeamDirectoryRejectedError(GitHubTeamMappingError):
+    """The external directory returned a malformed or mismatched snapshot."""
+
+
+class GitHubTeamMappingDeniedError(GitHubTeamMappingError):
+    """The actor is not an active persisted administrator."""
+
+
+class GitHubTeamMappingConflictError(GitHubTeamMappingError):
+    """A mapping or onboarding CAS conflicted with concurrent state."""
+
+
+class GitHubTeamMappingNotFoundError(GitHubTeamMappingError):
+    """A required user, class, identity, or mapping does not exist."""
+
+
+def _text(value: object, name: str, *, maximum: int = 512) -> str:
+    if type(value) is not str:
+        raise GitHubTeamDirectoryRejectedError(f"{name} non valido.")
+    normalized = value.strip()
+    if (
+        not normalized
+        or normalized != value
+        or len(normalized) > maximum
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in normalized)
+    ):
+        raise GitHubTeamDirectoryRejectedError(f"{name} non valido.")
+    return normalized
+
+
+def _numeric_subject(value: object, name: str) -> str:
+    normalized = _text(value, name, maximum=19)
+    if (
+        not normalized.isascii()
+        or not normalized.isdecimal()
+        or normalized.startswith("0")
+    ):
+        raise GitHubTeamDirectoryRejectedError(f"{name} deve essere un ID numerico canonico.")
+    number = int(normalized)
+    if number <= 0 or number > _MAX_GITHUB_SUBJECT or str(number) != normalized:
+        raise GitHubTeamDirectoryRejectedError(f"{name} fuori intervallo.")
+    return normalized
+
+
+def _utc(value: datetime, name: str = "clock") -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise GitHubTeamDirectoryUnavailableError(f"{name} non valido.")
+    return value.astimezone(timezone.utc)
+
+
+def _next_generation(candidate: datetime, previous: datetime | None) -> datetime:
+    try:
+        if previous is not None and previous >= candidate:
+            return previous + timedelta(microseconds=1)
+        return candidate
+    except OverflowError as error:
+        raise GitHubTeamMappingConflictError("Generazioni mapping esaurite.") from error
+
+
+@dataclass(frozen=True)
+class GitHubTeamMembership:
+    organization_subject: str
+    team_subject: str
+    display_name: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "organization_subject",
+            _numeric_subject(self.organization_subject, "organization_subject"),
+        )
+        object.__setattr__(
+            self,
+            "team_subject",
+            _numeric_subject(self.team_subject, "team_subject"),
+        )
+        if self.display_name is not None:
+            object.__setattr__(self, "display_name", _text(self.display_name, "display_name"))
+
+    @property
+    def provider_key(self) -> tuple[str, str, str]:
+        return ("github", self.organization_subject, self.team_subject)
+
+
+@dataclass(frozen=True)
+class GitHubTeamMembershipSnapshot:
+    user_subject: str
+    teams: tuple[GitHubTeamMembership, ...]
+    captured_at: datetime
+    complete: bool = True
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "user_subject", _numeric_subject(self.user_subject, "user_subject"))
+        if type(self.teams) is not tuple or len(self.teams) > _MAX_TEAMS:
+            raise GitHubTeamDirectoryRejectedError("Snapshot team GitHub non valido.")
+        keys = []
+        for team in self.teams:
+            if type(team) is not GitHubTeamMembership:
+                raise GitHubTeamDirectoryRejectedError("Snapshot team GitHub non valido.")
+            keys.append(team.provider_key)
+        if len(keys) != len(set(keys)):
+            raise GitHubTeamDirectoryRejectedError("Snapshot team GitHub contiene duplicati.")
+        if self.complete is not True:
+            raise GitHubTeamDirectoryRejectedError("Snapshot team GitHub non completo.")
+        object.__setattr__(self, "captured_at", _utc(self.captured_at, "captured_at"))
+
+
+class GitHubTeamDirectory(Protocol):
+    def read_complete_memberships(self, user_subject: str) -> GitHubTeamMembershipSnapshot: ...
+
+
+class FakeGitHubTeamDirectory:
+    """Deterministic complete-snapshot directory for tests and local demos."""
+
+    def __init__(
+        self,
+        snapshots: Mapping[str, GitHubTeamMembershipSnapshot],
+        *,
+        unavailable_subjects: Sequence[str] = (),
+    ) -> None:
+        self._snapshots = dict(snapshots)
+        self._unavailable = frozenset(unavailable_subjects)
+
+    def read_complete_memberships(self, user_subject: str) -> GitHubTeamMembershipSnapshot:
+        subject = _numeric_subject(user_subject, "user_subject")
+        if subject in self._unavailable:
+            raise GitHubTeamDirectoryUnavailableError("Directory team GitHub non disponibile.")
+        snapshot = self._snapshots.get(subject)
+        if snapshot is None:
+            return GitHubTeamMembershipSnapshot(subject, (), datetime.now(timezone.utc))
+        return snapshot
+
+
+class GitHubTeamMappingStorage(Protocol):
+    def read_user(self, user_id: str) -> UserAccount | None: ...
+    def read_class(self, class_id: str) -> ClassGroup | None: ...
+    def list_external_identities(self, user_id: str) -> list[ExternalIdentity]: ...
+    def read_external_group_mapping(
+        self, provider: str, organization_subject: str, group_subject: str
+    ) -> ExternalGroupMapping | None: ...
+    def read_latest_external_group_mapping_generation(
+        self, provider: str, organization_subject: str, group_subject: str
+    ) -> datetime | None: ...
+    def save_external_group_mapping_for_admin(
+        self,
+        mapping: ExternalGroupMapping,
+        *,
+        admin_user_id: str,
+        expected_admin_updated_at: datetime,
+        expected_class_updated_at: datetime,
+    ) -> None: ...
+    def delete_external_group_mapping_for_admin(
+        self,
+        mapping: ExternalGroupMapping,
+        *,
+        admin_user_id: str,
+        expected_admin_updated_at: datetime,
+        expected_class_updated_at: datetime,
+    ) -> bool: ...
+    def onboard_pending_user_from_external_group(
+        self,
+        membership: ClassMembership,
+        *,
+        expected_user_updated_at: datetime,
+        expected_identity_subject: str,
+        expected_identity_linked_at: datetime,
+        expected_mapping: ExternalGroupMapping,
+        expected_class_updated_at: datetime,
+    ) -> None: ...
+
+
+class GitHubTeamClassMappingService:
+    """Admin-only mapping management with persisted actor/class CAS."""
+
+    def __init__(
+        self,
+        storage: GitHubTeamMappingStorage,
+        *,
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self.storage = storage
+        self.clock = clock
+
+    def _admin_and_class(self, admin_user_id: str, class_id: str) -> tuple[UserAccount, ClassGroup]:
+        actor = self.storage.read_user(_text(admin_user_id, "admin_user_id"))
+        if actor is None or not actor.active or actor.role != "admin":
+            raise GitHubTeamMappingDeniedError("Admin TheBitLab non autorizzato.")
+        class_group = self.storage.read_class(_text(class_id, "class_id"))
+        if class_group is None:
+            raise GitHubTeamMappingNotFoundError("Classe TheBitLab non trovata.")
+        if not class_group.active:
+            raise GitHubTeamMappingConflictError("Classe TheBitLab non attiva.")
+        return actor, class_group
+
+    def save_mapping(
+        self,
+        admin_user_id: str,
+        class_id: str,
+        organization_subject: str,
+        team_subject: str,
+        *,
+        display_name: str | None = None,
+    ) -> ExternalGroupMapping:
+        team = GitHubTeamMembership(organization_subject, team_subject, display_name)
+        actor, class_group = self._admin_and_class(admin_user_id, class_id)
+        existing = self.storage.read_external_group_mapping(*team.provider_key)
+        if existing is not None:
+            if existing.class_id != class_group.class_id:
+                raise GitHubTeamMappingConflictError(
+                    "Team GitHub gia associato a un'altra classe."
+                )
+            mapping = ExternalGroupMapping(
+                *team.provider_key,
+                class_group.class_id,
+                existing.created_at,
+                team.display_name,
+            )
+            try:
+                self.storage.save_external_group_mapping_for_admin(
+                    mapping,
+                    admin_user_id=actor.user_id,
+                    expected_admin_updated_at=actor.updated_at,
+                    expected_class_updated_at=class_group.updated_at,
+                )
+            except (IdentityStorageConflictError, IdentityStorageNotFoundError) as error:
+                raise GitHubTeamMappingConflictError(
+                    "Mapping modificato durante il salvataggio."
+                ) from error
+            return mapping
+
+        candidate = _utc(self.clock())
+        for _attempt in range(_MAX_ATTEMPTS):
+            previous = self.storage.read_latest_external_group_mapping_generation(
+                *team.provider_key
+            )
+            created_at = _next_generation(candidate, previous)
+            mapping = ExternalGroupMapping(
+                *team.provider_key,
+                class_group.class_id,
+                created_at,
+                team.display_name,
+            )
+            try:
+                self.storage.save_external_group_mapping_for_admin(
+                    mapping,
+                    admin_user_id=actor.user_id,
+                    expected_admin_updated_at=actor.updated_at,
+                    expected_class_updated_at=class_group.updated_at,
+                )
+                return mapping
+            except IdentityStorageMappingGenerationConflictError:
+                candidate = _next_generation(created_at, created_at)
+            except (IdentityStorageConflictError, IdentityStorageNotFoundError) as error:
+                raise GitHubTeamMappingConflictError(
+                    "Admin, classe o mapping modificati durante il salvataggio."
+                ) from error
+        raise GitHubTeamMappingConflictError("Impossibile riservare il mapping GitHub.")
+
+    def delete_mapping(
+        self,
+        admin_user_id: str,
+        organization_subject: str,
+        team_subject: str,
+    ) -> ExternalGroupMapping:
+        team = GitHubTeamMembership(organization_subject, team_subject)
+        mapping = self.storage.read_external_group_mapping(*team.provider_key)
+        if mapping is None:
+            raise GitHubTeamMappingNotFoundError("Mapping GitHub non trovato.")
+        actor, class_group = self._admin_and_class(admin_user_id, mapping.class_id)
+        try:
+            removed = self.storage.delete_external_group_mapping_for_admin(
+                mapping,
+                admin_user_id=actor.user_id,
+                expected_admin_updated_at=actor.updated_at,
+                expected_class_updated_at=class_group.updated_at,
+            )
+        except IdentityStorageConflictError as error:
+            raise GitHubTeamMappingConflictError(
+                "Mapping modificato durante la rimozione."
+            ) from error
+        if removed is not True:
+            raise GitHubTeamMappingConflictError("Mapping gia rimosso.")
+        return mapping
+
+
+@dataclass(frozen=True)
+class GitHubPendingOnboardingResult:
+    status: str
+    reason: str
+    membership: ClassMembership | None = None
+
+
+class GitHubPendingOnboardingService:
+    """Promote only one pending user with exactly one mapped GitHub team."""
+
+    def __init__(
+        self,
+        storage: GitHubTeamMappingStorage,
+        directory: GitHubTeamDirectory,
+        *,
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self.storage = storage
+        self.directory = directory
+        self.clock = clock
+
+    def reconcile(self, user_id: str) -> GitHubPendingOnboardingResult:
+        account = self.storage.read_user(_text(user_id, "user_id"))
+        if account is None:
+            raise GitHubTeamMappingNotFoundError("Utente TheBitLab non trovato.")
+        if not account.active or account.role != "pending":
+            return GitHubPendingOnboardingResult("pending", "not-eligible")
+        github_identities = [
+            identity
+            for identity in self.storage.list_external_identities(account.user_id)
+            if identity.provider == "github"
+        ]
+        if len(github_identities) != 1:
+            return GitHubPendingOnboardingResult("pending", "github-not-linked")
+        identity = github_identities[0]
+        try:
+            snapshot = self.directory.read_complete_memberships(identity.subject)
+        except GitHubTeamDirectoryUnavailableError:
+            raise
+        except Exception as error:
+            raise GitHubTeamDirectoryUnavailableError(
+                "Directory team GitHub non disponibile."
+            ) from error
+        if type(snapshot) is not GitHubTeamMembershipSnapshot or snapshot.user_subject != identity.subject:
+            raise GitHubTeamDirectoryRejectedError("Snapshot GitHub non correlato all'utente.")
+
+        mapped: list[ExternalGroupMapping] = []
+        for team in snapshot.teams:
+            mapping = self.storage.read_external_group_mapping(*team.provider_key)
+            if mapping is not None:
+                mapped.append(mapping)
+        if not mapped:
+            return GitHubPendingOnboardingResult("pending", "no-mapped-team")
+        if len(mapped) != 1:
+            return GitHubPendingOnboardingResult("pending", "ambiguous-mapped-teams")
+        mapping = mapped[0]
+        class_group = self.storage.read_class(mapping.class_id)
+        if class_group is None or not class_group.active:
+            return GitHubPendingOnboardingResult("pending", "class-unavailable")
+        joined_at = _next_generation(_utc(self.clock()), account.updated_at)
+        membership = ClassMembership(
+            account.user_id,
+            class_group.class_id,
+            "student",
+            joined_at,
+            "github",
+            mapping.group_subject,
+        )
+        try:
+            self.storage.onboard_pending_user_from_external_group(
+                membership,
+                expected_user_updated_at=account.updated_at,
+                expected_identity_subject=identity.subject,
+                expected_identity_linked_at=identity.linked_at,
+                expected_mapping=mapping,
+                expected_class_updated_at=class_group.updated_at,
+            )
+        except (IdentityStorageConflictError, IdentityStorageNotFoundError) as error:
+            raise GitHubTeamMappingConflictError(
+                "Stato modificato durante onboarding GitHub."
+            ) from error
+        return GitHubPendingOnboardingResult("onboarded", "single-mapped-team", membership)

--- a/scripts/thebitlab_github_team_mapping.py
+++ b/scripts/thebitlab_github_team_mapping.py
@@ -78,7 +78,13 @@ def _numeric_subject(value: object, name: str) -> str:
 
 def _utc(value: datetime, name: str = "clock") -> datetime:
     if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
-        raise GitHubTeamDirectoryUnavailableError(f"{name} non valido.")
+        raise GitHubTeamMappingConflictError(f"{name} locale non valido.")
+    return value.astimezone(timezone.utc)
+
+
+def _provider_timestamp(value: datetime, name: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise GitHubTeamDirectoryRejectedError(f"{name} provider non valido.")
     return value.astimezone(timezone.utc)
 
 
@@ -136,7 +142,11 @@ class GitHubTeamMembershipSnapshot:
             raise GitHubTeamDirectoryRejectedError("Snapshot team GitHub contiene duplicati.")
         if self.complete is not True:
             raise GitHubTeamDirectoryRejectedError("Snapshot team GitHub non completo.")
-        object.__setattr__(self, "captured_at", _utc(self.captured_at, "captured_at"))
+        object.__setattr__(
+            self,
+            "captured_at",
+            _provider_timestamp(self.captured_at, "captured_at"),
+        )
 
 
 class GitHubTeamDirectory(Protocol):

--- a/scripts/thebitlab_github_team_mapping.py
+++ b/scripts/thebitlab_github_team_mapping.py
@@ -193,6 +193,7 @@ class GitHubTeamMappingStorage(Protocol):
         expected_admin_updated_at: datetime,
         expected_class_updated_at: datetime,
         expected_mapping_created_at: datetime | None,
+        expected_mapping_updated_at: datetime | None,
     ) -> None: ...
     def delete_external_group_mapping_for_admin(
         self,
@@ -263,6 +264,7 @@ class GitHubTeamClassMappingService:
                 class_group.class_id,
                 existing.created_at,
                 team.display_name,
+                _next_generation(_utc(self.clock()), existing.updated_at),
             )
             try:
                 self.storage.save_external_group_mapping_for_admin(
@@ -271,6 +273,7 @@ class GitHubTeamClassMappingService:
                     expected_admin_updated_at=actor.updated_at,
                     expected_class_updated_at=class_group.updated_at,
                     expected_mapping_created_at=existing.created_at,
+                    expected_mapping_updated_at=existing.updated_at,
                 )
             except (IdentityStorageConflictError, IdentityStorageNotFoundError) as error:
                 raise GitHubTeamMappingConflictError(
@@ -297,6 +300,7 @@ class GitHubTeamClassMappingService:
                     expected_admin_updated_at=actor.updated_at,
                     expected_class_updated_at=class_group.updated_at,
                     expected_mapping_created_at=None,
+                    expected_mapping_updated_at=None,
                 )
                 return mapping
             except IdentityStorageMappingGenerationConflictError as error:

--- a/scripts/thebitlab_identity.py
+++ b/scripts/thebitlab_identity.py
@@ -227,6 +227,7 @@ class ExternalGroupMapping:
     class_id: str
     created_at: datetime
     display_name: str | None = None
+    updated_at: datetime | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "provider", _required_text(self.provider, "provider", lowercase=True))
@@ -237,8 +238,15 @@ class ExternalGroupMapping:
         )
         object.__setattr__(self, "group_subject", _required_text(self.group_subject, "group_subject"))
         object.__setattr__(self, "class_id", _required_text(self.class_id, "class_id"))
-        object.__setattr__(self, "created_at", _aware_datetime(self.created_at, "created_at"))
+        created_at = _aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "created_at", created_at)
         object.__setattr__(self, "display_name", _optional_text(self.display_name, "display_name"))
+        updated_at = created_at if self.updated_at is None else _aware_datetime(
+            self.updated_at, "updated_at"
+        )
+        if updated_at < created_at:
+            raise InvalidIdentityDataError("updated_at mapping non puo precedere created_at.")
+        object.__setattr__(self, "updated_at", updated_at)
 
     @property
     def provider_key(self) -> tuple[str, str, str]:

--- a/scripts/thebitlab_identity_ports.py
+++ b/scripts/thebitlab_identity_ports.py
@@ -214,6 +214,7 @@ class ClassDirectoryStorage(Protocol):
         expected_identity_subject: str,
         expected_identity_linked_at: datetime,
         expected_mapping: ExternalGroupMapping,
+        expected_snapshot_group_keys: tuple[tuple[str, str], ...],
         expected_class_updated_at: datetime,
     ) -> None: ...
 

--- a/scripts/thebitlab_identity_ports.py
+++ b/scripts/thebitlab_identity_ports.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Protocol
 
 from scripts.thebitlab_identity import (
@@ -195,6 +195,7 @@ class ClassDirectoryStorage(Protocol):
         admin_user_id: str,
         expected_admin_updated_at: datetime,
         expected_class_updated_at: datetime,
+        expected_mapping_created_at: datetime | None,
     ) -> None: ...
 
     def delete_external_group_mapping_for_admin(
@@ -215,6 +216,9 @@ class ClassDirectoryStorage(Protocol):
         expected_identity_linked_at: datetime,
         expected_mapping: ExternalGroupMapping,
         expected_snapshot_group_keys: tuple[tuple[str, str], ...],
+        expected_snapshot_captured_at: datetime,
+        max_snapshot_age: timedelta,
+        future_skew: timedelta,
         expected_class_updated_at: datetime,
     ) -> None: ...
 

--- a/scripts/thebitlab_identity_ports.py
+++ b/scripts/thebitlab_identity_ports.py
@@ -165,7 +165,12 @@ class ClassDirectoryStorage(Protocol):
 
     def delete_membership(self, user_id: str, class_id: str, role: str) -> bool: ...
 
-    def save_external_group_mapping(self, mapping: ExternalGroupMapping) -> None: ...
+    def save_external_group_mapping(
+        self,
+        mapping: ExternalGroupMapping,
+        *,
+        expected_updated_at: datetime | None,
+    ) -> None: ...
 
     def read_external_group_mapping(
         self,
@@ -183,6 +188,7 @@ class ClassDirectoryStorage(Protocol):
         group_subject: str,
         *,
         expected_created_at: datetime,
+        expected_updated_at: datetime,
     ) -> bool: ...
 
     def read_latest_external_group_mapping_generation(
@@ -200,6 +206,7 @@ class ClassDirectoryStorage(Protocol):
         expected_admin_updated_at: datetime,
         expected_class_updated_at: datetime,
         expected_mapping_created_at: datetime | None,
+        expected_mapping_updated_at: datetime | None,
     ) -> None: ...
 
     def delete_external_group_mapping_for_admin(

--- a/scripts/thebitlab_identity_ports.py
+++ b/scripts/thebitlab_identity_ports.py
@@ -151,7 +151,9 @@ class ClassDirectoryStorage(Protocol):
 
     def read_class(self, class_id: str) -> ClassGroup | None: ...
 
-    def save_class(self, class_group: ClassGroup) -> None: ...
+    def save_class(
+        self, class_group: ClassGroup, *, expected_updated_at: datetime
+    ) -> None: ...
 
     def list_classes(self, *, active_only: bool = False) -> list[ClassGroup]: ...
 
@@ -179,6 +181,8 @@ class ClassDirectoryStorage(Protocol):
         provider: str,
         organization_subject: str,
         group_subject: str,
+        *,
+        expected_created_at: datetime,
     ) -> bool: ...
 
     def read_latest_external_group_mapping_generation(

--- a/scripts/thebitlab_identity_ports.py
+++ b/scripts/thebitlab_identity_ports.py
@@ -26,6 +26,10 @@ class IdentityStorageGenerationConflictError(IdentityStorageConflictError):
     """Raised when an immutable external-identity generation was already used."""
 
 
+class IdentityStorageMappingGenerationConflictError(IdentityStorageConflictError):
+    """Raised when an immutable external-group mapping generation was already used."""
+
+
 class IdentityStorageNotFoundError(IdentityStorageError):
     """Raised when an update targets a missing identity record."""
 
@@ -176,6 +180,42 @@ class ClassDirectoryStorage(Protocol):
         organization_subject: str,
         group_subject: str,
     ) -> bool: ...
+
+    def read_latest_external_group_mapping_generation(
+        self,
+        provider: str,
+        organization_subject: str,
+        group_subject: str,
+    ) -> datetime | None: ...
+
+    def save_external_group_mapping_for_admin(
+        self,
+        mapping: ExternalGroupMapping,
+        *,
+        admin_user_id: str,
+        expected_admin_updated_at: datetime,
+        expected_class_updated_at: datetime,
+    ) -> None: ...
+
+    def delete_external_group_mapping_for_admin(
+        self,
+        mapping: ExternalGroupMapping,
+        *,
+        admin_user_id: str,
+        expected_admin_updated_at: datetime,
+        expected_class_updated_at: datetime,
+    ) -> bool: ...
+
+    def onboard_pending_user_from_external_group(
+        self,
+        membership: ClassMembership,
+        *,
+        expected_user_updated_at: datetime,
+        expected_identity_subject: str,
+        expected_identity_linked_at: datetime,
+        expected_mapping: ExternalGroupMapping,
+        expected_class_updated_at: datetime,
+    ) -> None: ...
 
 
 class SessionStorage(Protocol):

--- a/scripts/thebitlab_identity_sqlite.py
+++ b/scripts/thebitlab_identity_sqlite.py
@@ -26,7 +26,7 @@ from scripts.thebitlab_identity_ports import (
 )
 
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 _T = TypeVar("_T")
 
 
@@ -190,6 +190,11 @@ _MIGRATION_3 = (
     """,
 )
 
+_MIGRATION_5 = (
+    "ALTER TABLE external_group_mappings ADD COLUMN updated_at TEXT",
+    "UPDATE external_group_mappings SET updated_at = created_at",
+)
+
 _MIGRATION_4 = (
     """
     CREATE TABLE external_group_mapping_generations (
@@ -304,11 +309,21 @@ class SqliteIdentityStorage:
                 (2, _MIGRATION_2),
                 (3, _MIGRATION_3),
                 (4, _MIGRATION_4),
+                (5, _MIGRATION_5),
             )
             for version, statements in migrations:
                 if version in versions:
                     continue
                 for statement in statements:
+                    if version == 5 and statement.startswith("ALTER TABLE"):
+                        columns = {
+                            row["name"]
+                            for row in connection.execute(
+                                "PRAGMA table_info(external_group_mappings)"
+                            )
+                        }
+                        if "updated_at" in columns:
+                            continue
                     connection.execute(statement)
                 connection.execute(
                     "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
@@ -442,6 +457,7 @@ class SqliteIdentityStorage:
             class_id=row["class_id"],
             created_at=_decode_datetime(row["created_at"]),
             display_name=row["display_name"],
+            updated_at=_decode_datetime(row["updated_at"]),
         )
 
     @classmethod
@@ -1128,47 +1144,82 @@ class SqliteIdentityStorage:
             )
             return cursor.rowcount == 1
 
-    def save_external_group_mapping(self, mapping: ExternalGroupMapping) -> None:
+    def save_external_group_mapping(
+        self,
+        mapping: ExternalGroupMapping,
+        *,
+        expected_updated_at: datetime | None,
+    ) -> None:
         created_at = _encode_datetime(mapping.created_at, "created_at")
+        updated_at = _encode_datetime(mapping.updated_at, "updated_at")
+        expected_revision = (
+            None
+            if expected_updated_at is None
+            else _encode_datetime(expected_updated_at, "expected_updated_at")
+        )
+        if expected_revision is None:
+            if updated_at != created_at:
+                raise IdentityStorageConflictError(
+                    "Un nuovo mapping deve iniziare dalla revisione di creazione."
+                )
+        elif updated_at <= expected_revision:
+            raise IdentityStorageConflictError(
+                "La revisione mapping deve avanzare monotonicamente."
+            )
         with self._transaction("save_external_group_mapping") as connection:
             existing = connection.execute(
                 """
-                SELECT class_id, created_at FROM external_group_mappings
+                SELECT class_id, created_at, updated_at FROM external_group_mappings
                 WHERE provider = ? AND organization_subject = ? AND group_subject = ?
                 """,
                 mapping.provider_key,
             ).fetchone()
-            if existing is None:
+            if expected_revision is None:
+                if existing is not None:
+                    raise IdentityStorageMappingGenerationConflictError(
+                        "Mapping creato da un'altra operazione."
+                    )
                 self._reserve_external_group_mapping_generation(
                     connection, mapping, created_at
                 )
                 cursor = connection.execute(
                     """
-                    INSERT INTO external_group_mappings VALUES (?, ?, ?, ?, ?, ?)
+                    INSERT INTO external_group_mappings
+                        (provider, organization_subject, group_subject, class_id,
+                         created_at, display_name, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         *mapping.provider_key,
                         mapping.class_id,
                         created_at,
                         mapping.display_name,
+                        updated_at,
                     ),
                 )
             else:
-                if existing["created_at"] != created_at:
+                if (
+                    existing is None
+                    or existing["created_at"] != created_at
+                    or existing["updated_at"] != expected_revision
+                ):
                     raise IdentityStorageMappingGenerationConflictError(
-                        "Mapping rimosso o ricreato da un'altra operazione."
+                        "Mapping modificato, rimosso o ricreato da un'altra operazione."
                     )
                 cursor = connection.execute(
                     """
-                    UPDATE external_group_mappings SET display_name = ?
+                    UPDATE external_group_mappings
+                    SET display_name = ?, updated_at = ?
                     WHERE provider = ? AND organization_subject = ? AND group_subject = ?
-                        AND class_id = ? AND created_at = ?
+                        AND class_id = ? AND created_at = ? AND updated_at = ?
                     """,
                     (
                         mapping.display_name,
+                        updated_at,
                         *mapping.provider_key,
                         mapping.class_id,
                         created_at,
+                        expected_revision,
                     ),
                 )
             if cursor.rowcount != 1:
@@ -1215,22 +1266,27 @@ class SqliteIdentityStorage:
         group_subject: str,
         *,
         expected_created_at: datetime,
+        expected_updated_at: datetime,
     ) -> bool:
         expected_generation = _encode_datetime(
             expected_created_at, "expected_created_at"
+        )
+        expected_revision = _encode_datetime(
+            expected_updated_at, "expected_updated_at"
         )
         with self._transaction("delete_external_group_mapping") as connection:
             cursor = connection.execute(
                 """
                 DELETE FROM external_group_mappings
                 WHERE provider = ? AND organization_subject = ? AND group_subject = ?
-                    AND created_at = ?
+                    AND created_at = ? AND updated_at = ?
                 """,
                 (
                     provider.lower(),
                     organization_subject,
                     group_subject,
                     expected_generation,
+                    expected_revision,
                 ),
             )
             if cursor.rowcount == 1:
@@ -1272,6 +1328,19 @@ class SqliteIdentityStorage:
         mapping: ExternalGroupMapping,
         created_at: str,
     ) -> None:
+        latest = connection.execute(
+            """
+            SELECT MAX(created_at) AS created_at
+            FROM external_group_mapping_generations
+            WHERE provider = ? AND organization_subject = ? AND group_subject = ?
+            """,
+            mapping.provider_key,
+        ).fetchone()
+        if latest is not None and latest["created_at"] is not None:
+            if created_at <= latest["created_at"]:
+                raise IdentityStorageMappingGenerationConflictError(
+                    "Generazione mapping non monotona."
+                )
         try:
             connection.execute(
                 """
@@ -1294,8 +1363,10 @@ class SqliteIdentityStorage:
         expected_admin_updated_at: datetime,
         expected_class_updated_at: datetime,
         expected_mapping_created_at: datetime | None,
+        expected_mapping_updated_at: datetime | None,
     ) -> None:
         created_at = _encode_datetime(mapping.created_at, "created_at")
+        updated_at = _encode_datetime(mapping.updated_at, "updated_at")
         expected_mapping_generation = (
             None
             if expected_mapping_created_at is None
@@ -1303,6 +1374,18 @@ class SqliteIdentityStorage:
                 expected_mapping_created_at, "expected_mapping_created_at"
             )
         )
+        expected_mapping_revision = (
+            None
+            if expected_mapping_updated_at is None
+            else _encode_datetime(
+                expected_mapping_updated_at, "expected_mapping_updated_at"
+            )
+        )
+        if expected_mapping_generation is None:
+            if expected_mapping_revision is not None or updated_at != created_at:
+                raise IdentityStorageConflictError("Intent create mapping non valido.")
+        elif expected_mapping_revision is None or updated_at <= expected_mapping_revision:
+            raise IdentityStorageConflictError("Revisione mapping non monotona.")
         admin_revision = _encode_datetime(
             expected_admin_updated_at, "expected_admin_updated_at"
         )
@@ -1314,7 +1397,7 @@ class SqliteIdentityStorage:
         ) as connection:
             existing = connection.execute(
                 """
-                SELECT class_id, created_at FROM external_group_mappings
+                SELECT class_id, created_at, updated_at FROM external_group_mappings
                 WHERE provider = ? AND organization_subject = ? AND group_subject = ?
                 """,
                 mapping.provider_key,
@@ -1331,8 +1414,8 @@ class SqliteIdentityStorage:
                     """
                     INSERT INTO external_group_mappings
                         (provider, organization_subject, group_subject, class_id,
-                         created_at, display_name)
-                    SELECT ?, ?, ?, ?, ?, ?
+                         created_at, display_name, updated_at)
+                    SELECT ?, ?, ?, ?, ?, ?, ?
                     WHERE EXISTS (
                         SELECT 1 FROM users
                         WHERE user_id = ? AND active = 1 AND role = 'admin'
@@ -1347,6 +1430,7 @@ class SqliteIdentityStorage:
                         mapping.class_id,
                         created_at,
                         mapping.display_name,
+                        updated_at,
                         admin_user_id,
                         admin_revision,
                         mapping.class_id,
@@ -1357,15 +1441,17 @@ class SqliteIdentityStorage:
                 if (
                     existing is None
                     or existing["created_at"] != expected_mapping_generation
+                    or existing["updated_at"] != expected_mapping_revision
                 ):
                     raise IdentityStorageMappingGenerationConflictError(
                         "Mapping rimosso o ricreato da un'altra operazione."
                     )
                 cursor = connection.execute(
                     """
-                    UPDATE external_group_mappings SET display_name = ?
+                    UPDATE external_group_mappings
+                    SET display_name = ?, updated_at = ?
                     WHERE provider = ? AND organization_subject = ? AND group_subject = ?
-                        AND class_id = ? AND created_at = ?
+                        AND class_id = ? AND created_at = ? AND updated_at = ?
                         AND EXISTS (
                             SELECT 1 FROM users
                             WHERE user_id = ? AND active = 1 AND role = 'admin'
@@ -1378,9 +1464,11 @@ class SqliteIdentityStorage:
                     """,
                     (
                         mapping.display_name,
+                        updated_at,
                         *mapping.provider_key,
                         mapping.class_id,
                         created_at,
+                        expected_mapping_revision,
                         admin_user_id,
                         admin_revision,
                         mapping.class_id,
@@ -1401,6 +1489,7 @@ class SqliteIdentityStorage:
         expected_class_updated_at: datetime,
     ) -> bool:
         created_at = _encode_datetime(mapping.created_at, "created_at")
+        mapping_revision = _encode_datetime(mapping.updated_at, "updated_at")
         admin_revision = _encode_datetime(
             expected_admin_updated_at, "expected_admin_updated_at"
         )
@@ -1414,7 +1503,7 @@ class SqliteIdentityStorage:
                 """
                 DELETE FROM external_group_mappings
                 WHERE provider = ? AND organization_subject = ? AND group_subject = ?
-                    AND class_id = ? AND created_at = ?
+                    AND class_id = ? AND created_at = ? AND updated_at = ?
                     AND EXISTS (
                         SELECT 1 FROM users
                         WHERE user_id = ? AND active = 1 AND role = 'admin'
@@ -1429,6 +1518,7 @@ class SqliteIdentityStorage:
                     *mapping.provider_key,
                     mapping.class_id,
                     created_at,
+                    mapping_revision,
                     admin_user_id,
                     admin_revision,
                     mapping.class_id,
@@ -1536,7 +1626,7 @@ class SqliteIdentityStorage:
             mapped_rows = connection.execute(
                 """
                 SELECT mappings.organization_subject, mappings.group_subject,
-                       mappings.class_id, mappings.created_at
+                       mappings.class_id, mappings.created_at, mappings.updated_at
                 FROM external_group_mappings AS mappings
                 INNER JOIN onboarding_expected_groups AS expected
                     ON expected.organization_subject = mappings.organization_subject
@@ -1549,6 +1639,7 @@ class SqliteIdentityStorage:
                 expected_mapping.group_subject,
                 expected_mapping.class_id,
                 mapping_generation,
+                _encode_datetime(expected_mapping.updated_at, "expected_mapping_updated_at"),
             )
             if len(mapped_rows) != 1 or tuple(mapped_rows[0]) != expected_row:
                 raise IdentityStorageConflictError(
@@ -1568,6 +1659,7 @@ class SqliteIdentityStorage:
                         SELECT 1 FROM external_group_mappings
                         WHERE provider = ? AND organization_subject = ?
                             AND group_subject = ? AND class_id = ? AND created_at = ?
+                            AND updated_at = ?
                     )
                     AND EXISTS (
                         SELECT 1 FROM classes
@@ -1583,6 +1675,7 @@ class SqliteIdentityStorage:
                     *expected_mapping.provider_key,
                     expected_mapping.class_id,
                     mapping_generation,
+                    _encode_datetime(expected_mapping.updated_at, "expected_mapping_updated_at"),
                     membership.class_id,
                     class_revision,
                 ),

--- a/scripts/thebitlab_identity_sqlite.py
+++ b/scripts/thebitlab_identity_sqlite.py
@@ -21,11 +21,12 @@ from scripts.thebitlab_identity_ports import (
     IdentityStorageCorruptionError,
     IdentityStorageError,
     IdentityStorageGenerationConflictError,
+    IdentityStorageMappingGenerationConflictError,
     IdentityStorageNotFoundError,
 )
 
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 _T = TypeVar("_T")
 
 
@@ -189,6 +190,24 @@ _MIGRATION_3 = (
     """,
 )
 
+_MIGRATION_4 = (
+    """
+    CREATE TABLE external_group_mapping_generations (
+        provider TEXT NOT NULL,
+        organization_subject TEXT NOT NULL,
+        group_subject TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (provider, organization_subject, group_subject, created_at)
+    )
+    """,
+    """
+    INSERT INTO external_group_mapping_generations
+        (provider, organization_subject, group_subject, created_at)
+    SELECT provider, organization_subject, group_subject, created_at
+    FROM external_group_mappings
+    """,
+)
+
 _MIGRATION_2 = (
     """
     CREATE TABLE external_identity_generations (
@@ -284,6 +303,7 @@ class SqliteIdentityStorage:
                 (1, _MIGRATION_1),
                 (2, _MIGRATION_2),
                 (3, _MIGRATION_3),
+                (4, _MIGRATION_4),
             )
             for version, statements in migrations:
                 if version in versions:
@@ -1156,6 +1176,269 @@ class SqliteIdentityStorage:
                 (provider.lower(), organization_subject, group_subject),
             )
             return cursor.rowcount == 1
+
+    def read_latest_external_group_mapping_generation(
+        self,
+        provider: str,
+        organization_subject: str,
+        group_subject: str,
+    ) -> datetime | None:
+        row = self._query_one(
+            """
+            SELECT MAX(created_at) AS created_at
+            FROM external_group_mapping_generations
+            WHERE provider = ? AND organization_subject = ? AND group_subject = ?
+            """,
+            (provider.lower(), organization_subject, group_subject),
+        )
+        if row is None or row["created_at"] is None:
+            return None
+        return _decode_datetime(row["created_at"])
+
+    @staticmethod
+    def _reserve_external_group_mapping_generation(
+        connection: sqlite3.Connection,
+        mapping: ExternalGroupMapping,
+        created_at: str,
+    ) -> None:
+        try:
+            connection.execute(
+                """
+                INSERT INTO external_group_mapping_generations
+                    (provider, organization_subject, group_subject, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (*mapping.provider_key, created_at),
+            )
+        except sqlite3.IntegrityError as error:
+            raise IdentityStorageMappingGenerationConflictError(
+                "Generazione mapping gruppo esterno gia utilizzata."
+            ) from error
+
+    def save_external_group_mapping_for_admin(
+        self,
+        mapping: ExternalGroupMapping,
+        *,
+        admin_user_id: str,
+        expected_admin_updated_at: datetime,
+        expected_class_updated_at: datetime,
+    ) -> None:
+        created_at = _encode_datetime(mapping.created_at, "created_at")
+        admin_revision = _encode_datetime(
+            expected_admin_updated_at, "expected_admin_updated_at"
+        )
+        class_revision = _encode_datetime(
+            expected_class_updated_at, "expected_class_updated_at"
+        )
+        with self._transaction(
+            "save_external_group_mapping_for_admin"
+        ) as connection:
+            existing = connection.execute(
+                """
+                SELECT class_id, created_at FROM external_group_mappings
+                WHERE provider = ? AND organization_subject = ? AND group_subject = ?
+                """,
+                mapping.provider_key,
+            ).fetchone()
+            if existing is None:
+                self._reserve_external_group_mapping_generation(
+                    connection, mapping, created_at
+                )
+                cursor = connection.execute(
+                    """
+                    INSERT INTO external_group_mappings
+                        (provider, organization_subject, group_subject, class_id,
+                         created_at, display_name)
+                    SELECT ?, ?, ?, ?, ?, ?
+                    WHERE EXISTS (
+                        SELECT 1 FROM users
+                        WHERE user_id = ? AND active = 1 AND role = 'admin'
+                            AND updated_at = ?
+                    ) AND EXISTS (
+                        SELECT 1 FROM classes
+                        WHERE class_id = ? AND active = 1 AND updated_at = ?
+                    )
+                    """,
+                    (
+                        *mapping.provider_key,
+                        mapping.class_id,
+                        created_at,
+                        mapping.display_name,
+                        admin_user_id,
+                        admin_revision,
+                        mapping.class_id,
+                        class_revision,
+                    ),
+                )
+            else:
+                cursor = connection.execute(
+                    """
+                    UPDATE external_group_mappings SET display_name = ?
+                    WHERE provider = ? AND organization_subject = ? AND group_subject = ?
+                        AND class_id = ? AND created_at = ?
+                        AND EXISTS (
+                            SELECT 1 FROM users
+                            WHERE user_id = ? AND active = 1 AND role = 'admin'
+                                AND updated_at = ?
+                        )
+                        AND EXISTS (
+                            SELECT 1 FROM classes
+                            WHERE class_id = ? AND active = 1 AND updated_at = ?
+                        )
+                    """,
+                    (
+                        mapping.display_name,
+                        *mapping.provider_key,
+                        mapping.class_id,
+                        created_at,
+                        admin_user_id,
+                        admin_revision,
+                        mapping.class_id,
+                        class_revision,
+                    ),
+                )
+            if cursor.rowcount != 1:
+                raise IdentityStorageConflictError(
+                    "Admin, classe o mapping modificati durante il salvataggio."
+                )
+
+    def delete_external_group_mapping_for_admin(
+        self,
+        mapping: ExternalGroupMapping,
+        *,
+        admin_user_id: str,
+        expected_admin_updated_at: datetime,
+        expected_class_updated_at: datetime,
+    ) -> bool:
+        created_at = _encode_datetime(mapping.created_at, "created_at")
+        admin_revision = _encode_datetime(
+            expected_admin_updated_at, "expected_admin_updated_at"
+        )
+        class_revision = _encode_datetime(
+            expected_class_updated_at, "expected_class_updated_at"
+        )
+        with self._transaction(
+            "delete_external_group_mapping_for_admin"
+        ) as connection:
+            cursor = connection.execute(
+                """
+                DELETE FROM external_group_mappings
+                WHERE provider = ? AND organization_subject = ? AND group_subject = ?
+                    AND class_id = ? AND created_at = ?
+                    AND EXISTS (
+                        SELECT 1 FROM users
+                        WHERE user_id = ? AND active = 1 AND role = 'admin'
+                            AND updated_at = ?
+                    )
+                    AND EXISTS (
+                        SELECT 1 FROM classes
+                        WHERE class_id = ? AND active = 1 AND updated_at = ?
+                    )
+                """,
+                (
+                    *mapping.provider_key,
+                    mapping.class_id,
+                    created_at,
+                    admin_user_id,
+                    admin_revision,
+                    mapping.class_id,
+                    class_revision,
+                ),
+            )
+            if cursor.rowcount == 1:
+                return True
+            exists = connection.execute(
+                """
+                SELECT 1 FROM external_group_mappings
+                WHERE provider = ? AND organization_subject = ? AND group_subject = ?
+                """,
+                mapping.provider_key,
+            ).fetchone()
+            if exists is None:
+                return False
+            raise IdentityStorageConflictError(
+                "Admin, classe o mapping modificati durante la rimozione."
+            )
+
+    def onboard_pending_user_from_external_group(
+        self,
+        membership: ClassMembership,
+        *,
+        expected_user_updated_at: datetime,
+        expected_identity_subject: str,
+        expected_identity_linked_at: datetime,
+        expected_mapping: ExternalGroupMapping,
+        expected_class_updated_at: datetime,
+    ) -> None:
+        joined_at = _encode_datetime(membership.joined_at, "joined_at")
+        user_revision = _encode_datetime(
+            expected_user_updated_at, "expected_user_updated_at"
+        )
+        identity_generation = _encode_datetime(
+            expected_identity_linked_at, "expected_identity_linked_at"
+        )
+        mapping_generation = _encode_datetime(
+            expected_mapping.created_at, "expected_mapping_created_at"
+        )
+        class_revision = _encode_datetime(
+            expected_class_updated_at, "expected_class_updated_at"
+        )
+        with self._transaction(
+            "onboard_pending_user_from_external_group"
+        ) as connection:
+            cursor = connection.execute(
+                """
+                UPDATE users SET role = 'student', updated_at = ?
+                WHERE user_id = ? AND active = 1 AND role = 'pending'
+                    AND updated_at = ?
+                    AND EXISTS (
+                        SELECT 1 FROM external_identities
+                        WHERE provider = 'github' AND subject = ?
+                            AND user_id = users.user_id AND linked_at = ?
+                    )
+                    AND EXISTS (
+                        SELECT 1 FROM external_group_mappings
+                        WHERE provider = ? AND organization_subject = ?
+                            AND group_subject = ? AND class_id = ? AND created_at = ?
+                    )
+                    AND EXISTS (
+                        SELECT 1 FROM classes
+                        WHERE class_id = ? AND active = 1 AND updated_at = ?
+                    )
+                """,
+                (
+                    joined_at,
+                    membership.user_id,
+                    user_revision,
+                    expected_identity_subject,
+                    identity_generation,
+                    *expected_mapping.provider_key,
+                    expected_mapping.class_id,
+                    mapping_generation,
+                    membership.class_id,
+                    class_revision,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise IdentityStorageConflictError(
+                    "Utente, identita, mapping o classe modificati durante onboarding."
+                )
+            connection.execute(
+                """
+                INSERT INTO class_memberships
+                    (user_id, class_id, role, joined_at, source_provider,
+                     source_group_subject)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    membership.user_id,
+                    membership.class_id,
+                    membership.role,
+                    joined_at,
+                    membership.source_provider,
+                    membership.source_group_subject,
+                ),
+            )
 
     def create_session(self, session: UserSession) -> None:
         with self._transaction("create_session") as connection:

--- a/scripts/thebitlab_identity_sqlite.py
+++ b/scripts/thebitlab_identity_sqlite.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Iterator, TypeVar
 
@@ -1243,8 +1243,16 @@ class SqliteIdentityStorage:
         admin_user_id: str,
         expected_admin_updated_at: datetime,
         expected_class_updated_at: datetime,
+        expected_mapping_created_at: datetime | None,
     ) -> None:
         created_at = _encode_datetime(mapping.created_at, "created_at")
+        expected_mapping_generation = (
+            None
+            if expected_mapping_created_at is None
+            else _encode_datetime(
+                expected_mapping_created_at, "expected_mapping_created_at"
+            )
+        )
         admin_revision = _encode_datetime(
             expected_admin_updated_at, "expected_admin_updated_at"
         )
@@ -1261,7 +1269,11 @@ class SqliteIdentityStorage:
                 """,
                 mapping.provider_key,
             ).fetchone()
-            if existing is None:
+            if expected_mapping_generation is None:
+                if existing is not None:
+                    raise IdentityStorageMappingGenerationConflictError(
+                        "Mapping creato da un'altra operazione."
+                    )
                 self._reserve_external_group_mapping_generation(
                     connection, mapping, created_at
                 )
@@ -1292,6 +1304,13 @@ class SqliteIdentityStorage:
                     ),
                 )
             else:
+                if (
+                    existing is None
+                    or existing["created_at"] != expected_mapping_generation
+                ):
+                    raise IdentityStorageMappingGenerationConflictError(
+                        "Mapping rimosso o ricreato da un'altra operazione."
+                    )
                 cursor = connection.execute(
                     """
                     UPDATE external_group_mappings SET display_name = ?
@@ -1390,6 +1409,9 @@ class SqliteIdentityStorage:
         expected_identity_linked_at: datetime,
         expected_mapping: ExternalGroupMapping,
         expected_snapshot_group_keys: tuple[tuple[str, str], ...],
+        expected_snapshot_captured_at: datetime,
+        max_snapshot_age: timedelta,
+        future_skew: timedelta,
         expected_class_updated_at: datetime,
     ) -> None:
         if (
@@ -1406,8 +1428,17 @@ class SqliteIdentityStorage:
             or membership.source_provider != "github"
             or membership.class_id != expected_mapping.class_id
             or membership.source_group_subject != expected_mapping.group_subject
+            or type(max_snapshot_age) is not timedelta
+            or max_snapshot_age <= timedelta(0)
+            or type(future_skew) is not timedelta
+            or future_skew < timedelta(0)
         ):
             raise IdentityStorageError("Snapshot gruppi onboarding non valido.")
+        snapshot_captured_at = _decode_datetime(
+            _encode_datetime(
+                expected_snapshot_captured_at, "expected_snapshot_captured_at"
+            )
+        )
         joined_at = _encode_datetime(membership.joined_at, "joined_at")
         user_revision = _encode_datetime(
             expected_user_updated_at, "expected_user_updated_at"
@@ -1424,6 +1455,21 @@ class SqliteIdentityStorage:
         with self._transaction(
             "onboard_pending_user_from_external_group"
         ) as connection:
+            transaction_now = self._clock()
+            if (
+                not isinstance(transaction_now, datetime)
+                or transaction_now.tzinfo is None
+                or transaction_now.utcoffset() is None
+            ):
+                raise IdentityStorageError("Clock storage onboarding non valido.")
+            transaction_now = transaction_now.astimezone(timezone.utc)
+            if (
+                snapshot_captured_at <= transaction_now - max_snapshot_age
+                or snapshot_captured_at > transaction_now + future_skew
+            ):
+                raise IdentityStorageConflictError(
+                    "Snapshot GitHub scaduto durante onboarding."
+                )
             connection.execute(
                 """
                 CREATE TEMP TABLE onboarding_expected_groups (

--- a/scripts/thebitlab_identity_sqlite.py
+++ b/scripts/thebitlab_identity_sqlite.py
@@ -1107,23 +1107,44 @@ class SqliteIdentityStorage:
             return cursor.rowcount == 1
 
     def save_external_group_mapping(self, mapping: ExternalGroupMapping) -> None:
+        created_at = _encode_datetime(mapping.created_at, "created_at")
         with self._transaction("save_external_group_mapping") as connection:
-            cursor = connection.execute(
+            existing = connection.execute(
                 """
-                INSERT INTO external_group_mappings VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT(provider, organization_subject, group_subject) DO UPDATE SET
-                    display_name = excluded.display_name
-                WHERE external_group_mappings.class_id = excluded.class_id
+                SELECT class_id, created_at FROM external_group_mappings
+                WHERE provider = ? AND organization_subject = ? AND group_subject = ?
                 """,
-                (
-                    mapping.provider,
-                    mapping.organization_subject,
-                    mapping.group_subject,
-                    mapping.class_id,
-                    _encode_datetime(mapping.created_at, "created_at"),
-                    mapping.display_name,
-                ),
-            )
+                mapping.provider_key,
+            ).fetchone()
+            if existing is None:
+                self._reserve_external_group_mapping_generation(
+                    connection, mapping, created_at
+                )
+                cursor = connection.execute(
+                    """
+                    INSERT INTO external_group_mappings VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        *mapping.provider_key,
+                        mapping.class_id,
+                        created_at,
+                        mapping.display_name,
+                    ),
+                )
+            else:
+                cursor = connection.execute(
+                    """
+                    UPDATE external_group_mappings SET display_name = ?
+                    WHERE provider = ? AND organization_subject = ? AND group_subject = ?
+                        AND class_id = ? AND created_at = ?
+                    """,
+                    (
+                        mapping.display_name,
+                        *mapping.provider_key,
+                        mapping.class_id,
+                        existing["created_at"],
+                    ),
+                )
             if cursor.rowcount != 1:
                 raise IdentityStorageConflictError(
                     "Il gruppo provider e gia associato a una classe diversa."
@@ -1368,8 +1389,25 @@ class SqliteIdentityStorage:
         expected_identity_subject: str,
         expected_identity_linked_at: datetime,
         expected_mapping: ExternalGroupMapping,
+        expected_snapshot_group_keys: tuple[tuple[str, str], ...],
         expected_class_updated_at: datetime,
     ) -> None:
+        if (
+            type(expected_snapshot_group_keys) is not tuple
+            or not expected_snapshot_group_keys
+            or any(
+                type(key) is not tuple
+                or len(key) != 2
+                or any(type(value) is not str or not value for value in key)
+                for key in expected_snapshot_group_keys
+            )
+            or len(expected_snapshot_group_keys) != len(set(expected_snapshot_group_keys))
+            or expected_mapping.provider != "github"
+            or membership.source_provider != "github"
+            or membership.class_id != expected_mapping.class_id
+            or membership.source_group_subject != expected_mapping.group_subject
+        ):
+            raise IdentityStorageError("Snapshot gruppi onboarding non valido.")
         joined_at = _encode_datetime(membership.joined_at, "joined_at")
         user_revision = _encode_datetime(
             expected_user_updated_at, "expected_user_updated_at"
@@ -1386,6 +1424,40 @@ class SqliteIdentityStorage:
         with self._transaction(
             "onboard_pending_user_from_external_group"
         ) as connection:
+            connection.execute(
+                """
+                CREATE TEMP TABLE onboarding_expected_groups (
+                    organization_subject TEXT NOT NULL,
+                    group_subject TEXT NOT NULL,
+                    PRIMARY KEY (organization_subject, group_subject)
+                )
+                """
+            )
+            connection.executemany(
+                "INSERT INTO onboarding_expected_groups VALUES (?, ?)",
+                expected_snapshot_group_keys,
+            )
+            mapped_rows = connection.execute(
+                """
+                SELECT mappings.organization_subject, mappings.group_subject,
+                       mappings.class_id, mappings.created_at
+                FROM external_group_mappings AS mappings
+                INNER JOIN onboarding_expected_groups AS expected
+                    ON expected.organization_subject = mappings.organization_subject
+                    AND expected.group_subject = mappings.group_subject
+                WHERE mappings.provider = 'github'
+                """
+            ).fetchall()
+            expected_row = (
+                expected_mapping.organization_subject,
+                expected_mapping.group_subject,
+                expected_mapping.class_id,
+                mapping_generation,
+            )
+            if len(mapped_rows) != 1 or tuple(mapped_rows[0]) != expected_row:
+                raise IdentityStorageConflictError(
+                    "Insieme mapping GitHub modificato durante onboarding."
+                )
             cursor = connection.execute(
                 """
                 UPDATE users SET role = 'student', updated_at = ?

--- a/scripts/thebitlab_identity_sqlite.py
+++ b/scripts/thebitlab_identity_sqlite.py
@@ -1040,24 +1040,46 @@ class SqliteIdentityStorage:
         row = self._query_one("SELECT * FROM classes WHERE class_id = ?", (class_id,))
         return None if row is None else self._class_group(row)
 
-    def save_class(self, class_group: ClassGroup) -> None:
+    def save_class(
+        self, class_group: ClassGroup, *, expected_updated_at: datetime
+    ) -> None:
+        created_at = _encode_datetime(class_group.created_at, "created_at")
+        updated_at = _encode_datetime(class_group.updated_at, "updated_at")
+        expected_revision = _encode_datetime(
+            expected_updated_at, "expected_updated_at"
+        )
+        if updated_at <= expected_revision:
+            raise IdentityStorageConflictError(
+                "Il nuovo updated_at classe deve essere successivo alla revisione attesa."
+            )
         with self._transaction("save_class") as connection:
             cursor = connection.execute(
                 """
-                UPDATE classes SET label = ?, school_year = ?, active = ?, created_at = ?,
-                    updated_at = ? WHERE class_id = ?
+                UPDATE classes SET label = ?, school_year = ?, active = ?, updated_at = ?
+                WHERE class_id = ? AND created_at = ? AND updated_at = ?
                 """,
                 (
                     class_group.label,
                     class_group.school_year,
                     int(class_group.active),
-                    _encode_datetime(class_group.created_at, "created_at"),
-                    _encode_datetime(class_group.updated_at, "updated_at"),
+                    updated_at,
                     class_group.class_id,
+                    created_at,
+                    expected_revision,
                 ),
             )
             if cursor.rowcount != 1:
-                raise IdentityStorageNotFoundError("Classe da aggiornare non trovata.")
+                exists = connection.execute(
+                    "SELECT 1 FROM classes WHERE class_id = ?",
+                    (class_group.class_id,),
+                ).fetchone()
+                if exists is None:
+                    raise IdentityStorageNotFoundError(
+                        "Classe da aggiornare non trovata."
+                    )
+                raise IdentityStorageConflictError(
+                    "Classe modificata da un'altra operazione."
+                )
 
     def list_classes(self, *, active_only: bool = False) -> list[ClassGroup]:
         where = " WHERE active = 1" if active_only else ""
@@ -1132,6 +1154,10 @@ class SqliteIdentityStorage:
                     ),
                 )
             else:
+                if existing["created_at"] != created_at:
+                    raise IdentityStorageMappingGenerationConflictError(
+                        "Mapping rimosso o ricreato da un'altra operazione."
+                    )
                 cursor = connection.execute(
                     """
                     UPDATE external_group_mappings SET display_name = ?
@@ -1142,7 +1168,7 @@ class SqliteIdentityStorage:
                         mapping.display_name,
                         *mapping.provider_key,
                         mapping.class_id,
-                        existing["created_at"],
+                        created_at,
                     ),
                 )
             if cursor.rowcount != 1:
@@ -1187,16 +1213,40 @@ class SqliteIdentityStorage:
         provider: str,
         organization_subject: str,
         group_subject: str,
+        *,
+        expected_created_at: datetime,
     ) -> bool:
+        expected_generation = _encode_datetime(
+            expected_created_at, "expected_created_at"
+        )
         with self._transaction("delete_external_group_mapping") as connection:
             cursor = connection.execute(
                 """
                 DELETE FROM external_group_mappings
                 WHERE provider = ? AND organization_subject = ? AND group_subject = ?
+                    AND created_at = ?
+                """,
+                (
+                    provider.lower(),
+                    organization_subject,
+                    group_subject,
+                    expected_generation,
+                ),
+            )
+            if cursor.rowcount == 1:
+                return True
+            exists = connection.execute(
+                """
+                SELECT 1 FROM external_group_mappings
+                WHERE provider = ? AND organization_subject = ? AND group_subject = ?
                 """,
                 (provider.lower(), organization_subject, group_subject),
+            ).fetchone()
+            if exists is None:
+                return False
+            raise IdentityStorageMappingGenerationConflictError(
+                "Mapping rimosso o ricreato da un'altra operazione."
             )
-            return cursor.rowcount == 1
 
     def read_latest_external_group_mapping_generation(
         self,

--- a/tests/test_thebitlab_github_team_mapping.py
+++ b/tests/test_thebitlab_github_team_mapping.py
@@ -130,18 +130,46 @@ def test_mapping_rejects_non_admin_inactive_class_and_reassignment(setup) -> Non
 def test_legacy_mapping_writes_also_reserve_aba_tombstone(setup) -> None:
     storage, service, _clock = setup
     legacy = ExternalGroupMapping("github", "1001", "2002", "class-01", NOW)
-    storage.save_external_group_mapping(legacy)
+    storage.save_external_group_mapping(legacy, expected_updated_at=None)
     storage.delete_external_group_mapping(
-        "github", "1001", "2002", expected_created_at=legacy.created_at
+        "github",
+        "1001",
+        "2002",
+        expected_created_at=legacy.created_at,
+        expected_updated_at=legacy.updated_at,
     )
     relinked = service.save_mapping("admin-01", "class-01", "1001", "2002")
     assert relinked.created_at == NOW + timedelta(microseconds=1)
     with pytest.raises(IdentityStorageConflictError):
-        storage.save_external_group_mapping(replace(legacy, display_name="stale"))
+        storage.save_external_group_mapping(
+            replace(legacy, display_name="stale", updated_at=NOW + timedelta(seconds=1)),
+            expected_updated_at=legacy.updated_at,
+        )
     with pytest.raises(IdentityStorageConflictError):
         storage.delete_external_group_mapping(
-            "github", "1001", "2002", expected_created_at=legacy.created_at
+            "github",
+            "1001",
+            "2002",
+            expected_created_at=legacy.created_at,
+            expected_updated_at=legacy.updated_at,
         )
+
+    storage.delete_external_group_mapping(
+        "github",
+        "1001",
+        "2002",
+        expected_created_at=relinked.created_at,
+        expected_updated_at=relinked.updated_at,
+    )
+    older_unused = ExternalGroupMapping(
+        "github",
+        "1001",
+        "2002",
+        "class-01",
+        NOW - timedelta(seconds=1),
+    )
+    with pytest.raises(IdentityStorageConflictError):
+        storage.save_external_group_mapping(older_unused, expected_updated_at=None)
 
 
 def test_concurrent_create_cannot_be_misread_as_mapping_rename(
@@ -160,6 +188,30 @@ def test_concurrent_create_cannot_be_misread_as_mapping_rename(
 
     monkeypatch.setattr(
         storage, "save_external_group_mapping_for_admin", create_other_then_save
+    )
+    with pytest.raises(GitHubTeamMappingConflictError):
+        service.save_mapping(
+            "admin-01", "class-01", "1001", "2002", display_name="stale"
+        )
+    persisted = storage.read_external_group_mapping("github", "1001", "2002")
+    assert persisted.display_name == "winner"
+
+
+def test_concurrent_rename_cannot_overwrite_winner(setup, monkeypatch) -> None:
+    storage, service, _clock = setup
+    service.save_mapping("admin-01", "class-01", "1001", "2002", display_name="base")
+    original = storage.save_external_group_mapping_for_admin
+    injected = False
+
+    def rename_other_then_save(mapping, **kwargs):
+        nonlocal injected
+        if not injected:
+            injected = True
+            original(replace(mapping, display_name="winner"), **kwargs)
+        return original(mapping, **kwargs)
+
+    monkeypatch.setattr(
+        storage, "save_external_group_mapping_for_admin", rename_other_then_save
     )
     with pytest.raises(GitHubTeamMappingConflictError):
         service.save_mapping(

--- a/tests/test_thebitlab_github_team_mapping.py
+++ b/tests/test_thebitlab_github_team_mapping.py
@@ -23,6 +23,7 @@ from scripts.thebitlab_identity import (
     ExternalIdentity,
     UserAccount,
 )
+from scripts.thebitlab_identity_ports import IdentityStorageConflictError
 from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
 
 NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
@@ -81,6 +82,8 @@ def test_snapshot_requires_complete_unique_correlated_team_set() -> None:
         GitHubTeamMembershipSnapshot("123456", (team, team), NOW)
     with pytest.raises(GitHubTeamDirectoryRejectedError):
         GitHubTeamMembershipSnapshot("123456", (team,), NOW, complete=False)
+    with pytest.raises(GitHubTeamDirectoryRejectedError):
+        GitHubTeamMembershipSnapshot("123456", (team,), datetime(2026, 9, 1))
 
 
 def test_admin_can_create_rename_delete_and_relink_mapping_monotonically(setup) -> None:
@@ -96,6 +99,15 @@ def test_admin_can_create_rename_delete_and_relink_mapping_monotonically(setup) 
     assert relinked.created_at == first.created_at + timedelta(microseconds=1)
 
 
+def test_mapping_rejects_naive_local_clock(setup) -> None:
+    storage, _service, _clock = setup
+    service = GitHubTeamClassMappingService(
+        storage, clock=lambda: datetime(2026, 9, 1)
+    )
+    with pytest.raises(GitHubTeamMappingConflictError):
+        service.save_mapping("admin-01", "class-01", "1001", "2002")
+
+
 def test_mapping_rejects_non_admin_inactive_class_and_reassignment(setup) -> None:
     storage, service, _clock = setup
     with pytest.raises(GitHubTeamMappingDeniedError):
@@ -107,7 +119,10 @@ def test_mapping_rejects_non_admin_inactive_class_and_reassignment(setup) -> Non
         service.save_mapping("admin-01", "class-02", "1001", "2002")
 
     current = storage.read_class("class-02")
-    storage.save_class(replace(current, active=False, updated_at=NOW + timedelta(seconds=1)))
+    storage.save_class(
+        replace(current, active=False, updated_at=NOW + timedelta(seconds=1)),
+        expected_updated_at=current.updated_at,
+    )
     with pytest.raises(GitHubTeamMappingConflictError):
         service.save_mapping("admin-01", "class-02", "1001", "3003")
 
@@ -116,9 +131,17 @@ def test_legacy_mapping_writes_also_reserve_aba_tombstone(setup) -> None:
     storage, service, _clock = setup
     legacy = ExternalGroupMapping("github", "1001", "2002", "class-01", NOW)
     storage.save_external_group_mapping(legacy)
-    storage.delete_external_group_mapping("github", "1001", "2002")
+    storage.delete_external_group_mapping(
+        "github", "1001", "2002", expected_created_at=legacy.created_at
+    )
     relinked = service.save_mapping("admin-01", "class-01", "1001", "2002")
     assert relinked.created_at == NOW + timedelta(microseconds=1)
+    with pytest.raises(IdentityStorageConflictError):
+        storage.save_external_group_mapping(replace(legacy, display_name="stale"))
+    with pytest.raises(IdentityStorageConflictError):
+        storage.delete_external_group_mapping(
+            "github", "1001", "2002", expected_created_at=legacy.created_at
+        )
 
 
 def test_concurrent_create_cannot_be_misread_as_mapping_rename(

--- a/tests/test_thebitlab_github_team_mapping.py
+++ b/tests/test_thebitlab_github_team_mapping.py
@@ -19,6 +19,7 @@ from scripts.thebitlab_github_team_mapping import (
 from scripts.thebitlab_identity import (
     ClassGroup,
     ClassMembership,
+    ExternalGroupMapping,
     ExternalIdentity,
     UserAccount,
 )
@@ -111,6 +112,15 @@ def test_mapping_rejects_non_admin_inactive_class_and_reassignment(setup) -> Non
         service.save_mapping("admin-01", "class-02", "1001", "3003")
 
 
+def test_legacy_mapping_writes_also_reserve_aba_tombstone(setup) -> None:
+    storage, service, _clock = setup
+    legacy = ExternalGroupMapping("github", "1001", "2002", "class-01", NOW)
+    storage.save_external_group_mapping(legacy)
+    storage.delete_external_group_mapping("github", "1001", "2002")
+    relinked = service.save_mapping("admin-01", "class-01", "1001", "2002")
+    assert relinked.created_at == NOW + timedelta(microseconds=1)
+
+
 def test_admin_revision_race_cannot_create_mapping(setup, monkeypatch) -> None:
     storage, service, _clock = setup
     original = storage.save_external_group_mapping_for_admin
@@ -180,6 +190,22 @@ def test_zero_or_multiple_mapped_teams_remain_pending_without_partial_membership
     assert storage.list_user_memberships("pending-01") == []
 
 
+def test_stale_snapshot_never_onboards_pending_user(setup) -> None:
+    storage, mappings, _clock = setup
+    mappings.save_mapping("admin-01", "class-01", "1001", "2002")
+    stale = GitHubTeamMembershipSnapshot(
+        "123456",
+        (GitHubTeamMembership("1001", "2002"),),
+        NOW - timedelta(minutes=3),
+    )
+    directory = FakeGitHubTeamDirectory({"123456": stale})
+    with pytest.raises(GitHubTeamDirectoryRejectedError):
+        GitHubPendingOnboardingService(storage, directory, clock=lambda: NOW).reconcile(
+            "pending-01"
+        )
+    assert storage.read_user("pending-01").role == "pending"
+
+
 def test_provider_unavailable_or_mismatched_snapshot_never_mutates_user(setup) -> None:
     storage, mappings, _clock = setup
     mappings.save_mapping("admin-01", "class-01", "1001", "2002")
@@ -187,11 +213,52 @@ def test_provider_unavailable_or_mismatched_snapshot_never_mutates_user(setup) -
     with pytest.raises(GitHubTeamDirectoryUnavailableError):
         GitHubPendingOnboardingService(storage, unavailable).reconcile("pending-01")
 
+    class RejectingDirectory:
+        def read_complete_memberships(self, _subject):
+            raise GitHubTeamDirectoryRejectedError("malformed")
+
+    with pytest.raises(GitHubTeamDirectoryRejectedError):
+        GitHubPendingOnboardingService(storage, RejectingDirectory()).reconcile(
+            "pending-01"
+        )
+
     mismatched = FakeGitHubTeamDirectory(
         {"123456": snapshot("654321", GitHubTeamMembership("1001", "2002"))}
     )
     with pytest.raises(GitHubTeamDirectoryRejectedError):
         GitHubPendingOnboardingService(storage, mismatched).reconcile("pending-01")
+    assert storage.read_user("pending-01").role == "pending"
+    assert storage.list_user_memberships("pending-01") == []
+
+
+def test_second_team_mapped_during_onboarding_blocks_promotion(
+    setup, monkeypatch
+) -> None:
+    storage, mappings, _clock = setup
+    storage.create_class(class_group("class-02"))
+    mappings.save_mapping("admin-01", "class-01", "1001", "2002")
+    directory = FakeGitHubTeamDirectory(
+        {
+            "123456": snapshot(
+                "123456",
+                GitHubTeamMembership("1001", "2002"),
+                GitHubTeamMembership("1001", "3003"),
+            )
+        }
+    )
+    original = storage.onboard_pending_user_from_external_group
+
+    def map_second_then_onboard(*args, **kwargs):
+        mappings.save_mapping("admin-01", "class-02", "1001", "3003")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        storage, "onboard_pending_user_from_external_group", map_second_then_onboard
+    )
+    with pytest.raises(GitHubTeamMappingConflictError):
+        GitHubPendingOnboardingService(storage, directory, clock=lambda: NOW).reconcile(
+            "pending-01"
+        )
     assert storage.read_user("pending-01").role == "pending"
     assert storage.list_user_memberships("pending-01") == []
 

--- a/tests/test_thebitlab_github_team_mapping.py
+++ b/tests/test_thebitlab_github_team_mapping.py
@@ -121,6 +121,31 @@ def test_legacy_mapping_writes_also_reserve_aba_tombstone(setup) -> None:
     assert relinked.created_at == NOW + timedelta(microseconds=1)
 
 
+def test_concurrent_create_cannot_be_misread_as_mapping_rename(
+    setup, monkeypatch
+) -> None:
+    storage, service, _clock = setup
+    original = storage.save_external_group_mapping_for_admin
+    injected = False
+
+    def create_other_then_save(mapping, **kwargs):
+        nonlocal injected
+        if not injected:
+            injected = True
+            original(replace(mapping, display_name="winner"), **kwargs)
+        return original(mapping, **kwargs)
+
+    monkeypatch.setattr(
+        storage, "save_external_group_mapping_for_admin", create_other_then_save
+    )
+    with pytest.raises(GitHubTeamMappingConflictError):
+        service.save_mapping(
+            "admin-01", "class-01", "1001", "2002", display_name="stale"
+        )
+    persisted = storage.read_external_group_mapping("github", "1001", "2002")
+    assert persisted.display_name == "winner"
+
+
 def test_admin_revision_race_cannot_create_mapping(setup, monkeypatch) -> None:
     storage, service, _clock = setup
     original = storage.save_external_group_mapping_for_admin
@@ -204,6 +229,29 @@ def test_stale_snapshot_never_onboards_pending_user(setup) -> None:
             "pending-01"
         )
     assert storage.read_user("pending-01").role == "pending"
+
+
+def test_snapshot_expiring_before_storage_commit_cannot_onboard(
+    setup, monkeypatch
+) -> None:
+    storage, mappings, clock = setup
+    mappings.save_mapping("admin-01", "class-01", "1001", "2002")
+    directory = FakeGitHubTeamDirectory(
+        {"123456": snapshot("123456", GitHubTeamMembership("1001", "2002"))}
+    )
+    original = storage.onboard_pending_user_from_external_group
+
+    def delay_then_onboard(*args, **kwargs):
+        clock.value += timedelta(minutes=3)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(storage, "onboard_pending_user_from_external_group", delay_then_onboard)
+    with pytest.raises(GitHubTeamMappingConflictError):
+        GitHubPendingOnboardingService(storage, directory, clock=clock).reconcile(
+            "pending-01"
+        )
+    assert storage.read_user("pending-01").role == "pending"
+    assert storage.list_user_memberships("pending-01") == []
 
 
 def test_provider_unavailable_or_mismatched_snapshot_never_mutates_user(setup) -> None:

--- a/tests/test_thebitlab_github_team_mapping.py
+++ b/tests/test_thebitlab_github_team_mapping.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.thebitlab_github_team_mapping import (
+    FakeGitHubTeamDirectory,
+    GitHubPendingOnboardingService,
+    GitHubTeamClassMappingService,
+    GitHubTeamDirectoryRejectedError,
+    GitHubTeamDirectoryUnavailableError,
+    GitHubTeamMappingConflictError,
+    GitHubTeamMappingDeniedError,
+    GitHubTeamMembership,
+    GitHubTeamMembershipSnapshot,
+)
+from scripts.thebitlab_identity import (
+    ClassGroup,
+    ClassMembership,
+    ExternalIdentity,
+    UserAccount,
+)
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+
+
+class Clock:
+    def __init__(self, value=NOW):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+
+def account(user_id: str, role: str) -> UserAccount:
+    return UserAccount(user_id, user_id, role, True, NOW, NOW)
+
+
+def class_group(class_id: str = "class-01") -> ClassGroup:
+    return ClassGroup(class_id, "3A TPSI", "2026/27", True, NOW, NOW)
+
+
+def snapshot(subject="123456", *teams) -> GitHubTeamMembershipSnapshot:
+    return GitHubTeamMembershipSnapshot(subject, tuple(teams), NOW)
+
+
+@pytest.fixture
+def setup(tmp_path):
+    clock = Clock()
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3", clock=clock)
+    storage.create_user(account("admin-01", "admin"))
+    storage.create_user(account("pending-01", "pending"))
+    storage.create_class(class_group())
+    storage.link_external_identity(
+        ExternalIdentity("pending-01", "github", "123456", NOW)
+    )
+    mappings = GitHubTeamClassMappingService(storage, clock=clock)
+    return storage, mappings, clock
+
+
+def test_team_subjects_are_canonical_numeric_ids() -> None:
+    team = GitHubTeamMembership("1001", "2002", "3A TPSI")
+    assert team.provider_key == ("github", "1001", "2002")
+    for organization, subject in (
+        ("org-slug", "2002"),
+        ("01001", "2002"),
+        ("1001", "0"),
+        ("1001", str(2**63)),
+    ):
+        with pytest.raises(GitHubTeamDirectoryRejectedError):
+            GitHubTeamMembership(organization, subject)
+
+
+def test_snapshot_requires_complete_unique_correlated_team_set() -> None:
+    team = GitHubTeamMembership("1001", "2002")
+    with pytest.raises(GitHubTeamDirectoryRejectedError):
+        GitHubTeamMembershipSnapshot("123456", (team, team), NOW)
+    with pytest.raises(GitHubTeamDirectoryRejectedError):
+        GitHubTeamMembershipSnapshot("123456", (team,), NOW, complete=False)
+
+
+def test_admin_can_create_rename_delete_and_relink_mapping_monotonically(setup) -> None:
+    storage, service, clock = setup
+    first = service.save_mapping("admin-01", "class-01", "1001", "2002", display_name="old")
+    renamed = service.save_mapping("admin-01", "class-01", "1001", "2002", display_name="new")
+    assert renamed.created_at == first.created_at
+    assert storage.read_external_group_mapping("github", "1001", "2002") == renamed
+
+    assert service.delete_mapping("admin-01", "1001", "2002") == renamed
+    clock.value -= timedelta(hours=1)
+    relinked = service.save_mapping("admin-01", "class-01", "1001", "2002")
+    assert relinked.created_at == first.created_at + timedelta(microseconds=1)
+
+
+def test_mapping_rejects_non_admin_inactive_class_and_reassignment(setup) -> None:
+    storage, service, _clock = setup
+    with pytest.raises(GitHubTeamMappingDeniedError):
+        service.save_mapping("pending-01", "class-01", "1001", "2002")
+
+    storage.create_class(class_group("class-02"))
+    service.save_mapping("admin-01", "class-01", "1001", "2002")
+    with pytest.raises(GitHubTeamMappingConflictError):
+        service.save_mapping("admin-01", "class-02", "1001", "2002")
+
+    current = storage.read_class("class-02")
+    storage.save_class(replace(current, active=False, updated_at=NOW + timedelta(seconds=1)))
+    with pytest.raises(GitHubTeamMappingConflictError):
+        service.save_mapping("admin-01", "class-02", "1001", "3003")
+
+
+def test_admin_revision_race_cannot_create_mapping(setup, monkeypatch) -> None:
+    storage, service, _clock = setup
+    original = storage.save_external_group_mapping_for_admin
+
+    def demote_then_save(*args, **kwargs):
+        admin = storage.read_user("admin-01")
+        storage.save_user(
+            replace(admin, role="teacher", updated_at=NOW + timedelta(seconds=1)),
+            expected_updated_at=admin.updated_at,
+        )
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(storage, "save_external_group_mapping_for_admin", demote_then_save)
+    with pytest.raises(GitHubTeamMappingConflictError):
+        service.save_mapping("admin-01", "class-01", "1001", "2002")
+    assert storage.read_external_group_mapping("github", "1001", "2002") is None
+
+
+def test_exactly_one_mapped_team_onboards_pending_student_atomically(setup) -> None:
+    storage, mappings, _clock = setup
+    mappings.save_mapping("admin-01", "class-01", "1001", "2002", display_name="3A")
+    directory = FakeGitHubTeamDirectory(
+        {"123456": snapshot("123456", GitHubTeamMembership("1001", "2002", "renamed"))}
+    )
+
+    result = GitHubPendingOnboardingService(storage, directory, clock=lambda: NOW).reconcile(
+        "pending-01"
+    )
+
+    assert result.status == "onboarded"
+    assert result.membership.class_id == "class-01"
+    assert result.membership.source_provider == "github"
+    assert result.membership.source_group_subject == "2002"
+    assert storage.read_user("pending-01").role == "student"
+    assert storage.list_user_memberships("pending-01") == [result.membership]
+
+
+def test_zero_or_multiple_mapped_teams_remain_pending_without_partial_membership(setup) -> None:
+    storage, mappings, _clock = setup
+    none = FakeGitHubTeamDirectory(
+        {"123456": snapshot("123456", GitHubTeamMembership("1001", "9999"))}
+    )
+    result = GitHubPendingOnboardingService(storage, none, clock=lambda: NOW).reconcile(
+        "pending-01"
+    )
+    assert result.reason == "no-mapped-team"
+    assert storage.read_user("pending-01").role == "pending"
+    assert storage.list_user_memberships("pending-01") == []
+
+    storage.create_class(class_group("class-02"))
+    mappings.save_mapping("admin-01", "class-01", "1001", "2002")
+    mappings.save_mapping("admin-01", "class-02", "1001", "3003")
+    many = FakeGitHubTeamDirectory(
+        {
+            "123456": snapshot(
+                "123456",
+                GitHubTeamMembership("1001", "2002"),
+                GitHubTeamMembership("1001", "3003"),
+            )
+        }
+    )
+    result = GitHubPendingOnboardingService(storage, many, clock=lambda: NOW).reconcile(
+        "pending-01"
+    )
+    assert result.reason == "ambiguous-mapped-teams"
+    assert storage.read_user("pending-01").role == "pending"
+    assert storage.list_user_memberships("pending-01") == []
+
+
+def test_provider_unavailable_or_mismatched_snapshot_never_mutates_user(setup) -> None:
+    storage, mappings, _clock = setup
+    mappings.save_mapping("admin-01", "class-01", "1001", "2002")
+    unavailable = FakeGitHubTeamDirectory({}, unavailable_subjects=("123456",))
+    with pytest.raises(GitHubTeamDirectoryUnavailableError):
+        GitHubPendingOnboardingService(storage, unavailable).reconcile("pending-01")
+
+    mismatched = FakeGitHubTeamDirectory(
+        {"123456": snapshot("654321", GitHubTeamMembership("1001", "2002"))}
+    )
+    with pytest.raises(GitHubTeamDirectoryRejectedError):
+        GitHubPendingOnboardingService(storage, mismatched).reconcile("pending-01")
+    assert storage.read_user("pending-01").role == "pending"
+    assert storage.list_user_memberships("pending-01") == []
+
+
+def test_existing_membership_conflict_rolls_back_role_promotion(setup) -> None:
+    storage, mappings, _clock = setup
+    mappings.save_mapping("admin-01", "class-01", "1001", "2002")
+    storage.save_membership(
+        ClassMembership("pending-01", "class-01", "student", NOW)
+    )
+    directory = FakeGitHubTeamDirectory(
+        {"123456": snapshot("123456", GitHubTeamMembership("1001", "2002"))}
+    )
+    with pytest.raises(GitHubTeamMappingConflictError):
+        GitHubPendingOnboardingService(storage, directory, clock=lambda: NOW).reconcile(
+            "pending-01"
+        )
+    assert storage.read_user("pending-01").role == "pending"
+
+
+def test_unlink_or_mapping_delete_race_rolls_back_onboarding(setup, monkeypatch) -> None:
+    storage, mappings, _clock = setup
+    mappings.save_mapping("admin-01", "class-01", "1001", "2002")
+    directory = FakeGitHubTeamDirectory(
+        {"123456": snapshot("123456", GitHubTeamMembership("1001", "2002"))}
+    )
+    original = storage.onboard_pending_user_from_external_group
+
+    def unlink_then_onboard(*args, **kwargs):
+        storage.unlink_external_identity("github", "123456")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(storage, "onboard_pending_user_from_external_group", unlink_then_onboard)
+    with pytest.raises(GitHubTeamMappingConflictError):
+        GitHubPendingOnboardingService(storage, directory, clock=lambda: NOW).reconcile(
+            "pending-01"
+        )
+    assert storage.read_user("pending-01").role == "pending"
+    assert storage.list_user_memberships("pending-01") == []

--- a/tests/test_thebitlab_identity_sqlite.py
+++ b/tests/test_thebitlab_identity_sqlite.py
@@ -300,6 +300,28 @@ def test_user_updates_are_monotonic_and_stale_snapshot_cannot_reactivate(storage
     assert storage.read_user("user-01") == disabled
 
 
+def test_class_updates_require_monotonic_compare_and_swap(storage) -> None:
+    original = class_group()
+    storage.create_class(original)
+    with pytest.raises(IdentityStorageConflictError, match="successivo"):
+        storage.save_class(
+            replace(original, label="changed"),
+            expected_updated_at=original.updated_at,
+        )
+    updated = replace(
+        original,
+        label="changed",
+        updated_at=original.updated_at + timedelta(seconds=1),
+    )
+    storage.save_class(updated, expected_updated_at=original.updated_at)
+    with pytest.raises(IdentityStorageConflictError):
+        storage.save_class(
+            replace(updated, label="stale", updated_at=updated.updated_at + timedelta(seconds=1)),
+            expected_updated_at=original.updated_at,
+        )
+    assert storage.read_class(original.class_id) == updated
+
+
 def test_missing_foreign_key_rolls_back_without_partial_state(storage) -> None:
     identity = ExternalIdentity("missing-user", "google", "subject-01", NOW)
 
@@ -333,16 +355,18 @@ def test_classes_memberships_and_group_mapping_crud(storage) -> None:
 
     mapping = ExternalGroupMapping("github", "org-7", "team-42", "class-01", NOW, "3A")
     storage.save_external_group_mapping(mapping)
-    renamed = replace(mapping, created_at=LATER, display_name="3A Informatica")
+    renamed = replace(mapping, display_name="3A Informatica")
     storage.save_external_group_mapping(renamed)
-    expected_mapping = replace(renamed, created_at=mapping.created_at)
+    expected_mapping = renamed
     assert storage.read_external_group_mapping("GITHUB", "org-7", "team-42") == expected_mapping
     assert storage.list_external_group_mappings("class-01") == [expected_mapping]
 
     with pytest.raises(IdentityStorageConflictError, match="classe diversa"):
         storage.save_external_group_mapping(replace(mapping, class_id="class-02"))
     assert storage.read_external_group_mapping("github", "org-7", "team-42") == expected_mapping
-    assert storage.delete_external_group_mapping("github", "org-7", "team-42") is True
+    assert storage.delete_external_group_mapping(
+        "github", "org-7", "team-42", expected_created_at=mapping.created_at
+    ) is True
     assert storage.delete_membership("user-01", "class-01", "STUDENT") is True
 
 
@@ -613,7 +637,9 @@ def test_save_requires_existing_primary_record(storage) -> None:
     with pytest.raises(IdentityStorageNotFoundError):
         storage.save_user(account(), expected_updated_at=NOW - timedelta(seconds=1))
     with pytest.raises(IdentityStorageNotFoundError):
-        storage.save_class(class_group())
+        storage.save_class(
+            class_group(), expected_updated_at=NOW - timedelta(seconds=1)
+        )
     with pytest.raises(IdentityStorageNotFoundError):
         storage.save_session(session())
     with pytest.raises(IdentityStorageNotFoundError):

--- a/tests/test_thebitlab_identity_sqlite.py
+++ b/tests/test_thebitlab_identity_sqlite.py
@@ -146,6 +146,7 @@ def test_migration_v2_upgrades_and_backfills_existing_v1_identity(database_path)
         connection.execute("DROP INDEX uq_external_identities_user_provider")
         connection.execute("DROP TABLE external_identity_link_conflicts")
         connection.execute("DROP TABLE external_identity_generations")
+        connection.execute("DROP TABLE external_group_mapping_generations")
         connection.execute("DELETE FROM schema_migrations WHERE version >= 2")
 
     upgraded = SqliteIdentityStorage(database_path)
@@ -205,6 +206,23 @@ def test_user_and_external_identity_round_trip_and_uniqueness(storage) -> None:
     assert storage.unlink_external_identity("github", "4242") is False
 
 
+def test_migration_v4_backfills_external_group_mapping_generations(database_path) -> None:
+    storage = SqliteIdentityStorage(database_path)
+    storage.create_class(class_group())
+    mapping = ExternalGroupMapping(
+        "github", "1001", "2002", "class-01", NOW, "3A"
+    )
+    storage.save_external_group_mapping(mapping)
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("DROP TABLE external_group_mapping_generations")
+        connection.execute("DELETE FROM schema_migrations WHERE version = 4")
+
+    upgraded = SqliteIdentityStorage(database_path)
+    assert upgraded.read_latest_external_group_mapping_generation(
+        "github", "1001", "2002"
+    ) == NOW
+
+
 def test_migration_v3_quarantines_ambiguous_provider_links(database_path) -> None:
     storage = SqliteIdentityStorage(database_path)
     storage.create_user(account())
@@ -214,7 +232,8 @@ def test_migration_v3_quarantines_ambiguous_provider_links(database_path) -> Non
     with sqlite3.connect(database_path) as connection:
         connection.execute("DROP INDEX uq_external_identities_user_provider")
         connection.execute("DROP TABLE external_identity_link_conflicts")
-        connection.execute("DELETE FROM schema_migrations WHERE version = 3")
+        connection.execute("DROP TABLE external_group_mapping_generations")
+        connection.execute("DELETE FROM schema_migrations WHERE version >= 3")
         connection.execute(
             """
             INSERT INTO external_identities

--- a/tests/test_thebitlab_identity_sqlite.py
+++ b/tests/test_thebitlab_identity_sqlite.py
@@ -206,16 +206,35 @@ def test_user_and_external_identity_round_trip_and_uniqueness(storage) -> None:
     assert storage.unlink_external_identity("github", "4242") is False
 
 
+def test_migration_v5_backfills_mapping_revision(database_path) -> None:
+    storage = SqliteIdentityStorage(database_path)
+    storage.create_class(class_group())
+    mapping = ExternalGroupMapping(
+        "github", "1001", "2002", "class-01", NOW, "3A"
+    )
+    storage.save_external_group_mapping(mapping, expected_updated_at=None)
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            "UPDATE external_group_mappings SET updated_at = NULL"
+        )
+        connection.execute("DELETE FROM schema_migrations WHERE version = 5")
+
+    upgraded = SqliteIdentityStorage(database_path)
+    assert upgraded.read_external_group_mapping(
+        "github", "1001", "2002"
+    ) == mapping
+
+
 def test_migration_v4_backfills_external_group_mapping_generations(database_path) -> None:
     storage = SqliteIdentityStorage(database_path)
     storage.create_class(class_group())
     mapping = ExternalGroupMapping(
         "github", "1001", "2002", "class-01", NOW, "3A"
     )
-    storage.save_external_group_mapping(mapping)
+    storage.save_external_group_mapping(mapping, expected_updated_at=None)
     with sqlite3.connect(database_path) as connection:
         connection.execute("DROP TABLE external_group_mapping_generations")
-        connection.execute("DELETE FROM schema_migrations WHERE version = 4")
+        connection.execute("DELETE FROM schema_migrations WHERE version >= 4")
 
     upgraded = SqliteIdentityStorage(database_path)
     assert upgraded.read_latest_external_group_mapping_generation(
@@ -354,18 +373,31 @@ def test_classes_memberships_and_group_mapping_crud(storage) -> None:
     assert storage.list_classes(active_only=True) == [first_class]
 
     mapping = ExternalGroupMapping("github", "org-7", "team-42", "class-01", NOW, "3A")
-    storage.save_external_group_mapping(mapping)
-    renamed = replace(mapping, display_name="3A Informatica")
-    storage.save_external_group_mapping(renamed)
+    storage.save_external_group_mapping(mapping, expected_updated_at=None)
+    renamed = replace(mapping, display_name="3A Informatica", updated_at=LATER)
+    storage.save_external_group_mapping(
+        renamed, expected_updated_at=mapping.updated_at
+    )
     expected_mapping = renamed
     assert storage.read_external_group_mapping("GITHUB", "org-7", "team-42") == expected_mapping
     assert storage.list_external_group_mappings("class-01") == [expected_mapping]
 
     with pytest.raises(IdentityStorageConflictError, match="classe diversa"):
-        storage.save_external_group_mapping(replace(mapping, class_id="class-02"))
+        storage.save_external_group_mapping(
+            replace(
+                renamed,
+                class_id="class-02",
+                updated_at=LATER + timedelta(microseconds=1),
+            ),
+            expected_updated_at=renamed.updated_at,
+        )
     assert storage.read_external_group_mapping("github", "org-7", "team-42") == expected_mapping
     assert storage.delete_external_group_mapping(
-        "github", "org-7", "team-42", expected_created_at=mapping.created_at
+        "github",
+        "org-7",
+        "team-42",
+        expected_created_at=renamed.created_at,
+        expected_updated_at=renamed.updated_at,
     ) is True
     assert storage.delete_membership("user-01", "class-01", "STUDENT") is True
 


### PR DESCRIPTION
## Summary

Implements #554 as the GitHub team-to-class mapping increment under #535.

- introduces stable numeric GitHub organization/team membership snapshots and a deterministic fake directory;
- adds admin-only team-to-class mapping management with persisted admin/class CAS;
- adds schema v4/v5 mapping generation tombstones and monotonic mapping revisions;
- makes create, rename, delete, relink and legacy CRUD fail closed under stale/racing operations;
- onboards an active `pending` user only from a complete, fresh, correlated snapshot containing exactly one mapped team;
- atomically verifies the full snapshot mapping set, user revision, GitHub identity generation, mapping generation/revision, and class revision before role+membership mutation;
- keeps zero-team, multi-team, stale, malformed, unavailable, and concurrent-change cases pending without partial membership;
- documents the future GitHub App adapter boundary without storing provider credentials.

## Validation

- targeted identity/auth/GitHub suite: 151 passed;
- full required CI green on minimum Python, Linux/Windows Python 3.11–3.13, Windows filesystem, and Docker;
- independent isolated reviews rounds 5 and 6: `Nessun finding` at `e75f20c`.

## Scope

A real GitHub App adapter, periodic revocation/synchronization, concrete HTTP/admin UI, and repository discovery remain follow-up increments.

Closes #554
