### PR TITLE
Pulisci i collegamenti a fine disinstallazione

### DIFF
--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -142,6 +142,7 @@ function Install-ClassroomLauncher {
         "manage-classroom-windows.ps1"
         "launch-classroom-windows.ps1"
         "prepare-wsl-windows.ps1"
+        "remove-classroom-shortcuts-windows.ps1"
         "remove-wsl-windows.ps1"
         "update-classroom-windows.ps1"
         "uninstall-classroom-windows.ps1"

--- a/scripts/uninstall-classroom-windows.ps1
+++ b/scripts/uninstall-classroom-windows.ps1
@@ -414,9 +414,27 @@ Remove-ItemProperty `
     -Name "2cornot2c-resume" `
     -ErrorAction SilentlyContinue
 
-foreach ($ShortcutPath in Get-ClassroomShortcutPaths) {
-    if (Test-Path $ShortcutPath) {
-        Remove-Item -LiteralPath $ShortcutPath -Force
+$ShortcutCleanup = Join-Path `
+    $LauncherDir "remove-classroom-shortcuts-windows.ps1"
+$ShortcutCleanupSucceeded = $false
+if (Test-Path $ShortcutCleanup) {
+    $CleanupPowerShell = Join-Path `
+        $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+    & $CleanupPowerShell `
+        -NoProfile `
+        -ExecutionPolicy Bypass `
+        -File $ShortcutCleanup
+    $ShortcutCleanupSucceeded = $LASTEXITCODE -eq 0
+}
+if (-not $ShortcutCleanupSucceeded) {
+    Write-Warning (
+        "Uso la pulizia collegamenti integrata perché lo script dedicato " +
+        "non è disponibile."
+    )
+    foreach ($ShortcutPath in Get-ClassroomShortcutPaths) {
+        if (Test-Path $ShortcutPath) {
+            Remove-Item -LiteralPath $ShortcutPath -Force
+        }
     }
 }
 if (Test-Path $LauncherDir) {

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -82,6 +82,7 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "launch-classroom-windows.ps1" in bootstrap
     assert "prepare-wsl-windows.ps1" in bootstrap
     assert "remove-wsl-windows.ps1" in bootstrap
+    assert "remove-classroom-shortcuts-windows.ps1" in bootstrap
     assert "Ambiente 2cornot2c.lnk" in bootstrap
     assert "bootstrap-classroom-windows.ps1" in update
     assert ".installer-venv\\Scripts\\python.exe" in manager
@@ -96,6 +97,8 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "Test-PackageStillInstalled" in uninstall
     assert '$Record.status -ne "succeeded"' in uninstall
     assert "Get-ClassroomShortcutPaths" in uninstall
+    assert '$LauncherDir "remove-classroom-shortcuts-windows.ps1"' in uninstall
+    assert "$ShortcutCleanupSucceeded" in uninstall
     assert "OneDriveConsumer" in uninstall
     assert "CommonDesktopDirectory" in uninstall
     assert "CommonPrograms" in uninstall


### PR DESCRIPTION
## Cosa cambia

- copia `remove-classroom-shortcuts-windows.ps1` nel launcher durante il bootstrap
- esegue lo script dedicato come ultimo passo della disinstallazione
- lo esegue prima di cancellare la cartella del launcher
- mantiene la pulizia incorporata come fallback se lo script non è disponibile o termina con errore

## Perché

La logica incorporata non si è dimostrata affidabile nel collaudo reale, mentre lo script dedicato rimuove correttamente le icone residue dal Desktop e dal menu Start. Il flusso automatico deve usare lo stesso percorso già verificato manualmente.

## Verifica

- 53 test mirati superati
- `git diff --check`