### PR TITLE
Auth: landing federata separata dalla Board docente

### DIFF
--- a/doc/architecture/auth-runtime-composition.md
+++ b/doc/architecture/auth-runtime-composition.md
@@ -25,7 +25,7 @@ La configurazione avviene prima della creazione del server HTTP. Qualunque valor
 Opzionali:
 
 - `THEBITLAB_AUTH_DB_PATH`: file SQLite assoluto o relativo al data root; default `.thebitlab-auth/auth.sqlite3` in una directory dedicata;
-- `THEBITLAB_GOOGLE_POST_LOGIN_PATH`: path locale successivo al login; default `/tools/course_board.html`.
+- `THEBITLAB_GOOGLE_POST_LOGIN_PATH`: landing successiva al login; se presente deve essere esattamente `/auth/account`, default autenticato e role-aware.
 
 I tre segreti binari (CSRF, rate limit e pairing) devono essere indipendenti. Per generarli:
 

--- a/doc/architecture/github-oauth-http-routes.md
+++ b/doc/architecture/github-oauth-http-routes.md
@@ -43,7 +43,7 @@ THEBITLAB_GITHUB_REDIRECT_URI=https://HOST-PUBBLICO/auth/github/callback
 Opzionale:
 
 ```text
-THEBITLAB_GITHUB_POST_LINK_PATH=/tools/course_board.html
+THEBITLAB_GITHUB_POST_LINK_PATH=/auth/account
 ```
 
 I valori segreti devono essere forniti soltanto tramite environment/secret store e mai salvati nel repository, nei file di configurazione versionati o nella shell history.

--- a/doc/architecture/web-session-http-routes.md
+++ b/doc/architecture/web-session-http-routes.md
@@ -5,6 +5,7 @@
 `scripts/thebitlab_session_http.py` espone due route concrete sullo stesso grafo web creato dalla composizione runtime:
 
 - `GET /auth/session`;
+- `GET /auth/account`;
 - `POST /auth/logout`.
 
 Il principal deriva esclusivamente dal cookie di sessione `web`; nessun `user_id`, ruolo o identificatore inviato dal client viene usato per scegliere l'utente.
@@ -25,6 +26,12 @@ Query, fragment, request-target non origin-form, path params, body, transfer enc
 - token CSRF legato tramite HMAC al bearer corrente.
 
 Email, identità provider, bearer, digest e appartenenze non vengono serializzati. Il token CSRF è necessario al browser per le successive mutazioni, ma body e request sensibili sono esclusi dai `repr`.
+
+## Landing account
+
+`GET /auth/account` richiede la sessione web e rende una pagina HTML minimale `no-store` senza identificativi, email o CSRF. La pagina è role-aware: `pending` mostra soltanto lo stato di attesa, `student` espone il collegamento al pairing TUI, mentre `teacher` e `admin` espongono un accesso esplicito alla Course Design Board. La Board conserva la propria autenticazione Basic separata. CSP, `nosniff` e `DENY` impediscono risorse, form e framing non necessari.
+
+I redirect Google e GitHub usano obbligatoriamente questa landing nella composizione runtime. Override verso Board o path generici sono rifiutati all'avvio, così una configurazione legacy non può reinviare implicitamente studenti o utenti pending alla superficie docente.
 
 ## Logout
 

--- a/scripts/thebitlab_auth_runtime.py
+++ b/scripts/thebitlab_auth_runtime.py
@@ -181,9 +181,13 @@ def compose_google_oidc_runtime(
             )
         trusted_proxy_cidrs = _trusted_proxy_cidrs(environment)
         post_login_path = environment.get(
-            "THEBITLAB_GOOGLE_POST_LOGIN_PATH", "/tools/course_board.html"
+            "THEBITLAB_GOOGLE_POST_LOGIN_PATH", "/auth/account"
         )
         _validate_post_login_path(post_login_path)
+        if post_login_path != "/auth/account":
+            raise AuthRuntimeConfigurationError(
+                "THEBITLAB_GOOGLE_POST_LOGIN_PATH deve usare la landing account canonica."
+            )
         database_path = _database_path(environment, data_root)
         _prepare_database_file(database_path)
         _require_auth_dependencies()
