### PR TITLE
Auth: route HTTP per link e unlink GitHub

### DIFF
--- a/doc/architecture/github-account-linking.md
+++ b/doc/architecture/github-account-linking.md
@@ -25,9 +25,12 @@
 - un utente può collegare un solo account per il provider configurato e uno stesso subject non può avere due owner;
 - la migrazione v3 mette in quarantena tutti i link legacy ambigui prima di applicare il vincolo unico `(user_id, provider)`.
 
+## Confine HTTP
+
+Le route concrete, la callback canonica e la composizione runtime sono documentate in [`github-oauth-http-routes.md`](github-oauth-http-routes.md).
+
 ## Fuori scope
 
-- route concrete e gestione header HTTP;
 - credenziali GitHub reali/browser E2E;
 - organization/team mapping e membership classi;
 - GitHub App installation token e repository discovery;

--- a/doc/architecture/github-oauth-http-routes.md
+++ b/doc/architecture/github-oauth-http-routes.md
@@ -1,0 +1,55 @@
+# Route HTTP concrete per collegamento GitHub
+
+## Scopo
+
+`scripts/thebitlab_github_oauth_http.py` espone il collegamento GitHub soltanto a una sessione web TheBitLab già autenticata. Google autentica la persona; GitHub collega il suo account tecnico allo stesso `user_id` interno.
+
+Route canoniche:
+
+- `GET /auth/github/link`;
+- `GET /auth/github/callback`;
+- `POST /auth/github/unlink`.
+
+La callback da registrare nella GitHub OAuth App è:
+
+```text
+https://HOST-PUBBLICO/auth/github/callback
+```
+
+## Flusso
+
+`GET /auth/github/link` autentica il cookie web corrente, crea state, PKCE e browser binding one-time, quindi risponde `302` verso l'endpoint canonico GitHub. Il cookie transazionale è `__Host-`, `Secure`, `HttpOnly`, `SameSite=Lax`, bounded e distinto per state.
+
+`GET /auth/github/callback` richiede ancora la stessa sessione web e lo stesso browser binding. Query duplicate, percent encoding invalido, replay, flow scaduti e session/user revision races falliscono chiusi. Il server scambia il code, legge esclusivamente il profilo pubblico `/user`, collega l'ID numerico GitHub e risponde `303` verso un path locale. Access token, code, verifier, state e secret non sono persistiti né restituiti al browser.
+
+`POST /auth/github/unlink` richiede cookie web e `X-CSRF-Token`. Lo storage elimina identità GitHub e membership `student` governate da GitHub nella stessa transazione, preservando membership manuali o di altri provider.
+
+## Confine HTTP
+
+Tutte le route richiedono TLS diretto oppure un peer trusted con un solo `X-Forwarded-Proto: https`. Accettano soltanto request-target origin-form canoniche, metodo esatto, body vuoto, framing non ambiguo, query/header/cookie bounded e redirect/cookie validati contro endpoint e attributi attesi.
+
+Le risposte usano `Cache-Control: no-store` e `Referrer-Policy: no-referrer`. Callback query e credenziali non vengono scritte nell'access log: `CourseBoardHandler` registra soltanto il path canonico redatto.
+
+## Composizione runtime
+
+Le route GitHub restano disabilitate quando tutte le variabili seguenti sono assenti. Se almeno una è presente, la configurazione deve essere completa:
+
+```text
+THEBITLAB_GITHUB_CLIENT_ID
+THEBITLAB_GITHUB_CLIENT_SECRET
+THEBITLAB_GITHUB_REDIRECT_URI=https://HOST-PUBBLICO/auth/github/callback
+```
+
+Opzionale:
+
+```text
+THEBITLAB_GITHUB_POST_LINK_PATH=/tools/course_board.html
+```
+
+I valori segreti devono essere forniti soltanto tramite environment/secret store e mai salvati nel repository, nei file di configurazione versionati o nella shell history.
+
+## Limiti
+
+- La registrazione OAuth reale e il browser E2E richiedono un URL HTTPS pubblico stabile o temporaneo.
+- La lettura organization/team richiede un adapter GitHub App separato; il link OAuth usa scope pubblico minimo e non persiste token.
+- Non viene introdotta UI grafica in questo incremento: le route sono invocabili direttamente e pronte per il collaudo browser.

--- a/doc/architecture/github-oauth-http-routes.md
+++ b/doc/architecture/github-oauth-http-routes.md
@@ -18,7 +18,7 @@ https://HOST-PUBBLICO/auth/github/callback
 
 ## Flusso
 
-`GET /auth/github/link` autentica il cookie web corrente, crea state, PKCE e browser binding one-time, quindi risponde `302` verso l'endpoint canonico GitHub. Il cookie transazionale è `__Host-`, `Secure`, `HttpOnly`, `SameSite=Lax`, bounded e distinto per state.
+`GET /auth/github/link` autentica il cookie web corrente, applica admission atomica globale e per-sessione prima dell'allocazione, crea state, PKCE e browser binding one-time, quindi risponde `302` verso l'endpoint canonico GitHub. Il cookie transazionale è `__Host-`, `Secure`, `HttpOnly`, `SameSite=Lax`, bounded e distinto per state.
 
 `GET /auth/github/callback` richiede ancora la stessa sessione web e lo stesso browser binding. Query duplicate, percent encoding invalido, replay, flow scaduti e session/user revision races falliscono chiusi. Il server scambia il code, legge esclusivamente il profilo pubblico `/user`, collega l'ID numerico GitHub e risponde `303` verso un path locale. Access token, code, verifier, state e secret non sono persistiti né restituiti al browser.
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -4261,37 +4261,17 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
         routes = getattr(self.server, "github_oauth_http_routes", None)
         request_parts = str(getattr(self, "requestline", "")).split()
-        if routes is not None and routes.handles(parsed.path) and len(request_parts) != 3:
-            self.write_oidc_transport_error(400, "bad_auth_request")
-            return True
-        if routes is not None and len(request_parts) == 3:
-            raw_target = request_parts[1]
-            raw_parsed = urlparse(raw_target)
-            candidate_path = raw_parsed.path if routes.handles(raw_parsed.path) else parsed.path
-            if routes.handles(candidate_path) and not (
-                raw_target == candidate_path
-                or raw_target.startswith(candidate_path + "?")
-                or raw_target.startswith(candidate_path + "#")
-                or raw_target.startswith(candidate_path + ";")
-            ):
-                self.write_oidc_transport_error(400, "bad_auth_request")
-                return True
-            if routes.handles(raw_parsed.path):
-                parsed = raw_parsed
-        request_parts = None
-        raw_target = None
-        raw_parsed = None
-        candidate_path = None
-        if routes is None or not routes.handles(parsed.path):
-            return False
-        if parsed.scheme or parsed.netloc or parsed.params:
-            self.write_oidc_transport_error(400, "bad_auth_request")
-            return True
-        try:
+        raw_target = request_parts[1] if len(request_parts) == 3 else None
+        raw_parsed = urlparse(raw_target) if raw_target is not None else None
+        is_github_target = routes is not None and (
+            routes.handles(parsed.path)
+            or (raw_parsed is not None and routes.handles(raw_parsed.path))
+        )
+        raw_headers = None
+        content_lengths = None
+        transfer_encodings = None
+        if is_github_target:
             raw_headers = tuple(self.headers.raw_items())
-            edge = thebitlab_github_oauth_http.EdgeRequestMetadata(
-                str(self.client_address[0]), raw_headers
-            )
             content_lengths = [
                 value.strip()
                 for name, value in raw_headers
@@ -4308,6 +4288,35 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 or (content_lengths and content_lengths != ["0"])
             ):
                 self.close_connection = True
