### PR TITLE
Add one-click Windows environment lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,8 +461,10 @@ adulto e vieta esplicitamente di modificare Secure Boot, TPM o altre opzioni.
 
 #### Aggiornare su Windows
 
-Lo stesso bootstrap può essere rilanciato in sicurezza. È disponibile anche il
-comando esplicito:
+Apri **Ambiente 2cornot2c** dal desktop o dal menu Start e scegli
+**Aggiorna l'ambiente**. Non occorre aprire PowerShell. Lo stesso bootstrap può
+comunque essere rilanciato in sicurezza; il comando esplicito resta disponibile
+per il supporto tecnico:
 
 ```powershell
 irm https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/update-classroom-windows.ps1 | iex
@@ -473,6 +475,12 @@ digest. Le modifiche locali non vengono sovrascritte: un `git pull` non sicuro
 interrompe la procedura.
 
 #### Disinstallare da Windows
+
+Apri **Ambiente 2cornot2c** dal desktop o dal menu Start e scegli
+**Disinstalla l'ambiente**. La TUI mostra il piano, chiede conferma e apre la
+procedura protetta in una finestra separata.
+
+Il comando seguente resta disponibile per il supporto tecnico:
 
 ```powershell
 irm https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/uninstall-classroom-windows.ps1 | iex
@@ -555,8 +563,10 @@ predefinita al massimo 512 MB di RAM e una CPU.
 
 Il bootstrap monocomando descritto in `installer/README.md` misura la RAM e,
 quando il computer ha al massimo 8 GiB, propone per primo **Docker leggero**.
-Installa Docker Desktop, richiede di avviarlo una volta e scarica l'immagine
-pubblica adatta al processore.
+Installa e avvia Docker Desktop, attende automaticamente che sia pronto e
+scarica l'immagine pubblica adatta al processore. Al primo utilizzo resta
+necessario confermare soltanto le eventuali finestre di sicurezza, licenza o
+riavvio mostrate direttamente da Windows.
 
 Dopo la preparazione, dalla cartella del progetto esegui:
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -58,10 +58,18 @@ diagnostica e installa poi l'ambiente selezionato:
 - VMware Fusion o VirtualBox per una VM grafica completa;
 - Docker Desktop e l'immagine pubblica `student-dev` per il percorso da 512 MB.
 
-Docker Desktop richiede un primo avvio manuale per autorizzazioni, condizioni
-d'uso ed eventuale configurazione WSL 2. La procedura si ferma senza saltare il
-passaggio; dopo aver completato Docker Desktop basta rilanciare lo stesso
-bootstrap, che riprende dal primo componente mancante.
+Il bootstrap crea il collegamento **Ambiente 2cornot2c** sul desktop e nel
+menu Start. Da quel momento non servono altri comandi: lo stesso menu permette
+di completare o riparare l'installazione, aggiornarla e disinstallarla. Il
+launcher è conservato separatamente dal repository, quindi può riprendere anche
+una preparazione interrotta.
+
+La procedura avvia automaticamente Docker Desktop e attende che sia pronto
+prima di scaricare l'ambiente. Soltanto al primo utilizzo Windows può mostrare
+una finestra che richiede di accettare le condizioni, autorizzare WSL 2 o
+riavviare il computer. In quel caso basta seguire l'unica richiesta mostrata e,
+dopo un eventuale riavvio, rilanciare lo stesso comando: la procedura riprende
+dal primo componente mancante senza reinstallare ciò che è già presente.
 
 ## Diagnosi
 
