### PR TITLE
Rendi visibile il credential helper Docker

### DIFF
--- a/installer/plans.py
+++ b/installer/plans.py
@@ -340,8 +340,16 @@ def _docker_plan(host: Host) -> InstallPlan:
                     "Bypass",
                     "-Command",
                     (
-                        "$cli = Join-Path $env:ProgramFiles "
-                        "'Docker\\Docker\\resources\\bin\\docker.exe'; "
+                        "$dockerBin = Join-Path $env:ProgramFiles "
+                        "'Docker\\Docker\\resources\\bin'; "
+                        "$env:Path = $dockerBin + ';' + $env:Path; "
+                        "$cli = Join-Path $dockerBin 'docker.exe'; "
+                        "$credential = Join-Path $dockerBin "
+                        "'docker-credential-desktop.exe'; "
+                        "if (-not (Test-Path $credential)) { "
+                        "Write-Error "
+                        "'Helper credenziali Docker Desktop non trovato'; "
+                        "exit 20 }; "
                         f"& $cli pull '{image}'; exit $LASTEXITCODE"
                     ),
                 ),

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -79,6 +79,8 @@ def test_docker_plans_install_desktop_and_pull_immutable_image() -> None:
     )
     assert windows_image_step.command is not None
     assert " pull " in windows_image_step.command[-1]
+    assert "$env:Path = $dockerBin" in windows_image_step.command[-1]
+    assert "docker-credential-desktop.exe" in windows_image_step.command[-1]
     assert image in windows_image_step.command[-1]
     assert "@sha256:" in image
     assert load_lock()["platforms"] == ["linux/amd64", "linux/arm64"]


### PR DESCRIPTION
## Cosa cambia

- aggiunge `Docker\Docker\resources\bin` al `PATH` della sessione prima del download di `student-dev`
- usa il percorso assoluto della CLI Docker
- verifica esplicitamente `docker-credential-desktop.exe` prima del pull

## Causa

Docker Desktop viene installato e avviato nella stessa sessione PowerShell del bootstrap. La CLI era invocata tramite percorso assoluto, ma il credential helper indicato dalla configurazione Docker viene risolto esclusivamente tramite `PATH`. La sessione non ancora aggiornata produceva E21 con `executable file not found in %PATH%`, anche scegliendo correttamente Skip al login.

## Verifica

- 52 test mirati superati
- `git diff --check`
- `python3 -m compileall -q installer`