+        if routes is not None and routes.handles(parsed.path) and len(request_parts) != 3:
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        if routes is not None and raw_parsed is not None:
+            candidate_path = raw_parsed.path if routes.handles(raw_parsed.path) else parsed.path
+            if routes.handles(candidate_path) and not (
+                raw_target == candidate_path
+                or raw_target.startswith(candidate_path + "?")
+                or raw_target.startswith(candidate_path + "#")
+                or raw_target.startswith(candidate_path + ";")
+            ):
+                self.write_oidc_transport_error(400, "bad_auth_request")
+                return True
+            if routes.handles(raw_parsed.path):
+                parsed = raw_parsed
+        request_parts = None
+        raw_target = None
+        raw_parsed = None
+        candidate_path = None
+        is_github_target = None
+        if routes is None or not routes.handles(parsed.path):
+            return False
+        if parsed.scheme or parsed.netloc or parsed.params:
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        try:
+            edge = thebitlab_github_oauth_http.EdgeRequestMetadata(
+                str(self.client_address[0]), raw_headers
+            )
             raw_query = parsed.query
             if parsed.fragment:
                 raw_query += "#" + parsed.fragment

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -4288,9 +4288,26 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             self.write_oidc_transport_error(400, "bad_auth_request")
             return True
         try:
+            raw_headers = tuple(self.headers.raw_items())
             edge = thebitlab_github_oauth_http.EdgeRequestMetadata(
-                str(self.client_address[0]), tuple(self.headers.raw_items())
+                str(self.client_address[0]), raw_headers
             )
+            content_lengths = [
+                value.strip()
+                for name, value in raw_headers
+                if name.lower() == "content-length"
+            ]
+            transfer_encodings = [
+                value
+                for name, value in raw_headers
+                if name.lower() == "transfer-encoding"
+            ]
+            if (
+                transfer_encodings
+                or len(content_lengths) > 1
+                or (content_lengths and content_lengths != ["0"])
+            ):
+                self.close_connection = True
             raw_query = parsed.query
             if parsed.fragment:
                 raw_query += "#" + parsed.fragment
@@ -4315,6 +4332,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             edge = None
             request = None
             raw_query = None
