### PR TITLE
feat: enforce dashboard role and class scopes

### DIFF
--- a/doc/architecture/dashboard-authorization.md
+++ b/doc/architecture/dashboard-authorization.md
@@ -31,7 +31,7 @@ Un cambio ruolo/disabilitazione tra autenticazione e lettura produce quindi dini
 - `teacher`: può richiedere uno studente attivo soltanto se esiste almeno una classe attiva condivisa tra membership `teacher` e `student`;
 - `admin`: può richiedere uno studente attivo con almeno una membership di classe attiva;
 - target `pending`, docente, disabilitato, inesistente o senza classe attiva: diniego;
-- ID vuoti, sovradimensionati o con controlli: diniego senza distinguere esistenza e formato.
+- ID vuoti, sovradimensionati, con controlli o surrogate Unicode non codificabili: diniego senza distinguere esistenza e formato.
 
 Lo scope del dettaglio contiene l'intersezione visibile, non tutte le classi del target. L'adapter dati deve usare `class_ids` per filtrare ogni record prima della serializzazione e `student_user_id` come unico target ammesso. Non deve rileggere `student_id` o `class_id` dal client dopo l'autorizzazione.
 
@@ -48,7 +48,7 @@ Il boundary conserva gli errori HTTP esistenti:
 - `401 authentication_required` per sessione assente/non valida;
 - `403 csrf_rejected` per metodi unsafe senza token corretto;
 - `403 authorization_denied` per ruolo, membership, classe o target non autorizzati;
-- `503 dashboard_authorization_unavailable` per storage, corruzione o contratti adapter malformati.
+- `503 dashboard_authorization_unavailable` per storage, corruzione o contratti adapter malformati, incluso uno snapshot che restituisce un target diverso da quello richiesto.
 
 ## Fuori scope
 

--- a/doc/architecture/dashboard-authorization.md
+++ b/doc/architecture/dashboard-authorization.md
@@ -39,7 +39,7 @@ Lo scope del dettaglio contiene l'intersezione visibile, non tutte le classi del
 
 SQLite fornisce uno snapshot coerente di utente, target, membership e stato classi. Membership e classi cambiate prima dello snapshot sono osservate immediatamente. Come in una normale autorizzazione request-scoped, una revoca successiva alla decisione vale dalla richiesta seguente; l'adapter non deve conservare o riutilizzare uno scope tra richieste.
 
-`DashboardAccessScope` contiene solo identificatori interni, è immutabile e valida ordinamento/unicità. Soltanto uno scope della dashboard docente può essere globale; uno scope globale non può contenere contemporaneamente classi parziali. Lo snapshot ricevuto dal port storage viene ricostruito e rivalidato integralmente, quindi anche istanze mutate o adapter malformati falliscono con il 503 sanitizzato.
+`DashboardAccessScope` contiene solo identificatori interni e il ruolo interno corrente dell'attore. È una capability strutturalmente immutabile basata su tupla, valida ordinamento/unicità e non è alterabile neppure tramite `object.__setattr__`. Soltanto un attore `admin` può ottenere uno scope globale della dashboard docente; lo scope `teacher` richiede classi limitate e ogni scope studente richiede classi visibili. Lo snapshot ricevuto dal port storage viene ricostruito e rivalidato integralmente, quindi anche istanze snapshot mutate o adapter malformati falliscono con il 503 sanitizzato.
 
 ## Errori pubblici
 

