### PR TITLE
Add safe Intel and AMD virtualization guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,9 @@ istruzioni semplici in giallo. Ogni messaggio spiega cosa è successo, cosa fare
 e quale codice comunicare al docente, per esempio `E03` quando la
 virtualizzazione è disabilitata. I dettagli tecnici restano separati e non è
 mai richiesto a uno studente di modificare da solo BIOS, antivirus o file Git.
+Su Windows `E03` rileva automaticamente una CPU Intel o AMD e indica soltanto i
+nomi pertinenti della voce di virtualizzazione. Chiede comunque l'aiuto di un
+adulto e vieta esplicitamente di modificare Secure Boot, TPM o altre opzioni.
 
 #### Aggiornare su Windows
 

--- a/installer/student_errors.py
+++ b/installer/student_errors.py
@@ -42,7 +42,10 @@ ERRORS = {
         "Docker e le VM ne hanno bisogno. Non hai rotto nulla.",
         (
             "Apri Gestione attività, poi Prestazioni e infine CPU.",
-            "Non cambiare il BIOS da solo: chiedi a un adulto o al docente.",
+            "Con Intel cerca Intel Virtualization Technology oppure Intel VT-x.",
+            "Con AMD cerca SVM Mode, AMD-V oppure Secure Virtual Machine.",
+            "Fatti aiutare da un adulto e attiva soltanto quella voce.",
+            "Non modificare Secure Boot, TPM o altre impostazioni.",
         ),
     ),
     "disk": StudentError(

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -125,16 +125,32 @@ function Test-HostResources {
     }
 
     try {
-        $Virtualization = Get-CimInstance Win32_Processor |
-            Select-Object -First 1 -ExpandProperty VirtualizationFirmwareEnabled
+        $Processor = Get-CimInstance Win32_Processor | Select-Object -First 1
+        $Virtualization = $Processor.VirtualizationFirmwareEnabled
         if ($Virtualization -eq $false) {
+            $VirtualizationSetting = switch -Regex ($Processor.Manufacturer) {
+                "Intel" {
+                    "Intel Virtualization Technology oppure Intel VT-x"
+                    break
+                }
+                "AMD" {
+                    "SVM Mode, AMD-V oppure Secure Virtual Machine"
+                    break
+                }
+                default {
+                    "Intel Virtualization Technology, Intel VT-x, SVM Mode oppure AMD-V"
+                }
+            }
+            $ComputerModel = "$($Computer.Manufacturer) $($Computer.Model)".Trim()
             Stop-WithMessage "E03" "La virtualizzazione del computer è disabilitata" `
                 "Docker e le macchine virtuali hanno bisogno di questa funzione. Il computer probabilmente la possiede, ma è spenta. Non hai rotto nulla." `
                 @(
                     "Premi Ctrl+Maiusc+Esc, apri Prestazioni e poi CPU."
                     "Controlla se accanto a Virtualizzazione compare Disabilitata."
-                    "Non cambiare il BIOS da solo: chiedi a un adulto o al docente e comunica E03 e il modello del computer."
-                )
+                    "Nel BIOS/UEFI cerca soltanto: $VirtualizationSetting."
+                    "Fatti aiutare da un adulto. Attiva soltanto questa voce, salva e riavvia Windows."
+                    "Non modificare Secure Boot, TPM o altre impostazioni. Se non trovi la voce, fermati e comunica E03 al docente."
+                ) "CPU: $($Processor.Name); computer: $ComputerModel"
         }
     } catch {
         Write-Host "AVVISO W04 - Virtualizzazione non verificabile automaticamente." `

--- a/tests/test_student_errors.py
+++ b/tests/test_student_errors.py
@@ -51,6 +51,16 @@ def test_docker_errors_are_specific() -> None:
     assert for_step("docker").code == "E18"
 
 
+def test_virtualization_guidance_is_specific_and_conservative() -> None:
+    guidance = "\n".join(ERRORS["virtualization"].lines())
+
+    assert "Intel VT-x" in guidance
+    assert "SVM Mode" in guidance
+    assert "Secure Boot" in guidance
+    assert "TPM" in guidance
+    assert "adulto" in guidance
+
+
 def test_tui_paints_error_red_and_explanation_yellow_after_layout() -> None:
     assert "\x1b[31mERRORE E03" in _paint_guidance(
         "│ ERRORE E03 - Virtualizzazione disabilitata │"
@@ -73,6 +83,14 @@ def test_windows_scripts_render_error_and_explanation_colors() -> None:
         assert "ForegroundColor Red" in source
         assert "ForegroundColor Yellow" in source
         assert "COSA SIGNIFICA" in source
+
+    bootstrap = (
+        root / "scripts" / "bootstrap-classroom-windows.ps1"
+    ).read_text(encoding="utf-8")
+    assert "$Processor.Manufacturer" in bootstrap
+    assert "Intel Virtualization Technology" in bootstrap
+    assert "SVM Mode, AMD-V" in bootstrap
+    assert "Non modificare Secure Boot, TPM" in bootstrap
 
 
 def test_student_facing_messages_use_italian_accents() -> None:


### PR DESCRIPTION
## Cosa cambia

- rileva automaticamente il produttore della CPU su Windows;
- mostra i nomi Intel VT-x oppure AMD/SVM pertinenti;
- include CPU, marca e modello del PC nei dettagli per il docente;
- chiede l’aiuto di un adulto;
- vieta esplicitamente modifiche a Secure Boot, TPM e altre impostazioni.

## Verifiche

- 29 test mirati superati;
- compilazione Python e controllo ortografico superati;
- la CI Windows valida la sintassi PowerShell.