### PR TITLE
Automate Windows WSL preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,9 +564,11 @@ predefinita al massimo 512 MB di RAM e una CPU.
 Il bootstrap monocomando descritto in `installer/README.md` misura la RAM e,
 quando il computer ha al massimo 8 GiB, propone per primo **Docker leggero**.
 Installa e avvia Docker Desktop, attende automaticamente che sia pronto e
-scarica l'immagine pubblica adatta al processore. Al primo utilizzo resta
-necessario confermare soltanto le eventuali finestre di sicurezza, licenza o
-riavvio mostrate direttamente da Windows.
+scarica l'immagine pubblica adatta al processore. Se WSL 2 non è presente, lo
+prepara automaticamente senza installare una seconda distribuzione Ubuntu,
+richiede un riavvio e riapre il launcher al nuovo accesso. Al primo utilizzo
+resta necessario confermare soltanto le finestre di sicurezza e licenza
+mostrate direttamente da Windows.
 
 Dopo la preparazione, dalla cartella del progetto esegui:
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -65,11 +65,14 @@ launcher è conservato separatamente dal repository, quindi può riprendere anch
 una preparazione interrotta.
 
 La procedura avvia automaticamente Docker Desktop e attende che sia pronto
-prima di scaricare l'ambiente. Soltanto al primo utilizzo Windows può mostrare
-una finestra che richiede di accettare le condizioni, autorizzare WSL 2 o
-riavviare il computer. In quel caso basta seguire l'unica richiesta mostrata e,
-dopo un eventuale riavvio, rilanciare lo stesso comando: la procedura riprende
-dal primo componente mancante senza reinstallare ciò che è già presente.
+prima di scaricare l'ambiente. Se WSL 2 non è presente, lo installa senza
+aggiungere una distribuzione Linux duplicata: Windows mostra soltanto la
+richiesta di autorizzazione. La TUI chiede poi di riavviare con un messaggio
+giallo, non con un errore. Dopo il riavvio il launcher si riapre
+automaticamente e la procedura riprende dal primo componente mancante.
+
+Soltanto al primo utilizzo Docker Desktop può ancora chiedere di accettare le
+proprie condizioni d'uso.
 
 ## Diagnosi
 