@@ -121,6 +129,10 @@ cd "$HOME\2cornot2c"
 ```
 
 ## Aggiornamento e disinstallazione Windows
+
+Il percorso raccomandato è aprire **Ambiente 2cornot2c** dal desktop o dal menu
+Start e scegliere l'operazione desiderata. I comandi seguenti restano
+disponibili per il supporto tecnico.
 
 Aggiornamento idempotente:
 

--- a/installer/lifecycle.py
+++ b/installer/lifecycle.py
@@ -1,0 +1,56 @@
+"""Avvio sicuro delle operazioni Windows che devono sopravvivere alla TUI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import subprocess
+
+
+WINDOWS_ACTION_SCRIPTS = {
+    "update": "update-classroom-windows.ps1",
+    "uninstall": "uninstall-classroom-windows.ps1",
+}
+
+
+def launcher_directory() -> Path:
+    """Restituisce la cartella persistente preparata dal bootstrap Windows."""
+
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if not local_app_data:
+        raise RuntimeError("LOCALAPPDATA non è disponibile")
+    return Path(local_app_data) / "2cornot2c"
+
+
+def powershell_action_command(action: str) -> tuple[str, ...]:
+    """Costruisce il comando senza shell per uno script verificato."""
+
+    try:
+        script_name = WINDOWS_ACTION_SCRIPTS[action]
+    except KeyError as error:
+        raise ValueError(f"Operazione non supportata: {action}") from error
+    script = launcher_directory() / script_name
+    if not script.is_file():
+        raise RuntimeError(f"Script di gestione non trovato: {script}")
+    command = (
+        "powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(script),
+    )
+    if action == "uninstall":
+        command += ("-ConfirmedFromTui",)
+    return command
+
+
+def launch_windows_action(action: str) -> None:
+    """Apre una nuova console, lasciando che la TUI possa terminare."""
+
+    creation_flags = getattr(subprocess, "CREATE_NEW_CONSOLE", 0)
+    subprocess.Popen(  # noqa: S603 - comando costruito da valori interni
+        powershell_action_command(action),
+        creationflags=creation_flags,
+        close_fds=True,
+    )

--- a/installer/plans.py
+++ b/installer/plans.py
@@ -238,15 +238,53 @@ def _docker_plan(host: Host) -> InstallPlan:
             ),
             Step(
                 "docker-engine",
-                "Avvia Docker Desktop",
-                None,
-                manual=True,
-                detail=(
-                    "Avvia Docker Desktop, completa la configurazione WSL 2 e "
-                    "riavvia Windows se richiesto; poi rilancia l'installer."
+                "Avvia e prepara Docker Desktop",
+                (
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    (
+                        "$app = Join-Path $env:ProgramFiles "
+                        "'Docker\\Docker\\Docker Desktop.exe'; "
+                        "$cli = Join-Path $env:ProgramFiles "
+                        "'Docker\\Docker\\resources\\bin\\docker.exe'; "
+                        "if (-not (Test-Path $app)) { "
+                        "Write-Error 'Docker Desktop non trovato'; exit 17 }; "
+                        "Start-Process -FilePath $app; "
+                        "Write-Output "
+                        "'Docker Desktop avviato: attendo che sia pronto...'; "
+                        "for ($i = 0; $i -lt 120; $i++) { "
+                        "& $cli info *> $null; "
+                        "if ($LASTEXITCODE -eq 0) { "
+                        "Write-Output 'Docker Desktop è pronto'; exit 0 }; "
+                        "Start-Sleep -Seconds 5 }; "
+                        "Write-Error "
+                        "'Docker Desktop non è diventato pronto in 10 minuti'; "
+                        "exit 19"
+                    ),
                 ),
-                deferred=True,
+                detail=(
+                    "Docker Desktop viene aperto automaticamente e il setup "
+                    "attende che sia pronto."
+                ),
             ),
-            Step("student-image", "Scarica student-dev", ("docker", "pull", image)),
+            Step(
+                "student-image",
+                "Scarica student-dev",
+                (
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    (
+                        "$cli = Join-Path $env:ProgramFiles "
+                        "'Docker\\Docker\\resources\\bin\\docker.exe'; "
+                        f"& $cli pull '{image}'; exit $LASTEXITCODE"
+                    ),
+                ),
+            ),
         ),
     )

--- a/installer/student_errors.py
+++ b/installer/student_errors.py
@@ -89,12 +89,16 @@ ERRORS = {
     ),
     "docker-engine": StudentError(
         "E19",
-        "Docker Desktop è installato ma non è acceso",
-        "Il programma è presente, ma il suo motore non è ancora pronto.",
+        "Docker Desktop non è riuscito a diventare pronto",
         (
-            "Avvia Docker Desktop dal menu Start.",
-            "Completa WSL 2, accetta le condizioni e riavvia se richiesto.",
-            "Attendi che Docker sia pronto e rilancia l'installer.",
+            "Il setup lo ha già avviato e ha atteso automaticamente. "
+            "Windows sta chiedendo un intervento che non può essere confermato "
+            "al posto tuo."
+        ),
+        (
+            "Guarda la finestra di Docker Desktop e premi Accetta o Continua.",
+            "Se Windows chiede di riavviare, fallo.",
+            "Dopo il riavvio rilancia lo stesso comando: riprenderà da solo.",
         ),
     ),
     "student-image": StudentError(

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -29,6 +29,7 @@ from utui import (
 
 from installer.diagnostics import diagnose
 from installer.executor import StepResult, execute_plan
+from installer.lifecycle import launch_windows_action
 from installer.model import Host, Provider
 from installer.platforms import detect_host
 from installer.plans import install_plan, supported_providers
@@ -43,6 +44,8 @@ class State:
     host: Host
     providers: tuple[Provider, ...]
     memory_bytes: int | None = None
+    screen: str = "providers"
+    action_index: int = 0
     active_index: int = 0
     report: tuple[str, ...] = ("Premi Invio per eseguire la diagnosi.",)
     confirmation_pending: bool = False
@@ -59,6 +62,14 @@ class State:
     running: bool = True
 
 
+ACTION_LABELS = (
+    "Installa, completa o ripara",
+    "Aggiorna l'ambiente",
+    "Disinstalla l'ambiente",
+    "Esci",
+)
+
+
 def build_screen(
     state: State,
     *,
@@ -67,48 +78,75 @@ def build_screen(
 ):
     """Costruisce la schermata senza I/O o mutazioni."""
 
-    names = {
+    if state.screen == "home":
+        choices = Panel(
+            ListView(
+                ACTION_LABELS,
+                active_index=state.action_index,
+                focused=True,
+            ),
+            title="Gestisci ambiente 2cornot2c",
+            min_width=38,
+        )
+        visible_report = state.report
+        report_title = "Informazioni"
+        if state.confirmation_pending:
+            command_text = "s: conferma\nn/Esc: annulla"
+        else:
+            command_text = (
+                "Su/Giu oppure k/j: scegli\n"
+                "Invio: apri\n"
+                "q/Esc: esci"
+            )
+    else:
+        names = {
         Provider.VMWARE: "VM completa - VMware Fusion",
         Provider.VIRTUALBOX: "VM completa - VirtualBox",
         Provider.DOCKER: "Docker leggero - 512 MB",
-    }
-    provider_labels = tuple(
-        f"{names[provider]}{' (raccomandato)' if index == 0 else ''}"
-        for index, provider in enumerate(state.providers)
-    )
-    memory_label = (
-        f", RAM {state.memory_bytes / 1024**3:.1f} GiB"
-        if state.memory_bytes is not None
-        else ""
-    )
-    choices = Panel(
-        ListView(provider_labels, active_index=state.active_index, focused=True),
-        title=f"Ambiente 2cornot2c - {state.host.value}{memory_label}",
-        min_width=38,
-    )
-    visible_report = (
-        _installation_report(state) if state.installing else state.report
-    )
+        }
+        provider_labels = tuple(
+            f"{names[provider]}{' (raccomandato)' if index == 0 else ''}"
+            for index, provider in enumerate(state.providers)
+        )
+        memory_label = (
+            f", RAM {state.memory_bytes / 1024**3:.1f} GiB"
+            if state.memory_bytes is not None
+            else ""
+        )
+        choices = Panel(
+            ListView(
+                provider_labels,
+                active_index=state.active_index,
+                focused=True,
+            ),
+            title=f"Ambiente 2cornot2c - {state.host.value}{memory_label}",
+            min_width=38,
+        )
+        visible_report = (
+            _installation_report(state) if state.installing else state.report
+        )
+        report_title = "Diagnosi"
+        if state.installing:
+            command_text = (
+                "Installazione in corso\n"
+                "Attendi il completamento\n"
+                "Non chiudere la finestra"
+            )
+        elif state.confirmation_pending:
+            command_text = "s: conferma installazione\nn/Esc: annulla"
+        else:
+            command_text = (
+                "Su/Giu oppure k/j: scegli\n"
+                "Invio: controlla\n"
+                "a: installa\n"
+                "m: menu principale\n"
+                "q/Esc: esci"
+            )
     report = Panel(
         Label("\n".join(visible_report), wrap=True),
-        title="Diagnosi",
+        title=report_title,
         min_width=50,
     )
-    if state.installing:
-        command_text = (
-            "Installazione in corso\n"
-            "Attendi il completamento\n"
-            "Non chiudere la finestra"
-        )
-    elif state.confirmation_pending:
-        command_text = "s: conferma installazione\nn/Esc: annulla"
-    else:
-        command_text = (
-            "Su/Giu oppure k/j: scegli\n"
-            "Invio: controlla\n"
-            "a: installa\n"
-            "q/Esc: esci"
-        )
     commands = Panel(
         Label(command_text),
         title="Comandi",
@@ -262,6 +300,41 @@ def request_confirmation(state: State) -> None:
         "Saranno installati solo i componenti mancanti.",
         "Premi s per confermare oppure n per annullare.",
     )
+
+
+def open_home_action(state: State) -> None:
+    """Apre la funzione selezionata oppure ne richiede conferma."""
+
+    if state.action_index == 0:
+        state.screen = "providers"
+        state.confirmation_pending = False
+        state.report = ("Premi Invio per eseguire la diagnosi.",)
+    elif state.action_index == 1:
+        state.confirmation_pending = True
+        state.report = (
+            "Aggiornamento dell'ambiente",
+            "Gli esercizi e le impostazioni personali saranno conservati.",
+            "Premi s per continuare oppure n per annullare.",
+        )
+    elif state.action_index == 2:
+        state.confirmation_pending = True
+        state.report = (
+            "Disinstallazione protetta",
+            "Prima della rimozione verrà creato un backup degli esercizi.",
+            "Verranno rimossi solo i componenti installati da 2cornot2c.",
+            "Premi s per continuare oppure n per annullare.",
+        )
+    else:
+        state.running = False
+
+
+def confirm_home_action(state: State) -> None:
+    """Passa l'operazione a una console separata e termina la TUI."""
+
+    action = "update" if state.action_index == 1 else "uninstall"
+    launch_windows_action(action)
+    state.confirmation_pending = False
+    state.running = False
 
 
 def _format_results(
@@ -426,6 +499,15 @@ def main() -> int:
         host,
         order_by_recommendation(supported_providers(host), memory_bytes),
         memory_bytes,
+        screen="home" if host is Host.WINDOWS_AMD64 else "providers",
+        report=(
+            (
+                "Scegli cosa vuoi fare.",
+                "Puoi riprendere in sicurezza anche un'installazione incompleta.",
+            )
+            if host is Host.WINDOWS_AMD64
+            else ("Premi Invio per eseguire la diagnosi.",)
+        ),
     )
     watcher = ResizeWatcher()
     color = supports_color()
@@ -453,6 +535,42 @@ def main() -> int:
                     character = event.character if event.key is Key.CHARACTER else ""
                     if state.installing:
                         changed = True
+                    elif state.screen == "home":
+                        if character == "s" and state.confirmation_pending:
+                            try:
+                                confirm_home_action(state)
+                            except Exception as error:
+                                state.confirmation_pending = False
+                                message = for_check("installer", str(error))
+                                state.report = message.lines(str(error))
+                        elif (
+                            character == "n" or event.key is Key.ESCAPE
+                        ) and state.confirmation_pending:
+                            state.confirmation_pending = False
+                            state.report = ("Operazione annullata senza modifiche.",)
+                        elif state.confirmation_pending:
+                            changed = True
+                        elif event.key is Key.UP or character == "k":
+                            state.action_index = max(0, state.action_index - 1)
+                        elif event.key is Key.DOWN or character == "j":
+                            state.action_index = min(
+                                len(ACTION_LABELS) - 1,
+                                state.action_index + 1,
+                            )
+                        elif event.key is Key.ENTER and not state.confirmation_pending:
+                            open_home_action(state)
+                        elif event.key is Key.ESCAPE or character == "q":
+                            state.running = False
+                    elif character == "s" and state.confirmation_pending:
+                        start_selected(state)
+                        progress_refreshed_at = monotonic()
+                    elif (
+                        character == "n" or event.key is Key.ESCAPE
+                    ) and state.confirmation_pending:
+                        state.confirmation_pending = False
+                        state.report = ("Installazione annullata senza modifiche.",)
+                    elif state.confirmation_pending:
+                        changed = True
                     elif event.key is Key.UP or character == "k":
                         state.active_index = max(0, state.active_index - 1)
                     elif event.key is Key.DOWN or character == "j":
@@ -463,14 +581,10 @@ def main() -> int:
                         refresh_report(state)
                     elif character == "a" and not state.confirmation_pending:
                         request_confirmation(state)
-                    elif character == "s" and state.confirmation_pending:
-                        start_selected(state)
-                        progress_refreshed_at = monotonic()
-                    elif (
-                        character == "n" or event.key is Key.ESCAPE
-                    ) and state.confirmation_pending:
+                    elif character == "m":
+                        state.screen = "home"
                         state.confirmation_pending = False
-                        state.report = ("Installazione annullata senza modifiche.",)
+                        state.report = ("Scegli cosa vuoi fare.",)
                     elif event.key is Key.ESCAPE or character == "q":
                         state.running = False
                     changed = True

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -84,6 +84,38 @@ function Save-BootstrapState {
     Move-Item -Force $TemporaryPath $StatePath
 }
 
+function Install-ClassroomLauncher {
+    $LauncherDir = Join-Path $env:LOCALAPPDATA "2cornot2c"
+    New-Item -ItemType Directory -Force -Path $LauncherDir | Out-Null
+    foreach ($ScriptName in @(
+        "manage-classroom-windows.ps1"
+        "update-classroom-windows.ps1"
+        "uninstall-classroom-windows.ps1"
+    )) {
+        Copy-Item -Force `
+            (Join-Path $InstallDir "scripts\$ScriptName") `
+            (Join-Path $LauncherDir $ScriptName)
+    }
+
+    $PowerShell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+    $Manager = Join-Path $LauncherDir "manage-classroom-windows.ps1"
+    $ShortcutTargets = @(
+        (Join-Path ([Environment]::GetFolderPath("Desktop")) "Ambiente 2cornot2c.lnk")
+        (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Ambiente 2cornot2c.lnk")
+    )
+    $Shell = New-Object -ComObject WScript.Shell
+    foreach ($ShortcutPath in $ShortcutTargets) {
+        $Shortcut = $Shell.CreateShortcut($ShortcutPath)
+        $Shortcut.TargetPath = $PowerShell
+        $Shortcut.Arguments = (
+            "-NoProfile -ExecutionPolicy Bypass -File `"$Manager`""
+        )
+        $Shortcut.WorkingDirectory = $LauncherDir
+        $Shortcut.Description = "Installa e gestisci l'ambiente 2cornot2c"
+        $Shortcut.Save()
+    }
+}
+
 function Test-HostResources {
     try {
         $Computer = Get-CimInstance Win32_ComputerSystem
@@ -262,6 +294,8 @@ if (Test-Path (Join-Path $InstallDir ".git")) {
             ) "git clone exit code $LASTEXITCODE"
     }
 }
