### PR TITLE
feat: wire concrete Google OIDC HTTP routes

### DIFF
--- a/doc/architecture/auth-edge-rate-limiting.md
+++ b/doc/architecture/auth-edge-rate-limiting.md
@@ -55,7 +55,7 @@ Test concorrenti verificano che, con più worker, il numero degli ammessi sia es
 
 ## Ordine nella route concreta
 
-La futura `/auth/google/login` deve costruire `EdgeRequestMetadata` dal peer reale e dagli header originali, poi chiamare esclusivamente:
+La route `/auth/google/login`, implementata dal router descritto in [google-oidc-http-routes.md](google-oidc-http-routes.md), costruisce `EdgeRequestMetadata` dal peer reale e dagli header originali, poi chiama esclusivamente:
 
 ```python
 admission.begin_login(metadata)
@@ -67,7 +67,7 @@ Il reverse proxy può applicare limiti aggiuntivi, ma non sostituisce questo bou
 
 ## Fuori scope
 
-- route concrete e serializzazione della risposta HTTP 302;
+- composizione runtime/deployment della route concreta;
 - limiti del callback Google e delle route GitHub;
 - limiti specifici per begin/authorize/consume del pairing TUI;
 - store multi-host concreto;

--- a/doc/architecture/google-oidc-adapter.md
+++ b/doc/architecture/google-oidc-adapter.md
@@ -2,7 +2,7 @@
 
 ## Scopo
 
-`thebitlab_google_oidc.py` implementa il login Google tramite Authorization Code Flow sopra `FederatedIdentityService` e `HttpSessionAuthBoundary`. Non introduce route nel Course Board: il futuro adapter HTTP tradurrà `/auth/google/login` e `/auth/google/callback` nei contratti qui descritti.
+`thebitlab_google_oidc.py` implementa il login Google tramite Authorization Code Flow sopra `FederatedIdentityService` e `HttpSessionAuthBoundary`. Le route Course Board che traducono `/auth/google/login` e `/auth/google/callback` sono descritte in [google-oidc-http-routes.md](google-oidc-http-routes.md); questo modulo resta il service provider-independent sottostante.
 
 ## Configurazione
 
@@ -91,7 +91,8 @@ I messaggi non includono valori OAuth raw o dettagli backend.
 ## Fuori scope
 
 - credenziali reali nel repository o CI;
-- route concrete, UI e browser E2E Google;
+- UI e browser E2E Google;
+- composizione runtime da environment delle route concrete;
 - protezione dashboard;
 - persistenza flow multi-process;
 - GitHub linking;

--- a/doc/architecture/google-oidc-http-routes.md
+++ b/doc/architecture/google-oidc-http-routes.md
@@ -46,12 +46,12 @@ La callback accetta una query massima di 8192 byte e 16 campi. Il parser:
 
 Header `Cookie` multipli vengono concatenati in ordine con `; ` entro 16 KiB, come richiesto dal boundary sessione. Controlli, overflow e body non vuoti falliscono prima del callback service.
 
-Al successo la route percent-encoda il path locale come URI ASCII e risponde `303`; questo evita errori Latin-1 del trasporto anche per path Unicode validi. Invia due `Set-Cookie` separati, con nomi `__Host-`, valori base64url, `Path=/`, `Secure`, `HttpOnly`, `SameSite=Lax`, età bounded e nessun `Domain`:
+Al successo la route percent-encoda il path locale come URI ASCII e risponde `303`; questo evita errori Latin-1 del trasporto anche per path Unicode validi. Invia due `Set-Cookie` separati, con nomi `__Host-`, valori base64url, `Path=/`, `Secure`, `HttpOnly`, SameSite coerente con la `SessionCookiePolicy` prevalidata, età bounded e nessun `Domain`:
 
 1. sessione web nuova;
 2. cancellazione del cookie transazionale one-time.
 
-Anche gli errori terminali che hanno consumato il flow propagano esclusivamente il cookie di cleanup validato. State/callback non validi diventano 400, identità rifiutata 403, provider/configurazione/infrastruttura 503.
+Anche gli errori terminali che hanno consumato il flow propagano esclusivamente il cookie di cleanup validato. La route richiede inoltre un `EstablishedSessionDiscarder`: se un risultato post-callback non può essere serializzato, revoca best-effort la sessione appena emessa e cancella il cookie transazionale, evitando sessioni attive irraggiungibili. La policy cookie dichiarata dalla route deve coincidere con quella del callback service. State/callback non validi diventano 400, identità rifiutata 403, provider/configurazione/infrastruttura 503.
 
 ## Segreti e browser policy
 
@@ -60,7 +60,7 @@ Authorization code, state, cookie transazionale e cookie sessione:
 - non compaiono nei body JSON di errore;
 - sono esclusi dal `repr` di request/response;
 - vengono rimossi dai frame route prima di propagare o tradurre errori;
-- non vengono scritti nell'access log: `CourseBoardHandler.log_request()` registra soltanto metodo e path per le route Google, mai la query;
+- non vengono scritti nell'access log: `CourseBoardHandler.log_request()` registra soltanto metodo e path per le route Google, mai la query; anche `log_error()` redige request-line OAuth malformate prima che `BaseHTTPRequestHandler` abbia popolato `self.path`;
 - non vengono propagati come `Referer`, grazie a `Referrer-Policy: no-referrer` su redirect e errori.
 
 Redirect e cookie adapter sono bounded e rifiutano controlli/header injection. Il login accetta soltanto redirect assoluto HTTPS senza fragment; il callback soltanto path locale assoluto senza scheme, authority, query o fragment.

--- a/doc/architecture/google-oidc-http-routes.md
+++ b/doc/architecture/google-oidc-http-routes.md
@@ -67,7 +67,7 @@ Redirect e cookie adapter sono bounded e rifiutano controlli/header injection. I
 
 ## Integrazione Course Board
 
-`CourseBoardHandler` costruisce `EdgeRequestMetadata` dal peer TCP e da `HTTPMessage.raw_items()`, preservando header duplicati. La delega avviene prima dell'autenticazione Basic legacy, così le route pubbliche non vengono scambiate per API docente. GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, TRACE e CONNECT verso path Google esatti passano dallo stesso router; metodi non consentiti ricevono 405 e `Allow: GET`. Query/fragments sovradimensionati o malformati vengono classificati 400 già durante la costruzione della request transport, non 503.
+`CourseBoardHandler` costruisce `EdgeRequestMetadata` dal peer TCP e da `HTTPMessage.raw_items()`, preservando header duplicati. La delega avviene prima dell'autenticazione Basic legacy, così le route pubbliche non vengono scambiate per API docente. Qualunque metodo verso path Google esatti passa dallo stesso router: oltre ai metodi comuni, un fallback dinamico `do_*` copre estensioni come WebDAV `PROPFIND`. Ogni metodo diverso da GET riceve 405 e `Allow: GET`. Query/fragments sovradimensionati o malformati vengono classificati 400 già durante la costruzione della request transport, non 503.
 
 La composizione runtime deve costruire e iniettare:
 

--- a/doc/architecture/google-oidc-http-routes.md
+++ b/doc/architecture/google-oidc-http-routes.md
@@ -1,0 +1,89 @@
+# Route HTTP concrete Google OIDC
+
+## Scopo
+
+`scripts/thebitlab_google_oidc_http.py` traduce i boundary Google OIDC e rate-limit già esistenti in semantica HTTP concreta. `CourseBoardHandler` delega le route esatte a un'istanza iniettata come `server.google_oidc_http_routes`; senza composizione esplicita le route non vengono esposte.
+
+Le route sono:
+
+- `GET /auth/google/login`;
+- `GET /auth/google/callback`.
+
+Non esiste alcuna route che accetti un `user_id` scelto dal client.
+
+## HTTPS e proxy trusted
+
+Ogni richiesta deve essere TLS diretta (`SSLSocket`) oppure arrivare da un peer incluso nei CIDR trusted del medesimo `TrustedProxyClientResolver`, con esattamente un header:
+
+```text
+X-Forwarded-Proto: https
+```
+
+Header forwarded da peer non trusted non rendono sicura una richiesta HTTP. Valori mancanti, duplicati o diversi da `https` producono `400 https_required`. Il resolver edge continua separatamente ad applicare la policy bounded su `X-Forwarded-For` prima dell'allocazione del flow.
+
+Il deployment deve impedire accesso diretto al backend HTTP quando usa TLS termination sul reverse proxy. I CIDR trusted devono descrivere soltanto proxy controllati.
+
+## Login
+
+`/auth/google/login`:
+
+1. richiede `GET`, query vuota e nessun body/transfer encoding;
+2. passa da `GoogleOidcLoginAdmissionBoundary`, quindi i bucket globali e per-client vengono consumati prima di creare state/nonce/PKCE;
+3. valida fail-closed il risultato adapter;
+4. risponde `302` con authorization URL HTTPS canonica e cookie transazionale;
+5. aggiunge `Cache-Control: no-store`, `Pragma: no-cache`, `Referrer-Policy: no-referrer` e body vuoto.
+
+Una negazione edge diventa `429 rate_limit_exceeded` con `Retry-After`. Errori edge/storage diventano 503 sanitizzato.
+
+## Callback
+
+La callback accetta una query massima di 8192 byte e 16 campi. Il parser:
+
+- preserva valori duplicati come sequenze, lasciando al service OIDC la validazione dei parametri ammessi;
+- mantiene valori vuoti;
+- rifiuta percent escape malformati, UTF-8 invalido, campi senza `=`, fragment e query vuota;
+- non concatena o sceglie arbitrariamente valori duplicati.
+
+Header `Cookie` multipli vengono concatenati in ordine con `; ` entro 16 KiB, come richiesto dal boundary sessione. Controlli, overflow e body non vuoti falliscono prima del callback service.
+
+Al successo la route risponde `303` verso il solo path locale configurato e invia due `Set-Cookie` separati:
+
+1. sessione web nuova;
+2. cancellazione del cookie transazionale one-time.
+
+Anche gli errori terminali che hanno consumato il flow propagano esclusivamente il cookie di cleanup validato. State/callback non validi diventano 400, identità rifiutata 403, provider/configurazione/infrastruttura 503.
+
+## Segreti e browser policy
+
+Authorization code, state, cookie transazionale e cookie sessione:
+
+- non compaiono nei body JSON di errore;
+- sono esclusi dal `repr` di request/response;
+- vengono rimossi dai frame route prima di propagare o tradurre errori;
+- non vengono scritti nell'access log: `CourseBoardHandler.log_request()` registra soltanto metodo e path per le route Google, mai la query;
+- non vengono propagati come `Referer`, grazie a `Referrer-Policy: no-referrer` su redirect e errori.
+
+Redirect e cookie adapter sono bounded e rifiutano controlli/header injection. Il login accetta soltanto redirect assoluto HTTPS senza fragment; il callback soltanto path locale assoluto senza scheme, authority, query o fragment.
+
+## Integrazione Course Board
+
+`CourseBoardHandler` costruisce `EdgeRequestMetadata` dal peer TCP e da `HTTPMessage.raw_items()`, preservando header duplicati. La delega avviene prima dell'autenticazione Basic legacy, così le route pubbliche non vengono scambiate per API docente. GET, POST e HEAD verso path Google esatti passano dallo stesso router; metodi non consentiti ricevono 405 e `Allow: GET`.
+
+La composizione runtime deve costruire e iniettare:
+
+- identity/session storage e service;
+- `GoogleOidcLoginService` con credenziali da environment/secret store;
+- `GoogleOidcLoginAdmissionBoundary` con store condiviso;
+- `TrustedProxyClientResolver` con CIDR deployment;
+- `GoogleOidcHttpRoutes`.
+
+Questa PR non abilita automaticamente credenziali reali nel comando locale predefinito.
+
+## Fuori scope
+
+- caricamento completo della composizione da environment;
+- terminazione TLS e configurazione reverse proxy;
+- browser E2E con credenziali Google reali;
+- route GitHub e pairing TUI;
+- session/status/logout frontend;
+- autorizzazione dei payload dashboard legacy.

--- a/doc/architecture/google-oidc-http-routes.md
+++ b/doc/architecture/google-oidc-http-routes.md
@@ -29,7 +29,7 @@ Il deployment deve impedire accesso diretto al backend HTTP quando usa TLS termi
 
 1. richiede `GET`, query vuota e nessun body/transfer encoding;
 2. passa da `GoogleOidcLoginAdmissionBoundary`, quindi i bucket globali e per-client vengono consumati prima di creare state/nonce/PKCE;
-3. valida fail-closed il risultato adapter;
+3. valida fail-closed il risultato adapter: endpoint esatto `https://accounts.google.com/o/oauth2/v2/auth`, nessuna userinfo/porta estranea/fragment, cookie `__Host-thebitlab_oidc_txn-*` con valore base64url e attributi sicuri senza `Domain`;
 4. risponde `302` con authorization URL HTTPS canonica e cookie transazionale;
 5. aggiunge `Cache-Control: no-store`, `Pragma: no-cache`, `Referrer-Policy: no-referrer` e body vuoto.
 
