### PR TITLE
Aggiungi il ripristino completo della VM

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -181,6 +181,13 @@ Python installati da lui. L'executor registra separatamente i passi riusciti.
 La disinstallazione usa entrambi i registri, crea un backup del lavoro, richiede
 `DISINSTALLA` e non esegue mai `vagrant destroy`. Se trova una VM, si ferma.
 
+Dal menu è disponibile anche **Ripristina il PC - elimina anche la VM**. Questa
+modalità crea prima lo stesso backup, poi esegue `vagrant destroy --force`
+soltanto nelle directory di stato del progetto e rimuove il relativo disco.
+Elimina dalla cache esclusivamente box con namespace `2cornot2c/`; non tocca
+altre VM, box Bento o software preesistente. Il comando diretto richiede la
+frase distinta `DISINSTALLA TUTTO`.
+
 La parte VM non scarica ancora la box Packer reale e non avvia la VM. Questi
 passi verranno attivati dopo aver fissato URL, versione e checksum degli
 artefatti che superano il collaudo VirtualBox AMD64.

--- a/installer/lifecycle.py
+++ b/installer/lifecycle.py
@@ -11,6 +11,7 @@ WINDOWS_ACTION_SCRIPTS = {
     "launch": "launch-classroom-windows.ps1",
     "update": "update-classroom-windows.ps1",
     "uninstall": "uninstall-classroom-windows.ps1",
+    "reset": "uninstall-classroom-windows.ps1",
 }
 
 
@@ -41,8 +42,10 @@ def powershell_action_command(action: str) -> tuple[str, ...]:
         "-File",
         str(script),
     )
-    if action == "uninstall":
+    if action in {"uninstall", "reset"}:
         command += ("-ConfirmedFromTui",)
+    if action == "reset":
+        command += ("-DestroyClassroomVm",)
     return command
 
 

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -72,6 +72,7 @@ ACTION_LABELS = (
     "Installa, completa o ripara",
     "Aggiorna l'ambiente",
     "Disinstalla l'ambiente",
+    "Ripristina il PC - elimina anche la VM",
     "Esci",
 )
 
@@ -369,6 +370,15 @@ def open_home_action(state: State) -> None:
             "Verranno rimossi solo i componenti installati da 2cornot2c.",
             "Premi s per continuare oppure n per annullare.",
         )
+    elif state.action_index == 4:
+        state.confirmation_pending = True
+        state.report = (
+            "RIPRISTINO COMPLETO DEL PC",
+            "Gli esercizi condivisi verranno salvati in un backup.",
+            "La VM 2cornot2c e il suo disco verranno eliminati definitivamente.",
+            "Le altre VM presenti sul computer non verranno toccate.",
+            "Premi s per confermare oppure n per annullare.",
+        )
     else:
         state.running = False
 
@@ -376,7 +386,13 @@ def open_home_action(state: State) -> None:
 def confirm_home_action(state: State) -> None:
     """Passa l'operazione a una console separata e termina la TUI."""
 
-    action = "update" if state.action_index == 2 else "uninstall"
+    action = (
+        "update"
+        if state.action_index == 2
+        else "reset"
+        if state.action_index == 4
+        else "uninstall"
+    )
     launch_windows_action(action)
     state.confirmation_pending = False
     state.running = False

--- a/scripts/uninstall-classroom-windows.ps1
+++ b/scripts/uninstall-classroom-windows.ps1
@@ -1,5 +1,6 @@
 param(
-    [switch]$ConfirmedFromTui
+    [switch]$ConfirmedFromTui,
+    [switch]$DestroyClassroomVm
 )
 
 $ErrorActionPreference = "Stop"
@@ -74,7 +75,8 @@ function Test-SafeInstallDirectory {
                     @("Non rimuovere la cartella manualmente."; "Comunica E27 al docente.") $FullPath
             }
         }
