### PR TITLE
Mantieni allineati i pannelli colorati

### DIFF
--- a/installer/tui.py
+++ b/installer/tui.py
@@ -219,6 +219,25 @@ def _border_positions(row: str) -> tuple[int, ...]:
     return tuple(index for index, character in enumerate(row) if character == border)
 
 
+def _paint_text_only(
+    row: str,
+    start: int,
+    end: int,
+    escape: str,
+) -> str:
+    """Colora il contenuto senza includere padding o bordi del pannello."""
+
+    segment = row[start:end]
+    text = segment.rstrip(" ")
+    padding = segment[len(text) :]
+    if not text:
+        return row
+    return (
+        f"{row[:start]}{escape}{text}\x1b[0m"
+        f"{padding}{row[end:]}"
+    )
+
+
 def _paint_guidance_rows(rows: list[str]) -> list[str]:
     """Propaga il colore sulle righe visuali prodotte dal wrapping."""
 
@@ -260,15 +279,17 @@ def _paint_guidance_rows(rows: list[str]) -> list[str]:
             if not right_indices:
                 active_right_border = None
                 result.append(
-                    f"{row[:start]}{active_escape}{row[start:]}\x1b[0m"
+                    _paint_text_only(
+                        row,
+                        start,
+                        len(row),
+                        active_escape,
+                    )
                 )
                 continue
             active_right_border = right_indices[0]
             end = borders[active_right_border]
-            result.append(
-                f"{row[:start]}{active_escape}{row[start:end]}"
-                f"\x1b[0m{row[end:]}"
-            )
+            result.append(_paint_text_only(row, start, end, active_escape))
             continue
         if (
             active_escape is None
@@ -286,9 +307,7 @@ def _paint_guidance_rows(rows: list[str]) -> list[str]:
             active_right_border = None
             result.append(row)
             continue
-        result.append(
-            f"{row[:start]}{active_escape}{row[start:end]}\x1b[0m{row[end:]}"
-        )
+        result.append(_paint_text_only(row, start, end, active_escape))
     return result
 
 

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -399,6 +399,35 @@ def test_tui_stacks_panels_when_terminal_is_narrow_and_tall() -> None:
     assert positions["Diagnosi"] < positions["Comandi"]
 
 
+def test_colored_diagnostics_leave_panel_padding_unstyled() -> None:
+    pytest.importorskip("utui")
+    from utui import strip_ansi
+
+    from installer.student_errors import ERRORS
+    from installer.tui import State, frame
+
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.DOCKER, Provider.VIRTUALBOX),
+        report=ERRORS["resources"].lines("dettaglio"),
+    )
+    rows = frame(state, 150, 20, color=True)
+    command_row = next(row for row in rows if "q/Esc: esci" in row)
+    plain = strip_ansi(command_row)
+
+    assert len(plain) == 150
+    assert [index for index, char in enumerate(plain) if char == "|"] == [
+        0,
+        47,
+        49,
+        114,
+        116,
+        149,
+    ]
+    assert "\x1b[0m " in command_row
+    assert "\x1b[33mCOSA FARE" in command_row
+
+
 def check_results(plan, *, missing: set[str] = set()):
     return tuple(
         CheckResult(check, check.key not in missing, "manca")

--- a/tests/test_student_errors.py
+++ b/tests/test_student_errors.py
@@ -79,8 +79,11 @@ def test_tui_resets_guidance_color_at_diagnosis_panel_boundary() -> None:
 
     painted = _paint_guidance(row)
 
-    assert "\x1b[31mERRORE E03 - Virtualizzazione disabilitata " in painted
-    assert "\x1b[0m│ │ Comandi │" in painted
+    assert (
+        "\x1b[31mERRORE E03 - Virtualizzazione disabilitata\x1b[0m "
+        in painted
+    )
+    assert " │ │ Comandi │" in painted
     assert painted.index("\x1b[0m") < painted.index("Comandi")
 
 
@@ -97,8 +100,10 @@ def test_tui_keeps_guidance_color_on_wrapped_rows_only() -> None:
 
     assert "\x1b[31m computer è disabilitata" in painted[1]
     assert "\x1b[33m della virtualizzazione." in painted[3]
-    assert "\x1b[0m│ │ bianco" in painted[1]
-    assert "\x1b[0m│ │ bianco" in painted[3]
+    assert "\x1b[0m " in painted[1]
+    assert "\x1b[0m " in painted[3]
+    assert "│ │ bianco" in painted[1]
+    assert "│ │ bianco" in painted[3]
     assert "\x1b[" not in painted[4]
 
 


### PR DESCRIPTION
## Cosa cambia

- colora soltanto il testo effettivo dei messaggi diagnostici
- lascia fuori dalle sequenze ANSI gli spazi di padding e i bordi dei pannelli
- mantiene la propagazione del colore sulle righe mandate a capo
- aggiunge una regressione sulle colonne dei sei bordi nella riga `q/Esc: esci`

## Causa

La geometria restituita da uTUI era corretta. La post-elaborazione del consumer inseriva però il colore anche negli spazi fino al bordo destro del pannello Diagnosi. Alcuni terminali Windows gestiscono male le sequenze SGR estese sul padding a fine cella e spostano visivamente i bordi nelle righe adiacenti.

## Verifica

- 53 test mirati superati
- ogni riga mantiene larghezza visibile 150 nel caso di regressione
- bordi invariati alle colonne 0, 47, 49, 114, 116 e 149
- `git diff --check`
- `python3 -m compileall -q installer`