### PR TITLE
Launch student environment from TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,11 @@ richiede un riavvio e riapre il launcher al nuovo accesso. Al primo utilizzo
 resta necessario confermare soltanto le finestre di sicurezza e licenza
 mostrate direttamente da Windows.
 
-Dopo la preparazione, dalla cartella del progetto esegui:
+Dopo la preparazione, su Windows apri **Ambiente 2cornot2c** e scegli
+**Avvia l'ambiente**. La console Ubuntu viene aperta automaticamente senza
+mostrare comandi Python.
+
+Su macOS, dalla cartella del progetto esegui:
 
 ```bash
 python3 scripts/student_dev_shell.py

--- a/installer/README.md
+++ b/installer/README.md
@@ -135,10 +135,9 @@ cd ~/2cornot2c
 
 Su Windows:
 
-```powershell
-cd "$HOME\2cornot2c"
-& .installer-venv\Scripts\python.exe scripts\student_dev_shell.py
-```
+apri **Ambiente 2cornot2c** dal desktop o dal menu Start e scegli
+**Avvia l'ambiente**. Il launcher usa automaticamente Docker o VirtualBox in
+base all'ultima installazione completata.
 
 ## Aggiornamento e disinstallazione Windows
 

--- a/installer/lifecycle.py
+++ b/installer/lifecycle.py
@@ -8,6 +8,7 @@ import subprocess
 
 
 WINDOWS_ACTION_SCRIPTS = {
+    "launch": "launch-classroom-windows.ps1",
     "update": "update-classroom-windows.ps1",
     "uninstall": "uninstall-classroom-windows.ps1",
 }

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -66,6 +66,7 @@ class State:
 
 
 ACTION_LABELS = (
+    "Avvia l'ambiente",
     "Installa, completa o ripara",
     "Aggiorna l'ambiente",
     "Disinstalla l'ambiente",
@@ -322,17 +323,24 @@ def open_home_action(state: State) -> None:
     """Apre la funzione selezionata oppure ne richiede conferma."""
 
     if state.action_index == 0:
+        try:
+            launch_windows_action("launch")
+            state.running = False
+        except Exception as error:
+            message = for_check("installer", str(error))
+            state.report = message.lines(str(error))
+    elif state.action_index == 1:
         state.screen = "providers"
         state.confirmation_pending = False
         state.report = ("Premi Invio per eseguire la diagnosi.",)
-    elif state.action_index == 1:
+    elif state.action_index == 2:
         state.confirmation_pending = True
         state.report = (
             "Aggiornamento dell'ambiente",
             "Gli esercizi e le impostazioni personali saranno conservati.",
             "Premi s per continuare oppure n per annullare.",
         )
-    elif state.action_index == 2:
+    elif state.action_index == 3:
         state.confirmation_pending = True
         state.report = (
             "Disinstallazione protetta",
@@ -347,7 +355,7 @@ def open_home_action(state: State) -> None:
 def confirm_home_action(state: State) -> None:
     """Passa l'operazione a una console separata e termina la TUI."""
 
-    action = "update" if state.action_index == 1 else "uninstall"
+    action = "update" if state.action_index == 2 else "uninstall"
     launch_windows_action(action)
     state.confirmation_pending = False
     state.running = False
@@ -389,10 +397,21 @@ def _format_results(
         and all(result.status in {"skipped", "succeeded"} for result in results)
     ):
         formatted += (
-            "Pronto. Esci con q, poi avvia:",
-            "python scripts/student_dev_shell.py",
+            "Pronto.",
+            "Premi m e scegli Avvia l'ambiente.",
         )
     return formatted
+
+
+def _remember_provider(provider: Provider) -> None:
+    """Salva la scelta che il launcher userà al prossimo avvio."""
+
+    state_dir = Path.home() / ".2cornot2c"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    temporary = state_dir / "selected-provider.txt.tmp"
+    destination = state_dir / "selected-provider.txt"
+    temporary.write_text(provider.value, encoding="utf-8")
+    temporary.replace(destination)
 
 
 def apply_selected(state: State) -> None:
@@ -406,6 +425,10 @@ def apply_selected(state: State) -> None:
         log_path=Path.home() / ".2cornot2c" / "installer.jsonl",
     )
     state.confirmation_pending = False
+    if results and all(
+        result.status in {"skipped", "succeeded"} for result in results
+    ):
+        _remember_provider(provider)
     state.report = _format_results(provider, results)
 
 
@@ -548,6 +571,11 @@ def poll_installation(state: State) -> bool:
                 state.install_completed = index
         elif kind == "result":
             provider = state.providers[state.active_index]
+            if payload and all(
+                result.status in {"skipped", "succeeded"}
+                for result in payload
+            ):
+                _remember_provider(provider)
             state.report = _format_results(provider, payload)
             state.installing = False
             state.install_thread = None

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -89,6 +89,7 @@ function Install-ClassroomLauncher {
     New-Item -ItemType Directory -Force -Path $LauncherDir | Out-Null
     foreach ($ScriptName in @(
         "manage-classroom-windows.ps1"
+        "launch-classroom-windows.ps1"
         "prepare-wsl-windows.ps1"
         "remove-wsl-windows.ps1"
         "update-classroom-windows.ps1"

--- a/scripts/launch-classroom-windows.ps1
+++ b/scripts/launch-classroom-windows.ps1
@@ -1,0 +1,53 @@
+$ErrorActionPreference = "Stop"
+
+$StateDir = Join-Path $HOME ".2cornot2c"
+$StatePath = Join-Path $StateDir "bootstrap-state.json"
+$ProviderPath = Join-Path $StateDir "selected-provider.txt"
+$InstallDir = Join-Path $HOME "2cornot2c"
+if (Test-Path $StatePath) {
+    try {
+        $SavedInstallDir = [string](
+            Get-Content $StatePath -Raw | ConvertFrom-Json
+        ).install_dir
+        if ($SavedInstallDir) {
+            $InstallDir = $SavedInstallDir
+        }
+    } catch {
+        Write-Warning "Configurazione precedente non leggibile."
+    }
+}
+
+if (-not (Test-Path $ProviderPath)) {
+    Write-Host "AMBIENTE NON ANCORA PRONTO" -ForegroundColor Yellow
+    Write-Host (
+        "Apri Ambiente 2cornot2c e scegli Installa, completa o ripara."
+    ) -ForegroundColor Yellow
+    Read-Host "Premi Invio per chiudere"
+    exit 1
+}
+
+$Provider = (Get-Content $ProviderPath -Raw).Trim()
+Push-Location $InstallDir
+try {
+    if ($Provider -eq "docker") {
+        $Python = Join-Path $InstallDir ".installer-venv\Scripts\python.exe"
+        & $Python (Join-Path $InstallDir "scripts\student_dev_shell.py")
+        exit $LASTEXITCODE
+    }
+    if ($Provider -eq "virtualbox") {
+        & vagrant up --provider=virtualbox
+        exit $LASTEXITCODE
+    }
+    Write-Host "ERRORE E31 - Ambiente da avviare non riconosciuto" `
+        -ForegroundColor Red
+    Write-Host "COSA SIGNIFICA" -ForegroundColor Yellow
+    Write-Host "La configurazione salvata non è valida." -ForegroundColor Yellow
+    Write-Host "COSA DEVI FARE" -ForegroundColor Yellow
+    Write-Host (
+        "Apri Ambiente 2cornot2c e scegli Installa, completa o ripara."
+    ) -ForegroundColor Yellow
+    Read-Host "Premi Invio per chiudere"
+    exit 1
+} finally {
+    Pop-Location
+}

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -125,6 +125,7 @@ def test_tui_home_exposes_the_complete_lifecycle() -> None:
     rendered = "\n".join(frame(state, 150, 14, color=False))
 
     assert "Gestisci ambiente 2cornot2c" in rendered
