### PR TITLE
feat: rate limit public Google login admission

### DIFF
--- a/doc/architecture/auth-edge-rate-limiting.md
+++ b/doc/architecture/auth-edge-rate-limiting.md
@@ -1,0 +1,74 @@
+# Rate limiting edge per le route di autenticazione pubbliche
+
+## Scopo
+
+`scripts/thebitlab_edge_rate_limit.py` protegge l'ammissione alla route pubblica di avvio Google OIDC prima che `GoogleOidcLoginService.begin_login()` allochi `state`, nonce, PKCE verifier e binding browser. Il limite di capacità dello store OIDC resta una difesa interna e non viene usato come controllo abuso.
+
+L'incremento chiude il requisito #549 per `/auth/google/login`. Il wiring `BaseHTTPRequestHandler`, il callback Google, le route pairing TUI e il browser E2E restano incrementi separati.
+
+## Attribuzione del client
+
+`TrustedProxyClientResolver` riceve l'IP del peer TCP e gli header preservati come sequenza, così duplicati e ambiguità non vengono persi.
+
+- Se il peer non appartiene a un CIDR esplicitamente trusted, ogni `X-Forwarded-For` o `Forwarded` viene ignorato e il bucket usa il peer diretto.
+- Se il peer è trusted, è accettato al massimo un `X-Forwarded-For` bounded.
+- La catena viene percorsa da destra rimuovendo soltanto proxy trusted; il primo hop non trusted è il client attribuito.
+- `Forwarded`, combinazioni `Forwarded` + `X-Forwarded-For`, header duplicati, hop vuoti, host con porta, zone ID IPv6, catene eccessive e valori non IP falliscono con `400 invalid_client_address`.
+- IPv4 e IPv6 sono canonicalizzati con `ipaddress`.
+
+La configurazione dei CIDR deve corrispondere esattamente ai reverse proxy controllati dal deployment. Non è sicuro fidarsi indiscriminatamente di reti LAN o degli header provenienti da Internet.
+
+## Bucket e minimizzazione dati
+
+Ogni richiesta ammessa verifica atomicamente due finestre fisse:
+
+1. bucket globale della route;
+2. bucket per client.
+
+Il client key è `HMAC-SHA256(pepper, route_id || NUL || ip_canonico)`. L'indirizzo IP raw non viene persistito. Il pepper è esterno, contiene almeno 32 byte ed è distinto dai secret CSRF, pairing e OAuth.
+
+Se un bucket ha raggiunto il limite, nessun bucket della richiesta viene incrementato. La risposta pubblica è `429 rate_limit_exceeded` con `Retry-After` intero e `Cache-Control: no-store`. Errori store, clock, configurazione runtime o risultati adapter malformati diventano `503 auth_admission_unavailable` senza dettagli backend.
+
+## Store atomici
+
+`AtomicRateLimitStore` è la porta sostituibile richiesta dal deployment. L'operazione `admit()` deve controllare e incrementare tutti i bucket in modo all-or-nothing.
+
+Sono inclusi:
+
+- `InMemoryAtomicRateLimitStore`: bounded e thread-safe, soltanto per test o processo singolo;
+- `SqliteAtomicRateLimitStore`: transazione `BEGIN IMMEDIATE`, WAL e busy timeout, condivisibile da più worker/processi sullo stesso host.
+
+Lo store SQLite elimina finestre concluse durante l'ammissione. Poiché ogni richiesta ammessa consuma anche il bucket globale, il numero di contatori client creati in una finestra è limitato dal limite globale. Le richieste già negate non creano nuove righe.
+
+Un deployment multi-host deve iniettare un'implementazione realmente condivisa di `AtomicRateLimitStore` con la stessa semantica atomica (per esempio uno script transazionale nel data store scelto). Non sono ammesse istanze in-memory indipendenti per replica né sticky session come sostituto del limite globale.
+
+## Clock e concorrenza
+
+Le finestre usano UTC aware e scadenza esclusiva. Ogni store conserva un high-water mark del clock:
+
+- avanzamento o uguaglianza sono ammessi;
+- rollback, timestamp naive/non finiti o anteriori all'epoch falliscono chiusi;
+- su SQLite il controllo, cleanup, decisione e incremento avvengono nella stessa transazione.
+
+Test concorrenti verificano che, con più worker, il numero degli ammessi sia esattamente il limite e che una negazione per-client non consumi capacità globale.
+
+## Ordine nella route concreta
+
+La futura `/auth/google/login` deve costruire `EdgeRequestMetadata` dal peer reale e dagli header originali, poi chiamare esclusivamente:
+
+```python
+admission.begin_login(metadata)
+```
+
+Soltanto una decisione ammessa raggiunge `GoogleOidcLoginService.begin_login()`. Il redirect Google e il cookie transazionale restituiti mantengono i contratti già descritti in `google-oidc-adapter.md`.
+
+Il reverse proxy può applicare limiti aggiuntivi, ma non sostituisce questo boundary applicativo: l'applicazione deve mantenere un limite globale coerente con la capacità del proprio flow store.
+
+## Fuori scope
+
+- route concrete e serializzazione della risposta HTTP 302;
+- limiti del callback Google e delle route GitHub;
+- limiti specifici per begin/authorize/consume del pairing TUI;
+- store multi-host concreto;
+- CAPTCHA, challenge adattive e ban persistenti;
+- browser E2E e configurazione TLS/reverse proxy.

--- a/doc/architecture/auth-edge-rate-limiting.md
+++ b/doc/architecture/auth-edge-rate-limiting.md
@@ -14,7 +14,7 @@ L'incremento chiude il requisito #549 per `/auth/google/login`. Il wiring `BaseH
 - Se il peer è trusted, è accettato al massimo un `X-Forwarded-For` bounded.
 - La catena viene percorsa da destra rimuovendo soltanto proxy trusted; il primo hop non trusted è il client attribuito.
 - `Forwarded`, combinazioni `Forwarded` + `X-Forwarded-For`, header duplicati, hop vuoti, host con porta, zone ID IPv6, catene eccessive e valori non IP falliscono con `400 invalid_client_address`.
-- IPv4 e IPv6 sono canonicalizzati con `ipaddress`.
+- IPv4 e IPv6 sono canonicalizzati con `ipaddress`; gli IPv4-mapped IPv6 vengono normalizzati all'IPv4 equivalente prima sia del trust check sia della derivazione bucket.
 
 La configurazione dei CIDR deve corrispondere esattamente ai reverse proxy controllati dal deployment. Non è sicuro fidarsi indiscriminatamente di reti LAN o degli header provenienti da Internet.
 
@@ -38,7 +38,7 @@ Sono inclusi:
 - `InMemoryAtomicRateLimitStore`: bounded e thread-safe, soltanto per test o processo singolo;
 - `SqliteAtomicRateLimitStore`: transazione `BEGIN IMMEDIATE`, WAL e busy timeout, condivisibile da più worker/processi sullo stesso host.
 
-Lo store SQLite elimina finestre concluse durante l'ammissione. Poiché ogni richiesta ammessa consuma anche il bucket globale, il numero di contatori client creati in una finestra è limitato dal limite globale. Le richieste già negate non creano nuove righe.
+Lo store SQLite elimina finestre concluse durante l'ammissione e applica anche un cap esplicito `max_counters` nella stessa transazione. Poiché ogni richiesta ammessa consuma anche il bucket globale, il numero di contatori client creati in una finestra è inoltre limitato dal limite globale. Le richieste già negate non creano nuove righe.
 
 Un deployment multi-host deve iniettare un'implementazione realmente condivisa di `AtomicRateLimitStore` con la stessa semantica atomica (per esempio uno script transazionale nel data store scelto). Non sono ammesse istanze in-memory indipendenti per replica né sticky session come sostituto del limite globale.
 
