### PR TITLE
Add safe installation cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,12 @@ La procedura mostra il piano e richiede la parola esatta `DISINSTALLA`. Salva
 programmi registrati come installati da 2cornot2c. Una VM esistente blocca la
 disinstallazione e non viene mai distrutta implicitamente.
 
+Anche un'installazione in corso può essere annullata premendo `c` nella TUI e
+confermando con `s`. Il passo Windows già avviato termina in sicurezza, poi la
+procedura rimuove automaticamente quanto installato fino a quel momento. WSL
+viene rimosso soltanto quando risulta installato da 2cornot2c e non contiene
+distribuzioni personali.
+
 ### Preparazione automatica del Mac
 
 Su un Mac Apple Silicon nuovo, oppure per riparare un'installazione incompleta,

--- a/installer/README.md
+++ b/installer/README.md
@@ -64,6 +64,13 @@ di completare o riparare l'installazione, aggiornarla e disinstallarla. Il
 launcher è conservato separatamente dal repository, quindi può riprendere anche
 una preparazione interrotta.
 
+Durante l'installazione `c` apre una conferma di annullamento. Per non lasciare
+un installer di Windows a metà, il comando attivo viene lasciato terminare;
+subito dopo parte automaticamente la disinstallazione protetta. Vengono rimossi
+soltanto i componenti registrati come installati da 2cornot2c, compreso WSL
+quando era assente prima della procedura. Se WSL contiene una distribuzione
+personale, viene conservato e la rimozione si ferma per proteggere i dati.
+
 La procedura avvia automaticamente Docker Desktop e attende che sia pronto
 prima di scaricare l'ambiente. Se WSL 2 non è presente, lo installa senza
 aggiungere una distribuzione Linux duplicata: Windows mostra soltanto la

