### PR TITLE
Gestisci le versioni dei prerequisiti Windows

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -87,6 +87,13 @@ al termine, in caso di errore e quando l'installazione viene annullata.
 Soltanto al primo utilizzo Docker Desktop può ancora chiedere di accettare le
 proprie condizioni d'uso.
 
+Su Windows la diagnosi distingue software assente, compatibile e troppo
+vecchio. Le soglie supportate sono Git 2.30, Vagrant 2.4, VirtualBox 7.1 e
+Docker CLI 24. Una versione più recente viene conservata; una versione più
+vecchia viene aggiornata con `winget`. Gli aggiornamenti di programmi già
+presenti sono registrati come `updated` e non diventano proprietà di
+2cornot2c: la successiva disinstallazione dell'ambiente li conserva.
+
 ## Diagnosi
 
 La prima fetta implementa rilevamento, scelta provider e diagnosi read-only:

--- a/installer/diagnostics.py
+++ b/installer/diagnostics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 import subprocess
 
 from installer.model import Check, InstallPlan
@@ -15,6 +16,29 @@ class CheckResult:
     check: Check
     ok: bool
     detail: str
+    present: bool = False
+
+
+_VERSION = re.compile(r"(?<!\d)(\d+(?:\.\d+){1,3})(?!\d)")
+
+
+def parse_version(output: str) -> tuple[int, ...] | None:
+    """Estrae una versione numerica tollerando prefissi e suffissi vendor."""
+
+    match = _VERSION.search(output)
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def version_at_least(found: tuple[int, ...], minimum: str) -> bool:
+    """Confronta versioni numeriche con un numero diverso di componenti."""
+
+    required = tuple(int(part) for part in minimum.split("."))
+    width = max(len(found), len(required))
+    return found + (0,) * (width - len(found)) >= required + (0,) * (
+        width - len(required)
+    )
 
 
 def run_check(check: Check) -> CheckResult:
@@ -30,12 +54,29 @@ def run_check(check: Check) -> CheckResult:
     combined_output = f"{result.stdout}\n{result.stderr}".strip()
     output = combined_output.splitlines()
     detail = output[0][:160] if output else f"exit code {result.returncode}"
-    ok = result.returncode == 0
+    present = result.returncode == 0
+    ok = present
     if check.expected_text:
         ok = ok and check.expected_text in combined_output
+        present = ok
         if not ok and result.returncode == 0:
             detail = f"non trovato: {check.expected_text}"
-    return CheckResult(check, ok, detail)
+    if ok and check.minimum_version:
+        found = parse_version(combined_output)
+        ok = found is not None and version_at_least(
+            found,
+            check.minimum_version,
+        )
+        if not ok:
+            rendered = (
+                ".".join(str(part) for part in found)
+                if found
+                else "sconosciuta"
+            )
+            detail = (
+                f"versione {rendered}; serve almeno {check.minimum_version}"
+            )
+    return CheckResult(check, ok, detail, present)
 
 
 def diagnose(plan: InstallPlan) -> tuple[CheckResult, ...]:
@@ -46,5 +87,5 @@ def diagnose(plan: InstallPlan) -> tuple[CheckResult, ...]:
         try:
             results.append(run_check(check))
         except (FileNotFoundError, subprocess.TimeoutExpired) as error:
-            results.append(CheckResult(check, False, type(error).__name__))
+            results.append(CheckResult(check, False, type(error).__name__, False))
     return tuple(results)