@@ -47,8 +47,9 @@ Un deployment multi-host deve iniettare un'implementazione realmente condivisa d
 Le finestre usano UTC aware e scadenza esclusiva. Ogni store conserva un high-water mark del clock:
 
 - avanzamento o uguaglianza sono ammessi;
-- rollback, timestamp naive/non finiti o anteriori all'epoch falliscono chiusi;
-- su SQLite il controllo, cleanup, decisione e incremento avvengono nella stessa transazione.
+- timestamp concorrenti fuori ordine e rollback vengono clampati al massimo già osservato: non producono falsi 503 e non possono riaprire finestre precedenti;
+- timestamp naive/non finiti o anteriori all'epoch falliscono chiusi;
+- su SQLite high-water mark, cap, cleanup, decisione e incremento avvengono nella stessa transazione.
 
 Test concorrenti verificano che, con più worker, il numero degli ammessi sia esattamente il limite e che una negazione per-client non consumi capacità globale.
 

--- a/doc/architecture/auth-edge-rate-limiting.md
+++ b/doc/architecture/auth-edge-rate-limiting.md
@@ -14,7 +14,7 @@ L'incremento chiude il requisito #549 per `/auth/google/login`. Il wiring `BaseH
 - Se il peer è trusted, è accettato al massimo un `X-Forwarded-For` bounded.
 - La catena viene percorsa da destra rimuovendo soltanto proxy trusted; il primo hop non trusted è il client attribuito.
 - `Forwarded`, combinazioni `Forwarded` + `X-Forwarded-For`, header duplicati, hop vuoti, host con porta, zone ID IPv6, catene eccessive e valori non IP falliscono con `400 invalid_client_address`.
-- IPv4 e IPv6 sono canonicalizzati con `ipaddress`; gli IPv4-mapped IPv6 vengono normalizzati all'IPv4 equivalente prima sia del trust check sia della derivazione bucket.
+- IPv4 e IPv6 sono canonicalizzati con `ipaddress`; indirizzi e CIDR IPv4-mapped IPv6 vengono normalizzati all'IPv4 equivalente prima sia del trust check sia della derivazione bucket, mentre supernet mapped ambigue vengono rifiutate.
 
 La configurazione dei CIDR deve corrispondere esattamente ai reverse proxy controllati dal deployment. Non è sicuro fidarsi indiscriminatamente di reti LAN o degli header provenienti da Internet.
 

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -42,7 +42,7 @@ State e nonce raw esistono soltanto nella URL consegnata al browser. Lo store co
 
 `InMemoryGoogleOidcFlowStore` è protetto da lock e consuma lo state con una singola `pop`: un solo callback concorrente può vincere. La scadenza è esclusiva (`now >= expires_at`). Errori provider con state valido consumano comunque il flow. Il cleanup riceve un cutoff esplicito; ogni creazione elimina inoltre i flow già scaduti e lo store impone un cap configurabile, evitando crescita non limitata dei verifier raw.
 
-Lo store è adatto al server MVP a processo singolo. Deployment multi-process richiederà uno store transazionale condiviso; non è ammesso usare sticky session come unica garanzia di replay protection. Il cap limita la memoria ma non sostituisce il controllo abuso: la futura route pubblica deve applicare rate limit per-client e globale, trusted-proxy-aware, prima di `begin_login()`; il requisito è tracciato in #549.
+Lo store è adatto al server MVP a processo singolo. Deployment multi-process richiederà uno store transazionale condiviso; non è ammesso usare sticky session come unica garanzia di replay protection. Il cap limita la memoria ma non sostituisce il controllo abuso: `GoogleOidcLoginAdmissionBoundary`, documentato in [auth-edge-rate-limiting.md](auth-edge-rate-limiting.md), applica rate limit atomici per-client e globali, trusted-proxy-aware, prima di `begin_login()`. La futura route concreta deve passare esclusivamente da quel boundary.
 
 ## Callback
 
@@ -95,4 +95,5 @@ I messaggi non includono valori OAuth raw o dettagli backend.
 - protezione dashboard;
 - persistenza flow multi-process;
 - GitHub linking;
-- TLS termination e deployment pubblico.
+- TLS termination e deployment pubblico;
+- wiring HTTP concreto del boundary edge e store rate-limit multi-host.

--- a/scripts/thebitlab_edge_rate_limit.py
+++ b/scripts/thebitlab_edge_rate_limit.py
@@ -166,8 +166,7 @@ class TrustedProxyClientResolver:
             raise ValueError("max_forwarded_header_bytes non valido.")
         try:
             networks = tuple(
-                ipaddress.ip_network(value, strict=True)
-                for value in trusted_proxy_cidrs
+                self._network(value) for value in trusted_proxy_cidrs
             )
         except (TypeError, ValueError) as error:
             raise ValueError("CIDR proxy trusted non valido.") from error