+            raw_headers = None
+            content_lengths = None
+            transfer_encodings = None
         self.write_session_http_response(response)
         return True
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -67,6 +67,7 @@ from scripts import (
     thebitlab_auth_runtime,
     thebitlab_grading_artifacts,
     thebitlab_google_oidc_http,
+    thebitlab_github_oauth_http,
     thebitlab_http_auth,
     thebitlab_services,
     thebitlab_session_http,
@@ -3735,6 +3736,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             auth_path in combined
             for auth_path in (
                 "/auth/google/",
+                "/auth/github/",
                 "/auth/session",
                 "/auth/logout",
                 "/auth/tui/",
@@ -3748,7 +3750,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             any(
                 auth_path in str(argument)
                 for auth_path in (
-                    "/auth/google/", "/auth/session", "/auth/logout", "/auth/tui/"
+                    "/auth/google/", "/auth/github/", "/auth/session", "/auth/logout", "/auth/tui/"
                 )
             )
             for argument in args
@@ -3768,6 +3770,12 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 safe_path = "/auth/google/callback"
             elif "/auth/google/login" in combined:
                 safe_path = "/auth/google/login"
+            elif "/auth/github/callback" in combined:
+                safe_path = "/auth/github/callback"
+            elif "/auth/github/link" in combined:
+                safe_path = "/auth/github/link"
+            elif "/auth/github/unlink" in combined:
+                safe_path = "/auth/github/unlink"
             elif "/auth/session" in combined:
                 safe_path = "/auth/session"
             elif "/auth/logout" in combined:
@@ -4248,6 +4256,68 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         except Exception:  # noqa: BLE001
             return
 
+    def dispatch_github_oauth(self, parsed) -> bool:
+        """Delegate exact authenticated GitHub OAuth routes."""
+
+        routes = getattr(self.server, "github_oauth_http_routes", None)
+        request_parts = str(getattr(self, "requestline", "")).split()
+        if routes is not None and routes.handles(parsed.path) and len(request_parts) != 3:
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        if routes is not None and len(request_parts) == 3:
+            raw_target = request_parts[1]
+            raw_parsed = urlparse(raw_target)
+            candidate_path = raw_parsed.path if routes.handles(raw_parsed.path) else parsed.path
+            if routes.handles(candidate_path) and not (
+                raw_target == candidate_path
+                or raw_target.startswith(candidate_path + "?")
+                or raw_target.startswith(candidate_path + "#")
+                or raw_target.startswith(candidate_path + ";")
+            ):
+                self.write_oidc_transport_error(400, "bad_auth_request")
+                return True
+            if routes.handles(raw_parsed.path):
+                parsed = raw_parsed
+        request_parts = None
+        raw_target = None
+        raw_parsed = None
+        candidate_path = None
+        if routes is None or not routes.handles(parsed.path):
+            return False
+        if parsed.scheme or parsed.netloc or parsed.params:
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        try:
+            edge = thebitlab_github_oauth_http.EdgeRequestMetadata(
+                str(self.client_address[0]), tuple(self.headers.raw_items())
+            )
+            raw_query = parsed.query
+            if parsed.fragment:
+                raw_query += "#" + parsed.fragment
+            request = thebitlab_github_oauth_http.GitHubOAuthHttpRequest(
+                self.command,
+                parsed.path,
+                raw_query,
+                edge,
+                is_tls=isinstance(self.connection, ssl.SSLSocket),
+            )
+        except (ValueError, thebitlab_github_oauth_http.EdgeClientAttributionError):
+            self.write_oidc_transport_error(400, "bad_auth_request")
+            return True
+        try:
+            response = routes.dispatch(request)
+            if response is None:
+                raise RuntimeError("Router GitHub senza risposta.")
+        except Exception:  # noqa: BLE001
+            self.write_oidc_transport_error(503, "authentication_unavailable")
+            return True
+        finally:
+            edge = None
+            request = None
+            raw_query = None
+        self.write_session_http_response(response)
+        return True
+
     def dispatch_google_oidc(self, parsed) -> bool:
         """Delegate exact Google auth routes to the injected secure router."""
 
@@ -4355,6 +4425,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return
         if self.dispatch_session_http(parsed):
             return
+        if self.dispatch_github_oauth(parsed):
+            return
         if self.dispatch_google_oidc(parsed):
             return
         self.send_error(501)
@@ -4364,6 +4436,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if self.dispatch_tui_pairing_http(parsed):
             return
         if self.dispatch_session_http(parsed):
+            return
+        if self.dispatch_github_oauth(parsed):
             return
         if self.dispatch_google_oidc(parsed):
             return
@@ -4392,6 +4466,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if self.dispatch_tui_pairing_http(parsed):
             return
         if self.dispatch_session_http(parsed):
+            return
+        if self.dispatch_github_oauth(parsed):
             return
         if self.dispatch_google_oidc(parsed):
             return
@@ -4539,6 +4615,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if self.dispatch_tui_pairing_http(parsed):
             return
         if self.dispatch_session_http(parsed):
+            return
+        if self.dispatch_github_oauth(parsed):
             return
         if self.dispatch_google_oidc(parsed):
             return
@@ -5052,6 +5130,7 @@ def main() -> int:
         if auth_runtime is not None:
             server.google_oidc_runtime = auth_runtime
             server.google_oidc_http_routes = auth_runtime.routes
+            server.github_oauth_http_routes = auth_runtime.github_routes
             server.session_http_routes = auth_runtime.session_routes
             server.tui_pairing_http_routes = auth_runtime.tui_pairing_routes
         if not is_loopback_bind_host(args.host):

--- a/scripts/thebitlab_auth_runtime.py
+++ b/scripts/thebitlab_auth_runtime.py
@@ -15,6 +15,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from scripts.thebitlab_auth_services import (
+    ExternalIdentityLinkService,
     FederatedIdentityService,
     PairingService,
     SessionService,
@@ -33,6 +34,13 @@ from scripts.thebitlab_google_oidc import (
     UrllibGoogleTokenTransport,
 )
 from scripts.thebitlab_google_oidc_http import GoogleOidcHttpRoutes
+from scripts.thebitlab_github_oauth import (
+    GitHubAccountLinkService,
+    GitHubOAuthConfig,
+    InMemoryGitHubLinkFlowStore,
+    UrllibGitHubOAuthTransport,
+)
+from scripts.thebitlab_github_oauth_http import GitHubOAuthHttpRoutes
 from scripts.thebitlab_http_auth import HttpSessionAuthBoundary, SessionCookiePolicy
 from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
 from scripts.thebitlab_session_http import SessionHttpRoutes
@@ -44,6 +52,7 @@ from scripts.thebitlab_tui_pairing_http import (
 
 _SECRET_RE = re.compile(r"^[A-Za-z0-9_-]{43,86}$")
 _CALLBACK_PATH = "/auth/google/callback"
+_GITHUB_CALLBACK_PATH = "/auth/github/callback"
 _DEFAULT_DATABASE_NAME = ".thebitlab-auth/auth.sqlite3"
 _WINDOWS_REPARSE_POINT = 0x400
 _SID_RE = re.compile(r"^S-1-(?:[0-9]+-)+[0-9]+$")
@@ -59,13 +68,19 @@ class AuthRuntimeConfigurationError(RuntimeError):
 class GoogleOidcRuntime:
     """Own the composed service graph while exposing only its HTTP routes."""
 
-    __slots__ = ("_routes", "_session_routes", "_tui_pairing_routes")
+    __slots__ = (
+        "_routes",
+        "_session_routes",
+        "_tui_pairing_routes",
+        "_github_routes",
+    )
 
     def __init__(
         self,
         routes: GoogleOidcHttpRoutes,
         session_routes: SessionHttpRoutes,
         tui_pairing_routes: TuiPairingHttpRoutes,
+        github_routes: GitHubOAuthHttpRoutes | None = None,
     ) -> None:
         if (
             type(routes) is not GoogleOidcHttpRoutes
@@ -75,11 +90,20 @@ class GoogleOidcRuntime:
             or type(tui_pairing_routes) is not TuiPairingHttpRoutes
             or tui_pairing_routes.proxy_resolver is not routes.proxy_resolver
             or tui_pairing_routes.boundary.http_sessions is not routes.session_discarder
+            or (
+                github_routes is not None
+                and (
+                    type(github_routes) is not GitHubOAuthHttpRoutes
+                    or github_routes.http_sessions is not routes.session_discarder
+                    or github_routes.proxy_resolver is not routes.proxy_resolver
+                )
+            )
         ):
             raise AuthRuntimeConfigurationError("Grafo autenticazione non valido.")
         self._routes = routes
         self._session_routes = session_routes
         self._tui_pairing_routes = tui_pairing_routes
+        self._github_routes = github_routes
 
     @property
     def routes(self) -> GoogleOidcHttpRoutes:
@@ -92,6 +116,10 @@ class GoogleOidcRuntime:
     @property
     def tui_pairing_routes(self) -> TuiPairingHttpRoutes:
         return self._tui_pairing_routes
+
+    @property
+    def github_routes(self) -> GitHubOAuthHttpRoutes | None:
+        return self._github_routes
 
     def __repr__(self) -> str:
         return "GoogleOidcRuntime(configured=True)"
@@ -125,6 +153,10 @@ def compose_google_oidc_runtime(
     pairing_sessions = None
     tui_sessions = None
     pairing_boundary = None
+    github_client_secret = None
+    github_config = None
+    github_service = None
+    github_routes = None
     try:
         client_id = _required(environment, "THEBITLAB_GOOGLE_CLIENT_ID")
         client_secret = _required(environment, "THEBITLAB_GOOGLE_CLIENT_SECRET")
@@ -217,7 +249,54 @@ def compose_google_oidc_runtime(
                 pepper=rate_limit_pepper,
             ),
         )
-        return GoogleOidcRuntime(routes, session_routes, tui_pairing_routes)
+        github_values = {
+            name: environment.get(name)
+            for name in (
+                "THEBITLAB_GITHUB_CLIENT_ID",
+                "THEBITLAB_GITHUB_CLIENT_SECRET",
+                "THEBITLAB_GITHUB_REDIRECT_URI",
+            )
+        }
+        if any(value is not None for value in github_values.values()):
+            github_client_id = _required(environment, "THEBITLAB_GITHUB_CLIENT_ID")
+            github_client_secret = _required(environment, "THEBITLAB_GITHUB_CLIENT_SECRET")
+            github_redirect_uri = _required(environment, "THEBITLAB_GITHUB_REDIRECT_URI")
+            parsed_github_callback = urllib.parse.urlsplit(github_redirect_uri)
+            if (
+                parsed_github_callback.path != _GITHUB_CALLBACK_PATH
+                or parsed_github_callback.query
+                or parsed_github_callback.fragment
+            ):
+                raise AuthRuntimeConfigurationError(
+                    "THEBITLAB_GITHUB_REDIRECT_URI deve terminare con il path callback canonico."
+                )
+            github_post_link_path = environment.get(
+                "THEBITLAB_GITHUB_POST_LINK_PATH", "/tools/course_board.html"
+            )
+            _validate_post_login_path(github_post_link_path)
+            github_config = GitHubOAuthConfig(
+                github_client_id,
+                github_client_secret,
+                github_redirect_uri,
+                post_link_path=github_post_link_path,
+            )
+            github_service = GitHubAccountLinkService(
+                github_config,
+                InMemoryGitHubLinkFlowStore(),
+                UrllibGitHubOAuthTransport(),
+                ExternalIdentityLinkService(storage, expected_provider="github"),
+            )
+            github_routes = GitHubOAuthHttpRoutes(
+                github_service,
+                http_sessions,
+                proxy_resolver,
+            )
+        return GoogleOidcRuntime(
+            routes,
+            session_routes,
+            tui_pairing_routes,
+            github_routes,
+        )
     except AuthRuntimeConfigurationError:
         raise
     except Exception:
@@ -246,6 +325,10 @@ def compose_google_oidc_runtime(
         pairing_sessions = None
         tui_sessions = None
         pairing_boundary = None
+        github_client_secret = None
+        github_config = None
+        github_service = None
+        github_routes = None
 
 
 def _require_auth_dependencies() -> None:

--- a/scripts/thebitlab_auth_runtime.py
+++ b/scripts/thebitlab_auth_runtime.py
@@ -40,7 +40,10 @@ from scripts.thebitlab_github_oauth import (
     InMemoryGitHubLinkFlowStore,
     UrllibGitHubOAuthTransport,
 )
-from scripts.thebitlab_github_oauth_http import GitHubOAuthHttpRoutes
+from scripts.thebitlab_github_oauth_http import (
+    GitHubLinkHttpRateLimiter,
+    GitHubOAuthHttpRoutes,
+)
 from scripts.thebitlab_http_auth import HttpSessionAuthBoundary, SessionCookiePolicy
 from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
 from scripts.thebitlab_session_http import SessionHttpRoutes
@@ -249,15 +252,15 @@ def compose_google_oidc_runtime(
                 pepper=rate_limit_pepper,
             ),
         )
-        github_values = {
-            name: environment.get(name)
+        github_configured = any(
+            environment.get(name) is not None
             for name in (
                 "THEBITLAB_GITHUB_CLIENT_ID",
                 "THEBITLAB_GITHUB_CLIENT_SECRET",
                 "THEBITLAB_GITHUB_REDIRECT_URI",
             )
-        }
-        if any(value is not None for value in github_values.values()):
+        )
+        if github_configured:
             github_client_id = _required(environment, "THEBITLAB_GITHUB_CLIENT_ID")
             github_client_secret = _required(environment, "THEBITLAB_GITHUB_CLIENT_SECRET")
             github_redirect_uri = _required(environment, "THEBITLAB_GITHUB_REDIRECT_URI")
@@ -290,6 +293,10 @@ def compose_google_oidc_runtime(
                 github_service,
                 http_sessions,
                 proxy_resolver,
+                GitHubLinkHttpRateLimiter(
+                    rate_limit_store,
+                    pepper=rate_limit_pepper,
+                ),
             )
         return GoogleOidcRuntime(
             routes,

--- a/scripts/thebitlab_github_oauth_http.py
+++ b/scripts/thebitlab_github_oauth_http.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import re
 import urllib.parse
 from dataclasses import dataclass, field
-from typing import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Callable, Mapping, Sequence
 
 from scripts.thebitlab_edge_rate_limit import (
+    AtomicRateLimitStore,
     EdgeClientAttributionError,
+    EdgeRateLimitExceededError,
+    EdgeRateLimitStoreError,
     EdgeRequestMetadata,
+    RateLimitBucket,
     TrustedProxyClientResolver,
 )
 from scripts.thebitlab_github_oauth import (
@@ -103,6 +110,50 @@ class GitHubOAuthHttpResponse:
             raise ValueError("Risposta GitHub HTTP non valida.")
 
 
+class GitHubLinkHttpRateLimiter:
+    """Bound authenticated flow allocation globally and per web session."""
+
+    def __init__(
+        self,
+        store: AtomicRateLimitStore,
+        *,
+        pepper: bytes,
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        if not callable(getattr(store, "admit", None)) or type(pepper) is not bytes or len(pepper) < 32:
+            raise ValueError("Rate limiter GitHub non valido.")
+        self.store = store
+        self.pepper = pepper
+        self.clock = clock
+
+    def admit(self, user_id: str, session_id: str) -> None:
+        if type(user_id) is not str or not user_id or type(session_id) is not str or not session_id:
+            raise EdgeRateLimitStoreError("Identità admission GitHub non valida.")
+        digest = hmac.new(
+            self.pepper,
+            b"thebitlab-github-link-rate-v1\0"
+            + user_id.encode("utf-8")
+            + b"\0"
+            + session_id.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        try:
+            now = self.clock()
+            retry_after = self.store.admit(
+                (
+                    RateLimitBucket("global:github-link", 1000, 600),
+                    RateLimitBucket(f"hmac-sha256:{digest}", 20, 600),
+                ),
+                now=now,
+            )
+        except EdgeRateLimitStoreError:
+            raise
+        except Exception as error:
+            raise EdgeRateLimitStoreError("Admission GitHub non disponibile.") from error
+        if retry_after is not None:
+            raise EdgeRateLimitExceededError(retry_after)
+
+
 class GitHubOAuthHttpRoutes:
     """Link, callback, and unlink routes bound to an authenticated web session."""
 
@@ -111,16 +162,19 @@ class GitHubOAuthHttpRoutes:
         service: GitHubAccountLinkService,
         http_sessions: HttpSessionAuthBoundary,
         proxy_resolver: TrustedProxyClientResolver,
+        rate_limiter: GitHubLinkHttpRateLimiter,
     ) -> None:
         if (
             type(service) is not GitHubAccountLinkService
             or type(http_sessions) is not HttpSessionAuthBoundary
             or type(proxy_resolver) is not TrustedProxyClientResolver
+            or type(rate_limiter) is not GitHubLinkHttpRateLimiter
         ):
             raise ValueError("Router GitHub non valido.")
         self.service = service
         self.http_sessions = http_sessions
         self.proxy_resolver = proxy_resolver
+        self.rate_limiter = rate_limiter
 
     def handles(self, path: str) -> bool:
         return path in {_LINK_PATH, _CALLBACK_PATH, _UNLINK_PATH}
@@ -149,6 +203,19 @@ class GitHubOAuthHttpRoutes:
             return self._unlink(request)
         except HttpAuthError as error:
             return self._error(error.status_code, error.error_code, error.public_message)
+        except EdgeRateLimitExceededError as error:
+            return self._error(
+                429,
+                error.error_code,
+                error.public_message,
+                (("Retry-After", str(error.retry_after_seconds)),),
+            )
+        except EdgeRateLimitStoreError:
+            return self._error(
+                503,
+                "auth_admission_unavailable",
+                "Servizio GitHub temporaneamente non disponibile.",
+            )
         except _GitHubHttpRequestError as error:
             return self._error(error.status_code, error.error_code, error.public_message)
         except GitHubLinkError as error:
@@ -189,7 +256,9 @@ class GitHubOAuthHttpRoutes:
     def _begin(self, request: GitHubOAuthHttpRequest) -> GitHubOAuthHttpResponse:
         if request.query:
             raise _GitHubHttpRequestError(400, "bad_auth_request", "Query non consentita.")
-        started = self.service.begin_link(self._context(request))
+        context = self._context(request)
+        self.rate_limiter.admit(context.user.user_id, context.session.session_id)
+        started = self.service.begin_link(context)
         if type(started) is not GitHubLinkAuthorizationRequest:
             raise GitHubLinkProviderUnavailableError("Avvio linking non valido.")
         location = _github_authorization_location(started.authorization_url)

--- a/scripts/thebitlab_github_oauth_http.py
+++ b/scripts/thebitlab_github_oauth_http.py
@@ -1,0 +1,450 @@
+"""Concrete authenticated HTTP routes for GitHub account linking."""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.parse
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence
+
+from scripts.thebitlab_edge_rate_limit import (
+    EdgeClientAttributionError,
+    EdgeRequestMetadata,
+    TrustedProxyClientResolver,
+)
+from scripts.thebitlab_github_oauth import (
+    GitHubAccountLinkService,
+    GitHubLinkAuthorizationRequest,
+    GitHubLinkCallbackError,
+    GitHubLinkCapacityError,
+    GitHubLinkConfigurationError,
+    GitHubLinkConsumedStateError,
+    GitHubLinkError,
+    GitHubLinkIdentityConflictError,
+    GitHubLinkProviderRejectedError,
+    GitHubLinkProviderUnavailableError,
+    GitHubLinkResult,
+    GitHubLinkStateError,
+)
+from scripts.thebitlab_http_auth import (
+    HttpAuthError,
+    HttpAuthRequest,
+    HttpSessionAuthBoundary,
+)
+from scripts.thebitlab_identity import ExternalIdentity
+
+_LINK_PATH = "/auth/github/link"
+_CALLBACK_PATH = "/auth/github/callback"
+_UNLINK_PATH = "/auth/github/unlink"
+_MAX_QUERY_BYTES = 8192
+_MAX_QUERY_FIELDS = 16
+_MAX_COOKIE_HEADER_BYTES = 16_384
+_MAX_RESPONSE_HEADER_BYTES = 16_384
+_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+_TRANSACTION_COOKIE_RE = re.compile(r"^__Host-thebitlab_github_link-[0-9a-f]{24}$")
+_COOKIE_VALUE_RE = re.compile(r"^[A-Za-z0-9_-]{32,256}$")
+
+
+@dataclass(frozen=True)
+class GitHubOAuthHttpRequest:
+    method: str
+    path: str
+    query: str = field(repr=False, compare=False)
+    edge: EdgeRequestMetadata
+    is_tls: bool = False
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.method) is not str
+            or not self.method
+            or len(self.method) > 65_535
+            or _HEADER_NAME_RE.fullmatch(self.method) is None
+            or type(self.path) is not str
+            or not self.path.startswith("/")
+            or len(self.path) > 256
+            or type(self.query) is not str
+            or len(self.query.encode("utf-8", errors="surrogatepass")) > _MAX_QUERY_BYTES
+            or type(self.edge) is not EdgeRequestMetadata
+            or type(self.is_tls) is not bool
+        ):
+            raise ValueError("Richiesta GitHub HTTP non valida.")
+
+
+@dataclass(frozen=True)
+class GitHubOAuthHttpResponse:
+    status_code: int
+    headers: tuple[tuple[str, str], ...] = field(repr=False, compare=False)
+    body: bytes = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if type(self.status_code) is not int or not 100 <= self.status_code <= 599:
+            raise ValueError("Risposta GitHub HTTP non valida.")
+        if type(self.headers) is not tuple or len(self.headers) > 32:
+            raise ValueError("Risposta GitHub HTTP non valida.")
+        total = 0
+        for item in self.headers:
+            if (
+                type(item) is not tuple
+                or len(item) != 2
+                or type(item[0]) is not str
+                or type(item[1]) is not str
+                or _HEADER_NAME_RE.fullmatch(item[0]) is None
+                or any(ord(character) < 32 or ord(character) == 127 for character in item[1])
+            ):
+                raise ValueError("Risposta GitHub HTTP non valida.")
+            try:
+                encoded = item[1].encode("latin-1")
+            except UnicodeEncodeError:
+                raise ValueError("Risposta GitHub HTTP non serializzabile.") from None
+            total += len(item[0]) + len(encoded) + 4
+        if total > _MAX_RESPONSE_HEADER_BYTES or type(self.body) is not bytes or len(self.body) > 4096:
+            raise ValueError("Risposta GitHub HTTP non valida.")
+
+
+class GitHubOAuthHttpRoutes:
+    """Link, callback, and unlink routes bound to an authenticated web session."""
+
+    def __init__(
+        self,
+        service: GitHubAccountLinkService,
+        http_sessions: HttpSessionAuthBoundary,
+        proxy_resolver: TrustedProxyClientResolver,
+    ) -> None:
+        if (
+            type(service) is not GitHubAccountLinkService
+            or type(http_sessions) is not HttpSessionAuthBoundary
+            or type(proxy_resolver) is not TrustedProxyClientResolver
+        ):
+            raise ValueError("Router GitHub non valido.")
+        self.service = service
+        self.http_sessions = http_sessions
+        self.proxy_resolver = proxy_resolver
+
+    def handles(self, path: str) -> bool:
+        return path in {_LINK_PATH, _CALLBACK_PATH, _UNLINK_PATH}
+
+    def dispatch(self, request: GitHubOAuthHttpRequest) -> GitHubOAuthHttpResponse | None:
+        if type(request) is not GitHubOAuthHttpRequest:
+            return self._error(400, "bad_auth_request", "Richiesta non valida.")
+        if not self.handles(request.path):
+            return None
+        cleanup_cookie = None
+        try:
+            self._require_https(request)
+            self._require_empty_body(request.edge)
+            expected_method = "POST" if request.path == _UNLINK_PATH else "GET"
+            if request.method != expected_method:
+                return self._error(
+                    405,
+                    "auth_method_not_allowed",
+                    "Metodo non consentito.",
+                    (("Allow", expected_method),),
+                )
+            if request.path == _LINK_PATH:
+                return self._begin(request)
+            if request.path == _CALLBACK_PATH:
+                return self._callback(request)
+            return self._unlink(request)
+        except HttpAuthError as error:
+            return self._error(error.status_code, error.error_code, error.public_message)
+        except _GitHubHttpRequestError as error:
+            return self._error(error.status_code, error.error_code, error.public_message)
+        except GitHubLinkError as error:
+            cleanup_cookie = getattr(error, "clear_transaction_cookie", None)
+            extra = ()
+            if cleanup_cookie is not None:
+                extra = (("Set-Cookie", _validated_transaction_cookie(cleanup_cookie, clear=True)),)
+            if isinstance(error, (GitHubLinkStateError, GitHubLinkCallbackError, GitHubLinkConsumedStateError)):
+                return self._error(400, "invalid_oauth_callback", "Callback GitHub non valida.", extra)
+            if isinstance(error, GitHubLinkIdentityConflictError):
+                return self._error(409, "github_identity_conflict", "Account GitHub non collegabile.", extra)
+            if isinstance(error, GitHubLinkProviderRejectedError):
+                return self._error(400, "github_provider_rejected", "Risposta GitHub non valida.", extra)
+            if isinstance(error, GitHubLinkCapacityError):
+                return self._error(503, "github_link_capacity", "Servizio GitHub temporaneamente non disponibile.", extra)
+            if isinstance(error, (GitHubLinkProviderUnavailableError, GitHubLinkConfigurationError)):
+                return self._error(503, "github_link_unavailable", "Servizio GitHub temporaneamente non disponibile.", extra)
+            return self._error(503, "github_link_unavailable", "Servizio GitHub temporaneamente non disponibile.", extra)
+        except EdgeClientAttributionError:
+            return self._error(400, "invalid_client_address", "Indirizzo client non valido.")
+        except Exception:
+            return self._error(503, "github_link_unavailable", "Servizio GitHub temporaneamente non disponibile.")
+        finally:
+            request = None
+            cleanup_cookie = None
+
+    def _context(self, request: GitHubOAuthHttpRequest, *, csrf: bool = False):
+        cookie = _combined_cookie_header(request.edge.headers)
+        csrf_token = _single_header(request.edge.headers, "x-csrf-token") if csrf else None
+        try:
+            return self.http_sessions.authenticate(
+                HttpAuthRequest(request.method, cookie_header=cookie, csrf_token=csrf_token)
+            )
+        finally:
+            cookie = None
+            csrf_token = None
+
+    def _begin(self, request: GitHubOAuthHttpRequest) -> GitHubOAuthHttpResponse:
+        if request.query:
+            raise _GitHubHttpRequestError(400, "bad_auth_request", "Query non consentita.")
+        started = self.service.begin_link(self._context(request))
+        if type(started) is not GitHubLinkAuthorizationRequest:
+            raise GitHubLinkProviderUnavailableError("Avvio linking non valido.")
+        location = _github_authorization_location(started.authorization_url)
+        cookie = _validated_transaction_cookie(started.set_cookie)
+        return GitHubOAuthHttpResponse(
+            302,
+            (
+                ("Location", location),
+                ("Set-Cookie", cookie),
+                ("Cache-Control", "no-store"),
+                ("Pragma", "no-cache"),
+                ("Referrer-Policy", "no-referrer"),
+                ("Content-Length", "0"),
+            ),
+            b"",
+        )
+
+    def _callback(self, request: GitHubOAuthHttpRequest) -> GitHubOAuthHttpResponse:
+        parameters = _callback_query(request.query)
+        cookie = _combined_cookie_header(request.edge.headers)
+        context = self._context(request)
+        expected_user_id = context.user.user_id
+        try:
+            result = self.service.complete_link(parameters, cookie_header=cookie, context=context)
+        finally:
+            parameters = None
+            cookie = None
+            context = None
+        if (
+            type(result) is not GitHubLinkResult
+            or type(result.identity) is not ExternalIdentity
+            or result.identity.provider != "github"
+            or result.identity.user_id != expected_user_id
+        ):
+            raise GitHubLinkProviderUnavailableError("Risultato linking non valido.")
+        location = _local_redirect(result.redirect_path)
+        clear_cookie = _validated_transaction_cookie(result.clear_transaction_cookie, clear=True)
+        return GitHubOAuthHttpResponse(
+            303,
+            (
+                ("Location", location),
+                ("Set-Cookie", clear_cookie),
+                ("Cache-Control", "no-store"),
+                ("Pragma", "no-cache"),
+                ("Referrer-Policy", "no-referrer"),
+                ("Content-Length", "0"),
+            ),
+            b"",
+        )
+
+    def _unlink(self, request: GitHubOAuthHttpRequest) -> GitHubOAuthHttpResponse:
+        if request.query:
+            raise _GitHubHttpRequestError(400, "bad_auth_request", "Query non consentita.")
+        context = self._context(request, csrf=True)
+        identity = self.service.links.unlink(
+            context.user.user_id,
+            expected_session=context.session,
+        )
+        if (
+            type(identity) is not ExternalIdentity
+            or identity.provider != "github"
+            or identity.user_id != context.user.user_id
+        ):
+            raise GitHubLinkProviderUnavailableError("Risultato unlink non valido.")
+        return GitHubOAuthHttpResponse(
+            204,
+            (
+                ("Cache-Control", "no-store"),
+                ("Pragma", "no-cache"),
+                ("Referrer-Policy", "no-referrer"),
+                ("Content-Length", "0"),
+            ),
+            b"",
+        )
+
+    def _require_https(self, request: GitHubOAuthHttpRequest) -> None:
+        if request.is_tls:
+            return
+        if not self.proxy_resolver.is_trusted_peer(request.edge):
+            raise _GitHubHttpRequestError(400, "https_required", "HTTPS obbligatorio.")
+        forwarded = [
+            value.strip().lower()
+            for name, value in request.edge.headers
+            if name.lower() == "x-forwarded-proto"
+        ]
+        if forwarded != ["https"]:
+            raise _GitHubHttpRequestError(400, "https_required", "HTTPS obbligatorio.")
+
+    @staticmethod
+    def _require_empty_body(edge: EdgeRequestMetadata) -> None:
+        lengths = [value.strip() for name, value in edge.headers if name.lower() == "content-length"]
+        transfers = [value for name, value in edge.headers if name.lower() == "transfer-encoding"]
+        if transfers or len(lengths) > 1 or (lengths and lengths != ["0"]):
+            raise _GitHubHttpRequestError(400, "bad_auth_request", "Body non consentito.")
+
+    @staticmethod
+    def _error(
+        status_code: int,
+        error_code: str,
+        message: str,
+        extra_headers: tuple[tuple[str, str], ...] = (),
+    ) -> GitHubOAuthHttpResponse:
+        body = json.dumps(
+            {"error": error_code, "message": message},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return GitHubOAuthHttpResponse(
+            status_code,
+            extra_headers
+            + (
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Cache-Control", "no-store"),
+                ("Referrer-Policy", "no-referrer"),
+                ("Content-Length", str(len(body))),
+            ),
+            body,
+        )
+
+
+class _GitHubHttpRequestError(RuntimeError):
+    def __init__(self, status_code: int, error_code: str, public_message: str) -> None:
+        self.status_code = status_code
+        self.error_code = error_code
+        self.public_message = public_message
+        super().__init__(public_message)
+
+
+def _single_header(headers: tuple[tuple[str, str], ...], name: str) -> str | None:
+    values = [value for key, value in headers if key.lower() == name]
+    if len(values) != 1:
+        return None
+    value = values[0]
+    if not value or len(value) > 4096 or any(ord(character) < 0x21 or ord(character) == 0x7F for character in value):
+        raise _GitHubHttpRequestError(400, "bad_auth_request", "Header non valido.")
+    return value
+
+
+def _combined_cookie_header(headers: tuple[tuple[str, str], ...]) -> str | None:
+    values = [value for name, value in headers if name.lower() == "cookie"]
+    if not values:
+        return None
+    combined = "; ".join(values)
+    if (
+        len(combined.encode("utf-8", errors="surrogatepass")) > _MAX_COOKIE_HEADER_BYTES
+        or any(ord(character) < 32 or ord(character) == 127 for character in combined)
+    ):
+        raise _GitHubHttpRequestError(400, "bad_auth_request", "Cookie non valido.")
+    return combined
+
+
+def _callback_query(raw_query: str) -> dict[str, tuple[str, ...]]:
+    if (
+        type(raw_query) is not str
+        or not raw_query
+        or len(raw_query.encode("utf-8", errors="surrogatepass")) > _MAX_QUERY_BYTES
+        or "#" in raw_query
+        or _PERCENT_ESCAPE_RE.search(raw_query) is not None
+    ):
+        raise _GitHubHttpRequestError(400, "bad_auth_request", "Query callback non valida.")
+    try:
+        parsed = urllib.parse.parse_qs(
+            raw_query,
+            keep_blank_values=True,
+            strict_parsing=True,
+            max_num_fields=_MAX_QUERY_FIELDS,
+            encoding="utf-8",
+            errors="strict",
+        )
+    except (UnicodeError, ValueError):
+        raise _GitHubHttpRequestError(400, "bad_auth_request", "Query callback non valida.") from None
+    return {key: tuple(values) for key, values in parsed.items()}
+
+
+def _github_authorization_location(value: object) -> str:
+    if type(value) is not str or not value or len(value) > 8192:
+        raise ValueError("Redirect GitHub non valido.")
+    parsed = urllib.parse.urlsplit(value)
+    try:
+        port = parsed.port
+    except ValueError:
+        raise ValueError("Redirect GitHub non valido.") from None
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "github.com"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in {None, 443}
+        or parsed.path != "/login/oauth/authorize"
+        or not parsed.query
+        or parsed.fragment
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise ValueError("Redirect GitHub non valido.")
+    value.encode("ascii")
+    return value
+
+
+def _local_redirect(value: object) -> str:
+    if type(value) is not str or not value or len(value) > 2048:
+        raise ValueError("Redirect locale non valido.")
+    parsed = urllib.parse.urlsplit(value)
+    if (
+        not value.startswith("/")
+        or value.startswith("//")
+        or parsed.scheme
+        or parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or _PERCENT_ESCAPE_RE.search(value) is not None
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise ValueError("Redirect locale non valido.")
+    return urllib.parse.quote(value, safe="/-._~!$&'()*+,;=:@%")
+
+
+def _validated_transaction_cookie(value: object, *, clear: bool = False) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or len(value.encode("utf-8", errors="surrogatepass")) > 4096
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise ValueError("Cookie GitHub non valido.")
+    parts = [part.strip() for part in value.split(";")]
+    if not parts or "=" not in parts[0] or any(not part for part in parts):
+        raise ValueError("Cookie GitHub non valido.")
+    name, cookie_value = parts[0].split("=", 1)
+    flags: set[str] = set()
+    attributes: dict[str, str] = {}
+    for part in parts[1:]:
+        if "=" in part:
+            key, attribute = part.split("=", 1)
+            lowered = key.lower()
+            if lowered in attributes or lowered in flags:
+                raise ValueError("Cookie GitHub non valido.")
+            attributes[lowered] = attribute
+        else:
+            lowered = part.lower()
+            if lowered in attributes or lowered in flags:
+                raise ValueError("Cookie GitHub non valido.")
+            flags.add(lowered)
+    if (
+        _TRANSACTION_COOKIE_RE.fullmatch(name) is None
+        or flags != {"secure", "httponly"}
+        or attributes.get("path") != "/"
+        or attributes.get("samesite", "").lower() != "lax"
+        or set(attributes) - {"path", "samesite", "max-age", "expires"}
+    ):
+        raise ValueError("Cookie GitHub non valido.")
+    if clear:
+        valid = cookie_value == "" and attributes.get("max-age") == "0" and "expires" in attributes
+    else:
+        max_age = attributes.get("max-age", "")
+        valid = _COOKIE_VALUE_RE.fullmatch(cookie_value) is not None and max_age.isdigit() and 1 <= int(max_age) <= 1800
+    if not valid:
+        raise ValueError("Cookie GitHub non valido.")
+    return value

--- a/tests/test_thebitlab_auth_runtime.py
+++ b/tests/test_thebitlab_auth_runtime.py
@@ -60,6 +60,36 @@ def valid_environment() -> dict[str, str]:
     }
 
 
+def test_composition_adds_github_routes_only_with_complete_configuration(tmp_path: Path) -> None:
+    environment = valid_environment()
+    assert compose_google_oidc_runtime(environment, data_root=tmp_path).github_routes is None
+
+    environment.update(
+        {
+            "THEBITLAB_GITHUB_CLIENT_ID": "github-client-id-123",
+            "THEBITLAB_GITHUB_CLIENT_SECRET": "github-client-secret-raw",
+            "THEBITLAB_GITHUB_REDIRECT_URI": "https://lab.example.edu/auth/github/callback",
+        }
+    )
+    runtime = compose_google_oidc_runtime(environment, data_root=tmp_path)
+
+    assert runtime.github_routes is not None
+    assert runtime.github_routes.http_sessions is runtime.routes.session_discarder
+    assert runtime.github_routes.proxy_resolver is runtime.routes.proxy_resolver
+    assert runtime.github_routes.service.config.redirect_uri.endswith(
+        "/auth/github/callback"
+    )
+    assert environment["THEBITLAB_GITHUB_CLIENT_SECRET"] not in repr(runtime)
+
+
+def test_partial_github_runtime_configuration_fails_closed(tmp_path: Path) -> None:
+    environment = valid_environment()
+    environment["THEBITLAB_GITHUB_CLIENT_ID"] = "github-client-id-123"
+
+    with pytest.raises(AuthRuntimeConfigurationError):
+        compose_google_oidc_runtime(environment, data_root=tmp_path)
+
+
 def test_composition_builds_one_coherent_production_graph(tmp_path: Path) -> None:
     runtime = compose_google_oidc_runtime(valid_environment(), data_root=tmp_path)
 
@@ -302,7 +332,10 @@ def test_course_board_main_requires_explicit_google_auth_opt_in(
     from scripts import course_board_server
 
     runtime = SimpleNamespace(
-        routes=object(), session_routes=object(), tui_pairing_routes=object()
+        routes=object(),
+        session_routes=object(),
+        tui_pairing_routes=object(),
+        github_routes=None,
     )
     composition_calls = []
     servers = []

--- a/tests/test_thebitlab_github_oauth_http.py
+++ b/tests/test_thebitlab_github_oauth_http.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from urllib.parse import parse_qs, urlsplit
+
+from scripts.thebitlab_auth_services import ExternalIdentityLinkService, SessionService
+from scripts.thebitlab_edge_rate_limit import EdgeRequestMetadata, TrustedProxyClientResolver
+from scripts.thebitlab_github_oauth import (
+    GitHubAccountLinkService,
+    GitHubOAuthConfig,
+    InMemoryGitHubLinkFlowStore,
+)
+from scripts.thebitlab_github_oauth_http import (
+    GitHubOAuthHttpRequest,
+    GitHubOAuthHttpRoutes,
+)
+from scripts.thebitlab_http_auth import HttpSessionAuthBoundary
+from scripts.thebitlab_identity import UserAccount
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+STATE = "s" * 43
+BROWSER = "b" * 43
+ACCESS_TOKEN = "token-" + "x" * 40
+
+
+class Clock:
+    def __call__(self):
+        return NOW
+
+
+class Transport:
+    def exchange_code(self, **_kwargs):
+        return {"access_token": ACCESS_TOKEN, "token_type": "bearer"}
+
+    def read_user(self, **_kwargs):
+        return {
+            "id": 123456,
+            "login": "mario-gh",
+            "name": "Mario Rossi",
+            "email": None,
+        }
+
+
+def setup_routes(tmp_path):
+    clock = Clock()
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3", clock=clock)
+    storage.create_user(
+        UserAccount("user-01", "Mario", "student", True, NOW, NOW)
+    )
+    sessions = SessionService(
+        storage,
+        clock=clock,
+        token_factory=lambda: "A" * 40,
+        session_id_factory=lambda: "session-01",
+    )
+    http = HttpSessionAuthBoundary(sessions, csrf_secret=b"c" * 32, clock=clock)
+    established = http.establish_session("user-01")
+    service = GitHubAccountLinkService(
+        GitHubOAuthConfig(
+            "github-client-id-123",
+            "github-client-secret-raw",
+            "https://lab.example.test/auth/github/callback",
+            post_link_path="/tools/course_board.html",
+        ),
+        InMemoryGitHubLinkFlowStore(),
+        Transport(),
+        ExternalIdentityLinkService(storage, expected_provider="github", clock=clock),
+        clock=clock,
+        state_factory=lambda: STATE,
+        verifier_factory=lambda: "v" * 64,
+        browser_factory=lambda: BROWSER,
+    )
+    routes = GitHubOAuthHttpRoutes(
+        service,
+        http,
+        TrustedProxyClientResolver(()),
+    )
+    session_cookie = established.set_cookie.split(";", 1)[0]
+    return routes, storage, established, session_cookie
+
+
+def request(path, *, method="GET", query="", headers=()):
+    return GitHubOAuthHttpRequest(
+        method,
+        path,
+        query,
+        EdgeRequestMetadata("127.0.0.1", tuple(headers)),
+        is_tls=True,
+    )
+
+
+def header(response, name):
+    return [value for key, value in response.headers if key.lower() == name.lower()]
+
+
+def test_authenticated_link_callback_and_unlink_round_trip(tmp_path) -> None:
+    routes, storage, established, session_cookie = setup_routes(tmp_path)
+
+    started = routes.dispatch(
+        request("/auth/github/link", headers=(("Cookie", session_cookie),))
+    )
+    assert started.status_code == 302
+    location = header(started, "Location")[0]
+    assert urlsplit(location).hostname == "github.com"
+    assert urlsplit(location).path == "/login/oauth/authorize"
+    assert parse_qs(urlsplit(location).query)["state"] == [STATE]
+    transaction_cookie = header(started, "Set-Cookie")[0].split(";", 1)[0]
+
+    completed = routes.dispatch(
+        request(
+            "/auth/github/callback",
+            query=f"code={'c' * 32}&state={STATE}",
+            headers=(("Cookie", session_cookie), ("Cookie", transaction_cookie)),
+        )
+    )
+    assert completed.status_code == 303
+    assert header(completed, "Location") == ["/tools/course_board.html"]
+    assert "Max-Age=0" in header(completed, "Set-Cookie")[0]
+    assert storage.read_external_identity("github", "123456").user_id == "user-01"
+
+    unlinked = routes.dispatch(
+        request(
+            "/auth/github/unlink",
+            method="POST",
+            headers=(
+                ("Cookie", session_cookie),
+                ("X-CSRF-Token", established.context.csrf_token),
+                ("Content-Length", "0"),
+            ),
+        )
+    )
+    assert unlinked.status_code == 204
+    assert unlinked.body == b""
+    assert storage.read_external_identity("github", "123456") is None
+
+
+def test_routes_require_https_session_csrf_and_exact_methods(tmp_path) -> None:
+    routes, _storage, _established, session_cookie = setup_routes(tmp_path)
+
+    anonymous = routes.dispatch(request("/auth/github/link"))
+    assert anonymous.status_code == 401
+
+    insecure = GitHubOAuthHttpRequest(
+        "GET",
+        "/auth/github/link",
+        "",
+        EdgeRequestMetadata("127.0.0.1", (("Cookie", session_cookie),)),
+        is_tls=False,
+    )
+    assert routes.dispatch(insecure).status_code == 400
+
+    wrong_method = routes.dispatch(
+        request("/auth/github/link", method="POST", headers=(("Cookie", session_cookie),))
+    )
+    assert wrong_method.status_code == 405
+    assert header(wrong_method, "Allow") == ["GET"]
+
+    no_csrf = routes.dispatch(
+        request(
+            "/auth/github/unlink",
+            method="POST",
+            headers=(("Cookie", session_cookie), ("Content-Length", "0")),
+        )
+    )
+    assert no_csrf.status_code == 403
+
+
+def test_callback_rejects_duplicate_or_malformed_parameters_without_secrets(tmp_path) -> None:
+    routes, _storage, _established, session_cookie = setup_routes(tmp_path)
+    started = routes.dispatch(
+        request("/auth/github/link", headers=(("Cookie", session_cookie),))
+    )
+    transaction_cookie = header(started, "Set-Cookie")[0].split(";", 1)[0]
+
+    response = routes.dispatch(
+        request(
+            "/auth/github/callback",
+            query=f"code=one&code=two&state={STATE}",
+            headers=(("Cookie", f"{session_cookie}; {transaction_cookie}"),),
+        )
+    )
+
+    assert response.status_code == 400
+    serialized = repr(response) + response.body.decode("utf-8")
+    assert STATE not in serialized
+    assert BROWSER not in serialized
+    assert "one" not in serialized
+    assert "two" not in serialized

--- a/tests/test_thebitlab_github_oauth_http.py
+++ b/tests/test_thebitlab_github_oauth_http.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from urllib.parse import parse_qs, urlsplit
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit, urlparse
+
+from scripts.course_board_server import CourseBoardHandler
 
 from scripts.thebitlab_auth_services import ExternalIdentityLinkService, SessionService
 from scripts.thebitlab_edge_rate_limit import (
@@ -103,6 +106,35 @@ def request(path, *, method="GET", query="", headers=()):
 
 def header(response, name):
     return [value for key, value in response.headers if key.lower() == name.lower()]
+
+
+def test_handler_closes_connection_when_auth_body_framing_is_rejected() -> None:
+    class Headers:
+        def raw_items(self):
+            return [("Content-Length", "5")]
+
+    class Routes:
+        @staticmethod
+        def handles(path):
+            return path == "/auth/github/link"
+
+        @staticmethod
+        def dispatch(_request):
+            return SimpleNamespace(status_code=400, headers=(), body=b"")
+
+    handler = object.__new__(CourseBoardHandler)
+    handler.server = SimpleNamespace(github_oauth_http_routes=Routes())
+    handler.requestline = "GET /auth/github/link HTTP/1.1"
+    handler.path = "/auth/github/link"
+    handler.command = "GET"
+    handler.client_address = ("127.0.0.1", 12345)
+    handler.headers = Headers()
+    handler.connection = object()
+    handler.close_connection = False
+    handler.write_session_http_response = lambda _response: None
+
+    assert handler.dispatch_github_oauth(urlparse(handler.path)) is True
+    assert handler.close_connection is True
 
 
 def test_flow_allocation_is_bounded_per_authenticated_session() -> None:

--- a/tests/test_thebitlab_github_oauth_http.py
+++ b/tests/test_thebitlab_github_oauth_http.py
@@ -4,13 +4,19 @@ from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlsplit
 
 from scripts.thebitlab_auth_services import ExternalIdentityLinkService, SessionService
-from scripts.thebitlab_edge_rate_limit import EdgeRequestMetadata, TrustedProxyClientResolver
+from scripts.thebitlab_edge_rate_limit import (
+    EdgeRateLimitExceededError,
+    EdgeRequestMetadata,
+    InMemoryAtomicRateLimitStore,
+    TrustedProxyClientResolver,
+)
 from scripts.thebitlab_github_oauth import (
     GitHubAccountLinkService,
     GitHubOAuthConfig,
     InMemoryGitHubLinkFlowStore,
 )
 from scripts.thebitlab_github_oauth_http import (
+    GitHubLinkHttpRateLimiter,
     GitHubOAuthHttpRequest,
     GitHubOAuthHttpRoutes,
 )
@@ -75,6 +81,11 @@ def setup_routes(tmp_path):
         service,
         http,
         TrustedProxyClientResolver(()),
+        GitHubLinkHttpRateLimiter(
+            InMemoryAtomicRateLimitStore(),
+            pepper=b"r" * 32,
+            clock=clock,
+        ),
     )
     session_cookie = established.set_cookie.split(";", 1)[0]
     return routes, storage, established, session_cookie
@@ -92,6 +103,24 @@ def request(path, *, method="GET", query="", headers=()):
 
 def header(response, name):
     return [value for key, value in response.headers if key.lower() == name.lower()]
+
+
+def test_flow_allocation_is_bounded_per_authenticated_session() -> None:
+    limiter = GitHubLinkHttpRateLimiter(
+        InMemoryAtomicRateLimitStore(),
+        pepper=b"r" * 32,
+        clock=Clock(),
+    )
+
+    for _attempt in range(20):
+        limiter.admit("user-01", "session-01")
+
+    try:
+        limiter.admit("user-01", "session-01")
+    except EdgeRateLimitExceededError as error:
+        assert 1 <= error.retry_after_seconds <= 600
+    else:
+        raise AssertionError("the 21st flow allocation must be rejected")
 
 
 def test_authenticated_link_callback_and_unlink_round_trip(tmp_path) -> None:

--- a/tests/test_thebitlab_github_oauth_http.py
+++ b/tests/test_thebitlab_github_oauth_http.py
@@ -124,14 +124,15 @@ def test_handler_closes_connection_when_auth_body_framing_is_rejected() -> None:
 
     handler = object.__new__(CourseBoardHandler)
     handler.server = SimpleNamespace(github_oauth_http_routes=Routes())
-    handler.requestline = "GET /auth/github/link HTTP/1.1"
-    handler.path = "/auth/github/link"
+    handler.requestline = "GET https://evil.test/auth/github/link HTTP/1.1"
+    handler.path = "https://evil.test/auth/github/link"
     handler.command = "GET"
     handler.client_address = ("127.0.0.1", 12345)
     handler.headers = Headers()
     handler.connection = object()
     handler.close_connection = False
     handler.write_session_http_response = lambda _response: None
+    handler.write_oidc_transport_error = lambda _status, _code: None
 
     assert handler.dispatch_github_oauth(urlparse(handler.path)) is True
     assert handler.close_connection is True


### PR DESCRIPTION
## Summary
- add authenticated HTTPS routes for GitHub link, callback, and CSRF-protected unlink
- compose optional complete GitHub OAuth configuration into the existing auth runtime
- integrate canonical routing and secret-redacted logging in CourseBoardHandler
- document the definitive `/auth/github/callback` URL and environment contract

## Validation
- 229 targeted tests passed, 2 skipped
- py_compile and diff checks clean

Closes #603
Relates to #535 and #292