### PR TITLE
feat: expose secure web session and logout routes

### DIFF
--- a/doc/architecture/auth-runtime-composition.md
+++ b/doc/architecture/auth-runtime-composition.md
@@ -43,7 +43,8 @@ python -c "import base64,secrets; print(base64.urlsafe_b64encode(secrets.token_b
 5. flow OIDC bounded in memoria, transport Google HTTPS e verifier ufficiale X.509-only;
 6. `SqliteAtomicRateLimitStore` sullo stesso file, condivisibile fra processi dello stesso host;
 7. un solo `TrustedProxyClientResolver`, condiviso fra attribuzione client e verifica HTTPS;
-8. `GoogleOidcHttpRoutes` con lo stesso boundary sessione usato dal callback e dal delivery cleanup.
+8. `GoogleOidcHttpRoutes` con lo stesso boundary sessione usato dal callback e dal delivery cleanup;
+9. `SessionHttpRoutes` per session status/logout, vincolato allo stesso boundary web e allo stesso resolver proxy.
 
 Il flow OIDC resta volutamente in memoria: un callback deve raggiungere lo stesso processo che ha iniziato il login. Un deployment multi-replica richiede sticky routing oppure un futuro flow store condiviso.
 

--- a/doc/architecture/web-session-http-routes.md
+++ b/doc/architecture/web-session-http-routes.md
@@ -1,0 +1,57 @@
+# Route HTTP sessione web e logout
+
+## Scopo
+
+`scripts/thebitlab_session_http.py` espone due route concrete sullo stesso grafo web creato dalla composizione runtime:
+
+- `GET /auth/session`;
+- `POST /auth/logout`.
+
+Il principal deriva esclusivamente dal cookie di sessione `web`; nessun `user_id`, ruolo o identificatore inviato dal client viene usato per scegliere l'utente.
+
+## Requisito HTTPS
+
+Le route applicano la stessa attestazione delle route Google: TLS diretto oppure peer appartenente allo stesso `TrustedProxyClientResolver` con un solo `X-Forwarded-Proto: https`. Il backend dietro reverse proxy non deve essere raggiungibile direttamente.
+
+Query, fragment, request-target non origin-form, path params, body, transfer encoding e Content-Length diverso da zero sono rifiutati. Il trasporto conserva header duplicati: Cookie multipli vengono concatenati in ordine e lasciati alla validazione fail-closed del boundary; header CSRF o forwarded duplicati non vengono selezionati arbitrariamente.
+
+## Sessione corrente
+
+`GET /auth/session` chiama `HttpSessionAuthBoundary.authenticate()` e quindi rilegge sessione e utente correnti dallo storage per ogni richiesta. La risposta contiene soltanto:
+
+- `authenticated: true`;
+- `user_id`, display name e ruolo correnti;
+- scadenza canonica UTC della sessione;
+- token CSRF legato tramite HMAC al bearer corrente.
+
+Email, identità provider, bearer, digest e appartenenze non vengono serializzati. Il token CSRF è necessario al browser per le successive mutazioni, ma body e request sensibili sono esclusi dai `repr`.
+
+## Logout
+
+`POST /auth/logout` richiede:
+
+- cookie web valido o bearer sintatticamente valido ma già stale;
+- esattamente un header `X-CSRF-Token` bounded;
+- verifica CSRF per una sessione ancora attiva.
+
+Una sessione attiva viene revocata nello storage prima della risposta. Il risultato `204` cancella il cookie con la stessa policy `__Host-`, `Secure`, `HttpOnly`, `SameSite` del login. Un bearer stale ben formato produce comunque cleanup del cookie senza rivelare se una sessione esistesse. Un fallimento socket dopo la revoca non riattiva la sessione; il client può ripetere il logout con il token già ottenuto.
+
+## Risposte e browser policy
+
+Le risposte sono bounded e aggiungono sempre:
+
+- `Cache-Control: no-store`;
+- `Pragma: no-cache`;
+- `Referrer-Policy: no-referrer`;
+- `Content-Length` esplicito.
+
+La tassonomia stabile comprende 400 per trasporto/configurazione request non valida, 401 per cookie assente/invalido/scaduto, 403 per CSRF, 405 con `Allow` per metodo errato e 503 per indisponibilità infrastrutturale. Callback, cookie, bearer e CSRF non vengono riflessi negli errori o negli access log; le request-line auth malformate vengono redatte dal Course Board.
+
+## Composizione
+
+`GoogleOidcRuntime` mantiene sia `GoogleOidcHttpRoutes` sia `SessionHttpRoutes` e valida che condividano esattamente:
+
+- lo stesso `HttpSessionAuthBoundary`;
+- lo stesso `TrustedProxyClientResolver`.
+
+Il Course Board inietta entrambe solo con `--enable-google-auth`; senza opt-in le route sessione non sono esposte.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -64,6 +64,7 @@ from scripts import (
     thebitlab_grading_artifacts,
     thebitlab_google_oidc_http,
     thebitlab_services,
+    thebitlab_session_http,
     thebitlab_storage,
     thebitlab_tracking_reports,
     track_assignments,
@@ -3275,18 +3276,30 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return self.do_unsupported_auth_method
         raise AttributeError(name)
 
-    def _is_google_auth_request_line(self) -> bool:
+    def _is_sensitive_auth_request_line(self) -> bool:
         path = str(getattr(self, "path", ""))
         requestline = str(getattr(self, "requestline", ""))
-        return "/auth/google/" in path or "/auth/google/" in requestline
+        combined = path + " " + requestline
+        return any(
+            auth_path in combined
+            for auth_path in (
+                "/auth/google/",
+                "/auth/session",
+                "/auth/logout",
+            )
+        )
 
     def log_error(self, format, *args) -> None:
         """Redact even malformed OAuth request lines before parser completion."""
 
-        if self._is_google_auth_request_line() or any(
-            "/auth/google/" in str(argument) for argument in args
+        if self._is_sensitive_auth_request_line() or any(
+            any(
+                auth_path in str(argument)
+                for auth_path in ("/auth/google/", "/auth/session", "/auth/logout")
+            )
+            for argument in args
         ):
-            self.log_message("Google auth request non valida")
+            self.log_message("Auth request non valida")
             return
         super().log_error(format, *args)
 
@@ -3295,14 +3308,18 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
         path = str(getattr(self, "path", ""))
         requestline = str(getattr(self, "requestline", ""))
-        if self._is_google_auth_request_line():
+        if self._is_sensitive_auth_request_line():
             combined = path + " " + requestline
             if "/auth/google/callback" in combined:
                 safe_path = "/auth/google/callback"
             elif "/auth/google/login" in combined:
                 safe_path = "/auth/google/login"
+            elif "/auth/session" in combined:
+                safe_path = "/auth/session"
+            elif "/auth/logout" in combined:
+                safe_path = "/auth/logout"
             else:
-                safe_path = "/auth/google/invalid"
+                safe_path = "/auth/invalid"
             safe_line = f"AUTH {safe_path} HTTP"
             self.log_message('"%s" %s %s', safe_line, str(code), str(size))
             return
@@ -3311,7 +3328,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
     def send_error(self, code, message=None, explain=None) -> None:
         """Never reflect malformed OAuth request-lines in HTML error bodies."""
 
-        if self._is_google_auth_request_line():
+        if self._is_sensitive_auth_request_line():
             self.close_connection = True
             self.write_oidc_transport_error(400, "bad_auth_request")
             return
@@ -3434,6 +3451,79 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return None
         return payload
 
+    def dispatch_session_http(self, parsed) -> bool:
+        """Delegate exact web-session routes to the injected secure router."""
+
+        routes = getattr(self.server, "session_http_routes", None)
+        request_parts = str(getattr(self, "requestline", "")).split()
+        if routes is not None and routes.handles(parsed.path) and len(request_parts) != 3:
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        if routes is not None and len(request_parts) == 3:
+            raw_target = request_parts[1]
+            raw_parsed = urlparse(raw_target)
+            if routes.handles(raw_parsed.path):
+                parsed = raw_parsed
+            elif routes.handles(parsed.path) and not (
+                raw_target == parsed.path
+                or raw_target.startswith(parsed.path + "?")
+                or raw_target.startswith(parsed.path + "#")
+                or raw_target.startswith(parsed.path + ";")
+            ):
+                self.write_oidc_transport_error(400, "bad_auth_request")
+                return True
+        request_parts = None
+        raw_target = None
+        if routes is None or not routes.handles(parsed.path):
+            return False
+        if parsed.scheme or parsed.netloc or parsed.params:
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        try:
+            edge = thebitlab_google_oidc_http.EdgeRequestMetadata(
+                str(self.client_address[0]), tuple(self.headers.raw_items())
+            )
+            raw_query = parsed.query
+            if parsed.fragment:
+                raw_query += "#" + parsed.fragment
+            request = thebitlab_session_http.SessionHttpRequest(
+                self.command,
+                parsed.path,
+                raw_query,
+                edge,
+                is_tls=isinstance(self.connection, ssl.SSLSocket),
+            )
+        except (
+            ValueError,
+            thebitlab_google_oidc_http.EdgeClientAttributionError,
+        ):
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        try:
+            response = routes.dispatch(request)
+            if response is None:
+                raise RuntimeError("Router sessione senza risposta.")
+        except Exception:  # noqa: BLE001
+            self.write_oidc_transport_error(503, "authentication_unavailable")
+            return True
+        finally:
+            edge = None
+            request = None
+            raw_query = None
+        self.write_session_http_response(response)
+        return True
+
+    def write_session_http_response(self, response) -> None:
+        try:
+            self.send_response(response.status_code)
+            for name, value in response.headers:
+                self.send_header(name, value)
+            self.end_headers()
+            if response.body and self.command != "HEAD":
+                self.wfile.write(response.body)
+        except Exception:  # noqa: BLE001
+            return
+
     def dispatch_google_oidc(self, parsed) -> bool:
         """Delegate exact Google auth routes to the injected secure router."""
 
@@ -3531,12 +3621,16 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def do_unsupported_auth_method(self) -> None:
         parsed = urlparse(self.path)
+        if self.dispatch_session_http(parsed):
+            return
         if self.dispatch_google_oidc(parsed):
             return
         self.send_error(501)
 
     def do_HEAD(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
+        if self.dispatch_session_http(parsed):
+            return
         if self.dispatch_google_oidc(parsed):
             return
         self.send_error(501)
@@ -3561,6 +3655,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
+        if self.dispatch_session_http(parsed):
+            return
         if self.dispatch_google_oidc(parsed):
             return
         if self.reject_unauthenticated_teacher_api("GET", parsed.path):
@@ -3652,6 +3748,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
+        if self.dispatch_session_http(parsed):
+            return
         if self.dispatch_google_oidc(parsed):
             return
         if self.reject_unauthenticated_teacher_api("POST", parsed.path):
@@ -4115,6 +4213,7 @@ def main() -> int:
         if auth_runtime is not None:
             server.google_oidc_runtime = auth_runtime
             server.google_oidc_http_routes = auth_runtime.routes
+            server.session_http_routes = auth_runtime.session_routes
         if not is_loopback_bind_host(args.host):
             print("ATTENZIONE: dashboard e credenziali Basic sono esposte su HTTP non cifrato.")
             print("Preferisci loopback con tunnel SSH oppure un reverse proxy HTTPS.")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3462,16 +3462,22 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if routes is not None and len(request_parts) == 3:
             raw_target = request_parts[1]
             raw_parsed = urlparse(raw_target)
-            if routes.handles(raw_parsed.path):
-                parsed = raw_parsed
-            elif routes.handles(parsed.path) and not (
-                raw_target == parsed.path
-                or raw_target.startswith(parsed.path + "?")
-                or raw_target.startswith(parsed.path + "#")
-                or raw_target.startswith(parsed.path + ";")
+            candidate_path = (
+                raw_parsed.path
+                if routes.handles(raw_parsed.path)
+                else parsed.path
+            )
+            if routes.handles(candidate_path) and not (
+                raw_target == candidate_path
+                or raw_target.startswith(candidate_path + "?")
+                or raw_target.startswith(candidate_path + "#")
+                or raw_target.startswith(candidate_path + ";")
             ):
                 self.write_oidc_transport_error(400, "bad_auth_request")
                 return True
+            if routes.handles(raw_parsed.path):
+                parsed = raw_parsed
+            candidate_path = None
         request_parts = None
         raw_target = None
         if routes is None or not routes.handles(parsed.path):
@@ -3539,16 +3545,22 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if routes is not None and len(request_parts) == 3:
             raw_target = request_parts[1]
             raw_parsed = urlparse(raw_target)
-            if routes.handles(raw_parsed.path):
-                parsed = raw_parsed
-            elif routes.handles(parsed.path) and not (
-                raw_target == parsed.path
-                or raw_target.startswith(parsed.path + "?")
-                or raw_target.startswith(parsed.path + "#")
-                or raw_target.startswith(parsed.path + ";")
+            candidate_path = (
+                raw_parsed.path
+                if routes.handles(raw_parsed.path)
+                else parsed.path
+            )
+            if routes.handles(candidate_path) and not (
+                raw_target == candidate_path
+                or raw_target.startswith(candidate_path + "?")
+                or raw_target.startswith(candidate_path + "#")
+                or raw_target.startswith(candidate_path + ";")
             ):
                 self.write_oidc_transport_error(400, "bad_auth_request")
                 return True
+            if routes.handles(raw_parsed.path):
+                parsed = raw_parsed
+            candidate_path = None
         request_parts = None
         raw_target = None
         if routes is None or not routes.handles(parsed.path):

--- a/scripts/thebitlab_auth_runtime.py
+++ b/scripts/thebitlab_auth_runtime.py
@@ -30,6 +30,7 @@ from scripts.thebitlab_google_oidc import (
 from scripts.thebitlab_google_oidc_http import GoogleOidcHttpRoutes
 from scripts.thebitlab_http_auth import HttpSessionAuthBoundary, SessionCookiePolicy
 from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+from scripts.thebitlab_session_http import SessionHttpRoutes
 
 _SECRET_RE = re.compile(r"^[A-Za-z0-9_-]{43,86}$")
 _CALLBACK_PATH = "/auth/google/callback"
@@ -48,16 +49,30 @@ class AuthRuntimeConfigurationError(RuntimeError):
 class GoogleOidcRuntime:
     """Own the composed service graph while exposing only its HTTP routes."""
 
-    __slots__ = ("_routes",)
+    __slots__ = ("_routes", "_session_routes")
 
-    def __init__(self, routes: GoogleOidcHttpRoutes) -> None:
-        if type(routes) is not GoogleOidcHttpRoutes:
+    def __init__(
+        self,
+        routes: GoogleOidcHttpRoutes,
+        session_routes: SessionHttpRoutes,
+    ) -> None:
+        if (
+            type(routes) is not GoogleOidcHttpRoutes
+            or type(session_routes) is not SessionHttpRoutes
+            or session_routes.sessions is not routes.session_discarder
+            or session_routes.proxy_resolver is not routes.proxy_resolver
+        ):
             raise AuthRuntimeConfigurationError("Grafo autenticazione non valido.")
         self._routes = routes
+        self._session_routes = session_routes
 
     @property
     def routes(self) -> GoogleOidcHttpRoutes:
         return self._routes
+
+    @property
+    def session_routes(self) -> SessionHttpRoutes:
+        return self._session_routes
 
     def __repr__(self) -> str:
         return "GoogleOidcRuntime(configured=True)"
@@ -83,6 +98,7 @@ def compose_google_oidc_runtime(
     login = None
     admission = None
     routes = None
+    session_routes = None
     try:
         client_id = _required(environment, "THEBITLAB_GOOGLE_CLIENT_ID")
         client_secret = _required(environment, "THEBITLAB_GOOGLE_CLIENT_SECRET")
@@ -149,7 +165,8 @@ def compose_google_oidc_runtime(
             http_sessions,
             session_cookie_policy=cookie_policy,
         )
-        return GoogleOidcRuntime(routes)
+        session_routes = SessionHttpRoutes(http_sessions, proxy_resolver)
+        return GoogleOidcRuntime(routes, session_routes)
     except AuthRuntimeConfigurationError:
         raise
     except Exception:
@@ -170,6 +187,7 @@ def compose_google_oidc_runtime(
         login = None
         admission = None
         routes = None
+        session_routes = None
 
 
 def _require_auth_dependencies() -> None:

--- a/scripts/thebitlab_session_http.py
+++ b/scripts/thebitlab_session_http.py
@@ -1,0 +1,293 @@
+"""Concrete HTTPS routes for current web session status and logout."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from scripts.thebitlab_edge_rate_limit import (
+    EdgeClientAttributionError,
+    EdgeRequestMetadata,
+    TrustedProxyClientResolver,
+)
+from scripts.thebitlab_http_auth import (
+    HttpAuthError,
+    HttpAuthRequest,
+    HttpAuthenticationRequiredError,
+    HttpBadRequestError,
+    HttpCsrfRejectedError,
+    HttpMethodNotAllowedError,
+    HttpSessionAuthBoundary,
+)
+
+_SESSION_PATH = "/auth/session"
+_LOGOUT_PATH = "/auth/logout"
+_MAX_COOKIE_HEADER_BYTES = 16 * 1024
+_CSRF_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+
+
+@dataclass(frozen=True)
+class SessionHttpRequest:
+    method: str
+    path: str
+    raw_query: str = field(default="", repr=False)
+    edge: EdgeRequestMetadata = field(default=None, repr=False)
+    is_tls: bool = False
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.method) is not str
+            or type(self.path) is not str
+            or type(self.raw_query) is not str
+            or type(self.edge) is not EdgeRequestMetadata
+            or type(self.is_tls) is not bool
+        ):
+            raise ValueError("Richiesta sessione HTTP non valida.")
+
+
+@dataclass(frozen=True)
+class SessionHttpResponse:
+    status_code: int
+    headers: tuple[tuple[str, str], ...]
+    body: bytes = field(default=b"", repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.status_code) is not int
+            or not 100 <= self.status_code <= 599
+            or type(self.headers) is not tuple
+            or type(self.body) is not bytes
+            or len(self.body) > 16 * 1024
+        ):
+            raise ValueError("Risposta sessione HTTP non valida.")
+        for header in self.headers:
+            if (
+                type(header) is not tuple
+                or len(header) != 2
+                or type(header[0]) is not str
+                or type(header[1]) is not str
+                or not header[0]
+                or any(ord(character) < 32 or ord(character) == 127 for character in header[0] + header[1])
+            ):
+                raise ValueError("Header sessione HTTP non valido.")
+
+
+class SessionHttpRoutes:
+    """Expose a minimal authenticated session snapshot and CSRF logout."""
+
+    def __init__(
+        self,
+        sessions: HttpSessionAuthBoundary,
+        proxy_resolver: TrustedProxyClientResolver,
+    ) -> None:
+        if type(sessions) is not HttpSessionAuthBoundary:
+            raise ValueError("Boundary sessione HTTP non valido.")
+        if type(proxy_resolver) is not TrustedProxyClientResolver:
+            raise ValueError("Resolver proxy sessione non valido.")
+        if not sessions.cookie_policy.secure:
+            raise ValueError("Le route sessione richiedono cookie Secure.")
+        self.sessions = sessions
+        self.proxy_resolver = proxy_resolver
+
+    def handles(self, path: str) -> bool:
+        return path in {_SESSION_PATH, _LOGOUT_PATH}
+
+    def dispatch(self, request: SessionHttpRequest) -> SessionHttpResponse | None:
+        if type(request) is not SessionHttpRequest:
+            return self._error(400, "bad_auth_request", "Richiesta non valida.")
+        if not self.handles(request.path):
+            return None
+        cookie_header = None
+        csrf_token = None
+        context = None
+        result = None
+        try:
+            self._require_https(request)
+            self._require_empty_request(request)
+            if request.path == _SESSION_PATH and request.method != "GET":
+                return self._method_error("GET")
+            if request.path == _LOGOUT_PATH and request.method != "POST":
+                return self._method_error("POST")
+            cookie_header = _combined_header(
+                request.edge, "cookie", maximum_bytes=_MAX_COOKIE_HEADER_BYTES,
+                separator="; ", required=True
+            )
+            if request.path == _SESSION_PATH:
+                csrf_headers = _header_values(request.edge, "x-csrf-token")
+                if csrf_headers:
+                    _csrf_header(csrf_headers)
+                context = self.sessions.authenticate(
+                    HttpAuthRequest("GET", cookie_header=cookie_header)
+                )
+                return self._session_response(context)
+            csrf_token = _csrf_header(
+                _header_values(request.edge, "x-csrf-token")
+            )
+            result = self.sessions.logout(
+                HttpAuthRequest(
+                    "POST",
+                    cookie_header=cookie_header,
+                    csrf_token=csrf_token,
+                )
+            )
+            return SessionHttpResponse(
+                204,
+                self._base_headers() + (
+                    ("Set-Cookie", result.set_cookie),
+                    ("Content-Length", "0"),
+                ),
+            )
+        except _SessionRequestError as error:
+            return self._error(error.status_code, error.error_code, error.public_message)
+        except HttpAuthError as error:
+            extra = (("Allow", "POST"),) if isinstance(error, HttpMethodNotAllowedError) else ()
+            return self._error(error.status_code, error.error_code, error.public_message, extra)
+        except EdgeClientAttributionError:
+            return self._error(400, "invalid_client_address", "Indirizzo client non valido.")
+        except Exception:
+            return self._error(
+                503,
+                "authentication_unavailable",
+                "Servizio di autenticazione temporaneamente non disponibile.",
+            )
+        finally:
+            request = None
+            cookie_header = None
+            csrf_token = None
+            context = None
+            result = None
+
+    def _require_https(self, request: SessionHttpRequest) -> None:
+        if request.is_tls:
+            return
+        if not self.proxy_resolver.is_trusted_peer(request.edge):
+            raise _SessionRequestError(400, "https_required", "HTTPS obbligatorio.")
+        forwarded = [
+            value.strip().lower()
+            for name, value in request.edge.headers
+            if name.lower() == "x-forwarded-proto"
+        ]
+        if forwarded != ["https"]:
+            raise _SessionRequestError(400, "https_required", "HTTPS obbligatorio.")
+
+    @staticmethod
+    def _require_empty_request(request: SessionHttpRequest) -> None:
+        if request.raw_query:
+            raise _SessionRequestError(400, "bad_auth_request", "Query non consentita.")
+        lengths = _header_values(request.edge, "content-length")
+        transfers = _header_values(request.edge, "transfer-encoding")
+        if transfers or len(lengths) > 1 or (lengths and lengths != ["0"]):
+            raise _SessionRequestError(400, "bad_auth_request", "Body non consentito.")
+
+    @staticmethod
+    def _base_headers() -> tuple[tuple[str, str], ...]:
+        return (
+            ("Cache-Control", "no-store"),
+            ("Pragma", "no-cache"),
+            ("Referrer-Policy", "no-referrer"),
+        )
+
+    def _session_response(self, context) -> SessionHttpResponse:
+        user = context.user
+        session = context.session
+        expires_at = _utc_z(session.expires_at)
+        payload = {
+            "authenticated": True,
+            "user": {
+                "user_id": user.user_id,
+                "display_name": user.display_name,
+                "role": user.role,
+            },
+            "session": {"expires_at": expires_at},
+            "csrf_token": context.csrf_token,
+        }
+        body = json.dumps(
+            payload, ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8")
+        return SessionHttpResponse(
+            200,
+            self._base_headers() + (
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Content-Length", str(len(body))),
+            ),
+            body,
+        )
+
+    def _method_error(self, allowed: str) -> SessionHttpResponse:
+        return self._error(
+            405,
+            "auth_method_not_allowed",
+            "Metodo non consentito.",
+            (("Allow", allowed),),
+        )
+
+    def _error(
+        self,
+        status_code: int,
+        error_code: str,
+        message: str,
+        extra_headers: tuple[tuple[str, str], ...] = (),
+    ) -> SessionHttpResponse:
+        body = json.dumps(
+            {"error": error_code, "message": message},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return SessionHttpResponse(
+            status_code,
+            extra_headers + self._base_headers() + (
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Content-Length", str(len(body))),
+            ),
+            body,
+        )
+
+
+class _SessionRequestError(RuntimeError):
+    def __init__(self, status_code: int, error_code: str, public_message: str) -> None:
+        self.status_code = status_code
+        self.error_code = error_code
+        self.public_message = public_message
+        super().__init__(public_message)
+
+
+def _header_values(edge: EdgeRequestMetadata, lowered_name: str) -> list[str]:
+    return [value.strip() for name, value in edge.headers if name.lower() == lowered_name]
+
+
+def _combined_header(
+    edge: EdgeRequestMetadata,
+    lowered_name: str,
+    *,
+    maximum_bytes: int,
+    separator: str,
+    required: bool,
+) -> str | None:
+    values = _header_values(edge, lowered_name)
+    if not values:
+        if required:
+            raise HttpAuthenticationRequiredError()
+        return None
+    combined = separator.join(values)
+    if (
+        len(combined.encode("utf-8", errors="surrogatepass")) > maximum_bytes
+        or any(ord(character) < 32 or ord(character) == 127 for character in combined)
+    ):
+        combined = None
+        raise HttpBadRequestError()
+    return combined
+
+
+def _csrf_header(values: list[str]) -> str:
+    if len(values) != 1 or _CSRF_RE.fullmatch(values[0]) is None:
+        values = []
+        raise HttpCsrfRejectedError()
+    return values[0]
+
+
+def _utc_z(value: datetime) -> str:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("Scadenza sessione non valida.")
+    return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")

--- a/tests/test_thebitlab_auth_runtime.py
+++ b/tests/test_thebitlab_auth_runtime.py
@@ -67,6 +67,8 @@ def test_composition_builds_one_coherent_production_graph(tmp_path: Path) -> Non
     assert routes.admission.login is login
     assert routes.proxy_resolver is routes.admission.resolver
     assert routes.session_discarder is login.http_sessions
+    assert runtime.session_routes.sessions is login.http_sessions
+    assert runtime.session_routes.proxy_resolver is routes.proxy_resolver
     assert login.http_sessions.sessions.audience == "web"
     assert routes.session_cookie_policy.name == "__Host-thebitlab_session"
     assert routes.session_cookie_policy.secure is True
@@ -293,7 +295,7 @@ def test_course_board_main_requires_explicit_google_auth_opt_in(
 ) -> None:
     from scripts import course_board_server
 
-    runtime = SimpleNamespace(routes=object())
+    runtime = SimpleNamespace(routes=object(), session_routes=object())
     composition_calls = []
     servers = []
 
@@ -345,7 +347,9 @@ def test_course_board_main_requires_explicit_google_auth_opt_in(
         assert len(composition_calls) == 1
         assert servers[0].google_oidc_runtime is runtime
         assert servers[0].google_oidc_http_routes is runtime.routes
+        assert servers[0].session_http_routes is runtime.session_routes
     else:
         assert composition_calls == []
         assert not hasattr(servers[0], "google_oidc_runtime")
         assert not hasattr(servers[0], "google_oidc_http_routes")
+        assert not hasattr(servers[0], "session_http_routes")

--- a/tests/test_thebitlab_session_http.py
+++ b/tests/test_thebitlab_session_http.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import socket
 import threading
 from datetime import datetime, timezone
 
@@ -271,6 +272,19 @@ def test_course_board_socket_serves_status_and_logout_without_basic_auth(graph) 
         )
         after = exchange("GET", "/auth/session", common)
         malformed = exchange("GET", "//auth/session", common)
+        raw = socket.create_connection(server.server_address, timeout=5)
+        try:
+            raw.sendall(
+                (
+                    "GET ///auth/session HTTP/1.1\r\n"
+                    "Host: localhost\r\n"
+                    "X-Forwarded-Proto: https\r\n"
+                    f"Cookie: {browser_cookie}\r\n\r\n"
+                ).encode("ascii")
+            )
+            triple_slash = raw.recv(4096)
+        finally:
+            raw.close()
     finally:
         server.shutdown()
         server.server_close()
@@ -282,3 +296,4 @@ def test_course_board_socket_serves_status_and_logout_without_basic_auth(graph) 
     assert "Max-Age=0" in logout[1]["Set-Cookie"]
     assert after[0] == 401
     assert malformed[0] == 400
+    assert b"400" in triple_slash

--- a/tests/test_thebitlab_session_http.py
+++ b/tests/test_thebitlab_session_http.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import http.client
+import json
+import threading
+from datetime import datetime, timezone
+
+import pytest
+
+from scripts.thebitlab_auth_services import SessionService
+from scripts.thebitlab_edge_rate_limit import EdgeRequestMetadata, TrustedProxyClientResolver
+from scripts.thebitlab_http_auth import HttpSessionAuthBoundary, SessionCookiePolicy
+from scripts.thebitlab_identity import UserAccount
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+from scripts.course_board_server import BoundedThreadingHTTPServer, CourseBoardHandler
+from scripts.thebitlab_session_http import SessionHttpRequest, SessionHttpRoutes
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+
+
+class SequenceFactory:
+    def __init__(self, *values):
+        self.values = iter(values)
+
+    def __call__(self):
+        return next(self.values)
+
+
+def account(role="student"):
+    return UserAccount(
+        user_id="user-01",
+        display_name="Mario Rossi",
+        role=role,
+        active=True,
+        created_at=NOW,
+        updated_at=NOW,
+        primary_email="private@example.test",
+    )
+
+
+@pytest.fixture
+def graph(tmp_path):
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3", clock=lambda: NOW)
+    storage.create_user(account())
+    sessions = SessionService(
+        storage,
+        clock=lambda: NOW,
+        token_factory=SequenceFactory("A" * 40),
+        session_id_factory=SequenceFactory("session-01"),
+    )
+    boundary = HttpSessionAuthBoundary(
+        sessions,
+        csrf_secret=b"c" * 32,
+        cookie_policy=SessionCookiePolicy(),
+        clock=lambda: NOW,
+    )
+    routes = SessionHttpRoutes(
+        boundary,
+        TrustedProxyClientResolver(("127.0.0.1/32",)),
+    )
+    established = boundary.establish_session("user-01")
+    return storage, boundary, routes, established
+
+
+def edge(*headers):
+    return EdgeRequestMetadata(
+        "127.0.0.1",
+        (("X-Forwarded-Proto", "https"),) + tuple(headers),
+    )
+
+
+def cookie(established):
+    return established.set_cookie.split(";", 1)[0]
+
+
+def request(method, path, *headers, query=""):
+    return SessionHttpRequest(method, path, query, edge(*headers))
+
+
+def header(response, name):
+    values = [value for key, value in response.headers if key.lower() == name.lower()]
+    return values[0] if len(values) == 1 else values
+
+
+def test_current_session_returns_minimal_snapshot_and_csrf(graph) -> None:
+    _storage, _boundary, routes, established = graph
+
+    response = routes.dispatch(
+        request("GET", "/auth/session", ("Cookie", cookie(established)))
+    )
+
+    assert response.status_code == 200
+    payload = json.loads(response.body)
+    assert payload == {
+        "authenticated": True,
+        "user": {
+            "user_id": "user-01",
+            "display_name": "Mario Rossi",
+            "role": "student",
+        },
+        "session": {"expires_at": "2026-09-01T16:00:00.000000Z"},
+        "csrf_token": established.context.csrf_token,
+    }
+    assert "private@example.test" not in response.body.decode("utf-8")
+    assert header(response, "Cache-Control") == "no-store"
+    assert header(response, "Referrer-Policy") == "no-referrer"
+    assert established.context.csrf_token not in repr(response)
+    assert cookie(established) not in repr(response)
+
+
+def test_logout_requires_csrf_revokes_session_and_clears_cookie(graph) -> None:
+    _storage, _boundary, routes, established = graph
+    browser_cookie = cookie(established)
+
+    rejected = routes.dispatch(
+        request("POST", "/auth/logout", ("Cookie", browser_cookie))
+    )
+    logged_out = routes.dispatch(
+        request(
+            "POST",
+            "/auth/logout",
+            ("Cookie", browser_cookie),
+            ("X-CSRF-Token", established.context.csrf_token),
+        )
+    )
+    after = routes.dispatch(
+        request("GET", "/auth/session", ("Cookie", browser_cookie))
+    )
+
+    assert rejected.status_code == 403
+    assert json.loads(rejected.body)["error"] == "csrf_rejected"
+    assert logged_out.status_code == 204
+    assert logged_out.body == b""
+    cleared = header(logged_out, "Set-Cookie")
+    assert cleared.startswith("__Host-thebitlab_session=;")
+    assert "Max-Age=0" in cleared
+    assert "Secure" in cleared and "HttpOnly" in cleared
+    assert after.status_code == 401
+
+
+def test_logout_clears_well_formed_stale_cookie_without_csrf_oracle(graph) -> None:
+    _storage, _boundary, routes, _established = graph
+    stale_cookie = "__Host-thebitlab_session=" + "Z" * 40
+
+    response = routes.dispatch(
+        request(
+            "POST",
+            "/auth/logout",
+            ("Cookie", stale_cookie),
+            ("X-CSRF-Token", "x" * 43),
+        )
+    )
+
+    assert response.status_code == 204
+    assert "Max-Age=0" in header(response, "Set-Cookie")
+    assert stale_cookie not in repr(response)
+
+
+@pytest.mark.parametrize(
+    ("candidate", "status", "error_code", "allow"),
+    (
+        (SessionHttpRequest("GET", "/auth/session", "", EdgeRequestMetadata("127.0.0.1")), 400, "https_required", None),
+        (request("GET", "/auth/session", query="unexpected=1"), 400, "bad_auth_request", None),
+        (request("POST", "/auth/session", ("Content-Length", "1")), 400, "bad_auth_request", None),
+        (request("DELETE", "/auth/session"), 405, "auth_method_not_allowed", "GET"),
+    ),
+)
+def test_route_rejects_transport_before_sensitive_operations(
+    graph, candidate, status, error_code, allow
+) -> None:
+    _storage, _boundary, routes, _established = graph
+
+    response = routes.dispatch(candidate)
+
+    assert response.status_code == status
+    assert json.loads(response.body)["error"] == error_code
+    if allow is not None:
+        assert header(response, "Allow") == allow
+
+
+def test_method_and_header_policy_is_exact(graph) -> None:
+    _storage, _boundary, routes, established = graph
+    browser_cookie = cookie(established)
+
+    wrong_session_method = routes.dispatch(
+        request("POST", "/auth/session", ("Cookie", browser_cookie))
+    )
+    wrong_logout_method = routes.dispatch(
+        request("GET", "/auth/logout", ("Cookie", browser_cookie))
+    )
+    duplicate_csrf = routes.dispatch(
+        request(
+            "POST",
+            "/auth/logout",
+            ("Cookie", browser_cookie),
+            ("X-CSRF-Token", established.context.csrf_token),
+            ("X-CSRF-Token", established.context.csrf_token),
+        )
+    )
+    duplicate_forwarded = routes.dispatch(SessionHttpRequest(
+        "GET",
+        "/auth/session",
+        "",
+        EdgeRequestMetadata(
+            "127.0.0.1",
+            (
+                ("X-Forwarded-Proto", "https"),
+                ("X-Forwarded-Proto", "https"),
+                ("Cookie", browser_cookie),
+            ),
+        ),
+    ))
+
+    assert wrong_session_method.status_code == 405
+    assert header(wrong_session_method, "Allow") == "GET"
+    assert wrong_logout_method.status_code == 405
+    assert header(wrong_logout_method, "Allow") == "POST"
+    assert duplicate_csrf.status_code == 403
+    assert duplicate_forwarded.status_code == 400
+
+
+def test_duplicate_cookie_headers_are_preserved_for_boundary_rejection(graph) -> None:
+    _storage, _boundary, routes, established = graph
+    browser_cookie = cookie(established)
+
+    response = routes.dispatch(
+        request(
+            "GET",
+            "/auth/session",
+            ("Cookie", browser_cookie),
+            ("Cookie", browser_cookie),
+        )
+    )
+
+    assert response.status_code == 401
+    assert json.loads(response.body)["error"] == "authentication_required"
+
+
+def test_unknown_path_is_not_claimed(graph) -> None:
+    _storage, _boundary, routes, _established = graph
+    assert routes.dispatch(request("GET", "/auth/other")) is None
+
+
+def test_course_board_socket_serves_status_and_logout_without_basic_auth(graph) -> None:
+    _storage, _boundary, routes, established = graph
+    server = BoundedThreadingHTTPServer(("127.0.0.1", 0), CourseBoardHandler)
+    server.session_http_routes = routes
+    server.teacher_token = "T" * 32
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def exchange(method, path, headers):
+        connection = http.client.HTTPConnection(
+            "127.0.0.1", server.server_address[1], timeout=5
+        )
+        try:
+            connection.request(method, path, headers=headers)
+            response = connection.getresponse()
+            return response.status, dict(response.getheaders()), response.read()
+        finally:
+            connection.close()
+
+    browser_cookie = cookie(established)
+    common = {"X-Forwarded-Proto": "https", "Cookie": browser_cookie}
+    try:
+        status = exchange("GET", "/auth/session", common)
+        logout = exchange(
+            "POST",
+            "/auth/logout",
+            {**common, "X-CSRF-Token": established.context.csrf_token},
+        )
+        after = exchange("GET", "/auth/session", common)
+        malformed = exchange("GET", "//auth/session", common)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status[0] == 200
+    assert json.loads(status[2])["user"]["user_id"] == "user-01"
+    assert logout[0] == 204
+    assert "Max-Age=0" in logout[1]["Set-Cookie"]
+    assert after[0] == 401
+    assert malformed[0] == 400


### PR DESCRIPTION
Closes #583

## Cosa cambia

- aggiunge `GET /auth/session` con snapshot minimo corrente e token CSRF;
- aggiunge `POST /auth/logout` con verifica CSRF, revoca server-side e cancellazione cookie;
- richiede TLS diretto o attestazione dallo stesso trusted proxy resolver Google;
- rifiuta query, body, transfer encoding, request-target non origin-form e metodi errati;
- preserva header Cookie/CSRF/forwarded duplicati per validazione fail-closed;
- integra entrambe le route nel runtime e nel Course Board solo con opt-in auth;
- estende la redazione delle request-line/access log alle route sessione;
- documenta payload, tassonomia errori, browser policy e lifecycle logout.

## Test

- suite mirata session/runtime/edge/OIDC/HTTP/SQLite/Course Board: 209 passed, 1 skipped POSIX-only;
- test socket reali per status, logout, revoca e target multi-slash;
- full required CI green su Linux/Windows, Python 3.11–3.13, minimum Python, Docker e Windows filesystem;
- `py_compile` e `git diff --check` puliti;
- review indipendenti finali 3–4 a `abe680e`: `Nessun finding`.

## Fuori scope

- UI account/logout;
- route pairing TUI e polling CLI;
- sostituzione del secret student-help.