@@ -208,6 +207,23 @@ class TrustedProxyClientResolver:
 
     def _trusted(self, address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
         return any(address in network for network in self._trusted_networks)
+
+    @staticmethod
+    def _network(value: str) -> ipaddress.IPv4Network | ipaddress.IPv6Network:
+        network = ipaddress.ip_network(value, strict=True)
+        if isinstance(network, ipaddress.IPv6Network):
+            mapped_space = ipaddress.IPv6Network("::ffff:0:0/96")
+            if network.subnet_of(mapped_space):
+                mapped = network.network_address.ipv4_mapped
+                if mapped is None:
+                    raise ValueError("CIDR mapped non valido.")
+                return ipaddress.IPv4Network(
+                    (mapped, network.prefixlen - mapped_space.prefixlen),
+                    strict=True,
+                )
+            if network.overlaps(mapped_space):
+                raise ValueError("CIDR mapped ambiguo.")
+        return network
 
     @staticmethod
     def _address(value: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:

--- a/scripts/thebitlab_edge_rate_limit.py
+++ b/scripts/thebitlab_edge_rate_limit.py
@@ -1,0 +1,499 @@
+"""Trusted-proxy-aware, atomic admission limits for public auth routes."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import ipaddress
+import math
+import re
+import sqlite3
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Mapping, Protocol, Sequence
+
+from scripts.thebitlab_google_oidc import GoogleAuthorizationRequest
+
+
+_ROUTE_RE = re.compile(r"^[a-z0-9][a-z0-9_.:-]{0,127}$")
+_DIGEST_RE = re.compile(r"^hmac-sha256:[0-9a-f]{64}$")
+_MAX_FORWARDED_HEADER_BYTES = 4096
+_MAX_PROXY_HOPS = 16
+_MAX_BUCKETS_PER_ADMISSION = 8
+
+
+class EdgeRateLimitError(RuntimeError):
+    """Base public-auth admission error."""
+
+    status_code = 503
+    error_code = "auth_admission_unavailable"
+    public_message = "Servizio di autenticazione temporaneamente non disponibile."
+
+    def __init__(self) -> None:
+        super().__init__(self.public_message)
+
+
+class EdgeClientAttributionError(EdgeRateLimitError):
+    status_code = 400
+    error_code = "invalid_client_address"
+    public_message = "Indirizzo client non valido."
+
+
+class EdgeRateLimitExceededError(EdgeRateLimitError):
+    status_code = 429
+    error_code = "rate_limit_exceeded"
+    public_message = "Troppe richieste. Riprovare più tardi."
+
+    def __init__(self, retry_after_seconds: int) -> None:
+        if type(retry_after_seconds) is not int or retry_after_seconds < 1:
+            raise ValueError("retry_after_seconds non valido.")
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__()
+
+    @property
+    def response_headers(self) -> tuple[tuple[str, str], ...]:
+        return (
+            ("Retry-After", str(self.retry_after_seconds)),
+            ("Cache-Control", "no-store"),
+        )
+
+
+class EdgeRateLimitUnavailableError(EdgeRateLimitError):
+    pass
+
+
+class EdgeRateLimitStoreError(RuntimeError):
+    """Raised when an atomic admission store cannot decide safely."""
+
+
+class EdgeRateLimitClockRollbackError(EdgeRateLimitStoreError):
+    """Raised when a store observes time moving behind its high-water mark."""
+
+
+@dataclass(frozen=True)
+class EdgeRequestMetadata:
+    """Minimal network metadata supplied by a concrete HTTP adapter."""
+
+    peer_ip: str
+    headers: tuple[tuple[str, str], ...] = field(default=(), repr=False)
+
+    def __post_init__(self) -> None:
+        if type(self.peer_ip) is not str or not self.peer_ip or len(self.peer_ip) > 128:
+            raise EdgeClientAttributionError()
+        if type(self.headers) is not tuple or len(self.headers) > 128:
+            raise EdgeClientAttributionError()
+        for item in self.headers:
+            if (
+                type(item) is not tuple
+                or len(item) != 2
+                or type(item[0]) is not str
+                or type(item[1]) is not str
+                or not item[0]
+                or len(item[0]) > 128
+                or len(item[1].encode("utf-8", errors="surrogatepass")) > 8192
+                or any(ord(character) < 32 or ord(character) == 127 for character in item[0])
+            ):
+                raise EdgeClientAttributionError()
+
+
+@dataclass(frozen=True)
+class RateLimitRule:
+    name: str
+    limit: int
+    window: timedelta
+
+    def __post_init__(self) -> None:
+        if type(self.name) is not str or _ROUTE_RE.fullmatch(self.name) is None:
+            raise ValueError("Nome regola rate limit non valido.")
+        if type(self.limit) is not int or not 1 <= self.limit <= 1_000_000:
+            raise ValueError("Limite rate limit non valido.")
+        if not isinstance(self.window, timedelta):
+            raise ValueError("Finestra rate limit non valida.")
+        seconds = self.window.total_seconds()
+        if not seconds.is_integer() or not 1 <= seconds <= 86_400:
+            raise ValueError("Finestra rate limit non valida.")
+
+    @property
+    def window_seconds(self) -> int:
+        return int(self.window.total_seconds())
+
+
+@dataclass(frozen=True)
+class RateLimitBucket:
+    key: str
+    limit: int
+    window_seconds: int
+
+    def __post_init__(self) -> None:
+        if type(self.key) is not str or (
+            not self.key.startswith("global:") and _DIGEST_RE.fullmatch(self.key) is None
+        ):
+            raise ValueError("Chiave bucket non valida.")
+        if type(self.limit) is not int or not 1 <= self.limit <= 1_000_000:
+            raise ValueError("Limite bucket non valido.")
+        if type(self.window_seconds) is not int or not 1 <= self.window_seconds <= 86_400:
+            raise ValueError("Finestra bucket non valida.")
+
+
+class AtomicRateLimitStore(Protocol):
+    """Atomically admit every bucket or increment none of them."""
+
+    def admit(
+        self, buckets: tuple[RateLimitBucket, ...], *, now: datetime
+    ) -> int | None:
+        """Return retry-after seconds when denied, otherwise ``None``."""
+        ...
+
+
+class GoogleLoginStarter(Protocol):
+    def begin_login(self) -> GoogleAuthorizationRequest: ...
+
+
+class TrustedProxyClientResolver:
+    """Resolve one client IP from a direct peer and a trusted XFF chain."""
+
+    def __init__(
+        self,
+        trusted_proxy_cidrs: Sequence[str] = (),
+        *,
+        max_proxy_hops: int = _MAX_PROXY_HOPS,
+        max_forwarded_header_bytes: int = _MAX_FORWARDED_HEADER_BYTES,
+    ) -> None:
+        if type(max_proxy_hops) is not int or not 1 <= max_proxy_hops <= 64:
+            raise ValueError("max_proxy_hops non valido.")
+        if (
+            type(max_forwarded_header_bytes) is not int
+            or not 128 <= max_forwarded_header_bytes <= 65_536
+        ):
+            raise ValueError("max_forwarded_header_bytes non valido.")
+        try:
+            networks = tuple(
+                ipaddress.ip_network(value, strict=True)
+                for value in trusted_proxy_cidrs
+            )
+        except (TypeError, ValueError) as error:
+            raise ValueError("CIDR proxy trusted non valido.") from error
+        self._trusted_networks = networks
+        self.max_proxy_hops = max_proxy_hops
+        self.max_forwarded_header_bytes = max_forwarded_header_bytes
+
+    def resolve(self, request: EdgeRequestMetadata) -> str:
+        if type(request) is not EdgeRequestMetadata:
+            raise EdgeClientAttributionError()
+        peer = self._address(request.peer_ip)
+        if not self._trusted(peer):
+            return peer.compressed
+        forwarded_values: list[str] = []
+        has_standard_forwarded = False
+        for name, value in request.headers:
+            lowered = name.lower()
+            if lowered == "x-forwarded-for":
+                forwarded_values.append(value)
+            elif lowered == "forwarded":
+                has_standard_forwarded = True
+        if has_standard_forwarded or len(forwarded_values) > 1:
+            raise EdgeClientAttributionError()
+        if not forwarded_values:
+            return peer.compressed
+        raw_chain = forwarded_values[0]
+        if len(raw_chain.encode("utf-8", errors="surrogatepass")) > self.max_forwarded_header_bytes:
+            raise EdgeClientAttributionError()
+        parts = raw_chain.split(",")
+        if not 1 <= len(parts) <= self.max_proxy_hops:
+            raise EdgeClientAttributionError()
+        chain = [self._address(part.strip()) for part in parts]
+        chain.append(peer)
+        index = len(chain) - 1
+        while index > 0 and self._trusted(chain[index]):
+            index -= 1
+        return chain[index].compressed
+
+    def _trusted(self, address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+        return any(address in network for network in self._trusted_networks)
+
+    @staticmethod
+    def _address(value: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+        if type(value) is not str or not value or "%" in value:
+            raise EdgeClientAttributionError()
+        try:
+            return ipaddress.ip_address(value)
+        except ValueError:
+            raise EdgeClientAttributionError() from None
+
+
+class InMemoryAtomicRateLimitStore:
+    """Bounded single-process fixed-window store for tests/local deployments."""
+
+    def __init__(self, *, max_counters: int = 10_000) -> None:
+        if type(max_counters) is not int or not 1 <= max_counters <= 1_000_000:
+            raise ValueError("max_counters non valido.")
+        self.max_counters = max_counters
+        self._lock = threading.Lock()
+        self._counters: dict[tuple[str, int, int], int] = {}
+        self._high_water_epoch: float | None = None
+
+    def admit(
+        self, buckets: tuple[RateLimitBucket, ...], *, now: datetime
+    ) -> int | None:
+        validated, epoch = _admission_input(buckets, now)
+        with self._lock:
+            if self._high_water_epoch is not None and epoch < self._high_water_epoch:
+                raise EdgeRateLimitClockRollbackError("Clock rate limit arretrato.")
+            self._high_water_epoch = epoch
+            active: dict[tuple[str, int, int], int] = {}
+            for key, count in self._counters.items():
+                _bucket_key, window_seconds, window_id = key
+                if (window_id + 1) * window_seconds > epoch:
+                    active[key] = count
+            self._counters = active
+            keys = tuple(
+                (bucket.key, bucket.window_seconds, int(epoch // bucket.window_seconds))
+                for bucket in validated
+            )
+            retry_after = _retry_after(validated, keys, self._counters, epoch)
+            if retry_after is not None:
+                return retry_after
+            new_keys = sum(1 for key in keys if key not in self._counters)
+            if len(self._counters) + new_keys > self.max_counters:
+                raise EdgeRateLimitStoreError("Capacità rate limit esaurita.")
+            for key in keys:
+                self._counters[key] = self._counters.get(key, 0) + 1
+            return None
+
+
+class SqliteAtomicRateLimitStore:
+    """Atomic fixed-window store shared by worker processes on one host."""
+
+    def __init__(
+        self,
+        database_path: Path | str,
+        *,
+        busy_timeout_seconds: float = 5.0,
+    ) -> None:
+        if str(database_path) == ":memory:":
+            raise ValueError("SQLite :memory: non supportato per rate limit condiviso.")
+        if not isinstance(busy_timeout_seconds, (int, float)) or not 0.1 <= busy_timeout_seconds <= 30:
+            raise ValueError("busy_timeout_seconds non valido.")
+        self.database_path = Path(database_path)
+        self.busy_timeout_seconds = float(busy_timeout_seconds)
+        try:
+            self.database_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._connect() as connection:
+                connection.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS rate_limit_counters (
+                        bucket_key TEXT NOT NULL,
+                        window_seconds INTEGER NOT NULL,
+                        window_id INTEGER NOT NULL,
+                        request_count INTEGER NOT NULL CHECK (request_count >= 1),
+                        PRIMARY KEY (bucket_key, window_seconds, window_id)
+                    );
+                    CREATE TABLE IF NOT EXISTS rate_limit_metadata (
+                        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                        high_water_epoch REAL NOT NULL
+                    );
+                    """
+                )
+        except (OSError, sqlite3.Error) as error:
+            raise EdgeRateLimitStoreError("Impossibile inizializzare il rate limit.") from error
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(
+            self.database_path,
+            timeout=self.busy_timeout_seconds,
+            isolation_level=None,
+        )
+        connection.execute(f"PRAGMA busy_timeout = {int(self.busy_timeout_seconds * 1000)}")
+        connection.execute("PRAGMA journal_mode = WAL")
+        return connection
+
+    def admit(
+        self, buckets: tuple[RateLimitBucket, ...], *, now: datetime
+    ) -> int | None:
+        validated, epoch = _admission_input(buckets, now)
+        connection: sqlite3.Connection | None = None
+        try:
+            connection = self._connect()
+            connection.execute("BEGIN IMMEDIATE")
+            metadata = connection.execute(
+                "SELECT high_water_epoch FROM rate_limit_metadata WHERE singleton = 1"
+            ).fetchone()
+            if metadata is not None and epoch < float(metadata[0]):
+                raise EdgeRateLimitClockRollbackError("Clock rate limit arretrato.")
+            connection.execute(
+                """
+                INSERT INTO rate_limit_metadata(singleton, high_water_epoch)
+                VALUES (1, ?)
+                ON CONFLICT(singleton) DO UPDATE SET high_water_epoch = excluded.high_water_epoch
+                """,
+                (epoch,),
+            )
+            connection.execute(
+                "DELETE FROM rate_limit_counters WHERE (window_id + 1) * window_seconds <= ?",
+                (epoch,),
+            )
+            keys = tuple(
+                (bucket.key, bucket.window_seconds, int(epoch // bucket.window_seconds))
+                for bucket in validated
+            )
+            counts: dict[tuple[str, int, int], int] = {}
+            for key in keys:
+                row = connection.execute(
+                    """
+                    SELECT request_count FROM rate_limit_counters
+                    WHERE bucket_key = ? AND window_seconds = ? AND window_id = ?
+                    """,
+                    key,
+                ).fetchone()
+                if row is not None:
+                    counts[key] = int(row[0])
+            retry_after = _retry_after(validated, keys, counts, epoch)
+            if retry_after is None:
+                for key in keys:
+                    connection.execute(
+                        """
+                        INSERT INTO rate_limit_counters
+                            (bucket_key, window_seconds, window_id, request_count)
+                        VALUES (?, ?, ?, 1)
+                        ON CONFLICT(bucket_key, window_seconds, window_id)
+                        DO UPDATE SET request_count = request_count + 1
+                        """,
+                        key,
+                    )
+            connection.commit()
+            return retry_after
+        except EdgeRateLimitStoreError:
+            if connection is not None:
+                connection.rollback()
+            raise
+        except (OSError, sqlite3.Error, ValueError, OverflowError) as error:
+            if connection is not None:
+                connection.rollback()
+            raise EdgeRateLimitStoreError("Rate limit non disponibile.") from error
+        finally:
+            if connection is not None:
+                connection.close()
+
+
+class GoogleOidcLoginAdmissionBoundary:
+    """Apply edge admission before allocating an OIDC flow."""
+
+    def __init__(
+        self,
+        login: GoogleLoginStarter,
+        store: AtomicRateLimitStore,
+        resolver: TrustedProxyClientResolver,
+        *,
+        client_key_pepper: bytes,
+        route_id: str = "auth.google.login",
+        global_rule: RateLimitRule = RateLimitRule(
+            "global", 120, timedelta(minutes=1)
+        ),
+        client_rule: RateLimitRule = RateLimitRule(
+            "client", 10, timedelta(minutes=1)
+        ),
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        if _ROUTE_RE.fullmatch(route_id) is None:
+            raise ValueError("route_id non valido.")
+        if type(client_key_pepper) is not bytes or len(client_key_pepper) < 32:
+            raise ValueError("Pepper rate limit non valido.")
+        if type(global_rule) is not RateLimitRule or type(client_rule) is not RateLimitRule:
+            raise ValueError("Regole rate limit non valide.")
+        self.login = login
+        self.store = store
+        self.resolver = resolver
+        self._client_key_pepper = client_key_pepper
+        self.route_id = route_id
+        self.global_rule = global_rule
+        self.client_rule = client_rule
+        self.clock = clock
+
+    def begin_login(self, request: EdgeRequestMetadata) -> GoogleAuthorizationRequest:
+        client_ip = None
+        client_key = None
+        try:
+            client_ip = self.resolver.resolve(request)
+            client_key = "hmac-sha256:" + hmac.new(
+                self._client_key_pepper,
+                (self.route_id + "\0" + client_ip).encode("ascii"),
+                hashlib.sha256,
+            ).hexdigest()
+            now = _utc(self.clock())
+            buckets = (
+                RateLimitBucket(
+                    f"global:{self.route_id}:{self.global_rule.name}",
+                    self.global_rule.limit,
+                    self.global_rule.window_seconds,
+                ),
+                RateLimitBucket(
+                    client_key,
+                    self.client_rule.limit,
+                    self.client_rule.window_seconds,
+                ),
+            )
+            retry_after = self.store.admit(buckets, now=now)
+        except EdgeClientAttributionError:
+            raise
+        except Exception:
+            raise EdgeRateLimitUnavailableError() from None
+        finally:
+            request = None
+            client_ip = None
+            client_key = None
+        if retry_after is not None:
+            if type(retry_after) is not int or retry_after < 1:
+                raise EdgeRateLimitUnavailableError()
+            raise EdgeRateLimitExceededError(retry_after)
+        try:
+            result = self.login.begin_login()
+        except Exception:
+            raise
+        if type(result) is not GoogleAuthorizationRequest:
+            raise EdgeRateLimitUnavailableError()
+        return result
+
+
+def _utc(value: datetime) -> datetime:
+    if type(value) is not datetime or value.tzinfo is None or value.utcoffset() is None:
+        raise EdgeRateLimitStoreError("Clock rate limit non valido.")
+    return value.astimezone(timezone.utc)
+
+
+def _admission_input(
+    buckets: tuple[RateLimitBucket, ...], now: datetime
+) -> tuple[tuple[RateLimitBucket, ...], float]:
+    if (
+        type(buckets) is not tuple
+        or not 1 <= len(buckets) <= _MAX_BUCKETS_PER_ADMISSION
+        or any(type(bucket) is not RateLimitBucket for bucket in buckets)
+        or len({(bucket.key, bucket.window_seconds) for bucket in buckets}) != len(buckets)
+    ):
+        raise EdgeRateLimitStoreError("Bucket rate limit non validi.")
+    current = _utc(now)
+    try:
+        epoch = current.timestamp()
+    except (OSError, OverflowError, ValueError) as error:
+        raise EdgeRateLimitStoreError("Clock rate limit non valido.") from error
+    if not math.isfinite(epoch) or epoch < 0:
+        raise EdgeRateLimitStoreError("Clock rate limit non valido.")
+    return buckets, epoch
+
+
+def _retry_after(
+    buckets: tuple[RateLimitBucket, ...],
+    keys: tuple[tuple[str, int, int], ...],
+    counts: Mapping[tuple[str, int, int], int],
+    epoch: float,
+) -> int | None:
+    waits = []
+    for bucket, key in zip(buckets, keys):
+        count = counts.get(key, 0)
+        if type(count) is not int or count < 0:
+            raise EdgeRateLimitStoreError("Contatore rate limit corrotto.")
+        if count >= bucket.limit:
+            window_end = (key[2] + 1) * bucket.window_seconds
+            waits.append(max(1, math.ceil(window_end - epoch)))
+    return None if not waits else max(waits)

--- a/scripts/thebitlab_edge_rate_limit.py
+++ b/scripts/thebitlab_edge_rate_limit.py
@@ -68,10 +68,6 @@ class EdgeRateLimitStoreError(RuntimeError):
     """Raised when an atomic admission store cannot decide safely."""
 
 
-class EdgeRateLimitClockRollbackError(EdgeRateLimitStoreError):
-    """Raised when a store observes time moving behind its high-water mark."""
-
-
 @dataclass(frozen=True)
 class EdgeRequestMetadata:
     """Minimal network metadata supplied by a concrete HTTP adapter."""
@@ -218,7 +214,12 @@ class TrustedProxyClientResolver:
         if type(value) is not str or not value or "%" in value:
             raise EdgeClientAttributionError()
         try:
-            return ipaddress.ip_address(value)
+            address = ipaddress.ip_address(value)
+            if isinstance(address, ipaddress.IPv6Address):
+                mapped = address.ipv4_mapped
+                if mapped is not None:
+                    return mapped
+            return address
         except ValueError:
             raise EdgeClientAttributionError() from None
 
@@ -239,8 +240,8 @@ class InMemoryAtomicRateLimitStore:
     ) -> int | None:
         validated, epoch = _admission_input(buckets, now)
         with self._lock:
-            if self._high_water_epoch is not None and epoch < self._high_water_epoch:
-                raise EdgeRateLimitClockRollbackError("Clock rate limit arretrato.")
+            if self._high_water_epoch is not None:
+                epoch = max(epoch, self._high_water_epoch)
             self._high_water_epoch = epoch
             active: dict[tuple[str, int, int], int] = {}
             for key, count in self._counters.items():
@@ -271,13 +272,17 @@ class SqliteAtomicRateLimitStore:
         database_path: Path | str,
         *,
         busy_timeout_seconds: float = 5.0,
+        max_counters: int = 10_000,
     ) -> None:
         if str(database_path) == ":memory:":
             raise ValueError("SQLite :memory: non supportato per rate limit condiviso.")
         if not isinstance(busy_timeout_seconds, (int, float)) or not 0.1 <= busy_timeout_seconds <= 30:
             raise ValueError("busy_timeout_seconds non valido.")
+        if type(max_counters) is not int or not 1 <= max_counters <= 1_000_000:
+            raise ValueError("max_counters non valido.")
         self.database_path = Path(database_path)
         self.busy_timeout_seconds = float(busy_timeout_seconds)
+        self.max_counters = max_counters
         try:
             self.database_path.parent.mkdir(parents=True, exist_ok=True)
             with self._connect() as connection:
@@ -320,8 +325,8 @@ class SqliteAtomicRateLimitStore:
             metadata = connection.execute(
                 "SELECT high_water_epoch FROM rate_limit_metadata WHERE singleton = 1"
             ).fetchone()
-            if metadata is not None and epoch < float(metadata[0]):
-                raise EdgeRateLimitClockRollbackError("Clock rate limit arretrato.")
+            if metadata is not None:
+                epoch = max(epoch, float(metadata[0]))
             connection.execute(
                 """
                 INSERT INTO rate_limit_metadata(singleton, high_water_epoch)
@@ -351,6 +356,16 @@ class SqliteAtomicRateLimitStore:
                     counts[key] = int(row[0])
             retry_after = _retry_after(validated, keys, counts, epoch)
             if retry_after is None:
+                total_counters = int(
+                    connection.execute(
+                        "SELECT COUNT(*) FROM rate_limit_counters"
+                    ).fetchone()[0]
+                )
+                new_counters = sum(1 for key in keys if key not in counts)
+                if total_counters + new_counters > self.max_counters:
+                    raise EdgeRateLimitStoreError(
+                        "Capacità rate limit esaurita."
+                    )
                 for key in keys:
                     connection.execute(
                         """

--- a/tests/test_thebitlab_edge_rate_limit.py
+++ b/tests/test_thebitlab_edge_rate_limit.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.thebitlab_edge_rate_limit import (
+    EdgeClientAttributionError,
+    EdgeRateLimitClockRollbackError,
+    EdgeRateLimitExceededError,
+    EdgeRateLimitStoreError,
+    EdgeRateLimitUnavailableError,
+    EdgeRequestMetadata,
+    GoogleOidcLoginAdmissionBoundary,
+    InMemoryAtomicRateLimitStore,
+    RateLimitBucket,
+    RateLimitRule,
+    SqliteAtomicRateLimitStore,
+    TrustedProxyClientResolver,
+)
+from scripts.thebitlab_google_oidc import GoogleAuthorizationRequest
+
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+PEPPER = b"r" * 32
+
+
+class MutableClock:
+    def __init__(self, value=NOW):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+
+class FakeLogin:
+    def __init__(self, *, capacity=100):
+        self.capacity = capacity
+        self.calls = 0
+
+    def begin_login(self):
+        if self.calls >= self.capacity:
+            raise RuntimeError("flow capacity exhausted")
+        self.calls += 1
+        return GoogleAuthorizationRequest(
+            f"https://accounts.google.com/o/oauth2/v2/auth?request={self.calls}",
+            f"__Host-thebitlab_oidc_txn-{self.calls}=secret; Secure; HttpOnly; Path=/",
+        )
+
+
+def request(peer, *headers):
+    return EdgeRequestMetadata(peer, tuple(headers))
+
+
+def rules(*, global_limit=5, client_limit=2, seconds=60):
+    return (
+        RateLimitRule("global", global_limit, timedelta(seconds=seconds)),
+        RateLimitRule("client", client_limit, timedelta(seconds=seconds)),
+    )
+
+
+def boundary(
+    login,
+    store,
+    clock,
+    *,
+    resolver=None,
+    global_limit=5,
+    client_limit=2,
+    seconds=60,
+):
+    global_rule, client_rule = rules(
+        global_limit=global_limit,
+        client_limit=client_limit,
+        seconds=seconds,
+    )
+    return GoogleOidcLoginAdmissionBoundary(
+        login,
+        store,
+        resolver or TrustedProxyClientResolver(),
+        client_key_pepper=PEPPER,
+        global_rule=global_rule,
+        client_rule=client_rule,
+        clock=clock,
+    )
+
+
+def test_untrusted_peer_cannot_spoof_forwarded_address() -> None:
+    resolver = TrustedProxyClientResolver(("10.0.0.0/8",))
+    metadata = request(
+        "203.0.113.7",
+        ("X-Forwarded-For", "198.51.100.9, definitely-not-an-ip"),
+        ("Forwarded", "for=198.51.100.20"),
+    )
+
+    assert resolver.resolve(metadata) == "203.0.113.7"
+
+
+def test_trusted_proxy_walks_chain_from_the_right() -> None:
+    resolver = TrustedProxyClientResolver(("10.0.0.0/8", "192.0.2.0/24"))
+    metadata = request(
+        "10.0.0.5",
+        ("X-Forwarded-For", "198.51.100.8, 192.0.2.20"),
+    )
+
+    assert resolver.resolve(metadata) == "198.51.100.8"
+
+
+def test_trusted_proxy_rejects_ambiguous_or_malformed_forwarding() -> None:
+    resolver = TrustedProxyClientResolver(("10.0.0.0/8",), max_proxy_hops=2)
+    bad_requests = (
+        request("10.0.0.5", ("X-Forwarded-For", "198.51.100.1"), ("X-Forwarded-For", "198.51.100.2")),
+        request("10.0.0.5", ("X-Forwarded-For", "198.51.100.1"), ("Forwarded", "for=198.51.100.1")),
+        request("10.0.0.5", ("X-Forwarded-For", "198.51.100.1,,192.0.2.1")),
+        request("10.0.0.5", ("X-Forwarded-For", "198.51.100.1,192.0.2.1,203.0.113.1")),
+        request("10.0.0.5", ("X-Forwarded-For", "198.51.100.1:443")),
+    )
+    for metadata in bad_requests:
+        with pytest.raises(EdgeClientAttributionError):
+            resolver.resolve(metadata)
+
+
+def test_resolver_canonicalizes_ipv6_and_rejects_zone_ids() -> None:
+    resolver = TrustedProxyClientResolver()
+    assert resolver.resolve(request("2001:0db8:0:0::1")) == "2001:db8::1"
+    with pytest.raises(EdgeClientAttributionError):
+        resolver.resolve(request("fe80::1%eth0"))
+
+
+def test_edge_request_metadata_is_bounded_and_hides_headers_from_repr() -> None:
+    metadata = request("127.0.0.1", ("Cookie", "raw-secret"))
+    assert "raw-secret" not in repr(metadata)
+    with pytest.raises(EdgeClientAttributionError):
+        EdgeRequestMetadata("127.0.0.1", (("X" * 129, "value"),))
+
+
+def test_memory_store_admits_all_buckets_or_increments_none() -> None:
+    store = InMemoryAtomicRateLimitStore()
+    global_bucket = RateLimitBucket("global:test:global", 2, 60)
+    client_a = RateLimitBucket("hmac-sha256:" + "a" * 64, 1, 60)
+    client_b = RateLimitBucket("hmac-sha256:" + "b" * 64, 1, 60)
+    client_c = RateLimitBucket("hmac-sha256:" + "c" * 64, 1, 60)
+
+    assert store.admit((global_bucket, client_a), now=NOW) is None
+    assert store.admit((global_bucket, client_a), now=NOW) == 60
+    assert store.admit((global_bucket, client_b), now=NOW) is None
+    assert store.admit((global_bucket, client_c), now=NOW) == 60
+
+
+def test_memory_store_retry_after_and_window_boundary() -> None:
+    store = InMemoryAtomicRateLimitStore()
+    bucket = RateLimitBucket("global:test:global", 1, 60)
+    assert store.admit((bucket,), now=NOW + timedelta(seconds=10)) is None
+    assert store.admit((bucket,), now=NOW + timedelta(seconds=30)) == 30
+    assert store.admit((bucket,), now=NOW + timedelta(seconds=60)) is None
+
+
+def test_memory_store_clock_rollback_fails_closed() -> None:
+    store = InMemoryAtomicRateLimitStore()
+    bucket = RateLimitBucket("global:test:global", 2, 60)
+    assert store.admit((bucket,), now=NOW + timedelta(seconds=1)) is None
+    with pytest.raises(EdgeRateLimitClockRollbackError):
+        store.admit((bucket,), now=NOW)
+
+
+def test_memory_store_capacity_is_bounded() -> None:
+    store = InMemoryAtomicRateLimitStore(max_counters=1)
+    first = RateLimitBucket("global:test:first", 2, 60)
+    second = RateLimitBucket("global:test:second", 2, 60)
+    assert store.admit((first,), now=NOW) is None
+    with pytest.raises(EdgeRateLimitStoreError):
+        store.admit((second,), now=NOW)
+    assert store.admit((first,), now=NOW) is None
+
+
+def test_sqlite_store_is_atomic_across_concurrent_workers(tmp_path) -> None:
+    store = SqliteAtomicRateLimitStore(tmp_path / "rate-limit.sqlite3")
+    buckets = (
+        RateLimitBucket("global:test:global", 7, 60),
+        RateLimitBucket("hmac-sha256:" + "d" * 64, 7, 60),
+    )
+
+    def admit_once(_index):
+        return store.admit(buckets, now=NOW)
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        outcomes = list(executor.map(admit_once, range(50)))
+
+    assert outcomes.count(None) == 7
+    assert outcomes.count(60) == 43
+
+
+def test_sqlite_store_persists_limits_and_clock_high_water(tmp_path) -> None:
+    path = tmp_path / "rate-limit.sqlite3"
+    bucket = RateLimitBucket("global:test:global", 1, 60)
+    first = SqliteAtomicRateLimitStore(path)
+    assert first.admit((bucket,), now=NOW) is None
+    second = SqliteAtomicRateLimitStore(path)
+    assert second.admit((bucket,), now=NOW) == 60
+    with pytest.raises(EdgeRateLimitClockRollbackError):
+        second.admit((bucket,), now=NOW - timedelta(microseconds=1))
+
+
+def test_sqlite_store_does_not_persist_raw_client_addresses(tmp_path) -> None:
+    path = tmp_path / "rate-limit.sqlite3"
+    login = FakeLogin()
+    clock = MutableClock()
+    protected = boundary(login, SqliteAtomicRateLimitStore(path), clock)
+
+    protected.begin_login(request("203.0.113.77"))
+
+    with sqlite3.connect(path) as connection:
+        rows = connection.execute(
+            "SELECT bucket_key FROM rate_limit_counters"
+        ).fetchall()
+    serialized = repr(rows)
+    assert "203.0.113.77" not in serialized
+    assert "hmac-sha256:" in serialized
+
+
+def test_public_login_limit_runs_before_flow_allocation() -> None:
+    login = FakeLogin(capacity=4)
+    clock = MutableClock()
+    protected = boundary(
+        login,
+        InMemoryAtomicRateLimitStore(),
+        clock,
+        global_limit=3,
+        client_limit=2,
+    )
+
+    outcomes = []
+    for _attempt in range(100):
+        try:
+            protected.begin_login(request("203.0.113.9"))
+            outcomes.append("allowed")
+        except EdgeRateLimitExceededError:
+            outcomes.append("limited")
+
+    assert outcomes.count("allowed") == 2
+    assert outcomes.count("limited") == 98
+    assert login.calls == 2
+    assert login.calls < login.capacity
+
+
+def test_global_limit_applies_across_distinct_clients() -> None:
+    login = FakeLogin()
+    protected = boundary(
+        login,
+        InMemoryAtomicRateLimitStore(),
+        MutableClock(),
+        global_limit=2,
+        client_limit=2,
+    )
+
+    protected.begin_login(request("203.0.113.1"))
+    protected.begin_login(request("203.0.113.2"))
+    with pytest.raises(EdgeRateLimitExceededError):
+        protected.begin_login(request("203.0.113.3"))
+    assert login.calls == 2
+
+
+def test_rate_limit_error_has_stable_429_and_retry_headers() -> None:
+    login = FakeLogin()
+    protected = boundary(
+        login,
+        InMemoryAtomicRateLimitStore(),
+        MutableClock(NOW + timedelta(seconds=10)),
+        global_limit=1,
+        client_limit=1,
+    )
+    protected.begin_login(request("203.0.113.1"))
+
+    with pytest.raises(EdgeRateLimitExceededError) as captured:
+        protected.begin_login(request("203.0.113.1"))
+
+    assert captured.value.status_code == 429
+    assert captured.value.error_code == "rate_limit_exceeded"
+    assert captured.value.response_headers == (
+        ("Retry-After", "50"),
+        ("Cache-Control", "no-store"),
+    )
+    assert "203.0.113.1" not in str(captured.value)
+
+
+def test_trusted_proxy_clients_receive_independent_buckets() -> None:
+    login = FakeLogin()
+    resolver = TrustedProxyClientResolver(("10.0.0.0/8",))
+    protected = boundary(
+        login,
+        InMemoryAtomicRateLimitStore(),
+        MutableClock(),
+        resolver=resolver,
+        client_limit=1,
+    )
+
+    protected.begin_login(
+        request("10.0.0.5", ("X-Forwarded-For", "198.51.100.1"))
+    )
+    protected.begin_login(
+        request("10.0.0.5", ("X-Forwarded-For", "198.51.100.2"))
+    )
+    with pytest.raises(EdgeRateLimitExceededError):
+        protected.begin_login(
+            request("10.0.0.5", ("X-Forwarded-For", "198.51.100.1"))
+        )
+    assert login.calls == 2
+
+
+def test_invalid_forwarding_does_not_allocate_flow() -> None:
+    login = FakeLogin()
+    protected = boundary(
+        login,
+        InMemoryAtomicRateLimitStore(),
+        MutableClock(),
+        resolver=TrustedProxyClientResolver(("10.0.0.0/8",)),
+    )
+
+    with pytest.raises(EdgeClientAttributionError) as captured:
+        protected.begin_login(
+            request("10.0.0.5", ("X-Forwarded-For", "raw-secret-address"))
+        )
+    assert captured.value.status_code == 400
+    assert "raw-secret-address" not in str(captured.value)
+    assert login.calls == 0
+
+
+def test_store_failure_and_malformed_results_fail_closed() -> None:
+    class BrokenStore:
+        def admit(self, _buckets, *, now):
+            raise RuntimeError("raw backend details")
+
+    class MalformedStore:
+        def admit(self, _buckets, *, now):
+            return "allow"
+
+    login = FakeLogin()
+    for store in (BrokenStore(), MalformedStore()):
+        protected = boundary(login, store, MutableClock())
+        with pytest.raises(EdgeRateLimitUnavailableError) as captured:
+            protected.begin_login(request("203.0.113.1"))
+        assert "raw backend" not in str(captured.value)
+    assert login.calls == 0
+
+
+def test_malformed_login_adapter_result_fails_closed() -> None:
+    class MalformedLogin:
+        def begin_login(self):
+            return "https://attacker.test"
+
+    protected = boundary(
+        MalformedLogin(), InMemoryAtomicRateLimitStore(), MutableClock()
+    )
+    with pytest.raises(EdgeRateLimitUnavailableError):
+        protected.begin_login(request("203.0.113.1"))
+
+
+def test_rule_and_store_configuration_validation(tmp_path) -> None:
+    with pytest.raises(ValueError):
+        RateLimitRule("bad name", 1, timedelta(seconds=60))
+    with pytest.raises(ValueError):
+        RateLimitRule("valid", 0, timedelta(seconds=60))
+    with pytest.raises(ValueError):
+        RateLimitRule("valid", 1, timedelta(milliseconds=1))
+    with pytest.raises(ValueError):
+        SqliteAtomicRateLimitStore(":memory:")
+    with pytest.raises(ValueError):
+        GoogleOidcLoginAdmissionBoundary(
+            FakeLogin(),
+            InMemoryAtomicRateLimitStore(),
+            TrustedProxyClientResolver(),
+            client_key_pepper=b"short",
+        )

--- a/tests/test_thebitlab_edge_rate_limit.py
+++ b/tests/test_thebitlab_edge_rate_limit.py
@@ -122,7 +122,9 @@ def test_trusted_proxy_rejects_ambiguous_or_malformed_forwarding() -> None:
 
 
 def test_resolver_canonicalizes_ipv6_mapped_ipv4_and_rejects_zone_ids() -> None:
-    resolver = TrustedProxyClientResolver(("10.0.0.0/8",))
+    resolver = TrustedProxyClientResolver(
+        ("10.0.0.0/8", "::ffff:10.0.0.0/104")
+    )
     assert resolver.resolve(request("2001:0db8:0:0::1")) == "2001:db8::1"
     assert resolver.resolve(request("::ffff:203.0.113.7")) == "203.0.113.7"
     assert resolver.resolve(
@@ -131,6 +133,13 @@ def test_resolver_canonicalizes_ipv6_mapped_ipv4_and_rejects_zone_ids() -> None:
             ("X-Forwarded-For", "::ffff:198.51.100.8"),
         )
     ) == "198.51.100.8"
+    mapped_only = TrustedProxyClientResolver(("::ffff:10.0.0.0/104",))
+    assert mapped_only.resolve(
+        request(
+            "::ffff:10.0.0.5",
+            ("X-Forwarded-For", "198.51.100.9"),
+        )
+    ) == "198.51.100.9"
     with pytest.raises(EdgeClientAttributionError):
         resolver.resolve(request("fe80::1%eth0"))
 
@@ -382,6 +391,8 @@ def test_malformed_login_adapter_result_fails_closed() -> None:
 
 
 def test_rule_and_store_configuration_validation(tmp_path) -> None:
+    with pytest.raises(ValueError):
+        TrustedProxyClientResolver(("::fffe:0:0/95",))
     with pytest.raises(ValueError):
         RateLimitRule("bad name", 1, timedelta(seconds=60))
     with pytest.raises(ValueError):

--- a/tests/test_thebitlab_edge_rate_limit.py
+++ b/tests/test_thebitlab_edge_rate_limit.py
@@ -8,7 +8,6 @@ import pytest
 
 from scripts.thebitlab_edge_rate_limit import (
     EdgeClientAttributionError,
-    EdgeRateLimitClockRollbackError,
     EdgeRateLimitExceededError,
     EdgeRateLimitStoreError,
     EdgeRateLimitUnavailableError,
@@ -122,9 +121,16 @@ def test_trusted_proxy_rejects_ambiguous_or_malformed_forwarding() -> None:
             resolver.resolve(metadata)
 
 
-def test_resolver_canonicalizes_ipv6_and_rejects_zone_ids() -> None:
-    resolver = TrustedProxyClientResolver()
+def test_resolver_canonicalizes_ipv6_mapped_ipv4_and_rejects_zone_ids() -> None:
+    resolver = TrustedProxyClientResolver(("10.0.0.0/8",))
     assert resolver.resolve(request("2001:0db8:0:0::1")) == "2001:db8::1"
+    assert resolver.resolve(request("::ffff:203.0.113.7")) == "203.0.113.7"
+    assert resolver.resolve(
+        request(
+            "::ffff:10.0.0.5",
+            ("X-Forwarded-For", "::ffff:198.51.100.8"),
+        )
+    ) == "198.51.100.8"
     with pytest.raises(EdgeClientAttributionError):
         resolver.resolve(request("fe80::1%eth0"))
 
@@ -157,12 +163,13 @@ def test_memory_store_retry_after_and_window_boundary() -> None:
     assert store.admit((bucket,), now=NOW + timedelta(seconds=60)) is None
 
 
-def test_memory_store_clock_rollback_fails_closed() -> None:
+def test_memory_store_clamps_out_of_order_and_rollback_timestamps() -> None:
     store = InMemoryAtomicRateLimitStore()
     bucket = RateLimitBucket("global:test:global", 2, 60)
-    assert store.admit((bucket,), now=NOW + timedelta(seconds=1)) is None
-    with pytest.raises(EdgeRateLimitClockRollbackError):
-        store.admit((bucket,), now=NOW)
+    later = NOW + timedelta(seconds=1)
+    assert store.admit((bucket,), now=later) is None
+    assert store.admit((bucket,), now=NOW) is None
+    assert store.admit((bucket,), now=NOW) == 59
 
 
 def test_memory_store_capacity_is_bounded() -> None:
@@ -192,15 +199,32 @@ def test_sqlite_store_is_atomic_across_concurrent_workers(tmp_path) -> None:
     assert outcomes.count(60) == 43
 
 
-def test_sqlite_store_persists_limits_and_clock_high_water(tmp_path) -> None:
+def test_sqlite_store_persists_limits_and_clamps_clock_high_water(tmp_path) -> None:
     path = tmp_path / "rate-limit.sqlite3"
     bucket = RateLimitBucket("global:test:global", 1, 60)
     first = SqliteAtomicRateLimitStore(path)
-    assert first.admit((bucket,), now=NOW) is None
+    later = NOW + timedelta(seconds=1)
+    assert first.admit((bucket,), now=later) is None
     second = SqliteAtomicRateLimitStore(path)
-    assert second.admit((bucket,), now=NOW) == 60
-    with pytest.raises(EdgeRateLimitClockRollbackError):
-        second.admit((bucket,), now=NOW - timedelta(microseconds=1))
+    assert second.admit((bucket,), now=NOW) == 59
+    assert second.admit((bucket,), now=NOW - timedelta(days=1)) == 59
+
+
+def test_sqlite_store_capacity_is_bounded(tmp_path) -> None:
+    store = SqliteAtomicRateLimitStore(
+        tmp_path / "bounded.sqlite3", max_counters=2
+    )
+    first = RateLimitBucket("global:test:first", 2, 60)
+    second = RateLimitBucket("global:test:second", 2, 60)
+    third = RateLimitBucket("global:test:third", 2, 60)
+    assert store.admit((first, second), now=NOW) is None
+    with pytest.raises(EdgeRateLimitStoreError):
+        store.admit((third,), now=NOW)
+    assert store.admit((first,), now=NOW) is None
+    with sqlite3.connect(store.database_path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM rate_limit_counters"
+        ).fetchone()[0] == 2
 
 
 def test_sqlite_store_does_not_persist_raw_client_addresses(tmp_path) -> None:
@@ -366,6 +390,8 @@ def test_rule_and_store_configuration_validation(tmp_path) -> None:
         RateLimitRule("valid", 1, timedelta(milliseconds=1))
     with pytest.raises(ValueError):
         SqliteAtomicRateLimitStore(":memory:")
+    with pytest.raises(ValueError):
+        SqliteAtomicRateLimitStore(tmp_path / "rate.sqlite3", max_counters=0)
     with pytest.raises(ValueError):
         GoogleOidcLoginAdmissionBoundary(
             FakeLogin(),


### PR DESCRIPTION
## Summary

Implements #549.

- resolves client IPs from the direct peer and bounded `X-Forwarded-For` chains only when the peer is in an explicit trusted CIDR;
- applies global and HMAC-pseudonymized per-client fixed-window limits atomically before `GoogleOidcLoginService.begin_login()`;
- provides bounded in-memory and multi-process SQLite stores behind a replaceable atomic store port;
- fails closed on clock rollback, malformed forwarding, storage errors, malformed adapter results, and capacity exhaustion;
- exposes stable sanitized 400/429/503 errors, including bounded `Retry-After` and `Cache-Control: no-store` for 429;
- proves denied floods do not allocate OIDC flows and concurrent workers cannot exceed the configured limit;
- documents reverse-proxy trust, privacy, single-host/multi-host deployment boundaries, and concrete route ordering.

## Validation

- targeted edge/OIDC/HTTP/auth/SQLite suite: 185 passed;
- full required CI green on Linux/Windows, Python 3.11–3.13, minimum Python, Docker and Windows filesystem;
- `py_compile` and `git diff --check` clean;
- independent review rounds 3 and 4 at `cc3b814`: `Nessun finding`.

## Out of scope

Concrete `BaseHTTPRequestHandler` wiring and HTTP 302 serialization, callback/GitHub/pairing-specific limits, a concrete multi-host store, TLS and browser E2E remain follow-ups.

Closes #549
