### PR TITLE
Contain diagnosis colors within the panel

### DIFF
--- a/installer/tui.py
+++ b/installer/tui.py
@@ -136,9 +136,12 @@ def _paint_guidance(row: str) -> str:
         start = row.find(marker)
         if start < 0:
             continue
-        end = row.rfind("│")
-        if end <= start:
-            end = len(row)
+        boundaries = tuple(
+            position
+            for border in ("│", "|")
+            if (position := row.find(border, start)) > start
+        )
+        end = min(boundaries, default=len(row))
         return f"{row[:start]}{escape}{row[start:end]}\x1b[0m{row[end:]}"
     return row
 

--- a/tests/test_student_errors.py
+++ b/tests/test_student_errors.py
@@ -70,6 +70,19 @@ def test_tui_paints_error_red_and_explanation_yellow_after_layout() -> None:
     )
 
 
+def test_tui_resets_guidance_color_at_diagnosis_panel_boundary() -> None:
+    row = (
+        "│ Ambiente │ │ ERRORE E03 - Virtualizzazione disabilitata │ "
+        "│ Comandi │"
+    )
+
+    painted = _paint_guidance(row)
+
+    assert "\x1b[31mERRORE E03 - Virtualizzazione disabilitata " in painted
+    assert "\x1b[0m│ │ Comandi │" in painted
+    assert painted.index("\x1b[0m") < painted.index("Comandi")
+
+
 def test_windows_scripts_render_error_and_explanation_colors() -> None:
     from pathlib import Path
 


### PR DESCRIPTION
## Correzione

Il post-processing ANSI cercava l’ultimo bordo dell’intera riga e colorava anche il pannello Comandi. Ora usa il primo bordo successivo al testo della Diagnosi, supportando sia `│` sia `|`.

## Verifiche

- test di regressione con tre pannelli sulla stessa riga;
- 25 test TUI e messaggi studente superati;
- compilazione Python e `git diff --check` superati.

Il problema era nel consumer 2cornot2c, non in uTUI.