### PR TITLE
Auth: accetta issuer canonico nella callback Google

### DIFF
--- a/doc/architecture/google-oidc-http-routes.md
+++ b/doc/architecture/google-oidc-http-routes.md
@@ -40,6 +40,7 @@ Una negazione edge diventa `429 rate_limit_exceeded` con `Retry-After`. Errori e
 La callback accetta una query massima di 8192 byte e 16 campi. Il parser:
 
 - preserva valori duplicati come sequenze, lasciando al service OIDC la validazione dei parametri ammessi;
+- accetta l'Authorization Response `iss` opzionale soltanto quando è singolo e uguale a `https://accounts.google.com`;
 - mantiene valori vuoti;
 - rifiuta percent escape malformati, UTF-8 invalido, campi senza `=`, fragment e query vuota;
 - non concatena o sceglie arbitrariamente valori duplicati.

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -1218,7 +1218,7 @@ class GoogleOidcLoginService:
         state = None
         provider_error = False
         try:
-            if not isinstance(parameters, Mapping):
+            if type(parameters) is not dict:
                 invalid = True
             else:
                 allowed = {

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -32,6 +32,7 @@ from scripts.thebitlab_identity import AccountDisabledError, IdentityDomainError
 
 _GOOGLE_ISSUERS = frozenset({"accounts.google.com", "https://accounts.google.com"})
 _GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+_GOOGLE_AUTHORIZATION_RESPONSE_ISSUER = "https://accounts.google.com"
 _GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 _UNRESERVED_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
 _CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{10,512}$")
@@ -1219,7 +1220,17 @@ class GoogleOidcLoginService:
             if not isinstance(parameters, Mapping):
                 invalid = True
             else:
-                allowed = {"code", "state", "error", "error_description", "scope", "authuser", "prompt", "hd"}
+                allowed = {
+                    "code",
+                    "state",
+                    "error",
+                    "error_description",
+                    "scope",
+                    "authuser",
+                    "prompt",
+                    "hd",
+                    "iss",
+                }
                 if any(type(key) is not str or key not in allowed for key in parameters):
                     invalid = True
                 for callback_values in parameters.values():
@@ -1232,6 +1243,14 @@ class GoogleOidcLoginService:
                         or any(ord(character) < 0x20 for character in callback_values[0])
                     ):
                         invalid = True
+                issuer_values = parameters.get("iss", ())
+                if issuer_values and (
+                    not isinstance(issuer_values, Sequence)
+                    or isinstance(issuer_values, (str, bytes))
+                    or len(issuer_values) != 1
+                    or issuer_values[0] != _GOOGLE_AUTHORIZATION_RESPONSE_ISSUER
+                ):
+                    invalid = True
                 values = parameters.get("state", ())
                 if (
                     not isinstance(values, Sequence)
@@ -1282,6 +1301,7 @@ class GoogleOidcLoginService:
             error_values = None
             code_values = None
             callback_values = None
+            issuer_values = None
         if invalid:
             code = None
             state = None

--- a/scripts/thebitlab_google_oidc.py
+++ b/scripts/thebitlab_google_oidc.py
@@ -33,6 +33,7 @@ from scripts.thebitlab_identity import AccountDisabledError, IdentityDomainError
 _GOOGLE_ISSUERS = frozenset({"accounts.google.com", "https://accounts.google.com"})
 _GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
 _GOOGLE_AUTHORIZATION_RESPONSE_ISSUER = "https://accounts.google.com"
+_MISSING_CALLBACK_VALUE = object()
 _GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 _UNRESERVED_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
 _CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{10,512}$")
@@ -1243,8 +1244,8 @@ class GoogleOidcLoginService:
                         or any(ord(character) < 0x20 for character in callback_values[0])
                     ):
                         invalid = True
