### PR TITLE
Preserve guidance colors across wrapped lines

### DIFF
--- a/installer/tui.py
+++ b/installer/tui.py
@@ -19,6 +19,7 @@ from utui import (
     Size,
     get_terminal_size,
     render_lines,
+    strip_ansi,
     supports_color,
 )
 
@@ -119,11 +120,24 @@ def frame(state: State, width: int, height: int, *, color: bool) -> list[str]:
     )
     if not color:
         return rows
-    return [_paint_guidance(row) for row in rows]
+    return _paint_guidance_rows(rows)
 
 
 def _paint_guidance(row: str) -> str:
-    """Colora dopo il layout, senza alterare i calcoli di larghezza uTUI."""
+    """Compatibilità per la colorazione di una singola riga."""
+
+    return _paint_guidance_rows([row])[0]
+
+
+def _border_positions(row: str) -> tuple[int, ...]:
+    """Trova i bordi del layout senza confonderne gli stili ANSI."""
+
+    border = "│" if "│" in row else "|"
+    return tuple(index for index, character in enumerate(row) if character == border)
+
+
+def _paint_guidance_rows(rows: list[str]) -> list[str]:
+    """Propaga il colore sulle righe visuali prodotte dal wrapping."""
 
     markers = (
         ("ERRORE E", "\x1b[31m"),
@@ -131,19 +145,67 @@ def _paint_guidance(row: str) -> str:
         ("COSA DEVI FARE:", "\x1b[33m"),
         ("COSA FARE ", "\x1b[33m"),
         ("CODICE DA COMUNICARE", "\x1b[33m"),
+        ("Dettagli tecnici:", "\x1b[90m"),
     )
-    for marker, escape in markers:
-        start = row.find(marker)
-        if start < 0:
-            continue
-        boundaries = tuple(
-            position
-            for border in ("│", "|")
-            if (position := row.find(border, start)) > start
+    result: list[str] = []
+    active_escape: str | None = None
+    active_right_border: int | None = None
+    new_report_prefixes = (
+        "[",
+        "Ambiente:",
+        "Saranno ",
+        "Premi ",
+        "Pronto.",
+        "Nessun ",
+    )
+    for row in rows:
+        match = next(
+            (
+                (row.find(marker), escape)
+                for marker, escape in markers
+                if marker in row
+            ),
+            None,
         )
-        end = min(boundaries, default=len(row))
-        return f"{row[:start]}{escape}{row[start:end]}\x1b[0m{row[end:]}"
-    return row
+        borders = _border_positions(row)
+        if match is not None:
+            start, active_escape = match
+            right_indices = [
+                index for index, position in enumerate(borders) if position > start
+            ]
+            if not right_indices:
+                active_right_border = None
+                result.append(
+                    f"{row[:start]}{active_escape}{row[start:]}\x1b[0m"
+                )
+                continue
+            active_right_border = right_indices[0]
+            end = borders[active_right_border]
+            result.append(
+                f"{row[:start]}{active_escape}{row[start:end]}"
+                f"\x1b[0m{row[end:]}"
+            )
+            continue
+        if (
+            active_escape is None
+            or active_right_border is None
+            or active_right_border == 0
+            or active_right_border >= len(borders)
+        ):
+            result.append(row)
+            continue
+        start = borders[active_right_border - 1] + 1
+        end = borders[active_right_border]
+        content = strip_ansi(row[start:end]).strip()
+        if not content or content.startswith(new_report_prefixes):
+            active_escape = None
+            active_right_border = None
+            result.append(row)
+            continue
+        result.append(
+            f"{row[:start]}{active_escape}{row[start:end]}\x1b[0m{row[end:]}"
+        )
+    return result
 
 
 def refresh_report(state: State) -> None:

--- a/tests/test_student_errors.py
+++ b/tests/test_student_errors.py
@@ -4,7 +4,7 @@ import re
 import unicodedata
 
 from installer.student_errors import ERRORS, for_check, for_step, resource_error
-from installer.tui import _paint_guidance
+from installer.tui import _paint_guidance, _paint_guidance_rows
 
 
 def test_every_student_error_has_actionable_structure_and_unique_code() -> None:
@@ -81,6 +81,24 @@ def test_tui_resets_guidance_color_at_diagnosis_panel_boundary() -> None:
     assert "\x1b[31mERRORE E03 - Virtualizzazione disabilitata " in painted
     assert "\x1b[0m│ │ Comandi │" in painted
     assert painted.index("\x1b[0m") < painted.index("Comandi")
+
+
+def test_tui_keeps_guidance_color_on_wrapped_rows_only() -> None:
+    rows = [
+        "│ Ambiente │ │ ERRORE E03 - La virtualizzazione del │ │ Comandi │",
+        "│          │ │ computer è disabilitata              │ │ bianco  │",
+        "│          │ │ COSA SIGNIFICA: Docker ha bisogno     │ │ bianco  │",
+        "│          │ │ della virtualizzazione.               │ │ bianco  │",
+        "│          │ │ [OK] Connessione disponibile          │ │ bianco  │",
+    ]
+
+    painted = _paint_guidance_rows(rows)
+
+    assert "\x1b[31m computer è disabilitata" in painted[1]
+    assert "\x1b[33m della virtualizzazione." in painted[3]
+    assert "\x1b[0m│ │ bianco" in painted[1]
+    assert "\x1b[0m│ │ bianco" in painted[3]
+    assert "\x1b[" not in painted[4]
 
 
 def test_windows_scripts_render_error_and_explanation_colors() -> None:


### PR DESCRIPTION
## Correzione

- propaga rosso e giallo sulle righe visuali create dal wrapping;
- cambia colore quando inizia una nuova sezione semantica;
- usa grigio per i dettagli tecnici;
- interrompe il colore prima di righe normali come `[OK]`;
- mantiene il reset sul bordo del pannello Diagnosi.

## Verifiche

- test con errore rosso e spiegazione gialla su più righe;
- test del pannello Comandi non colorato;
- test del ritorno al bianco su una riga `[OK]`;
- 30 test mirati superati;
- frame ANSI reale ispezionato;
- compilazione Python e `git diff --check` superati.