### PR TITLE
feat: expose browser-mediated TUI pairing routes

### DIFF
--- a/doc/architecture/auth-runtime-composition.md
+++ b/doc/architecture/auth-runtime-composition.md
@@ -19,6 +19,7 @@ La configurazione avviene prima della creazione del server HTTP. Qualunque valor
 | `THEBITLAB_GOOGLE_REDIRECT_URI` | URL HTTPS assoluto con path esatto `/auth/google/callback`, senza query o fragment |
 | `THEBITLAB_AUTH_CSRF_SECRET_B64` | 32–64 byte codificati base64url senza padding |
 | `THEBITLAB_RATE_LIMIT_PEPPER_B64` | 32–64 byte indipendenti, base64url senza padding |
+| `THEBITLAB_TUI_PAIRING_PEPPER_B64` | 32–64 byte indipendenti per il digest dei codici pairing, base64url senza padding |
 | `THEBITLAB_TRUSTED_PROXY_CIDRS` | da 1 a 16 reti CIDR canoniche bounded (massimo 4096 indirizzi IPv4 o 65536 IPv6 ciascuna), separate da virgola e senza spazi |
 
 Opzionali:
@@ -26,7 +27,7 @@ Opzionali:
 - `THEBITLAB_AUTH_DB_PATH`: file SQLite assoluto o relativo al data root; default `.thebitlab-auth/auth.sqlite3` in una directory dedicata;
 - `THEBITLAB_GOOGLE_POST_LOGIN_PATH`: path locale successivo al login; default `/tools/course_board.html`.
 