@@ -274,9 +278,13 @@ def compose_google_oidc_runtime(
                     "THEBITLAB_GITHUB_REDIRECT_URI deve terminare con il path callback canonico."
                 )
             github_post_link_path = environment.get(
-                "THEBITLAB_GITHUB_POST_LINK_PATH", "/tools/course_board.html"
+                "THEBITLAB_GITHUB_POST_LINK_PATH", "/auth/account"
             )
             _validate_post_login_path(github_post_link_path)
+            if github_post_link_path != "/auth/account":
+                raise AuthRuntimeConfigurationError(
+                    "THEBITLAB_GITHUB_POST_LINK_PATH deve usare la landing account canonica."
+                )
             github_config = GitHubOAuthConfig(
                 github_client_id,
                 github_client_secret,

--- a/scripts/thebitlab_session_http.py
+++ b/scripts/thebitlab_session_http.py
@@ -23,6 +23,7 @@ from scripts.thebitlab_http_auth import (
 )
 
 _SESSION_PATH = "/auth/session"
+_ACCOUNT_PATH = "/auth/account"
 _LOGOUT_PATH = "/auth/logout"
 _MAX_COOKIE_HEADER_BYTES = 16 * 1024
 _CSRF_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
@@ -92,7 +93,7 @@ class SessionHttpRoutes:
         self.proxy_resolver = proxy_resolver
 
     def handles(self, path: str) -> bool:
-        return path in {_SESSION_PATH, _LOGOUT_PATH}
+        return path in {_SESSION_PATH, _ACCOUNT_PATH, _LOGOUT_PATH}
 
     def dispatch(self, request: SessionHttpRequest) -> SessionHttpResponse | None:
         if type(request) is not SessionHttpRequest:
@@ -106,7 +107,10 @@ class SessionHttpRoutes:
         try:
             self._require_https(request)
             self._require_empty_request(request)
-            if request.path == _SESSION_PATH and request.method != "GET":
+            if (
+                request.path in {_SESSION_PATH, _ACCOUNT_PATH}
+                and request.method != "GET"
+            ):
                 return self._method_error("GET")
             if request.path == _LOGOUT_PATH and request.method != "POST":
                 return self._method_error("POST")
@@ -114,13 +118,15 @@ class SessionHttpRoutes:
                 request.edge, "cookie", maximum_bytes=_MAX_COOKIE_HEADER_BYTES,
                 separator="; ", required=True
             )
-            if request.path == _SESSION_PATH:
+            if request.path in {_SESSION_PATH, _ACCOUNT_PATH}:
                 csrf_headers = _header_values(request.edge, "x-csrf-token")
                 if csrf_headers:
                     _csrf_header(csrf_headers)
                 context = self.sessions.authenticate(
                     HttpAuthRequest("GET", cookie_header=cookie_header)
                 )