--- a/installer/executor.py
+++ b/installer/executor.py
@@ -127,6 +127,10 @@ def execute_plan(
                 (
                     "restart_required"
                     if returncode == 0 and step.restart_after_success
+                    else "updated"
+                    if returncode == 0
+                    and check_by_key.get(step.key) is not None
+                    and check_by_key[step.key].present
                     else "succeeded"
                     if returncode == 0
                     else "failed"

--- a/installer/model.py
+++ b/installer/model.py
@@ -32,6 +32,7 @@ class Check:
     label: str
     command: tuple[str, ...]
     expected_text: str = ""
+    minimum_version: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/installer/plans.py
+++ b/installer/plans.py
@@ -6,6 +6,29 @@ import sys
 
 from installer.model import Check, Host, InstallPlan, Provider, Step
 from installer.student_dev import immutable_reference
+from installer.tool_versions import MINIMUM_TOOL_VERSIONS
+
+
+def _winget_ensure(package_id: str) -> tuple[str, ...]:
+    """Aggiorna un pacchetto esistente oppure lo installa se assente."""
+
+    agreements = (
+        "--accept-package-agreements --accept-source-agreements"
+    )
+    command = (
+        f"winget upgrade --id '{package_id}' --exact --silent {agreements}; "
+        "if ($LASTEXITCODE -eq 0) { exit 0 }; "
+        f"winget install --id '{package_id}' --exact --silent {agreements}; "
+        "exit $LASTEXITCODE"
+    )
+    return (
+        "powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        command,
+    )
 
 
 def supported_providers(host: Host) -> tuple[Provider, ...]:
@@ -151,25 +174,40 @@ def _windows_plan() -> InstallPlan:
         Provider.VIRTUALBOX,
         (
             Check("winget", "Windows Package Manager", ("winget", "--version")),
-            Check("git", "Git", ("git", "--version")),
-            Check("vagrant", "Vagrant", ("vagrant", "--version")),
-            Check("virtualbox", "VirtualBox", ("VBoxManage.exe", "--version")),
+            Check(
+                "git",
+                "Git",
+                ("git", "--version"),
+                minimum_version=MINIMUM_TOOL_VERSIONS["git"],
+            ),
+            Check(
+                "vagrant",
+                "Vagrant",
+                ("vagrant", "--version"),
+                minimum_version=MINIMUM_TOOL_VERSIONS["vagrant"],
+            ),
+            Check(
+                "virtualbox",
+                "VirtualBox",
+                ("VBoxManage.exe", "--version"),
+                minimum_version=MINIMUM_TOOL_VERSIONS["virtualbox"],
+            ),
         ),
         (
             Step(
                 "git",
-                "Installa Git",
-                ("winget", "install", "--id", "Git.Git", "--exact"),
+                "Installa o aggiorna Git",
+                _winget_ensure("Git.Git"),
             ),
             Step(
                 "vagrant",
-                "Installa Vagrant",
-                ("winget", "install", "--id", "Hashicorp.Vagrant", "--exact"),
+                "Installa o aggiorna Vagrant",
+                _winget_ensure("Hashicorp.Vagrant"),
             ),
             Step(
                 "virtualbox",
-                "Installa VirtualBox",
-                ("winget", "install", "--id", "Oracle.VirtualBox", "--exact"),
+                "Installa o aggiorna VirtualBox",
+                _winget_ensure("Oracle.VirtualBox"),
             ),
         ),
     )
@@ -178,7 +216,16 @@ def _windows_plan() -> InstallPlan:
 def _docker_plan(host: Host) -> InstallPlan:
     image = immutable_reference()
     common_checks = (
-        Check("docker", "Docker Desktop", ("docker", "--version")),
+        Check(
+            "docker",
+            "Docker CLI",
+            ("docker", "--version"),
+            minimum_version=(
+                MINIMUM_TOOL_VERSIONS["docker"]
+                if host is Host.WINDOWS_AMD64
+                else ""
+            ),
+        ),
         Check("docker-engine", "Motore Docker avviato", ("docker", "info")),
         Check(
             "student-image",
@@ -246,16 +293,8 @@ def _docker_plan(host: Host) -> InstallPlan:
             ),
             Step(
                 "docker",
-                "Installa Docker Desktop",
-                (
-                    "winget",
-                    "install",
-                    "--id",
-                    "Docker.DockerDesktop",
-                    "--exact",
-                    "--accept-package-agreements",
-                    "--accept-source-agreements",
-                ),
+                "Installa o aggiorna Docker Desktop",
+                _winget_ensure("Docker.DockerDesktop"),
             ),
             Step(
                 "docker-engine",

--- a/installer/tool_versions.py
+++ b/installer/tool_versions.py
@@ -1,0 +1,8 @@
+"""Versioni minime supportate dall'ambiente didattico."""
+
+MINIMUM_TOOL_VERSIONS = {
+    "git": "2.30.0",
+    "vagrant": "2.4.0",
+    "virtualbox": "7.1.0",
+    "docker": "24.0.0",
+}

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -396,7 +396,10 @@ def _format_results(
     if (
         provider is Provider.DOCKER
         and results
-        and all(result.status in {"skipped", "succeeded"} for result in results)
+        and all(
+            result.status in {"skipped", "succeeded", "updated"}
+            for result in results
+        )
     ):
         formatted += (
             "Pronto.",
@@ -428,7 +431,8 @@ def apply_selected(state: State) -> None:
     )
     state.confirmation_pending = False
     if results and all(
-        result.status in {"skipped", "succeeded"} for result in results
+        result.status in {"skipped", "succeeded", "updated"}
+        for result in results
     ):
         _remember_provider(provider)
     state.report = _format_results(provider, results)
@@ -571,12 +575,12 @@ def poll_installation(state: State) -> bool:
             state.install_current = index
             state.install_total = total
             state.install_label = label
-            if phase in {"succeeded", "skipped"}:
+            if phase in {"succeeded", "updated", "skipped"}:
                 state.install_completed = index
         elif kind == "result":
             provider = state.providers[state.active_index]
             completed = payload and all(
-                result.status in {"skipped", "succeeded"}
+                result.status in {"skipped", "succeeded", "updated"}
                 for result in payload
             )
             if completed:

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -54,7 +54,10 @@ function Stop-WithMessage {
 }
 
 function Install-WingetPackage {
-    param([string]$Id)
+    param(
+        [string]$Id,
+        [bool]$TrackOwnership = $true
+    )
     winget install --id $Id --exact --silent `
         --accept-package-agreements --accept-source-agreements
     if ($LASTEXITCODE -ne 0) {
@@ -66,10 +69,37 @@ function Install-WingetPackage {
                 "Se ricompare, comunica E09 al docente."
             ) "winget exit code $LASTEXITCODE"
     }
-    if (-not $InstalledByBootstrap.Contains($Id)) {
+    if ($TrackOwnership -and -not $InstalledByBootstrap.Contains($Id)) {
         $InstalledByBootstrap.Add($Id)
     }
     Save-BootstrapState
+}
+
+function Update-WingetPackage {
+    param([string]$Id)
+    winget upgrade --id $Id --exact --silent `
+        --accept-package-agreements --accept-source-agreements
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithMessage "E09" "Aggiornamento di $Id non riuscito" `
+            "Il programma è presente, ma è troppo vecchio e Windows non è riuscito ad aggiornarlo." `
+            @(
+                "Chiudi il programma da aggiornare."
+                "Rilancia lo stesso comando."
+                "Se ricompare, comunica E09 al docente."
+            ) "winget exit code $LASTEXITCODE"
+    }
+    Save-BootstrapState
+}
+
+function Test-GitMinimumVersion {
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+    $Output = [string](& git --version)
+    if ($Output -notmatch "(\d+\.\d+(?:\.\d+)?)") {
+        return $false
+    }
+    return [version]$Matches[1] -ge [version]"2.30.0"
 }
 
 function Test-Python312 {
@@ -255,6 +285,9 @@ Test-HostResources
 Write-Host "[1/4] Preparazione Git e Python 3.12..."
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     Install-WingetPackage "Git.Git"
+} elseif (-not (Test-GitMinimumVersion)) {
+    Write-Host "Git è presente ma troppo vecchio: provo ad aggiornarlo."
+    Update-WingetPackage "Git.Git"
 }
 if (-not (Test-Python312)) {
     Install-WingetPackage "Python.Python.3.12"
@@ -268,10 +301,14 @@ $env:Path = @(
     $env:Path
 ) -join [IO.Path]::PathSeparator
 
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Stop-WithMessage "E10" "Git è installato ma Windows non riesce ancora a trovarlo" `
-        "A volte Windows riconosce un nuovo programma solamente dopo un riavvio." `
-        @("Riavvia Windows."; "Riapri PowerShell e rilancia lo stesso comando.")
+if (-not (Test-GitMinimumVersion)) {
+    Stop-WithMessage "E10" "Git non è disponibile in una versione compatibile" `
+        "Serve Git 2.30 o successivo per aggiornare il progetto in sicurezza." `
+        @(
+            "Chiudi PowerShell."
+            "Riapri PowerShell e rilancia lo stesso comando."
+            "Se ricompare, comunica E10 al docente."
+        )
 }
 if (-not (Test-Python312)) {
     Stop-WithMessage "E10" "Python 3.12 non è disponibile" `

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -68,8 +68,9 @@ def test_docker_plans_install_desktop_and_pull_immutable_image() -> None:
     }
     assert any(
         step.command
-        and step.command[:5]
-        == ("winget", "install", "--id", "Docker.DockerDesktop", "--exact")
+        and "Docker.DockerDesktop" in " ".join(step.command)
+        and "winget upgrade" in step.command[-1]
+        and "winget install" in step.command[-1]
         for step in windows.steps
     )
     assert ("docker", "pull", image) in {step.command for step in mac.steps}
@@ -95,6 +96,33 @@ def test_check_can_require_semantic_output() -> None:
 
     assert result.ok is False
     assert result.detail == "non trovato: vagrant-vmware-desktop"
+
+
+def test_check_rejects_an_old_but_present_version(monkeypatch) -> None:
+    from subprocess import CompletedProcess
+
+    monkeypatch.setattr(
+        "installer.diagnostics.subprocess.run",
+        lambda *args, **kwargs: CompletedProcess(
+            args[0],
+            0,
+            "Vagrant 2.3.7\n",
+            "",
+        ),
+    )
+
+    result = run_check(
+        Check(
+            "vagrant",
+            "Vagrant",
+            ("vagrant", "--version"),
+            minimum_version="2.4.0",
+        )
+    )
+
+    assert result.ok is False
+    assert result.present is True
+    assert result.detail == "versione 2.3.7; serve almeno 2.4.0"
 
 
 def test_tui_frame_lists_supported_provider() -> None:
@@ -388,7 +416,10 @@ def test_executor_skips_present_steps_and_applies_only_missing(tmp_path) -> None
     )
 
     assert [result.status for result in results] == ["skipped", "skipped", "succeeded"]
-    assert calls == [("winget", "install", "--id", "Oracle.VirtualBox", "--exact")]
+    assert len(calls) == 1
+    assert "Oracle.VirtualBox" in calls[0][-1]
+    assert "winget upgrade" in calls[0][-1]
+    assert "winget install" in calls[0][-1]
     assert (tmp_path / "installer.jsonl").read_text(encoding="utf-8").count("\n") == 3
 
 
@@ -404,13 +435,42 @@ def test_executor_reports_step_progress_without_inventing_percentages() -> None:
     )
 
     assert events == [
-        ("started", 1, 3, "Installa Git"),
-        ("skipped", 1, 3, "Installa Git"),
-        ("started", 2, 3, "Installa Vagrant"),
-        ("skipped", 2, 3, "Installa Vagrant"),
-        ("started", 3, 3, "Installa VirtualBox"),
-        ("succeeded", 3, 3, "Installa VirtualBox"),
+        ("started", 1, 3, "Installa o aggiorna Git"),
+        ("skipped", 1, 3, "Installa o aggiorna Git"),
+        ("started", 2, 3, "Installa o aggiorna Vagrant"),
+        ("skipped", 2, 3, "Installa o aggiorna Vagrant"),
+        ("started", 3, 3, "Installa o aggiorna VirtualBox"),
+        ("succeeded", 3, 3, "Installa o aggiorna VirtualBox"),
     ]
+
+
+def test_executor_marks_preexisting_old_software_as_updated(tmp_path) -> None:
+    plan = install_plan(Host.WINDOWS_AMD64, Provider.VIRTUALBOX)
+    checks = tuple(
+        CheckResult(
+            check,
+            check.key != "vagrant",
+            "versione 2.3.7; serve almeno 2.4.0",
+            check.key == "vagrant",
+        )
+        for check in plan.checks
+    )
+
+    results = execute_plan(
+        plan,
+        checks,
+        runner=lambda command: (0, "aggiornato"),
+        log_path=tmp_path / "installer.jsonl",
+    )
+
+    assert [result.status for result in results] == [
+        "skipped",
+        "updated",
+        "skipped",
+    ]
+    assert '"status": "updated"' in (
+        tmp_path / "installer.jsonl"
+    ).read_text(encoding="utf-8")
 
 
 def test_tui_installation_report_shows_step_bar_and_elapsed_time() -> None:
@@ -524,13 +584,9 @@ def test_windows_docker_install_starts_desktop_and_continues_automatically() -> 
         "succeeded",
         "succeeded",
     ]
-    assert calls[0][:5] == (
-        "winget",
-        "install",
-        "--id",
-        "Docker.DockerDesktop",
-        "--exact",
-    )
+    assert "Docker.DockerDesktop" in calls[0][-1]
+    assert "winget upgrade" in calls[0][-1]
+    assert "winget install" in calls[0][-1]
     assert calls[1][:4] == (
         "powershell.exe",
         "-NoProfile",

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -65,6 +65,10 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     )
 
     assert "Test-HostResources" in bootstrap
+    assert "function Test-GitMinimumVersion" in bootstrap
+    assert '[version]"2.30.0"' in bootstrap
+    assert "function Update-WingetPackage" in bootstrap
+    assert 'Update-WingetPackage "Git.Git"' in bootstrap
     assert "function Test-Python312" in bootstrap
     assert "sys.version_info[:2] != (3, 12)" in bootstrap
     assert '$ErrorActionPreference = "SilentlyContinue"' in bootstrap
@@ -90,6 +94,7 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "docker image rm --force" not in uninstall
     assert "Ambiente 2cornot2c.lnk" in uninstall
     assert "Test-PackageStillInstalled" in uninstall
+    assert '$Record.status -ne "succeeded"' in uninstall
     assert "Get-ClassroomShortcutPaths" in uninstall
     assert "OneDriveConsumer" in uninstall
     assert "CommonDesktopDirectory" in uninstall


### PR DESCRIPTION
## Cosa cambia

- introduce soglie centralizzate per Git 2.30, Vagrant 2.4, VirtualBox 7.1 e Docker CLI 24
- distingue un componente assente da uno presente ma troppo vecchio
- aggiorna con `winget` le installazioni obsolete e installa quelle mancanti
- registra gli aggiornamenti come `updated`, distinti dalle nuove installazioni
- considera `updated` un completamento valido nella TUI e nella ripresa automatica
- conserva durante la disinstallazione il software preesistente che è stato soltanto aggiornato
- verifica Git già nel bootstrap, prima di usare il repository
- documenta la politica Windows

## Perché

La sola presenza del comando non garantiva compatibilità. Una vecchia versione poteva essere accettata e fallire più avanti; inoltre un aggiornamento non deve trasformare un programma personale in un componente posseduto e rimosso da 2cornot2c.

## Politica

- versione compatibile o più recente: conservata
- versione troppo vecchia: aggiornata automaticamente
- software assente: installato e registrato come proprietà del setup
- software preesistente aggiornato: conservato dalla disinstallazione

## Verifica

- 52 test mirati superati
- `git diff --check`
- `python3 -m compileall -q installer`