+    assert "Avvia l'ambiente" in rendered
     assert "Installa, completa o ripara" in rendered
     assert "Aggiorna l'ambiente" in rendered
     assert "Disinstalla l'ambiente" in rendered
@@ -149,7 +150,7 @@ def test_tui_uninstall_requires_confirmation_and_launches_separately(
         Host.WINDOWS_AMD64,
         (Provider.DOCKER,),
         screen="home",
-        action_index=2,
+        action_index=3,
     )
 
     open_home_action(state)
@@ -185,6 +186,43 @@ def test_windows_lifecycle_uses_only_persistent_known_scripts(
     assert command[-1] == "-ConfirmedFromTui"
     with pytest.raises(ValueError, match="non supportata"):
         powershell_action_command("qualcosa")
+
+
+def test_tui_launches_environment_without_showing_python_commands(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("utui")
+    from installer.tui import State, open_home_action
+
+    launched = []
+    monkeypatch.setattr(
+        "installer.tui.launch_windows_action",
+        lambda action: launched.append(action),
+    )
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER,),
+        screen="home",
+        action_index=0,
+    )
+
+    open_home_action(state)
+
+    assert launched == ["launch"]
+    assert state.running is False
+
+
+def test_successful_installation_remembers_provider(monkeypatch, tmp_path) -> None:
+    pytest.importorskip("utui")
+    from installer.tui import _remember_provider
+
+    monkeypatch.setattr("installer.tui.Path.home", lambda: tmp_path)
+
+    _remember_provider(Provider.DOCKER)
+
+    assert (
+        tmp_path / ".2cornot2c" / "selected-provider.txt"
+    ).read_text(encoding="utf-8") == "docker"
 
 
 def test_tui_marks_first_low_memory_choice_as_recommended() -> None:
@@ -320,13 +358,17 @@ def test_tui_installation_report_shows_step_bar_and_elapsed_time() -> None:
     assert "▓" in report
 
 
-def test_tui_poll_updates_progress_and_finishes_installation() -> None:
+def test_tui_poll_updates_progress_and_finishes_installation(
+    monkeypatch,
+    tmp_path,
+) -> None:
     pytest.importorskip("utui")
     from queue import Queue
 
     from installer.executor import StepResult
     from installer.tui import State, poll_installation
 
+    monkeypatch.setattr("installer.tui.Path.home", lambda: tmp_path)
     updates = Queue()
     state = State(
         Host.WINDOWS_AMD64,

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -67,6 +67,7 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "Test-HostResources" in bootstrap
     assert "installed_by_bootstrap" in bootstrap
     assert "Install-ClassroomLauncher" in bootstrap
+    assert "launch-classroom-windows.ps1" in bootstrap
     assert "prepare-wsl-windows.ps1" in bootstrap
     assert "remove-wsl-windows.ps1" in bootstrap
     assert "Ambiente 2cornot2c.lnk" in bootstrap
@@ -80,6 +81,17 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "docker image rm $ImageReference" in uninstall
     assert "docker image rm --force" not in uninstall
     assert "Ambiente 2cornot2c.lnk" in uninstall
+
+
+def test_windows_launcher_hides_technical_start_commands() -> None:
+    launcher = (ROOT / "scripts" / "launch-classroom-windows.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    assert "selected-provider.txt" in launcher
+    assert "student_dev_shell.py" in launcher
+    assert "vagrant up --provider=virtualbox" in launcher
+    assert "AMBIENTE NON ANCORA PRONTO" in launcher
 
 
 def test_wsl_preparation_is_elevated_and_resumes_after_restart() -> None:

--- a/tests/test_student_errors.py
+++ b/tests/test_student_errors.py
@@ -108,6 +108,7 @@ def test_windows_scripts_render_error_and_explanation_colors() -> None:
     root = Path(__file__).resolve().parents[1]
     for name in (
         "bootstrap-classroom-windows.ps1",
+        "launch-classroom-windows.ps1",
         "manage-classroom-windows.ps1",
         "update-classroom-windows.ps1",
         "uninstall-classroom-windows.ps1",
@@ -131,6 +132,7 @@ def test_student_facing_messages_use_italian_accents() -> None:
     paths = (
         root / "installer" / "student_errors.py",
         root / "scripts" / "bootstrap-classroom-windows.ps1",
+        root / "scripts" / "launch-classroom-windows.ps1",
         root / "scripts" / "manage-classroom-windows.ps1",
         root / "scripts" / "update-classroom-windows.ps1",
         root / "scripts" / "uninstall-classroom-windows.ps1",


### PR DESCRIPTION
## Cosa cambia

- aggiunge **Avvia l’ambiente** come prima voce del menu Windows;
- salva automaticamente l’ultimo provider completato;
- apre una nuova console con la shell Docker senza mostrare comandi Python;
- supporta anche l’avvio VirtualBox tramite Vagrant;
- mostra un messaggio semplice se l’ambiente non è ancora pronto;
- sostituisce il vecchio invito a eseguire `student_dev_shell.py` con il percorso TUI;
- aggiorna launcher persistente, test e documentazione.

## Impatto

Dopo l’installazione lo studente torna al menu e sceglie **Avvia l’ambiente**. Non deve conoscere PowerShell, Python, Vagrant o il nome degli script interni.

## Verifiche

- 47 test mirati superati
- `python -m compileall -q installer`
- `git diff --check`