### PR TITLE
Detect existing Windows student environments

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -137,7 +137,9 @@ Su Windows:
 
 apri **Ambiente 2cornot2c** dal desktop o dal menu Start e scegli
 **Avvia l'ambiente**. Il launcher usa automaticamente Docker o VirtualBox in
-base all'ultima installazione completata.
+base all'ultima installazione completata. Al primo avvio dopo un aggiornamento,
+riconosce anche gli ambienti creati dalle versioni precedenti tramite il
+registro e una verifica diretta dell'immagine Docker.
 
 ## Aggiornamento e disinstallazione Windows
 

--- a/scripts/launch-classroom-windows.ps1
+++ b/scripts/launch-classroom-windows.ps1
@@ -17,13 +17,79 @@ if (Test-Path $StatePath) {
     }
 }
 
+function Find-ExistingProvider {
+    $LogPath = Join-Path $StateDir "installer.jsonl"
+    if (Test-Path $LogPath) {
+        $Lines = @(Get-Content $LogPath)
+        [array]::Reverse($Lines)
+        foreach ($Line in $Lines) {
+            try {
+                $Record = $Line | ConvertFrom-Json
+                if ($Record.host -eq "windows-amd64" -and
+                    $Record.provider -eq "docker" -and
+                    $Record.key -eq "student-image" -and
+                    $Record.status -in @("succeeded", "skipped")) {
+                    return "docker"
+                }
+            } catch {
+                continue
+            }
+        }
+    }
+
+    $DockerCommand = Get-Command docker -ErrorAction SilentlyContinue
+    $DockerExecutable = if ($DockerCommand) {
+        $DockerCommand.Source
+    } else {
+        $null
+    }
+    if (-not $DockerExecutable) {
+        $DockerPath = Join-Path $env:ProgramFiles `
+            "Docker\Docker\resources\bin\docker.exe"
+        if (Test-Path $DockerPath) {
+            $DockerExecutable = $DockerPath
+        }
+    }
+    $LockPath = Join-Path $InstallDir `
+        "docker\student-dev\toolchain.lock.json"
+    if ($DockerExecutable -and (Test-Path $LockPath)) {
+        try {
+            $Lock = Get-Content $LockPath -Raw | ConvertFrom-Json
+            $Image = "$($Lock.image_repository)@$($Lock.digest)"
+            & $DockerExecutable info *> $null
+            if ($LASTEXITCODE -eq 0) {
+                & $DockerExecutable image inspect $Image *> $null
+                if ($LASTEXITCODE -eq 0) {
+                    return "docker"
+                }
+            }
+        } catch {
+            Write-Warning "Ambiente Docker precedente non verificabile."
+        }
+    }
+
+    if (Test-Path (Join-Path $InstallDir ".vagrant")) {
+        return "virtualbox"
+    }
+    return $null
+}
+
 if (-not (Test-Path $ProviderPath)) {
-    Write-Host "AMBIENTE NON ANCORA PRONTO" -ForegroundColor Yellow
-    Write-Host (
-        "Apri Ambiente 2cornot2c e scegli Installa, completa o ripara."
-    ) -ForegroundColor Yellow
-    Read-Host "Premi Invio per chiudere"
-    exit 1
+    $ExistingProvider = Find-ExistingProvider
+    if ($ExistingProvider) {
+        New-Item -ItemType Directory -Force -Path $StateDir | Out-Null
+        Set-Content -Encoding UTF8 $ProviderPath $ExistingProvider
+        Write-Host (
+            "Ambiente precedente riconosciuto: $ExistingProvider."
+        ) -ForegroundColor Green
+    } else {
+        Write-Host "AMBIENTE NON ANCORA PRONTO" -ForegroundColor Yellow
+        Write-Host (
+            "Apri Ambiente 2cornot2c e scegli Installa, completa o ripara."
+        ) -ForegroundColor Yellow
+        Read-Host "Premi Invio per chiudere"
+        exit 1
+    }
 }
 
 $Provider = (Get-Content $ProviderPath -Raw).Trim()

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -92,6 +92,10 @@ def test_windows_launcher_hides_technical_start_commands() -> None:
     assert "student_dev_shell.py" in launcher
     assert "vagrant up --provider=virtualbox" in launcher
     assert "AMBIENTE NON ANCORA PRONTO" in launcher
+    assert "Find-ExistingProvider" in launcher
+    assert 'Record.key -eq "student-image"' in launcher
+    assert "image inspect" in launcher
+    assert "Ambiente precedente riconosciuto" in launcher
 
 
 def test_wsl_preparation_is_elevated_and_resumes_after_restart() -> None:


### PR DESCRIPTION
## Cosa cambia

- migra automaticamente gli ambienti installati prima della PR #576;
- cerca nel registro l’ultimo completamento dell’immagine `student-dev`;
- se il registro manca o contiene righe corrotte, verifica direttamente motore Docker e digest dell’immagine;
- riconosce anche uno stato VirtualBox esistente;
- salva il provider rilevato e avvia subito l’ambiente;
- mantiene il messaggio “non pronto” soltanto quando nessuna verifica riesce.

## Causa

Le installazioni precedenti non contenevano `selected-provider.txt`. Il nuovo pulsante **Avvia l’ambiente** interpretava quindi un ambiente realmente pronto come non installato.

## Verifiche

- 47 test mirati superati
- `python -m compileall -q installer`
- `git diff --check`