### PR TITLE
Auth smoke: supporta framing chunked canonico

### DIFF
--- a/doc/AUTH_STAGING_SMOKE.md
+++ b/doc/AUTH_STAGING_SMOKE.md
@@ -41,6 +41,8 @@ Un successo produce soltanto nomi check, status numerici e booleani:
 
 Location completa, query OIDC, cookie, body remoti e credenziali non vengono emessi. Redirect non vengono seguiti. Header/body oversized, contratti inattesi e timeout falliscono chiusi con exit code 1.
 
+Il framing della risposta deve essere non ambiguo: è ammesso un solo `Content-Length` canonico coerente con il body oppure un solo `Transfer-Encoding: chunked` senza `Content-Length`. Il secondo caso copre intermediary HTTPS, inclusi tunnel e CDN, che ricodificano una risposta originariamente length-delimited; il trasporto effettua il dechunking mantenendo il limite body di 32 KiB. CL+TE, codifiche composte o non supportate e header duplicati restano rifiutati.
+
 ## Workflow manuale
 
 Da GitHub Actions eseguire **Auth staging smoke** (`.github/workflows/auth-staging-smoke.yml`) e inserire soltanto origin, client ID pubblico atteso e timeout. Gli input vengono passati al comando via environment quotato, non interpolati nello script shell.

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -642,7 +642,7 @@ def _require_response_framing(response: ResponseSnapshot) -> None:
     chunked_framing = (
         not lengths
         and len(transfers) == 1
-        and transfers[0].strip().lower() == "chunked"
+        and transfers[0].lower() == "chunked"
     )
     if not (content_length_framing or chunked_framing):
         raise StagingSmokeError("Framing risposta staging non valido.")

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -636,10 +636,15 @@ class _PairingPageParser(HTMLParser):
 
 
 def _require_response_framing(response: ResponseSnapshot) -> None:
-    if (
-        _headers(response, "transfer-encoding")
-        or _headers(response, "content-length") != [str(len(response.body))]
-    ):
+    transfers = _headers(response, "transfer-encoding")
+    lengths = _headers(response, "content-length")
+    content_length_framing = not transfers and lengths == [str(len(response.body))]
+    chunked_framing = (
+        not lengths
+        and len(transfers) == 1
+        and transfers[0].strip().lower() == "chunked"
+    )
+    if not (content_length_framing or chunked_framing):
         raise StagingSmokeError("Framing risposta staging non valido.")
 
 

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -500,6 +500,44 @@ def test_staging_smoke_rejects_duplicate_or_contradictory_cookie_attributes() ->
         )
 
 
+def test_staging_smoke_accepts_single_chunked_framing_from_https_intermediary() -> None:
+    fixtures = responses()
+    key = ("GET", "https://school.test/auth/tui/pair")
+    current = fixtures[key]
+    fixtures[key] = smoke.ResponseSnapshot(
+        current.status,
+        tuple(
+            (name, value)
+            for name, value in current.headers
+            if name.lower() != "content-length"
+        )
+        + (("Transfer-Encoding", "chunked"),),
+        current.body,
+    )
+
+    smoke.run_smoke(
+        "https://school.test",
+        lambda method, url, timeout: fixtures[(method, url)],
+    )
+
+
+@pytest.mark.parametrize(
+    "headers",
+    (
+        (),
+        (("Content-Length", "3"), ("Content-Length", "3")),
+        (("Content-Length", "03"),),
+        (("Transfer-Encoding", "gzip"),),
+        (("Transfer-Encoding", "chunked, gzip"),),
+        (("Transfer-Encoding", "chunked"), ("Transfer-Encoding", "chunked")),
+        (("Content-Length", "3"), ("Transfer-Encoding", "chunked")),
+    ),
+)
+def test_response_framing_rejects_ambiguous_or_unsupported_forms(headers) -> None:
+    with pytest.raises(smoke.StagingSmokeError, match="Framing"):
+        smoke._require_response_framing(smoke.ResponseSnapshot(200, headers, b"abc"))
+
+
 def test_staging_smoke_rejects_conflicting_response_framing() -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/session")]

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -528,6 +528,8 @@ def test_staging_smoke_accepts_single_chunked_framing_from_https_intermediary() 
         (("Content-Length", "3"), ("Content-Length", "3")),
         (("Content-Length", "03"),),
         (("Transfer-Encoding", "gzip"),),
+        (("Transfer-Encoding", "chunked "),),
+        (("Transfer-Encoding", " chunked"),),
         (("Transfer-Encoding", "chunked, gzip"),),
         (("Transfer-Encoding", "chunked"), ("Transfer-Encoding", "chunked")),
         (("Content-Length", "3"), ("Transfer-Encoding", "chunked")),


### PR DESCRIPTION
## Summary
- accept exactly one canonical response framing: matching Content-Length or single chunked transfer coding
- continue rejecting CL+TE, duplicates, compound/unsupported codings, and non-canonical lengths
- retain dechunked 32 KiB body bound and absolute deadline
- document HTTPS intermediary behavior

## Validation
- 41 staging smoke tests passed
- py_compile and diff checks clean

Closes #611
Relates to #535 and #292