+                if request.path == _ACCOUNT_PATH:
+                    return self._account_response(context)
                 return self._session_response(context)
             csrf_token = _csrf_header(
                 _header_values(request.edge, "x-csrf-token")
@@ -210,6 +216,49 @@ class SessionHttpRoutes:
             200,
             self._base_headers() + (
                 ("Content-Type", "application/json; charset=utf-8"),
+                ("Content-Length", str(len(body))),
+            ),
+            body,
+        )
+
+    def _account_response(self, context) -> SessionHttpResponse:
+        role = context.user.role
+        if role == "pending":
+            title = "Account in attesa"
+            message = (
+                "L'account è autenticato, ma ruolo e classe devono ancora essere approvati."
+            )
+            action = ""
+        elif role == "student":
+            title = "Area studente"
+            message = (
+                "L'account studente è autorizzato. Puoi associare la TUI da questo browser."
+            )
+            action = '<p><a href="/auth/tui/pair">Associa la TUI</a></p>'
+        else:
+            title = "Area docente"
+            message = (
+                "L'account docente è autorizzato. "
+                "La Board mantiene una protezione docente separata."
+            )
+            action = '<p><a href="/tools/course_board.html">Apri la Course Design Board</a></p>'
+        body = (
+            "<!doctype html><html lang=\"it\"><head><meta charset=\"utf-8\">"
+            "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+            f"<title>{title} - TheBitLab</title></head><body><main><h1>{title}</h1>"
+            f"<p>{message}</p>{action}</main></body></html>"
+        ).encode("utf-8")
+        return SessionHttpResponse(
+            200,
+            self._base_headers() + (
+                (
+                    "Content-Security-Policy",
+                    "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; "
+                    "form-action 'none'",
+                ),
+                ("X-Content-Type-Options", "nosniff"),
+                ("X-Frame-Options", "DENY"),
+                ("Content-Type", "text/html; charset=utf-8"),
                 ("Content-Length", str(len(body))),
             ),
             body,

--- a/tests/test_thebitlab_auth_runtime.py
+++ b/tests/test_thebitlab_auth_runtime.py
@@ -81,6 +81,12 @@ def test_composition_adds_github_routes_only_with_complete_configuration(tmp_pat
     )
     assert environment["THEBITLAB_GITHUB_CLIENT_SECRET"] not in repr(runtime)
 
+    environment["THEBITLAB_GITHUB_POST_LINK_PATH"] = "/tools/course_board.html"
+    with pytest.raises(AuthRuntimeConfigurationError) as captured:
+        compose_google_oidc_runtime(environment, data_root=tmp_path / "rejected")
+    assert "landing account canonica" in str(captured.value)
+    assert "/tools/course_board.html" not in str(captured.value)
+
 
 def test_partial_github_runtime_configuration_fails_closed(tmp_path: Path) -> None:
     environment = valid_environment()
@@ -109,7 +115,7 @@ def test_composition_builds_one_coherent_production_graph(tmp_path: Path) -> Non
     assert login.config.redirect_uri == (
         "https://lab.example.edu/auth/google/callback"
     )
-    assert login.config.post_login_path == "/tools/course_board.html"
+    assert login.config.post_login_path == "/auth/account"
     assert repr(runtime) == "GoogleOidcRuntime(configured=True)"
 
     database = _test_data_root(tmp_path) / ".thebitlab-auth" / "auth.sqlite3"
@@ -125,14 +131,16 @@ def test_composition_builds_one_coherent_production_graph(tmp_path: Path) -> Non
         assert database.stat().st_mode & 0o777 == 0o600
 
 
-def test_composition_accepts_relative_database_and_local_post_login(tmp_path: Path) -> None:
+def test_composition_accepts_relative_database_and_canonical_account_landing(
+    tmp_path: Path,
+) -> None:
     environment = valid_environment()
     environment["THEBITLAB_AUTH_DB_PATH"] = "state/auth.sqlite3"
-    environment["THEBITLAB_GOOGLE_POST_LOGIN_PATH"] = "/welcome/%E2%9C%93"
+    environment["THEBITLAB_GOOGLE_POST_LOGIN_PATH"] = "/auth/account"
 
     runtime = compose_google_oidc_runtime(environment, data_root=tmp_path)
 
-    assert runtime.routes.callback.config.post_login_path == "/welcome/%E2%9C%93"
+    assert runtime.routes.callback.config.post_login_path == "/auth/account"
     assert (_test_data_root(tmp_path) / "state" / "auth.sqlite3").is_file()
 
 
@@ -157,6 +165,7 @@ def test_composition_accepts_relative_database_and_local_post_login(tmp_path: Pa
             "callback canonico",
         ),
         ("THEBITLAB_GOOGLE_POST_LOGIN_PATH", "/welcome?next=x", "POST_LOGIN"),
+        ("THEBITLAB_GOOGLE_POST_LOGIN_PATH", "/tools/course_board.html", "landing account canonica"),
         ("THEBITLAB_AUTH_DB_PATH", ":memory:", "AUTH_DB_PATH"),
     ),
 )

--- a/tests/test_thebitlab_session_http.py
+++ b/tests/test_thebitlab_session_http.py
@@ -39,10 +39,9 @@ def account(role="student"):
     )
 
 
-@pytest.fixture
-def graph(tmp_path):
-    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3", clock=lambda: NOW)
-    storage.create_user(account())
+def build_graph(tmp_path, role="student"):
+    storage = SqliteIdentityStorage(tmp_path / f"identity-{role}.sqlite3", clock=lambda: NOW)
+    storage.create_user(account(role))
     sessions = SessionService(
         storage,
         clock=lambda: NOW,
@@ -61,6 +60,11 @@ def graph(tmp_path):
     )
     established = boundary.establish_session("user-01")
     return storage, boundary, routes, established