--- a/doc/architecture/dashboard-authorization.md
+++ b/doc/architecture/dashboard-authorization.md
@@ -1,0 +1,59 @@
+# Autorizzazione dashboard per ruolo e classe
+
+## Scopo
+
+`scripts/thebitlab_dashboard_auth.py` è il boundary provider-independent tra una sessione HTTP autenticata e le query delle dashboard. Non usa email, username Google/GitHub, slug di team o identificatori scelti liberamente dal browser: l'attore e lo studente target sono sempre `user_id` interni TheBitLab.
+
+Questo incremento definisce la policy e lo scope obbligatorio per il successivo adapter delle route Course Board. Il server demo continua temporaneamente a usare Basic/HMAC; le route OAuth concrete, TLS e il rate limiting restano separati.
+
+## Sequenza di autorizzazione
+
+1. `HttpSessionAuthBoundary.authorize_application` autentica il cookie, ricontrolla sessione, account e ruolo e applica CSRF ai metodi unsafe.
+2. `SqliteIdentityStorage.read_dashboard_authorization_snapshot` apre una singola transazione di lettura SQLite.
+3. La transazione richiede che l'attore sia ancora attivo e che `updated_at` coincida con la revisione appena autenticata.
+4. Lo snapshot include soltanto membership del ruolo corrente collegate a classi attive. Per un target studente include soltanto membership `student` in classi attive.
+5. Il boundary confronta nuovamente identità, ruolo e revisione dello snapshot con il principal HTTP e produce un `DashboardAccessScope` minimo.
+
+Un cambio ruolo/disabilitazione tra autenticazione e lettura produce quindi diniego. Errori storage o risultati adapter malformati producono `503 dashboard_authorization_unavailable` senza dettagli interni.
+
+## Policy
+
+### Dashboard docente
+
+- `admin`: scope globale esplicito (`all_classes=True`) senza materializzare una lista potenzialmente incompleta;
+- `teacher`: soltanto classi attive con membership `teacher` corrente;
+- `student` e `pending`: diniego;
+- un docente senza classi attive: diniego fail-closed.
+
+### Dashboard studente e dettaglio studente
+
+- `student`: può richiedere soltanto il proprio `user_id`; lo scope contiene le sue classi attive;
+- `teacher`: può richiedere uno studente attivo soltanto se esiste almeno una classe attiva condivisa tra membership `teacher` e `student`;
+- `admin`: può richiedere uno studente attivo con almeno una membership di classe attiva;
+- target `pending`, docente, disabilitato, inesistente o senza classe attiva: diniego;
+- ID vuoti, sovradimensionati o con controlli: diniego senza distinguere esistenza e formato.
+
+Lo scope del dettaglio contiene l'intersezione visibile, non tutte le classi del target. L'adapter dati deve usare `class_ids` per filtrare ogni record prima della serializzazione e `student_user_id` come unico target ammesso. Non deve rileggere `student_id` o `class_id` dal client dopo l'autorizzazione.
+
+## Coerenza e revoca
+
+SQLite fornisce uno snapshot coerente di utente, target, membership e stato classi. Membership e classi cambiate prima dello snapshot sono osservate immediatamente. Come in una normale autorizzazione request-scoped, una revoca successiva alla decisione vale dalla richiesta seguente; l'adapter non deve conservare o riutilizzare uno scope tra richieste.
+
+`DashboardAccessScope` contiene solo identificatori interni, è immutabile e valida ordinamento/unicità. Uno scope globale non può contenere contemporaneamente classi parziali.
+
+## Errori pubblici
+
+Il boundary conserva gli errori HTTP esistenti:
+
+- `401 authentication_required` per sessione assente/non valida;
+- `403 csrf_rejected` per metodi unsafe senza token corretto;
+- `403 authorization_denied` per ruolo, membership, classe o target non autorizzati;
+- `503 dashboard_authorization_unavailable` per storage, corruzione o contratti adapter malformati.
+
+## Fuori scope
+
+- wiring delle route Google/GitHub/session/logout nel Course Board;
+- sostituzione dei token Basic/HMAC nella demo locale;
+- filtraggio concreto dei file legacy della dashboard;
+- TLS/reverse proxy e rate limiting (#549);
+- browser E2E e pairing TUI.

--- a/doc/architecture/dashboard-authorization.md
+++ b/doc/architecture/dashboard-authorization.md
@@ -39,7 +39,7 @@ Lo scope del dettaglio contiene l'intersezione visibile, non tutte le classi del
 
 SQLite fornisce uno snapshot coerente di utente, target, membership e stato classi. Membership e classi cambiate prima dello snapshot sono osservate immediatamente. Come in una normale autorizzazione request-scoped, una revoca successiva alla decisione vale dalla richiesta seguente; l'adapter non deve conservare o riutilizzare uno scope tra richieste.
 
-`DashboardAccessScope` contiene solo identificatori interni, è immutabile e valida ordinamento/unicità. Uno scope globale non può contenere contemporaneamente classi parziali.
+`DashboardAccessScope` contiene solo identificatori interni, è immutabile e valida ordinamento/unicità. Soltanto uno scope della dashboard docente può essere globale; uno scope globale non può contenere contemporaneamente classi parziali. Lo snapshot ricevuto dal port storage viene ricostruito e rivalidato integralmente, quindi anche istanze mutate o adapter malformati falliscono con il 503 sanitizzato.
 
 ## Errori pubblici
 

--- a/doc/architecture/http-session-authorization.md
+++ b/doc/architecture/http-session-authorization.md
@@ -53,6 +53,8 @@ Il secret CSRF contiene almeno 32 byte, proviene da ambiente/secret store ed è 
 
 `authenticate` permette anche a `pending` di raggiungere future route di onboarding. `authorize_application` accetta soltanto policy non vuote composte da `admin`, `teacher` e `student`: `pending` non può essere autorizzato ai dati applicativi per errore di configurazione.
 
+La policy successiva per dashboard è implementata da `thebitlab_dashboard_auth.py` e documentata in [dashboard-authorization.md](dashboard-authorization.md): ricontrolla atomicamente revisione utente, ruolo, membership e classi attive e restituisce uno scope dati minimo.
+
 Errori pubblici stabili:
 
 - `400 bad_auth_request`;
@@ -70,7 +72,7 @@ Il logout è esclusivamente `POST`. Per una sessione valida richiede CSRF, revoc
 
 ## Fuori scope
 
-- route concrete nel Course Board e protezione dashboard;
+- route concrete nel Course Board e applicazione dello scope ai file legacy della dashboard;
 - route e browser E2E Google OIDC (il protocol adapter `state`/`nonce`/PKCE è implementato);
 - account linking GitHub;
 - pairing TUI via browser;

--- a/scripts/thebitlab_dashboard_auth.py
+++ b/scripts/thebitlab_dashboard_auth.py
@@ -1,0 +1,131 @@
+"""Provider-independent role and class authorization for web dashboards."""
+
+from __future__ import annotations
+
+from scripts.thebitlab_dashboard_auth_ports import (
+    DashboardAccessScope,
+    DashboardAuthorizationSnapshot,
+    DashboardAuthorizationStorage,
+    dashboard_identifier,
+)
+from scripts.thebitlab_http_auth import (
+    HttpAuthContext,
+    HttpAuthError,
+    HttpAuthRequest,
+    HttpAuthorizationDeniedError,
+    HttpSessionAuthBoundary,
+)
+
+
+class DashboardAuthorizationUnavailableError(HttpAuthError):
+    """Stable infrastructure error suitable for an HTTP 503 response."""
+
+    status_code = 503
+    error_code = "dashboard_authorization_unavailable"
+    public_message = "Autorizzazione dashboard temporaneamente non disponibile."
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class DashboardAuthorizationBoundary:
+    """Combine live HTTP sessions with role and class-scoped dashboard policies."""
+
+    def __init__(
+        self,
+        http_sessions: HttpSessionAuthBoundary,
+        storage: DashboardAuthorizationStorage,
+    ) -> None:
+        self.http_sessions = http_sessions
+        self.storage = storage
+
+    def authorize_teacher_dashboard(
+        self, request: HttpAuthRequest
+    ) -> DashboardAccessScope:
+        context = self.http_sessions.authorize_application(
+            request, allowed_roles={"admin", "teacher"}
+        )
+        snapshot = self._snapshot(context)
+        if snapshot.actor_role == "admin":
+            return DashboardAccessScope(
+                "teacher", snapshot.actor_user_id, (), all_classes=True
+            )
+        if snapshot.actor_role != "teacher" or not snapshot.actor_class_ids:
+            raise HttpAuthorizationDeniedError()
+        return DashboardAccessScope(
+            "teacher", snapshot.actor_user_id, snapshot.actor_class_ids
+        )
+
+    def authorize_student_dashboard(
+        self,
+        request: HttpAuthRequest,
+        *,
+        requested_student_user_id: str,
+    ) -> DashboardAccessScope:
+        context = self.http_sessions.authorize_application(
+            request, allowed_roles={"admin", "teacher", "student"}
+        )
+        try:
+            target_user_id = dashboard_identifier(
+                requested_student_user_id, "requested_student_user_id"
+            )
+        except ValueError:
+            raise HttpAuthorizationDeniedError() from None
+        if context.user.role == "student" and target_user_id != context.user.user_id:
+            raise HttpAuthorizationDeniedError()
+        snapshot = self._snapshot(context, target_user_id=target_user_id)
+        if (
+            snapshot.target_user_id != target_user_id
+            or snapshot.target_role != "student"
+            or not snapshot.target_class_ids
+        ):
+            raise HttpAuthorizationDeniedError()
+        if snapshot.actor_role == "admin":
+            visible = snapshot.target_class_ids
+        elif snapshot.actor_role == "student":
+            if snapshot.actor_user_id != target_user_id:
+                raise HttpAuthorizationDeniedError()
+            visible = tuple(
+                sorted(set(snapshot.actor_class_ids) & set(snapshot.target_class_ids))
+            )
+        elif snapshot.actor_role == "teacher":
+            visible = tuple(
+                sorted(set(snapshot.actor_class_ids) & set(snapshot.target_class_ids))
+            )
+        else:
+            raise HttpAuthorizationDeniedError()
+        if not visible:
+            raise HttpAuthorizationDeniedError()
+        return DashboardAccessScope(
+            "student",
+            snapshot.actor_user_id,
+            visible,
+            student_user_id=target_user_id,
+        )
+
+    def _snapshot(
+        self, context: HttpAuthContext, *, target_user_id: str | None = None
+    ) -> DashboardAuthorizationSnapshot:
+        snapshot = None
+        unavailable = False
+        try:
+            snapshot = self.storage.read_dashboard_authorization_snapshot(
+                context.user.user_id,
+                expected_actor_updated_at=context.user.updated_at,
+                target_user_id=target_user_id,
+            )
+        except Exception:
+            unavailable = True
+        if unavailable:
+            raise DashboardAuthorizationUnavailableError()
+        if snapshot is None:
+            raise HttpAuthorizationDeniedError()
+        if type(snapshot) is not DashboardAuthorizationSnapshot:
+            raise DashboardAuthorizationUnavailableError()
+        if (
+            snapshot.actor_user_id != context.user.user_id
+            or snapshot.actor_role != context.user.role
+            or snapshot.actor_updated_at != context.user.updated_at
+        ):
+            raise DashboardAuthorizationUnavailableError()
+        return snapshot

--- a/scripts/thebitlab_dashboard_auth.py
+++ b/scripts/thebitlab_dashboard_auth.py
@@ -48,12 +48,19 @@ class DashboardAuthorizationBoundary:
         snapshot = self._snapshot(context)
         if snapshot.actor_role == "admin":
             return DashboardAccessScope(
-                "teacher", snapshot.actor_user_id, (), all_classes=True
+                "teacher",
+                snapshot.actor_user_id,
+                snapshot.actor_role,
+                (),
+                all_classes=True,
             )
         if snapshot.actor_role != "teacher" or not snapshot.actor_class_ids:
             raise HttpAuthorizationDeniedError()
         return DashboardAccessScope(
-            "teacher", snapshot.actor_user_id, snapshot.actor_class_ids
+            "teacher",
+            snapshot.actor_user_id,
+            snapshot.actor_role,
+            snapshot.actor_class_ids,
         )
 
     def authorize_student_dashboard(
@@ -99,6 +106,7 @@ class DashboardAuthorizationBoundary:
         return DashboardAccessScope(
             "student",
             snapshot.actor_user_id,
+            snapshot.actor_role,
             visible,
             student_user_id=target_user_id,
         )

--- a/scripts/thebitlab_dashboard_auth.py
+++ b/scripts/thebitlab_dashboard_auth.py
@@ -122,10 +122,26 @@ class DashboardAuthorizationBoundary:
             raise HttpAuthorizationDeniedError()
         if type(snapshot) is not DashboardAuthorizationSnapshot:
             raise DashboardAuthorizationUnavailableError()
+        malformed = False
+        canonical = None
+        try:
+            canonical = DashboardAuthorizationSnapshot(
+                actor_user_id=snapshot.actor_user_id,
+                actor_role=snapshot.actor_role,
+                actor_updated_at=snapshot.actor_updated_at,
+                actor_class_ids=snapshot.actor_class_ids,
+                target_user_id=snapshot.target_user_id,
+                target_role=snapshot.target_role,
+                target_class_ids=snapshot.target_class_ids,
+            )
+        except Exception:
+            malformed = True
+        if malformed or canonical is None:
+            raise DashboardAuthorizationUnavailableError()
         if (
-            snapshot.actor_user_id != context.user.user_id
-            or snapshot.actor_role != context.user.role
-            or snapshot.actor_updated_at != context.user.updated_at
+            canonical.actor_user_id != context.user.user_id
+            or canonical.actor_role != context.user.role
+            or canonical.actor_updated_at != context.user.updated_at
         ):
             raise DashboardAuthorizationUnavailableError()
-        return snapshot
+        return canonical

--- a/scripts/thebitlab_dashboard_auth.py
+++ b/scripts/thebitlab_dashboard_auth.py
@@ -82,7 +82,12 @@ class DashboardAuthorizationBoundary:
             raise HttpAuthorizationDeniedError()
         snapshot = self._snapshot(context, target_user_id=target_user_id)
         if (
-            snapshot.target_user_id != target_user_id
+            snapshot.target_user_id is not None
+            and snapshot.target_user_id != target_user_id
+        ):
+            raise DashboardAuthorizationUnavailableError()
+        if (
+            snapshot.target_user_id is None
             or snapshot.target_role != "student"
             or not snapshot.target_class_ids
         ):

--- a/scripts/thebitlab_dashboard_auth_ports.py
+++ b/scripts/thebitlab_dashboard_auth_ports.py
@@ -87,41 +87,64 @@ class DashboardAuthorizationSnapshot:
         )
 
 
-@dataclass(frozen=True)
-class DashboardAccessScope:
-    """Minimal internal identifiers a dashboard query is allowed to expose."""
+class DashboardAccessScope(tuple):
+    """Immutable minimal capability for one dashboard data query."""
 
-    dashboard: DashboardKind
-    actor_user_id: str
-    class_ids: tuple[str, ...]
-    student_user_id: str | None = None
-    all_classes: bool = False
+    __slots__ = ()
 
-    def __post_init__(self) -> None:
-        if self.dashboard not in {"student", "teacher"}:
+    def __new__(
+        cls,
+        dashboard: DashboardKind,
+        actor_user_id: str,
+        actor_role: str,
+        class_ids: tuple[str, ...],
+        student_user_id: str | None = None,
+        all_classes: bool = False,
+    ) -> "DashboardAccessScope":
+        if dashboard not in {"student", "teacher"}:
             raise ValueError("Dashboard non valida.")
-        object.__setattr__(
-            self,
-            "actor_user_id",
-            dashboard_identifier(self.actor_user_id, "actor_user_id"),
-        )
-        object.__setattr__(self, "class_ids", _class_ids(self.class_ids, "class_ids"))
-        if type(self.all_classes) is not bool:
+        actor_user_id = dashboard_identifier(actor_user_id, "actor_user_id")
+        if type(actor_role) is not str or actor_role not in {"admin", "teacher", "student"}:
+            raise ValueError("actor_role scope non valido.")
+        class_ids = _class_ids(class_ids, "class_ids")
+        if type(all_classes) is not bool:
             raise ValueError("all_classes deve essere booleano.")
-        if self.all_classes and self.dashboard != "teacher":
-            raise ValueError("Solo la dashboard docente supporta uno scope globale.")
-        if self.all_classes and self.class_ids:
-            raise ValueError("Uno scope globale non elenca classi parziali.")
-        if self.student_user_id is not None:
-            object.__setattr__(
-                self,
-                "student_user_id",
-                dashboard_identifier(self.student_user_id, "student_user_id"),
-            )
-        if self.dashboard == "teacher" and self.student_user_id is not None:
-            raise ValueError("La dashboard docente non accetta student_user_id.")
-        if self.dashboard == "student" and self.student_user_id is None:
-            raise ValueError("La dashboard studente richiede student_user_id.")
+        if dashboard == "teacher":
+            if student_user_id is not None:
+                raise ValueError("La dashboard docente non accetta student_user_id.")
+            if actor_role == "admin":
+                if not all_classes or class_ids:
+                    raise ValueError("Lo scope admin docente deve essere globale.")
+            elif actor_role != "teacher" or all_classes or not class_ids:
+                raise ValueError("Lo scope docente richiede classi teacher limitate.")
+        else:
+            if all_classes:
+                raise ValueError("La dashboard studente non supporta scope globale.")
+            if student_user_id is None:
+                raise ValueError("La dashboard studente richiede student_user_id.")
+            student_user_id = dashboard_identifier(student_user_id, "student_user_id")
+            if not class_ids:
+                raise ValueError("La dashboard studente richiede classi visibili.")
+            if actor_role == "student" and student_user_id != actor_user_id:
+                raise ValueError("Lo scope studente deve appartenere all'attore.")
+        return tuple.__new__(
+            cls,
+            (
+                dashboard,
+                actor_user_id,
+                actor_role,
+                class_ids,
+                student_user_id,
+                all_classes,
+            ),
+        )
+
+    dashboard = property(lambda self: self[0])
+    actor_user_id = property(lambda self: self[1])
+    actor_role = property(lambda self: self[2])
+    class_ids = property(lambda self: self[3])
+    student_user_id = property(lambda self: self[4])
+    all_classes = property(lambda self: self[5])
 
 
 class DashboardAuthorizationStorage(Protocol):

--- a/scripts/thebitlab_dashboard_auth_ports.py
+++ b/scripts/thebitlab_dashboard_auth_ports.py
@@ -1,0 +1,134 @@
+"""Provider-independent contracts and storage port for dashboard authorization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal, Protocol
+
+from scripts.thebitlab_identity import USER_ROLES
+
+DashboardKind = Literal["student", "teacher"]
+_MAX_IDENTIFIER_CHARS = 512
+
+
+def dashboard_identifier(value: str, field_name: str) -> str:
+    """Return one bounded internal identifier without accepting controls."""
+    if type(value) is not str:
+        raise ValueError(f"{field_name} deve essere una stringa.")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > _MAX_IDENTIFIER_CHARS
+        or any(ord(character) < 32 or ord(character) == 127 for character in normalized)
+    ):
+        raise ValueError(f"{field_name} non valido.")
+    return normalized
+
+
+def _utc(value: datetime, field_name: str) -> datetime:
+    if type(value) is not datetime or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} deve includere il timezone.")
+    return value.astimezone(timezone.utc)
+
+
+def _class_ids(values: tuple[str, ...], field_name: str) -> tuple[str, ...]:
+    if type(values) is not tuple:
+        raise ValueError(f"{field_name} deve essere una tupla.")
+    normalized = tuple(dashboard_identifier(value, field_name) for value in values)
+    if normalized != tuple(sorted(set(normalized))):
+        raise ValueError(f"{field_name} deve essere ordinato e senza duplicati.")
+    return normalized
+
+
+@dataclass(frozen=True)
+class DashboardAuthorizationSnapshot:
+    """One coherent storage snapshot used for a dashboard authorization decision."""
+
+    actor_user_id: str
+    actor_role: str
+    actor_updated_at: datetime
+    actor_class_ids: tuple[str, ...]
+    target_user_id: str | None = None
+    target_role: str | None = None
+    target_class_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "actor_user_id",
+            dashboard_identifier(self.actor_user_id, "actor_user_id"),
+        )
+        if type(self.actor_role) is not str or self.actor_role not in USER_ROLES:
+            raise ValueError("actor_role non valido.")
+        object.__setattr__(
+            self, "actor_updated_at", _utc(self.actor_updated_at, "actor_updated_at")
+        )
+        object.__setattr__(
+            self,
+            "actor_class_ids",
+            _class_ids(self.actor_class_ids, "actor_class_ids"),
+        )
+        if self.target_user_id is None:
+            if self.target_role is not None or self.target_class_ids:
+                raise ValueError("Target dashboard incompleto.")
+            return
+        object.__setattr__(
+            self,
+            "target_user_id",
+            dashboard_identifier(self.target_user_id, "target_user_id"),
+        )
+        if type(self.target_role) is not str or self.target_role not in USER_ROLES:
+            raise ValueError("target_role non valido.")
+        object.__setattr__(
+            self,
+            "target_class_ids",
+            _class_ids(self.target_class_ids, "target_class_ids"),
+        )
+
+
+@dataclass(frozen=True)
+class DashboardAccessScope:
+    """Minimal internal identifiers a dashboard query is allowed to expose."""
+
+    dashboard: DashboardKind
+    actor_user_id: str
+    class_ids: tuple[str, ...]
+    student_user_id: str | None = None
+    all_classes: bool = False
+
+    def __post_init__(self) -> None:
+        if self.dashboard not in {"student", "teacher"}:
+            raise ValueError("Dashboard non valida.")
+        object.__setattr__(
+            self,
+            "actor_user_id",
+            dashboard_identifier(self.actor_user_id, "actor_user_id"),
+        )
+        object.__setattr__(self, "class_ids", _class_ids(self.class_ids, "class_ids"))
+        if type(self.all_classes) is not bool:
+            raise ValueError("all_classes deve essere booleano.")
+        if self.all_classes and self.class_ids:
+            raise ValueError("Uno scope globale non elenca classi parziali.")
+        if self.student_user_id is not None:
+            object.__setattr__(
+                self,
+                "student_user_id",
+                dashboard_identifier(self.student_user_id, "student_user_id"),
+            )
+        if self.dashboard == "teacher" and self.student_user_id is not None:
+            raise ValueError("La dashboard docente non accetta student_user_id.")
+        if self.dashboard == "student" and self.student_user_id is None:
+            raise ValueError("La dashboard studente richiede student_user_id.")
+
+
+class DashboardAuthorizationStorage(Protocol):
+    """Atomic read port for current actor, target, memberships, and active classes."""
+
+    def read_dashboard_authorization_snapshot(
+        self,
+        actor_user_id: str,
+        *,
+        expected_actor_updated_at: datetime,
+        target_user_id: str | None = None,
+    ) -> DashboardAuthorizationSnapshot | None: ...

--- a/scripts/thebitlab_dashboard_auth_ports.py
+++ b/scripts/thebitlab_dashboard_auth_ports.py
@@ -108,6 +108,8 @@ class DashboardAccessScope:
         object.__setattr__(self, "class_ids", _class_ids(self.class_ids, "class_ids"))
         if type(self.all_classes) is not bool:
             raise ValueError("all_classes deve essere booleano.")
+        if self.all_classes and self.dashboard != "teacher":
+            raise ValueError("Solo la dashboard docente supporta uno scope globale.")
         if self.all_classes and self.class_ids:
             raise ValueError("Uno scope globale non elenca classi parziali.")
         if self.student_user_id is not None:

--- a/scripts/thebitlab_dashboard_auth_ports.py
+++ b/scripts/thebitlab_dashboard_auth_ports.py
@@ -20,7 +20,12 @@ def dashboard_identifier(value: str, field_name: str) -> str:
     if (
         not normalized
         or len(normalized) > _MAX_IDENTIFIER_CHARS
-        or any(ord(character) < 32 or ord(character) == 127 for character in normalized)
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in normalized
+        )
     ):
         raise ValueError(f"{field_name} non valido.")
     return normalized

--- a/scripts/thebitlab_identity_sqlite.py
+++ b/scripts/thebitlab_identity_sqlite.py
@@ -16,6 +16,7 @@ from scripts.thebitlab_identity import (
     UserAccount,
     UserSession,
 )
+from scripts.thebitlab_dashboard_auth_ports import DashboardAuthorizationSnapshot
 from scripts.thebitlab_identity_ports import (
     IdentityStorageConflictError,
     IdentityStorageCorruptionError,
@@ -1101,6 +1102,96 @@ class SqliteIdentityStorage:
         where = " WHERE active = 1" if active_only else ""
         rows = self._query_all(f"SELECT * FROM classes{where} ORDER BY class_id")
         return [self._class_group(row) for row in rows]
+
+    def read_dashboard_authorization_snapshot(
+        self,
+        actor_user_id: str,
+        *,
+        expected_actor_updated_at: datetime,
+        target_user_id: str | None = None,
+    ) -> DashboardAuthorizationSnapshot | None:
+        expected_revision = _encode_datetime(
+            expected_actor_updated_at, "expected_actor_updated_at"
+        )
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN")
+            actor = connection.execute(
+                """
+                SELECT user_id, role, updated_at FROM users
+                WHERE user_id = ? AND active = 1 AND updated_at = ?
+                """,
+                (actor_user_id, expected_revision),
+            ).fetchone()
+            if actor is None:
+                connection.commit()
+                return None
+            actor_classes = tuple(
+                row["class_id"]
+                for row in connection.execute(
+                    """
+                    SELECT memberships.class_id
+                    FROM class_memberships AS memberships
+                    JOIN classes ON classes.class_id = memberships.class_id
+                    WHERE memberships.user_id = ? AND memberships.role = ?
+                        AND classes.active = 1
+                    ORDER BY memberships.class_id
+                    """,
+                    (actor["user_id"], actor["role"]),
+                )
+            )
+            target = None
+            target_classes: tuple[str, ...] = ()
+            if target_user_id is not None:
+                target = connection.execute(
+                    """
+                    SELECT user_id, role FROM users
+                    WHERE user_id = ? AND active = 1
+                    """,
+                    (target_user_id,),
+                ).fetchone()
+                if target is not None:
+                    target_classes = tuple(
+                        row["class_id"]
+                        for row in connection.execute(
+                            """
+                            SELECT memberships.class_id
+                            FROM class_memberships AS memberships
+                            JOIN classes ON classes.class_id = memberships.class_id
+                            WHERE memberships.user_id = ?
+                                AND memberships.role = 'student'
+                                AND classes.active = 1
+                            ORDER BY memberships.class_id
+                            """,
+                            (target["user_id"],),
+                        )
+                    )
+            snapshot = DashboardAuthorizationSnapshot(
+                actor_user_id=actor["user_id"],
+                actor_role=actor["role"],
+                actor_updated_at=_decode_datetime(actor["updated_at"]),
+                actor_class_ids=actor_classes,
+                target_user_id=None if target is None else target["user_id"],
+                target_role=None if target is None else target["role"],
+                target_class_ids=target_classes,
+            )
+            connection.commit()
+            return snapshot
+        except (ValueError, TypeError) as error:
+            connection.rollback()
+            raise IdentityStorageCorruptionError(
+                "Snapshot autorizzazione dashboard persistito non valido."
+            ) from error
+        except sqlite3.DatabaseError as error:
+            connection.rollback()
+            raise IdentityStorageError(
+                "Errore SQLite durante autorizzazione dashboard."
+            ) from error
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
 
     def save_membership(self, membership: ClassMembership) -> None:
         with self._transaction("save_membership") as connection:

--- a/tests/test_thebitlab_dashboard_auth.py
+++ b/tests/test_thebitlab_dashboard_auth.py
@@ -7,6 +7,7 @@ import pytest
 
 from scripts.thebitlab_auth_services import SessionService
 from scripts.thebitlab_dashboard_auth import (
+    DashboardAccessScope,
     DashboardAuthorizationBoundary,
     DashboardAuthorizationSnapshot,
     DashboardAuthorizationUnavailableError,
@@ -239,6 +240,17 @@ def test_actor_revision_race_after_http_authentication_fails_closed(
         boundary.authorize_teacher_dashboard(request)
 
 
+def test_student_scope_can_never_be_global() -> None:
+    with pytest.raises(ValueError, match="Solo la dashboard docente"):
+        DashboardAccessScope(
+            "student",
+            "admin-01",
+            (),
+            student_user_id="student-01",
+            all_classes=True,
+        )
+
+
 def test_storage_failure_and_malformed_snapshot_are_sanitized(setup, monkeypatch) -> None:
     storage, boundary, http = setup
     request = established_request(http, "teacher-01")
@@ -261,6 +273,20 @@ def test_storage_failure_and_malformed_snapshot_are_sanitized(setup, monkeypatch
     )
     with pytest.raises(DashboardAuthorizationUnavailableError):
         boundary.authorize_teacher_dashboard(request)
+
+    malformed = DashboardAuthorizationSnapshot(
+        "teacher-01", "teacher", NOW, ("class-a",)
+    )
+    object.__setattr__(malformed, "actor_class_ids", ["class-a"])
+    monkeypatch.setattr(
+        storage,
+        "read_dashboard_authorization_snapshot",
+        lambda *_args, **_kwargs: malformed,
+    )
+    with pytest.raises(DashboardAuthorizationUnavailableError) as invalid_contract:
+        boundary.authorize_teacher_dashboard(request)
+    assert invalid_contract.value.__cause__ is None
+    assert invalid_contract.value.__context__ is None
 
 
 def test_snapshot_must_match_fresh_http_principal(setup, monkeypatch) -> None:

--- a/tests/test_thebitlab_dashboard_auth.py
+++ b/tests/test_thebitlab_dashboard_auth.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.thebitlab_auth_services import SessionService
+from scripts.thebitlab_dashboard_auth import (
+    DashboardAuthorizationBoundary,
+    DashboardAuthorizationSnapshot,
+    DashboardAuthorizationUnavailableError,
+)
+from scripts.thebitlab_http_auth import (
+    HttpAuthRequest,
+    HttpAuthenticationRequiredError,
+    HttpAuthorizationDeniedError,
+    HttpCsrfRejectedError,
+    HttpSessionAuthBoundary,
+    SessionCookiePolicy,
+)
+from scripts.thebitlab_identity import ClassGroup, ClassMembership, UserAccount
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+
+
+class SequenceFactory:
+    def __init__(self, *values):
+        self.values = iter(values)
+
+    def __call__(self):
+        return next(self.values)
+
+
+def user(user_id: str, role: str, *, active: bool = True) -> UserAccount:
+    return UserAccount(user_id, user_id, role, active, NOW, NOW)
+
+
+def class_group(class_id: str, *, active: bool = True) -> ClassGroup:
+    return ClassGroup(class_id, class_id, "2026/2027", active, NOW, NOW)
+
+
+def membership(user_id: str, class_id: str, role: str) -> ClassMembership:
+    return ClassMembership(user_id, class_id, role, NOW)
+
+
+@pytest.fixture
+def setup(tmp_path):
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3", clock=lambda: NOW)
+    for account in (
+        user("admin-01", "admin"),
+        user("teacher-01", "teacher"),
+        user("teacher-02", "teacher"),
+        user("student-01", "student"),
+        user("student-02", "student"),
+        user("pending-01", "pending"),
+    ):
+        storage.create_user(account)
+    for group in (
+        class_group("class-a"),
+        class_group("class-b"),
+        class_group("class-off", active=False),
+    ):
+        storage.create_class(group)
+    for item in (
+        membership("teacher-01", "class-a", "teacher"),
+        membership("teacher-01", "class-b", "student"),
+        membership("teacher-01", "class-off", "teacher"),
+        membership("teacher-02", "class-b", "teacher"),
+        membership("student-01", "class-a", "student"),
+        membership("student-01", "class-off", "student"),
+        membership("student-02", "class-b", "student"),
+    ):
+        storage.save_membership(item)
+    token_factory = SequenceFactory(*(character * 40 for character in "ABCDEFGH"))
+    session_id_factory = SequenceFactory(*(f"session-{index}" for index in range(8)))
+    sessions = SessionService(
+        storage,
+        clock=lambda: NOW,
+        token_factory=token_factory,
+        session_id_factory=session_id_factory,
+    )
+    http = HttpSessionAuthBoundary(
+        sessions,
+        csrf_secret=b"d" * 32,
+        cookie_policy=SessionCookiePolicy.loopback_development(),
+        clock=lambda: NOW,
+    )
+    return storage, DashboardAuthorizationBoundary(http, storage), http
+
+
+def established_request(http, user_id: str, method: str = "GET", *, csrf=False):
+    established = http.establish_session(user_id)
+    return HttpAuthRequest(
+        method,
+        established.set_cookie.split(";", 1)[0],
+        established.context.csrf_token if csrf else None,
+    )
+
+
+def test_teacher_scope_contains_only_active_teacher_memberships(setup) -> None:
+    _storage, boundary, http = setup
+
+    scope = boundary.authorize_teacher_dashboard(
+        established_request(http, "teacher-01")
+    )
+
+    assert scope.dashboard == "teacher"
+    assert scope.actor_user_id == "teacher-01"
+    assert scope.class_ids == ("class-a",)
+    assert scope.all_classes is False
+    assert scope.student_user_id is None
+
+
+def test_admin_teacher_scope_is_explicitly_global(setup) -> None:
+    _storage, boundary, http = setup
+
+    scope = boundary.authorize_teacher_dashboard(established_request(http, "admin-01"))
+
+    assert scope.all_classes is True
+    assert scope.class_ids == ()
+
+
+def test_pending_student_and_role_mismatch_are_denied(setup) -> None:
+    _storage, boundary, http = setup
+
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_teacher_dashboard(established_request(http, "student-01"))
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_student_dashboard(
+            established_request(http, "pending-01"),
+            requested_student_user_id="pending-01",
+        )
+
+
+def test_student_scope_is_bound_to_internal_owner_and_active_classes(setup) -> None:
+    _storage, boundary, http = setup
+
+    scope = boundary.authorize_student_dashboard(
+        established_request(http, "student-01"),
+        requested_student_user_id="student-01",
+    )
+
+    assert scope.student_user_id == "student-01"
+    assert scope.class_ids == ("class-a",)
+    assert scope.all_classes is False
+
+
+def test_student_cannot_select_another_or_malformed_identifier(setup) -> None:
+    _storage, boundary, http = setup
+
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_student_dashboard(
+            established_request(http, "student-01"),
+            requested_student_user_id="student-02",
+        )
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_student_dashboard(
+            established_request(http, "student-01"),
+            requested_student_user_id="\n",
+        )
+
+
+def test_teacher_student_detail_requires_active_shared_class(setup) -> None:
+    storage, boundary, http = setup
+    storage.save_membership(membership("student-01", "class-b", "student"))
+
+    allowed = boundary.authorize_student_dashboard(
+        established_request(http, "teacher-01"),
+        requested_student_user_id="student-01",
+    )
+    assert allowed.class_ids == ("class-a",)
+
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_student_dashboard(
+            established_request(http, "teacher-01"),
+            requested_student_user_id="student-02",
+        )
+
+
+def test_admin_student_detail_still_requires_active_student_membership(setup) -> None:
+    storage, boundary, http = setup
+
+    scope = boundary.authorize_student_dashboard(
+        established_request(http, "admin-01"),
+        requested_student_user_id="student-02",
+    )
+    assert scope.class_ids == ("class-b",)
+
+    target = storage.read_user("student-02")
+    storage.save_user(
+        replace(target, active=False, updated_at=NOW + timedelta(seconds=1)),
+        expected_updated_at=target.updated_at,
+    )
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_student_dashboard(
+            established_request(http, "admin-01"),
+            requested_student_user_id="student-02",
+        )
+
+
+def test_membership_removal_and_class_deactivation_are_observed(setup) -> None:
+    storage, boundary, http = setup
+    teacher_request = established_request(http, "teacher-01")
+    storage.delete_membership("teacher-01", "class-a", "teacher")
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_teacher_dashboard(teacher_request)
+
+    student_request = established_request(http, "student-01")
+    current = storage.read_class("class-a")
+    storage.save_class(
+        replace(current, active=False, updated_at=NOW + timedelta(seconds=1)),
+        expected_updated_at=current.updated_at,
+    )
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_student_dashboard(
+            student_request, requested_student_user_id="student-01"
+        )
+
+
+def test_actor_revision_race_after_http_authentication_fails_closed(
+    setup, monkeypatch
+) -> None:
+    storage, boundary, http = setup
+    request = established_request(http, "teacher-01")
+    original = storage.read_dashboard_authorization_snapshot
+
+    def mutate_then_read(*args, **kwargs):
+        actor = storage.read_user("teacher-01")
+        storage.save_user(
+            replace(actor, role="student", updated_at=NOW + timedelta(seconds=1)),
+            expected_updated_at=actor.updated_at,
+        )
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(storage, "read_dashboard_authorization_snapshot", mutate_then_read)
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_teacher_dashboard(request)
+
+
+def test_storage_failure_and_malformed_snapshot_are_sanitized(setup, monkeypatch) -> None:
+    storage, boundary, http = setup
+    request = established_request(http, "teacher-01")
+
+    def broken(*_args, **_kwargs):
+        raise RuntimeError("raw sqlite path and statement")
+
+    monkeypatch.setattr(storage, "read_dashboard_authorization_snapshot", broken)
+    with pytest.raises(DashboardAuthorizationUnavailableError) as unavailable:
+        boundary.authorize_teacher_dashboard(request)
+    assert unavailable.value.status_code == 503
+    assert "sqlite" not in str(unavailable.value).lower()
+    assert unavailable.value.__cause__ is None
+    assert unavailable.value.__context__ is None
+
+    monkeypatch.setattr(
+        storage,
+        "read_dashboard_authorization_snapshot",
+        lambda *_args, **_kwargs: object(),
+    )
+    with pytest.raises(DashboardAuthorizationUnavailableError):
+        boundary.authorize_teacher_dashboard(request)
+
+
+def test_snapshot_must_match_fresh_http_principal(setup, monkeypatch) -> None:
+    storage, boundary, http = setup
+    request = established_request(http, "teacher-01")
+    mismatch = DashboardAuthorizationSnapshot(
+        "teacher-02", "teacher", NOW, ("class-b",)
+    )
+    monkeypatch.setattr(
+        storage,
+        "read_dashboard_authorization_snapshot",
+        lambda *_args, **_kwargs: mismatch,
+    )
+    with pytest.raises(DashboardAuthorizationUnavailableError):
+        boundary.authorize_teacher_dashboard(request)
+
+
+def test_unsafe_dashboard_authorization_requires_session_csrf(setup) -> None:
+    _storage, boundary, http = setup
+
+    with pytest.raises(HttpCsrfRejectedError):
+        boundary.authorize_teacher_dashboard(
+            established_request(http, "teacher-01", method="POST")
+        )
+    scope = boundary.authorize_teacher_dashboard(
+        established_request(http, "teacher-01", method="POST", csrf=True)
+    )
+    assert scope.class_ids == ("class-a",)
+
+
+def test_missing_or_invalid_session_never_reaches_dashboard_storage(setup) -> None:
+    storage, boundary, _http = setup
+    calls = []
+    original = storage.read_dashboard_authorization_snapshot
+
+    def observed(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    storage.read_dashboard_authorization_snapshot = observed
+    with pytest.raises(HttpAuthenticationRequiredError):
+        boundary.authorize_teacher_dashboard(HttpAuthRequest("GET", None))
+    with pytest.raises(HttpAuthenticationRequiredError):
+        boundary.authorize_student_dashboard(
+            HttpAuthRequest("GET", None), requested_student_user_id="\n"
+        )
+    assert calls == []

--- a/tests/test_thebitlab_dashboard_auth.py
+++ b/tests/test_thebitlab_dashboard_auth.py
@@ -240,15 +240,25 @@ def test_actor_revision_race_after_http_authentication_fails_closed(
         boundary.authorize_teacher_dashboard(request)
 
 
-def test_student_scope_can_never_be_global() -> None:
-    with pytest.raises(ValueError, match="Solo la dashboard docente"):
+def test_scope_global_capability_is_admin_only_and_structurally_immutable() -> None:
+    with pytest.raises(ValueError, match="non supporta scope globale"):
         DashboardAccessScope(
             "student",
             "admin-01",
-            (),
+            "admin",
+            ("class-a",),
             student_user_id="student-01",
             all_classes=True,
         )
+    with pytest.raises(ValueError, match="classi teacher limitate"):
+        DashboardAccessScope(
+            "teacher", "teacher-01", "teacher", (), all_classes=True
+        )
+    global_scope = DashboardAccessScope(
+        "teacher", "admin-01", "admin", (), all_classes=True
+    )
+    with pytest.raises(AttributeError):
+        object.__setattr__(global_scope, "dashboard", "student")
 
 
 def test_storage_failure_and_malformed_snapshot_are_sanitized(setup, monkeypatch) -> None:

--- a/tests/test_thebitlab_dashboard_auth.py
+++ b/tests/test_thebitlab_dashboard_auth.py
@@ -161,6 +161,11 @@ def test_student_cannot_select_another_or_malformed_identifier(setup) -> None:
             established_request(http, "student-01"),
             requested_student_user_id="\n",
         )
+    with pytest.raises(HttpAuthorizationDeniedError):
+        boundary.authorize_student_dashboard(
+            established_request(http, "student-01"),
+            requested_student_user_id="\ud800",
+        )
 
 
 def test_teacher_student_detail_requires_active_shared_class(setup) -> None:
@@ -297,6 +302,29 @@ def test_storage_failure_and_malformed_snapshot_are_sanitized(setup, monkeypatch
         boundary.authorize_teacher_dashboard(request)
     assert invalid_contract.value.__cause__ is None
     assert invalid_contract.value.__context__ is None
+
+
+def test_storage_target_mismatch_is_adapter_failure(setup, monkeypatch) -> None:
+    storage, boundary, http = setup
+    request = established_request(http, "teacher-01")
+    mismatch = DashboardAuthorizationSnapshot(
+        "teacher-01",
+        "teacher",
+        NOW,
+        ("class-a",),
+        target_user_id="student-02",
+        target_role="student",
+        target_class_ids=("class-a",),
+    )
+    monkeypatch.setattr(
+        storage,
+        "read_dashboard_authorization_snapshot",
+        lambda *_args, **_kwargs: mismatch,
+    )
+    with pytest.raises(DashboardAuthorizationUnavailableError):
+        boundary.authorize_student_dashboard(
+            request, requested_student_user_id="student-01"
+        )
 
 
 def test_snapshot_must_match_fresh_http_principal(setup, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Implements #564 under #535.

- combines live HTTP session/CSRF authorization with current role and class policy;
- binds student dashboards to internal user IDs and active student memberships;
- limits teachers to active `teacher` memberships and shared active student classes;
- gives admins an explicit role-bound global teacher capability while requiring active class membership for student targets;
- returns structurally immutable, role-bound minimal data scopes;
- reads actor, target, memberships, and class state in one SQLite snapshot with actor revision CAS;
- rejects malformed identifiers, including non-encodable Unicode, before storage;
- reconstructs and validates storage snapshots and fails closed on stale state, impossible target mismatches, malformed adapters, and storage errors;
- documents the contract for the subsequent Course Board route/data adapter.

## Validation

- targeted dashboard/HTTP/identity/auth suite: 144 passed;
- full required CI green on minimum Python, Linux/Windows Python 3.11–3.13, Windows filesystem, and Docker;
- independent isolated reviews rounds 5 and 6: `Nessun finding` at `211bf29`.

## Out of scope

Concrete Course Board OAuth/session routes and legacy-file filtering, replacement of local demo Basic/HMAC credentials, TLS/rate limiting, browser E2E, and TUI pairing remain follow-ups.

Closes #564
