### PR TITLE
Auth: add staging HTTPS public-route smoke

### DIFF
--- a/.github/workflows/auth-staging-smoke.yml
+++ b/.github/workflows/auth-staging-smoke.yml
@@ -7,6 +7,10 @@ on:
         description: Canonical HTTPS staging origin, without path
         required: true
         type: string
+      google_client_id:
+        description: Expected public Google OAuth client ID
+        required: true
+        type: string
       timeout_seconds:
         description: Absolute smoke deadline (5-120 seconds)
         required: false
@@ -26,6 +30,7 @@ jobs:
     timeout-minutes: 5
     env:
       THEBITLAB_STAGING_ORIGIN: ${{ inputs.origin }}
+      THEBITLAB_GOOGLE_CLIENT_ID_EXPECTED: ${{ inputs.google_client_id }}
       THEBITLAB_STAGING_TIMEOUT: ${{ inputs.timeout_seconds }}
     steps:
       - uses: actions/checkout@v4
@@ -37,4 +42,5 @@ jobs:
         run: >-
           python scripts/thebitlab_auth_staging_smoke.py
           --origin "$THEBITLAB_STAGING_ORIGIN"
+          --google-client-id "$THEBITLAB_GOOGLE_CLIENT_ID_EXPECTED"
           --timeout "$THEBITLAB_STAGING_TIMEOUT"