--- a/installer/executor.py
+++ b/installer/executor.py
@@ -65,6 +65,7 @@ def execute_plan(
     runner: CommandRunner = subprocess_runner,
     log_path: Path | None = None,
     progress: ProgressCallback | None = None,
+    cancel_requested: Callable[[], bool] | None = None,
 ) -> tuple[StepResult, ...]:
     """Applica i soli passi mancanti, fermandosi al primo errore.
 
@@ -109,6 +110,8 @@ def execute_plan(
     applied: list[StepResult] = []
     total = len(plan.steps)
     for index, step in enumerate(plan.steps, 1):
+        if cancel_requested is not None and cancel_requested():
+            break
         if progress is not None:
             progress("started", index, total, step.label)
         if step.key not in missing:

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -7,7 +7,7 @@ from io import UnsupportedOperation
 from pathlib import Path
 from queue import Empty, Queue
 import sys
-from threading import Thread
+from threading import Event, Thread
 from time import monotonic
 from typing import Any
 
@@ -59,6 +59,9 @@ class State:
     install_tick: int = 0
     install_updates: Queue[tuple[str, Any]] | None = None
     install_thread: Thread | None = None
+    install_cancel: Event | None = None
+    cancel_confirmation_pending: bool = False
+    cancellation_requested: bool = False
     running: bool = True
 
 
@@ -123,15 +126,27 @@ def build_screen(
             min_width=38,
         )
         visible_report = (
-            _installation_report(state) if state.installing else state.report
+            _cancel_confirmation_report(state)
+            if state.cancel_confirmation_pending
+            else _installation_report(state)
+            if state.installing
+            else state.report
         )
         report_title = "Diagnosi"
         if state.installing:
-            command_text = (
-                "Installazione in corso\n"
-                "Attendi il completamento\n"
-                "Non chiudere la finestra"
-            )
+            if state.cancel_confirmation_pending:
+                command_text = "s: annulla e ripulisci\nn/Esc: continua"
+            elif state.cancellation_requested:
+                command_text = (
+                    "Annullamento richiesto\n"
+                    "Attendi la pulizia automatica"
+                )
+            else:
+                command_text = (
+                    "Installazione in corso\n"
+                    "c: annulla e ripulisci\n"
+                    "Non chiudere la finestra"
+                )
         elif state.confirmation_pending:
             command_text = "s: conferma installazione\nn/Esc: annulla"
         else:
@@ -406,14 +421,54 @@ def _installation_report(state: State) -> tuple[str, ...]:
         cells[min(width - 1, pulse)] = "▓"
     minutes, seconds = divmod(state.install_elapsed, 60)
     current = min(max(1, state.install_current), total)
+    status = (
+        "ANNULLAMENTO RICHIESTO"
+        if state.cancellation_requested
+        else "INSTALLAZIONE IN CORSO"
+    )
+    guidance = (
+        "Attendo che il passo corrente termini, poi ripulisco tutto."
+        if state.cancellation_requested
+        else "Controlla con Alt+Tab eventuali richieste di Windows."
+    )
     return (
-        "INSTALLAZIONE IN CORSO",
+        status,
         f"Passo {current} di {total} - {state.install_label}",
         f"[{''.join(cells)}] {state.install_completed}/{total}",
         f"Attività in corso - tempo trascorso {minutes:02d}:{seconds:02d}",
         "Non chiudere questa finestra.",
-        "Controlla con Alt+Tab eventuali richieste di Windows.",
+        guidance,
     )
+
+
+def _cancel_confirmation_report(state: State) -> tuple[str, ...]:
+    """Spiega perché il passo attivo non viene terminato brutalmente."""
+
+    return (
+        "ANNULLARE L'INSTALLAZIONE?",
+        f"Passo attuale: {state.install_label}",
+        "Il passo attuale terminerà in sicurezza.",
+        "Poi verranno rimossi tutti i componenti installati da 2cornot2c.",
+        "Gli eventuali esercizi verranno salvati.",
+        "Premi s per annullare oppure n per continuare.",
+    )
+
+
+def request_installation_cancel(state: State) -> None:
+    """Apre la conferma senza interrompere processi di sistema."""
+
+    if state.installing and not state.cancellation_requested:
+        state.cancel_confirmation_pending = True
+
+
+def confirm_installation_cancel(state: State) -> None:
+    """Richiede uno stop cooperativo al termine del comando corrente."""
+
+    if not state.installing or state.install_cancel is None:
+        return
+    state.cancel_confirmation_pending = False
+    state.cancellation_requested = True
+    state.install_cancel.set()
 
 
 def start_selected(state: State) -> None:
@@ -424,6 +479,7 @@ def start_selected(state: State) -> None:
     provider = state.providers[state.active_index]
     plan = install_plan(state.host, provider)
     updates: Queue[tuple[str, Any]] = Queue()
+    cancellation = Event()
     state.confirmation_pending = False
     state.installing = True
     state.install_current = 0
@@ -434,6 +490,9 @@ def start_selected(state: State) -> None:
     state.install_started_at = monotonic()
     state.install_tick = 0
     state.install_updates = updates
+    state.install_cancel = cancellation
+    state.cancel_confirmation_pending = False
+    state.cancellation_requested = False
 
     def publish(
         phase: str,
@@ -450,8 +509,13 @@ def start_selected(state: State) -> None:
                 diagnose(plan),
                 log_path=Path.home() / ".2cornot2c" / "installer.jsonl",
                 progress=publish,
+                cancel_requested=cancellation.is_set,
             )
-            updates.put(("result", results))
+            updates.put(
+                ("cancelled", results)
+                if cancellation.is_set()
+                else ("result", results)
+            )
         except Exception as error:
             updates.put(("error", error))
 
@@ -487,6 +551,15 @@ def poll_installation(state: State) -> bool:
             state.report = _format_results(provider, payload)
             state.installing = False
             state.install_thread = None
+        elif kind == "cancelled":
+            state.installing = False
+            state.install_thread = None
+            try:
+                launch_windows_action("uninstall")
+                state.running = False
+            except Exception as error:
+                message = for_check("installer", str(error))
+                state.report = message.lines(str(error))
         else:
             error = for_check("installer", str(payload))
             state.report = error.lines(str(payload))
@@ -547,6 +620,21 @@ def main() -> int:
                 if event is not None:
                     character = event.character if event.key is Key.CHARACTER else ""
                     if state.installing:
+                        if (
+                            character == "s"
+                            and state.cancel_confirmation_pending
+                        ):
+                            confirm_installation_cancel(state)
+                        elif (
+                            character == "n" or event.key is Key.ESCAPE
+                        ) and state.cancel_confirmation_pending:
+                            state.cancel_confirmation_pending = False
+                        elif (
+                            character == "c"
+                            and not state.cancel_confirmation_pending
+                            and not state.cancellation_requested
+                        ):
+                            request_installation_cancel(state)
                         changed = True
                     elif state.screen == "home":
                         if character == "s" and state.confirmation_pending:

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -90,6 +90,7 @@ function Install-ClassroomLauncher {
     foreach ($ScriptName in @(
         "manage-classroom-windows.ps1"
         "prepare-wsl-windows.ps1"
+        "remove-wsl-windows.ps1"
         "update-classroom-windows.ps1"
         "uninstall-classroom-windows.ps1"
     )) {

--- a/scripts/remove-wsl-windows.ps1
+++ b/scripts/remove-wsl-windows.ps1
@@ -1,0 +1,38 @@
+$ErrorActionPreference = "Stop"
+
+$Distributions = @(
+    & wsl.exe --list --quiet 2>$null |
+        ForEach-Object { ([string]$_).Trim() } |
+        Where-Object { $_ }
+)
+$PersonalDistributions = @(
+    $Distributions |
+        Where-Object { $_ -notmatch "^docker-desktop(?:-data)?$" }
+)
+if ($PersonalDistributions.Count -gt 0) {
+    Write-Error (
+        "WSL contiene distribuzioni non create da 2cornot2c: " +
+        ($PersonalDistributions -join ", ") +
+        ". WSL viene conservato per non cancellare dati personali."
+    )
+    exit 2
+}
+
+foreach ($Distribution in $Distributions) {
+    & wsl.exe --unregister $Distribution
+}
+& wsl.exe --shutdown 2>$null
+& wsl.exe --uninstall 2>$null
+
+Get-AppxPackage "MicrosoftCorporationII.WindowsSubsystemForLinux" |
+    Remove-AppxPackage -ErrorAction SilentlyContinue
+
+foreach ($Feature in @(
+    "VirtualMachinePlatform"
+    "Microsoft-Windows-Subsystem-Linux"
+)) {
+    & dism.exe /online /disable-feature `
+        /featurename:$Feature /norestart | Out-Null
+}
+
+Write-Host "WSL installato da 2cornot2c è stato rimosso."

--- a/scripts/uninstall-classroom-windows.ps1
+++ b/scripts/uninstall-classroom-windows.ps1
@@ -21,6 +21,12 @@ $InstallDir = if ($env:CLASSROOM_INSTALL_DIR) {
     $DefaultInstallDir
 }
 
+if ($ConfirmedFromTui) {
+    # Python è avviato dalla cartella che verrà rimossa: la TUI deve avere il
+    # tempo di chiudersi prima che inizi il rollback.
+    Start-Sleep -Seconds 2
+}
+
 function Stop-WithMessage {
     param(
         [string]$Code,
@@ -127,6 +133,25 @@ function Get-OwnedPackages {
     return @($Owned | ForEach-Object { $_ })
 }
 
+function Test-WslInstalledByClassroom {
+    if (-not (Test-Path $LogPath)) {
+        return $false
+    }
+    foreach ($Line in Get-Content $LogPath) {
+        try {
+            $Record = $Line | ConvertFrom-Json
+            if ($Record.host -eq "windows-amd64" -and
+                $Record.key -eq "wsl" -and
+                $Record.status -in @("restart_required", "succeeded")) {
+                return $true
+            }
+        } catch {
+            continue
+        }
+    }
+    return $false
+}
+
 function Backup-StudentWork {
     param([string]$Source)
     if (-not (Test-Path $Source)) {
@@ -180,6 +205,7 @@ function Backup-StudentWork {
 
 $SafeInstallDir = Test-SafeInstallDirectory
 $OwnedPackages = Get-OwnedPackages
+$OwnedWsl = Test-WslInstalledByClassroom
 $ImageReference = $null
 $LockPath = Join-Path $SafeInstallDir "docker\student-dev\toolchain.lock.json"
 if (Test-Path $LockPath) {
@@ -201,6 +227,10 @@ if ($OwnedPackages.Count -gt 0) {
     $OwnedPackages | Sort-Object | ForEach-Object { Write-Host "  - $_" }
 } else {
     Write-Host "Nessun programma esterno attribuito a 2cornot2c."
+}
+if ($OwnedWsl) {
+    Write-Host "Componente Windows installato da 2cornot2c:"
+    Write-Host "  - WSL 2 e Virtual Machine Platform"
 }
 if (-not $ConfirmedFromTui) {
     Write-Host ""
@@ -251,6 +281,30 @@ elseif ($OwnedPackages.Count -gt 0) {
         if ($LASTEXITCODE -ne 0) {
             Write-Warning "Disinstallazione non riuscita o già eseguita: $PackageId"
         }
+    }
+}
+
+if ($OwnedWsl) {
+    $WslCleanup = Join-Path $LauncherDir "remove-wsl-windows.ps1"
+    $PowerShell = Join-Path `
+        $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+    $Cleanup = Start-Process `
+        -FilePath $PowerShell `
+        -ArgumentList @(
+            "-NoProfile"
+            "-ExecutionPolicy"
+            "Bypass"
+            "-File"
+            "`"$WslCleanup`""
+        ) `
+        -Verb RunAs `
+        -Wait `
+        -PassThru
+    if ($Cleanup.ExitCode -ne 0) {
+        Write-Warning (
+            "WSL non è stato rimosso per proteggere eventuali dati personali. " +
+            "Comunica E30 al docente."
+        )
     }
 }
 

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -468,6 +468,90 @@ def test_tui_shows_wsl_restart_as_yellow_action_not_error() -> None:
     assert "ERRORE" not in rendered
 
 
+def test_executor_cancels_between_system_installers() -> None:
+    from threading import Event
+
+    plan = install_plan(Host.WINDOWS_AMD64, Provider.VIRTUALBOX)
+    cancellation = Event()
+    calls = []
+
+    def runner(command):
+        calls.append(command)
+        cancellation.set()
+        return 0, "installato"
+
+    results = execute_plan(
+        plan,
+        check_results(plan, missing={"git", "vagrant", "virtualbox"}),
+        runner=runner,
+        cancel_requested=cancellation.is_set,
+    )
+
+    assert [result.key for result in results] == ["git"]
+    assert results[0].status == "succeeded"
+    assert len(calls) == 1
+
+
+def test_tui_cancel_requires_confirmation_and_signals_worker() -> None:
+    pytest.importorskip("utui")
+    from threading import Event
+
+    from installer.tui import (
+        State,
+        _cancel_confirmation_report,
+        confirm_installation_cancel,
+        request_installation_cancel,
+    )
+
+    cancellation = Event()
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER,),
+        installing=True,
+        install_label="Installa Docker Desktop",
+        install_cancel=cancellation,
+    )
+
+    request_installation_cancel(state)
+    assert state.cancel_confirmation_pending is True
+    assert "terminerà in sicurezza" in " ".join(
+        _cancel_confirmation_report(state)
+    )
+    assert cancellation.is_set() is False
+
+    confirm_installation_cancel(state)
+    assert cancellation.is_set() is True
+    assert state.cancellation_requested is True
+
+
+def test_tui_cancelled_installation_launches_automatic_rollback(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("utui")
+    from queue import Queue
+
+    from installer.tui import State, poll_installation
+
+    launched = []
+    monkeypatch.setattr(
+        "installer.tui.launch_windows_action",
+        lambda action: launched.append(action),
+    )
+    updates = Queue()
+    updates.put(("cancelled", ()))
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER,),
+        installing=True,
+        install_updates=updates,
+    )
+
+    assert poll_installation(state) is True
+    assert launched == ["uninstall"]
+    assert state.installing is False
+    assert state.running is False
+
+
 def test_executor_stops_on_first_failed_command() -> None:
     plan = install_plan(Host.WINDOWS_AMD64, Provider.VIRTUALBOX)
     calls = []

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -61,6 +61,7 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "installed_by_bootstrap" in bootstrap
     assert "Install-ClassroomLauncher" in bootstrap
     assert "prepare-wsl-windows.ps1" in bootstrap
+    assert "remove-wsl-windows.ps1" in bootstrap
     assert "Ambiente 2cornot2c.lnk" in bootstrap
     assert "bootstrap-classroom-windows.ps1" in update
     assert ".installer-venv\\Scripts\\python.exe" in manager
@@ -83,3 +84,20 @@ def test_wsl_preparation_is_elevated_and_resumes_after_restart() -> None:
     assert "-Verb RunAs" in source
     assert "2cornot2c-resume" in source
     assert "RunOnce" in source
+
+
+def test_wsl_rollback_refuses_to_remove_personal_distributions() -> None:
+    cleanup = (ROOT / "scripts" / "remove-wsl-windows.ps1").read_text(
+        encoding="utf-8"
+    )
+    uninstall = (ROOT / "scripts" / "uninstall-classroom-windows.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    assert "PersonalDistributions" in cleanup
+    assert "docker-desktop" in cleanup
+    assert "dati personali" in cleanup
+    assert "wsl.exe --uninstall" in cleanup
+    assert "Test-WslInstalledByClassroom" in uninstall
+    assert '"restart_required", "succeeded"' in uninstall
+    assert "Start-Sleep -Seconds 2" in uninstall


### PR DESCRIPTION
## Cosa cambia

- aggiunge `c: annulla e ripulisci` durante l’installazione TUI;
- richiede una conferma esplicita prima del rollback;
- non termina brutalmente `winget` o altri installer Windows già attivi;
- interrompe il piano tra due passi e avvia automaticamente la disinstallazione protetta;
- rimuove tutti i componenti registrati come installati da 2cornot2c fino a quel momento;
- rimuove anche WSL 2 quando era stato installato dal setup;
- conserva WSL e segnala E30 se trova distribuzioni personali;
- lascia due secondi alla TUI Python per chiudersi prima di cancellare il repository;
- documenta annullamento e rollback.

## Sicurezza

Il rollback continua a usare registri di proprietà, backup degli esercizi e controlli sul repository. WSL non viene mai rimosso se contiene distribuzioni diverse da quelle tecniche di Docker.

## Verifiche

- 43 test mirati superati
- `python -m compileall -q installer`
- `git diff --check`