### PR TITLE
Consenti la VM sui PC con poca RAM

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -94,6 +94,13 @@ vecchia viene aggiornata con `winget`. Gli aggiornamenti di programmi già
 presenti sono registrati come `updated` e non diventano proprietà di
 2cornot2c: la successiva disinstallazione dell'ambiente li conserva.
 
+Per la VM completa 8 GiB di RAM restano la raccomandazione, non un blocco.
+Un computer nominalmente da 8 GB può dichiarare a Windows meno di 8 GiB:
+l'installer mostra un avviso giallo con le conseguenze, ma permette di
+continuare. Lo studente deve chiudere Docker Desktop, browser e programmi
+pesanti; Windows e la VM possono risultare lenti. Lo spazio disco minimo resta
+invece bloccante.
+
 ## Diagnosi
 
 La prima fetta implementa rilevamento, scelta provider e diagnosi read-only:

--- a/installer/preflight.py
+++ b/installer/preflight.py
@@ -102,12 +102,29 @@ def evaluate(
             ResourceResult("memory", "warning", "RAM non misurabile automaticamente")
         )
     elif measured.total_memory < minimum_memory:
+        status = (
+            "warning"
+            if provider in {Provider.VIRTUALBOX, Provider.VMWARE}
+            else "blocked"
+        )
+        consequence = (
+            "; installazione consentita, ma Windows e la VM possono "
+            "diventare lenti: chiudi gli altri programmi"
+            if status == "warning"
+            else ""
+        )
+        requirement = (
+            "sono consigliati almeno"
+            if status == "warning"
+            else "servono almeno"
+        )
         results.append(
             ResourceResult(
                 "memory",
-                "blocked",
+                status,
                 f"RAM {measured.total_memory / GIB:.1f} GiB; "
-                f"servono almeno {minimum_memory / GIB:.0f} GiB",
+                f"{requirement} {minimum_memory / GIB:.0f} GiB"
+                f"{consequence}",
             )
         )
     else:

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -244,6 +244,7 @@ def _paint_guidance_rows(rows: list[str]) -> list[str]:
 
     markers = (
         ("ERRORE E", "\x1b[31m"),
+        ("AVVISO -", "\x1b[33m"),
         ("AZIONE RICHIESTA", "\x1b[33m"),
         ("COSA SIGNIFICA:", "\x1b[33m"),
         ("COSA DEVI FARE:", "\x1b[33m"),
@@ -319,7 +320,21 @@ def refresh_report(state: State) -> None:
     results = diagnose(install_plan(state.host, provider))
     report: list[str] = []
     for result in results:
-        if not result.ok and result.check.key in {"resources", "network"}:
+        if (
+            result.check.key == "resources"
+            and result.ok
+            and "WARNING " in result.detail
+        ):
+            report.extend(
+                (
+                    "AVVISO - COMPUTER CON RISORSE LIMITATE",
+                    result.detail,
+                    "Puoi continuare comunque con la VM completa.",
+                    "Chiudi Docker Desktop, browser e altri programmi pesanti.",
+                    "Durante l'uso Windows e la VM potrebbero essere lenti.",
+                )
+            )
+        elif not result.ok and result.check.key in {"resources", "network"}:
             report.extend(for_check(result.check.key, result.detail).lines(result.detail))
         else:
             report.append(

--- a/tests/test_classroom_installer.py
+++ b/tests/test_classroom_installer.py
@@ -461,6 +461,35 @@ def test_colored_diagnostics_leave_panel_padding_unstyled() -> None:
     assert "\x1b[33mCOSA FARE" in command_row
 
 
+def test_low_memory_vm_warning_is_visible_but_does_not_block(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("utui")
+    from installer.diagnostics import CheckResult
+    from installer.tui import State, refresh_report
+
+    plan = install_plan(Host.WINDOWS_AMD64, Provider.VIRTUALBOX)
+    resource_check = next(check for check in plan.checks if check.key == "resources")
+    monkeypatch.setattr(
+        "installer.tui.diagnose",
+        lambda current_plan: (
+            CheckResult(
+                resource_check,
+                True,
+                "WARNING RAM 7.7 GiB; installazione consentita",
+                True,
+            ),
+        ),
+    )
+    state = State(Host.WINDOWS_AMD64, (Provider.VIRTUALBOX,))
+
+    refresh_report(state)
+
+    rendered = " ".join(state.report)
+    assert "AVVISO - COMPUTER CON RISORSE LIMITATE" in rendered
+    assert "Puoi continuare comunque" in rendered
+
+
 def check_results(plan, *, missing: set[str] = set()):
     return tuple(
         CheckResult(check, check.key not in missing, "manca")

--- a/tests/test_classroom_preflight.py
+++ b/tests/test_classroom_preflight.py
@@ -19,7 +19,7 @@ def test_docker_preflight_accepts_minimum_resources() -> None:
     assert {result.status for result in results} == {"ok"}
 
 
-def test_vm_preflight_blocks_resources_but_warns_on_unreliable_virtualization() -> None:
+def test_vm_preflight_warns_on_low_memory_but_blocks_low_disk() -> None:
     results = evaluate(
         Host.WINDOWS_AMD64,
         Provider.VIRTUALBOX,
@@ -27,10 +27,21 @@ def test_vm_preflight_blocks_resources_but_warns_on_unreliable_virtualization() 
     )
 
     assert [result.status for result in results] == [
-        "blocked",
+        "warning",
         "blocked",
         "warning",
     ]
+    assert "installazione consentita" in results[0].detail
+
+
+def test_vm_preflight_allows_nominal_eight_gb_reported_below_eight_gib() -> None:
+    results = evaluate(
+        Host.WINDOWS_AMD64,
+        Provider.VIRTUALBOX,
+        ResourceSnapshot(int(7.7 * GIB), 25 * GIB, True),
+    )
+
+    assert [result.status for result in results] == ["warning", "ok", "ok"]
 
 
 def test_unknown_measurements_warn_but_do_not_block_sufficient_disk() -> None:


### PR DESCRIPTION
## Cosa cambia

- trasforma la RAM sotto 8 GiB per VirtualBox/VMware da blocco a warning
- mantiene 8 GiB come raccomandazione per la VM completa
- mostra un avviso giallo con conseguenze e azioni semplici
- permette comunque di confermare e installare la VM
- mantiene bloccanti disco insufficiente e RAM sotto 4 GiB per Docker
- documenta il caso dei PC venduti come 8 GB che riportano circa 7,7 GiB

## Causa

La soglia usava GiB binari. Un PC nominalmente da 8 GB può esporre a Windows meno di 8 GiB e riceveva E02, benché fosse ancora possibile eseguire un collaudo della VM con prestazioni ridotte.

## Esperienza studente

L'avviso spiega di chiudere Docker Desktop, browser e programmi pesanti e informa che Windows e la VM potrebbero essere lenti. Non viene nascosta la scelta VM e l'installazione resta volontaria.

## Verifica

- 56 test mirati superati
- regressione esplicita con 7,7 GiB: `warning`, `ok`, `ok`
- `git diff --check`
- `python3 -m compileall -q installer`