--- a/.github/workflows/auth-staging-smoke.yml
+++ b/.github/workflows/auth-staging-smoke.yml
@@ -1,0 +1,40 @@
+name: Auth staging smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      origin:
+        description: Canonical HTTPS staging origin, without path
+        required: true
+        type: string
+      timeout_seconds:
+        description: Absolute smoke deadline (5-120 seconds)
+        required: false
+        default: "30"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auth-staging-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  public-auth-routes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      THEBITLAB_STAGING_ORIGIN: ${{ inputs.origin }}
+      THEBITLAB_STAGING_TIMEOUT: ${{ inputs.timeout_seconds }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Validate public authentication routes
+        shell: bash
+        run: >-
+          python scripts/thebitlab_auth_staging_smoke.py
+          --origin "$THEBITLAB_STAGING_ORIGIN"
+          --timeout "$THEBITLAB_STAGING_TIMEOUT"

--- a/doc/AUTH_STAGING_SMOKE.md
+++ b/doc/AUTH_STAGING_SMOKE.md
@@ -1,6 +1,6 @@
 # Preflight autenticazione su staging HTTPS
 
-Questo runbook verifica il wiring pubblico del runtime auth prima del collaudo browser con provider reali. Non richiede credenziali Google, non completa callback OAuth e non modifica dati didattici. Il check login crea un solo flow OIDC effimero in memoria, destinato a scadere automaticamente.
+Questo runbook verifica il wiring pubblico del runtime auth prima del collaudo browser con provider reali. Non richiede credenziali Google, non completa callback OAuth e non modifica dati didattici. Il check login crea due flow OIDC effimeri in memoria, destinati a scadere automaticamente; il confronto verifica che state, nonce, PKCE e browser binding non vengano riutilizzati.
 
 ## Prerequisiti
 
@@ -27,7 +27,7 @@ L'origin deve essere HTTPS canonica, senza path, query, fragment o userinfo. Il 
 
 Il comando verifica:
 
-1. `GET /auth/google/login` → redirect 302 all'endpoint Google canonico, query OIDC/PKCE completa e cookie transazionale `__Host-` sicuro;
+1. due `GET /auth/google/login` → redirect 302 all'endpoint Google canonico, client ID atteso, query OIDC/PKCE completa, materiali one-time distinti e cookie transazionale `__Host-` sicuro;
 2. `GET /auth/session` anonimo → 401 JSON `no-store`;
 3. `GET /auth/tui/pair` → pagina 200 con CSP, anti-framing e `no-store`;
 4. `GET /auth/tui/pairings` → 405 con `Allow: POST`, senza allocare pairing;

--- a/doc/AUTH_STAGING_SMOKE.md
+++ b/doc/AUTH_STAGING_SMOKE.md
@@ -1,0 +1,64 @@
+# Preflight autenticazione su staging HTTPS
+
+Questo runbook verifica il wiring pubblico del runtime auth prima del collaudo browser con provider reali. Non richiede credenziali Google, non completa callback OAuth e non modifica dati didattici. Il check login crea un solo flow OIDC effimero in memoria, destinato a scadere automaticamente.
+
+## Prerequisiti
+
+Lo staging deve avere:
+
+- origin HTTPS stabile e certificato valido;
+- runtime avviato con `--enable-google-auth`;
+- callback registrata in Google con path esatto `/auth/google/callback`;
+- reverse proxy configurato secondo `doc/architecture/auth-runtime-composition.md`;
+- accesso dalla macchina o dal runner GitHub che esegue lo smoke.
+
+Non passare client secret, cookie, bearer, proof, state o codici alla CLI.
+
+## Esecuzione locale
+
+```bash
+python scripts/thebitlab_auth_staging_smoke.py \
+  --origin https://staging.example.edu \
+  --timeout 30
+```
+
+L'origin deve essere HTTPS canonica, senza path, query, fragment o userinfo. Il timeout è una deadline assoluta compresa fra 5 e 120 secondi.
+
+Il comando verifica:
+
+1. `GET /auth/google/login` → redirect 302 all'endpoint Google canonico, query OIDC/PKCE completa e cookie transazionale `__Host-` sicuro;
+2. `GET /auth/session` anonimo → 401 JSON `no-store`;
+3. `GET /auth/tui/pair` → pagina 200 con CSP, anti-framing e `no-store`;
+4. `GET /auth/tui/pairings` → 405 con `Allow: POST`, senza allocare pairing;
+5. `POST /auth/tui/logout` anonimo → 401.
+
+Un successo produce soltanto nomi check, status numerici e booleani:
+
+```json
+{"schema_version":"thebitlab.auth_staging_smoke.v1","ok":true,"checks":[...]}
+```
+
+Location completa, query OIDC, cookie, body remoti e credenziali non vengono emessi. Redirect non vengono seguiti. Header/body oversized, contratti inattesi e timeout falliscono chiusi con exit code 1.
+
+## Workflow manuale
+
+Da GitHub Actions eseguire **Auth staging smoke** (`.github/workflows/auth-staging-smoke.yml`) e inserire soltanto origin e timeout. Gli input vengono passati al comando via environment quotato, non interpolati nello script shell.
+
+Lo staging deve consentire il traffico dal runner GitHub. Per ambienti non pubblici eseguire il comando da una macchina nella rete autorizzata.
+
+## Collaudo browser reale
+
+Dopo lo smoke verde, usare Codex Desktop o un browser controllato e verificare manualmente:
+
+1. apertura `/auth/google/login`;
+2. consenso/login Google con account di test;
+3. callback sulla stessa origin e cookie web `__Host-`;
+4. `/auth/session` autenticata senza dati provider o bearer;
+5. pagina `/auth/tui/pair`, pairing della CLI e accesso a una API student-lab;
+6. uscita dalla CLI e conferma che il bearer precedente riceva 401.
+
+Il collaudo reale richiede credenziali di test, callback Google registrata e autorizzazione esplicita. Non registrare video, screenshot, HAR o log contenenti cookie, codici, state, bearer o proof.
+
+## Limiti
+
+Lo smoke pubblico non prova l'identità Google, lo scambio code/token, il mapping GitHub o i contenuti dashboard. Questi passaggi restano E2E provider-backed separati.

--- a/doc/AUTH_STAGING_SMOKE.md
+++ b/doc/AUTH_STAGING_SMOKE.md
@@ -19,10 +19,11 @@ Non passare client secret, cookie, bearer, proof, state o codici alla CLI.
 ```bash
 python scripts/thebitlab_auth_staging_smoke.py \
   --origin https://staging.example.edu \
+  --google-client-id 123456-example.apps.googleusercontent.com \
   --timeout 30
 ```
 
-L'origin deve essere HTTPS canonica, senza path, query, fragment o userinfo. Il timeout è una deadline assoluta compresa fra 5 e 120 secondi.
+L'origin deve essere HTTPS canonica, senza path, query, fragment o userinfo. Il client ID è pubblico e deve coincidere esattamente con quello configurato nello staging; non inserire il client secret. Il timeout è una deadline assoluta compresa fra 5 e 120 secondi.
 
 Il comando verifica:
 
@@ -42,7 +43,7 @@ Location completa, query OIDC, cookie, body remoti e credenziali non vengono eme
 
 ## Workflow manuale
 
-Da GitHub Actions eseguire **Auth staging smoke** (`.github/workflows/auth-staging-smoke.yml`) e inserire soltanto origin e timeout. Gli input vengono passati al comando via environment quotato, non interpolati nello script shell.
+Da GitHub Actions eseguire **Auth staging smoke** (`.github/workflows/auth-staging-smoke.yml`) e inserire soltanto origin, client ID pubblico atteso e timeout. Gli input vengono passati al comando via environment quotato, non interpolati nello script shell.
 
 Lo staging deve consentire il traffico dal runner GitHub. Per ambienti non pubblici eseguire il comando da una macchina nella rete autorizzata.
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -122,6 +122,7 @@ Le GitHub Actions attive sono:
 | `.github/workflows/lab-snippets.yml` | PR e push su `main` quando cambiano `README.md`, `TEMPLATES.md`, `lab/**`, `scripts/update_lab_snippets.py` o il workflow | Controlla che snippet, codice lab e output inseriti nei documenti siano aggiornati | `python scripts/update_lab_snippets.py --check` |
 | `.github/workflows/lab-outputs.yml` | PR e push su `main` quando cambiano sorgenti/header lab, manifest JSON, output versionati, script output o il workflow | Installa la toolchain C e verifica che gli output dei lab siano aggiornati | `python scripts/update_lab_outputs.py --check` |
 | `.github/workflows/assignment-runner-docker.yml` | PR e push su `main` quando cambiano Dockerfile, script di grading o workflow | Verifica che l'immagine Docker del runner di grading venga costruita e riesca a correggere un sorgente C minimo | `docker build -t thebitlab-assignment-runner -f docker/assignment-runner/Dockerfile .` e smoke test con `python scripts/grade_activity.py --docker` |
+| `.github/workflows/auth-staging-smoke.yml` | Avvio manuale con origin HTTPS di staging | Verifica i contratti pubblici Google/sessione/pairing/logout senza seguire redirect o stampare segreti | `python scripts/thebitlab_auth_staging_smoke.py --origin https://staging.example.edu` |
 
 ### Workflow `Quality`
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -122,7 +122,7 @@ Le GitHub Actions attive sono:
 | `.github/workflows/lab-snippets.yml` | PR e push su `main` quando cambiano `README.md`, `TEMPLATES.md`, `lab/**`, `scripts/update_lab_snippets.py` o il workflow | Controlla che snippet, codice lab e output inseriti nei documenti siano aggiornati | `python scripts/update_lab_snippets.py --check` |
 | `.github/workflows/lab-outputs.yml` | PR e push su `main` quando cambiano sorgenti/header lab, manifest JSON, output versionati, script output o il workflow | Installa la toolchain C e verifica che gli output dei lab siano aggiornati | `python scripts/update_lab_outputs.py --check` |
 | `.github/workflows/assignment-runner-docker.yml` | PR e push su `main` quando cambiano Dockerfile, script di grading o workflow | Verifica che l'immagine Docker del runner di grading venga costruita e riesca a correggere un sorgente C minimo | `docker build -t thebitlab-assignment-runner -f docker/assignment-runner/Dockerfile .` e smoke test con `python scripts/grade_activity.py --docker` |
-| `.github/workflows/auth-staging-smoke.yml` | Avvio manuale con origin HTTPS di staging | Verifica i contratti pubblici Google/sessione/pairing/logout senza seguire redirect o stampare segreti | `python scripts/thebitlab_auth_staging_smoke.py --origin https://staging.example.edu` |
+| `.github/workflows/auth-staging-smoke.yml` | Avvio manuale con origin HTTPS di staging | Verifica i contratti pubblici Google/sessione/pairing/logout senza seguire redirect o stampare segreti | `python scripts/thebitlab_auth_staging_smoke.py --origin https://staging.example.edu --google-client-id 123456-example.apps.googleusercontent.com` |
 
 ### Workflow `Quality`
 

--- a/doc/architecture/auth-runtime-composition.md
+++ b/doc/architecture/auth-runtime-composition.md
@@ -67,7 +67,7 @@ Il proxy deve:
 
 Per proxy sullo stesso host usare tipicamente `127.0.0.1/32` e/o `::1/128`, non supernet ampie. La composizione rifiuta reti non bounded, incluso `0.0.0.0/0`: inserire una CIDR in trusted equivale ad autorizzare ogni peer in quella rete ad attestare HTTPS e indirizzo client.
 
-Non esiste un fallback HTTP di sviluppo per queste route: per un test browser reale occorre un proxy TLS locale o staging HTTPS.
+Non esiste un fallback HTTP di sviluppo per queste route: per un test browser reale occorre un proxy TLS locale o staging HTTPS. Prima del browser E2E eseguire il preflight pubblico secret-safe descritto in `doc/AUTH_STAGING_SMOKE.md`; il comando valida redirect, cookie e route senza seguire il provider o stampare materiale OAuth.
 
 ## Segreti e backup
 

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import math
+import os
 import re
 import sys
 import time
@@ -115,10 +117,16 @@ def run_smoke(
     origin: str,
     request_fn: RequestFn,
     *,
+    google_client_id: str | None = None,
     timeout: float = 30,
     monotonic: Callable[[], float] = time.monotonic,
 ) -> dict:
     origin = canonical_origin(origin)
+    google_client_id = _validated_google_client_id(
+        google_client_id
+        if google_client_id is not None
+        else os.environ.get("THEBITLAB_EXPECTED_GOOGLE_CLIENT_ID", "")
+    )
     timeout = _validated_timeout(timeout)
     started = _monotonic(monotonic)
     deadline = started + timeout
@@ -128,7 +136,11 @@ def run_smoke(
             "google_login",
             "GET",
             "/auth/google/login",
-            lambda response: _check_google_login(response, origin),
+            lambda response: _check_google_login(
+                response,
+                origin,
+                google_client_id,
+            ),
         ),
         ("anonymous_session", "GET", "/auth/session", _check_anonymous_session),
         ("pairing_page", "GET", "/auth/tui/pair", _check_pairing_page),
@@ -156,12 +168,17 @@ def run_smoke(
         return {"schema_version": "thebitlab.auth_staging_smoke.v1", "ok": True, "checks": checks}
     finally:
         origin = None
+        google_client_id = None
         request_fn = None
         snapshot = None
         specifications = None
 
 
-def _check_google_login(response: ResponseSnapshot, expected_origin: str) -> None:
+def _check_google_login(
+    response: ResponseSnapshot,
+    expected_origin: str,
+    expected_client_id: str,
+) -> None:
     _require_status(response, 302)
     _require_no_store(response)
     locations = _headers(response, "location")
@@ -184,11 +201,11 @@ def _check_google_login(response: ResponseSnapshot, expected_origin: str) -> Non
         or parsed.fragment
         or set(query) != _EXPECTED_GOOGLE_QUERY
         or any(type(values) is not list or len(values) != 1 or not values[0] for values in query.values())
-        or _GOOGLE_CLIENT_ID_RE.fullmatch(query["client_id"][0]) is None
+        or query["client_id"] != [expected_client_id]
         or query["redirect_uri"] != [expected_origin + "/auth/google/callback"]
         or _UNRESERVED_32_256_RE.fullmatch(query["state"][0]) is None
         or _UNRESERVED_32_256_RE.fullmatch(query["nonce"][0]) is None
-        or _PKCE_CHALLENGE_RE.fullmatch(query["code_challenge"][0]) is None
+        or not _valid_pkce_challenge(query["code_challenge"][0])
         or query["response_type"] != ["code"]
         or query["code_challenge_method"] != ["S256"]
         or query["scope"] != ["openid email profile"]
@@ -387,14 +404,14 @@ def _element_nonces(html: str, element: str) -> list[str]:
     tags = re.findall(rf"<{element}\b([^>]*)>", html, flags=re.IGNORECASE)
     nonces: list[str] = []
     for attributes in tags:
-        matches = re.findall(
-            r"(?:^|\s)nonce\s*=\s*(['\"])([^'\"]+)\1",
+        match = re.fullmatch(
+            r"\s*nonce\s*=\s*(['\"])([^'\"]+)\1\s*",
             attributes,
             flags=re.IGNORECASE,
         )
-        if len(matches) != 1:
+        if match is None:
             return []
-        nonces.append(matches[0][1])
+        nonces.append(match.group(2))
     return nonces
 
 
@@ -408,6 +425,23 @@ def _require_response_framing(response: ResponseSnapshot) -> None:
 
 def _headers(response: ResponseSnapshot, name: str) -> list[str]:
     return [value for key, value in response.headers if key.lower() == name]
+
+
+def _valid_pkce_challenge(value: str) -> bool:
+    if type(value) is not str or _PKCE_CHALLENGE_RE.fullmatch(value) is None:
+        return False
+    try:
+        decoded = base64.urlsafe_b64decode(value + "=")
+        canonical = base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii")
+    except Exception:
+        return False
+    return len(decoded) == 32 and canonical == value
+
+
+def _validated_google_client_id(value: str) -> str:
+    if type(value) is not str or _GOOGLE_CLIENT_ID_RE.fullmatch(value) is None:
+        raise StagingSmokeError("Google client ID atteso non valido.")
+    return value
 
 
 def _validated_timeout(value: float) -> float:
@@ -467,16 +501,36 @@ def _request(method: str, url: str, timeout: float) -> ResponseSnapshot:
 
 
 def _worker(specification: dict) -> dict:
-    if type(specification) is not dict or set(specification) != {"origin", "timeout"}:
+    if type(specification) is not dict or set(specification) != {
+        "origin",
+        "google_client_id",
+        "timeout",
+    }:
         raise StagingSmokeError("Specifica staging non valida.")
-    return run_smoke(specification["origin"], _request, timeout=specification["timeout"])
+    return run_smoke(
+        specification["origin"],
+        _request,
+        google_client_id=specification["google_client_id"],
+        timeout=specification["timeout"],
+    )
 
 
-def run_production_smoke(origin: str, *, timeout: float = 30) -> dict:
+def run_production_smoke(
+    origin: str,
+    google_client_id: str,
+    *,
+    timeout: float = 30,
+) -> dict:
     origin = canonical_origin(origin)
+    google_client_id = _validated_google_client_id(google_client_id)
     timeout = _validated_timeout(timeout)
     specification = json.dumps(
-        {"origin": origin, "timeout": timeout}, separators=(",", ":")
+        {
+            "origin": origin,
+            "google_client_id": google_client_id,
+            "timeout": timeout,
+        },
+        separators=(",", ":"),
     ).encode("utf-8")
     stdout = None
     try:
@@ -504,6 +558,7 @@ def run_production_smoke(origin: str, *, timeout: float = 30) -> dict:
         raise StagingSmokeError("Smoke staging non completato.") from None
     finally:
         origin = None
+        google_client_id = None
         specification = None
         stdout = None
 
@@ -532,6 +587,11 @@ def _run_worker() -> int:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Verifica le route auth pubbliche di uno staging HTTPS.")
     parser.add_argument("--origin", required=True, help="Origin HTTPS canonica dello staging.")
+    parser.add_argument(
+        "--google-client-id",
+        required=True,
+        help="Client ID Google pubblico atteso nel redirect staging.",
+    )
     parser.add_argument("--timeout", type=float, default=30, help="Deadline assoluta, 5-120 secondi.")
     return parser.parse_args()
 
@@ -539,7 +599,11 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     try:
-        result = run_production_smoke(args.origin, timeout=args.timeout)
+        result = run_production_smoke(
+            args.origin,
+            args.google_client_id,
+            timeout=args.timeout,
+        )
     except StagingSmokeError as error:
         print(json.dumps({"schema_version": "thebitlab.auth_staging_smoke.v1", "ok": False, "error": str(error)}, separators=(",", ":")))
         return 1

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Secret-safe public-route smoke test for an HTTPS TheBitLab staging deployment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import thebitlab_tui_pairing_client
+
+_MAX_BODY_BYTES = 32 * 1024
+_MAX_HEADER_BYTES = 32 * 1024
+_TRANSACTION_COOKIE_RE = re.compile(
+    r"^__Host-thebitlab_oidc_txn-[0-9a-f]{24}=[A-Za-z0-9_-]{32,512}$"
+)
+_EXPECTED_GOOGLE_QUERY = {
+    "client_id",
+    "redirect_uri",
+    "response_type",
+    "scope",
+    "state",
+    "nonce",
+    "code_challenge",
+    "code_challenge_method",
+}
+
+
+class StagingSmokeError(ValueError):
+    """A sanitized staging failure safe for logs and workflow output."""
+
+
+@dataclass(frozen=True)
+class ResponseSnapshot:
+    status: int
+    headers: tuple[tuple[str, str], ...] = field(repr=False, compare=False)
+    body: bytes = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.status) is not int
+            or not 100 <= self.status <= 599
+            or type(self.headers) is not tuple
+            or any(
+                type(item) is not tuple
+                or len(item) != 2
+                or type(item[0]) is not str
+                or type(item[1]) is not str
+                for item in self.headers
+            )
+            or type(self.body) is not bytes
+            or len(self.body) > _MAX_BODY_BYTES
+        ):
+            raise ValueError("Snapshot HTTP staging non valido.")
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        return None
+
+
+RequestFn = Callable[[str, str, float], ResponseSnapshot]
+
+
+def canonical_origin(value: str) -> str:
+    text = str(value or "").strip()
+    try:
+        parsed = urllib.parse.urlsplit(text)
+        port = parsed.port
+    except ValueError:
+        raise StagingSmokeError("Origin staging non valida.") from None
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise StagingSmokeError("È richiesta una origin staging HTTPS canonica.")
+    host = parsed.hostname.lower()
+    try:
+        host.encode("ascii")
+    except UnicodeEncodeError:
+        raise StagingSmokeError("Origin staging non valida.") from None
+    if "%" in host or any(character.isspace() for character in host):
+        raise StagingSmokeError("Origin staging non valida.")
+    authority = f"[{host}]" if ":" in host else host
+    if port is not None:
+        authority += f":{port}"
+    return f"https://{authority}"
+
+
+def run_smoke(
+    origin: str,
+    request_fn: RequestFn,
+    *,
+    timeout: float = 30,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> dict:
+    origin = canonical_origin(origin)
+    timeout = _validated_timeout(timeout)
+    started = _monotonic(monotonic)
+    deadline = started + timeout
+    checks: list[dict] = []
+    specifications = (
+        (
+            "google_login",
+            "GET",
+            "/auth/google/login",
+            lambda response: _check_google_login(response, origin),
+        ),
+        ("anonymous_session", "GET", "/auth/session", _check_anonymous_session),
+        ("pairing_page", "GET", "/auth/tui/pair", _check_pairing_page),
+        ("pairing_method", "GET", "/auth/tui/pairings", _check_pairing_method),
+        ("anonymous_tui_logout", "POST", "/auth/tui/logout", _check_anonymous_logout),
+    )
+    snapshot = None
+    try:
+        for name, method, path, validator in specifications:
+            remaining = deadline - _monotonic(monotonic)
+            if remaining <= 0:
+                raise StagingSmokeError(f"Check staging {name} scaduto.")
+            try:
+                snapshot = request_fn(method, origin + path, remaining)
+                if type(snapshot) is not ResponseSnapshot:
+                    raise ValueError("snapshot")
+                validator(snapshot)
+            except StagingSmokeError:
+                raise
+            except Exception:
+                raise StagingSmokeError(f"Check staging {name} non valido.") from None
+            checks.append({"name": name, "status": snapshot.status, "ok": True})
+            snapshot = None
+        return {"schema_version": "thebitlab.auth_staging_smoke.v1", "ok": True, "checks": checks}
+    finally:
+        origin = None
+        request_fn = None
+        snapshot = None
+        specifications = None
+
+
+def _check_google_login(response: ResponseSnapshot, expected_origin: str) -> None:
+    _require_status(response, 302)
+    _require_no_store(response)
+    locations = _headers(response, "location")
+    cookies = _headers(response, "set-cookie")
+    if len(locations) != 1 or len(cookies) != 1 or response.body:
+        raise StagingSmokeError("Check staging google_login non valido.")
+    location = locations[0]
+    try:
+        parsed = urllib.parse.urlsplit(location)
+        query = urllib.parse.parse_qs(
+            parsed.query,
+            keep_blank_values=True,
+            strict_parsing=True,
+            max_num_fields=16,
+        )
+    except (ValueError, UnicodeError):
+        raise StagingSmokeError("Check staging google_login non valido.") from None
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "accounts.google.com"
+        or parsed.port is not None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path != "/o/oauth2/v2/auth"
+        or parsed.fragment
+        or set(query) != _EXPECTED_GOOGLE_QUERY
+        or any(type(values) is not list or len(values) != 1 or not values[0] for values in query.values())
+        or query["redirect_uri"] != [expected_origin + "/auth/google/callback"]
+        or query["response_type"] != ["code"]
+        or query["code_challenge_method"] != ["S256"]
+        or query["scope"] != ["openid email profile"]
+    ):
+        raise StagingSmokeError("Check staging google_login non valido.")
+    cookie_parts = [part.strip() for part in cookies[0].split(";")]
+    max_ages = [
+        part.split("=", 1)[1]
+        for part in cookie_parts[1:]
+        if part.startswith("Max-Age=") and "=" in part
+    ]
+    if (
+        not cookie_parts
+        or _TRANSACTION_COOKIE_RE.fullmatch(cookie_parts[0]) is None
+        or "Path=/" not in cookie_parts[1:]
+        or "Secure" not in cookie_parts[1:]
+        or "HttpOnly" not in cookie_parts[1:]
+        or "SameSite=Lax" not in cookie_parts[1:]
+        or len(max_ages) != 1
+        or not max_ages[0].isdigit()
+        or not 1 <= int(max_ages[0]) <= 900
+        or any(part.lower().startswith("domain=") for part in cookie_parts[1:])
+    ):
+        raise StagingSmokeError("Check staging google_login non valido.")
+    location = None
+    parsed = None
+    query = None
+    cookie_parts = None
+    max_ages = None
+
+
+def _check_anonymous_session(response: ResponseSnapshot) -> None:
+    _require_status(response, 401)
+    _require_no_store(response)
+    _require_json(response)
+
+
+def _check_pairing_page(response: ResponseSnapshot) -> None:
+    _require_status(response, 200)
+    _require_no_store(response)
+    if _headers(response, "content-type") != ["text/html; charset=utf-8"]:
+        raise StagingSmokeError("Check staging pairing_page non valido.")
+    csp = _headers(response, "content-security-policy")
+    if (
+        len(csp) != 1
+        or "default-src 'none'" not in csp[0]
+        or "frame-ancestors 'none'" not in csp[0]
+        or "connect-src 'self'" not in csp[0]
+        or _headers(response, "x-frame-options") != ["DENY"]
+        or _headers(response, "x-content-type-options") != ["nosniff"]
+        or b"/auth/session" not in response.body
+        or b"/auth/tui/pair" not in response.body
+    ):
+        raise StagingSmokeError("Check staging pairing_page non valido.")
+
+
+def _check_pairing_method(response: ResponseSnapshot) -> None:
+    _require_status(response, 405)
+    _require_no_store(response)
+    _require_json(response)
+    if _headers(response, "allow") != ["POST"]:
+        raise StagingSmokeError("Check staging pairing_method non valido.")
+
+
+def _check_anonymous_logout(response: ResponseSnapshot) -> None:
+    _require_status(response, 401)
+    _require_no_store(response)
+    _require_json(response)
+
+
+def _require_status(response: ResponseSnapshot, expected: int) -> None:
+    if response.status != expected:
+        raise StagingSmokeError("Status staging inatteso.")
+
+
+def _require_no_store(response: ResponseSnapshot) -> None:
+    if (
+        _headers(response, "cache-control") != ["no-store"]
+        or _headers(response, "pragma") != ["no-cache"]
+        or _headers(response, "referrer-policy") != ["no-referrer"]
+    ):
+        raise StagingSmokeError("Policy cache staging non valida.")
+
+
+def _require_json(response: ResponseSnapshot) -> None:
+    if _headers(response, "content-type") != ["application/json; charset=utf-8"]:
+        raise StagingSmokeError("Content-Type staging non valido.")
+    try:
+        value = json.loads(response.body.decode("utf-8"), object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        raise StagingSmokeError("JSON staging non valido.") from None
+    if type(value) is not dict or not value:
+        raise StagingSmokeError("JSON staging non valido.")
+    value = None
+
+
+def _headers(response: ResponseSnapshot, name: str) -> list[str]:
+    return [value for key, value in response.headers if key.lower() == name]
+
+
+def _validated_timeout(value: float) -> float:
+    if type(value) not in {int, float} or isinstance(value, bool) or not math.isfinite(value):
+        raise StagingSmokeError("Timeout staging non valido.")
+    timeout = float(value)
+    if not 5 <= timeout <= 120:
+        raise StagingSmokeError("Timeout staging non valido.")
+    return timeout
+
+
+def _monotonic(clock: Callable[[], float]) -> float:
+    value = clock()
+    if type(value) not in {int, float} or isinstance(value, bool) or not math.isfinite(value):
+        raise StagingSmokeError("Clock staging non valido.")
+    return float(value)
+
+
+def _unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if type(key) is not str or key in result:
+            raise ValueError("duplicate")
+        result[key] = value
+    return result
+
+
+def _request(method: str, url: str, timeout: float) -> ResponseSnapshot:
+    request = urllib.request.Request(url, data=b"" if method == "POST" else None, method=method)
+    opener = urllib.request.build_opener(_NoRedirect())
+    response = None
+    body = None
+    try:
+        try:
+            response = opener.open(request, timeout=timeout)
+        except urllib.error.HTTPError as error:
+            response = error
+        status = getattr(response, "status", getattr(response, "code", None))
+        raw_headers = tuple(response.headers.raw_items())
+        if sum(len(name.encode("latin-1")) + len(value.encode("latin-1")) + 4 for name, value in raw_headers) > _MAX_HEADER_BYTES:
+            raise StagingSmokeError("Header staging troppo grandi.")
+        body = response.read(_MAX_BODY_BYTES + 1)
+        if type(body) is not bytes or len(body) > _MAX_BODY_BYTES:
+            raise StagingSmokeError("Risposta staging troppo grande.")
+        return ResponseSnapshot(status, raw_headers, body)
+    except (urllib.error.URLError, TimeoutError, OSError):
+        raise StagingSmokeError("Staging non raggiungibile.") from None
+    finally:
+        if response is not None:
+            try:
+                response.close()
+            except Exception:
+                pass
+        request = None
+        response = None
+        body = None
+
+
+def _worker(specification: dict) -> dict:
+    if type(specification) is not dict or set(specification) != {"origin", "timeout"}:
+        raise StagingSmokeError("Specifica staging non valida.")
+    return run_smoke(specification["origin"], _request, timeout=specification["timeout"])
+
+
+def run_production_smoke(origin: str, *, timeout: float = 30) -> dict:
+    origin = canonical_origin(origin)
+    timeout = _validated_timeout(timeout)
+    specification = json.dumps(
+        {"origin": origin, "timeout": timeout}, separators=(",", ":")
+    ).encode("utf-8")
+    stdout = None
+    try:
+        returncode, stdout = thebitlab_tui_pairing_client._run_killable_subprocess(
+            [sys.executable, str(Path(__file__).resolve()), "--worker"],
+            specification,
+            environment=thebitlab_tui_pairing_client._transport_environment(),
+            timeout=float(timeout),
+        )
+        if returncode != 0 or type(stdout) is not bytes or len(stdout) > 8192:
+            raise StagingSmokeError("Smoke staging non completato.")
+        result = json.loads(stdout.decode("utf-8"), object_pairs_hook=_unique_object)
+        if (
+            type(result) is not dict
+            or set(result) != {"schema_version", "ok", "checks"}
+            or result.get("schema_version") != "thebitlab.auth_staging_smoke.v1"
+            or result.get("ok") is not True
+            or type(result.get("checks")) is not list
+        ):
+            raise StagingSmokeError("Risultato smoke staging non valido.")
+        return result
+    except StagingSmokeError:
+        raise
+    except Exception:
+        raise StagingSmokeError("Smoke staging non completato.") from None
+    finally:
+        origin = None
+        specification = None
+        stdout = None
+
+
+def _run_worker() -> int:
+    raw = sys.stdin.buffer.read(4097)
+    result = None
+    try:
+        if len(raw) > 4096:
+            raise StagingSmokeError("Specifica staging non valida.")
+        specification = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+        result = _worker(specification)
+        encoded = json.dumps(result, separators=(",", ":")).encode("utf-8")
+        if len(encoded) > 8192:
+            return 1
+        sys.stdout.buffer.write(encoded)
+        sys.stdout.buffer.flush()
+        return 0
+    except Exception:
+        return 1
+    finally:
+        raw = None
+        result = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verifica le route auth pubbliche di uno staging HTTPS.")
+    parser.add_argument("--origin", required=True, help="Origin HTTPS canonica dello staging.")
+    parser.add_argument("--timeout", type=float, default=30, help="Deadline assoluta, 5-120 secondi.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = run_production_smoke(args.origin, timeout=args.timeout)
+    except StagingSmokeError as error:
+        print(json.dumps({"schema_version": "thebitlab.auth_staging_smoke.v1", "ok": False, "error": str(error)}, separators=(",", ":")))
+        return 1
+    print(json.dumps(result, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_worker() if sys.argv[1:] == ["--worker"] else main())

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -172,15 +172,17 @@ def run_smoke(
                 _require_response_framing(snapshot)
                 material = validator(snapshot)
                 if name == "google_login":
+                    if type(material) is not tuple or len(set(material)) != len(material):
+                        raise StagingSmokeError(
+                            "Check staging google_login non valido."
+                        )
                     first_login_material = material
                 elif name == "google_login_repeat" and (
                     type(first_login_material) is not tuple
                     or type(material) is not tuple
                     or len(material) != len(first_login_material)
-                    or any(
-                        first == second
-                        for first, second in zip(first_login_material, material)
-                    )
+                    or len(set(material)) != len(material)
+                    or not set(first_login_material).isdisjoint(material)
                 ):
                     raise StagingSmokeError(
                         "Check staging google_login_repeat non valido."
@@ -468,6 +470,16 @@ def _strict_query(raw_query: str) -> dict[str, list[str]]:
     return result
 
 
+_INERT_HTML_CONTAINERS = {
+    "template",
+    "noscript",
+    "textarea",
+    "xmp",
+    "iframe",
+    "noembed",
+}
+
+
 class _PairingPageParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
@@ -478,23 +490,23 @@ class _PairingPageParser(HTMLParser):
         self.data: list[str] = []
         self.stack: list[str] = []
         self.seen = {"html": 0, "head": 0, "body": 0}
-        self.template_depth = 0
+        self.inert_stack: list[str] = []
         self.invalid = False
 
     @property
     def complete(self) -> bool:
         return (
             not self.invalid
-            and self.template_depth == 0
+            and not self.inert_stack
             and not self.stack
             and self.seen == {"html": 1, "head": 1, "body": 1}
         )
 
     def handle_starttag(self, tag, attrs) -> None:
-        if tag == "template":
-            self.template_depth += 1
+        if tag in _INERT_HTML_CONTAINERS:
+            self.inert_stack.append(tag)
             return
-        if self.template_depth:
+        if self.inert_stack:
             return
         if tag in {"html", "head", "body"}:
             expected = {
@@ -527,13 +539,17 @@ class _PairingPageParser(HTMLParser):
         self.stack.append(tag)
 
     def handle_endtag(self, tag) -> None:
-        if tag == "template":
-            if self.template_depth == 0:
-                self.invalid = True
-            else:
-                self.template_depth -= 1
+        if self.inert_stack:
+            if tag in _INERT_HTML_CONTAINERS:
+                if self.inert_stack[-1] != tag:
+                    self.invalid = True
+                else:
+                    self.inert_stack.pop()
             return
-        if self.template_depth or tag not in {"html", "head", "body", "script", "style"}:
+        if tag in _INERT_HTML_CONTAINERS:
+            self.invalid = True
+            return
+        if tag not in {"html", "head", "body", "script", "style"}:
             return
         if not self.stack or self.stack[-1] != tag:
             self.invalid = True
@@ -545,11 +561,11 @@ class _PairingPageParser(HTMLParser):
             self.style_ends += 1
 
     def handle_startendtag(self, tag, attrs) -> None:
-        if tag in {"html", "head", "body", "script", "style", "template"}:
+        if tag in {"html", "head", "body", "script", "style"} | _INERT_HTML_CONTAINERS:
             self.invalid = True
 
     def handle_data(self, data) -> None:
-        if self.template_depth == 0 and self.stack and self.stack[-1] == "script":
+        if not self.inert_stack and self.stack and self.stack[-1] == "script":
             self.data.append(data)
 
 

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -143,12 +143,23 @@ def run_smoke(
                 google_client_id,
             ),
         ),
+        (
+            "google_login_repeat",
+            "GET",
+            "/auth/google/login",
+            lambda response: _check_google_login(
+                response,
+                origin,
+                google_client_id,
+            ),
+        ),
         ("anonymous_session", "GET", "/auth/session", _check_anonymous_session),
         ("pairing_page", "GET", "/auth/tui/pair", _check_pairing_page),
         ("pairing_method", "GET", "/auth/tui/pairings", _check_pairing_method),
         ("anonymous_tui_logout", "POST", "/auth/tui/logout", _check_anonymous_logout),
     )
     snapshot = None
+    first_login_material = None
     try:
         for name, method, path, validator in specifications:
             remaining = deadline - _monotonic(monotonic)
@@ -159,7 +170,21 @@ def run_smoke(
                 if type(snapshot) is not ResponseSnapshot:
                     raise ValueError("snapshot")
                 _require_response_framing(snapshot)
-                validator(snapshot)
+                material = validator(snapshot)
+                if name == "google_login":
+                    first_login_material = material
+                elif name == "google_login_repeat" and (
+                    type(first_login_material) is not tuple
+                    or type(material) is not tuple
+                    or len(material) != len(first_login_material)
+                    or any(
+                        first == second
+                        for first, second in zip(first_login_material, material)
+                    )
+                ):
+                    raise StagingSmokeError(
+                        "Check staging google_login_repeat non valido."
+                    )
             except StagingSmokeError:
                 raise
             except Exception:
@@ -172,6 +197,8 @@ def run_smoke(
         google_client_id = None
         request_fn = None
         snapshot = None
+        first_login_material = None
+        material = None
         specifications = None
 
 
@@ -179,7 +206,7 @@ def _check_google_login(
     response: ResponseSnapshot,
     expected_origin: str,
     expected_client_id: str,
-) -> None:
+) -> tuple[bytes, bytes, bytes, bytes]:
     _require_status(response, 302)
     _require_no_store(response)
     locations = _headers(response, "location")
@@ -223,17 +250,25 @@ def _check_google_login(
         if cookie_parts and "=" in cookie_parts[0]
         else None
     )
+    public_values = {
+        query["state"][0],
+        query["nonce"][0],
+        query["code_challenge"][0],
+    }
+    predictable_bindings = set(public_values)
+    for value in public_values:
+        digest = hashlib.sha256(value.encode("ascii")).digest()
+        predictable_bindings.add(digest.hex())
+        predictable_bindings.add(
+            base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+        )
     attributes = _cookie_attributes(cookie_parts[1:]) if cookie_parts else None
     max_age = None if attributes is None else attributes.get("max-age")
     if (
         not cookie_parts
         or _TRANSACTION_COOKIE_RE.fullmatch(cookie_parts[0]) is None
         or not cookie_parts[0].startswith(expected_cookie_prefix)
-        or cookie_value in {
-            query["state"][0],
-            query["nonce"][0],
-            query["code_challenge"][0],
-        }
+        or cookie_value in predictable_bindings
         or attributes is None
         or set(attributes) != {"path", "max-age", "secure", "httponly", "samesite"}
         or attributes.get("path") != "/"
@@ -245,14 +280,27 @@ def _check_google_login(
         or str(attributes.get("samesite", "")).lower() != "lax"
     ):
         raise StagingSmokeError("Check staging google_login non valido.")
+    material = tuple(
+        hashlib.sha256(value.encode("ascii")).digest()
+        for value in (
+            query["state"][0],
+            query["nonce"][0],
+            query["code_challenge"][0],
+            cookie_value,
+        )
+    )
     location = None
     parsed = None
     query = None
     cookie_parts = None
     cookie_value = None
+    public_values = None
+    predictable_bindings = None
+    digest = None
     attributes = None
     max_age = None
     expected_cookie_prefix = None
+    return material
 
 
 def _check_anonymous_session(response: ResponseSnapshot) -> None:
@@ -282,7 +330,7 @@ def _check_pairing_page(response: ResponseSnapshot) -> None:
     visible_source = "".join(parser.data)
     if (
         csp_nonce is None
-        or parser.invalid
+        or not parser.complete
         or parser.script_nonces != [csp_nonce]
         or parser.style_nonces != [csp_nonce]
         or parser.script_ends != 1
@@ -428,29 +476,81 @@ class _PairingPageParser(HTMLParser):
         self.script_ends = 0
         self.style_ends = 0
         self.data: list[str] = []
+        self.stack: list[str] = []
+        self.seen = {"html": 0, "head": 0, "body": 0}
+        self.template_depth = 0
         self.invalid = False
 
+    @property
+    def complete(self) -> bool:
+        return (
+            not self.invalid
+            and self.template_depth == 0
+            and not self.stack
+            and self.seen == {"html": 1, "head": 1, "body": 1}
+        )
+
     def handle_starttag(self, tag, attrs) -> None:
+        if tag == "template":
+            self.template_depth += 1
+            return
+        if self.template_depth:
+            return
+        if tag in {"html", "head", "body"}:
+            expected = {
+                "html": [],
+                "head": ["html"],
+                "body": ["html"],
+            }[tag]
+            if self.stack != expected or self.seen[tag] != 0:
+                self.invalid = True
+                return
+            if tag == "body" and self.seen["head"] != 1:
+                self.invalid = True
+                return
+            self.seen[tag] += 1
+            self.stack.append(tag)
+            return
         if tag not in {"script", "style"}:
             return
-        if len(attrs) != 1 or attrs[0][0] != "nonce" or not attrs[0][1]:
+        expected = ["html", "body"] if tag == "script" else ["html", "head"]
+        if (
+            self.stack != expected
+            or len(attrs) != 1
+            or attrs[0][0] != "nonce"
+            or not attrs[0][1]
+        ):
             self.invalid = True
             return
         target = self.script_nonces if tag == "script" else self.style_nonces
         target.append(attrs[0][1])
+        self.stack.append(tag)
 
     def handle_endtag(self, tag) -> None:
+        if tag == "template":
+            if self.template_depth == 0:
+                self.invalid = True
+            else:
+                self.template_depth -= 1
+            return
+        if self.template_depth or tag not in {"html", "head", "body", "script", "style"}:
+            return
+        if not self.stack or self.stack[-1] != tag:
+            self.invalid = True
+            return
+        self.stack.pop()
         if tag == "script":
             self.script_ends += 1
         elif tag == "style":
             self.style_ends += 1
 
     def handle_startendtag(self, tag, attrs) -> None:
-        if tag in {"script", "style"}:
+        if tag in {"html", "head", "body", "script", "style", "template"}:
             self.invalid = True
 
     def handle_data(self, data) -> None:
-        self.data.append(data)
+        if self.template_depth == 0 and self.stack and self.stack[-1] == "script":
+            self.data.append(data)
 
 
 def _require_response_framing(response: ResponseSnapshot) -> None:

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -321,9 +321,9 @@ def _check_pairing_page(response: ResponseSnapshot) -> None:
     _require_no_store(response)
     if _headers(response, "content-type") != ["text/html; charset=utf-8"]:
         raise StagingSmokeError("Check staging pairing_page non valido.")
-    csp = _headers(response, "content-security-policy")
-    directives = _csp_directives(csp[0]) if len(csp) == 1 else None
-    csp_nonce = None if directives is None else _pairing_csp_nonce(directives)
+    csp_nonce = _pairing_csp_contract(
+        _headers(response, "content-security-policy")
+    )
     try:
         html = response.body.decode("utf-8")
     except UnicodeDecodeError:
@@ -342,8 +342,12 @@ def _check_pairing_page(response: ResponseSnapshot) -> None:
         or parser.style_nonces != [csp_nonce]
         or parser.script_ends != 1
         or parser.style_ends != 1
-        or _headers(response, "x-frame-options") != ["DENY"]
-        or _headers(response, "x-content-type-options") != ["nosniff"]
+        or not _repeated_header_is(response, "x-frame-options", "DENY")
+        or not _repeated_header_is(
+            response,
+            "x-content-type-options",
+            "nosniff",
+        )
         or "/auth/session" not in visible_source
         or "/auth/tui/pair" not in visible_source
     ):
@@ -419,6 +423,24 @@ def _csp_directives(value: str) -> dict[str, list[str]] | None:
             return None
         directives[name] = tokens[1:]
     return directives
+
+
+def _pairing_csp_contract(values: list[str]) -> str | None:
+    if not 1 <= len(values) <= 2:
+        return None
+    nonce = None
+    for value in values:
+        directives = _csp_directives(value)
+        if directives is None:
+            return None
+        candidate = _pairing_csp_nonce(directives)
+        if candidate is not None:
+            if nonce is not None:
+                return None
+            nonce = candidate
+        elif directives != {"frame-ancestors": ["'none'"]}:
+            return None
+    return nonce
 
 
 def _pairing_csp_nonce(directives: dict[str, list[str]]) -> str | None:
@@ -623,6 +645,15 @@ def _require_response_framing(response: ResponseSnapshot) -> None:
 
 def _headers(response: ResponseSnapshot, name: str) -> list[str]:
     return [value for key, value in response.headers if key.lower() == name]
+
+
+def _repeated_header_is(
+    response: ResponseSnapshot,
+    name: str,
+    expected: str,
+) -> bool:
+    values = _headers(response, name)
+    return 1 <= len(values) <= 2 and all(value == expected for value in values)
 
 
 def _valid_pkce_challenge(value: str) -> bool:

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -16,6 +16,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Callable
 
@@ -217,12 +218,22 @@ def _check_google_login(
         + hashlib.sha256(query["state"][0].encode("ascii")).hexdigest()[:24]
         + "="
     )
+    cookie_value = (
+        cookie_parts[0].split("=", 1)[1]
+        if cookie_parts and "=" in cookie_parts[0]
+        else None
+    )
     attributes = _cookie_attributes(cookie_parts[1:]) if cookie_parts else None
     max_age = None if attributes is None else attributes.get("max-age")
     if (
         not cookie_parts
         or _TRANSACTION_COOKIE_RE.fullmatch(cookie_parts[0]) is None
         or not cookie_parts[0].startswith(expected_cookie_prefix)
+        or cookie_value in {
+            query["state"][0],
+            query["nonce"][0],
+            query["code_challenge"][0],
+        }
         or attributes is None
         or set(attributes) != {"path", "max-age", "secure", "httponly", "samesite"}
         or attributes.get("path") != "/"
@@ -238,6 +249,7 @@ def _check_google_login(
     parsed = None
     query = None
     cookie_parts = None
+    cookie_value = None
     attributes = None
     max_age = None
     expected_cookie_prefix = None
@@ -261,16 +273,24 @@ def _check_pairing_page(response: ResponseSnapshot) -> None:
         html = response.body.decode("utf-8")
     except UnicodeDecodeError:
         html = ""
-    script_nonces = _element_nonces(html, "script")
-    style_nonces = _element_nonces(html, "style")
+    parser = _PairingPageParser()
+    try:
+        parser.feed(html)
+        parser.close()
+    except Exception:
+        parser.invalid = True
+    visible_source = "".join(parser.data)
     if (
         csp_nonce is None
-        or script_nonces != [csp_nonce]
-        or style_nonces != [csp_nonce]
+        or parser.invalid
+        or parser.script_nonces != [csp_nonce]
+        or parser.style_nonces != [csp_nonce]
+        or parser.script_ends != 1
+        or parser.style_ends != 1
         or _headers(response, "x-frame-options") != ["DENY"]
         or _headers(response, "x-content-type-options") != ["nosniff"]
-        or b"/auth/session" not in response.body
-        or b"/auth/tui/pair" not in response.body
+        or "/auth/session" not in visible_source
+        or "/auth/tui/pair" not in visible_source
     ):
         raise StagingSmokeError("Check staging pairing_page non valido.")
 
@@ -400,19 +420,37 @@ def _strict_query(raw_query: str) -> dict[str, list[str]]:
     return result
 
 
-def _element_nonces(html: str, element: str) -> list[str]:
-    tags = re.findall(rf"<{element}\b([^>]*)>", html, flags=re.IGNORECASE)
-    nonces: list[str] = []
-    for attributes in tags:
-        match = re.fullmatch(
-            r"\s*nonce\s*=\s*(['\"])([^'\"]+)\1\s*",
-            attributes,
-            flags=re.IGNORECASE,
-        )
-        if match is None:
-            return []
-        nonces.append(match.group(2))
-    return nonces
+class _PairingPageParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.script_nonces: list[str] = []
+        self.style_nonces: list[str] = []
+        self.script_ends = 0
+        self.style_ends = 0
+        self.data: list[str] = []
+        self.invalid = False
+
+    def handle_starttag(self, tag, attrs) -> None:
+        if tag not in {"script", "style"}:
+            return
+        if len(attrs) != 1 or attrs[0][0] != "nonce" or not attrs[0][1]:
+            self.invalid = True
+            return
+        target = self.script_nonces if tag == "script" else self.style_nonces
+        target.append(attrs[0][1])
+
+    def handle_endtag(self, tag) -> None:
+        if tag == "script":
+            self.script_ends += 1
+        elif tag == "style":
+            self.style_ends += 1
+
+    def handle_startendtag(self, tag, attrs) -> None:
+        if tag in {"script", "style"}:
+            self.invalid = True
+
+    def handle_data(self, data) -> None:
+        self.data.append(data)
 
 
 def _require_response_framing(response: ResponseSnapshot) -> None:

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import re
@@ -29,6 +30,9 @@ _TRANSACTION_COOKIE_RE = re.compile(
 _UNRESERVED_32_256_RE = re.compile(r"^[A-Za-z0-9_-]{32,256}$")
 _PKCE_CHALLENGE_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
 _CSP_NONCE_RE = re.compile(r"^'nonce-([A-Za-z0-9_-]{32})'$")
+_GOOGLE_CLIENT_ID_RE = re.compile(
+    r"^[A-Za-z0-9_-]{6,256}\.apps\.googleusercontent\.com$"
+)
 _EXPECTED_GOOGLE_QUERY = {
     "client_id",
     "redirect_uri",
@@ -141,6 +145,7 @@ def run_smoke(
                 snapshot = request_fn(method, origin + path, remaining)
                 if type(snapshot) is not ResponseSnapshot:
                     raise ValueError("snapshot")
+                _require_response_framing(snapshot)
                 validator(snapshot)
             except StagingSmokeError:
                 raise
@@ -166,12 +171,7 @@ def _check_google_login(response: ResponseSnapshot, expected_origin: str) -> Non
     location = locations[0]
     try:
         parsed = urllib.parse.urlsplit(location)
-        query = urllib.parse.parse_qs(
-            parsed.query,
-            keep_blank_values=True,
-            strict_parsing=True,
-            max_num_fields=16,
-        )
+        query = _strict_query(parsed.query)
     except (ValueError, UnicodeError):
         raise StagingSmokeError("Check staging google_login non valido.") from None
     if (
@@ -184,6 +184,7 @@ def _check_google_login(response: ResponseSnapshot, expected_origin: str) -> Non
         or parsed.fragment
         or set(query) != _EXPECTED_GOOGLE_QUERY
         or any(type(values) is not list or len(values) != 1 or not values[0] for values in query.values())
+        or _GOOGLE_CLIENT_ID_RE.fullmatch(query["client_id"][0]) is None
         or query["redirect_uri"] != [expected_origin + "/auth/google/callback"]
         or _UNRESERVED_32_256_RE.fullmatch(query["state"][0]) is None
         or _UNRESERVED_32_256_RE.fullmatch(query["nonce"][0]) is None
@@ -194,11 +195,17 @@ def _check_google_login(response: ResponseSnapshot, expected_origin: str) -> Non
     ):
         raise StagingSmokeError("Check staging google_login non valido.")
     cookie_parts = [part.strip() for part in cookies[0].split(";")]
+    expected_cookie_prefix = (
+        "__Host-thebitlab_oidc_txn-"
+        + hashlib.sha256(query["state"][0].encode("ascii")).hexdigest()[:24]
+        + "="
+    )
     attributes = _cookie_attributes(cookie_parts[1:]) if cookie_parts else None
     max_age = None if attributes is None else attributes.get("max-age")
     if (
         not cookie_parts
         or _TRANSACTION_COOKIE_RE.fullmatch(cookie_parts[0]) is None
+        or not cookie_parts[0].startswith(expected_cookie_prefix)
         or attributes is None
         or set(attributes) != {"path", "max-age", "secure", "httponly", "samesite"}
         or attributes.get("path") != "/"
@@ -216,6 +223,7 @@ def _check_google_login(response: ResponseSnapshot, expected_origin: str) -> Non
     cookie_parts = None
     attributes = None
     max_age = None
+    expected_cookie_prefix = None
 
 
 def _check_anonymous_session(response: ResponseSnapshot) -> None:
@@ -231,9 +239,17 @@ def _check_pairing_page(response: ResponseSnapshot) -> None:
         raise StagingSmokeError("Check staging pairing_page non valido.")
     csp = _headers(response, "content-security-policy")
     directives = _csp_directives(csp[0]) if len(csp) == 1 else None
+    csp_nonce = None if directives is None else _pairing_csp_nonce(directives)
+    try:
+        html = response.body.decode("utf-8")
+    except UnicodeDecodeError:
+        html = ""
+    script_nonces = _element_nonces(html, "script")
+    style_nonces = _element_nonces(html, "style")
     if (
-        directives is None
-        or not _valid_pairing_csp(directives)
+        csp_nonce is None
+        or script_nonces != [csp_nonce]
+        or style_nonces != [csp_nonce]
         or _headers(response, "x-frame-options") != ["DENY"]
         or _headers(response, "x-content-type-options") != ["nosniff"]
         or b"/auth/session" not in response.body
@@ -313,7 +329,7 @@ def _csp_directives(value: str) -> dict[str, list[str]] | None:
     return directives
 
 
-def _valid_pairing_csp(directives: dict[str, list[str]]) -> bool:
+def _pairing_csp_nonce(directives: dict[str, list[str]]) -> str | None:
     if set(directives) != {
         "default-src",
         "script-src",
@@ -323,7 +339,7 @@ def _valid_pairing_csp(directives: dict[str, list[str]]) -> bool:
         "form-action",
         "frame-ancestors",
     }:
-        return False
+        return None
     if (
         directives["default-src"] != ["'none'"]
         or directives["connect-src"] != ["'self'"]
@@ -333,14 +349,61 @@ def _valid_pairing_csp(directives: dict[str, list[str]]) -> bool:
         or len(directives["script-src"]) != 1
         or len(directives["style-src"]) != 1
     ):
-        return False
+        return None
     script_nonce = _CSP_NONCE_RE.fullmatch(directives["script-src"][0])
     style_nonce = _CSP_NONCE_RE.fullmatch(directives["style-src"][0])
-    return (
-        script_nonce is not None
-        and style_nonce is not None
-        and script_nonce.group(1) == style_nonce.group(1)
+    if (
+        script_nonce is None
+        or style_nonce is None
+        or script_nonce.group(1) != style_nonce.group(1)
+    ):
+        return None
+    return script_nonce.group(1)
+
+
+def _strict_query(raw_query: str) -> dict[str, list[str]]:
+    if (
+        type(raw_query) is not str
+        or not raw_query
+        or len(raw_query.encode("ascii")) > 8192
+        or re.search(r"%(?![0-9A-Fa-f]{2})", raw_query) is not None
+    ):
+        raise ValueError("query")
+    pairs = urllib.parse.parse_qsl(
+        raw_query,
+        keep_blank_values=True,
+        strict_parsing=True,
+        encoding="utf-8",
+        errors="strict",
+        max_num_fields=16,
     )
+    result: dict[str, list[str]] = {}
+    for key, value in pairs:
+        result.setdefault(key, []).append(value)
+    return result
+
+
+def _element_nonces(html: str, element: str) -> list[str]:
+    tags = re.findall(rf"<{element}\b([^>]*)>", html, flags=re.IGNORECASE)
+    nonces: list[str] = []
+    for attributes in tags:
+        matches = re.findall(
+            r"(?:^|\s)nonce\s*=\s*(['\"])([^'\"]+)\1",
+            attributes,
+            flags=re.IGNORECASE,
+        )
+        if len(matches) != 1:
+            return []
+        nonces.append(matches[0][1])
+    return nonces
+
+
+def _require_response_framing(response: ResponseSnapshot) -> None:
+    if (
+        _headers(response, "transfer-encoding")
+        or _headers(response, "content-length") != [str(len(response.body))]
+    ):
+        raise StagingSmokeError("Framing risposta staging non valido.")
 
 
 def _headers(response: ResponseSnapshot, name: str) -> list[str]:

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -182,7 +182,9 @@ def run_smoke(
                     or type(material) is not tuple
                     or len(material) != len(first_login_material)
                     or len(set(material)) != len(material)
-                    or not set(first_login_material).isdisjoint(material)
+                    or not _forbidden_followup_fingerprints(
+                        first_login_material
+                    ).isdisjoint(material)
                 ):
                     raise StagingSmokeError(
                         "Check staging google_login_repeat non valido."
@@ -470,6 +472,17 @@ def _strict_query(raw_query: str) -> dict[str, list[str]]:
     return result
 
 
+def _forbidden_followup_fingerprints(material: tuple[bytes, ...]) -> set[bytes]:
+    forbidden = set(material)
+    for fingerprint in material:
+        for derived in (
+            fingerprint.hex(),
+            base64.urlsafe_b64encode(fingerprint).rstrip(b"=").decode("ascii"),
+        ):
+            forbidden.add(hashlib.sha256(derived.encode("ascii")).digest())
+    return forbidden
+
+
 _INERT_HTML_CONTAINERS = {
     "template",
     "noscript",
@@ -478,6 +491,7 @@ _INERT_HTML_CONTAINERS = {
     "iframe",
     "noembed",
 }
+_FORBIDDEN_HTML_ELEMENTS = {"plaintext"}
 
 
 class _PairingPageParser(HTMLParser):
@@ -503,6 +517,9 @@ class _PairingPageParser(HTMLParser):
         )
 
     def handle_starttag(self, tag, attrs) -> None:
+        if tag in _FORBIDDEN_HTML_ELEMENTS:
+            self.invalid = True
+            return
         if tag in _INERT_HTML_CONTAINERS:
             self.inert_stack.append(tag)
             return
@@ -539,6 +556,9 @@ class _PairingPageParser(HTMLParser):
         self.stack.append(tag)
 
     def handle_endtag(self, tag) -> None:
+        if tag in _FORBIDDEN_HTML_ELEMENTS:
+            self.invalid = True
+            return
         if self.inert_stack:
             if tag in _INERT_HTML_CONTAINERS:
                 if self.inert_stack[-1] != tag:
@@ -561,7 +581,11 @@ class _PairingPageParser(HTMLParser):
             self.style_ends += 1
 
     def handle_startendtag(self, tag, attrs) -> None:
-        if tag in {"html", "head", "body", "script", "style"} | _INERT_HTML_CONTAINERS:
+        if tag in (
+            {"html", "head", "body", "script", "style"}
+            | _INERT_HTML_CONTAINERS
+            | _FORBIDDEN_HTML_ELEMENTS
+        ):
             self.invalid = True
 
     def handle_data(self, data) -> None:

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -26,6 +26,9 @@ _MAX_HEADER_BYTES = 32 * 1024
 _TRANSACTION_COOKIE_RE = re.compile(
     r"^__Host-thebitlab_oidc_txn-[0-9a-f]{24}=[A-Za-z0-9_-]{32,512}$"
 )
+_UNRESERVED_32_256_RE = re.compile(r"^[A-Za-z0-9_-]{32,256}$")
+_PKCE_CHALLENGE_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_CSP_NONCE_RE = re.compile(r"^'nonce-([A-Za-z0-9_-]{32})'$")
 _EXPECTED_GOOGLE_QUERY = {
     "client_id",
     "redirect_uri",
@@ -182,35 +185,37 @@ def _check_google_login(response: ResponseSnapshot, expected_origin: str) -> Non
         or set(query) != _EXPECTED_GOOGLE_QUERY
         or any(type(values) is not list or len(values) != 1 or not values[0] for values in query.values())
         or query["redirect_uri"] != [expected_origin + "/auth/google/callback"]
+        or _UNRESERVED_32_256_RE.fullmatch(query["state"][0]) is None
+        or _UNRESERVED_32_256_RE.fullmatch(query["nonce"][0]) is None
+        or _PKCE_CHALLENGE_RE.fullmatch(query["code_challenge"][0]) is None
         or query["response_type"] != ["code"]
         or query["code_challenge_method"] != ["S256"]
         or query["scope"] != ["openid email profile"]
     ):
         raise StagingSmokeError("Check staging google_login non valido.")
     cookie_parts = [part.strip() for part in cookies[0].split(";")]
-    max_ages = [
-        part.split("=", 1)[1]
-        for part in cookie_parts[1:]
-        if part.startswith("Max-Age=") and "=" in part
-    ]
+    attributes = _cookie_attributes(cookie_parts[1:]) if cookie_parts else None
+    max_age = None if attributes is None else attributes.get("max-age")
     if (
         not cookie_parts
         or _TRANSACTION_COOKIE_RE.fullmatch(cookie_parts[0]) is None
-        or "Path=/" not in cookie_parts[1:]
-        or "Secure" not in cookie_parts[1:]
-        or "HttpOnly" not in cookie_parts[1:]
-        or "SameSite=Lax" not in cookie_parts[1:]
-        or len(max_ages) != 1
-        or not max_ages[0].isdigit()
-        or not 1 <= int(max_ages[0]) <= 900
-        or any(part.lower().startswith("domain=") for part in cookie_parts[1:])
+        or attributes is None
+        or set(attributes) != {"path", "max-age", "secure", "httponly", "samesite"}
+        or attributes.get("path") != "/"
+        or type(max_age) is not str
+        or not max_age.isdigit()
+        or not 1 <= int(max_age) <= 900
+        or attributes.get("secure") is not None
+        or attributes.get("httponly") is not None
+        or str(attributes.get("samesite", "")).lower() != "lax"
     ):
         raise StagingSmokeError("Check staging google_login non valido.")
     location = None
     parsed = None
     query = None
     cookie_parts = None
-    max_ages = None
+    attributes = None
+    max_age = None
 
 
 def _check_anonymous_session(response: ResponseSnapshot) -> None:
@@ -225,11 +230,10 @@ def _check_pairing_page(response: ResponseSnapshot) -> None:
     if _headers(response, "content-type") != ["text/html; charset=utf-8"]:
         raise StagingSmokeError("Check staging pairing_page non valido.")
     csp = _headers(response, "content-security-policy")
+    directives = _csp_directives(csp[0]) if len(csp) == 1 else None
     if (
-        len(csp) != 1
-        or "default-src 'none'" not in csp[0]
-        or "frame-ancestors 'none'" not in csp[0]
-        or "connect-src 'self'" not in csp[0]
+        directives is None
+        or not _valid_pairing_csp(directives)
         or _headers(response, "x-frame-options") != ["DENY"]
         or _headers(response, "x-content-type-options") != ["nosniff"]
         or b"/auth/session" not in response.body
@@ -276,6 +280,67 @@ def _require_json(response: ResponseSnapshot) -> None:
     if type(value) is not dict or not value:
         raise StagingSmokeError("JSON staging non valido.")
     value = None
+
+
+def _cookie_attributes(parts: list[str]) -> dict[str, str | None] | None:
+    attributes: dict[str, str | None] = {}
+    for part in parts:
+        if not part:
+            return None
+        name, separator, value = part.partition("=")
+        key = name.lower()
+        if not key or key in attributes:
+            return None
+        if separator:
+            if not value:
+                return None
+            attributes[key] = value
+        else:
+            attributes[key] = None
+    return attributes
+
+
+def _csp_directives(value: str) -> dict[str, list[str]] | None:
+    directives: dict[str, list[str]] = {}
+    for raw_directive in value.split(";"):
+        tokens = raw_directive.strip().split()
+        if not tokens:
+            continue
+        name = tokens[0].lower()
+        if name in directives or len(tokens) < 2:
+            return None
+        directives[name] = tokens[1:]
+    return directives
+
+
+def _valid_pairing_csp(directives: dict[str, list[str]]) -> bool:
+    if set(directives) != {
+        "default-src",
+        "script-src",
+        "style-src",
+        "connect-src",
+        "base-uri",
+        "form-action",
+        "frame-ancestors",
+    }:
+        return False
+    if (
+        directives["default-src"] != ["'none'"]
+        or directives["connect-src"] != ["'self'"]
+        or directives["base-uri"] != ["'none'"]
+        or directives["form-action"] != ["'none'"]
+        or directives["frame-ancestors"] != ["'none'"]
+        or len(directives["script-src"]) != 1
+        or len(directives["style-src"]) != 1
+    ):
+        return False
+    script_nonce = _CSP_NONCE_RE.fullmatch(directives["script-src"][0])
+    style_nonce = _CSP_NONCE_RE.fullmatch(directives["style-src"][0])
+    return (
+        script_nonce is not None
+        and style_nonce is not None
+        and script_nonce.group(1) == style_nonce.group(1)
+    )
 
 
 def _headers(response: ResponseSnapshot, name: str) -> list[str]:

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import base64
 import hashlib
+import itertools
 import json
 import math
 import os
@@ -210,7 +211,7 @@ def _check_google_login(
     response: ResponseSnapshot,
     expected_origin: str,
     expected_client_id: str,
-) -> tuple[bytes, bytes, bytes, bytes]:
+) -> tuple[bytes, ...]:
     _require_status(response, 302)
     _require_no_store(response)
     locations = _headers(response, "location")
@@ -259,13 +260,7 @@ def _check_google_login(
         query["nonce"][0],
         query["code_challenge"][0],
     }
-    predictable_bindings = set(public_values)
-    for value in public_values:
-        digest = hashlib.sha256(value.encode("ascii")).digest()
-        predictable_bindings.add(digest.hex())
-        predictable_bindings.add(
-            base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-        )
+    predictable_bindings = _predictable_public_bindings(public_values)
     attributes = _cookie_attributes(cookie_parts[1:]) if cookie_parts else None
     max_age = None if attributes is None else attributes.get("max-age")
     if (
@@ -284,13 +279,20 @@ def _check_google_login(
         or str(attributes.get("samesite", "")).lower() != "lax"
     ):
         raise StagingSmokeError("Check staging google_login non valido.")
+    actual_values = (
+        query["state"][0],
+        query["nonce"][0],
+        query["code_challenge"][0],
+        cookie_value,
+    )
+    if len(set(actual_values)) != len(actual_values):
+        raise StagingSmokeError("Check staging google_login non valido.")
     material = tuple(
-        hashlib.sha256(value.encode("ascii")).digest()
-        for value in (
-            query["state"][0],
-            query["nonce"][0],
-            query["code_challenge"][0],
-            cookie_value,
+        sorted(
+            {
+                hashlib.sha256(value.encode("ascii")).digest()
+                for value in predictable_bindings | set(actual_values)
+            }
         )
     )
     location = None
@@ -298,6 +300,7 @@ def _check_google_login(
     query = None
     cookie_parts = None
     cookie_value = None
+    actual_values = None
     public_values = None
     predictable_bindings = None
     digest = None
@@ -472,6 +475,22 @@ def _strict_query(raw_query: str) -> dict[str, list[str]]:
     return result
 
 
+def _predictable_public_bindings(public_values: set[str]) -> set[str]:
+    predictable = set(public_values)
+    ordered_values = tuple(public_values)
+    for length in (1, 2, 3):
+        for values in itertools.permutations(ordered_values, length):
+            for separator in ("", ":", ".", "|"):
+                combined = separator.join(values)
+                predictable.add(combined)
+                digest = hashlib.sha256(combined.encode("ascii")).digest()
+                predictable.add(digest.hex())
+                predictable.add(
+                    base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+                )
+    return predictable
+
+
 def _forbidden_followup_fingerprints(material: tuple[bytes, ...]) -> set[bytes]:
     forbidden = set(material)
     for fingerprint in material:
@@ -490,6 +509,7 @@ _INERT_HTML_CONTAINERS = {
     "xmp",
     "iframe",
     "noembed",
+    "title",
 }
 _FORBIDDEN_HTML_ELEMENTS = {"plaintext"}
 

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -206,6 +206,29 @@ def test_staging_smoke_validates_public_routes_without_exposing_secrets() -> Non
     assert all(call[2] == 30 for call in calls)
 
 
+def test_staging_smoke_accepts_runtime_global_security_headers() -> None:
+    fixtures = responses()
+    key = ("GET", "https://school.test/auth/tui/pair")
+    current = fixtures[key]
+    fixtures[key] = smoke.ResponseSnapshot(
+        current.status,
+        current.headers
+        + (
+            ("Content-Security-Policy", "frame-ancestors 'none'"),
+            ("X-Frame-Options", "DENY"),
+            ("X-Content-Type-Options", "nosniff"),
+        ),
+        current.body,
+    )
+
+    result = smoke.run_smoke(
+        "https://school.test",
+        lambda method, url, timeout: fixtures[(method, url)],
+    )
+
+    assert all(check["ok"] for check in result["checks"])
+
+
 @pytest.mark.parametrize(
     "origin",
     [

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -23,8 +23,8 @@ def google_location(**changes):
         "redirect_uri": "https://school.test/auth/google/callback",
         "response_type": "code",
         "scope": "openid email profile",
-        "state": "STATE_SECRET_123456",
-        "nonce": "NONCE_SECRET_123456",
+        "state": "STATE_SECRET_ABCDEFGHIJKLMNOPQRST",
+        "nonce": "NONCE_SECRET_ABCDEFGHIJKLMNOPQRST",
         "code_challenge": "C" * 43,
         "code_challenge_method": "S256",
     }
@@ -57,7 +57,7 @@ def responses():
                 ("Content-Type", "text/html; charset=utf-8"),
                 (
                     "Content-Security-Policy",
-                    "default-src 'none'; connect-src 'self'; frame-ancestors 'none'",
+                    "default-src 'none'; script-src 'nonce-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef'; style-src 'nonce-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef'; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
                 ),
                 ("X-Frame-Options", "DENY"),
                 ("X-Content-Type-Options", "nosniff"),
@@ -152,6 +152,72 @@ def test_staging_smoke_fails_closed_on_noncanonical_google_redirect() -> None:
 
     assert secret not in str(captured.value)
     assert "COOKIE_SECRET" not in str(captured.value)
+
+
+def test_staging_smoke_rejects_short_pkce_challenge() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/google/login")]
+    fixtures[("GET", "https://school.test/auth/google/login")] = smoke.ResponseSnapshot(
+        302,
+        tuple(
+            (name, google_location(code_challenge="x"))
+            if name.lower() == "location"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        b"",
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+def test_staging_smoke_rejects_duplicate_or_contradictory_cookie_attributes() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/google/login")]
+    fixtures[("GET", "https://school.test/auth/google/login")] = smoke.ResponseSnapshot(
+        302,
+        tuple(
+            (
+                name,
+                value + "; path=/wrong; SameSite=None",
+            )
+            if name.lower() == "set-cookie"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        b"",
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+def test_staging_smoke_rejects_csp_with_additional_sources() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/tui/pair")]
+    fixtures[("GET", "https://school.test/auth/tui/pair")] = smoke.ResponseSnapshot(
+        200,
+        tuple(
+            (name, value.replace("connect-src 'self'", "connect-src 'self' https://evil.test"))
+            if name.lower() == "content-security-policy"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        current.body,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
 
 
 def test_staging_smoke_uses_one_absolute_deadline() -> None:

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -384,7 +384,8 @@ def test_staging_smoke_rejects_cookie_binding_derived_from_public_state() -> Non
         )
 
 
-def test_staging_smoke_rejects_cross_flow_public_material_as_binding() -> None:
+@pytest.mark.parametrize("derive", [False, True])
+def test_staging_smoke_rejects_cross_flow_public_material_as_binding(derive) -> None:
     fixtures = responses()
     first = fixtures[FreshResponses.LOGIN_KEY]
     second = fixtures[FreshResponses.LOGIN_KEY]
@@ -395,10 +396,16 @@ def test_staging_smoke_rejects_cross_flow_public_material_as_binding() -> None:
         urllib.parse.urlsplit(first_location).query
     )["state"][0]
 
+    previous_material = first_state
+    if derive:
+        previous_material = base64.urlsafe_b64encode(
+            hashlib.sha256(first_state.encode("ascii")).digest()
+        ).rstrip(b"=").decode("ascii")
+
     def reuse_previous_state(value):
         cookie_name = value.split("=", 1)[0]
         attributes = value.split(";", 1)[1]
-        return f"{cookie_name}={first_state};{attributes}"
+        return f"{cookie_name}={previous_material};{attributes}"
 
     second = smoke.ResponseSnapshot(
         second.status,
@@ -549,7 +556,10 @@ def test_staging_smoke_ignores_script_and_routes_inside_html_comments() -> None:
         )
 
 
-@pytest.mark.parametrize("container", ["template", "noscript", "textarea", "xmp"])
+@pytest.mark.parametrize(
+    "container",
+    ["template", "noscript", "textarea", "xmp", "plaintext"],
+)
 def test_staging_smoke_rejects_pairing_logic_inside_inert_container(container) -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/tui/pair")]

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -384,6 +384,43 @@ def test_staging_smoke_rejects_cookie_binding_derived_from_public_state() -> Non
         )
 
 
+def test_staging_smoke_rejects_cross_flow_public_material_as_binding() -> None:
+    fixtures = responses()
+    first = fixtures[FreshResponses.LOGIN_KEY]
+    second = fixtures[FreshResponses.LOGIN_KEY]
+    first_location = next(
+        value for name, value in first.headers if name.lower() == "location"
+    )
+    first_state = urllib.parse.parse_qs(
+        urllib.parse.urlsplit(first_location).query
+    )["state"][0]
+
+    def reuse_previous_state(value):
+        cookie_name = value.split("=", 1)[0]
+        attributes = value.split(";", 1)[1]
+        return f"{cookie_name}={first_state};{attributes}"
+
+    second = smoke.ResponseSnapshot(
+        second.status,
+        tuple(
+            (name, reuse_previous_state(value))
+            if name.lower() == "set-cookie"
+            else (name, value)
+            for name, value in second.headers
+        ),
+        second.body,
+    )
+    login_responses = iter((first, second))
+
+    def request(method, url, timeout):
+        if (method, url) == FreshResponses.LOGIN_KEY:
+            return next(login_responses)
+        return fixtures[(method, url)]
+
+    with pytest.raises(smoke.StagingSmokeError, match="google_login_repeat"):
+        smoke.run_smoke("https://school.test", request)
+
+
 def test_staging_smoke_rejects_short_pkce_challenge() -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/google/login")]
@@ -512,15 +549,16 @@ def test_staging_smoke_ignores_script_and_routes_inside_html_comments() -> None:
         )
 
 
-def test_staging_smoke_rejects_pairing_logic_inside_inert_template() -> None:
+@pytest.mark.parametrize("container", ["template", "noscript", "textarea", "xmp"])
+def test_staging_smoke_rejects_pairing_logic_inside_inert_container(container) -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/tui/pair")]
     inert_body = current.body.replace(
         b"<body>",
-        b"<body><template>",
+        f"<body><{container}>".encode(),
     ).replace(
         b"</body>",
-        b"</template></body>",
+        f"</{container}></body>".encode(),
     )
     fixtures[("GET", "https://school.test/auth/tui/pair")] = smoke.ResponseSnapshot(
         200,

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -350,15 +350,19 @@ def test_staging_smoke_rejects_public_state_reused_as_cookie_binding() -> None:
         )
 
 
-def test_staging_smoke_rejects_cookie_binding_derived_from_public_state() -> None:
+@pytest.mark.parametrize("combine", [False, True])
+def test_staging_smoke_rejects_cookie_binding_derived_from_public_state(combine) -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/google/login")]
     location = next(
         value for name, value in current.headers if name.lower() == "location"
     )
-    state = urllib.parse.parse_qs(urllib.parse.urlsplit(location).query)["state"][0]
+    query = urllib.parse.parse_qs(urllib.parse.urlsplit(location).query)
+    public_source = query["state"][0]
+    if combine:
+        public_source += query["nonce"][0]
     derived = base64.urlsafe_b64encode(
-        hashlib.sha256(state.encode("ascii")).digest()
+        hashlib.sha256(public_source.encode("ascii")).digest()
     ).rstrip(b"=").decode("ascii")
 
     def derived_cookie(value):
@@ -558,7 +562,7 @@ def test_staging_smoke_ignores_script_and_routes_inside_html_comments() -> None:
 
 @pytest.mark.parametrize(
     "container",
-    ["template", "noscript", "textarea", "xmp", "plaintext"],
+    ["template", "noscript", "textarea", "xmp", "plaintext", "title"],
 )
 def test_staging_smoke_rejects_pairing_logic_inside_inert_container(container) -> None:
     fixtures = responses()

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -252,6 +252,37 @@ def test_staging_smoke_rejects_cookie_not_correlated_to_state() -> None:
         )
 
 
+def test_staging_smoke_rejects_public_state_reused_as_cookie_binding() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/google/login")]
+    location = next(
+        value for name, value in current.headers if name.lower() == "location"
+    )
+    state = urllib.parse.parse_qs(urllib.parse.urlsplit(location).query)["state"][0]
+
+    def reuse_state(value):
+        cookie_name = value.split("=", 1)[0]
+        attributes = value.split(";", 1)[1]
+        return f"{cookie_name}={state};{attributes}"
+
+    fixtures[("GET", "https://school.test/auth/google/login")] = smoke.ResponseSnapshot(
+        302,
+        tuple(
+            (name, reuse_state(value))
+            if name.lower() == "set-cookie"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        b"",
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
 def test_staging_smoke_rejects_short_pkce_challenge() -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/google/login")]
@@ -349,6 +380,28 @@ def test_staging_smoke_rejects_html_nonce_not_bound_to_csp() -> None:
             b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
             b"ZYXWVUTSRQPONMLKJIHGFEDCBAabcdef",
         ),
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+def test_staging_smoke_ignores_script_and_routes_inside_html_comments() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/tui/pair")]
+    commented_body = b"<!--" + current.body + b"-->"
+    fixtures[("GET", "https://school.test/auth/tui/pair")] = smoke.ResponseSnapshot(
+        200,
+        tuple(
+            (name, str(len(commented_body)))
+            if name.lower() == "content-length"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        commented_body,
     )
 
     with pytest.raises(smoke.StagingSmokeError):

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -44,6 +44,63 @@ def google_location(**changes):
     return "https://accounts.google.com/o/oauth2/v2/auth?" + urllib.parse.urlencode(query)
 
 
+class FreshResponses(dict):
+    LOGIN_KEY = ("GET", "https://school.test/auth/google/login")
+
+    def __init__(self, values):
+        super().__init__(values)
+        self.login_reads = 0
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        if key == self.LOGIN_KEY:
+            self.login_reads = 0
+
+    def __getitem__(self, key):
+        response = super().__getitem__(key)
+        if key != self.LOGIN_KEY:
+            return response
+        self.login_reads += 1
+        if self.login_reads == 1:
+            return response
+        query = urllib.parse.parse_qs(
+            urllib.parse.urlsplit(
+                next(value for name, value in response.headers if name.lower() == "location")
+            ).query
+        )
+        for field in ("state", "nonce"):
+            query[field] = [
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(f"{field}-{self.login_reads}".encode()).digest()
+                ).rstrip(b"=").decode("ascii")
+            ]
+        query["code_challenge"] = [
+            base64.urlsafe_b64encode(
+                hashlib.sha256(f"challenge-{self.login_reads}".encode()).digest()
+            ).rstrip(b"=").decode("ascii")
+        ]
+        location = "https://accounts.google.com/o/oauth2/v2/auth?" + urllib.parse.urlencode(
+            {name: values[0] for name, values in query.items()}
+        )
+        suffix = hashlib.sha256(query["state"][0].encode("ascii")).hexdigest()[:24]
+        binding = base64.urlsafe_b64encode(
+            hashlib.sha256(f"binding-{self.login_reads}".encode()).digest()
+        ).rstrip(b"=").decode("ascii")
+        cookie = (
+            f"__Host-thebitlab_oidc_txn-{suffix}={binding}; Path=/; Max-Age=600; "
+            "Secure; HttpOnly; SameSite=Lax"
+        )
+        headers = tuple(
+            (name, location)
+            if name.lower() == "location"
+            else (name, cookie)
+            if name.lower() == "set-cookie"
+            else (name, value)
+            for name, value in response.headers
+        )
+        return smoke.ResponseSnapshot(response.status, headers, response.body)
+
+
 def responses():
     location = google_location()
     state = urllib.parse.parse_qs(urllib.parse.urlsplit(location).query)["state"][0]
@@ -53,7 +110,12 @@ def responses():
         "COOKIE_SECRET_ABCDEFGHIJKLMNOPQRST; Path=/; Max-Age=600; "
         "Secure; HttpOnly; SameSite=Lax"
     )
-    return {
+    pairing_body = (
+        b'<html><head><style nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">'
+        b'</style></head><body><script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">'
+        b'/auth/session /auth/tui/pair</script></body></html>'
+    )
+    return FreshResponses({
         ("GET", "https://school.test/auth/google/login"): smoke.ResponseSnapshot(
             302,
             no_store(
@@ -81,9 +143,9 @@ def responses():
                 ),
                 ("X-Frame-Options", "DENY"),
                 ("X-Content-Type-Options", "nosniff"),
-                ("Content-Length", "155"),
+                ("Content-Length", str(len(pairing_body))),
             ),
-            b"<html><style nonce=\"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef\"></style>/auth/session /auth/tui/pair<script nonce=\"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef\"></script></html>",
+            pairing_body,
         ),
         ("GET", "https://school.test/auth/tui/pairings"): smoke.ResponseSnapshot(
             405,
@@ -102,7 +164,7 @@ def responses():
             ),
             b'{"error":"authentication_required"}',
         ),
-    }
+    })
 
 
 def test_staging_smoke_validates_public_routes_without_exposing_secrets() -> None:
@@ -125,6 +187,7 @@ def test_staging_smoke_validates_public_routes_without_exposing_secrets() -> Non
         "ok": True,
         "checks": [
             {"name": "google_login", "status": 302, "ok": True},
+            {"name": "google_login_repeat", "status": 302, "ok": True},
             {"name": "anonymous_session", "status": 401, "ok": True},
             {"name": "pairing_page", "status": 200, "ok": True},
             {"name": "pairing_method", "status": 405, "ok": True},
@@ -135,7 +198,11 @@ def test_staging_smoke_validates_public_routes_without_exposing_secrets() -> Non
     assert "STATE_SECRET" not in encoded
     assert "NONCE_SECRET" not in encoded
     assert "COOKIE_SECRET" not in encoded
-    assert [call[:2] for call in calls] == list(fixtures)
+    assert [call[:2] for call in calls] == [
+        FreshResponses.LOGIN_KEY,
+        FreshResponses.LOGIN_KEY,
+        *(key for key in fixtures if key != FreshResponses.LOGIN_KEY),
+    ]
     assert all(call[2] == 30 for call in calls)
 
 
@@ -283,6 +350,40 @@ def test_staging_smoke_rejects_public_state_reused_as_cookie_binding() -> None:
         )
 
 
+def test_staging_smoke_rejects_cookie_binding_derived_from_public_state() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/google/login")]
+    location = next(
+        value for name, value in current.headers if name.lower() == "location"
+    )
+    state = urllib.parse.parse_qs(urllib.parse.urlsplit(location).query)["state"][0]
+    derived = base64.urlsafe_b64encode(
+        hashlib.sha256(state.encode("ascii")).digest()
+    ).rstrip(b"=").decode("ascii")
+
+    def derived_cookie(value):
+        cookie_name = value.split("=", 1)[0]
+        attributes = value.split(";", 1)[1]
+        return f"{cookie_name}={derived};{attributes}"
+
+    fixtures[("GET", "https://school.test/auth/google/login")] = smoke.ResponseSnapshot(
+        302,
+        tuple(
+            (name, derived_cookie(value))
+            if name.lower() == "set-cookie"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        b"",
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
 def test_staging_smoke_rejects_short_pkce_challenge() -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/google/login")]
@@ -402,6 +503,59 @@ def test_staging_smoke_ignores_script_and_routes_inside_html_comments() -> None:
             for name, value in current.headers
         ),
         commented_body,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+def test_staging_smoke_rejects_pairing_logic_inside_inert_template() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/tui/pair")]
+    inert_body = current.body.replace(
+        b"<body>",
+        b"<body><template>",
+    ).replace(
+        b"</body>",
+        b"</template></body>",
+    )
+    fixtures[("GET", "https://school.test/auth/tui/pair")] = smoke.ResponseSnapshot(
+        200,
+        tuple(
+            (name, str(len(inert_body)))
+            if name.lower() == "content-length"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        inert_body,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+def test_staging_smoke_rejects_misordered_executable_tags() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/tui/pair")]
+    malformed_body = current.body.replace(
+        b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">',
+        b'</script><script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">',
+    )
+    fixtures[("GET", "https://school.test/auth/tui/pair")] = smoke.ResponseSnapshot(
+        200,
+        tuple(
+            (name, str(len(malformed_body)))
+            if name.lower() == "content-length"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        malformed_body,
     )
 
     with pytest.raises(smoke.StagingSmokeError):

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import urllib.parse
@@ -8,6 +9,14 @@ from pathlib import Path
 import pytest
 
 from scripts import thebitlab_auth_staging_smoke as smoke
+
+
+@pytest.fixture(autouse=True)
+def expected_google_client_id(monkeypatch):
+    monkeypatch.setenv(
+        "THEBITLAB_EXPECTED_GOOGLE_CLIENT_ID",
+        "client.apps.googleusercontent.com",
+    )
 
 
 def no_store(*extra):
@@ -26,7 +35,9 @@ def google_location(**changes):
         "scope": "openid email profile",
         "state": "STATE_SECRET_ABCDEFGHIJKLMNOPQRST",
         "nonce": "NONCE_SECRET_ABCDEFGHIJKLMNOPQRST",
-        "code_challenge": "C" * 43,
+        "code_challenge": base64.urlsafe_b64encode(
+            hashlib.sha256(b"test-verifier").digest()
+        ).rstrip(b"=").decode("ascii"),
         "code_challenge_method": "S256",
     }
     query.update(changes)
@@ -190,6 +201,30 @@ def test_staging_smoke_rejects_malformed_percent_encoding_in_google_query() -> N
         )
 
 
+def test_staging_smoke_rejects_unexpected_google_client_id() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/google/login")]
+    fixtures[("GET", "https://school.test/auth/google/login")] = smoke.ResponseSnapshot(
+        302,
+        tuple(
+            (
+                name,
+                google_location(client_id="different.apps.googleusercontent.com"),
+            )
+            if name.lower() == "location"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        b"",
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
 def test_staging_smoke_rejects_cookie_not_correlated_to_state() -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/google/login")]
@@ -323,6 +358,31 @@ def test_staging_smoke_rejects_html_nonce_not_bound_to_csp() -> None:
         )
 
 
+def test_staging_smoke_rejects_external_script_even_with_valid_nonce() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/tui/pair")]
+    changed_body = current.body.replace(
+        b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">',
+        b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef" src="https://evil.test/pwn.js">',
+    )
+    fixtures[("GET", "https://school.test/auth/tui/pair")] = smoke.ResponseSnapshot(
+        200,
+        tuple(
+            (name, str(len(changed_body)))
+            if name.lower() == "content-length"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        changed_body,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
 def test_staging_smoke_uses_one_absolute_deadline() -> None:
     fixtures = responses()
     times = iter([10.0, 10.0, 11.0, 12.0, 13.0, 41.0])
@@ -346,11 +406,14 @@ def test_manual_workflow_passes_untrusted_inputs_only_through_environment() -> N
 
     assert "workflow_dispatch:" in workflow
     assert "THEBITLAB_STAGING_ORIGIN: ${{ inputs.origin }}" in workflow
+    assert "THEBITLAB_GOOGLE_CLIENT_ID_EXPECTED: ${{ inputs.google_client_id }}" in workflow
     assert 'THEBITLAB_STAGING_TIMEOUT: ${{ inputs.timeout_seconds }}' in workflow
     run_block = workflow.split("run: >-", 1)[1]
     assert "${{ inputs.origin }}" not in run_block
+    assert "${{ inputs.google_client_id }}" not in run_block
     assert "${{ inputs.timeout_seconds }}" not in run_block
     assert '"$THEBITLAB_STAGING_ORIGIN"' in run_block
+    assert '"$THEBITLAB_GOOGLE_CLIENT_ID_EXPECTED"' in run_block
     assert '"$THEBITLAB_STAGING_TIMEOUT"' in run_block
 
 

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import urllib.parse
 from pathlib import Path
@@ -33,22 +34,30 @@ def google_location(**changes):
 
 
 def responses():
+    location = google_location()
+    state = urllib.parse.parse_qs(urllib.parse.urlsplit(location).query)["state"][0]
+    cookie_suffix = hashlib.sha256(state.encode("ascii")).hexdigest()[:24]
+    transaction_cookie = (
+        f"__Host-thebitlab_oidc_txn-{cookie_suffix}="
+        "COOKIE_SECRET_ABCDEFGHIJKLMNOPQRST; Path=/; Max-Age=600; "
+        "Secure; HttpOnly; SameSite=Lax"
+    )
     return {
         ("GET", "https://school.test/auth/google/login"): smoke.ResponseSnapshot(
             302,
             no_store(
-                ("Location", google_location()),
-                (
-                    "Set-Cookie",
-                    "__Host-thebitlab_oidc_txn-abcdef0123456789abcdef01=COOKIE_SECRET_ABCDEFGHIJKLMNOPQRST; Path=/; Max-Age=600; Secure; HttpOnly; SameSite=Lax",
-                ),
+                ("Location", location),
+                ("Set-Cookie", transaction_cookie),
                 ("Content-Length", "0"),
             ),
             b"",
         ),
         ("GET", "https://school.test/auth/session"): smoke.ResponseSnapshot(
             401,
-            no_store(("Content-Type", "application/json; charset=utf-8")),
+            no_store(
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Content-Length", "35"),
+            ),
             b'{"error":"authentication_required"}',
         ),
         ("GET", "https://school.test/auth/tui/pair"): smoke.ResponseSnapshot(
@@ -61,20 +70,25 @@ def responses():
                 ),
                 ("X-Frame-Options", "DENY"),
                 ("X-Content-Type-Options", "nosniff"),
+                ("Content-Length", "155"),
             ),
-            b"<html>/auth/session /auth/tui/pair</html>",
+            b"<html><style nonce=\"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef\"></style>/auth/session /auth/tui/pair<script nonce=\"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef\"></script></html>",
         ),
         ("GET", "https://school.test/auth/tui/pairings"): smoke.ResponseSnapshot(
             405,
             no_store(
                 ("Content-Type", "application/json; charset=utf-8"),
                 ("Allow", "POST"),
+                ("Content-Length", "35"),
             ),
             b'{"error":"auth_method_not_allowed"}',
         ),
         ("POST", "https://school.test/auth/tui/logout"): smoke.ResponseSnapshot(
             401,
-            no_store(("Content-Type", "application/json; charset=utf-8")),
+            no_store(
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Content-Length", "35"),
+            ),
             b'{"error":"authentication_required"}',
         ),
     }
@@ -140,6 +154,7 @@ def test_staging_smoke_fails_closed_on_noncanonical_google_redirect() -> None:
                 "Set-Cookie",
                 "__Host-thebitlab_oidc_txn-abcdef0123456789abcdef01=COOKIE_SECRET_ABCDEFGHIJKLMNOPQRST; Path=/; Max-Age=600; Secure; HttpOnly; SameSite=Lax",
             ),
+            ("Content-Length", "0"),
         ),
         b"",
     )
@@ -152,6 +167,54 @@ def test_staging_smoke_fails_closed_on_noncanonical_google_redirect() -> None:
 
     assert secret not in str(captured.value)
     assert "COOKIE_SECRET" not in str(captured.value)
+
+
+def test_staging_smoke_rejects_malformed_percent_encoding_in_google_query() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/google/login")]
+    fixtures[("GET", "https://school.test/auth/google/login")] = smoke.ResponseSnapshot(
+        302,
+        tuple(
+            (name, value.replace("client.apps.googleusercontent.com", "%ZZ.apps.googleusercontent.com"))
+            if name.lower() == "location"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        b"",
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+def test_staging_smoke_rejects_cookie_not_correlated_to_state() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/google/login")]
+
+    def unrelated_cookie(value):
+        prefix = "__Host-thebitlab_oidc_txn-"
+        suffix = value.split(prefix, 1)[1].split("=", 1)[0]
+        return value.replace(prefix + suffix, prefix + "0" * 24, 1)
+
+    fixtures[("GET", "https://school.test/auth/google/login")] = smoke.ResponseSnapshot(
+        302,
+        tuple(
+            (name, unrelated_cookie(value))
+            if name.lower() == "set-cookie"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        b"",
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
 
 
 def test_staging_smoke_rejects_short_pkce_challenge() -> None:
@@ -199,6 +262,22 @@ def test_staging_smoke_rejects_duplicate_or_contradictory_cookie_attributes() ->
         )
 
 
+def test_staging_smoke_rejects_conflicting_response_framing() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/session")]
+    fixtures[("GET", "https://school.test/auth/session")] = smoke.ResponseSnapshot(
+        current.status,
+        current.headers + (("Transfer-Encoding", "chunked"),),
+        current.body,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError, match="Framing"):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
 def test_staging_smoke_rejects_csp_with_additional_sources() -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/tui/pair")]
@@ -211,6 +290,30 @@ def test_staging_smoke_rejects_csp_with_additional_sources() -> None:
             for name, value in current.headers
         ),
         current.body,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+def test_staging_smoke_rejects_html_nonce_not_bound_to_csp() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/tui/pair")]
+    fixtures[("GET", "https://school.test/auth/tui/pair")] = smoke.ResponseSnapshot(
+        200,
+        tuple(
+            (name, str(len(current.body.replace(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef", b"ZYXWVUTSRQPONMLKJIHGFEDCBAabcdef"))))
+            if name.lower() == "content-length"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        current.body.replace(
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+            b"ZYXWVUTSRQPONMLKJIHGFEDCBAabcdef",
+        ),
     )
 
     with pytest.raises(smoke.StagingSmokeError):

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+from scripts import thebitlab_auth_staging_smoke as smoke
+
+
+def no_store(*extra):
+    return (
+        ("Cache-Control", "no-store"),
+        ("Pragma", "no-cache"),
+        ("Referrer-Policy", "no-referrer"),
+    ) + tuple(extra)
+
+
+def google_location(**changes):
+    query = {
+        "client_id": "client.apps.googleusercontent.com",
+        "redirect_uri": "https://school.test/auth/google/callback",
+        "response_type": "code",
+        "scope": "openid email profile",
+        "state": "STATE_SECRET_123456",
+        "nonce": "NONCE_SECRET_123456",
+        "code_challenge": "C" * 43,
+        "code_challenge_method": "S256",
+    }
+    query.update(changes)
+    return "https://accounts.google.com/o/oauth2/v2/auth?" + urllib.parse.urlencode(query)
+
+
+def responses():
+    return {
+        ("GET", "https://school.test/auth/google/login"): smoke.ResponseSnapshot(
+            302,
+            no_store(
+                ("Location", google_location()),
+                (
+                    "Set-Cookie",
+                    "__Host-thebitlab_oidc_txn-abcdef0123456789abcdef01=COOKIE_SECRET_ABCDEFGHIJKLMNOPQRST; Path=/; Max-Age=600; Secure; HttpOnly; SameSite=Lax",
+                ),
+                ("Content-Length", "0"),
+            ),
+            b"",
+        ),
+        ("GET", "https://school.test/auth/session"): smoke.ResponseSnapshot(
+            401,
+            no_store(("Content-Type", "application/json; charset=utf-8")),
+            b'{"error":"authentication_required"}',
+        ),
+        ("GET", "https://school.test/auth/tui/pair"): smoke.ResponseSnapshot(
+            200,
+            no_store(
+                ("Content-Type", "text/html; charset=utf-8"),
+                (
+                    "Content-Security-Policy",
+                    "default-src 'none'; connect-src 'self'; frame-ancestors 'none'",
+                ),
+                ("X-Frame-Options", "DENY"),
+                ("X-Content-Type-Options", "nosniff"),
+            ),
+            b"<html>/auth/session /auth/tui/pair</html>",
+        ),
+        ("GET", "https://school.test/auth/tui/pairings"): smoke.ResponseSnapshot(
+            405,
+            no_store(
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Allow", "POST"),
+            ),
+            b'{"error":"auth_method_not_allowed"}',
+        ),
+        ("POST", "https://school.test/auth/tui/logout"): smoke.ResponseSnapshot(
+            401,
+            no_store(("Content-Type", "application/json; charset=utf-8")),
+            b'{"error":"authentication_required"}',
+        ),
+    }
+
+
+def test_staging_smoke_validates_public_routes_without_exposing_secrets() -> None:
+    fixtures = responses()
+    calls = []
+
+    def request(method, url, timeout):
+        calls.append((method, url, timeout))
+        return fixtures[(method, url)]
+
+    result = smoke.run_smoke(
+        "https://SCHOOL.test/",
+        request,
+        timeout=30,
+        monotonic=lambda: 100.0,
+    )
+
+    assert result == {
+        "schema_version": "thebitlab.auth_staging_smoke.v1",
+        "ok": True,
+        "checks": [
+            {"name": "google_login", "status": 302, "ok": True},
+            {"name": "anonymous_session", "status": 401, "ok": True},
+            {"name": "pairing_page", "status": 200, "ok": True},
+            {"name": "pairing_method", "status": 405, "ok": True},
+            {"name": "anonymous_tui_logout", "status": 401, "ok": True},
+        ],
+    }
+    encoded = json.dumps(result)
+    assert "STATE_SECRET" not in encoded
+    assert "NONCE_SECRET" not in encoded
+    assert "COOKIE_SECRET" not in encoded
+    assert [call[:2] for call in calls] == list(fixtures)
+    assert all(call[2] == 30 for call in calls)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://school.test",
+        "https://user:password@school.test",
+        "https://school.test/path",
+        "https://school.test/?query=1",
+        "https://school.test/#fragment",
+    ],
+)
+def test_staging_smoke_requires_canonical_https_origin(origin) -> None:
+    with pytest.raises(smoke.StagingSmokeError, match="HTTPS canonica"):
+        smoke.run_smoke(origin, lambda *args: None)
+
+
+def test_staging_smoke_fails_closed_on_noncanonical_google_redirect() -> None:
+    fixtures = responses()
+    secret = "REFLECTED_SECRET"
+    fixtures[("GET", "https://school.test/auth/google/login")] = smoke.ResponseSnapshot(
+        302,
+        no_store(
+            ("Location", "https://attacker.test/?state=" + secret),
+            (
+                "Set-Cookie",
+                "__Host-thebitlab_oidc_txn-abcdef0123456789abcdef01=COOKIE_SECRET_ABCDEFGHIJKLMNOPQRST; Path=/; Max-Age=600; Secure; HttpOnly; SameSite=Lax",
+            ),
+        ),
+        b"",
+    )
+
+    with pytest.raises(smoke.StagingSmokeError) as captured:
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+    assert secret not in str(captured.value)
+    assert "COOKIE_SECRET" not in str(captured.value)
+
+
+def test_staging_smoke_uses_one_absolute_deadline() -> None:
+    fixtures = responses()
+    times = iter([10.0, 10.0, 11.0, 12.0, 13.0, 41.0])
+
+    with pytest.raises(smoke.StagingSmokeError, match="scaduto"):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+            timeout=30,
+            monotonic=lambda: next(times),
+        )
+
+
+def test_manual_workflow_passes_untrusted_inputs_only_through_environment() -> None:
+    workflow = (
+        Path(__file__).resolve().parents[1]
+        / ".github"
+        / "workflows"
+        / "auth-staging-smoke.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "THEBITLAB_STAGING_ORIGIN: ${{ inputs.origin }}" in workflow
+    assert 'THEBITLAB_STAGING_TIMEOUT: ${{ inputs.timeout_seconds }}' in workflow
+    run_block = workflow.split("run: >-", 1)[1]
+    assert "${{ inputs.origin }}" not in run_block
+    assert "${{ inputs.timeout_seconds }}" not in run_block
+    assert '"$THEBITLAB_STAGING_ORIGIN"' in run_block
+    assert '"$THEBITLAB_STAGING_TIMEOUT"' in run_block
+
+
+def test_response_snapshot_redacts_headers_and_body_from_repr() -> None:
+    snapshot = smoke.ResponseSnapshot(
+        500,
+        (("Location", "https://example.test/?state=HEADER_SECRET"),),
+        b"BODY_SECRET",
+    )
+    rendered = repr(snapshot)
+    assert "HEADER_SECRET" not in rendered
+    assert "BODY_SECRET" not in rendered


### PR DESCRIPTION
Closes #597

## Summary
- add a secret-safe HTTPS staging smoke CLI for public Google/session/pairing/logout routes;
- sample Google login twice and validate canonical OIDC/PKCE parameters, secure state-correlated browser bindings, and one-time material freshness;
- validate the active pairing page, CSP nonce contract, runtime-composed security headers, no-store policies, strict framing, and anonymous error contracts;
- run production requests in a bounded subprocess with minimal environment, absolute deadlines, redirect rejection, and bounded responses;
- emit only check names, numeric statuses, and booleans—never remote locations, cookies, query values, or bodies;
- add a quotation-safe manual GitHub Actions workflow and an operational staging runbook.

## Validation
- targeted smoke/workflow tests: 38 passed;
- `py_compile` and `git diff --check` clean;
- required CI green on Linux/Windows Python 3.11–3.13, minimum Python, Docker build, and Windows filesystem;
- final independent reviews 19–20 at `c9074f2`: `Nessun finding` twice.