--- a/installer/executor.py
+++ b/installer/executor.py
@@ -121,13 +121,19 @@ def execute_plan(
             result = StepResult(
                 step.key,
                 step.label,
-                "succeeded" if returncode == 0 else "failed",
+                (
+                    "restart_required"
+                    if returncode == 0 and step.restart_after_success
+                    else "succeeded"
+                    if returncode == 0
+                    else "failed"
+                ),
                 detail or f"exit code {returncode}",
             )
         applied.append(result)
         _append_log(log_path, plan, result)
         if progress is not None:
             progress(result.status, index, total, step.label)
-        if result.status in {"failed", "blocked"}:
+        if result.status in {"failed", "blocked", "restart_required"}:
             break
     return tuple(applied)

--- a/installer/main.py
+++ b/installer/main.py
@@ -83,6 +83,9 @@ def main(argv: list[str] | None = None) -> int:
     applied = execute_plan(plan, results, log_path=args.log)
     for result in applied:
         print(f"[{result.status.upper():9}] {result.label}: {result.detail}")
+    if any(result.status == "restart_required" for result in applied):
+        print("\nRiavvia Windows per continuare. L'installer riprenderà automaticamente.")
+        return 3
     if any(result.status in {"failed", "blocked"} for result in applied):
         print(f"\nInstallazione incompleta. Log: {args.log}")
         return 1

--- a/installer/model.py
+++ b/installer/model.py
@@ -44,6 +44,7 @@ class Step:
     manual: bool = False
     detail: str = ""
     deferred: bool = False
+    restart_after_success: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/installer/plans.py
+++ b/installer/plans.py
@@ -220,9 +220,30 @@ def _docker_plan(host: Host) -> InstallPlan:
         Provider.DOCKER,
         (
             Check("winget", "Windows Package Manager", ("winget", "--version")),
+            Check("wsl", "WSL 2", ("wsl.exe", "--status")),
             *common_checks,
         ),
         (
+            Step(
+                "wsl",
+                "Prepara WSL 2",
+                (
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    (
+                        "& (Join-Path $env:LOCALAPPDATA "
+                        "'2cornot2c\\prepare-wsl-windows.ps1')"
+                    ),
+                ),
+                detail=(
+                    "WSL 2 e Virtual Machine Platform vengono installati "
+                    "automaticamente."
+                ),
+                restart_after_success=True,
+            ),
             Step(
                 "docker",
                 "Installa Docker Desktop",

--- a/installer/student_errors.py
+++ b/installer/student_errors.py
@@ -87,6 +87,19 @@ ERRORS = {
         "Docker avvia l'ambiente Linux leggero.",
         ("Conferma l'installazione dal menu.", "Accetta la richiesta di Windows."),
     ),
+    "wsl": StudentError(
+        "E20",
+        "Windows non è riuscito a preparare WSL 2",
+        (
+            "WSL 2 è il componente di Windows che permette a Docker "
+            "di avviare Linux."
+        ),
+        (
+            "Controlla se Windows aspetta una richiesta di autorizzazione.",
+            "Scegli Sì e riprova.",
+            "Se ricompare, comunica E20 al docente.",
+        ),
+    ),
     "docker-engine": StudentError(
         "E19",
         "Docker Desktop non è riuscito a diventare pronto",

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -206,6 +206,7 @@ def _paint_guidance_rows(rows: list[str]) -> list[str]:
 
     markers = (
         ("ERRORE E", "\x1b[31m"),
+        ("AZIONE RICHIESTA", "\x1b[33m"),
         ("COSA SIGNIFICA:", "\x1b[33m"),
         ("COSA DEVI FARE:", "\x1b[33m"),
         ("COSA FARE ", "\x1b[33m"),
@@ -343,7 +344,19 @@ def _format_results(
 ) -> tuple[str, ...]:
     report: list[str] = []
     for result in results:
-        if result.status in {"failed", "blocked"}:
+        if result.status == "restart_required":
+            report.extend(
+                (
+                    "AZIONE RICHIESTA - RIAVVIA WINDOWS",
+                    "WSL 2 è stato preparato correttamente.",
+                    "Salva il tuo lavoro e riavvia il computer.",
+                    (
+                        "Dopo il riavvio Ambiente 2cornot2c si riaprirà "
+                        "e potrai continuare."
+                    ),
+                )
+            )
+        elif result.status in {"failed", "blocked"}:
             error = (
                 for_step(result.key)
                 if result.status == "failed"

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -89,6 +89,7 @@ function Install-ClassroomLauncher {
     New-Item -ItemType Directory -Force -Path $LauncherDir | Out-Null
     foreach ($ScriptName in @(
         "manage-classroom-windows.ps1"
+        "prepare-wsl-windows.ps1"
         "update-classroom-windows.ps1"
         "uninstall-classroom-windows.ps1"
     )) {

--- a/scripts/prepare-wsl-windows.ps1
+++ b/scripts/prepare-wsl-windows.ps1
@@ -1,0 +1,54 @@
+param(
+    [switch]$Elevated
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($Elevated) {
+    Write-Host "Preparazione di WSL 2 e Virtual Machine Platform..."
+    & wsl.exe --install --no-distribution
+    if ($LASTEXITCODE -notin @(0, 3010)) {
+        Write-Error "wsl --install non riuscito: exit code $LASTEXITCODE"
+        exit 1
+    }
+    exit 0
+}
+
+$PowerShell = Join-Path `
+    $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+$Arguments = @(
+    "-NoProfile"
+    "-ExecutionPolicy"
+    "Bypass"
+    "-File"
+    "`"$PSCommandPath`""
+    "-Elevated"
+)
+
+Write-Host "Windows mostrerà una richiesta di autorizzazione."
+$Process = Start-Process `
+    -FilePath $PowerShell `
+    -ArgumentList $Arguments `
+    -Verb RunAs `
+    -Wait `
+    -PassThru
+if ($Process.ExitCode -ne 0) {
+    Write-Error "Preparazione WSL 2 non riuscita o non autorizzata."
+    exit 1
+}
+
+$Manager = Join-Path $env:LOCALAPPDATA `
+    "2cornot2c\manage-classroom-windows.ps1"
+$RunOncePath = "HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce"
+$RunOnceCommand = (
+    "`"$PowerShell`" -NoProfile -ExecutionPolicy Bypass " +
+    "-File `"$Manager`""
+)
+New-ItemProperty `
+    -Path $RunOncePath `
+    -Name "2cornot2c-resume" `
+    -Value $RunOnceCommand `
+    -PropertyType String `
+    -Force | Out-Null
+
+Write-Host "WSL 2 preparato. Riavvia Windows per continuare."

--- a/scripts/uninstall-classroom-windows.ps1
+++ b/scripts/uninstall-classroom-windows.ps1
@@ -258,6 +258,12 @@ if (Test-Path $StateDir) {
     Remove-Item -LiteralPath $StateDir -Recurse -Force
 }
 
+$RunOncePath = "HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce"
+Remove-ItemProperty `
+    -Path $RunOncePath `
+    -Name "2cornot2c-resume" `
+    -ErrorAction SilentlyContinue
+
 foreach ($ShortcutPath in @(
     (Join-Path ([Environment]::GetFolderPath("Desktop")) "Ambiente 2cornot2c.lnk")
     (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Ambiente 2cornot2c.lnk")

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -391,11 +391,13 @@ def test_windows_docker_install_starts_desktop_and_continues_automatically() -> 
     )
 
     assert [result.key for result in results] == [
+        "wsl",
         "docker",
         "docker-engine",
         "student-image",
     ]
     assert [result.status for result in results] == [
+        "skipped",
         "succeeded",
         "succeeded",
         "succeeded",
@@ -422,6 +424,48 @@ def test_windows_docker_install_starts_desktop_and_continues_automatically() -> 
         "Bypass",
     )
     assert " pull " in calls[2][-1]
+
+
+def test_windows_docker_prepares_wsl_then_stops_for_restart() -> None:
+    plan = install_plan(Host.WINDOWS_AMD64, Provider.DOCKER)
+    calls = []
+
+    results = execute_plan(
+        plan,
+        check_results(
+            plan,
+            missing={"wsl", "docker", "docker-engine", "student-image"},
+        ),
+        runner=lambda command: (calls.append(command) or (0, "WSL 2 preparato")),
+    )
+
+    assert [result.key for result in results] == ["wsl"]
+    assert results[0].status == "restart_required"
+    assert len(calls) == 1
+    assert "prepare-wsl-windows.ps1" in calls[0][-1]
+
+
+def test_tui_shows_wsl_restart_as_yellow_action_not_error() -> None:
+    pytest.importorskip("utui")
+    from installer.executor import StepResult
+    from installer.tui import _format_results
+
+    report = _format_results(
+        Provider.DOCKER,
+        (
+            StepResult(
+                "wsl",
+                "Prepara WSL 2",
+                "restart_required",
+                "WSL 2 preparato",
+            ),
+        ),
+    )
+
+    rendered = "\n".join(report)
+    assert "AZIONE RICHIESTA - RIAVVIA WINDOWS" in rendered
+    assert "si riaprirà" in rendered
+    assert "ERRORE" not in rendered
 
 
 def test_executor_stops_on_first_failed_command() -> None:

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -60,6 +60,7 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "Test-HostResources" in bootstrap
     assert "installed_by_bootstrap" in bootstrap
     assert "Install-ClassroomLauncher" in bootstrap
+    assert "prepare-wsl-windows.ps1" in bootstrap
     assert "Ambiente 2cornot2c.lnk" in bootstrap
     assert "bootstrap-classroom-windows.ps1" in update
     assert ".installer-venv\\Scripts\\python.exe" in manager
@@ -71,3 +72,14 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "docker image rm $ImageReference" in uninstall
     assert "docker image rm --force" not in uninstall
     assert "Ambiente 2cornot2c.lnk" in uninstall
+
+
+def test_wsl_preparation_is_elevated_and_resumes_after_restart() -> None:
+    source = (ROOT / "scripts" / "prepare-wsl-windows.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    assert "wsl.exe --install --no-distribution" in source
+    assert "-Verb RunAs" in source
+    assert "2cornot2c-resume" in source
+    assert "RunOnce" in source

--- a/tests/test_student_errors.py
+++ b/tests/test_student_errors.py
@@ -46,6 +46,7 @@ def test_resource_error_uses_only_blocked_measurement() -> None:
 
 def test_docker_errors_are_specific() -> None:
     assert for_check("network", "").code == "E07"
+    assert for_step("wsl").code == "E20"
     assert for_check("docker-engine", "").code == "E19"
     assert for_check("student-image", "").code == "E21"
     assert for_step("docker").code == "E18"


### PR DESCRIPTION
## Cosa cambia

- rileva WSL 2 prima di installare o avviare Docker Desktop;
- installa automaticamente WSL 2 e Virtual Machine Platform con `wsl --install --no-distribution`;
- mostra una sola richiesta UAC, senza installare una distribuzione Ubuntu duplicata;
- tratta il riavvio come azione richiesta in giallo, non come errore;
- registra la riapertura automatica del launcher dopo il riavvio;
- interrompe correttamente il piano prima di Docker e riprende in modo idempotente;
- rimuove la ripresa programmata durante la disinstallazione;
- aggiunge il messaggio specifico E20 e aggiorna la documentazione.

## Causa

Il preflight verificava la virtualizzazione hardware ma non preparava WSL 2. Su un PC con virtualizzazione BIOS attiva e WSL assente, Docker Desktop restava quindi bloccato con `virtualization support not detected`.

## Impatto

Lo studente deve soltanto accettare la richiesta di Windows e riavviare. Al nuovo accesso il launcher si riapre e il setup può continuare senza ripetere i passaggi completati.

## Verifiche

- 39 test mirati superati
- `python -m compileall -q installer`
- `git diff --check`