-                issuer_values = parameters.get("iss", ())
-                if issuer_values and (
+                issuer_values = parameters.get("iss", _MISSING_CALLBACK_VALUE)
+                if issuer_values is not _MISSING_CALLBACK_VALUE and (
                     not isinstance(issuer_values, Sequence)
                     or isinstance(issuer_values, (str, bytes))
                     or len(issuer_values) != 1

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -643,6 +643,12 @@ def test_provider_error_consumes_state_and_duplicate_or_unknown_params_fail_clos
         def __bool__(self):
             return False
 
+    class InconsistentDict(dict):
+        def get(self, key, default=None):
+            if key == "iss":
+                return default
+            return super().get(key, default)
+
     malformed = (
         {"code": ["one", "two"], "state": [STATE]},
         {"code": ["one"], "state": [STATE, STATE]},
@@ -650,6 +656,7 @@ def test_provider_error_consumes_state_and_duplicate_or_unknown_params_fail_clos
         {"code": ["one"], "state": [STATE], "scope": ["one", "two"]},
         {"code": ["one"], "state": [STATE], "iss": ["https://evil.test"]},
         {"code": ["one"], "state": [STATE], "iss": FalseSequence(["https://evil.test"])},
+        InconsistentDict({"code": ["one"], "state": [STATE], "iss": ["https://evil.test"]}),
         {"code": ["one"], "state": [STATE], "iss": ["https://accounts.google.com", "https://accounts.google.com"]},
         {"code": ["one"], "error": ["access_denied"], "state": [STATE]},
         {"code": ["one"]},

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -433,7 +433,9 @@ def test_valid_callback_onboards_pending_user_and_issues_session_cookie(
     service, storage, flows, transport, verifier = make_service(database_path, clock)
     state = begin_state(service)
 
-    result = finish_callback(service, valid_callback(state))
+    callback = valid_callback(state)
+    callback["iss"] = ["https://accounts.google.com"]
+    result = finish_callback(service, callback)
 
     assert result.user_id == "internal-user-01"
     assert result.clear_transaction_cookie.startswith(
@@ -642,6 +644,8 @@ def test_provider_error_consumes_state_and_duplicate_or_unknown_params_fail_clos
         {"code": ["one"], "state": [STATE, STATE]},
         {"code": ["one"], "state": [STATE], "evil": ["value"]},
         {"code": ["one"], "state": [STATE], "scope": ["one", "two"]},
+        {"code": ["one"], "state": [STATE], "iss": ["https://evil.test"]},
+        {"code": ["one"], "state": [STATE], "iss": ["https://accounts.google.com", "https://accounts.google.com"]},
         {"code": ["one"], "error": ["access_denied"], "state": [STATE]},
         {"code": ["one"]},
         {"state": [STATE]},

--- a/tests/test_thebitlab_google_oidc.py
+++ b/tests/test_thebitlab_google_oidc.py
@@ -639,12 +639,17 @@ def test_provider_error_consumes_state_and_duplicate_or_unknown_params_fail_clos
     assert replayed.value.clear_transaction_cookie is None
     assert transport.calls == []
 
+    class FalseSequence(list):
+        def __bool__(self):
+            return False
+
     malformed = (
         {"code": ["one", "two"], "state": [STATE]},
         {"code": ["one"], "state": [STATE, STATE]},
         {"code": ["one"], "state": [STATE], "evil": ["value"]},
         {"code": ["one"], "state": [STATE], "scope": ["one", "two"]},
         {"code": ["one"], "state": [STATE], "iss": ["https://evil.test"]},
+        {"code": ["one"], "state": [STATE], "iss": FalseSequence(["https://evil.test"])},
         {"code": ["one"], "state": [STATE], "iss": ["https://accounts.google.com", "https://accounts.google.com"]},
         {"code": ["one"], "error": ["access_denied"], "state": [STATE]},
         {"code": ["one"]},

--- a/tests/test_thebitlab_google_oidc_http.py
+++ b/tests/test_thebitlab_google_oidc_http.py
@@ -222,7 +222,10 @@ def test_rate_limit_errors_map_to_sanitized_429_and_503() -> None:
 
 def test_callback_preserves_duplicate_parameters_and_combines_cookies() -> None:
     router, _admission, callback = routes()
-    raw_query = "state=raw-state&code=raw-code&scope=openid&scope=email"
+    raw_query = (
+        "state=raw-state&code=raw-code&scope=openid&scope=email"
+        "&iss=https%3A%2F%2Faccounts.google.com"
+    )
     callback_request = request(
         "/auth/google/callback",
         raw_query,
@@ -242,6 +245,7 @@ def test_callback_preserves_duplicate_parameters_and_combines_cookies() -> None:
         "state": ("raw-state",),
         "code": ("raw-code",),
         "scope": ("openid", "email"),
+        "iss": ("https://accounts.google.com",),
     }
     assert callback.cookie == "first=one; second=two"
 


### PR DESCRIPTION
## Summary
- accept optional OAuth authorization-response `iss` from Google only when exactly `https://accounts.google.com`
- reject duplicate, empty, or non-canonical issuer values before token exchange
- cover service and concrete HTTP parsing

## Validation
- 97 passed, 1 skipped
- py_compile and diff checks clean

Closes #607
Relates to #535 and #292