-        if (Test-Path (Join-Path $FullPath ".vagrant")) {
+        if ((Test-Path (Join-Path $FullPath ".vagrant")) -and
+            -not $DestroyClassroomVm) {
             Stop-WithMessage "E28" "C'è ancora una macchina virtuale VirtualBox" `
                 "La VM può contenere file. Per evitare perdite non verrà eliminata automaticamente." `
                 @(
@@ -83,7 +85,8 @@ function Test-SafeInstallDirectory {
                     "Poi ripeti la disinstallazione."
                 )
         }
-        if (Test-Path (Join-Path $FullPath ".vagrant-vmware")) {
+        if ((Test-Path (Join-Path $FullPath ".vagrant-vmware")) -and
+            -not $DestroyClassroomVm) {
             Stop-WithMessage "E28" "C'è ancora una macchina virtuale VMware" `
                 "La VM può contenere file. Per evitare perdite non verrà eliminata automaticamente." `
                 @(
@@ -273,6 +276,75 @@ function Backup-StudentWork {
     return $Backup
 }
 
+function Remove-ClassroomVirtualMachines {
+    param([string]$Project)
+
+    $StateDirectories = @(
+        ".vagrant"
+        ".vagrant-vmware"
+    ) | Where-Object { Test-Path (Join-Path $Project $_) }
+    if ($StateDirectories.Count -eq 0) {
+        return
+    }
+    if (-not (Get-Command vagrant -ErrorAction SilentlyContinue)) {
+        Stop-WithMessage "E33" "Non posso eliminare la macchina virtuale" `
+            "La VM esiste, ma Vagrant non è disponibile. Nessun disco è stato cancellato." `
+            @(
+                "Non eliminare file o dischi manualmente."
+                "Comunica E33 al docente."
+            )
+    }
+
+    Push-Location $Project
+    try {
+        foreach ($StateDirectory in $StateDirectories) {
+            $PreviousDotfile = $env:VAGRANT_DOTFILE
+            $env:VAGRANT_DOTFILE = $StateDirectory
+            & vagrant destroy --force
+            $ExitCode = $LASTEXITCODE
+            if ($null -eq $PreviousDotfile) {
+                Remove-Item Env:VAGRANT_DOTFILE -ErrorAction SilentlyContinue
+            } else {
+                $env:VAGRANT_DOTFILE = $PreviousDotfile
+            }
+            if ($ExitCode -ne 0) {
+                Stop-WithMessage "E33" "La VM non è stata eliminata" `
+                    "Vagrant non ha confermato la rimozione del disco. La disinstallazione si è fermata per sicurezza." `
+                    @(
+                        "Chiudi VirtualBox e VMware."
+                        "Riprova il ripristino completo."
+                        "Se ricompare, comunica E33 al docente."
+                    ) "vagrant destroy exit code $ExitCode; $StateDirectory"
+            }
+            $StatePath = Join-Path $Project $StateDirectory
+            if (Test-Path $StatePath) {
+                Remove-Item -LiteralPath $StatePath -Recurse -Force
+            }
+        }
+    } finally {
+        Pop-Location
+    }
+
+    $BoxFile = Join-Path $Project ".classroom-box"
+    if (Test-Path $BoxFile) {
+        $BoxName = (Get-Content $BoxFile -Raw).Trim()
+        if ($BoxName -match "^2cornot2c/") {
+            $ProviderFile = Join-Path $Project ".classroom-provider"
+            $ProviderArgs = @()
+            if (Test-Path $ProviderFile) {
+                $Provider = (Get-Content $ProviderFile -Raw).Trim()
+                if ($Provider -match "^[a-z0-9_-]+$") {
+                    $ProviderArgs = @("--provider", $Provider)
+                }
+            }
+            & vagrant box remove $BoxName @ProviderArgs --force
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "Box $BoxName già assente o non rimovibile."
+            }
+        }
+    }
+}
+
 $SafeInstallDir = Test-SafeInstallDirectory
 $OwnedPackages = Get-OwnedPackages
 $OwnedWsl = Test-WslInstalledByClassroom
@@ -305,8 +377,13 @@ if ($OwnedWsl) {
 if (-not $ConfirmedFromTui) {
     Write-Host ""
     Write-Host "lab, lab2 e modifiche locali verranno salvati prima della rimozione."
-    $Confirmation = Read-Host "Digita esattamente DISINSTALLA"
-    if ($Confirmation -ne "DISINSTALLA") {
+    $RequiredConfirmation = if ($DestroyClassroomVm) {
+        "DISINSTALLA TUTTO"
+    } else {
+        "DISINSTALLA"
+    }
+    $Confirmation = Read-Host "Digita esattamente $RequiredConfirmation"
+    if ($Confirmation -ne $RequiredConfirmation) {
         Write-Host "Disinstallazione annullata senza modifiche."
         exit 2
     }
@@ -328,6 +405,11 @@ try {
 }
 if ($BackupPath) {
     Write-Host "Backup creato: $BackupPath"
+}
+
+if ($DestroyClassroomVm) {
+    Write-Host "Eliminazione della VM 2cornot2c e del relativo disco..."
+    Remove-ClassroomVirtualMachines $SafeInstallDir
 }
 
 if ($ImageReference -and (Get-Command docker -ErrorAction SilentlyContinue)) {

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -159,6 +159,7 @@ def test_tui_home_exposes_the_complete_lifecycle() -> None:
     assert "Installa, completa o ripara" in rendered
     assert "Aggiorna l'ambiente" in rendered
     assert "Disinstalla l'ambiente" in rendered
+    assert "Ripristina il PC - elimina anche la VM" in rendered
 
 
 def test_tui_uninstall_requires_confirmation_and_launches_separately(
@@ -214,8 +215,40 @@ def test_windows_lifecycle_uses_only_persistent_known_scripts(
         str(launcher / "uninstall-classroom-windows.ps1"),
     )
     assert command[-1] == "-ConfirmedFromTui"
+
+    reset_command = powershell_action_command("reset")
+    assert reset_command[-2:] == (
+        "-ConfirmedFromTui",
+        "-DestroyClassroomVm",
+    )
     with pytest.raises(ValueError, match="non supportata"):
         powershell_action_command("qualcosa")
+
+
+def test_tui_complete_reset_requires_destructive_confirmation(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("utui")
+    from installer.tui import State, confirm_home_action, open_home_action
+
+    launched = []
+    monkeypatch.setattr(
+        "installer.tui.launch_windows_action",
+        lambda action: launched.append(action),
+    )
+    state = State(
+        Host.WINDOWS_AMD64,
+        (Provider.VIRTUALBOX,),
+        screen="home",
+        action_index=4,
+    )
+
+    open_home_action(state)
+    assert state.confirmation_pending is True
+    assert "eliminati definitivamente" in " ".join(state.report)
+
+    confirm_home_action(state)
+    assert launched == ["reset"]
 
 
 def test_tui_launches_environment_without_showing_python_commands(

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -87,10 +87,14 @@ def test_windows_lifecycle_scripts_keep_destructive_actions_guarded() -> None:
     assert "bootstrap-classroom-windows.ps1" in update
     assert ".installer-venv\\Scripts\\python.exe" in manager
     assert "bootstrap-classroom-windows.ps1" in manager
-    assert 'if ($Confirmation -ne "DISINSTALLA")' in uninstall
+    assert "if ($Confirmation -ne $RequiredConfirmation)" in uninstall
     assert "Remove-Item -LiteralPath $SafeInstallDir" in uninstall
     assert "TheBitPoets/2cornot2c" in uninstall
-    assert "vagrant destroy" not in uninstall
+    assert "Remove-ClassroomVirtualMachines" in uninstall
+    assert "vagrant destroy --force" in uninstall
+    assert '"DISINSTALLA TUTTO"' in uninstall
+    assert "[switch]$DestroyClassroomVm" in uninstall
+    assert '"^2cornot2c/"' in uninstall
     assert "docker image rm $ImageReference" in uninstall
     assert "docker image rm --force" not in uninstall
     assert "Ambiente 2cornot2c.lnk" in uninstall


### PR DESCRIPTION
## Cosa cambia

- aggiunge nel menu Windows `Ripristina il PC - elimina anche la VM`
- mantiene separata la disinstallazione protetta che continua a fermarsi con E28
- crea il backup di `lab`, `lab2` e modifiche prima di qualsiasi distruzione
- esegue `vagrant destroy --force` soltanto nelle directory di stato del progetto
- elimina il metadato locale della VM soltanto dopo il successo di Vagrant
- rimuove dalla cache esclusivamente box nel namespace `2cornot2c/`
- conserva box Bento, altre VM e software preesistente
- usa una conferma e un flag distinti dalla disinstallazione normale

## Sicurezza

Se Vagrant manca o non conferma la distruzione, il flusso si ferma con E33 prima di disinstallare programmi o cancellare il repository. La modalità diretta richiede la frase `DISINSTALLA TUTTO`; dalla TUI serve la conferma esplicita dedicata.

## Verifica

- 54 test mirati superati
- `git diff --check`
- `python3 -m compileall -q installer`