@@ -46,7 +46,7 @@ La callback accetta una query massima di 8192 byte e 16 campi. Il parser:
 
 Header `Cookie` multipli vengono concatenati in ordine con `; ` entro 16 KiB, come richiesto dal boundary sessione. Controlli, overflow e body non vuoti falliscono prima del callback service.
 
-Al successo la route risponde `303` verso il solo path locale configurato e invia due `Set-Cookie` separati:
+Al successo la route percent-encoda il path locale come URI ASCII e risponde `303`; questo evita errori Latin-1 del trasporto anche per path Unicode validi. Invia due `Set-Cookie` separati, con nomi `__Host-`, valori base64url, `Path=/`, `Secure`, `HttpOnly`, `SameSite=Lax`, età bounded e nessun `Domain`:
 
 1. sessione web nuova;
 2. cancellazione del cookie transazionale one-time.
@@ -67,7 +67,7 @@ Redirect e cookie adapter sono bounded e rifiutano controlli/header injection. I
 
 ## Integrazione Course Board
 
-`CourseBoardHandler` costruisce `EdgeRequestMetadata` dal peer TCP e da `HTTPMessage.raw_items()`, preservando header duplicati. La delega avviene prima dell'autenticazione Basic legacy, così le route pubbliche non vengono scambiate per API docente. GET, POST e HEAD verso path Google esatti passano dallo stesso router; metodi non consentiti ricevono 405 e `Allow: GET`.
+`CourseBoardHandler` costruisce `EdgeRequestMetadata` dal peer TCP e da `HTTPMessage.raw_items()`, preservando header duplicati. La delega avviene prima dell'autenticazione Basic legacy, così le route pubbliche non vengono scambiate per API docente. GET, HEAD, POST, PUT, DELETE, PATCH e OPTIONS verso path Google esatti passano dallo stesso router; metodi non consentiti ricevono 405 e `Allow: GET`. Query/fragments sovradimensionati o malformati vengono classificati 400 già durante la costruzione della request transport, non 503.
 
 La composizione runtime deve costruire e iniettare:
 

--- a/doc/architecture/google-oidc-http-routes.md
+++ b/doc/architecture/google-oidc-http-routes.md
@@ -60,14 +60,14 @@ Authorization code, state, cookie transazionale e cookie sessione:
 - non compaiono nei body JSON di errore;
 - sono esclusi dal `repr` di request/response;
 - vengono rimossi dai frame route prima di propagare o tradurre errori;
-- non vengono scritti nell'access log: `CourseBoardHandler.log_request()` registra soltanto metodo e path per le route Google, mai la query; anche `log_error()` redige request-line OAuth malformate prima che `BaseHTTPRequestHandler` abbia popolato `self.path`;
+- non vengono scritti nell'access log: `CourseBoardHandler.log_request()` registra soltanto metodo e path per le route Google, mai la query; anche `log_error()` redige request-line OAuth malformate prima che `BaseHTTPRequestHandler` abbia popolato `self.path`, e l'override `send_error()` restituisce JSON generico senza riflettere la request-line nel body HTML;
 - non vengono propagati come `Referer`, grazie a `Referrer-Policy: no-referrer` su redirect e errori.
 
 Redirect e cookie adapter sono bounded e rifiutano controlli/header injection. Il login accetta soltanto redirect assoluto HTTPS senza fragment; il callback soltanto path locale assoluto senza scheme, authority, query o fragment.
 
 ## Integrazione Course Board
 
-`CourseBoardHandler` costruisce `EdgeRequestMetadata` dal peer TCP e da `HTTPMessage.raw_items()`, preservando header duplicati. La delega avviene prima dell'autenticazione Basic legacy, così le route pubbliche non vengono scambiate per API docente. Qualunque metodo verso path Google esatti passa dallo stesso router: oltre ai metodi comuni, un fallback dinamico `do_*` copre estensioni come WebDAV `PROPFIND`. Ogni metodo diverso da GET riceve 405 e `Allow: GET`. Query/fragments sovradimensionati o malformati vengono classificati 400 già durante la costruzione della request transport, non 503.
+`CourseBoardHandler` costruisce `EdgeRequestMetadata` dal peer TCP e da `HTTPMessage.raw_items()`, preservando header duplicati. La delega avviene prima dell'autenticazione Basic legacy, così le route pubbliche non vengono scambiate per API docente. Qualunque metodo verso path Google esatti passa dallo stesso router: oltre ai metodi comuni, un fallback dinamico `do_*` copre estensioni come WebDAV `PROPFIND`. Ogni metodo diverso da GET riceve 405 e `Allow: GET`. Query/fragments sovradimensionati o malformati vengono classificati 400 già durante la costruzione della request transport, non 503. Sono ammesse soltanto request-target origin-form esatte: scheme, authority/network-path e path params (`;...`) sono rifiutati prima del router per evitare discrepanze con proxy o ACL upstream.
 
 La composizione runtime deve costruire e iniettare:
 