-I due segreti binari devono essere indipendenti. Per generarli:
+I tre segreti binari (CSRF, rate limit e pairing) devono essere indipendenti. Per generarli:
 
 ```bash
 python -c "import base64,secrets; print(base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b'=').decode())"
@@ -44,7 +45,8 @@ python -c "import base64,secrets; print(base64.urlsafe_b64encode(secrets.token_b
 6. `SqliteAtomicRateLimitStore` sullo stesso file, condivisibile fra processi dello stesso host;
 7. un solo `TrustedProxyClientResolver`, condiviso fra attribuzione client e verifica HTTPS;
 8. `GoogleOidcHttpRoutes` con lo stesso boundary sessione usato dal callback e dal delivery cleanup;
-9. `SessionHttpRoutes` per session status/logout, vincolato allo stesso boundary web e allo stesso resolver proxy.
+9. `SessionHttpRoutes` per session status/logout, vincolato allo stesso boundary web e allo stesso resolver proxy;
+10. servizi pairing e sessioni con audience `tui`, più `TuiPairingHttpRoutes`, sullo stesso storage e resolver.
 
 Il flow OIDC resta volutamente in memoria: un callback deve raggiungere lo stesso processo che ha iniziato il login. Un deployment multi-replica richiede sticky routing oppure un futuro flow store condiviso.
 

--- a/doc/architecture/tui-browser-pairing.md
+++ b/doc/architecture/tui-browser-pairing.md
@@ -4,7 +4,7 @@
 
 `scripts/thebitlab_tui_pairing.py` completa il protocollo provider-independent tra una TUI non autenticata e una sessione web TheBitLab già autenticata. Il terminale non riceve password, cookie, authorization code, access token Google/GitHub o altri segreti del provider.
 
-Questo incremento implementa boundary e transazione applicativa. Il costruttore richiede che sessioni web, servizio pairing interno e sessioni TUI condividano la stessa istanza del registro identity, impedendo confusione tra utenti omonimi di database distinti. I riferimenti storage e l'intero grafo `HttpSessionAuthBoundary`/`TuiPairingSessionService`/`PairingService` sono proprietà read-only; il service TUI deriva sempre il registro dal `PairingService`, senza conservarne una copia divergente. Ogni operazione pubblica ripete inoltre il controllo dell'intero grafo web/pairing/TUI prima e dopo ogni callback mutabile e prima di restituire risultati, quindi anche una sostituzione fault-injected successiva alla costruzione o durante una chiamata fallisce con 503. Le route concrete Course Board, l'apertura automatica del browser e la conservazione locale del bearer restano adapter successivi.
+Questo incremento implementa boundary e transazione applicativa. Il costruttore richiede che sessioni web, servizio pairing interno e sessioni TUI condividano la stessa istanza del registro identity, impedendo confusione tra utenti omonimi di database distinti. I riferimenti storage e l'intero grafo `HttpSessionAuthBoundary`/`TuiPairingSessionService`/`PairingService` sono proprietà read-only; il service TUI deriva sempre il registro dal `PairingService`, senza conservarne una copia divergente. Ogni operazione pubblica ripete inoltre il controllo dell'intero grafo web/pairing/TUI prima e dopo ogni callback mutabile e prima di restituire risultati, quindi anche una sostituzione fault-injected successiva alla costruzione o durante una chiamata fallisce con 503. Le route concrete Course Board sono ora descritte in `tui-pairing-http-routes.md`; l'apertura automatica del browser e la conservazione locale del bearer restano adapter successivi.
 
 ## Flusso
 
@@ -60,11 +60,11 @@ I dettagli storage e le credenziali non sono concatenati agli errori pubblici.
 
 ## Limiti prima dell'esposizione Internet
 
-Le route di `begin`, autorizzazione e consumo devono avere limiti globali/per-client e limiti specifici sui tentativi di codice. La policy trusted-proxy e il rate limiting sono tracciati in #549. Sono inoltre obbligatori HTTPS, header cache-control appropriati e nessun logging dei body/codici.
+Le route concrete applicano limiti atomici globali/per-client e un bucket per pairing sul consumo, condividendo store e trusted-proxy policy con il runtime auth. Sono obbligatori HTTPS, header cache-control appropriati e nessun logging dei body/codici.
 
 ## Fuori scope
 
-- wiring HTTP concreto e browser E2E;
+- browser E2E con pagina UI completa;
 - apertura browser e polling nella CLI/TUI;
 - persistenza locale del bearer;
 - sostituzione immediata dei token HMAC della demo;

--- a/doc/architecture/tui-pairing-http-routes.md
+++ b/doc/architecture/tui-pairing-http-routes.md
@@ -20,7 +20,7 @@ Tutte le route richiedono HTTPS diretto o attestato dallo stesso trusted proxy r
 
 Un unico store SQLite atomico, condiviso col login Google, applica bucket globali e per-client distinti a begin, authorize e consume. Consume aggiunge un bucket HMAC per pairing, impedendo tentativi distribuiti eccessivi sullo stesso identificatore. IP, pairing e codici non vengono persistiti nei bucket in chiaro.
 
-Prima di ogni begin ammesso viene eseguito cleanup fail-closed dei pairing scaduti non referenziati da sessioni TUI. La combinazione tra TTL, limiti globali/client e cleanup impedisce crescita persistente incontrollata da parte dell'ingresso pubblico.
+Prima di ogni begin ammesso vengono eliminate fail-closed prima le sessioni scadute di entrambe le audience e poi i pairing scaduti non più referenziati. L'ordine libera le correlazioni TUI consumate senza violare i vincoli SQLite. La combinazione tra TTL, limiti globali/client e cleanup impedisce crescita persistente incontrollata da parte dell'ingresso pubblico.
 
 ## Consegna one-shot
 

--- a/doc/architecture/tui-pairing-http-routes.md
+++ b/doc/architecture/tui-pairing-http-routes.md
@@ -1,0 +1,44 @@
+# Route HTTPS pairing browser–TUI
+
+## Protocollo
+
+Il runtime espone esclusivamente con opt-in auth:
+
+- `POST /auth/tui/pairings`: crea un pairing pending e restituisce `pairing_id`, `user_code`, path fisso di verifica e scadenza;
+- `POST /auth/tui/pair`: riceve `{"code":"..."}` dal browser, con cookie web e `X-CSRF-Token`, e autorizza soltanto uno student corrente;
+- `POST /auth/tui/pairings/{pairing_id}/token`: riceve lo stesso codice dalla TUI e tenta il consumo atomico. Un pairing ancora pending o già terminale produce 409; la CLI potrà trattare 409 come polling bounded fino alla scadenza.
+
+Codice e bearer sono accettati soltanto nel body JSON, mai in URL/query. Il browser non riceve il bearer TUI; il terminale non riceve cookie, CSRF o credenziali provider.
+
+## Trasporto
+
+Tutte le route richiedono HTTPS diretto o attestato dallo stesso trusted proxy resolver delle route Google/sessione. Sono accettati soltanto request-target origin-form canonici, `POST`, query vuota, Content-Length singolo e body massimo 2048 byte. Transfer-Encoding, JSON con chiavi duplicate, Content-Type diverso da `application/json`, campi extra e codici fuori grammatica falliscono chiusi.
+
+`/auth/tui/pairings` richiede body vuoto; autorizzazione e consumo richiedono un oggetto JSON con la sola chiave `code`. Il Course Board legge il body soltanto dopo avere validato framing e limite; framing invalido chiude la connessione per evitare request smuggling/desincronizzazione.
+
+## Rate limit e retention
+
+Un unico store SQLite atomico, condiviso col login Google, applica bucket globali e per-client distinti a begin, authorize e consume. Consume aggiunge un bucket HMAC per pairing, impedendo tentativi distribuiti eccessivi sullo stesso identificatore. IP, pairing e codici non vengono persistiti nei bucket in chiaro.
+
+Prima di ogni begin ammesso viene eseguito cleanup fail-closed dei pairing scaduti non referenziati da sessioni TUI. La combinazione tra TTL, limiti globali/client e cleanup impedisce crescita persistente incontrollata da parte dell'ingresso pubblico.
+
+## Consegna one-shot
+
+Il consumo SQLite autorizzato crea pairing `consumed` e sessione audience `tui` nella stessa transazione. La risposta 200 contiene bearer e scadenza una sola volta ed è associata a un delivery guard. Se serializzazione o scrittura socket falliscono, il guard verifica correlazione session ID/utente/scadenza e revoca best-effort quella specifica sessione TUI. Il pairing non torna pending e il terminale deve iniziare un nuovo flusso.
+
+Body, request e response escludono codice e bearer dai `repr`; gli access log usano il path fisso redatto `/auth/tui`. Tutte le risposte sono `no-store`, `no-cache` e `no-referrer`.
+
+## Errori
+
+- 400: richiesta/codice/formato non valido o HTTPS assente;
+- 401: sessione browser assente/invalida;
+- 403: CSRF o ruolo browser non consentito;
+- 405: metodo diverso da POST;
+- 409: pairing pending, già autorizzato/consumato/revocato o race;
+- 410: pairing scaduto;
+- 429: limite atomico superato, con `Retry-After`;
+- 503: storage, cleanup, clock, generatore o contratto adapter non disponibile.
+
+## Limiti
+
+La pagina UI che raccoglie manualmente il codice, l'apertura browser, il polling CLI, la persistenza sicura del bearer e l'uso nelle API student-help restano incrementi successivi.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -66,6 +66,7 @@ from scripts import (
     thebitlab_services,
     thebitlab_session_http,
     thebitlab_storage,
+    thebitlab_tui_pairing_http,
     thebitlab_tracking_reports,
     track_assignments,
     validate_activity,
@@ -3286,6 +3287,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 "/auth/google/",
                 "/auth/session",
                 "/auth/logout",
+                "/auth/tui/",
             )
         )
 
@@ -3295,7 +3297,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if self._is_sensitive_auth_request_line() or any(
             any(
                 auth_path in str(argument)
-                for auth_path in ("/auth/google/", "/auth/session", "/auth/logout")
+                for auth_path in (
+                    "/auth/google/", "/auth/session", "/auth/logout", "/auth/tui/"
+                )
             )
             for argument in args
         ):
@@ -3318,6 +3322,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 safe_path = "/auth/session"
             elif "/auth/logout" in combined:
                 safe_path = "/auth/logout"
+            elif "/auth/tui/" in combined:
+                safe_path = "/auth/tui"
             else:
                 safe_path = "/auth/invalid"
             safe_line = f"AUTH {safe_path} HTTP"
@@ -3450,6 +3456,111 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             self.write_error_json(400, "Il payload JSON deve essere un oggetto.")
             return None
         return payload
+
+    def dispatch_tui_pairing_http(self, parsed) -> bool:
+        """Delegate browser/TUI pairing routes with bounded body reads."""
+
+        routes = getattr(self.server, "tui_pairing_http_routes", None)
+        request_parts = str(getattr(self, "requestline", "")).split()
+        if routes is not None and routes.handles(parsed.path) and len(request_parts) != 3:
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        if routes is not None and len(request_parts) == 3:
+            raw_target = request_parts[1]
+            raw_parsed = urlparse(raw_target)
+            candidate_path = raw_parsed.path if routes.handles(raw_parsed.path) else parsed.path
+            if routes.handles(candidate_path) and not (
+                raw_target == candidate_path
+                or raw_target.startswith(candidate_path + "?")
+                or raw_target.startswith(candidate_path + "#")
+                or raw_target.startswith(candidate_path + ";")
+            ):
+                self.write_oidc_transport_error(400, "bad_auth_request")
+                return True
+            if routes.handles(raw_parsed.path):
+                parsed = raw_parsed
+        request_parts = None
+        raw_target = None
+        candidate_path = None
+        if routes is None or not routes.handles(parsed.path):
+            return False
+        if parsed.scheme or parsed.netloc or parsed.params:
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        body = b""
+        try:
+            edge = thebitlab_google_oidc_http.EdgeRequestMetadata(
+                str(self.client_address[0]), tuple(self.headers.raw_items())
+            )
+            lengths = [
+                value.strip()
+                for name, value in edge.headers
+                if name.lower() == "content-length"
+            ]
+            transfers = [
+                value for name, value in edge.headers
+                if name.lower() == "transfer-encoding"
+            ]
+            readable = (
+                not transfers
+                and len(lengths) == 1
+                and lengths[0].isdigit()
+                and 0 <= int(lengths[0]) <= 2048
+            )
+            if readable:
+                expected = int(lengths[0])
+                body = self.rfile.read(expected) if expected else b""
+                if len(body) != expected:
+                    self.close_connection = True
+            else:
+                self.close_connection = True
+            raw_query = parsed.query
+            if parsed.fragment:
+                raw_query += "#" + parsed.fragment
+            request = thebitlab_tui_pairing_http.TuiPairingHttpRequest(
+                self.command,
+                parsed.path,
+                raw_query,
+                body,
+                edge,
+                is_tls=isinstance(self.connection, ssl.SSLSocket),
+            )
+        except Exception:  # noqa: BLE001
+            self.close_connection = True
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        try:
+            response = routes.dispatch(request)
+            if response is None:
+                raise RuntimeError("Router pairing senza risposta.")
+        except Exception:  # noqa: BLE001
+            self.write_oidc_transport_error(503, "authentication_unavailable")
+            return True
+        finally:
+            edge = None
+            request = None
+            raw_query = None
+            body = None
+            lengths = None
+            transfers = None
+        self.write_tui_pairing_response(response)
+        return True
+
+    def write_tui_pairing_response(self, response) -> None:
+        guard = getattr(response, "delivery_guard", None)
+        try:
+            self.send_response(response.status_code)
+            for name, value in response.headers:
+                self.send_header(name, value)
+            self.end_headers()
+            if response.body and self.command != "HEAD":
+                self.wfile.write(response.body)
+        except Exception:  # noqa: BLE001
+            if guard is not None:
+                guard.failed()
+            return
+        if guard is not None:
+            guard.delivered()
 
     def dispatch_session_http(self, parsed) -> bool:
         """Delegate exact web-session routes to the injected secure router."""
@@ -3633,6 +3744,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def do_unsupported_auth_method(self) -> None:
         parsed = urlparse(self.path)
+        if self.dispatch_tui_pairing_http(parsed):
+            return
         if self.dispatch_session_http(parsed):
             return
         if self.dispatch_google_oidc(parsed):
@@ -3641,6 +3754,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def do_HEAD(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
+        if self.dispatch_tui_pairing_http(parsed):
+            return
         if self.dispatch_session_http(parsed):
             return
         if self.dispatch_google_oidc(parsed):
@@ -3667,6 +3782,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
+        if self.dispatch_tui_pairing_http(parsed):
+            return
         if self.dispatch_session_http(parsed):
             return
         if self.dispatch_google_oidc(parsed):
@@ -3760,6 +3877,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
+        if self.dispatch_tui_pairing_http(parsed):
+            return
         if self.dispatch_session_http(parsed):
             return
         if self.dispatch_google_oidc(parsed):
@@ -4226,6 +4345,7 @@ def main() -> int:
             server.google_oidc_runtime = auth_runtime
             server.google_oidc_http_routes = auth_runtime.routes
             server.session_http_routes = auth_runtime.session_routes
+            server.tui_pairing_http_routes = auth_runtime.tui_pairing_routes
         if not is_loopback_bind_host(args.host):
             print("ATTENZIONE: dashboard e credenziali Basic sono esposte su HTTP non cifrato.")
             print("Preferisci loopback con tunnel SSH oppure un reverse proxy HTTPS.")

--- a/scripts/thebitlab_auth_runtime.py
+++ b/scripts/thebitlab_auth_runtime.py
@@ -14,7 +14,12 @@ import urllib.parse
 from collections.abc import Mapping
 from pathlib import Path
 
-from scripts.thebitlab_auth_services import FederatedIdentityService, SessionService
+from scripts.thebitlab_auth_services import (
+    FederatedIdentityService,
+    PairingService,
+    SessionService,
+    TuiPairingSessionService,
+)
 from scripts.thebitlab_edge_rate_limit import (
     GoogleOidcLoginAdmissionBoundary,
     SqliteAtomicRateLimitStore,
@@ -31,6 +36,11 @@ from scripts.thebitlab_google_oidc_http import GoogleOidcHttpRoutes
 from scripts.thebitlab_http_auth import HttpSessionAuthBoundary, SessionCookiePolicy
 from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
 from scripts.thebitlab_session_http import SessionHttpRoutes
+from scripts.thebitlab_tui_pairing import TuiBrowserPairingBoundary
+from scripts.thebitlab_tui_pairing_http import (
+    TuiPairingHttpRateLimiter,
+    TuiPairingHttpRoutes,
+)
 
 _SECRET_RE = re.compile(r"^[A-Za-z0-9_-]{43,86}$")
 _CALLBACK_PATH = "/auth/google/callback"
@@ -49,22 +59,27 @@ class AuthRuntimeConfigurationError(RuntimeError):
 class GoogleOidcRuntime:
     """Own the composed service graph while exposing only its HTTP routes."""
 
-    __slots__ = ("_routes", "_session_routes")
+    __slots__ = ("_routes", "_session_routes", "_tui_pairing_routes")
 
     def __init__(
         self,
         routes: GoogleOidcHttpRoutes,
         session_routes: SessionHttpRoutes,
+        tui_pairing_routes: TuiPairingHttpRoutes,
     ) -> None:
         if (
             type(routes) is not GoogleOidcHttpRoutes
             or type(session_routes) is not SessionHttpRoutes
             or session_routes.sessions is not routes.session_discarder
             or session_routes.proxy_resolver is not routes.proxy_resolver
+            or type(tui_pairing_routes) is not TuiPairingHttpRoutes
+            or tui_pairing_routes.proxy_resolver is not routes.proxy_resolver
+            or tui_pairing_routes.boundary.http_sessions is not routes.session_discarder
         ):
             raise AuthRuntimeConfigurationError("Grafo autenticazione non valido.")
         self._routes = routes
         self._session_routes = session_routes
+        self._tui_pairing_routes = tui_pairing_routes
 
     @property
     def routes(self) -> GoogleOidcHttpRoutes:
@@ -73,6 +88,10 @@ class GoogleOidcRuntime:
     @property
     def session_routes(self) -> SessionHttpRoutes:
         return self._session_routes
+
+    @property
+    def tui_pairing_routes(self) -> TuiPairingHttpRoutes:
+        return self._tui_pairing_routes
 
     def __repr__(self) -> str:
         return "GoogleOidcRuntime(configured=True)"
@@ -89,6 +108,7 @@ def compose_google_oidc_runtime(
     client_secret = None
     csrf_secret = None
     rate_limit_pepper = None
+    pairing_pepper = None
     config = None
     cookie_policy = None
     proxy_resolver = None
@@ -99,6 +119,12 @@ def compose_google_oidc_runtime(
     admission = None
     routes = None
     session_routes = None
+    tui_pairing_routes = None
+    rate_limit_store = None
+    pairing_service = None
+    pairing_sessions = None
+    tui_sessions = None
+    pairing_boundary = None
     try:
         client_id = _required(environment, "THEBITLAB_GOOGLE_CLIENT_ID")
         client_secret = _required(environment, "THEBITLAB_GOOGLE_CLIENT_SECRET")
@@ -107,9 +133,16 @@ def compose_google_oidc_runtime(
         rate_limit_pepper = _secret(
             environment, "THEBITLAB_RATE_LIMIT_PEPPER_B64"
         )
-        if hmac.compare_digest(csrf_secret, rate_limit_pepper):
+        pairing_pepper = _secret(
+            environment, "THEBITLAB_TUI_PAIRING_PEPPER_B64"
+        )
+        if (
+            hmac.compare_digest(csrf_secret, rate_limit_pepper)
+            or hmac.compare_digest(csrf_secret, pairing_pepper)
+            or hmac.compare_digest(rate_limit_pepper, pairing_pepper)
+        ):
             raise AuthRuntimeConfigurationError(
-                "I segreti CSRF e rate limit devono essere indipendenti."
+                "I segreti CSRF, rate limit e pairing devono essere indipendenti."
             )
         trusted_proxy_cidrs = _trusted_proxy_cidrs(environment)
         post_login_path = environment.get(
@@ -152,9 +185,10 @@ def compose_google_oidc_runtime(
             FederatedIdentityService(storage),
             http_sessions,
         )
+        rate_limit_store = SqliteAtomicRateLimitStore(database_path)
         admission = GoogleOidcLoginAdmissionBoundary(
             login,
-            SqliteAtomicRateLimitStore(database_path),
+            rate_limit_store,
             proxy_resolver,
             client_key_pepper=rate_limit_pepper,
         )
@@ -166,7 +200,24 @@ def compose_google_oidc_runtime(
             session_cookie_policy=cookie_policy,
         )
         session_routes = SessionHttpRoutes(http_sessions, proxy_resolver)
-        return GoogleOidcRuntime(routes, session_routes)
+        pairing_service = PairingService(storage, pepper=pairing_pepper)
+        pairing_sessions = TuiPairingSessionService(pairing_service)
+        tui_sessions = SessionService(storage, audience="tui")
+        pairing_boundary = TuiBrowserPairingBoundary(
+            pairing_sessions,
+            http_sessions,
+            tui_sessions,
+        )
+        tui_pairing_routes = TuiPairingHttpRoutes(
+            pairing_boundary,
+            proxy_resolver,
+            TuiPairingHttpRateLimiter(
+                rate_limit_store,
+                proxy_resolver,
+                pepper=rate_limit_pepper,
+            ),
+        )
+        return GoogleOidcRuntime(routes, session_routes, tui_pairing_routes)
     except AuthRuntimeConfigurationError:
         raise
     except Exception:
@@ -178,6 +229,7 @@ def compose_google_oidc_runtime(
         client_secret = None
         csrf_secret = None
         rate_limit_pepper = None
+        pairing_pepper = None
         config = None
         cookie_policy = None
         proxy_resolver = None
@@ -188,6 +240,12 @@ def compose_google_oidc_runtime(
         admission = None
         routes = None
         session_routes = None
+        tui_pairing_routes = None
+        rate_limit_store = None
+        pairing_service = None
+        pairing_sessions = None
+        tui_sessions = None
+        pairing_boundary = None
 
 
 def _require_auth_dependencies() -> None:

--- a/scripts/thebitlab_tui_pairing.py
+++ b/scripts/thebitlab_tui_pairing.py
@@ -345,6 +345,41 @@ class TuiBrowserPairingBoundary:
             raise TuiPairingUnavailableError()
         return credential
 
+    def discard_issued_credential(self, credential: IssuedTuiCredential) -> bool:
+        """Best-effort revoke a bearer that could not be delivered to its TUI."""
+
+        bearer = None
+        session = None
+        digest = None
+        revoked = False
+        try:
+            self._require_shared_registry()
+            if type(credential) is not IssuedTuiCredential:
+                return False
+            bearer = credential.bearer_token
+            digest = session_token_digest(bearer)
+            session = self.tui_sessions.storage.read_session_by_token_digest(digest)
+            if (
+                type(session) is not UserSession
+                or session.audience != "tui"
+                or session.source_pairing_id is None
+                or session.session_id != credential.session_id
+                or session.user_id != credential.user_id
+                or session.expires_at != credential.expires_at
+                or not hmac.compare_digest(session.token_digest, digest)
+            ):
+                return False
+            revoked = self.tui_sessions.revoke(bearer) is True
+            self._require_shared_registry()
+        except Exception:
+            revoked = False
+        finally:
+            bearer = None
+            credential = None
+            session = None
+            digest = None
+        return revoked
+
     def authenticate_bearer(self, authorization_header: str) -> TuiAuthenticatedContext:
         bearer = None
         invalid = False

--- a/scripts/thebitlab_tui_pairing_http.py
+++ b/scripts/thebitlab_tui_pairing_http.py
@@ -1,0 +1,365 @@
+"""Concrete HTTPS transport for browser-mediated TUI pairing."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+from scripts.thebitlab_edge_rate_limit import (
+    AtomicRateLimitStore,
+    EdgeClientAttributionError,
+    EdgeRateLimitStoreError,
+    EdgeRequestMetadata,
+    RateLimitBucket,
+    TrustedProxyClientResolver,
+)
+from scripts.thebitlab_http_auth import (
+    HttpAuthError,
+    HttpAuthRequest,
+    HttpAuthenticationRequiredError,
+    HttpCsrfRejectedError,
+)
+from scripts.thebitlab_tui_pairing import (
+    IssuedTuiCredential,
+    TuiBrowserPairingBoundary,
+    TuiPairingBadRequestError,
+)
+
+_BEGIN_PATH = "/auth/tui/pairings"
+_AUTHORIZE_PATH = "/auth/tui/pair"
+_TOKEN_RE = re.compile(r"^/auth/tui/pairings/([A-Za-z0-9_-]{1,128})/token$")
+_CODE_RE = re.compile(r"^[A-Za-z0-9_-]{8,128}$")
+_MAX_BODY_BYTES = 2048
+
+
+@dataclass(frozen=True)
+class TuiPairingHttpRequest:
+    method: str
+    path: str
+    raw_query: str = field(default="", repr=False)
+    body: bytes = field(default=b"", repr=False, compare=False)
+    edge: EdgeRequestMetadata = field(default=None, repr=False)
+    is_tls: bool = False
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.method) is not str
+            or type(self.path) is not str
+            or type(self.raw_query) is not str
+            or type(self.body) is not bytes
+            or len(self.body) > _MAX_BODY_BYTES
+            or type(self.edge) is not EdgeRequestMetadata
+            or type(self.is_tls) is not bool
+        ):
+            raise ValueError("Richiesta pairing HTTP non valida.")
+
+
+class TuiCredentialDeliveryGuard:
+    __slots__ = ("_boundary", "_credential", "_completed")
+
+    def __init__(self, boundary: TuiBrowserPairingBoundary, credential: IssuedTuiCredential):
+        self._boundary = boundary
+        self._credential = credential
+        self._completed = False
+
+    def delivered(self) -> None:
+        self._completed = True
+        self._credential = None
+
+    def failed(self) -> None:
+        if self._completed:
+            return
+        credential = self._credential
+        self._credential = None
+        self._completed = True
+        if credential is not None:
+            self._boundary.discard_issued_credential(credential)
+        credential = None
+
+    def __repr__(self) -> str:
+        return "TuiCredentialDeliveryGuard(pending=%s)" % (not self._completed)
+
+
+@dataclass(frozen=True)
+class TuiPairingHttpResponse:
+    status_code: int
+    headers: tuple[tuple[str, str], ...]
+    body: bytes = field(default=b"", repr=False, compare=False)
+    delivery_guard: TuiCredentialDeliveryGuard | None = field(
+        default=None, repr=False, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.status_code) is not int
+            or not 100 <= self.status_code <= 599
+            or type(self.headers) is not tuple
+            or type(self.body) is not bytes
+            or len(self.body) > 16 * 1024
+            or (
+                self.delivery_guard is not None
+                and type(self.delivery_guard) is not TuiCredentialDeliveryGuard
+            )
+        ):
+            raise ValueError("Risposta pairing HTTP non valida.")
+
+
+class TuiPairingHttpRateLimiter:
+    def __init__(
+        self,
+        store: AtomicRateLimitStore,
+        resolver: TrustedProxyClientResolver,
+        *,
+        pepper: bytes,
+        clock=lambda: datetime.now(timezone.utc),
+    ) -> None:
+        if type(pepper) is not bytes or len(pepper) < 32:
+            raise ValueError("Pepper rate limit pairing non valido.")
+        self.store = store
+        self.resolver = resolver
+        self._pepper = pepper
+        self.clock = clock
+
+    def admit(self, route_id: str, edge: EdgeRequestMetadata, correlation: str | None = None) -> None:
+        client = self.resolver.resolve(edge)
+        now = self.clock()
+        if type(now) is not datetime or now.tzinfo is None or now.utcoffset() is None:
+            raise EdgeRateLimitStoreError("Clock pairing non valido.")
+        limits = {
+            "begin": (120, 8),
+            "authorize": (300, 20),
+            "consume": (600, 30),
+        }
+        if route_id not in limits:
+            raise EdgeRateLimitStoreError("Route pairing non valida.")
+        global_limit, client_limit = limits[route_id]
+        client_key = self._key(route_id, client)
+        buckets = [
+            RateLimitBucket(f"global:auth.tui.{route_id}", global_limit, 60),
+            RateLimitBucket(client_key, client_limit, 60),
+        ]
+        if correlation is not None:
+            buckets.append(RateLimitBucket(self._key(route_id, correlation), 20, 60))
+        retry_after = self.store.admit(tuple(buckets), now=now.astimezone(timezone.utc))
+        if retry_after is not None:
+            if type(retry_after) is not int or retry_after < 1:
+                raise EdgeRateLimitStoreError("Retry rate limit pairing non valido.")
+            raise _PairingRateLimitError(retry_after)
+
+    def _key(self, route_id: str, value: str) -> str:
+        return "hmac-sha256:" + hmac.new(
+            self._pepper,
+            ("auth.tui." + route_id + "\0" + value).encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+
+class TuiPairingHttpRoutes:
+    def __init__(
+        self,
+        boundary: TuiBrowserPairingBoundary,
+        proxy_resolver: TrustedProxyClientResolver,
+        rate_limiter: TuiPairingHttpRateLimiter,
+    ) -> None:
+        if (
+            type(boundary) is not TuiBrowserPairingBoundary
+            or type(proxy_resolver) is not TrustedProxyClientResolver
+            or type(rate_limiter) is not TuiPairingHttpRateLimiter
+            or rate_limiter.resolver is not proxy_resolver
+        ):
+            raise ValueError("Grafo route pairing non valido.")
+        self.boundary = boundary
+        self.proxy_resolver = proxy_resolver
+        self.rate_limiter = rate_limiter
+
+    def handles(self, path: str) -> bool:
+        return path in {_BEGIN_PATH, _AUTHORIZE_PATH} or _TOKEN_RE.fullmatch(path or "") is not None
+
+    def dispatch(self, request: TuiPairingHttpRequest) -> TuiPairingHttpResponse | None:
+        if type(request) is not TuiPairingHttpRequest:
+            return self._error(400, "tui_pairing_invalid", "Richiesta pairing non valida.")
+        if not self.handles(request.path):
+            return None
+        code = None
+        pairing_id = None
+        credential = None
+        payload = None
+        cookie_header = None
+        csrf_token = None
+        started = None
+        try:
+            self._require_https_and_query(request)
+            if request.method != "POST":
+                return self._error(405, "auth_method_not_allowed", "Metodo non consentito.", (("Allow", "POST"),))
+            self._require_framing(request)
+            if request.path == _BEGIN_PATH:
+                self._require_empty_body(request)
+                self.rate_limiter.admit("begin", request.edge)
+                self._cleanup_expired_pairings()
+                started = self.boundary.begin()
+                return self._json(201, {
+                    "pairing_id": started.pairing_id,
+                    "user_code": started.user_code,
+                    "verification_path": started.verification_path,
+                    "expires_at": _utc_z(started.expires_at),
+                })
+            payload = _json_object(request)
+            code = payload.get("code")
+            if set(payload) != {"code"} or type(code) is not str or _CODE_RE.fullmatch(code) is None:
+                raise TuiPairingBadRequestError()
+            if request.path == _AUTHORIZE_PATH:
+                self.rate_limiter.admit("authorize", request.edge)
+                cookie_header = _combined_cookie(request.edge)
+                csrf_token = _csrf_header(request.edge)
+                self.boundary.authorize_browser(
+                    HttpAuthRequest("POST", cookie_header, csrf_token), code
+                )
+                return TuiPairingHttpResponse(204, self._base_headers() + (("Content-Length", "0"),))
+            match = _TOKEN_RE.fullmatch(request.path)
+            pairing_id = match.group(1) if match is not None else None
+            if pairing_id is None:
+                raise TuiPairingBadRequestError()
+            self.rate_limiter.admit("consume", request.edge, pairing_id)
+            credential = self.boundary.consume(pairing_id, code)
+            response = self._json(200, {
+                "token_type": "Bearer",
+                "bearer_token": credential.bearer_token,
+                "expires_at": _utc_z(credential.expires_at),
+            }, guard=TuiCredentialDeliveryGuard(self.boundary, credential))
+            credential = None
+            return response
+        except _PairingRateLimitError as error:
+            return self._error(429, "rate_limit_exceeded", "Troppe richieste.", (("Retry-After", str(error.retry_after)),))
+        except EdgeClientAttributionError:
+            return self._error(400, "invalid_client_address", "Indirizzo client non valido.")
+        except HttpAuthError as error:
+            return self._error(error.status_code, error.error_code, error.public_message)
+        except Exception:
+            if credential is not None:
+                self.boundary.discard_issued_credential(credential)
+            return self._error(503, "tui_pairing_unavailable", "Servizio pairing temporaneamente non disponibile.")
+        finally:
+            request = None
+            code = None
+            pairing_id = None
+            credential = None
+            payload = None
+            cookie_header = None
+            csrf_token = None
+            started = None
+
+    def _require_https_and_query(self, request: TuiPairingHttpRequest) -> None:
+        if request.raw_query:
+            raise TuiPairingBadRequestError()
+        if request.is_tls:
+            return
+        if not self.proxy_resolver.is_trusted_peer(request.edge):
+            raise _HttpsRequiredError()
+        forwarded = [value.lower() for value in _header_values(request.edge, "x-forwarded-proto")]
+        if forwarded != ["https"]:
+            raise _HttpsRequiredError()
+
+    @staticmethod
+    def _require_framing(request: TuiPairingHttpRequest) -> None:
+        transfers = _header_values(request.edge, "transfer-encoding")
+        lengths = _header_values(request.edge, "content-length")
+        if (
+            transfers
+            or len(lengths) != 1
+            or not lengths[0].isdigit()
+            or int(lengths[0]) != len(request.body)
+        ):
+            raise TuiPairingBadRequestError()
+
+    def _cleanup_expired_pairings(self) -> None:
+        pairing_service = self.boundary.pairings.pairings
+        now = pairing_service.clock()
+        if type(now) is not datetime or now.tzinfo is None or now.utcoffset() is None:
+            raise EdgeRateLimitStoreError("Clock cleanup pairing non valido.")
+        removed = pairing_service.storage.delete_expired_pairings(
+            now.astimezone(timezone.utc)
+        )
+        if type(removed) is not int or removed < 0:
+            raise EdgeRateLimitStoreError("Cleanup pairing non valido.")
+
+    @staticmethod
+    def _require_empty_body(request: TuiPairingHttpRequest) -> None:
+        if request.body:
+            raise TuiPairingBadRequestError()
+
+    @staticmethod
+    def _base_headers() -> tuple[tuple[str, str], ...]:
+        return (("Cache-Control", "no-store"), ("Pragma", "no-cache"), ("Referrer-Policy", "no-referrer"))
+
+    def _json(self, status: int, payload: dict, *, guard=None) -> TuiPairingHttpResponse:
+        body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        return TuiPairingHttpResponse(status, self._base_headers() + (("Content-Type", "application/json; charset=utf-8"), ("Content-Length", str(len(body)))), body, guard)
+
+    def _error(self, status: int, code: str, message: str, extra=()) -> TuiPairingHttpResponse:
+        body = json.dumps({"error": code, "message": message}, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        return TuiPairingHttpResponse(status, tuple(extra) + self._base_headers() + (("Content-Type", "application/json; charset=utf-8"), ("Content-Length", str(len(body)))), body)
+
+
+class _PairingRateLimitError(RuntimeError):
+    def __init__(self, retry_after: int):
+        self.retry_after = retry_after
+        super().__init__("Troppe richieste.")
+
+
+class _HttpsRequiredError(HttpAuthError):
+    status_code = 400
+    error_code = "https_required"
+    public_message = "HTTPS obbligatorio."
+
+
+def _header_values(edge: EdgeRequestMetadata, name: str) -> list[str]:
+    return [value.strip() for key, value in edge.headers if key.lower() == name]
+
+
+def _combined_cookie(edge: EdgeRequestMetadata) -> str:
+    values = _header_values(edge, "cookie")
+    if not values:
+        raise HttpAuthenticationRequiredError()
+    combined = "; ".join(values)
+    if len(combined.encode("utf-8", errors="surrogatepass")) > 16384:
+        raise TuiPairingBadRequestError()
+    return combined
+
+
+def _csrf_header(edge: EdgeRequestMetadata) -> str:
+    values = _header_values(edge, "x-csrf-token")
+    if len(values) != 1 or not values[0] or len(values[0]) > 512:
+        raise HttpCsrfRejectedError()
+    return values[0]
+
+
+def _json_object(request: TuiPairingHttpRequest) -> dict:
+    content_types = _header_values(request.edge, "content-type")
+    if content_types != ["application/json"] or not 2 <= len(request.body) <= _MAX_BODY_BYTES:
+        raise TuiPairingBadRequestError()
+    try:
+        payload = json.loads(request.body.decode("utf-8"), object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        raise TuiPairingBadRequestError() from None
+    if type(payload) is not dict:
+        raise TuiPairingBadRequestError()
+    return payload
+
+
+def _unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate")
+        result[key] = value
+    return result
+
+
+def _utc_z(value: datetime) -> str:
+    if type(value) is not datetime or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("timestamp")
+    return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")

--- a/scripts/thebitlab_tui_pairing_http.py
+++ b/scripts/thebitlab_tui_pairing_http.py
@@ -280,10 +280,12 @@ class TuiPairingHttpRoutes:
         now = pairing_service.clock()
         if type(now) is not datetime or now.tzinfo is None or now.utcoffset() is None:
             raise EdgeRateLimitStoreError("Clock cleanup pairing non valido.")
-        removed = pairing_service.storage.delete_expired_pairings(
-            now.astimezone(timezone.utc)
-        )
-        if type(removed) is not int or removed < 0:
+        cutoff = now.astimezone(timezone.utc)
+        removed_sessions = pairing_service.storage.delete_expired_sessions(cutoff)
+        if type(removed_sessions) is not int or removed_sessions < 0:
+            raise EdgeRateLimitStoreError("Cleanup sessioni non valido.")
+        removed_pairings = pairing_service.storage.delete_expired_pairings(cutoff)
+        if type(removed_pairings) is not int or removed_pairings < 0:
             raise EdgeRateLimitStoreError("Cleanup pairing non valido.")
 
     @staticmethod

--- a/tests/test_thebitlab_auth_runtime.py
+++ b/tests/test_thebitlab_auth_runtime.py
@@ -55,6 +55,7 @@ def valid_environment() -> dict[str, str]:
         ),
         "THEBITLAB_AUTH_CSRF_SECRET_B64": encoded_secret(1),
         "THEBITLAB_RATE_LIMIT_PEPPER_B64": encoded_secret(2),
+        "THEBITLAB_TUI_PAIRING_PEPPER_B64": encoded_secret(3),
         "THEBITLAB_TRUSTED_PROXY_CIDRS": "127.0.0.1/32,::1/128",
     }
 
@@ -69,6 +70,9 @@ def test_composition_builds_one_coherent_production_graph(tmp_path: Path) -> Non
     assert routes.session_discarder is login.http_sessions
     assert runtime.session_routes.sessions is login.http_sessions
     assert runtime.session_routes.proxy_resolver is routes.proxy_resolver
+    assert runtime.tui_pairing_routes.proxy_resolver is routes.proxy_resolver
+    assert runtime.tui_pairing_routes.boundary.http_sessions is login.http_sessions
+    assert runtime.tui_pairing_routes.boundary.tui_sessions.audience == "tui"
     assert login.http_sessions.sessions.audience == "web"
     assert routes.session_cookie_policy.name == "__Host-thebitlab_session"
     assert routes.session_cookie_policy.secure is True
@@ -107,6 +111,7 @@ def test_composition_accepts_relative_database_and_local_post_login(tmp_path: Pa
     (
         ("THEBITLAB_AUTH_CSRF_SECRET_B64", "too-short", "CSRF_SECRET"),
         ("THEBITLAB_RATE_LIMIT_PEPPER_B64", "=" * 43, "RATE_LIMIT_PEPPER"),
+        ("THEBITLAB_TUI_PAIRING_PEPPER_B64", "too-short", "TUI_PAIRING_PEPPER"),
         ("THEBITLAB_TRUSTED_PROXY_CIDRS", "", "TRUSTED_PROXY"),
         ("THEBITLAB_TRUSTED_PROXY_CIDRS", "127.0.0.1/8", "TRUSTED_PROXY"),
         ("THEBITLAB_TRUSTED_PROXY_CIDRS", "0.0.0.0/0", "TRUSTED_PROXY"),
@@ -142,6 +147,7 @@ def test_composition_rejects_unsafe_configuration_without_echoing_values(
         "THEBITLAB_GOOGLE_CLIENT_SECRET",
         "THEBITLAB_AUTH_CSRF_SECRET_B64",
         "THEBITLAB_RATE_LIMIT_PEPPER_B64",
+        "THEBITLAB_TUI_PAIRING_PEPPER_B64",
     ):
         assert environment[secret_name] not in serialized
 
@@ -295,7 +301,9 @@ def test_course_board_main_requires_explicit_google_auth_opt_in(
 ) -> None:
     from scripts import course_board_server
 
-    runtime = SimpleNamespace(routes=object(), session_routes=object())
+    runtime = SimpleNamespace(
+        routes=object(), session_routes=object(), tui_pairing_routes=object()
+    )
     composition_calls = []
     servers = []
 
@@ -348,8 +356,10 @@ def test_course_board_main_requires_explicit_google_auth_opt_in(
         assert servers[0].google_oidc_runtime is runtime
         assert servers[0].google_oidc_http_routes is runtime.routes
         assert servers[0].session_http_routes is runtime.session_routes
+        assert servers[0].tui_pairing_http_routes is runtime.tui_pairing_routes
     else:
         assert composition_calls == []
         assert not hasattr(servers[0], "google_oidc_runtime")
         assert not hasattr(servers[0], "google_oidc_http_routes")
         assert not hasattr(servers[0], "session_http_routes")
+        assert not hasattr(servers[0], "tui_pairing_http_routes")

--- a/tests/test_thebitlab_tui_pairing_http.py
+++ b/tests/test_thebitlab_tui_pairing_http.py
@@ -4,7 +4,7 @@ import http.client as http_client
 import json
 import threading
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -212,6 +212,35 @@ def test_browser_authorization_requires_cookie_and_csrf(graph) -> None:
 def test_transport_is_fail_closed(graph, candidate, status) -> None:
     _storage, _http, _boundary, routes = graph
     assert routes.dispatch(candidate).status_code == status
+
+
+def test_begin_cleans_expired_tui_session_before_consumed_pairing(graph) -> None:
+    storage, http, boundary, routes = graph
+    start = json.loads(routes.dispatch(request("/auth/tui/pairings")).body)
+    browser = http.establish_session("student-01")
+    routes.dispatch(
+        json_request(
+            "/auth/tui/pair",
+            {"code": start["user_code"]},
+            ("Cookie", cookie(browser)),
+            ("X-CSRF-Token", browser.context.csrf_token),
+        )
+    )
+    consumed = routes.dispatch(
+        json_request(
+            f"/auth/tui/pairings/{start['pairing_id']}/token",
+            {"code": start["user_code"]},
+        )
+    )
+    bearer = json.loads(consumed.body)["bearer_token"]
+    consumed.delivery_guard.delivered()
+    boundary.pairings.pairings.clock = lambda: NOW + timedelta(hours=9)
+
+    fresh = routes.dispatch(request("/auth/tui/pairings"))
+
+    assert fresh.status_code == 201
+    assert storage.read_session_by_token_digest(session_token_digest(bearer)) is None
+    assert storage.read_pairing(start["pairing_id"]) is None
 
 
 def test_begin_rate_limit_prevents_ninth_pairing_allocation(graph) -> None:

--- a/tests/test_thebitlab_tui_pairing_http.py
+++ b/tests/test_thebitlab_tui_pairing_http.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import http.client as http_client
+import json
+import threading
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+
+from scripts.thebitlab_auth_services import (
+    PairingService,
+    SessionService,
+    TuiPairingSessionService,
+    session_token_digest,
+)
+from scripts.thebitlab_edge_rate_limit import EdgeRequestMetadata, InMemoryAtomicRateLimitStore, TrustedProxyClientResolver
+from scripts.thebitlab_http_auth import HttpAuthenticationRequiredError, HttpSessionAuthBoundary, SessionCookiePolicy
+from scripts.thebitlab_identity import UserAccount
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+from scripts.thebitlab_tui_pairing import TuiBrowserPairingBoundary
+from scripts.course_board_server import BoundedThreadingHTTPServer, CourseBoardHandler
+from scripts.thebitlab_tui_pairing_http import TuiPairingHttpRateLimiter, TuiPairingHttpRequest, TuiPairingHttpRoutes
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+
+
+class CounterFactory:
+    def __init__(self, prefix):
+        self.prefix = prefix
+        self.value = 0
+
+    def __call__(self):
+        self.value += 1
+        return f"{self.prefix}{self.value:04d}"
+
+
+@pytest.fixture
+def graph(tmp_path):
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3", clock=lambda: NOW)
+    storage.create_user(UserAccount("student-01", "Student", "student", True, NOW, NOW))
+    pairings = PairingService(
+        storage,
+        pepper=b"p" * 32,
+        clock=lambda: NOW,
+        code_factory=CounterFactory("PAIRCODE"),
+        pairing_id_factory=CounterFactory("pairing-"),
+    )
+    pairing_sessions = TuiPairingSessionService(
+        pairings,
+        token_factory=CounterFactory("T" * 40),
+        session_id_factory=CounterFactory("tui-session-"),
+    )
+    web_sessions = SessionService(
+        storage,
+        clock=lambda: NOW,
+        token_factory=lambda: "W" * 40,
+        session_id_factory=lambda: "web-session-01",
+    )
+    http = HttpSessionAuthBoundary(
+        web_sessions,
+        csrf_secret=b"c" * 32,
+        cookie_policy=SessionCookiePolicy(),
+        clock=lambda: NOW,
+    )
+    boundary = TuiBrowserPairingBoundary(
+        pairing_sessions,
+        http,
+        SessionService(storage, clock=lambda: NOW, audience="tui"),
+    )
+    resolver = TrustedProxyClientResolver(("127.0.0.1/32",))
+    routes = TuiPairingHttpRoutes(
+        boundary,
+        resolver,
+        TuiPairingHttpRateLimiter(
+            InMemoryAtomicRateLimitStore(),
+            resolver,
+            pepper=b"r" * 32,
+            clock=lambda: NOW,
+        ),
+    )
+    return storage, http, boundary, routes
+
+
+def request(path, body=b"", *headers, method="POST"):
+    edge = EdgeRequestMetadata(
+        "127.0.0.1",
+        (
+            ("X-Forwarded-Proto", "https"),
+            ("Content-Length", str(len(body))),
+        ) + tuple(headers),
+    )
+    return TuiPairingHttpRequest(method, path, "", body, edge)
+
+
+def json_request(path, payload, *headers):
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return request(path, body, ("Content-Type", "application/json"), *headers)
+
+
+def cookie(established):
+    return established.set_cookie.split(";", 1)[0]
+
+
+def test_full_browser_pairing_delivers_one_tui_bearer(graph) -> None:
+    storage, http, boundary, routes = graph
+
+    begun = routes.dispatch(request("/auth/tui/pairings"))
+    start = json.loads(begun.body)
+    browser = http.establish_session("student-01")
+    authorized = routes.dispatch(
+        json_request(
+            "/auth/tui/pair",
+            {"code": start["user_code"]},
+            ("Cookie", cookie(browser)),
+            ("X-CSRF-Token", browser.context.csrf_token),
+        )
+    )
+    consumed = routes.dispatch(
+        json_request(
+            f"/auth/tui/pairings/{start['pairing_id']}/token",
+            {"code": start["user_code"]},
+        )
+    )
+    payload = json.loads(consumed.body)
+
+    assert begun.status_code == 201
+    assert "bearer" not in start
+    assert authorized.status_code == 204 and authorized.body == b""
+    assert consumed.status_code == 200
+    assert payload["token_type"] == "Bearer"
+    assert "Cookie" not in repr(consumed)
+    assert payload["bearer_token"] not in repr(consumed)
+    context = boundary.authenticate_bearer("Bearer " + payload["bearer_token"])
+    assert context.user.user_id == "student-01"
+    assert context.session.source_pairing_id == start["pairing_id"]
+    assert storage.read_pairing(start["pairing_id"]).status == "consumed"
+    consumed.delivery_guard.delivered()
+
+    replay = routes.dispatch(
+        json_request(
+            f"/auth/tui/pairings/{start['pairing_id']}/token",
+            {"code": start["user_code"]},
+        )
+    )
+    assert replay.status_code == 409
+
+
+def test_delivery_failure_revokes_new_tui_session(graph) -> None:
+    storage, http, boundary, routes = graph
+    start = json.loads(routes.dispatch(request("/auth/tui/pairings")).body)
+    browser = http.establish_session("student-01")
+    routes.dispatch(
+        json_request(
+            "/auth/tui/pair",
+            {"code": start["user_code"]},
+            ("Cookie", cookie(browser)),
+            ("X-CSRF-Token", browser.context.csrf_token),
+        )
+    )
+    response = routes.dispatch(
+        json_request(
+            f"/auth/tui/pairings/{start['pairing_id']}/token",
+            {"code": start["user_code"]},
+        )
+    )
+    bearer = json.loads(response.body)["bearer_token"]
+
+    current = storage.read_user("student-01")
+    storage.save_user(
+        replace(current, role="teacher", updated_at=current.updated_at.replace(microsecond=1)),
+        expected_updated_at=current.updated_at,
+    )
+    response.delivery_guard.failed()
+
+    persisted = storage.read_session_by_token_digest(session_token_digest(bearer))
+    assert persisted.revoked_at is not None
+    with pytest.raises(HttpAuthenticationRequiredError):
+        boundary.authenticate_bearer("Bearer " + bearer)
+
+
+def test_browser_authorization_requires_cookie_and_csrf(graph) -> None:
+    _storage, http, _boundary, routes = graph
+    start = json.loads(routes.dispatch(request("/auth/tui/pairings")).body)
+    browser = http.establish_session("student-01")
+
+    no_cookie = routes.dispatch(
+        json_request("/auth/tui/pair", {"code": start["user_code"]})
+    )
+    no_csrf = routes.dispatch(
+        json_request(
+            "/auth/tui/pair",
+            {"code": start["user_code"]},
+            ("Cookie", cookie(browser)),
+        )
+    )
+
+    assert no_cookie.status_code == 401
+    assert no_csrf.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "candidate,status",
+    (
+        (TuiPairingHttpRequest("POST", "/auth/tui/pairings", "", b"", EdgeRequestMetadata("127.0.0.1", (("Content-Length", "0"),))), 400),
+        (request("/auth/tui/pairings", method="GET"), 405),
+        (TuiPairingHttpRequest("POST", "/auth/tui/pairings", "x=1", b"", EdgeRequestMetadata("127.0.0.1", (("X-Forwarded-Proto", "https"), ("Content-Length", "0")))), 400),
+        (request("/auth/tui/pairings", b"{}"), 400),
+        (json_request("/auth/tui/pair", {"code": "PAIRCODE0001", "extra": 1}), 400),
+    ),
+)
+def test_transport_is_fail_closed(graph, candidate, status) -> None:
+    _storage, _http, _boundary, routes = graph
+    assert routes.dispatch(candidate).status_code == status
+
+
+def test_begin_rate_limit_prevents_ninth_pairing_allocation(graph) -> None:
+    storage, _http, _boundary, routes = graph
+
+    responses = [routes.dispatch(request("/auth/tui/pairings")) for _ in range(9)]
+
+    assert [response.status_code for response in responses] == [201] * 8 + [429]
+    with storage._connect() as connection:
+        count = connection.execute("SELECT COUNT(*) FROM tui_pairings").fetchone()[0]
+    assert count == 8
+
+
+def test_unknown_path_is_not_claimed(graph) -> None:
+    _storage, _http, _boundary, routes = graph
+    assert routes.dispatch(request("/auth/tui/unknown")) is None
+
+
+def test_course_board_socket_delivers_complete_pairing_flow(graph) -> None:
+    _storage, http, boundary, routes = graph
+    server = BoundedThreadingHTTPServer(("127.0.0.1", 0), CourseBoardHandler)
+    server.tui_pairing_http_routes = routes
+    server.teacher_token = "T" * 32
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def exchange(path, payload=None, headers=None, method="POST"):
+        body = b"" if payload is None else json.dumps(payload, separators=(",", ":")).encode()
+        request_headers = {"X-Forwarded-Proto": "https", **(headers or {})}
+        if payload is not None:
+            request_headers["Content-Type"] = "application/json"
+        connection = http_client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+        try:
+            connection.request(method, path, body=body, headers=request_headers)
+            response = connection.getresponse()
+            return response.status, response.read()
+        finally:
+            connection.close()
+
+    browser = http.establish_session("student-01")
+    try:
+        begin_status, begin_body = exchange("/auth/tui/pairings")
+        start = json.loads(begin_body)
+        authorize_status, _ = exchange(
+            "/auth/tui/pair",
+            {"code": start["user_code"]},
+            {
+                "Cookie": cookie(browser),
+                "X-CSRF-Token": browser.context.csrf_token,
+            },
+        )
+        consume_status, consume_body = exchange(
+            f"/auth/tui/pairings/{start['pairing_id']}/token",
+            {"code": start["user_code"]},
+        )
+        wrong_method, _ = exchange("/auth/tui/pairings", method="GET")
+        network_path, _ = exchange("//auth/tui/pairings")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    bearer = json.loads(consume_body)["bearer_token"]
+    assert begin_status == 201
+    assert authorize_status == 204
+    assert consume_status == 200
+    assert wrong_method == 405
+    assert network_path == 400
+    assert boundary.authenticate_bearer("Bearer " + bearer).user.user_id == "student-01"


### PR DESCRIPTION
Closes #585

## Cosa cambia

- espone begin, browser authorization e consume/token per pairing TUI;
- compone pairing service, sessioni audience `tui` e route sullo stesso storage web;
- richiede sessione student+CSRF nel browser senza restituire bearer al browser;
- consegna al terminale un bearer one-shot senza cookie o credenziali provider;
- applica HTTPS/trusted proxy e framing/body JSON bounded senza segreti negli URL;
- applica rate limit SQLite atomico globale/per-client e per pairing prima delle mutazioni;
- pulisce fail-closed pairing pubblici scaduti prima delle nuove allocazioni;
- revoca la specifica sessione TUI se serializzazione o consegna socket falliscono;
- estende redazione log/request-line alle route `/auth/tui/`;
- aggiunge il secret deployment indipendente `THEBITLAB_TUI_PAIRING_PEPPER_B64`.

## Test

- suite mirata pairing HTTP/domain/runtime/session/edge/OIDC/SQLite/Course Board: 249 passed, 1 skipped POSIX-only;
- flusso socket completo begin → browser CSRF → consume → bearer auth;
- full required CI green su Linux/Windows, Python 3.11–3.13, minimum Python, Docker e Windows filesystem;
- `py_compile` e `git diff --check` puliti;
- review indipendenti finali 3–4 a `7c62d45`: `Nessun finding`.

## Fuori scope

- UI completa della pagina pairing;
- apertura browser/polling CLI;
- persistenza bearer e uso nelle API student-help.
