### PR TITLE
Show live installation progress in the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,11 @@ per installare. Su computer con al massimo 8 GiB viene mostrato per primo
 **Docker leggero - 512 MB**; tutte le alternative compatibili restano
 selezionabili.
 
+Durante l'installazione la TUI resta reattiva e mostra il passo corrente, una
+barra basata sui passaggi realmente completati, un indicatore di attività e il
+tempo trascorso. Non presenta percentuali di download stimate e ignora i
+comandi di uscita finché l'operazione non termina.
+
 Prima di installare, la procedura controlla RAM, spazio libero, architettura,
 virtualizzazione hardware e connessione. Docker richiede almeno 4 GiB di RAM e
 8 GiB liberi; una VM richiede almeno 8 GiB di RAM e 20 GiB liberi. Se una

--- a/installer/README.md
+++ b/installer/README.md
@@ -98,6 +98,11 @@ python -m installer.tui
 ```
 
 Nel menu premi `a`, controlla il provider mostrato e premi `s` per confermare.
+
+L'esecuzione avviene in un worker mentre il ciclo TUI continua a ridisegnare la
+schermata. `execute_plan` pubblica eventi per inizio e fine di ciascun passo;
+la UI mostra avanzamento per passi, attività indeterminata durante i comandi
+lunghi e tempo trascorso, senza inventare una percentuale di download.
 `n` o `Esc` annullano senza modifiche.
 
 Il percorso Docker scarica già l'immagine Ubuntu multiarch da GHCR usando il

--- a/installer/executor.py
+++ b/installer/executor.py
@@ -24,6 +24,7 @@ class StepResult:
 
 
 CommandRunner = Callable[[tuple[str, ...]], tuple[int, str]]
+ProgressCallback = Callable[[str, int, int, str], None]
 
 
 def subprocess_runner(command: tuple[str, ...]) -> tuple[int, str]:
@@ -63,6 +64,7 @@ def execute_plan(
     *,
     runner: CommandRunner = subprocess_runner,
     log_path: Path | None = None,
+    progress: ProgressCallback | None = None,
 ) -> tuple[StepResult, ...]:
     """Applica i soli passi mancanti, fermandosi al primo errore.
 
@@ -100,10 +102,15 @@ def execute_plan(
         )
         for result in results:
             _append_log(log_path, plan, result)
+        if progress is not None:
+            progress("blocked", 0, len(plan.steps), results[0].label)
         return results
 
     applied: list[StepResult] = []
-    for step in plan.steps:
+    total = len(plan.steps)
+    for index, step in enumerate(plan.steps, 1):
+        if progress is not None:
+            progress("started", index, total, step.label)
         if step.key not in missing:
             result = StepResult(step.key, step.label, "skipped", "già presente")
         elif step.command is None:
@@ -119,6 +126,8 @@ def execute_plan(
             )
         applied.append(result)
         _append_log(log_path, plan, result)
+        if progress is not None:
+            progress(result.status, index, total, step.label)
         if result.status in {"failed", "blocked"}:
             break
     return tuple(applied)

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from io import UnsupportedOperation
 from pathlib import Path
+from queue import Empty, Queue
 import sys
+from threading import Thread
+from time import monotonic
+from typing import Any
 
 from utui import (
     Column,
@@ -24,7 +28,7 @@ from utui import (
 )
 
 from installer.diagnostics import diagnose
-from installer.executor import execute_plan
+from installer.executor import StepResult, execute_plan
 from installer.model import Host, Provider
 from installer.platforms import detect_host
 from installer.plans import install_plan, supported_providers
@@ -42,6 +46,16 @@ class State:
     active_index: int = 0
     report: tuple[str, ...] = ("Premi Invio per eseguire la diagnosi.",)
     confirmation_pending: bool = False
+    installing: bool = False
+    install_current: int = 0
+    install_completed: int = 0
+    install_total: int = 0
+    install_label: str = ""
+    install_elapsed: int = 0
+    install_started_at: float = 0.0
+    install_tick: int = 0
+    install_updates: Queue[tuple[str, Any]] | None = None
+    install_thread: Thread | None = None
     running: bool = True
 
 
@@ -72,16 +86,29 @@ def build_screen(
         title=f"Ambiente 2cornot2c - {state.host.value}{memory_label}",
         min_width=38,
     )
+    visible_report = (
+        _installation_report(state) if state.installing else state.report
+    )
     report = Panel(
-        Label("\n".join(state.report), wrap=True),
+        Label("\n".join(visible_report), wrap=True),
         title="Diagnosi",
         min_width=50,
     )
-    command_text = (
-        "s: conferma installazione\nn/Esc: annulla"
-        if state.confirmation_pending
-        else "Su/Giu oppure k/j: scegli\nInvio: controlla\na: installa\nq/Esc: esci"
-    )
+    if state.installing:
+        command_text = (
+            "Installazione in corso\n"
+            "Attendi il completamento\n"
+            "Non chiudere la finestra"
+        )
+    elif state.confirmation_pending:
+        command_text = "s: conferma installazione\nn/Esc: annulla"
+    else:
+        command_text = (
+            "Su/Giu oppure k/j: scegli\n"
+            "Invio: controlla\n"
+            "a: installa\n"
+            "q/Esc: esci"
+        )
     commands = Panel(
         Label(command_text),
         title="Comandi",
@@ -237,17 +264,10 @@ def request_confirmation(state: State) -> None:
     )
 
 
-def apply_selected(state: State) -> None:
-    """Applica il piano selezionato e mostra un riepilogo compatto."""
-
-    provider = state.providers[state.active_index]
-    plan = install_plan(state.host, provider)
-    results = execute_plan(
-        plan,
-        diagnose(plan),
-        log_path=Path.home() / ".2cornot2c" / "installer.jsonl",
-    )
-    state.confirmation_pending = False
+def _format_results(
+    provider: Provider,
+    results: tuple[StepResult, ...],
+) -> tuple[str, ...]:
     report: list[str] = []
     for result in results:
         if result.status in {"failed", "blocked"}:
@@ -261,16 +281,132 @@ def apply_selected(state: State) -> None:
             report.append(
                 f"[{result.status.upper()}] {result.label}: {result.detail}"
             )
-    state.report = tuple(report) or ("Nessun passo necessario.",)
+    formatted = tuple(report) or ("Nessun passo necessario.",)
     if (
         provider is Provider.DOCKER
         and results
         and all(result.status in {"skipped", "succeeded"} for result in results)
     ):
-        state.report += (
+        formatted += (
             "Pronto. Esci con q, poi avvia:",
             "python scripts/student_dev_shell.py",
         )
+    return formatted
+
+
+def apply_selected(state: State) -> None:
+    """Applica il piano selezionato e mostra un riepilogo compatto."""
+
+    provider = state.providers[state.active_index]
+    plan = install_plan(state.host, provider)
+    results = execute_plan(
+        plan,
+        diagnose(plan),
+        log_path=Path.home() / ".2cornot2c" / "installer.jsonl",
+    )
+    state.confirmation_pending = False
+    state.report = _format_results(provider, results)
+
+
+def _installation_report(state: State) -> tuple[str, ...]:
+    """Crea una barra onesta: passi completati più attività indeterminata."""
+
+    width = 24
+    total = max(1, state.install_total)
+    filled = min(width, int(width * state.install_completed / total))
+    cells = ["█" if index < filled else "░" for index in range(width)]
+    if filled < width:
+        pulse = filled + state.install_tick % max(1, width - filled)
+        cells[min(width - 1, pulse)] = "▓"
+    minutes, seconds = divmod(state.install_elapsed, 60)
+    current = min(max(1, state.install_current), total)
+    return (
+        "INSTALLAZIONE IN CORSO",
+        f"Passo {current} di {total} - {state.install_label}",
+        f"[{''.join(cells)}] {state.install_completed}/{total}",
+        f"Attività in corso - tempo trascorso {minutes:02d}:{seconds:02d}",
+        "Non chiudere questa finestra.",
+        "Controlla con Alt+Tab eventuali richieste di Windows.",
+    )
+
+
+def start_selected(state: State) -> None:
+    """Avvia il lavoro in background lasciando reattivo il rendering."""
+
+    if state.installing:
+        return
+    provider = state.providers[state.active_index]
+    plan = install_plan(state.host, provider)
+    updates: Queue[tuple[str, Any]] = Queue()
+    state.confirmation_pending = False
+    state.installing = True
+    state.install_current = 0
+    state.install_completed = 0
+    state.install_total = len(plan.steps)
+    state.install_label = "Controllo dei prerequisiti"
+    state.install_elapsed = 0
+    state.install_started_at = monotonic()
+    state.install_tick = 0
+    state.install_updates = updates
+
+    def publish(
+        phase: str,
+        index: int,
+        total: int,
+        label: str,
+    ) -> None:
+        updates.put(("progress", (phase, index, total, label)))
+
+    def worker() -> None:
+        try:
+            results = execute_plan(
+                plan,
+                diagnose(plan),
+                log_path=Path.home() / ".2cornot2c" / "installer.jsonl",
+                progress=publish,
+            )
+            updates.put(("result", results))
+        except Exception as error:
+            updates.put(("error", error))
+
+    state.install_thread = Thread(
+        target=worker,
+        name="2cornot2c-installer",
+        daemon=True,
+    )
+    state.install_thread.start()
+
+
+def poll_installation(state: State) -> bool:
+    """Consuma aggiornamenti prodotti dal worker senza bloccare il terminale."""
+
+    if not state.installing or state.install_updates is None:
+        return False
+    changed = False
+    while True:
+        try:
+            kind, payload = state.install_updates.get_nowait()
+        except Empty:
+            break
+        changed = True
+        if kind == "progress":
+            phase, index, total, label = payload
+            state.install_current = index
+            state.install_total = total
+            state.install_label = label
+            if phase in {"succeeded", "skipped"}:
+                state.install_completed = index
+        elif kind == "result":
+            provider = state.providers[state.active_index]
+            state.report = _format_results(provider, payload)
+            state.installing = False
+            state.install_thread = None
+        else:
+            error = for_check("installer", str(payload))
+            state.report = error.lines(str(payload))
+            state.installing = False
+            state.install_thread = None
+    return changed
 
 
 def present(rows: list[str]) -> None:
@@ -293,6 +429,7 @@ def main() -> int:
     )
     watcher = ResizeWatcher()
     color = supports_color()
+    progress_refreshed_at = monotonic()
 
     try:
         with KeyReader() as reader:
@@ -302,11 +439,21 @@ def main() -> int:
                 event = reader.read(timeout=0.05)
                 resized = watcher.poll()
                 changed = resized is not None
+                if poll_installation(state):
+                    changed = True
+                now = monotonic()
+                if state.installing and now - progress_refreshed_at >= 0.15:
+                    state.install_tick += 1
+                    state.install_elapsed = int(now - state.install_started_at)
+                    progress_refreshed_at = now
+                    changed = True
                 if resized is not None:
                     size = resized
                 if event is not None:
                     character = event.character if event.key is Key.CHARACTER else ""
-                    if event.key is Key.UP or character == "k":
+                    if state.installing:
+                        changed = True
+                    elif event.key is Key.UP or character == "k":
                         state.active_index = max(0, state.active_index - 1)
                     elif event.key is Key.DOWN or character == "j":
                         state.active_index = min(
@@ -317,7 +464,8 @@ def main() -> int:
                     elif character == "a" and not state.confirmation_pending:
                         request_confirmation(state)
                     elif character == "s" and state.confirmation_pending:
-                        apply_selected(state)
+                        start_selected(state)
+                        progress_refreshed_at = monotonic()
                     elif (
                         character == "n" or event.key is Key.ESCAPE
                     ) and state.confirmation_pending:

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -195,6 +195,94 @@ def test_executor_skips_present_steps_and_applies_only_missing(tmp_path) -> None
     assert (tmp_path / "installer.jsonl").read_text(encoding="utf-8").count("\n") == 3
 
 
+def test_executor_reports_step_progress_without_inventing_percentages() -> None:
+    plan = install_plan(Host.WINDOWS_AMD64, Provider.VIRTUALBOX)
+    events = []
+
+    execute_plan(
+        plan,
+        check_results(plan, missing={"virtualbox"}),
+        runner=lambda command: (0, "installato"),
+        progress=lambda *event: events.append(event),
+    )
+
+    assert events == [
+        ("started", 1, 3, "Installa Git"),
+        ("skipped", 1, 3, "Installa Git"),
+        ("started", 2, 3, "Installa Vagrant"),
+        ("skipped", 2, 3, "Installa Vagrant"),
+        ("started", 3, 3, "Installa VirtualBox"),
+        ("succeeded", 3, 3, "Installa VirtualBox"),
+    ]
+
+
+def test_tui_installation_report_shows_step_bar_and_elapsed_time() -> None:
+    pytest.importorskip("utui")
+    from installer.tui import State, _installation_report
+
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER,),
+        installing=True,
+        install_current=1,
+        install_completed=0,
+        install_total=2,
+        install_label="Installa Docker Desktop",
+        install_elapsed=135,
+        install_tick=3,
+    )
+    report = "\n".join(_installation_report(state))
+
+    assert "INSTALLAZIONE IN CORSO" in report
+    assert "Passo 1 di 2 - Installa Docker Desktop" in report
+    assert "0/2" in report
+    assert "02:15" in report
+    assert "Non chiudere questa finestra." in report
+    assert "▓" in report
+
+
+def test_tui_poll_updates_progress_and_finishes_installation() -> None:
+    pytest.importorskip("utui")
+    from queue import Queue
+
+    from installer.executor import StepResult
+    from installer.tui import State, poll_installation
+
+    updates = Queue()
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER,),
+        installing=True,
+        install_updates=updates,
+    )
+    updates.put(("progress", ("started", 1, 2, "Installa Docker Desktop")))
+    updates.put(("progress", ("succeeded", 1, 2, "Installa Docker Desktop")))
+
+    assert poll_installation(state) is True
+    assert state.installing is True
+    assert state.install_current == 1
+    assert state.install_completed == 1
+    assert state.install_label == "Installa Docker Desktop"
+
+    updates.put(
+        (
+            "result",
+            (
+                StepResult(
+                    "docker",
+                    "Installa Docker Desktop",
+                    "succeeded",
+                    "installato",
+                ),
+            ),
+        )
+    )
+
+    assert poll_installation(state) is True
+    assert state.installing is False
+    assert "SUCCEEDED" in "\n".join(state.report)
+
+
 def test_executor_blocks_manual_prerequisite_before_writes() -> None:
     plan = install_plan(Host.MACOS_ARM64, Provider.VMWARE)
     calls = []


### PR DESCRIPTION
## Cosa cambia

- esegue diagnosi e installazione in un worker dedicato;
- mantiene reattivo il ciclo di rendering;
- mostra passo corrente, barra per passi completati, impulso di attività e timer;
- evita percentuali di download inventate;
- ignora i comandi di uscita durante l’installazione;
- mostra un richiamo per eventuali finestre UAC dietro al terminale;
- pubblica eventi di avanzamento dal core `execute_plan`.

## Verifiche

- 57 test mirati superati;
- test degli eventi started/skipped/succeeded;
- test della barra e del timer;
- test del polling e del completamento;
- rendering 140x12 e 100x30 ispezionato;
- compilazione Python e `git diff --check` superati.