### PR TITLE
Riprendi e verifica il setup Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,14 @@ barra basata sui passaggi realmente completati, un indicatore di attività e il
 tempo trascorso. Non presenta percentuali di download stimate e ignora i
 comandi di uscita finché l'operazione non termina.
 
+Se Windows deve essere riavviato per completare WSL 2, il launcher viene
+riaperto automaticamente al nuovo accesso. Conserva la scelta tra Docker e
+VirtualBox, ripete i controlli e riparte dal primo componente mancante senza
+chiedere allo studente di selezionare o confermare nuovamente l'ambiente. Non
+forza il riavvio e non ripete l'installazione quando il launcher viene aperto
+manualmente. Lo stato temporaneo viene cancellato al termine, in caso di errore
+o dopo un annullamento.
+
 Prima di installare, la procedura controlla RAM, spazio libero, architettura,
 virtualizzazione hardware e connessione. Docker richiede almeno 4 GiB di RAM e
 8 GiB liberi; una VM richiede almeno 8 GiB di RAM e 20 GiB liberi. Se una
@@ -574,9 +582,10 @@ quando il computer ha al massimo 8 GiB, propone per primo **Docker leggero**.
 Installa e avvia Docker Desktop, attende automaticamente che sia pronto e
 scarica l'immagine pubblica adatta al processore. Se WSL 2 non è presente, lo
 prepara automaticamente senza installare una seconda distribuzione Ubuntu,
-richiede un riavvio e riapre il launcher al nuovo accesso. Al primo utilizzo
-resta necessario confermare soltanto le finestre di sicurezza e licenza
-mostrate direttamente da Windows.
+richiede un riavvio e riapre il launcher al nuovo accesso, riprendendo da solo
+il percorso Docker dal primo passaggio mancante. Al primo utilizzo resta
+necessario confermare soltanto le finestre di sicurezza e licenza mostrate
+direttamente da Windows.
 
 Dopo la preparazione, su Windows apri **Ambiente 2cornot2c** e scegli
 **Avvia l'ambiente**. La console Ubuntu viene aperta automaticamente senza

--- a/installer/README.md
+++ b/installer/README.md
@@ -78,7 +78,11 @@ prima di scaricare l'ambiente. Se WSL 2 non è presente, lo installa senza
 aggiungere una distribuzione Linux duplicata: Windows mostra soltanto la
 richiesta di autorizzazione. La TUI chiede poi di riavviare con un messaggio
 giallo, non con un errore. Dopo il riavvio il launcher si riapre
-automaticamente e la procedura riprende dal primo componente mancante.
+automaticamente, mantiene la scelta tra Docker e VirtualBox, ripete la diagnosi
+e riprende dal primo componente mancante: lo studente non deve scegliere di
+nuovo il provider né confermare una seconda installazione. I passaggi già
+completati vengono riconosciuti e saltati. Lo stato di ripresa viene eliminato
+al termine, in caso di errore e quando l'installazione viene annullata.
 
 Soltanto al primo utilizzo Docker Desktop può ancora chiedere di accettare le
 proprie condizioni d'uso.

