### PR TITLE
Avoid false Windows virtualization blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,12 +452,14 @@ risorsa obbligatoria manca, nessun componente viene modificato.
 
 Gli errori destinati agli studenti hanno un codice stabile, un titolo rosso e
 istruzioni semplici in giallo. Ogni messaggio spiega cosa è successo, cosa fare
-e quale codice comunicare al docente, per esempio `E03` quando la
-virtualizzazione è disabilitata. I dettagli tecnici restano separati e non è
-mai richiesto a uno studente di modificare da solo BIOS, antivirus o file Git.
-Su Windows `E03` rileva automaticamente una CPU Intel o AMD e indica soltanto i
-nomi pertinenti della voce di virtualizzazione. Chiede comunque l'aiuto di un
-adulto e vieta esplicitamente di modificare Secure Boot, TPM o altre opzioni.
+e quale codice comunicare al docente. I dettagli tecnici restano separati e non
+è mai richiesto a uno studente di modificare da solo BIOS, antivirus o file
+Git. Il valore WMI usato da Windows per la virtualizzazione può essere errato
+anche quando Gestione attività mostra **Abilitata**: in questo caso il setup
+mostra `W03` e continua, lasciando a WSL la verifica reale. `E03` e le
+indicazioni Intel/AMD restano disponibili soltanto quando la disabilitazione è
+accertata; chiedono l'aiuto di un adulto e vietano di modificare Secure Boot,
+TPM o altre opzioni.
 
 #### Aggiornare su Windows
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -33,7 +33,9 @@ Gli errori mostrati dalla procedura usano un catalogo stabile:
 Il catalogo Python è in `installer/student_errors.py`. Gli script PowerShell
 usano la stessa convenzione durante bootstrap, aggiornamento e disinstallazione.
 Gli studenti non vengono invitati a disattivare protezioni o modificare da soli
-il BIOS; il caso `E03` chiede espressamente l'aiuto di un adulto o del docente.
+il BIOS. Poiché alcuni PC restituiscono un valore WMI errato, un contrasto con
+lo stato mostrato da Gestione attività produce l'avviso `W03` e non blocca
+l'installazione; sarà WSL a eseguire la verifica reale.
 
 ## Bootstrap monocomando
 

--- a/installer/preflight.py
+++ b/installer/preflight.py
@@ -56,9 +56,10 @@ def virtualization_available(host: Host) -> bool | None:
                 "-NoProfile",
                 "-NonInteractive",
                 "-Command",
-                "(Get-CimInstance Win32_Processor | "
-                "Select-Object -First 1 -ExpandProperty "
-                "VirtualizationFirmwareEnabled)",
+                "$computer = Get-CimInstance Win32_ComputerSystem; "
+                "if ($computer.HypervisorPresent) { 'true' } else { "
+                "(Get-CimInstance Win32_Processor | Select-Object -First 1 "
+                "-ExpandProperty VirtualizationFirmwareEnabled) }",
             ),
             check=False,
             capture_output=True,