--- a/doc/architecture/google-oidc-http-routes.md
+++ b/doc/architecture/google-oidc-http-routes.md
@@ -51,7 +51,7 @@ Al successo la route percent-encoda il path locale come URI ASCII e risponde `30
 1. sessione web nuova;
 2. cancellazione del cookie transazionale one-time.
 
-Anche gli errori terminali che hanno consumato il flow propagano esclusivamente il cookie di cleanup validato. La route richiede inoltre un `EstablishedSessionDiscarder`: se un risultato post-callback non può essere serializzato, revoca best-effort la sessione appena emessa e cancella il cookie transazionale, evitando sessioni attive irraggiungibili. La policy cookie dichiarata dalla route deve coincidere con quella del callback service. State/callback non validi diventano 400, identità rifiutata 403, provider/configurazione/infrastruttura 503.
+Anche gli errori terminali che hanno consumato il flow propagano esclusivamente il cookie di cleanup validato. La route richiede inoltre un `EstablishedSessionDiscarder`: se un risultato post-callback non può essere serializzato, revoca best-effort la sessione appena emessa e cancella il cookie transazionale, evitando sessioni attive irraggiungibili. Una risposta callback valida porta un delivery guard one-shot: `CourseBoardHandler` lo conferma soltanto dopo aver scritto status/header/body; qualunque eccezione socket durante la scrittura revoca la sessione prima di abbandonare la richiesta. La policy cookie dichiarata dalla route deve coincidere con quella del callback service. State/callback non validi diventano 400, identità rifiutata 403, provider/configurazione/infrastruttura 503.
 
 ## Segreti e browser policy
 
@@ -67,7 +67,7 @@ Redirect e cookie adapter sono bounded e rifiutano controlli/header injection. I
 
 ## Integrazione Course Board
 
-`CourseBoardHandler` costruisce `EdgeRequestMetadata` dal peer TCP e da `HTTPMessage.raw_items()`, preservando header duplicati. La delega avviene prima dell'autenticazione Basic legacy, così le route pubbliche non vengono scambiate per API docente. GET, HEAD, POST, PUT, DELETE, PATCH e OPTIONS verso path Google esatti passano dallo stesso router; metodi non consentiti ricevono 405 e `Allow: GET`. Query/fragments sovradimensionati o malformati vengono classificati 400 già durante la costruzione della request transport, non 503.
+`CourseBoardHandler` costruisce `EdgeRequestMetadata` dal peer TCP e da `HTTPMessage.raw_items()`, preservando header duplicati. La delega avviene prima dell'autenticazione Basic legacy, così le route pubbliche non vengono scambiate per API docente. GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, TRACE e CONNECT verso path Google esatti passano dallo stesso router; metodi non consentiti ricevono 405 e `Allow: GET`. Query/fragments sovradimensionati o malformati vengono classificati 400 già durante la costruzione della request transport, non 503.
 
 La composizione runtime deve costruire e iniettare:
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3303,6 +3303,18 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return
         super().log_request(code, size)
 
+    def send_error(self, code, message=None, explain=None) -> None:
+        """Never reflect malformed OAuth request-lines in HTML error bodies."""
+
+        if self._is_google_auth_request_line():
+            self.close_connection = True
+            self.write_oidc_transport_error(
+                int(code) if isinstance(code, int) else 400,
+                "bad_auth_request",
+            )
+            return
+        super().send_error(code, message, explain)
+
     def end_headers(self) -> None:
         """Add browser hardening headers to every server response."""
 
@@ -3424,8 +3436,17 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         """Delegate exact Google auth routes to the injected secure router."""
 
         routes = getattr(self.server, "google_oidc_http_routes", None)
+        request_parts = str(getattr(self, "requestline", "")).split()
+        if routes is not None and len(request_parts) == 3:
+            raw_parsed = urlparse(request_parts[1])
+            if routes.handles(raw_parsed.path):
+                parsed = raw_parsed
+        request_parts = None
         if routes is None or not routes.handles(parsed.path):
             return False
+        if parsed.scheme or parsed.netloc or parsed.params:
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
         try:
             edge = thebitlab_google_oidc_http.EdgeRequestMetadata(
                 str(self.client_address[0]), tuple(self.headers.raw_items())

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3406,25 +3406,33 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             edge = thebitlab_google_oidc_http.EdgeRequestMetadata(
                 str(self.client_address[0]), tuple(self.headers.raw_items())
             )
+            raw_query = parsed.query
+            if parsed.fragment:
+                raw_query += "#" + parsed.fragment
             request = thebitlab_google_oidc_http.GoogleOidcHttpRequest(
                 self.command,
                 parsed.path,
-                parsed.query,
+                raw_query,
                 edge,
                 is_tls=isinstance(self.connection, ssl.SSLSocket),
             )
+        except (
+            ValueError,
+            thebitlab_google_oidc_http.EdgeClientAttributionError,
+        ):
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        try:
             response = routes.dispatch(request)
             if response is None:
                 raise RuntimeError("Router OIDC senza risposta.")
         except Exception:  # noqa: BLE001
-            body = b'{"error":"authentication_unavailable"}'
-            self.send_response(503)
-            self.send_header("Content-Type", "application/json; charset=utf-8")
-            self.send_header("Cache-Control", "no-store")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+            self.write_oidc_transport_error(503, "authentication_unavailable")
             return True
+        finally:
+            edge = None
+            request = None
+            raw_query = None
         self.send_response(response.status_code)
         for name, value in response.headers:
             self.send_header(name, value)
@@ -3433,11 +3441,42 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             self.wfile.write(response.body)
         return True
 
+    def write_oidc_transport_error(self, status_code: int, error_code: str) -> None:
+        body = json.dumps(
+            {"error": error_code}, separators=(",", ":")
+        ).encode("utf-8")
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def do_unsupported_auth_method(self) -> None:
+        parsed = urlparse(self.path)
+        if self.dispatch_google_oidc(parsed):
+            return
+        self.send_error(501)
+
     def do_HEAD(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
         if self.dispatch_google_oidc(parsed):
             return
         self.send_error(501)
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self.do_unsupported_auth_method()
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self.do_unsupported_auth_method()
+
+    def do_PATCH(self) -> None:  # noqa: N802
+        self.do_unsupported_auth_method()
+
+    def do_OPTIONS(self) -> None:  # noqa: N802
+        self.do_unsupported_auth_method()
 
     def do_GET(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3438,6 +3438,13 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
         routes = getattr(self.server, "google_oidc_http_routes", None)
         request_parts = str(getattr(self, "requestline", "")).split()
+        if (
+            routes is not None
+            and routes.handles(parsed.path)
+            and len(request_parts) != 3
+        ):
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
         if routes is not None and len(request_parts) == 3:
             raw_target = request_parts[1]
             raw_parsed = urlparse(raw_target)

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3293,12 +3293,16 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         """Never write OAuth callback queries or codes to access logs."""
 
         path = str(getattr(self, "path", ""))
+        requestline = str(getattr(self, "requestline", ""))
         if self._is_google_auth_request_line():
-            parsed = urlparse(path)
-            safe_path = parsed.path if parsed.path else "/auth/google/invalid"
-            command = str(getattr(self, "command", "INVALID"))
-            version = str(getattr(self, "request_version", "HTTP/1.1"))
-            safe_line = f"{command} {safe_path} {version}"
+            combined = path + " " + requestline
+            if "/auth/google/callback" in combined:
+                safe_path = "/auth/google/callback"
+            elif "/auth/google/login" in combined:
+                safe_path = "/auth/google/login"
+            else:
+                safe_path = "/auth/google/invalid"
+            safe_line = f"AUTH {safe_path} HTTP"
             self.log_message('"%s" %s %s', safe_line, str(code), str(size))
             return
         super().log_request(code, size)
@@ -3308,10 +3312,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
         if self._is_google_auth_request_line():
             self.close_connection = True
-            self.write_oidc_transport_error(
-                int(code) if isinstance(code, int) else 400,
-                "bad_auth_request",
-            )
+            self.write_oidc_transport_error(400, "bad_auth_request")
             return
         super().send_error(code, message, explain)
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3269,12 +3269,31 @@ class BoundedThreadingHTTPServer(ThreadingHTTPServer):
 class CourseBoardHandler(BaseHTTPRequestHandler):
     """HTTP handler for the local board and its JSON API."""
 
+    def _is_google_auth_request_line(self) -> bool:
+        path = str(getattr(self, "path", ""))
+        requestline = str(getattr(self, "requestline", ""))
+        return "/auth/google/" in path or "/auth/google/" in requestline
+
+    def log_error(self, format, *args) -> None:
+        """Redact even malformed OAuth request lines before parser completion."""
+
+        if self._is_google_auth_request_line() or any(
+            "/auth/google/" in str(argument) for argument in args
+        ):
+            self.log_message("Google auth request non valida")
+            return
+        super().log_error(format, *args)
+
     def log_request(self, code="-", size="-") -> None:
         """Never write OAuth callback queries or codes to access logs."""
 
-        parsed = urlparse(self.path)
-        if parsed.path in {"/auth/google/login", "/auth/google/callback"}:
-            safe_line = f"{self.command} {parsed.path} {self.request_version}"
+        path = str(getattr(self, "path", ""))
+        if self._is_google_auth_request_line():
+            parsed = urlparse(path)
+            safe_path = parsed.path if parsed.path else "/auth/google/invalid"
+            command = str(getattr(self, "command", "INVALID"))
+            version = str(getattr(self, "request_version", "HTTP/1.1"))
+            safe_line = f"{command} {safe_path} {version}"
             self.log_message('"%s" %s %s', safe_line, str(code), str(size))
             return
         super().log_request(code, size)

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3269,6 +3269,11 @@ class BoundedThreadingHTTPServer(ThreadingHTTPServer):
 class CourseBoardHandler(BaseHTTPRequestHandler):
     """HTTP handler for the local board and its JSON API."""
 
+    def __getattr__(self, name):
+        if type(name) is str and name.startswith("do_"):
+            return self.do_unsupported_auth_method
+        raise AttributeError(name)
+
     def _is_google_auth_request_line(self) -> bool:
         path = str(getattr(self, "path", ""))
         requestline = str(getattr(self, "requestline", ""))

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -27,6 +27,7 @@ import os
 import re
 import secrets
 import shutil
+import ssl
 import subprocess
 import sys
 import tempfile
@@ -60,6 +61,7 @@ from scripts import (
     student_help_service,
     student_lab_service,
     thebitlab_grading_artifacts,
+    thebitlab_google_oidc_http,
     thebitlab_services,
     thebitlab_storage,
     thebitlab_tracking_reports,
@@ -3267,6 +3269,16 @@ class BoundedThreadingHTTPServer(ThreadingHTTPServer):
 class CourseBoardHandler(BaseHTTPRequestHandler):
     """HTTP handler for the local board and its JSON API."""
 
+    def log_request(self, code="-", size="-") -> None:
+        """Never write OAuth callback queries or codes to access logs."""
+
+        parsed = urlparse(self.path)
+        if parsed.path in {"/auth/google/login", "/auth/google/callback"}:
+            safe_line = f"{self.command} {parsed.path} {self.request_version}"
+            self.log_message('"%s" %s %s', safe_line, str(code), str(size))
+            return
+        super().log_request(code, size)
+
     def end_headers(self) -> None:
         """Add browser hardening headers to every server response."""
 
@@ -3384,8 +3396,53 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return None
         return payload
 
+    def dispatch_google_oidc(self, parsed) -> bool:
+        """Delegate exact Google auth routes to the injected secure router."""
+
+        routes = getattr(self.server, "google_oidc_http_routes", None)
+        if routes is None or not routes.handles(parsed.path):
+            return False
+        try:
+            edge = thebitlab_google_oidc_http.EdgeRequestMetadata(
+                str(self.client_address[0]), tuple(self.headers.raw_items())
+            )
+            request = thebitlab_google_oidc_http.GoogleOidcHttpRequest(
+                self.command,
+                parsed.path,
+                parsed.query,
+                edge,
+                is_tls=isinstance(self.connection, ssl.SSLSocket),
+            )
+            response = routes.dispatch(request)
+            if response is None:
+                raise RuntimeError("Router OIDC senza risposta.")
+        except Exception:  # noqa: BLE001
+            body = b'{"error":"authentication_unavailable"}'
+            self.send_response(503)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return True
+        self.send_response(response.status_code)
+        for name, value in response.headers:
+            self.send_header(name, value)
+        self.end_headers()
+        if response.body and self.command != "HEAD":
+            self.wfile.write(response.body)
+        return True
+
+    def do_HEAD(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if self.dispatch_google_oidc(parsed):
+            return
+        self.send_error(501)
+
     def do_GET(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
+        if self.dispatch_google_oidc(parsed):
+            return
         if self.reject_unauthenticated_teacher_api("GET", parsed.path):
             return
         if parsed.path in {"/api/student-lab/assignments", "/api/student-lab/help-history"}:
@@ -3475,6 +3532,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
+        if self.dispatch_google_oidc(parsed):
+            return
         if self.reject_unauthenticated_teacher_api("POST", parsed.path):
             return
         if self.reject_unsafe_teacher_post(parsed.path):

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3452,13 +3452,24 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             edge = None
             request = None
             raw_query = None
-        self.send_response(response.status_code)
-        for name, value in response.headers:
-            self.send_header(name, value)
-        self.end_headers()
-        if response.body and self.command != "HEAD":
-            self.wfile.write(response.body)
+        self.write_google_oidc_response(response)
         return True
+
+    def write_google_oidc_response(self, response) -> None:
+        guard = getattr(response, "delivery_guard", None)
+        try:
+            self.send_response(response.status_code)
+            for name, value in response.headers:
+                self.send_header(name, value)
+            self.end_headers()
+            if response.body and self.command != "HEAD":
+                self.wfile.write(response.body)
+        except Exception:  # noqa: BLE001
+            if guard is not None:
+                guard.failed()
+            return
+        if guard is not None:
+            guard.delivered()
 
     def write_oidc_transport_error(self, status_code: int, error_code: str) -> None:
         body = json.dumps(
@@ -3495,6 +3506,12 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         self.do_unsupported_auth_method()
 
     def do_OPTIONS(self) -> None:  # noqa: N802
+        self.do_unsupported_auth_method()
+
+    def do_TRACE(self) -> None:  # noqa: N802
+        self.do_unsupported_auth_method()
+
+    def do_CONNECT(self) -> None:  # noqa: N802
         self.do_unsupported_auth_method()
 
     def do_GET(self) -> None:  # noqa: N802

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3439,10 +3439,20 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         routes = getattr(self.server, "google_oidc_http_routes", None)
         request_parts = str(getattr(self, "requestline", "")).split()
         if routes is not None and len(request_parts) == 3:
-            raw_parsed = urlparse(request_parts[1])
+            raw_target = request_parts[1]
+            raw_parsed = urlparse(raw_target)
             if routes.handles(raw_parsed.path):
                 parsed = raw_parsed
+            elif routes.handles(parsed.path) and not (
+                raw_target == parsed.path
+                or raw_target.startswith(parsed.path + "?")
+                or raw_target.startswith(parsed.path + "#")
+                or raw_target.startswith(parsed.path + ";")
+            ):
+                self.write_oidc_transport_error(400, "bad_auth_request")
+                return True
         request_parts = None
+        raw_target = None
         if routes is None or not routes.handles(parsed.path):
             return False
         if parsed.scheme or parsed.netloc or parsed.params:

--- a/scripts/thebitlab_edge_rate_limit.py
+++ b/scripts/thebitlab_edge_rate_limit.py
@@ -174,6 +174,11 @@ class TrustedProxyClientResolver:
         self.max_proxy_hops = max_proxy_hops
         self.max_forwarded_header_bytes = max_forwarded_header_bytes
 
+    def is_trusted_peer(self, request: EdgeRequestMetadata) -> bool:
+        if type(request) is not EdgeRequestMetadata:
+            raise EdgeClientAttributionError()
+        return self._trusted(self._address(request.peer_ip))
+
     def resolve(self, request: EdgeRequestMetadata) -> str:
         if type(request) is not EdgeRequestMetadata:
             raise EdgeClientAttributionError()

--- a/scripts/thebitlab_google_oidc_http.py
+++ b/scripts/thebitlab_google_oidc_http.py
@@ -1,0 +1,393 @@
+"""Concrete HTTP semantics for Google OIDC login and callback routes."""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.parse
+from dataclasses import dataclass, field
+from typing import Mapping, Protocol, Sequence
+
+from scripts.thebitlab_edge_rate_limit import (
+    EdgeClientAttributionError,
+    EdgeRateLimitExceededError,
+    EdgeRateLimitUnavailableError,
+    EdgeRequestMetadata,
+    GoogleOidcLoginAdmissionBoundary,
+    TrustedProxyClientResolver,
+)
+from scripts.thebitlab_google_oidc import (
+    GoogleAuthorizationRequest,
+    GoogleOidcCallbackError,
+    GoogleOidcConfigurationError,
+    GoogleOidcError,
+    GoogleOidcIdentityRejectedError,
+    GoogleOidcLoginResult,
+    GoogleOidcProviderUnavailableError,
+    GoogleOidcStateError,
+    GoogleOidcTokenRejectedError,
+)
+
+
+_LOGIN_PATH = "/auth/google/login"
+_CALLBACK_PATH = "/auth/google/callback"
+_MAX_QUERY_BYTES = 8192
+_MAX_QUERY_FIELDS = 16
+_MAX_COOKIE_HEADER_BYTES = 16_384
+_MAX_RESPONSE_HEADER_BYTES = 16_384
+_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+
+
+@dataclass(frozen=True)
+class GoogleOidcHttpRequest:
+    method: str
+    path: str
+    query: str = field(repr=False, compare=False)
+    edge: EdgeRequestMetadata
+    is_tls: bool = False
+
+    def __post_init__(self) -> None:
+        if type(self.method) is not str or not self.method or len(self.method) > 16:
+            raise ValueError("Metodo HTTP non valido.")
+        if type(self.path) is not str or not self.path.startswith("/") or len(self.path) > 256:
+            raise ValueError("Path HTTP non valido.")
+        if type(self.query) is not str or len(
+            self.query.encode("utf-8", errors="surrogatepass")
+        ) > _MAX_QUERY_BYTES:
+            raise ValueError("Query HTTP non valida.")
+        if type(self.edge) is not EdgeRequestMetadata or type(self.is_tls) is not bool:
+            raise ValueError("Metadati HTTP non validi.")
+
+
+@dataclass(frozen=True)
+class GoogleOidcHttpResponse:
+    status_code: int
+    headers: tuple[tuple[str, str], ...] = field(repr=False, compare=False)
+    body: bytes = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if type(self.status_code) is not int or not 100 <= self.status_code <= 599:
+            raise ValueError("Status HTTP non valido.")
+        if type(self.headers) is not tuple or len(self.headers) > 32:
+            raise ValueError("Header risposta non validi.")
+        total = 0
+        for item in self.headers:
+            if (
+                type(item) is not tuple
+                or len(item) != 2
+                or type(item[0]) is not str
+                or type(item[1]) is not str
+                or _HEADER_NAME_RE.fullmatch(item[0]) is None
+                or any(ord(character) < 32 or ord(character) == 127 for character in item[1])
+            ):
+                raise ValueError("Header risposta non validi.")
+            total += len(item[0].encode("ascii")) + len(item[1].encode("utf-8")) + 4
+        if total > _MAX_RESPONSE_HEADER_BYTES or type(self.body) is not bytes or len(self.body) > 4096:
+            raise ValueError("Risposta HTTP non valida.")
+
+
+class GoogleCallbackCompleter(Protocol):
+    def complete_callback(
+        self,
+        parameters: Mapping[str, Sequence[str]],
+        *,
+        existing_cookie_header: str | None = None,
+    ) -> GoogleOidcLoginResult: ...
+
+
+class GoogleOidcHttpRoutes:
+    """Dispatch the two public Google OIDC routes with strict HTTP policy."""
+
+    def __init__(
+        self,
+        admission: GoogleOidcLoginAdmissionBoundary,
+        callback: GoogleCallbackCompleter,
+        proxy_resolver: TrustedProxyClientResolver,
+    ) -> None:
+        self.admission = admission
+        self.callback = callback
+        self.proxy_resolver = proxy_resolver
+
+    def handles(self, path: str) -> bool:
+        return path in {_LOGIN_PATH, _CALLBACK_PATH}
+
+    def dispatch(self, request: GoogleOidcHttpRequest) -> GoogleOidcHttpResponse | None:
+        if type(request) is not GoogleOidcHttpRequest:
+            return self._error(400, "bad_auth_request", "Richiesta non valida.")
+        if not self.handles(request.path):
+            return None
+        try:
+            self._require_https(request)
+            self._require_empty_body(request.edge)
+            if request.method != "GET":
+                return self._error(
+                    405,
+                    "auth_method_not_allowed",
+                    "Metodo non consentito.",
+                    (("Allow", "GET"),),
+                )
+            if request.path == _LOGIN_PATH:
+                return self._login(request)
+            return self._callback(request)
+        except EdgeClientAttributionError:
+            return self._error(400, "invalid_client_address", "Indirizzo client non valido.")
+        except EdgeRateLimitExceededError as error:
+            return self._error(
+                429,
+                error.error_code,
+                error.public_message,
+                (("Retry-After", str(error.retry_after_seconds)),),
+            )
+        except EdgeRateLimitUnavailableError:
+            return self._error(
+                503,
+                "auth_admission_unavailable",
+                "Servizio di autenticazione temporaneamente non disponibile.",
+            )
+        except _HttpRequestError as error:
+            return self._error(error.status_code, error.error_code, error.public_message)
+        except Exception:
+            return self._error(
+                503,
+                "authentication_unavailable",
+                "Servizio di autenticazione temporaneamente non disponibile.",
+            )
+        finally:
+            request = None
+
+    def _login(self, request: GoogleOidcHttpRequest) -> GoogleOidcHttpResponse:
+        if request.query:
+            raise _HttpRequestError(400, "bad_auth_request", "Query non consentita.")
+        started = None
+        try:
+            started = self.admission.begin_login(request.edge)
+            if type(started) is not GoogleAuthorizationRequest:
+                raise EdgeRateLimitUnavailableError()
+            location = _redirect_location(started.authorization_url, absolute_https=True)
+            transaction_cookie = _set_cookie(started.set_cookie)
+            response = GoogleOidcHttpResponse(
+                302,
+                (
+                    ("Location", location),
+                    ("Set-Cookie", transaction_cookie),
+                    ("Cache-Control", "no-store"),
+                    ("Pragma", "no-cache"),
+                    ("Referrer-Policy", "no-referrer"),
+                    ("Content-Length", "0"),
+                ),
+                b"",
+            )
+        finally:
+            started = None
+        return response
+
+    def _callback(self, request: GoogleOidcHttpRequest) -> GoogleOidcHttpResponse:
+        parameters = None
+        cookie_header = None
+        result = None
+        try:
+            parameters = _callback_query(request.query)
+            cookie_header = _combined_cookie_header(request.edge.headers)
+            try:
+                result = self.callback.complete_callback(
+                    parameters,
+                    existing_cookie_header=cookie_header,
+                )
+            except GoogleOidcError as error:
+                clear_cookie = getattr(error, "clear_transaction_cookie", None)
+                return self._oidc_error(error, clear_cookie)
+            if type(result) is not GoogleOidcLoginResult:
+                raise GoogleOidcProviderUnavailableError(
+                    "Risultato callback non valido."
+                )
+            location = _redirect_location(result.redirect_path, absolute_https=False)
+            session_cookie = _set_cookie(result.session.set_cookie)
+            clear_cookie = _set_cookie(result.clear_transaction_cookie)
+            response = GoogleOidcHttpResponse(
+                303,
+                (
+                    ("Location", location),
+                    ("Set-Cookie", session_cookie),
+                    ("Set-Cookie", clear_cookie),
+                    ("Cache-Control", "no-store"),
+                    ("Pragma", "no-cache"),
+                    ("Referrer-Policy", "no-referrer"),
+                    ("Content-Length", "0"),
+                ),
+                b"",
+            )
+        finally:
+            request = None
+            parameters = None
+            cookie_header = None
+            result = None
+        return response
+
+    def _oidc_error(
+        self, error: GoogleOidcError, clear_cookie: object
+    ) -> GoogleOidcHttpResponse:
+        extra_headers: tuple[tuple[str, str], ...] = ()
+        if clear_cookie is not None:
+            try:
+                extra_headers = (("Set-Cookie", _set_cookie(clear_cookie)),)
+            except Exception:
+                return self._error(
+                    503,
+                    "authentication_unavailable",
+                    "Servizio di autenticazione temporaneamente non disponibile.",
+                )
+        if isinstance(error, GoogleOidcIdentityRejectedError):
+            return self._error(403, "identity_rejected", "Identità non autorizzata.", extra_headers)
+        if isinstance(error, GoogleOidcProviderUnavailableError) or isinstance(
+            error, GoogleOidcConfigurationError
+        ):
+            return self._error(
+                503,
+                "authentication_unavailable",
+                "Servizio di autenticazione temporaneamente non disponibile.",
+                extra_headers,
+            )
+        if isinstance(error, GoogleOidcStateError):
+            return self._error(400, "invalid_oauth_state", "Sessione login non valida.", extra_headers)
+        if isinstance(error, (GoogleOidcCallbackError, GoogleOidcTokenRejectedError)):
+            return self._error(400, "invalid_oauth_callback", "Callback login non valida.", extra_headers)
+        return self._error(
+            503,
+            "authentication_unavailable",
+            "Servizio di autenticazione temporaneamente non disponibile.",
+            extra_headers,
+        )
+
+    def _require_https(self, request: GoogleOidcHttpRequest) -> None:
+        if request.is_tls:
+            return
+        if not self.proxy_resolver.is_trusted_peer(request.edge):
+            raise _HttpRequestError(400, "https_required", "HTTPS obbligatorio.")
+        values = [
+            value.strip().lower()
+            for name, value in request.edge.headers
+            if name.lower() == "x-forwarded-proto"
+        ]
+        if values != ["https"]:
+            raise _HttpRequestError(400, "https_required", "HTTPS obbligatorio.")
+
+    @staticmethod
+    def _require_empty_body(edge: EdgeRequestMetadata) -> None:
+        lengths = [value.strip() for name, value in edge.headers if name.lower() == "content-length"]
+        transfers = [value for name, value in edge.headers if name.lower() == "transfer-encoding"]
+        if transfers or len(lengths) > 1 or (lengths and lengths != ["0"]):
+            raise _HttpRequestError(400, "bad_auth_request", "Body non consentito.")
+
+    @staticmethod
+    def _error(
+        status_code: int,
+        error_code: str,
+        public_message: str,
+        extra_headers: tuple[tuple[str, str], ...] = (),
+    ) -> GoogleOidcHttpResponse:
+        body = json.dumps(
+            {"error": error_code, "message": public_message},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        headers = extra_headers + (
+            ("Content-Type", "application/json; charset=utf-8"),
+            ("Cache-Control", "no-store"),
+            ("Referrer-Policy", "no-referrer"),
+            ("Content-Length", str(len(body))),
+        )
+        return GoogleOidcHttpResponse(status_code, headers, body)
+
+
+class _HttpRequestError(RuntimeError):
+    def __init__(self, status_code: int, error_code: str, public_message: str) -> None:
+        self.status_code = status_code
+        self.error_code = error_code
+        self.public_message = public_message
+        super().__init__(public_message)
+
+
+def _callback_query(raw_query: str) -> dict[str, tuple[str, ...]]:
+    parsed: dict[str, list[str]] | None = None
+    result = None
+    try:
+        if (
+            type(raw_query) is not str
+            or not raw_query
+            or len(raw_query.encode("utf-8", errors="surrogatepass")) > _MAX_QUERY_BYTES
+            or "#" in raw_query
+            or _PERCENT_ESCAPE_RE.search(raw_query) is not None
+        ):
+            raise _HttpRequestError(400, "bad_auth_request", "Query callback non valida.")
+        try:
+            parsed = urllib.parse.parse_qs(
+                raw_query,
+                keep_blank_values=True,
+                strict_parsing=True,
+                max_num_fields=_MAX_QUERY_FIELDS,
+                encoding="utf-8",
+                errors="strict",
+            )
+        except (UnicodeError, ValueError):
+            raise _HttpRequestError(
+                400, "bad_auth_request", "Query callback non valida."
+            ) from None
+        result = {key: tuple(values) for key, values in parsed.items()}
+        return result
+    finally:
+        raw_query = None
+        parsed = None
+        result = None
+
+
+def _combined_cookie_header(headers: tuple[tuple[str, str], ...]) -> str | None:
+    values = None
+    combined = None
+    try:
+        values = [value for name, value in headers if name.lower() == "cookie"]
+        if not values:
+            return None
+        combined = "; ".join(values)
+        if (
+            len(combined.encode("utf-8", errors="surrogatepass")) > _MAX_COOKIE_HEADER_BYTES
+            or any(ord(character) < 32 or ord(character) == 127 for character in combined)
+        ):
+            raise _HttpRequestError(400, "bad_auth_request", "Cookie non valido.")
+        return combined
+    finally:
+        headers = ()
+        values = None
+        combined = None
+
+
+def _redirect_location(value: object, *, absolute_https: bool) -> str:
+    if type(value) is not str or not value or len(value) > 8192:
+        raise ValueError("Redirect non valido.")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError("Redirect non valido.")
+    parsed = urllib.parse.urlsplit(value)
+    if absolute_https:
+        if parsed.scheme != "https" or not parsed.netloc or parsed.fragment:
+            raise ValueError("Redirect non valido.")
+    elif (
+        not value.startswith("/")
+        or value.startswith("//")
+        or parsed.scheme
+        or parsed.netloc
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("Redirect non valido.")
+    return value
+
+
+def _set_cookie(value: object) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or len(value.encode("utf-8", errors="surrogatepass")) > 4096
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise ValueError("Cookie risposta non valido.")
+    return value

--- a/scripts/thebitlab_google_oidc_http.py
+++ b/scripts/thebitlab_google_oidc_http.py
@@ -16,6 +16,7 @@ from scripts.thebitlab_edge_rate_limit import (
     GoogleOidcLoginAdmissionBoundary,
     TrustedProxyClientResolver,
 )
+from scripts.thebitlab_http_auth import SessionCookiePolicy
 from scripts.thebitlab_google_oidc import (
     GoogleAuthorizationRequest,
     GoogleOidcCallbackError,
@@ -95,6 +96,10 @@ class GoogleOidcHttpResponse:
             raise ValueError("Risposta HTTP non valida.")
 
 
+class EstablishedSessionDiscarder(Protocol):
+    def discard_established_session(self, established: object) -> bool: ...
+
+
 class GoogleCallbackCompleter(Protocol):
     def complete_callback(
         self,
@@ -112,10 +117,28 @@ class GoogleOidcHttpRoutes:
         admission: GoogleOidcLoginAdmissionBoundary,
         callback: GoogleCallbackCompleter,
         proxy_resolver: TrustedProxyClientResolver,
+        session_discarder: EstablishedSessionDiscarder,
+        *,
+        session_cookie_policy: SessionCookiePolicy = SessionCookiePolicy(),
     ) -> None:
+        if (
+            type(session_cookie_policy) is not SessionCookiePolicy
+            or not session_cookie_policy.secure
+            or session_cookie_policy.allow_insecure_loopback
+            or not session_cookie_policy.name.startswith("__Host-")
+        ):
+            raise ValueError("Policy cookie sessione non valida per route HTTPS.")
+        callback_http = getattr(callback, "http_sessions", None)
+        callback_policy = getattr(callback_http, "cookie_policy", None)
+        if callback_policy is not None and callback_policy != session_cookie_policy:
+            raise ValueError("Policy cookie callback non coerente.")
+        if callback_http is not None and session_discarder is not callback_http:
+            raise ValueError("Discarder sessione callback non coerente.")
         self.admission = admission
         self.callback = callback
         self.proxy_resolver = proxy_resolver
+        self.session_discarder = session_discarder
+        self.session_cookie_policy = session_cookie_policy
 
     def handles(self, path: str) -> bool:
         return path in {_LOGIN_PATH, _CALLBACK_PATH}
@@ -211,26 +234,56 @@ class GoogleOidcHttpRoutes:
                 raise GoogleOidcProviderUnavailableError(
                     "Risultato callback non valido."
                 )
-            location = _redirect_location(result.redirect_path, absolute_https=False)
-            session_cookie = _validated_cookie(
-                result.session.set_cookie, kind="session"
-            )
-            clear_cookie = _validated_cookie(
-                result.clear_transaction_cookie, kind="clear_transaction"
-            )
-            response = GoogleOidcHttpResponse(
-                303,
-                (
-                    ("Location", location),
-                    ("Set-Cookie", session_cookie),
-                    ("Set-Cookie", clear_cookie),
-                    ("Cache-Control", "no-store"),
-                    ("Pragma", "no-cache"),
-                    ("Referrer-Policy", "no-referrer"),
-                    ("Content-Length", "0"),
-                ),
-                b"",
-            )
+            try:
+                location = _redirect_location(
+                    result.redirect_path, absolute_https=False
+                )
+                session_cookie = _validated_cookie(
+                    result.session.set_cookie,
+                    kind="session",
+                    session_policy=self.session_cookie_policy,
+                )
+                clear_cookie = _validated_cookie(
+                    result.clear_transaction_cookie,
+                    kind="clear_transaction",
+                )
+                response = GoogleOidcHttpResponse(
+                    303,
+                    (
+                        ("Location", location),
+                        ("Set-Cookie", session_cookie),
+                        ("Set-Cookie", clear_cookie),
+                        ("Cache-Control", "no-store"),
+                        ("Pragma", "no-cache"),
+                        ("Referrer-Policy", "no-referrer"),
+                        ("Content-Length", "0"),
+                    ),
+                    b"",
+                )
+            except Exception:
+                cleanup_header: tuple[tuple[str, str], ...] = ()
+                try:
+                    cleanup_header = ((
+                        "Set-Cookie",
+                        _validated_cookie(
+                            result.clear_transaction_cookie,
+                            kind="clear_transaction",
+                        ),
+                    ),)
+                except Exception:
+                    cleanup_header = ()
+                try:
+                    self.session_discarder.discard_established_session(
+                        result.session
+                    )
+                except Exception:
+                    pass
+                return self._error(
+                    503,
+                    "authentication_unavailable",
+                    "Servizio di autenticazione temporaneamente non disponibile.",
+                    cleanup_header,
+                )
         finally:
             request = None
             parameters = None
@@ -419,7 +472,12 @@ def _redirect_location(value: object, *, absolute_https: bool) -> str:
     return urllib.parse.quote(value, safe="/-._~!$&'()*+,;=:@%")
 
 
-def _validated_cookie(value: object, *, kind: str) -> str:
+def _validated_cookie(
+    value: object,
+    *,
+    kind: str,
+    session_policy: SessionCookiePolicy | None = None,
+) -> str:
     if (
         type(value) is not str
         or not value
@@ -431,7 +489,11 @@ def _validated_cookie(value: object, *, kind: str) -> str:
     if not parts or "=" not in parts[0] or any(not part for part in parts):
         raise ValueError("Cookie risposta non valido.")
     name, cookie_value = parts[0].split("=", 1)
-    expected_name = "__Host-thebitlab_session" if kind == "session" else None
+    expected_name = (
+        session_policy.name
+        if kind == "session" and type(session_policy) is SessionCookiePolicy
+        else None
+    )
     if kind in {"transaction", "clear_transaction"}:
         valid_name = _TRANSACTION_COOKIE_NAME_RE.fullmatch(name) is not None
     else:
@@ -454,9 +516,15 @@ def _validated_cookie(value: object, *, kind: str) -> str:
         not valid_name
         or flags != {"secure", "httponly"}
         or attributes.get("path") != "/"
-        or attributes.get("samesite", "").lower() != "lax"
         or set(attributes) - {"path", "samesite", "max-age", "expires"}
     ):
+        raise ValueError("Cookie risposta non valido.")
+    expected_same_site = (
+        session_policy.same_site.lower()
+        if kind == "session" and type(session_policy) is SessionCookiePolicy
+        else "lax"
+    )
+    if attributes.get("samesite", "").lower() != expected_same_site:
         raise ValueError("Cookie risposta non valido.")
     max_age = attributes.get("max-age")
     if kind == "clear_transaction":

--- a/scripts/thebitlab_google_oidc_http.py
+++ b/scripts/thebitlab_google_oidc_http.py
@@ -65,11 +65,40 @@ class GoogleOidcHttpRequest:
             raise ValueError("Metadati HTTP non validi.")
 
 
+class GoogleOidcDeliveryGuard:
+    """Discard one issued session unless the HTTP response is delivered."""
+
+    def __init__(
+        self, discarder: EstablishedSessionDiscarder, established: object
+    ) -> None:
+        self._discarder = discarder
+        self._established = established
+
+    def delivered(self) -> None:
+        self._established = None
+        self._discarder = None
+
+    def failed(self) -> None:
+        established = self._established
+        discarder = self._discarder
+        self._established = None
+        self._discarder = None
+        if established is None or discarder is None:
+            return
+        try:
+            discarder.discard_established_session(established)
+        except Exception:
+            pass
+
+
 @dataclass(frozen=True)
 class GoogleOidcHttpResponse:
     status_code: int
     headers: tuple[tuple[str, str], ...] = field(repr=False, compare=False)
     body: bytes = field(repr=False, compare=False)
+    delivery_guard: GoogleOidcDeliveryGuard | None = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         if type(self.status_code) is not int or not 100 <= self.status_code <= 599:
@@ -92,7 +121,15 @@ class GoogleOidcHttpResponse:
             except UnicodeEncodeError:
                 raise ValueError("Header risposta non serializzabile.") from None
             total += len(item[0].encode("ascii")) + len(encoded_value) + 4
-        if total > _MAX_RESPONSE_HEADER_BYTES or type(self.body) is not bytes or len(self.body) > 4096:
+        if (
+            total > _MAX_RESPONSE_HEADER_BYTES
+            or type(self.body) is not bytes
+            or len(self.body) > 4096
+            or (
+                self.delivery_guard is not None
+                and type(self.delivery_guard) is not GoogleOidcDeliveryGuard
+            )
+        ):
             raise ValueError("Risposta HTTP non valida.")
 
 
@@ -259,6 +296,9 @@ class GoogleOidcHttpRoutes:
                         ("Content-Length", "0"),
                     ),
                     b"",
+                    GoogleOidcDeliveryGuard(
+                        self.session_discarder, result.session
+                    ),
                 )
             except Exception:
                 cleanup_header: tuple[tuple[str, str], ...] = ()

--- a/scripts/thebitlab_google_oidc_http.py
+++ b/scripts/thebitlab_google_oidc_http.py
@@ -53,7 +53,12 @@ class GoogleOidcHttpRequest:
     is_tls: bool = False
 
     def __post_init__(self) -> None:
-        if type(self.method) is not str or not self.method or len(self.method) > 16:
+        if (
+            type(self.method) is not str
+            or not self.method
+            or len(self.method) > 65_535
+            or _HEADER_NAME_RE.fullmatch(self.method) is None
+        ):
             raise ValueError("Metodo HTTP non valido.")
         if type(self.path) is not str or not self.path.startswith("/") or len(self.path) > 256:
             raise ValueError("Path HTTP non valido.")

--- a/scripts/thebitlab_google_oidc_http.py
+++ b/scripts/thebitlab_google_oidc_http.py
@@ -37,6 +37,10 @@ _MAX_COOKIE_HEADER_BYTES = 16_384
 _MAX_RESPONSE_HEADER_BYTES = 16_384
 _PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 _HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+_COOKIE_VALUE_RE = re.compile(r"^[A-Za-z0-9_-]{32,1024}$")
+_TRANSACTION_COOKIE_NAME_RE = re.compile(
+    r"^__Host-thebitlab_oidc_txn-[0-9a-f]{24}$"
+)
 
 
 @dataclass(frozen=True)
@@ -82,7 +86,11 @@ class GoogleOidcHttpResponse:
                 or any(ord(character) < 32 or ord(character) == 127 for character in item[1])
             ):
                 raise ValueError("Header risposta non validi.")
-            total += len(item[0].encode("ascii")) + len(item[1].encode("utf-8")) + 4
+            try:
+                encoded_value = item[1].encode("latin-1")
+            except UnicodeEncodeError:
+                raise ValueError("Header risposta non serializzabile.") from None
+            total += len(item[0].encode("ascii")) + len(encoded_value) + 4
         if total > _MAX_RESPONSE_HEADER_BYTES or type(self.body) is not bytes or len(self.body) > 4096:
             raise ValueError("Risposta HTTP non valida.")
 
@@ -165,7 +173,9 @@ class GoogleOidcHttpRoutes:
             if type(started) is not GoogleAuthorizationRequest:
                 raise EdgeRateLimitUnavailableError()
             location = _redirect_location(started.authorization_url, absolute_https=True)
-            transaction_cookie = _set_cookie(started.set_cookie)
+            transaction_cookie = _validated_cookie(
+                started.set_cookie, kind="transaction"
+            )
             response = GoogleOidcHttpResponse(
                 302,
                 (
@@ -202,8 +212,12 @@ class GoogleOidcHttpRoutes:
                     "Risultato callback non valido."
                 )
             location = _redirect_location(result.redirect_path, absolute_https=False)
-            session_cookie = _set_cookie(result.session.set_cookie)
-            clear_cookie = _set_cookie(result.clear_transaction_cookie)
+            session_cookie = _validated_cookie(
+                result.session.set_cookie, kind="session"
+            )
+            clear_cookie = _validated_cookie(
+                result.clear_transaction_cookie, kind="clear_transaction"
+            )
             response = GoogleOidcHttpResponse(
                 303,
                 (
@@ -230,7 +244,10 @@ class GoogleOidcHttpRoutes:
         extra_headers: tuple[tuple[str, str], ...] = ()
         if clear_cookie is not None:
             try:
-                extra_headers = (("Set-Cookie", _set_cookie(clear_cookie)),)
+                extra_headers = ((
+                    "Set-Cookie",
+                    _validated_cookie(clear_cookie, kind="clear_transaction"),
+                ),)
             except Exception:
                 return self._error(
                     503,
@@ -368,9 +385,27 @@ def _redirect_location(value: object, *, absolute_https: bool) -> str:
         raise ValueError("Redirect non valido.")
     parsed = urllib.parse.urlsplit(value)
     if absolute_https:
-        if parsed.scheme != "https" or not parsed.netloc or parsed.fragment:
+        try:
+            port = parsed.port
+        except ValueError:
+            raise ValueError("Redirect non valido.") from None
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname != "accounts.google.com"
+            or parsed.username is not None
+            or parsed.password is not None
+            or port not in {None, 443}
+            or parsed.path != "/o/oauth2/v2/auth"
+            or not parsed.query
+            or parsed.fragment
+        ):
             raise ValueError("Redirect non valido.")
-    elif (
+        try:
+            value.encode("ascii")
+        except UnicodeEncodeError:
+            raise ValueError("Redirect non valido.") from None
+        return value
+    if (
         not value.startswith("/")
         or value.startswith("//")
         or parsed.scheme
@@ -379,15 +414,60 @@ def _redirect_location(value: object, *, absolute_https: bool) -> str:
         or parsed.fragment
     ):
         raise ValueError("Redirect non valido.")
-    return value
+    if _PERCENT_ESCAPE_RE.search(value) is not None:
+        raise ValueError("Redirect non valido.")
+    return urllib.parse.quote(value, safe="/-._~!$&'()*+,;=:@%")
 
 
-def _set_cookie(value: object) -> str:
+def _validated_cookie(value: object, *, kind: str) -> str:
     if (
         type(value) is not str
         or not value
         or len(value.encode("utf-8", errors="surrogatepass")) > 4096
         or any(ord(character) < 32 or ord(character) == 127 for character in value)
     ):
+        raise ValueError("Cookie risposta non valido.")
+    parts = [part.strip() for part in value.split(";")]
+    if not parts or "=" not in parts[0] or any(not part for part in parts):
+        raise ValueError("Cookie risposta non valido.")
+    name, cookie_value = parts[0].split("=", 1)
+    expected_name = "__Host-thebitlab_session" if kind == "session" else None
+    if kind in {"transaction", "clear_transaction"}:
+        valid_name = _TRANSACTION_COOKIE_NAME_RE.fullmatch(name) is not None
+    else:
+        valid_name = kind == "session" and name == expected_name
+    flags: set[str] = set()
+    attributes: dict[str, str] = {}
+    for part in parts[1:]:
+        if "=" in part:
+            key, attribute_value = part.split("=", 1)
+            lowered = key.lower()
+            if lowered in attributes or lowered in flags:
+                raise ValueError("Cookie risposta non valido.")
+            attributes[lowered] = attribute_value
+        else:
+            lowered = part.lower()
+            if lowered in flags or lowered in attributes:
+                raise ValueError("Cookie risposta non valido.")
+            flags.add(lowered)
+    if (
+        not valid_name
+        or flags != {"secure", "httponly"}
+        or attributes.get("path") != "/"
+        or attributes.get("samesite", "").lower() != "lax"
+        or set(attributes) - {"path", "samesite", "max-age", "expires"}
+    ):
+        raise ValueError("Cookie risposta non valido.")
+    max_age = attributes.get("max-age")
+    if kind == "clear_transaction":
+        valid_value = cookie_value == "" and max_age == "0" and "expires" in attributes
+    else:
+        valid_value = (
+            _COOKIE_VALUE_RE.fullmatch(cookie_value) is not None
+            and max_age is not None
+            and max_age.isdigit()
+            and 1 <= int(max_age) <= 2_678_400
+        )
+    if not valid_value:
         raise ValueError("Cookie risposta non valido.")
     return value

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -426,6 +426,24 @@ def test_unknown_path_is_not_handled() -> None:
     assert router.dispatch(request("/auth/google/unknown")) is None
 
 
+def test_transport_write_failure_discards_issued_session() -> None:
+    router, _admission, callback = routes()
+    response = router.dispatch(
+        request("/auth/google/callback", "state=x&code=y")
+    )
+    handler = object.__new__(CourseBoardHandler)
+    handler.command = "GET"
+
+    def fail_send_response(_status):
+        raise BrokenPipeError("socket closed")
+
+    handler.send_response = fail_send_response
+    handler.write_google_oidc_response(response)
+
+    assert router.session_discarder.calls == [callback.result.session]
+    assert response.delivery_guard._established is None
+
+
 def test_malformed_request_line_redacts_callback_secret_and_returns_400() -> None:
     class RecordingHandler(CourseBoardHandler):
         messages = []
@@ -493,7 +511,9 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
         )
         unsupported = {
             method: exchange(method, "/auth/google/login")
-            for method in ("PUT", "DELETE", "PATCH", "OPTIONS")
+            for method in (
+                "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE", "CONNECT"
+            )
         }
     finally:
         server.shutdown()
@@ -504,7 +524,9 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
     assert fragmented == (400, None)
     assert unsupported == {
         method: (405, "GET")
-        for method in ("PUT", "DELETE", "PATCH", "OPTIONS")
+        for method in (
+            "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE", "CONNECT"
+        )
     }
     assert callback.calls == 0
     assert admission.calls == 0

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -513,7 +513,7 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
             method: exchange(method, "/auth/google/login")
             for method in (
                 "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE", "CONNECT",
-                "PROPFIND",
+                "PROPFIND", "LONGEXTENSIONMETHOD",
             )
         }
     finally:
@@ -527,7 +527,7 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
         method: (405, "GET")
         for method in (
             "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE", "CONNECT",
-            "PROPFIND",
+            "PROPFIND", "LONGEXTENSIONMETHOD",
         )
     }
     assert callback.calls == 0

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import http.client
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.course_board_server import BoundedThreadingHTTPServer, CourseBoardHandler
+from scripts.thebitlab_edge_rate_limit import (
+    EdgeRateLimitExceededError,
+    EdgeRateLimitUnavailableError,
+    EdgeRequestMetadata,
+    TrustedProxyClientResolver,
+)
+from scripts.thebitlab_google_oidc import (
+    GoogleAuthorizationRequest,
+    GoogleOidcCallbackError,
+    GoogleOidcIdentityRejectedError,
+    GoogleOidcLoginResult,
+    GoogleOidcProviderUnavailableError,
+    GoogleOidcStateError,
+)
+from scripts.thebitlab_google_oidc_http import (
+    GoogleOidcHttpRequest,
+    GoogleOidcHttpRoutes,
+)
+
+
+AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth?state=raw-state"
+TXN_COOKIE = "__Host-thebitlab_oidc_txn-deadbeef=raw-binding; Path=/; Secure; HttpOnly; SameSite=Lax"
+SESSION_COOKIE = "__Host-thebitlab_session=raw-session; Path=/; Secure; HttpOnly; SameSite=Lax"
+CLEAR_COOKIE = "__Host-thebitlab_oidc_txn-deadbeef=; Path=/; Max-Age=0; Secure; HttpOnly; SameSite=Lax"
+
+
+class FakeAdmission:
+    def __init__(self):
+        self.calls = 0
+        self.error = None
+        self.result = GoogleAuthorizationRequest(AUTH_URL, TXN_COOKIE)
+
+    def begin_login(self, _metadata):
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class FakeCallback:
+    def __init__(self):
+        self.calls = 0
+        self.parameters = None
+        self.cookie = None
+        self.error = None
+        self.result = GoogleOidcLoginResult(
+            "user-01",
+            "student",
+            SimpleNamespace(set_cookie=SESSION_COOKIE),
+            "/student",
+            CLEAR_COOKIE,
+        )
+
+    def complete_callback(self, parameters, *, existing_cookie_header=None):
+        self.calls += 1
+        self.parameters = parameters
+        self.cookie = existing_cookie_header
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def metadata(peer="127.0.0.1", *headers):
+    return EdgeRequestMetadata(peer, tuple(headers))
+
+
+def request(path, query="", *, method="GET", peer="127.0.0.1", headers=(), tls=True):
+    return GoogleOidcHttpRequest(
+        method,
+        path,
+        query,
+        metadata(peer, *headers),
+        is_tls=tls,
+    )
+
+
+def routes(*, trusted=()):
+    admission = FakeAdmission()
+    callback = FakeCallback()
+    resolver = TrustedProxyClientResolver(trusted)
+    return GoogleOidcHttpRoutes(admission, callback, resolver), admission, callback
+
+
+def header_values(response, name):
+    return [value for key, value in response.headers if key.lower() == name.lower()]
+
+
+def traceback_values(error, *function_names):
+    values = []
+    current = error.__traceback__
+    while current is not None:
+        if current.tb_frame.f_code.co_name in function_names:
+            values.extend(current.tb_frame.f_locals.values())
+        current = current.tb_next
+    return repr(values)
+
+
+def test_login_returns_bounded_no_store_redirect_and_cookie() -> None:
+    router, admission, _callback = routes()
+
+    response = router.dispatch(request("/auth/google/login"))
+
+    assert response.status_code == 302
+    assert header_values(response, "Location") == [AUTH_URL]
+    assert header_values(response, "Set-Cookie") == [TXN_COOKIE]
+    assert header_values(response, "Cache-Control") == ["no-store"]
+    assert header_values(response, "Pragma") == ["no-cache"]
+    assert header_values(response, "Referrer-Policy") == ["no-referrer"]
+    assert response.body == b""
+    assert admission.calls == 1
+    assert "raw-state" not in repr(response)
+    assert "raw-binding" not in repr(response)
+
+
+def test_login_rejects_query_body_and_non_get_before_admission() -> None:
+    router, admission, _callback = routes()
+    cases = (
+        request("/auth/google/login", "next=/student"),
+        request(
+            "/auth/google/login",
+            headers=(("Content-Length", "1"),),
+        ),
+        request(
+            "/auth/google/login",
+            headers=(("Transfer-Encoding", "chunked"),),
+        ),
+        request("/auth/google/login", method="POST"),
+    )
+
+    responses = [router.dispatch(candidate) for candidate in cases]
+
+    assert [response.status_code for response in responses] == [400, 400, 400, 405]
+    assert header_values(responses[-1], "Allow") == ["GET"]
+    assert admission.calls == 0
+
+
+def test_https_is_direct_or_from_one_explicitly_trusted_proxy() -> None:
+    router, admission, _callback = routes(trusted=("127.0.0.0/8",))
+
+    trusted = router.dispatch(
+        request(
+            "/auth/google/login",
+            headers=(("X-Forwarded-Proto", "https"),),
+            tls=False,
+        )
+    )
+    missing = router.dispatch(request("/auth/google/login", tls=False))
+    duplicate = router.dispatch(
+        request(
+            "/auth/google/login",
+            headers=(
+                ("X-Forwarded-Proto", "https"),
+                ("X-Forwarded-Proto", "https"),
+            ),
+            tls=False,
+        )
+    )
+    untrusted_router, untrusted_admission, _ = routes(trusted=("10.0.0.0/8",))
+    spoofed = untrusted_router.dispatch(
+        request(
+            "/auth/google/login",
+            peer="203.0.113.9",
+            headers=(("X-Forwarded-Proto", "https"),),
+            tls=False,
+        )
+    )
+
+    assert trusted.status_code == 302
+    assert missing.status_code == 400
+    assert duplicate.status_code == 400
+    assert spoofed.status_code == 400
+    assert admission.calls == 1
+    assert untrusted_admission.calls == 0
+
+
+def test_rate_limit_errors_map_to_sanitized_429_and_503() -> None:
+    router, admission, _callback = routes()
+    admission.error = EdgeRateLimitExceededError(17)
+    limited = router.dispatch(request("/auth/google/login"))
+    admission.error = EdgeRateLimitUnavailableError()
+    unavailable = router.dispatch(request("/auth/google/login"))
+
+    assert limited.status_code == 429
+    assert header_values(limited, "Retry-After") == ["17"]
+    assert b"rate_limit_exceeded" in limited.body
+    assert unavailable.status_code == 503
+    assert b"raw" not in unavailable.body
+
+
+def test_callback_preserves_duplicate_parameters_and_combines_cookies() -> None:
+    router, _admission, callback = routes()
+    raw_query = "state=raw-state&code=raw-code&scope=openid&scope=email"
+    callback_request = request(
+        "/auth/google/callback",
+        raw_query,
+        headers=(
+            ("Cookie", "first=one"),
+            ("Cookie", "second=two"),
+        ),
+    )
+    assert "raw-code" not in repr(callback_request)
+    assert "first=one" not in repr(callback_request)
+    response = router.dispatch(callback_request)
+
+    assert response.status_code == 303
+    assert header_values(response, "Location") == ["/student"]
+    assert header_values(response, "Set-Cookie") == [SESSION_COOKIE, CLEAR_COOKIE]
+    assert callback.parameters == {
+        "state": ("raw-state",),
+        "code": ("raw-code",),
+        "scope": ("openid", "email"),
+    }
+    assert callback.cookie == "first=one; second=two"
+
+
+def test_callback_rejects_malformed_query_and_cookie_before_service() -> None:
+    router, _admission, callback = routes()
+    queries = ("", "state=x&broken", "state=%ZZ", "state=%FF")
+    for raw_query in queries:
+        response = router.dispatch(request("/auth/google/callback", raw_query))
+        assert response.status_code == 400
+    oversized_cookie = "x=" + "a" * 8190
+    response = router.dispatch(
+        request(
+            "/auth/google/callback",
+            "state=x&code=y",
+            headers=(
+                ("Cookie", oversized_cookie),
+                ("Cookie", oversized_cookie),
+            ),
+        )
+    )
+    assert response.status_code == 400
+    assert callback.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("error", "status", "code"),
+    (
+        (GoogleOidcStateError("raw state details"), 400, b"invalid_oauth_state"),
+        (GoogleOidcCallbackError("raw callback details"), 400, b"invalid_oauth_callback"),
+        (GoogleOidcIdentityRejectedError("raw identity details"), 403, b"identity_rejected"),
+        (GoogleOidcProviderUnavailableError("raw backend details"), 503, b"authentication_unavailable"),
+    ),
+)
+def test_callback_error_taxonomy_is_sanitized_and_clears_terminal_cookie(
+    error, status, code
+) -> None:
+    router, _admission, callback = routes()
+    error.clear_transaction_cookie = CLEAR_COOKIE
+    callback.error = error
+
+    response = router.dispatch(
+        request("/auth/google/callback", "state=raw-state&code=raw-code")
+    )
+
+    assert response.status_code == status
+    assert code in response.body
+    assert b"raw backend details" not in response.body
+    assert header_values(response, "Set-Cookie") == [CLEAR_COOKIE]
+
+
+def test_malformed_adapter_redirects_cookies_and_results_fail_closed() -> None:
+    router, admission, callback = routes()
+    admission.result = GoogleAuthorizationRequest("http://attacker.test", TXN_COOKIE)
+    assert router.dispatch(request("/auth/google/login")).status_code == 503
+    admission.result = GoogleAuthorizationRequest(AUTH_URL, "bad\r\nX-Evil: yes")
+    assert router.dispatch(request("/auth/google/login")).status_code == 503
+    callback.result = "malformed"
+    assert router.dispatch(
+        request("/auth/google/callback", "state=x&code=y")
+    ).status_code == 503
+
+
+def test_query_and_cookie_secrets_are_removed_from_route_traceback_frames() -> None:
+    class ExplodingCallback(FakeCallback):
+        def complete_callback(self, parameters, *, existing_cookie_header=None):
+            raise RuntimeError("raw backend")
+
+    admission = FakeAdmission()
+    callback = ExplodingCallback()
+    router = GoogleOidcHttpRoutes(
+        admission, callback, TrustedProxyClientResolver()
+    )
+    query_secret = "state=raw-state&code=raw-code"
+    cookie_secret = "txn=raw-cookie"
+
+    response = router.dispatch(
+        request(
+            "/auth/google/callback",
+            query_secret,
+            headers=(("Cookie", cookie_secret),),
+        )
+    )
+
+    assert response.status_code == 503
+    assert query_secret.encode() not in response.body
+    assert cookie_secret.encode() not in response.body
+
+
+def test_unknown_path_is_not_handled() -> None:
+    router, _admission, _callback = routes()
+    assert router.dispatch(request("/auth/google/unknown")) is None
+
+
+def test_course_board_access_log_redacts_callback_query() -> None:
+    class RecordingHandler(CourseBoardHandler):
+        messages = []
+
+        def log_message(self, format, *args):
+            self.messages.append(format % args)
+
+    router, _admission, callback = routes(trusted=("127.0.0.0/8",))
+    server = BoundedThreadingHTTPServer(("127.0.0.1", 0), RecordingHandler)
+    server.google_oidc_http_routes = router
+    server.teacher_token = "T" * 32
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection(
+        "127.0.0.1", server.server_address[1], timeout=5
+    )
+    try:
+        connection.request(
+            "GET",
+            "/auth/google/callback?state=raw-state&code=raw-code",
+            headers={"X-Forwarded-Proto": "https"},
+        )
+        response = connection.getresponse()
+        response.read()
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 303
+    assert callback.calls == 1
+    serialized = repr(RecordingHandler.messages)
+    assert "/auth/google/callback" in serialized
+    assert "raw-state" not in serialized
+    assert "raw-code" not in serialized
+
+
+def test_course_board_handler_delegates_real_http_request() -> None:
+    router, admission, _callback = routes(trusted=("127.0.0.0/8",))
+    server = BoundedThreadingHTTPServer(("127.0.0.1", 0), CourseBoardHandler)
+    server.google_oidc_http_routes = router
+    server.teacher_token = "T" * 32
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection(
+        "127.0.0.1", server.server_address[1], timeout=5
+    )
+    try:
+        connection.request(
+            "GET",
+            "/auth/google/login",
+            headers={"X-Forwarded-Proto": "https"},
+        )
+        response = connection.getresponse()
+        response.read()
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 302
+    assert response.getheader("Location") == AUTH_URL
+    assert response.getheader("Set-Cookie") == TXN_COOKIE
+    assert response.getheader("Cache-Control") == "no-store"
+    assert admission.calls == 1

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -512,7 +512,8 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
         unsupported = {
             method: exchange(method, "/auth/google/login")
             for method in (
-                "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE", "CONNECT"
+                "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE", "CONNECT",
+                "PROPFIND",
             )
         }
     finally:
@@ -525,7 +526,8 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
     assert unsupported == {
         method: (405, "GET")
         for method in (
-            "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE", "CONNECT"
+            "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE", "CONNECT",
+            "PROPFIND",
         )
     }
     assert callback.calls == 0

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -457,26 +457,41 @@ def test_malformed_request_line_redacts_callback_secret_and_returns_400() -> Non
     server.teacher_token = "T" * 32
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
+    def raw_exchange(request_line):
+        connection = socket.create_connection(server.server_address, timeout=5)
+        try:
+            connection.sendall(
+                (request_line + "\r\nHost: localhost\r\n\r\n").encode("ascii")
+            )
+            return connection.recv(4096)
+        finally:
+            connection.close()
+
     raw_secret = "RAW-CALLBACK-CODE"
-    connection = socket.create_connection(server.server_address, timeout=5)
+    method_secret = "METHODSECRET"
     try:
-        connection.sendall(
-            (
-                "GET /auth/google/callback?code="
-                + raw_secret
-                + " EXTRA HTTP/1.1\r\nHost: localhost\r\n\r\n"
-            ).encode("ascii")
+        response = raw_exchange(
+            "GET /auth/google/callback?code="
+            + raw_secret
+            + " EXTRA HTTP/1.1"
         )
-        response = connection.recv(4096)
+        malformed_method = raw_exchange(
+            "/auth/google/callback?code="
+            + method_secret
+            + " / HTTP/1.1"
+        )
     finally:
-        connection.close()
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
 
     assert b"400" in response
+    assert b"400" in malformed_method
     assert raw_secret.encode("ascii") not in response
-    assert raw_secret not in repr(RecordingHandler.messages)
+    assert method_secret.encode("ascii") not in malformed_method
+    serialized = repr(RecordingHandler.messages)
+    assert raw_secret not in serialized
+    assert method_secret not in serialized
 
 
 def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import http.client
+import socket
 import threading
 from types import SimpleNamespace
 
@@ -13,6 +14,7 @@ from scripts.thebitlab_edge_rate_limit import (
     EdgeRequestMetadata,
     TrustedProxyClientResolver,
 )
+from scripts.thebitlab_http_auth import SessionCookiePolicy
 from scripts.thebitlab_google_oidc import (
     GoogleAuthorizationRequest,
     GoogleOidcCallbackError,
@@ -45,6 +47,15 @@ class FakeAdmission:
         if self.error is not None:
             raise self.error
         return self.result
+
+
+class FakeDiscarder:
+    def __init__(self):
+        self.calls = []
+
+    def discard_established_session(self, established):
+        self.calls.append(established)
+        return True
 
 
 class FakeCallback:
@@ -84,11 +95,23 @@ def request(path, query="", *, method="GET", peer="127.0.0.1", headers=(), tls=T
     )
 
 
-def routes(*, trusted=()):
+def routes(*, trusted=(), session_cookie_policy=None):
     admission = FakeAdmission()
     callback = FakeCallback()
     resolver = TrustedProxyClientResolver(trusted)
-    return GoogleOidcHttpRoutes(admission, callback, resolver), admission, callback
+    discarder = FakeDiscarder()
+    kwargs = (
+        {}
+        if session_cookie_policy is None
+        else {"session_cookie_policy": session_cookie_policy}
+    )
+    return (
+        GoogleOidcHttpRoutes(
+            admission, callback, resolver, discarder, **kwargs
+        ),
+        admission,
+        callback,
+    )
 
 
 def header_values(response, name):
@@ -298,6 +321,55 @@ def test_callback_error_taxonomy_is_sanitized_and_clears_terminal_cookie(
     assert header_values(response, "Set-Cookie") == [CLEAR_COOKIE]
 
 
+def test_session_cookie_policy_is_preflighted_and_failed_result_is_discarded() -> None:
+    mismatched_callback = FakeCallback()
+    mismatched_callback.http_sessions = SimpleNamespace(
+        cookie_policy=SessionCookiePolicy(same_site="Strict")
+    )
+    with pytest.raises(ValueError, match="Policy cookie"):
+        GoogleOidcHttpRoutes(
+            FakeAdmission(),
+            mismatched_callback,
+            TrustedProxyClientResolver(),
+            FakeDiscarder(),
+        )
+
+    strict_policy = SessionCookiePolicy(same_site="Strict")
+    strict_router, _admission, strict_callback = routes(
+        session_cookie_policy=strict_policy
+    )
+    strict_callback.result = GoogleOidcLoginResult(
+        "user-01",
+        "student",
+        SimpleNamespace(
+            set_cookie=SESSION_COOKIE.replace("SameSite=Lax", "SameSite=Strict")
+        ),
+        "/student",
+        CLEAR_COOKIE,
+    )
+    strict_response = strict_router.dispatch(
+        request("/auth/google/callback", "state=x&code=y")
+    )
+    assert strict_response.status_code == 303
+
+    router, _admission, callback = routes()
+    callback.result = GoogleOidcLoginResult(
+        "user-01",
+        "student",
+        SimpleNamespace(
+            set_cookie=SESSION_COOKIE.replace("SameSite=Lax", "SameSite=Strict")
+        ),
+        "/student",
+        CLEAR_COOKIE,
+    )
+    failed = router.dispatch(
+        request("/auth/google/callback", "state=x&code=y")
+    )
+    assert failed.status_code == 503
+    assert header_values(failed, "Set-Cookie") == [CLEAR_COOKIE]
+    assert router.session_discarder.calls == [callback.result.session]
+
+
 def test_malformed_adapter_redirects_cookies_and_results_fail_closed() -> None:
     router, admission, callback = routes()
     for bad_url in (
@@ -328,7 +400,10 @@ def test_query_and_cookie_secrets_are_removed_from_route_traceback_frames() -> N
     admission = FakeAdmission()
     callback = ExplodingCallback()
     router = GoogleOidcHttpRoutes(
-        admission, callback, TrustedProxyClientResolver()
+        admission,
+        callback,
+        TrustedProxyClientResolver(),
+        FakeDiscarder(),
     )
     query_secret = "state=raw-state&code=raw-code"
     cookie_secret = "txn=raw-cookie"
@@ -349,6 +424,40 @@ def test_query_and_cookie_secrets_are_removed_from_route_traceback_frames() -> N
 def test_unknown_path_is_not_handled() -> None:
     router, _admission, _callback = routes()
     assert router.dispatch(request("/auth/google/unknown")) is None
+
+
+def test_malformed_request_line_redacts_callback_secret_and_returns_400() -> None:
+    class RecordingHandler(CourseBoardHandler):
+        messages = []
+
+        def log_message(self, format, *args):
+            self.messages.append(format % args)
+
+    router, _admission, _callback = routes(trusted=("127.0.0.0/8",))
+    server = BoundedThreadingHTTPServer(("127.0.0.1", 0), RecordingHandler)
+    server.google_oidc_http_routes = router
+    server.teacher_token = "T" * 32
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    raw_secret = "RAW-CALLBACK-CODE"
+    connection = socket.create_connection(server.server_address, timeout=5)
+    try:
+        connection.sendall(
+            (
+                "GET /auth/google/callback?code="
+                + raw_secret
+                + " EXTRA HTTP/1.1\r\nHost: localhost\r\n\r\n"
+            ).encode("ascii")
+        )
+        response = connection.recv(4096)
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert b"400" in response
+    assert raw_secret not in repr(RecordingHandler.messages)
 
 
 def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -475,6 +475,7 @@ def test_malformed_request_line_redacts_callback_secret_and_returns_400() -> Non
         thread.join(timeout=5)
 
     assert b"400" in response
+    assert raw_secret.encode("ascii") not in response
     assert raw_secret not in repr(RecordingHandler.messages)
 
 
@@ -509,6 +510,13 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
         fragmented = exchange(
             "GET", "/auth/google/callback?state=x&code=y#fragment"
         )
+        parameterized = exchange("GET", "/auth/google/login;unexpected")
+        network_path = exchange(
+            "GET", "//evil.example/auth/google/callback?state=x&code=y"
+        )
+        absolute_target = exchange(
+            "GET", "https://evil.example/auth/google/login"
+        )
         unsupported = {
             method: exchange(method, "/auth/google/login")
             for method in (
@@ -523,6 +531,9 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
 
     assert oversized == (400, None)
     assert fragmented == (400, None)
+    assert parameterized == (400, None)
+    assert network_path == (400, None)
+    assert absolute_target == (400, None)
     assert unsupported == {
         method: (405, "GET")
         for method in (

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -28,9 +28,10 @@ from scripts.thebitlab_google_oidc_http import (
 
 
 AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth?state=raw-state"
-TXN_COOKIE = "__Host-thebitlab_oidc_txn-deadbeef=raw-binding; Path=/; Secure; HttpOnly; SameSite=Lax"
-SESSION_COOKIE = "__Host-thebitlab_session=raw-session; Path=/; Secure; HttpOnly; SameSite=Lax"
-CLEAR_COOKIE = "__Host-thebitlab_oidc_txn-deadbeef=; Path=/; Max-Age=0; Secure; HttpOnly; SameSite=Lax"
+TXN_NAME = "__Host-thebitlab_oidc_txn-" + "a" * 24
+TXN_COOKIE = f"{TXN_NAME}={'B' * 40}; Path=/; Max-Age=600; Secure; HttpOnly; SameSite=Lax"
+SESSION_COOKIE = f"__Host-thebitlab_session={'S' * 40}; Path=/; Max-Age=28800; Secure; HttpOnly; SameSite=Lax"
+CLEAR_COOKIE = f"{TXN_NAME}=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax"
 
 
 class FakeAdmission:
@@ -118,7 +119,7 @@ def test_login_returns_bounded_no_store_redirect_and_cookie() -> None:
     assert response.body == b""
     assert admission.calls == 1
     assert "raw-state" not in repr(response)
-    assert "raw-binding" not in repr(response)
+    assert "B" * 40 not in repr(response)
 
 
 def test_login_rejects_query_body_and_non_get_before_admission() -> None:
@@ -222,6 +223,34 @@ def test_callback_preserves_duplicate_parameters_and_combines_cookies() -> None:
     assert callback.cookie == "first=one; second=two"
 
 
+def test_callback_percent_encodes_unicode_local_redirect() -> None:
+    router, _admission, callback = routes()
+    callback.result = GoogleOidcLoginResult(
+        "user-01",
+        "student",
+        SimpleNamespace(set_cookie=SESSION_COOKIE),
+        "/student/😀",
+        CLEAR_COOKIE,
+    )
+    response = router.dispatch(
+        request("/auth/google/callback", "state=x&code=y")
+    )
+    assert response.status_code == 303
+    assert header_values(response, "Location") == ["/student/%F0%9F%98%80"]
+    header_values(response, "Location")[0].encode("ascii")
+    callback.result = GoogleOidcLoginResult(
+        "user-01",
+        "student",
+        SimpleNamespace(set_cookie=SESSION_COOKIE),
+        "/student/%F0%9F%98%80",
+        CLEAR_COOKIE,
+    )
+    encoded = router.dispatch(
+        request("/auth/google/callback", "state=x&code=y")
+    )
+    assert header_values(encoded, "Location") == ["/student/%F0%9F%98%80"]
+
+
 def test_callback_rejects_malformed_query_and_cookie_before_service() -> None:
     router, _admission, callback = routes()
     queries = ("", "state=x&broken", "state=%ZZ", "state=%FF")
@@ -271,10 +300,20 @@ def test_callback_error_taxonomy_is_sanitized_and_clears_terminal_cookie(
 
 def test_malformed_adapter_redirects_cookies_and_results_fail_closed() -> None:
     router, admission, callback = routes()
-    admission.result = GoogleAuthorizationRequest("http://attacker.test", TXN_COOKIE)
-    assert router.dispatch(request("/auth/google/login")).status_code == 503
-    admission.result = GoogleAuthorizationRequest(AUTH_URL, "bad\r\nX-Evil: yes")
-    assert router.dispatch(request("/auth/google/login")).status_code == 503
+    for bad_url in (
+        "http://attacker.test",
+        "https://evil.example/phish?state=x",
+        "https://accounts.google.com.evil.example/o/oauth2/v2/auth?state=x",
+    ):
+        admission.result = GoogleAuthorizationRequest(bad_url, TXN_COOKIE)
+        assert router.dispatch(request("/auth/google/login")).status_code == 503
+    for bad_cookie in (
+        "bad\r\nX-Evil: yes",
+        f"{TXN_NAME}={'B' * 40}; Domain=example.test; Path=/; Max-Age=600; Secure; HttpOnly; SameSite=Lax",
+        f"attacker={'B' * 40}; Path=/; Max-Age=600; Secure; HttpOnly; SameSite=Lax",
+    ):
+        admission.result = GoogleAuthorizationRequest(AUTH_URL, bad_cookie)
+        assert router.dispatch(request("/auth/google/login")).status_code == 503
     callback.result = "malformed"
     assert router.dispatch(
         request("/auth/google/callback", "state=x&code=y")
@@ -310,6 +349,56 @@ def test_query_and_cookie_secrets_are_removed_from_route_traceback_frames() -> N
 def test_unknown_path_is_not_handled() -> None:
     router, _admission, _callback = routes()
     assert router.dispatch(request("/auth/google/unknown")) is None
+
+
+def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
+    router, admission, callback = routes(trusted=("127.0.0.0/8",))
+    server = BoundedThreadingHTTPServer(("127.0.0.1", 0), CourseBoardHandler)
+    server.google_oidc_http_routes = router
+    server.teacher_token = "T" * 32
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def exchange(method, target):
+        connection = http.client.HTTPConnection(
+            "127.0.0.1", server.server_address[1], timeout=5
+        )
+        try:
+            connection.request(
+                method,
+                target,
+                headers={"X-Forwarded-Proto": "https"},
+            )
+            response = connection.getresponse()
+            response.read()
+            return response.status, response.getheader("Allow")
+        finally:
+            connection.close()
+
+    try:
+        oversized = exchange(
+            "GET", "/auth/google/callback?state=x&code=" + "a" * 8200
+        )
+        fragmented = exchange(
+            "GET", "/auth/google/callback?state=x&code=y#fragment"
+        )
+        unsupported = {
+            method: exchange(method, "/auth/google/login")
+            for method in ("PUT", "DELETE", "PATCH", "OPTIONS")
+        }
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert oversized == (400, None)
+    assert fragmented == (400, None)
+    assert unsupported == {
+        method: (405, "GET")
+        for method in ("PUT", "DELETE", "PATCH", "OPTIONS")
+    }
+    assert callback.calls == 0
+    assert admission.calls == 0
 
 
 def test_course_board_access_log_redacts_callback_query() -> None:

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -480,6 +480,9 @@ def test_malformed_request_line_redacts_callback_secret_and_returns_400() -> Non
             + method_secret
             + " / HTTP/1.1"
         )
+        triple_slash = raw_exchange(
+            "GET ///auth/google/login HTTP/1.1"
+        )
     finally:
         server.shutdown()
         server.server_close()
@@ -487,6 +490,7 @@ def test_malformed_request_line_redacts_callback_secret_and_returns_400() -> Non
 
     assert b"400" in response
     assert b"400" in malformed_method
+    assert b"400" in triple_slash
     assert raw_secret.encode("ascii") not in response
     assert method_secret.encode("ascii") not in malformed_method
     serialized = repr(RecordingHandler.messages)
@@ -529,6 +533,7 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
         network_path = exchange(
             "GET", "//evil.example/auth/google/callback?state=x&code=y"
         )
+        normalized_network_path = exchange("GET", "//auth/google/login")
         absolute_target = exchange(
             "GET", "https://evil.example/auth/google/login"
         )
@@ -548,6 +553,7 @@ def test_course_board_transport_maps_oversized_fragment_and_methods() -> None:
     assert fragmented == (400, None)
     assert parameterized == (400, None)
     assert network_path == (400, None)
+    assert normalized_network_path == (400, None)
     assert absolute_target == (400, None)
     assert unsupported == {
         method: (405, "GET")


### PR DESCRIPTION
## Summary

Implements #575 under #535.

- adds strict concrete HTTP semantics for `GET /auth/google/login` and `GET /auth/google/callback`;
- requires direct TLS or exactly one `X-Forwarded-Proto: https` from an explicitly trusted proxy;
- runs login exclusively through the global/per-client edge admission boundary before OIDC flow allocation;
- parses callback queries boundedly while preserving duplicates and combines multiple Cookie headers deterministically;
- emits validated 302/303 redirects, separate transaction/session cleanup cookies, no-store/no-referrer headers and empty redirect bodies;
- maps admission/OIDC failures to sanitized stable 400/403/429/503 responses;
- delegates exact routes from `CourseBoardHandler` before legacy Basic auth while redacting callback queries from access logs;
- rejects bodies, transfer encoding, unsupported methods, malformed redirects/cookies and malformed adapter results;
- documents HTTPS/proxy trust, secret handling and runtime composition boundaries.

## Validation

- targeted route/edge/OIDC/HTTP/auth/SQLite/Course Board suite: 233 passed;
- full required CI green on Linux/Windows, Python 3.11–3.13, minimum Python, Docker and Windows filesystem;
- `py_compile` and `git diff --check` clean;
- independent review rounds 14 and 15 at `fdaea37`: `Nessun finding`.

## Out of scope

Environment-based production composition, real Google credentials/browser E2E, TLS termination, GitHub routes, pairing TUI routes, session/logout frontend and dashboard data wiring remain follow-ups.

Closes #575