--- a/installer/resume.py
+++ b/installer/resume.py
@@ -1,0 +1,64 @@
+"""Stato minimo e validato per riprendere un'installazione Windows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from installer.model import Provider
+
+
+SCHEMA = "2cornot2c.install-resume.v1"
+VALID_STATUSES = {"installing", "awaiting_restart"}
+
+
+def resume_path() -> Path:
+    return Path.home() / ".2cornot2c" / "resume-state.json"
+
+
+def save_intent(provider: Provider, status: str) -> None:
+    """Salva atomicamente soltanto stati conosciuti."""
+
+    if status not in VALID_STATUSES:
+        raise ValueError(f"Stato di ripresa non valido: {status}")
+    destination = resume_path()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(".tmp")
+    temporary.write_text(
+        json.dumps(
+            {
+                "schema_version": SCHEMA,
+                "provider": provider.value,
+                "status": status,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(destination)
+
+
+def load_intent() -> tuple[Provider, str] | None:
+    """Ignora in sicurezza file assenti, corrotti o di versioni sconosciute."""
+
+    try:
+        payload = json.loads(resume_path().read_text(encoding="utf-8"))
+        if payload.get("schema_version") != SCHEMA:
+            return None
+        provider = Provider(payload["provider"])
+        status = str(payload["status"])
+        if status not in VALID_STATUSES:
+            return None
+        return provider, status
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def clear_intent() -> None:
+    """Rimuove lo stato senza fallire quando è già assente."""
+
+    try:
+        resume_path().unlink()
+    except FileNotFoundError:
+        pass

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -502,7 +502,7 @@ def start_selected(state: State, *, persist_intent: bool = True) -> None:
     if state.installing:
         return
     provider = state.providers[state.active_index]
-    if persist_intent:
+    if persist_intent and state.host is Host.WINDOWS_AMD64:
         save_intent(provider, "installing")
     plan = install_plan(state.host, provider)
     updates: Queue[tuple[str, Any]] = Queue()

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from io import UnsupportedOperation
+import os
 from pathlib import Path
 from queue import Empty, Queue
 import sys
@@ -34,6 +35,7 @@ from installer.model import Host, Provider
 from installer.platforms import detect_host
 from installer.plans import install_plan, supported_providers
 from installer.resources import order_by_recommendation, total_memory_bytes
+from installer.resume import clear_intent, load_intent, save_intent
 from installer.student_errors import ERRORS, for_check, for_step
 
 
@@ -494,12 +496,14 @@ def confirm_installation_cancel(state: State) -> None:
     state.install_cancel.set()
 
 
-def start_selected(state: State) -> None:
+def start_selected(state: State, *, persist_intent: bool = True) -> None:
     """Avvia il lavoro in background lasciando reattivo il rendering."""
 
     if state.installing:
         return
     provider = state.providers[state.active_index]
+    if persist_intent:
+        save_intent(provider, "installing")
     plan = install_plan(state.host, provider)
     updates: Queue[tuple[str, Any]] = Queue()
     cancellation = Event()
@@ -571,15 +575,24 @@ def poll_installation(state: State) -> bool:
                 state.install_completed = index
         elif kind == "result":
             provider = state.providers[state.active_index]
-            if payload and all(
+            completed = payload and all(
                 result.status in {"skipped", "succeeded"}
                 for result in payload
-            ):
+            )
+            if completed:
                 _remember_provider(provider)
+                clear_intent()
+            elif any(
+                result.status == "restart_required" for result in payload
+            ):
+                save_intent(provider, "awaiting_restart")
+            else:
+                clear_intent()
             state.report = _format_results(provider, payload)
             state.installing = False
             state.install_thread = None
         elif kind == "cancelled":
+            clear_intent()
             state.installing = False
             state.install_thread = None
             try:
@@ -589,6 +602,7 @@ def poll_installation(state: State) -> bool:
                 message = for_check("installer", str(error))
                 state.report = message.lines(str(error))
         else:
+            clear_intent()
             error = for_check("installer", str(payload))
             state.report = error.lines(str(payload))
             state.installing = False
@@ -623,6 +637,22 @@ def main() -> int:
             else ("Premi Invio per eseguire la diagnosi.",)
         ),
     )
+    if (
+        host is Host.WINDOWS_AMD64
+        and os.environ.get("CLASSROOM_AUTO_RESUME") == "1"
+    ):
+        intent = load_intent()
+        if intent is not None:
+            provider, _status = intent
+            if provider in state.providers:
+                state.screen = "providers"
+                state.active_index = state.providers.index(provider)
+                state.report = (
+                    "RIPRESA AUTOMATICA DELL'INSTALLAZIONE",
+                    f"Ambiente: {provider.value}",
+                    "Controllo i componenti già presenti.",
+                )
+                start_selected(state, persist_intent=False)
     watcher = ResizeWatcher()
     color = supports_color()
     progress_refreshed_at = monotonic()

--- a/scripts/manage-classroom-windows.ps1
+++ b/scripts/manage-classroom-windows.ps1
@@ -1,4 +1,12 @@
+param(
+    [switch]$Resume
+)
+
 $ErrorActionPreference = "Stop"
+
+if ($Resume) {
+    $env:CLASSROOM_AUTO_RESUME = "1"
+}
 
 $StatePath = Join-Path $HOME ".2cornot2c\bootstrap-state.json"
 $DefaultInstallDir = Join-Path $HOME "2cornot2c"

--- a/scripts/prepare-wsl-windows.ps1
+++ b/scripts/prepare-wsl-windows.ps1
@@ -42,7 +42,7 @@ $Manager = Join-Path $env:LOCALAPPDATA `
 $RunOncePath = "HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce"
 $RunOnceCommand = (
     "`"$PowerShell`" -NoProfile -ExecutionPolicy Bypass " +
-    "-File `"$Manager`""
+    "-File `"$Manager`" -Resume"
 )
 New-ItemProperty `
     -Path $RunOncePath `

--- a/scripts/remove-wsl-windows.ps1
+++ b/scripts/remove-wsl-windows.ps1
@@ -35,4 +35,29 @@ foreach ($Feature in @(
         /featurename:$Feature /norestart | Out-Null
 }
 
+$RemainingApp = Get-AppxPackage `
+    "MicrosoftCorporationII.WindowsSubsystemForLinux" `
+    -ErrorAction SilentlyContinue
+$RemainingFeatures = @(
+    foreach ($Feature in @(
+        "VirtualMachinePlatform"
+        "Microsoft-Windows-Subsystem-Linux"
+    )) {
+        $FeatureState = Get-WindowsOptionalFeature `
+            -Online `
+            -FeatureName $Feature `
+            -ErrorAction SilentlyContinue
+        if ($FeatureState -and $FeatureState.State -ne "Disabled") {
+            $Feature
+        }
+    }
+)
+if ($RemainingApp -or $RemainingFeatures.Count -gt 0) {
+    Write-Error (
+        "La verifica finale rileva ancora WSL: " +
+        ($RemainingFeatures -join ", ")
+    )
+    exit 3
+}
+
 Write-Host "WSL installato da 2cornot2c è stato rimosso."

--- a/scripts/uninstall-classroom-windows.ps1
+++ b/scripts/uninstall-classroom-windows.ps1
@@ -152,6 +152,62 @@ function Test-WslInstalledByClassroom {
     return $false
 }
 
+function Test-PackageStillInstalled {
+    param([string]$PackageId)
+
+    $DisplayNamePattern = switch ($PackageId) {
+        "Docker.DockerDesktop" { "^Docker Desktop(?: |$)" }
+        "Git.Git" { "^Git(?: |$)" }
+        "Hashicorp.Vagrant" { "^Vagrant(?: |$)" }
+        "Oracle.VirtualBox" { "^(?:Oracle VM )?VirtualBox(?: |$)" }
+        default { return $false }
+    }
+    $UninstallRoots = @(
+        "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
+        "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+        "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    )
+    foreach ($Root in $UninstallRoots) {
+        $Match = Get-ItemProperty $Root -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.DisplayName -match $DisplayNamePattern
+            } |
+            Select-Object -First 1
+        if ($Match) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Get-ClassroomShortcutPaths {
+    $Candidates = [System.Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($DesktopDir in @(
+        [Environment]::GetFolderPath("Desktop")
+        (Join-Path $HOME "Desktop")
+        $(if ($env:OneDrive) { Join-Path $env:OneDrive "Desktop" })
+        $(if ($env:OneDriveConsumer) {
+            Join-Path $env:OneDriveConsumer "Desktop"
+        })
+        $(if ($env:OneDriveCommercial) {
+            Join-Path $env:OneDriveCommercial "Desktop"
+        })
+    )) {
+        if ($DesktopDir) {
+            [void]$Candidates.Add(
+                (Join-Path $DesktopDir "Ambiente 2cornot2c.lnk")
+            )
+        }
+    }
+    [void]$Candidates.Add(
+        (Join-Path $env:APPDATA `
+            "Microsoft\Windows\Start Menu\Programs\Ambiente 2cornot2c.lnk")
+    )
+    return @($Candidates)
+}
+
 function Backup-StudentWork {
     param([string]$Source)
     if (-not (Test-Path $Source)) {
@@ -267,20 +323,34 @@ if ($ImageReference -and (Get-Command docker -ErrorAction SilentlyContinue)) {
     }
 }
 
-if (Test-Path $SafeInstallDir) {
-    Remove-Item -LiteralPath $SafeInstallDir -Recurse -Force
-}
-
 if ($OwnedPackages.Count -gt 0 -and -not (Get-Command winget -ErrorAction SilentlyContinue)) {
-    Write-Warning "winget non è disponibile: i prerequisiti gestiti non verranno disinstallati."
-    Write-Warning "Pacchetti ancora presenti: $($OwnedPackages -join ', ')"
+    Stop-WithMessage "E31" "Non posso rimuovere i programmi installati" `
+        "Windows Package Manager non è disponibile. Conservo il registro e il collegamento per permetterti di riprovare." `
+        @(
+            "Non cancellare manualmente le cartelle."
+            "Riavvia Windows e scegli di nuovo Disinstalla l'ambiente."
+            "Se ricompare, comunica E31 al docente."
+        ) "Pacchetti ancora presenti: $($OwnedPackages -join ', ')"
 }
 elseif ($OwnedPackages.Count -gt 0) {
+    $PackageFailures = [System.Collections.Generic.List[string]]::new()
     foreach ($PackageId in $OwnedPackages | Sort-Object) {
         winget uninstall --id $PackageId --exact --silent
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warning "Disinstallazione non riuscita o già eseguita: $PackageId"
+        $ExitCode = $LASTEXITCODE
+        Start-Sleep -Seconds 2
+        if (Test-PackageStillInstalled $PackageId) {
+            $PackageFailures.Add("$PackageId (codice $ExitCode)")
         }
+    }
+    if ($PackageFailures.Count -gt 0) {
+        Stop-WithMessage "E31" "Uno o più programmi non sono stati rimossi" `
+            "La disinstallazione si è fermata senza cancellare il registro, così puoi riprovare in sicurezza." `
+            @(
+                "Chiudi Docker Desktop e gli altri programmi dell'ambiente."
+                "Riavvia Windows."
+                "Scegli di nuovo Disinstalla l'ambiente."
+                "Se ricompare, comunica E31 al docente."
+            ) ($PackageFailures -join ", ")
     }
 }
 
@@ -300,12 +370,24 @@ if ($OwnedWsl) {
         -Verb RunAs `
         -Wait `
         -PassThru
-    if ($Cleanup.ExitCode -ne 0) {
+    if ($Cleanup.ExitCode -eq 2) {
         Write-Warning (
             "WSL non è stato rimosso per proteggere eventuali dati personali. " +
             "Comunica E30 al docente."
         )
+    } elseif ($Cleanup.ExitCode -ne 0) {
+        Stop-WithMessage "E32" "Windows non ha completato la rimozione di WSL" `
+            "La verifica finale rileva ancora uno o più componenti di WSL. Il registro è stato conservato per permetterti di riprovare." `
+            @(
+                "Riavvia Windows."
+                "Scegli di nuovo Disinstalla l'ambiente."
+                "Se ricompare, comunica E32 al docente."
+            ) "remove-wsl-windows.ps1 exit code $($Cleanup.ExitCode)"
     }
+}
+
+if (Test-Path $SafeInstallDir) {
+    Remove-Item -LiteralPath $SafeInstallDir -Recurse -Force
 }
 
 if (Test-Path $StateDir) {
@@ -318,10 +400,7 @@ Remove-ItemProperty `
     -Name "2cornot2c-resume" `
     -ErrorAction SilentlyContinue
 
-foreach ($ShortcutPath in @(
-    (Join-Path ([Environment]::GetFolderPath("Desktop")) "Ambiente 2cornot2c.lnk")
-    (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Ambiente 2cornot2c.lnk")
-)) {
+foreach ($ShortcutPath in Get-ClassroomShortcutPaths) {
     if (Test-Path $ShortcutPath) {
         Remove-Item -LiteralPath $ShortcutPath -Force
     }

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -284,6 +284,27 @@ def test_restart_result_preserves_resume_intent(monkeypatch, tmp_path) -> None:
     assert load_intent() == (Provider.DOCKER, "awaiting_restart")
 
 
+def test_macos_install_does_not_create_windows_resume_intent(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    pytest.importorskip("utui")
+    from installer.resume import resume_path
+    from installer.tui import State, start_selected
+
+    monkeypatch.setattr("installer.resume.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "installer.tui.Thread.start",
+        lambda self: None,
+    )
+    state = State(Host.MACOS_ARM64, (Provider.VMWARE,))
+
+    start_selected(state)
+
+    assert state.installing is True
+    assert not resume_path().exists()
+
+
 def test_tui_marks_first_low_memory_choice_as_recommended() -> None:
     pytest.importorskip("utui")
     from installer.tui import State, frame

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -225,6 +225,65 @@ def test_successful_installation_remembers_provider(monkeypatch, tmp_path) -> No
     ).read_text(encoding="utf-8") == "docker"
 
 
+def test_resume_intent_is_atomic_validated_and_removable(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from installer.resume import (
+        clear_intent,
+        load_intent,
+        resume_path,
+        save_intent,
+    )
+
+    monkeypatch.setattr("installer.resume.Path.home", lambda: tmp_path)
+
+    save_intent(Provider.DOCKER, "awaiting_restart")
+    assert load_intent() == (Provider.DOCKER, "awaiting_restart")
+    assert not resume_path().with_suffix(".tmp").exists()
+
+    resume_path().write_text('{"schema_version":"sbagliato"}', encoding="utf-8")
+    assert load_intent() is None
+
+    clear_intent()
+    clear_intent()
+    assert not resume_path().exists()
+
+
+def test_restart_result_preserves_resume_intent(monkeypatch, tmp_path) -> None:
+    pytest.importorskip("utui")
+    from queue import Queue
+
+    from installer.executor import StepResult
+    from installer.resume import load_intent
+    from installer.tui import State, poll_installation
+
+    monkeypatch.setattr("installer.resume.Path.home", lambda: tmp_path)
+    updates = Queue()
+    updates.put(
+        (
+            "result",
+            (
+                StepResult(
+                    "wsl",
+                    "Prepara WSL 2",
+                    "restart_required",
+                    "riavvio",
+                ),
+            ),
+        )
+    )
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER,),
+        installing=True,
+        install_updates=updates,
+    )
+
+    assert poll_installation(state) is True
+    assert load_intent() == (Provider.DOCKER, "awaiting_restart")
+
+
 def test_tui_marks_first_low_memory_choice_as_recommended() -> None:
     pytest.importorskip("utui")
     from installer.tui import State, frame

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -81,6 +81,13 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "docker image rm $ImageReference" in uninstall
     assert "docker image rm --force" not in uninstall
     assert "Ambiente 2cornot2c.lnk" in uninstall
+    assert "Test-PackageStillInstalled" in uninstall
+    assert "Get-ClassroomShortcutPaths" in uninstall
+    assert "OneDriveConsumer" in uninstall
+    assert '"E31"' in uninstall
+    assert uninstall.index("winget uninstall") < uninstall.index(
+        "Remove-Item -LiteralPath $SafeInstallDir"
+    )
 
 
 def test_windows_launcher_hides_technical_start_commands() -> None:
@@ -107,6 +114,13 @@ def test_wsl_preparation_is_elevated_and_resumes_after_restart() -> None:
     assert "-Verb RunAs" in source
     assert "2cornot2c-resume" in source
     assert "RunOnce" in source
+    assert '-File `"$Manager`" -Resume' in source
+
+    manager = (ROOT / "scripts" / "manage-classroom-windows.ps1").read_text(
+        encoding="utf-8"
+    )
+    assert "[switch]$Resume" in manager
+    assert 'CLASSROOM_AUTO_RESUME = "1"' in manager
 
 
 def test_wsl_rollback_refuses_to_remove_personal_distributions() -> None:
@@ -121,6 +135,9 @@ def test_wsl_rollback_refuses_to_remove_personal_distributions() -> None:
     assert "docker-desktop" in cleanup
     assert "dati personali" in cleanup
     assert "wsl.exe --uninstall" in cleanup
+    assert "Get-WindowsOptionalFeature" in cleanup
+    assert "$RemainingFeatures" in cleanup
     assert "Test-WslInstalledByClassroom" in uninstall
     assert '"restart_required", "succeeded"' in uninstall
     assert "Start-Sleep -Seconds 2" in uninstall
+    assert '"E32"' in uninstall


### PR DESCRIPTION
## Cosa cambia

- salva atomicamente provider e stato dell'installazione Windows
- dopo il riavvio richiesto da WSL riapre il launcher e riprende automaticamente dallo stesso provider
- ripete la diagnosi e salta i passaggi già completati senza chiedere una seconda conferma
- cancella lo stato temporaneo dopo successo, errore o annullamento
- verifica realmente la rimozione dei pacchetti installati dal setup
- conserva registro, repository e launcher quando Docker, VirtualBox, Vagrant o Git non vengono rimossi
- verifica separatamente la rimozione di WSL e distingue la protezione di distribuzioni personali da un errore reale
- rimuove il collegamento Ambiente 2cornot2c anche dai Desktop gestiti tramite OneDrive
- documenta la ripresa automatica

## Perché

Il setup si fermava correttamente quando WSL richiedeva un riavvio, ma al nuovo accesso lo studente doveva ricominciare manualmente. Inoltre il disinstallatore poteva ignorare un errore di `winget`, cancellare il proprio registro e dichiarare comunque l'operazione completata, lasciando Docker Desktop o altri prerequisiti installati.

## Impatto

Lo studente può riavviare Windows e lasciare che la preparazione continui da sola. La disinstallazione ora termina come completata soltanto dopo aver verificato i componenti; in caso contrario mostra un codice semplice (`E31` o `E32`) e rimane ripetibile.

## Verifica

- `49 passed`: `tests/test_classroom_installer.py`, `tests/test_classroom_preflight.py`, `tests/test_student_errors.py`
- `git diff --check`
- `python3 -m compileall -q installer`
- suite completa eseguita: i soli 7 fallimenti residui riguardano test preesistenti del grading/scaffold sensibili al filesystem macOS e non file modificati da questa PR