@@ -141,8 +142,11 @@ def evaluate(
         results.append(
             ResourceResult(
                 "virtualization",
-                "blocked",
-                "virtualizzazione hardware disabilitata nel firmware",
+                "warning",
+                (
+                    "stato virtualizzazione incerto: controlla Gestione "
+                    "attività, Prestazioni, CPU"
+                ),
             )
         )
     elif measured.virtualization is None:

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -161,30 +161,21 @@ function Test-HostResources {
     try {
         $Processor = Get-CimInstance Win32_Processor | Select-Object -First 1
         $Virtualization = $Processor.VirtualizationFirmwareEnabled
-        if ($Virtualization -eq $false) {
-            $VirtualizationSetting = switch -Regex ($Processor.Manufacturer) {
-                "Intel" {
-                    "Intel Virtualization Technology oppure Intel VT-x"
-                    break
-                }
-                "AMD" {
-                    "SVM Mode, AMD-V oppure Secure Virtual Machine"
-                    break
-                }
-                default {
-                    "Intel Virtualization Technology, Intel VT-x, SVM Mode oppure AMD-V"
-                }
-            }
-            $ComputerModel = "$($Computer.Manufacturer) $($Computer.Model)".Trim()
-            Stop-WithMessage "E03" "La virtualizzazione del computer è disabilitata" `
-                "Docker e le macchine virtuali hanno bisogno di questa funzione. Il computer probabilmente la possiede, ma è spenta. Non hai rotto nulla." `
-                @(
-                    "Premi Ctrl+Maiusc+Esc, apri Prestazioni e poi CPU."
-                    "Controlla se accanto a Virtualizzazione compare Disabilitata."
-                    "Nel BIOS/UEFI cerca soltanto: $VirtualizationSetting."
-                    "Fatti aiutare da un adulto. Attiva soltanto questa voce, salva e riavvia Windows."
-                    "Non modificare Secure Boot, TPM o altre impostazioni. Se non trovi la voce, fermati e comunica E03 al docente."
-                ) "CPU: $($Processor.Name); computer: $ComputerModel"
+        if ($Computer.HypervisorPresent -eq $true) {
+            Write-Host "Virtualizzazione: disponibile (hypervisor Windows attivo)."
+        } elseif ($Virtualization -eq $false) {
+            Write-Host (
+                "AVVISO W03 - Windows fornisce indicazioni contrastanti " +
+                "sulla virtualizzazione."
+            ) -ForegroundColor Yellow
+            Write-Host (
+                "Il controllo automatico non è abbastanza affidabile per " +
+                "fermare l'installazione."
+            ) -ForegroundColor Yellow
+            Write-Host (
+                "Se Gestione attività, Prestazioni, CPU mostra Abilitata, " +
+                "puoi continuare."
+            ) -ForegroundColor Yellow
         }
     } catch {
         Write-Host "AVVISO W04 - Virtualizzazione non verificabile automaticamente." `

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -19,7 +19,7 @@ def test_docker_preflight_accepts_minimum_resources() -> None:
     assert {result.status for result in results} == {"ok"}
 
 
-def test_vm_preflight_blocks_low_memory_disk_and_virtualization() -> None:
+def test_vm_preflight_blocks_resources_but_warns_on_unreliable_virtualization() -> None:
     results = evaluate(
         Host.WINDOWS_AMD64,
         Provider.VIRTUALBOX,
@@ -29,7 +29,7 @@ def test_vm_preflight_blocks_low_memory_disk_and_virtualization() -> None:
     assert [result.status for result in results] == [
         "blocked",
         "blocked",
-        "blocked",
+        "warning",
     ]
 
 
@@ -41,6 +41,13 @@ def test_unknown_measurements_warn_but_do_not_block_sufficient_disk() -> None:
     )
 
     assert [result.status for result in results] == ["warning", "ok", "warning"]
+
+
+def test_windows_virtualization_probe_accepts_an_active_hypervisor() -> None:
+    source = (ROOT / "installer" / "preflight.py").read_text(encoding="utf-8")
+
+    assert "HypervisorPresent" in source
+    assert "stato virtualizzazione incerto" in source
 
 
 def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:

--- a/tests/test_student_errors.py
+++ b/tests/test_student_errors.py
@@ -120,10 +120,8 @@ def test_windows_scripts_render_error_and_explanation_colors() -> None:
     bootstrap = (
         root / "scripts" / "bootstrap-classroom-windows.ps1"
     ).read_text(encoding="utf-8")
-    assert "$Processor.Manufacturer" in bootstrap
-    assert "Intel Virtualization Technology" in bootstrap
-    assert "SVM Mode, AMD-V" in bootstrap
-    assert "Non modificare Secure Boot, TPM" in bootstrap
+    assert "AVVISO W03" in bootstrap
+    assert "indicazioni contrastanti" in bootstrap
 
 
 def test_student_facing_messages_use_italian_accents() -> None:


### PR DESCRIPTION
## Cosa cambia

- riconosce `Win32_ComputerSystem.HypervisorPresent` come prova positiva;
- non usa più `VirtualizationFirmwareEnabled=false` come blocco definitivo;
- trasforma il dato WMI contrastante in `AVVISO W03` e continua;
- lascia a WSL la verifica reale della virtualizzazione;
- applica la stessa logica nel bootstrap PowerShell e nel preflight Python;
- aggiorna test e documentazione.

## Causa

Su alcuni PC Windows 11 `Win32_Processor.VirtualizationFirmwareEnabled` restituisce `false` anche quando il BIOS e Gestione attività mostrano correttamente la virtualizzazione abilitata. Il precedente controllo generava quindi E03 falsi.

## Verifiche

- 44 test mirati superati
- `python -m compileall -q installer`
- `git diff --check`