### PR TITLE
Make installer diagnosis panel responsive

### DIFF
--- a/installer/tui.py
+++ b/installer/tui.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sys
 
 from utui import (
+    Column,
     Key,
     KeyReader,
     Label,
@@ -15,6 +16,7 @@ from utui import (
     Panel,
     ResizeWatcher,
     Row,
+    Size,
     get_terminal_size,
     render_lines,
     supports_color,
@@ -42,7 +44,12 @@ class State:
     running: bool = True
 
 
-def build_screen(state: State):
+def build_screen(
+    state: State,
+    *,
+    width: int | None = None,
+    height: int | None = None,
+):
     """Costruisce la schermata senza I/O o mutazioni."""
 
     names = {
@@ -65,9 +72,9 @@ def build_screen(state: State):
         min_width=38,
     )
     report = Panel(
-        Label("\n".join(state.report)),
+        Label("\n".join(state.report), wrap=True),
         title="Diagnosi",
-        min_width=38,
+        min_width=50,
     )
     command_text = (
         "s: conferma installazione\nn/Esc: annulla"
@@ -79,13 +86,37 @@ def build_screen(state: State):
         title="Comandi",
         min_width=28,
     )
-    return Row((choices, report, commands), gap=1)
+    panels = (choices, report, commands)
+    if width is not None and height is not None and width < 120 and height >= 24:
+        return Column(
+            panels,
+            sizes=(
+                Size.flexible(2, minimum=6, maximum=8),
+                Size.flexible(5, minimum=10),
+                Size.flexible(2, minimum=6, maximum=8),
+            ),
+            gap=1,
+        )
+    return Row(
+        panels,
+        sizes=(
+            Size.flexible(3, minimum=38),
+            Size.flexible(5, minimum=50),
+            Size.flexible(2, minimum=28),
+        ),
+        gap=1,
+    )
 
 
 def frame(state: State, width: int, height: int, *, color: bool) -> list[str]:
     """Renderizza un frame deterministico."""
 
-    rows = render_lines(build_screen(state), width, height, color=color)
+    rows = render_lines(
+        build_screen(state, width=width, height=height),
+        width,
+        height,
+        color=color,
+    )
     if not color:
         return rows
     return [_paint_guidance(row) for row in rows]

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -136,6 +136,42 @@ def test_tui_confirmation_is_explicit_and_cancellable() -> None:
     assert "Saranno installati solo i componenti mancanti." in state.report
 
 
+def test_tui_wraps_diagnosis_and_gives_it_more_space() -> None:
+    pytest.importorskip("utui")
+    from installer.tui import State, frame
+
+    message = (
+        "COSA SIGNIFICA: questa spiegazione deve restare completamente leggibile "
+        "anche quando supera la larghezza originaria del pannello centrale."
+    )
+    state = State(Host.WINDOWS_AMD64, (Provider.DOCKER,), report=(message,))
+    rendered = "\n".join(frame(state, 140, 14, color=False))
+
+    assert "questa spiegazione deve restare" in rendered
+    assert "completamente leggibile anche quando supera la larghezza" in rendered
+    assert "originaria del pannello centrale." in rendered
+    assert "…" not in rendered
+
+
+def test_tui_stacks_panels_when_terminal_is_narrow_and_tall() -> None:
+    pytest.importorskip("utui")
+    from installer.tui import State, frame
+
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER, Provider.VIRTUALBOX),
+        report=("Diagnosi leggibile",),
+    )
+    rows = frame(state, 100, 30, color=False)
+    positions = {
+        title: next(index for index, row in enumerate(rows) if title in row)
+        for title in ("Ambiente 2cornot2c", "Diagnosi", "Comandi")
+    }
+
+    assert positions["Ambiente 2cornot2c"] < positions["Diagnosi"]
+    assert positions["Diagnosi"] < positions["Comandi"]
+
+
 def check_results(plan, *, missing: set[str] = set()):
     return tuple(
         CheckResult(check, check.key not in missing, "manca")


### PR DESCRIPTION
## Cosa cambia

- abilita il ritorno a capo nel pannello Diagnosi;
- assegna larghezze 30/50/20 ad Ambiente, Diagnosi e Comandi;
- su terminali sotto 120 colonne e alti almeno 24 righe impila i pannelli verticalmente;
- assegna la maggior parte dell’altezza alla Diagnosi;
- aggiunge test per wrapping senza ellissi e ordine responsive.

## Verifiche

- 31 test mirati superati;
- compilazione Python superata;
- `git diff --check` pulito.