### PR TITLE
Rimuovi tutti i collegamenti Windows residui

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -163,6 +163,12 @@ Disinstallazione protetta:
 irm https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/uninstall-classroom-windows.ps1 | iex
 ```
 
+Pulizia dei soli collegamenti residui lasciati da versioni precedenti:
+
+```powershell
+irm https://raw.githubusercontent.com/TheBitPoets/2cornot2c/main/scripts/remove-classroom-shortcuts-windows.ps1 | iex
+```
+
 Il bootstrap registra in `~/.2cornot2c/bootstrap-state.json` soltanto Git e
 Python installati da lui. L'executor registra separatamente i passi riusciti.
 La disinstallazione usa entrambi i registri, crea un backup del lavoro, richiede

--- a/scripts/remove-classroom-shortcuts-windows.ps1
+++ b/scripts/remove-classroom-shortcuts-windows.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = "Stop"
+
+$Candidates = [System.Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::OrdinalIgnoreCase
+)
+foreach ($DesktopDir in @(
+    [Environment]::GetFolderPath("Desktop")
+    [Environment]::GetFolderPath("CommonDesktopDirectory")
+    (Join-Path $HOME "Desktop")
+    $(if ($env:PUBLIC) { Join-Path $env:PUBLIC "Desktop" })
+    $(if ($env:OneDrive) { Join-Path $env:OneDrive "Desktop" })
+    $(if ($env:OneDriveConsumer) {
+        Join-Path $env:OneDriveConsumer "Desktop"
+    })
+    $(if ($env:OneDriveCommercial) {
+        Join-Path $env:OneDriveCommercial "Desktop"
+    })
+)) {
+    if ($DesktopDir) {
+        [void]$Candidates.Add(
+            (Join-Path $DesktopDir "Ambiente 2cornot2c.lnk")
+        )
+    }
+}
+foreach ($ProgramsDir in @(
+    [Environment]::GetFolderPath("Programs")
+    [Environment]::GetFolderPath("CommonPrograms")
+    $(if ($env:APPDATA) {
+        Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
+    })
+    $(if ($env:ProgramData) {
+        Join-Path $env:ProgramData "Microsoft\Windows\Start Menu\Programs"
+    })
+)) {
+    if ($ProgramsDir) {
+        [void]$Candidates.Add(
+            (Join-Path $ProgramsDir "Ambiente 2cornot2c.lnk")
+        )
+    }
+}
+
+$Removed = 0
+foreach ($ShortcutPath in $Candidates) {
+    if (Test-Path -LiteralPath $ShortcutPath) {
+        Remove-Item -LiteralPath $ShortcutPath -Force
+        $Removed++
+        Write-Host "Collegamento rimosso: $ShortcutPath"
+    }
+}
+
+$IconRefresh = Join-Path $env:SystemRoot "System32\ie4uinit.exe"
+if (Test-Path $IconRefresh) {
+    & $IconRefresh -show
+}
+
+if ($Removed -eq 0) {
+    Write-Host "Nessun collegamento 2cornot2c residuo trovato."
+} else {
+    Write-Host "Pulizia dei collegamenti completata."
+}

--- a/scripts/uninstall-classroom-windows.ps1
+++ b/scripts/uninstall-classroom-windows.ps1
@@ -186,7 +186,9 @@ function Get-ClassroomShortcutPaths {
     )
     foreach ($DesktopDir in @(
         [Environment]::GetFolderPath("Desktop")
+        [Environment]::GetFolderPath("CommonDesktopDirectory")
         (Join-Path $HOME "Desktop")
+        $(if ($env:PUBLIC) { Join-Path $env:PUBLIC "Desktop" })
         $(if ($env:OneDrive) { Join-Path $env:OneDrive "Desktop" })
         $(if ($env:OneDriveConsumer) {
             Join-Path $env:OneDriveConsumer "Desktop"
@@ -201,10 +203,22 @@ function Get-ClassroomShortcutPaths {
             )
         }
     }
-    [void]$Candidates.Add(
-        (Join-Path $env:APPDATA `
-            "Microsoft\Windows\Start Menu\Programs\Ambiente 2cornot2c.lnk")
-    )
+    foreach ($ProgramsDir in @(
+        [Environment]::GetFolderPath("Programs")
+        [Environment]::GetFolderPath("CommonPrograms")
+        $(if ($env:APPDATA) {
+            Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
+        })
+        $(if ($env:ProgramData) {
+            Join-Path $env:ProgramData "Microsoft\Windows\Start Menu\Programs"
+        })
+    )) {
+        if ($ProgramsDir) {
+            [void]$Candidates.Add(
+                (Join-Path $ProgramsDir "Ambiente 2cornot2c.lnk")
+            )
+        }
+    }
     return @($Candidates)
 }
 

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -84,10 +84,21 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "Test-PackageStillInstalled" in uninstall
     assert "Get-ClassroomShortcutPaths" in uninstall
     assert "OneDriveConsumer" in uninstall
+    assert "CommonDesktopDirectory" in uninstall
+    assert "CommonPrograms" in uninstall
     assert '"E31"' in uninstall
     assert uninstall.index("winget uninstall") < uninstall.index(
         "Remove-Item -LiteralPath $SafeInstallDir"
     )
+
+    shortcut_cleanup = (
+        ROOT / "scripts" / "remove-classroom-shortcuts-windows.ps1"
+    ).read_text(encoding="utf-8")
+    assert "Ambiente 2cornot2c.lnk" in shortcut_cleanup
+    assert "CommonDesktopDirectory" in shortcut_cleanup
+    assert "CommonPrograms" in shortcut_cleanup
+    assert "OneDriveConsumer" in shortcut_cleanup
+    assert "ie4uinit.exe" in shortcut_cleanup
 
 
 def test_windows_launcher_hides_technical_start_commands() -> None:


### PR DESCRIPTION
## Cosa cambia

- cerca il collegamento `Ambiente 2cornot2c` anche nel Desktop pubblico e nei percorsi comuni del menu Start
- mantiene la copertura dei Desktop OneDrive personali e aziendali
- aggiunge uno script indipendente per ripulire un PC già disinstallato senza reinstallare nulla
- aggiorna la cache delle icone di Windows dopo la rimozione
- documenta il comando riservato al supporto

## Perché

Una vecchia installazione può creare o lasciare il collegamento in una cartella diversa da quella restituita per il solo utente corrente. Il disinstallatore completava la rimozione dei programmi ma l'icona morta restava visibile sul Desktop e nel menu Start.

## Sicurezza

La pulizia elimina esclusivamente file chiamati esattamente `Ambiente 2cornot2c.lnk` nelle cartelle standard di Windows; non effettua scansioni generiche e non rimuove applicazioni o dati.

## Verifica

- 50 test mirati superati
- `git diff --check`