+
+Install-ClassroomLauncher
 
 Write-Host "[3/4] Preparazione interfaccia guidata..."
 $VenvDir = Join-Path $InstallDir ".installer-venv"

--- a/scripts/manage-classroom-windows.ps1
+++ b/scripts/manage-classroom-windows.ps1
@@ -1,0 +1,56 @@
+$ErrorActionPreference = "Stop"
+
+$StatePath = Join-Path $HOME ".2cornot2c\bootstrap-state.json"
+$DefaultInstallDir = Join-Path $HOME "2cornot2c"
+$BootstrapUrl = if ($env:CLASSROOM_BOOTSTRAP_URL) {
+    $env:CLASSROOM_BOOTSTRAP_URL
+} else {
+    "https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/bootstrap-classroom-windows.ps1"
+}
+
+$InstallDir = $DefaultInstallDir
+if (Test-Path $StatePath) {
+    try {
+        $SavedInstallDir = [string](
+            Get-Content $StatePath -Raw | ConvertFrom-Json
+        ).install_dir
+        if ($SavedInstallDir) {
+            $InstallDir = $SavedInstallDir
+        }
+    } catch {
+        Write-Warning "Configurazione precedente non leggibile."
+    }
+}
+
+$VenvPython = Join-Path $InstallDir ".installer-venv\Scripts\python.exe"
+if ((Test-Path (Join-Path $InstallDir ".git")) -and
+    (Test-Path $VenvPython)) {
+    Push-Location $InstallDir
+    try {
+        & $VenvPython -m installer.tui
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+}
+
+Write-Host "L'ambiente non è ancora completo."
+Write-Host "Avvio automaticamente la preparazione guidata..."
+try {
+    $Bootstrap = Invoke-RestMethod -TimeoutSec 30 $BootstrapUrl
+} catch {
+    Write-Host "ERRORE E25 - Non riesco a scaricare la preparazione" `
+        -ForegroundColor Red
+    Write-Host "COSA SIGNIFICA" -ForegroundColor Yellow
+    Write-Host "Internet non è disponibile oppure GitHub non risponde." `
+        -ForegroundColor Yellow
+    Write-Host "COSA DEVI FARE" -ForegroundColor Yellow
+    Write-Host "1. Controlla Internet e fai doppio clic di nuovo sul collegamento." `
+        -ForegroundColor Yellow
+    Write-Host "2. Se ricompare, comunica E25 al docente." `
+        -ForegroundColor Yellow
+    Read-Host "Premi Invio per chiudere"
+    exit 1
+}
+
+& ([ScriptBlock]::Create([string]$Bootstrap))

--- a/scripts/uninstall-classroom-windows.ps1
+++ b/scripts/uninstall-classroom-windows.ps1
@@ -1,9 +1,14 @@
+param(
+    [switch]$ConfirmedFromTui
+)
+
 $ErrorActionPreference = "Stop"
 
 $StateDir = Join-Path $HOME ".2cornot2c"
 $StatePath = Join-Path $StateDir "bootstrap-state.json"
 $LogPath = Join-Path $StateDir "installer.jsonl"
 $DefaultInstallDir = Join-Path $HOME "2cornot2c"
+$LauncherDir = Join-Path $env:LOCALAPPDATA "2cornot2c"
 $InstallDir = if ($env:CLASSROOM_INSTALL_DIR) {
     $env:CLASSROOM_INSTALL_DIR
 } elseif (Test-Path $StatePath) {
@@ -197,12 +202,17 @@ if ($OwnedPackages.Count -gt 0) {
 } else {
     Write-Host "Nessun programma esterno attribuito a 2cornot2c."
 }
-Write-Host ""
-Write-Host "lab, lab2 e modifiche locali verranno salvati prima della rimozione."
-$Confirmation = Read-Host "Digita esattamente DISINSTALLA"
-if ($Confirmation -ne "DISINSTALLA") {
-    Write-Host "Disinstallazione annullata senza modifiche."
-    exit 2
+if (-not $ConfirmedFromTui) {
+    Write-Host ""
+    Write-Host "lab, lab2 e modifiche locali verranno salvati prima della rimozione."
+    $Confirmation = Read-Host "Digita esattamente DISINSTALLA"
+    if ($Confirmation -ne "DISINSTALLA") {
+        Write-Host "Disinstallazione annullata senza modifiche."
+        exit 2
+    }
+} else {
+    Write-Host ""
+    Write-Host "Conferma ricevuta dal menu guidato."
 }
 
 try {
@@ -246,6 +256,18 @@ elseif ($OwnedPackages.Count -gt 0) {
 
 if (Test-Path $StateDir) {
     Remove-Item -LiteralPath $StateDir -Recurse -Force
+}
+
+foreach ($ShortcutPath in @(
+    (Join-Path ([Environment]::GetFolderPath("Desktop")) "Ambiente 2cornot2c.lnk")
+    (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Ambiente 2cornot2c.lnk")
+)) {
+    if (Test-Path $ShortcutPath) {
+        Remove-Item -LiteralPath $ShortcutPath -Force
+    }
+}
+if (Test-Path $LauncherDir) {
+    Remove-Item -LiteralPath $LauncherDir -Recurse -Force
 }
 
 Write-Host "Disinstallazione completata."

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -73,7 +73,12 @@ def test_docker_plans_install_desktop_and_pull_immutable_image() -> None:
         for step in windows.steps
     )
     assert ("docker", "pull", image) in {step.command for step in mac.steps}
-    assert ("docker", "pull", image) in {step.command for step in windows.steps}
+    windows_image_step = next(
+        step for step in windows.steps if step.key == "student-image"
+    )
+    assert windows_image_step.command is not None
+    assert " pull " in windows_image_step.command[-1]
+    assert image in windows_image_step.command[-1]
     assert "@sha256:" in image
     assert load_lock()["platforms"] == ["linux/amd64", "linux/arm64"]
 
@@ -106,6 +111,80 @@ def test_tui_frame_lists_supported_provider() -> None:
     rendered = "\n".join(rows)
     assert "VirtualBox" in rendered
     assert "VMware Fusion" not in rendered
+
+
+def test_tui_home_exposes_the_complete_lifecycle() -> None:
+    pytest.importorskip("utui")
+    from installer.tui import State, frame
+
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER, Provider.VIRTUALBOX),
+        screen="home",
+    )
+    rendered = "\n".join(frame(state, 150, 14, color=False))
+
+    assert "Gestisci ambiente 2cornot2c" in rendered
+    assert "Installa, completa o ripara" in rendered
+    assert "Aggiorna l'ambiente" in rendered
+    assert "Disinstalla l'ambiente" in rendered
+
+
+def test_tui_uninstall_requires_confirmation_and_launches_separately(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("utui")
+    from installer.tui import (
+        State,
+        confirm_home_action,
+        open_home_action,
+    )
+
+    launched = []
+    monkeypatch.setattr(
+        "installer.tui.launch_windows_action",
+        lambda action: launched.append(action),
+    )
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER,),
+        screen="home",
+        action_index=2,
+    )
+
+    open_home_action(state)
+    assert state.confirmation_pending is True
+    assert "backup" in " ".join(state.report)
+
+    confirm_home_action(state)
+    assert launched == ["uninstall"]
+    assert state.running is False
+
+
+def test_windows_lifecycle_uses_only_persistent_known_scripts(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from installer.lifecycle import powershell_action_command
+
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    launcher = tmp_path / "2cornot2c"
+    launcher.mkdir()
+    (launcher / "uninstall-classroom-windows.ps1").touch()
+
+    command = powershell_action_command("uninstall")
+
+    assert command[:6] == (
+        "powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(launcher / "uninstall-classroom-windows.ps1"),
+    )
+    assert command[-1] == "-ConfirmedFromTui"
+    with pytest.raises(ValueError, match="non supportata"):
+        powershell_action_command("qualcosa")
 
 
 def test_tui_marks_first_low_memory_choice_as_recommended() -> None:
@@ -298,7 +377,7 @@ def test_executor_blocks_manual_prerequisite_before_writes() -> None:
     assert calls == []
 
 
-def test_docker_install_runs_before_deferred_first_start() -> None:
+def test_windows_docker_install_starts_desktop_and_continues_automatically() -> None:
     plan = install_plan(Host.WINDOWS_AMD64, Provider.DOCKER)
     calls = []
 
@@ -311,8 +390,16 @@ def test_docker_install_runs_before_deferred_first_start() -> None:
         runner=lambda command: (calls.append(command) or (0, "installato")),
     )
 
-    assert [result.key for result in results] == ["docker", "docker-engine"]
-    assert [result.status for result in results] == ["succeeded", "blocked"]
+    assert [result.key for result in results] == [
+        "docker",
+        "docker-engine",
+        "student-image",
+    ]
+    assert [result.status for result in results] == [
+        "succeeded",
+        "succeeded",
+        "succeeded",
+    ]
     assert calls[0][:5] == (
         "winget",
         "install",
@@ -320,6 +407,21 @@ def test_docker_install_runs_before_deferred_first_start() -> None:
         "Docker.DockerDesktop",
         "--exact",
     )
+    assert calls[1][:4] == (
+        "powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+    )
+    assert "Start-Process" in calls[1][-1]
+    assert "docker.exe" in calls[1][-1]
+    assert calls[2][:4] == (
+        "powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+    )
+    assert " pull " in calls[2][-1]
 
 
 def test_executor_stops_on_first_failed_command() -> None:

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -53,13 +53,21 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     uninstall = (ROOT / "scripts" / "uninstall-classroom-windows.ps1").read_text(
         encoding="utf-8"
     )
+    manager = (ROOT / "scripts" / "manage-classroom-windows.ps1").read_text(
+        encoding="utf-8"
+    )
 
     assert "Test-HostResources" in bootstrap
     assert "installed_by_bootstrap" in bootstrap
+    assert "Install-ClassroomLauncher" in bootstrap
+    assert "Ambiente 2cornot2c.lnk" in bootstrap
     assert "bootstrap-classroom-windows.ps1" in update
+    assert ".installer-venv\\Scripts\\python.exe" in manager
+    assert "bootstrap-classroom-windows.ps1" in manager
     assert 'if ($Confirmation -ne "DISINSTALLA")' in uninstall
     assert "Remove-Item -LiteralPath $SafeInstallDir" in uninstall
     assert "TheBitPoets/2cornot2c" in uninstall
     assert "vagrant destroy" not in uninstall
     assert "docker image rm $ImageReference" in uninstall
     assert "docker image rm --force" not in uninstall
+    assert "Ambiente 2cornot2c.lnk" in uninstall

--- a/tests/test_student_errors.py
+++ b/tests/test_student_errors.py
@@ -107,6 +107,7 @@ def test_windows_scripts_render_error_and_explanation_colors() -> None:
     root = Path(__file__).resolve().parents[1]
     for name in (
         "bootstrap-classroom-windows.ps1",
+        "manage-classroom-windows.ps1",
         "update-classroom-windows.ps1",
         "uninstall-classroom-windows.ps1",
     ):
@@ -131,6 +132,7 @@ def test_student_facing_messages_use_italian_accents() -> None:
     paths = (
         root / "installer" / "student_errors.py",
         root / "scripts" / "bootstrap-classroom-windows.ps1",
+        root / "scripts" / "manage-classroom-windows.ps1",
         root / "scripts" / "update-classroom-windows.ps1",
         root / "scripts" / "uninstall-classroom-windows.ps1",
     )


### PR DESCRIPTION
## Cosa cambia

- aggiunge una schermata TUI unica per installare/riparare, aggiornare e disinstallare l’ambiente Windows;
- crea il collegamento **Ambiente 2cornot2c** sul desktop e nel menu Start;
- mantiene un launcher separato dal repository, capace di riprendere un’installazione incompleta;
- esegue aggiornamento e disinstallazione in una console separata per non cancellare file Python ancora in uso;
- conserva backup e controlli di proprietà della disinstallazione, con una sola conferma dalla TUI;
- avvia Docker Desktop automaticamente, ne attende la disponibilità e usa il percorso assoluto del client appena installato;
- aggiorna documentazione e messaggi E19.

## Perché

Il precedente flusso richiedeva comandi PowerShell diversi e passaggi manuali al primo avvio di Docker. È troppo complesso per studenti di 14 anni e rende difficile riprendere un collaudo interrotto.

## Impatto

Dopo il bootstrap iniziale lo studente gestisce tutto tramite un solo collegamento e una sola interfaccia. I programmi già presenti prima di 2cornot2c non vengono rimossi e gli esercizi vengono salvati prima della disinstallazione.

## Verifiche

- `python -m pytest tests/test_classroom_installer.py tests/test_classroom_preflight.py tests/test_student_errors.py -q` — 36 test superati
- `python -m compileall -q installer`
- `git diff --check`