+
+
+@pytest.fixture
+def graph(tmp_path):
+    return build_graph(tmp_path)
 
 
 def edge(*headers):
@@ -107,6 +111,57 @@ def test_current_session_returns_minimal_snapshot_and_csrf(graph) -> None:
     assert header(response, "Referrer-Policy") == "no-referrer"
     assert established.context.csrf_token not in repr(response)
     assert cookie(established) not in repr(response)
+
+
+@pytest.mark.parametrize(
+    ("role", "heading", "expected_link", "forbidden_link"),
+    (
+        ("pending", "Account in attesa", None, "/tools/course_board.html"),
+        ("student", "Area studente", "/auth/tui/pair", "/tools/course_board.html"),
+        ("teacher", "Area docente", "/tools/course_board.html", "/auth/tui/pair"),
+        ("admin", "Area docente", "/tools/course_board.html", "/auth/tui/pair"),
+    ),
+)
+def test_account_landing_is_authenticated_and_role_aware(
+    tmp_path, role, heading, expected_link, forbidden_link
+) -> None:
+    _storage, _boundary, routes, established = build_graph(tmp_path, role)
+
+    anonymous = routes.dispatch(request("GET", "/auth/account"))
+    response = routes.dispatch(
+        request("GET", "/auth/account", ("Cookie", cookie(established)))
+    )
+
+    assert anonymous.status_code == 401
+    assert response.status_code == 200
+    body = response.body.decode("utf-8")
+    assert heading in body
+    if expected_link is not None:
+        assert expected_link in body
+    assert forbidden_link not in body
+    assert "user-01" not in body
+    assert "private@example.test" not in body
+    assert established.context.csrf_token not in body
+    assert header(response, "Content-Security-Policy").startswith("default-src 'none'")
+    assert header(response, "X-Frame-Options") == "DENY"
+    assert header(response, "X-Content-Type-Options") == "nosniff"
+    assert header(response, "Cache-Control") == "no-store"
+
+
+def test_account_landing_rejects_non_get_query_and_body(graph) -> None:
+    _storage, _boundary, routes, established = graph
+    browser_cookie = ("Cookie", cookie(established))
+
+    wrong_method = routes.dispatch(request("POST", "/auth/account", browser_cookie))
+    query = routes.dispatch(request("GET", "/auth/account", browser_cookie, query="x=1"))
+    body = routes.dispatch(
+        request("GET", "/auth/account", browser_cookie, ("Content-Length", "1"))
+    )
+
+    assert wrong_method.status_code == 405
+    assert header(wrong_method, "Allow") == "GET"
+    assert query.status_code == 400
+    assert body.status_code == 400
 
 
 def test_logout_requires_csrf_revokes_session_and_clears_cookie(graph) -> None:
@@ -265,6 +320,7 @@ def test_course_board_socket_serves_status_and_logout_without_basic_auth(graph) 
     common = {"X-Forwarded-Proto": "https", "Cookie": browser_cookie}
     try:
         status = exchange("GET", "/auth/session", common)
+        landing = exchange("GET", "/auth/account", common)
         logout = exchange(
             "POST",
             "/auth/logout",
@@ -292,6 +348,10 @@ def test_course_board_socket_serves_status_and_logout_without_basic_auth(graph) 
 
     assert status[0] == 200
     assert json.loads(status[2])["user"]["user_id"] == "user-01"
+    assert landing[0] == 200
+    assert landing[1]["Content-Type"] == "text/html; charset=utf-8"
+    assert "WWW-Authenticate" not in landing[1]
+    assert b"/auth/tui/pair" in landing[2]
     assert logout[0] == 204
     assert "Max-Age=0" in logout[1]["Set-Cookie"]
     assert after[0] == 401


### PR DESCRIPTION
## Summary
- add authenticated `/auth/account` landing with fail-closed role-specific actions
- keep pending/student away from the Basic-protected teacher Board
- make canonical account landing mandatory for runtime Google/GitHub redirects
- add CSP, no-store, framing protections, route/socket tests, and docs

## Validation
- 145 focused auth tests passed, 1 skipped
- 40 focused session/runtime tests passed, 1 skipped
- py_compile and diff checks clean

Closes #609
Relates to #535 and #292