### PR TITLE
Auth: provisioning amministrativo atomico di utenti e classi

### DIFF
--- a/doc/architecture/admin-provisioning-service.md
+++ b/doc/architecture/admin-provisioning-service.md
@@ -1,0 +1,14 @@
+# Provisioning amministrativo utenti e classi
+
+`AdminProvisioningService` è il confine applicativo provider-independent per l'approvazione esplicita degli account `pending`. Non usa email, username Google/GitHub o subject provider come chiavi: attore, target e classi usano esclusivamente ID TheBitLab.
+
+## Operazioni
+
+- snapshot bounded di utenti pending e classi, autorizzato rileggendo nello stesso snapshot un admin attivo e la sua revisione;
+- creazione di una classe attiva da parte di un admin corrente;
+- approvazione di un pending come `teacher` senza membership implicite;
+- approvazione di un pending come `student` soltanto insieme a una membership manuale verso una classe attiva.
+
+L'approvazione avviene in una singola transazione SQLite. Sono ricontrollati ruolo/revisione dell'admin, stato/revisione del target, assenza di membership pregresse, classe attiva e monotonicità del clock. Cambio ruolo, eventuale membership e revoca di tutte le sessioni attive del target sono atomici. Replay, CAS stale, classi mancanti/inattive e sessioni temporalmente più nuove causano rollback completo.
+
+Gli errori applicativi sono sanitizzati e non serializzano identità provider o dettagli SQLite. Il bootstrap iniziale dell'admin e la superficie HTTP/GUI amministrativa sono confini separati: questo service non consente auto-approvazione e non trasforma un pending in admin.

--- a/scripts/thebitlab_admin_provisioning.py
+++ b/scripts/thebitlab_admin_provisioning.py
@@ -1,0 +1,173 @@
+"""Provider-independent admin application service for explicit onboarding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable
+
+from scripts.thebitlab_identity import ClassGroup, ClassMembership, UserAccount
+from scripts.thebitlab_identity_ports import AdminProvisioningStorage, IdentityStorageError
+
+
+class AdminProvisioningError(RuntimeError):
+    """Sanitized base error for administrative onboarding."""
+
+
+class AdminProvisioningConflictError(AdminProvisioningError):
+    """Raised when authorization, revisions, or domain state are no longer current."""
+
+
+@dataclass(frozen=True)
+class AdminProvisioningSnapshot:
+    pending_users: tuple[UserAccount, ...]
+    classes: tuple[ClassGroup, ...]
+
+
+@dataclass(frozen=True)
+class AdminApprovalResult:
+    user: UserAccount
+    membership: ClassMembership | None
+    revoked_sessions: int
+
+
+class AdminProvisioningService:
+    """Authorize admin-owned role, class, and membership transitions atomically."""
+
+    def __init__(
+        self,
+        storage: AdminProvisioningStorage,
+        *,
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        maximum_snapshot_items: int = 1_000,
+    ) -> None:
+        required = (
+            "read_admin_provisioning_snapshot",
+            "create_class_as_admin",
+            "approve_pending_user_as_admin",
+        )
+        if any(not callable(getattr(storage, name, None)) for name in required):
+            raise ValueError("Storage provisioning amministrativo non valido.")
+        if not callable(clock):
+            raise ValueError("Clock provisioning amministrativo non valido.")
+        if type(maximum_snapshot_items) is not int or not 1 <= maximum_snapshot_items <= 10_000:
+            raise ValueError("Limite provisioning amministrativo non valido.")
+        self.storage = storage
+        self.clock = clock
+        self.maximum_snapshot_items = maximum_snapshot_items
+
+    def snapshot(self, actor: UserAccount) -> AdminProvisioningSnapshot:
+        self._actor(actor)
+        try:
+            users, classes = self.storage.read_admin_provisioning_snapshot(
+                actor.user_id,
+                expected_actor_updated_at=actor.updated_at,
+                maximum_items=self.maximum_snapshot_items,
+            )
+            if type(users) is not tuple or type(classes) is not tuple:
+                raise AdminProvisioningConflictError("Snapshot amministrativo non valido.")
+            if any(type(item) is not UserAccount or item.role != "pending" for item in users):
+                raise AdminProvisioningConflictError("Snapshot amministrativo non valido.")
+            if any(type(item) is not ClassGroup for item in classes):
+                raise AdminProvisioningConflictError("Snapshot amministrativo non valido.")
+            return AdminProvisioningSnapshot(users, classes)
+        except AdminProvisioningError:
+            raise
+        except IdentityStorageError as error:
+            raise AdminProvisioningConflictError(
+                "Provisioning amministrativo non disponibile o non corrente."
+            ) from error
+        except Exception as error:
+            raise AdminProvisioningConflictError(
+                "Provisioning amministrativo non disponibile o non corrente."
+            ) from error
+
+    def create_class(
+        self,
+        actor: UserAccount,
+        *,
+        class_id: str,
+        label: str,
+        school_year: str,
+    ) -> ClassGroup:
+        self._actor(actor)
+        now = self._now()
+        class_group = ClassGroup(class_id, label, school_year, True, now, now)
+        try:
+            self.storage.create_class_as_admin(
+                actor.user_id,
+                class_group,
+                expected_actor_updated_at=actor.updated_at,
+            )
+            return class_group
+        except IdentityStorageError as error:
+            raise AdminProvisioningConflictError(
+                "Creazione classe non disponibile o non corrente."
+            ) from error
+        except Exception as error:
+            raise AdminProvisioningConflictError(
+                "Creazione classe non disponibile o non corrente."
+            ) from error
+
+    def approve(
+        self,
+        actor: UserAccount,
+        *,
+        target_user_id: str,
+        expected_target_updated_at: datetime,
+        role: str,
+        class_id: str | None = None,
+    ) -> AdminApprovalResult:
+        self._actor(actor)
+        if type(target_user_id) is not str or not target_user_id.strip():
+            raise ValueError("Target provisioning non valido.")
+        if type(expected_target_updated_at) is not datetime:
+            raise ValueError("Revisione target provisioning non valida.")
+        if role not in {"teacher", "student"}:
+            raise ValueError("Ruolo provisioning non valido.")
+        if role == "student":
+            if type(class_id) is not str or not class_id.strip():
+                raise ValueError("Classe studente obbligatoria.")
+        elif class_id is not None:
+            raise ValueError("La classe non è ammessa per il ruolo docente.")
+        try:
+            user, membership, revoked = self.storage.approve_pending_user_as_admin(
+                actor.user_id,
+                target_user_id,
+                role,
+                class_id,
+                self._now(),
+                expected_actor_updated_at=actor.updated_at,
+                expected_target_updated_at=expected_target_updated_at,
+            )
+            if (
+                type(user) is not UserAccount
+                or user.user_id != target_user_id
+                or user.role != role
+                or type(revoked) is not int
+                or revoked < 0
+                or (role == "student") != (type(membership) is ClassMembership)
+            ):
+                raise AdminProvisioningConflictError("Risultato approvazione non valido.")
+            return AdminApprovalResult(user, membership, revoked)
+        except AdminProvisioningError:
+            raise
+        except IdentityStorageError as error:
+            raise AdminProvisioningConflictError(
+                "Approvazione non disponibile o non corrente."
+            ) from error
+        except Exception as error:
+            raise AdminProvisioningConflictError(
+                "Approvazione non disponibile o non corrente."
+            ) from error
+
+    @staticmethod
+    def _actor(actor: UserAccount) -> None:
+        if type(actor) is not UserAccount:
+            raise ValueError("Attore provisioning non valido.")
+
+    def _now(self) -> datetime:
+        value = self.clock()
+        if type(value) is not datetime or value.tzinfo is None or value.utcoffset() is None:
+            raise AdminProvisioningConflictError("Clock provisioning non disponibile.")
+        return value.astimezone(timezone.utc)

--- a/scripts/thebitlab_identity_ports.py
+++ b/scripts/thebitlab_identity_ports.py
@@ -271,6 +271,38 @@ class ClassDirectoryStorage(Protocol):
     ) -> None: ...
 
 
+class AdminProvisioningStorage(Protocol):
+    """Atomic persistence boundary for explicit admin-owned onboarding."""
+
+    def read_admin_provisioning_snapshot(
+        self,
+        actor_user_id: str,
+        *,
+        expected_actor_updated_at: datetime,
+        maximum_items: int,
+    ) -> tuple[tuple[UserAccount, ...], tuple[ClassGroup, ...]]: ...
+
+    def create_class_as_admin(
+        self,
+        actor_user_id: str,
+        class_group: ClassGroup,
+        *,
+        expected_actor_updated_at: datetime,
+    ) -> None: ...
+
+    def approve_pending_user_as_admin(
+        self,
+        actor_user_id: str,
+        target_user_id: str,
+        role: str,
+        class_id: str | None,
+        updated_at: datetime,
+        *,
+        expected_actor_updated_at: datetime,
+        expected_target_updated_at: datetime,
+    ) -> tuple[UserAccount, ClassMembership | None, int]: ...
+
+
 class SessionStorage(Protocol):
     """Persistence port for hashed web sessions."""
 

--- a/scripts/thebitlab_identity_sqlite.py
+++ b/scripts/thebitlab_identity_sqlite.py
@@ -716,6 +716,159 @@ class SqliteIdentityStorage:
     def list_users(self) -> list[UserAccount]:
         return [self._user(row) for row in self._query_all("SELECT * FROM users ORDER BY user_id")]
 
+    @classmethod
+    def _require_current_admin(
+        cls,
+        connection: sqlite3.Connection,
+        actor_user_id: str,
+        expected_actor_updated_at: str,
+    ) -> UserAccount:
+        row = connection.execute(
+            "SELECT * FROM users WHERE user_id = ?", (actor_user_id,)
+        ).fetchone()
+        if row is None:
+            raise IdentityStorageNotFoundError("Account amministratore non trovato.")
+        actor = cls._user(row)
+        if (
+            actor.role != "admin"
+            or not actor.active
+            or row["updated_at"] != expected_actor_updated_at
+        ):
+            raise IdentityStorageConflictError("Autorizzazione amministrativa non corrente.")
+        return actor
+
+    def read_admin_provisioning_snapshot(
+        self,
+        actor_user_id: str,
+        *,
+        expected_actor_updated_at: datetime,
+        maximum_items: int,
+    ) -> tuple[tuple[UserAccount, ...], tuple[ClassGroup, ...]]:
+        if type(maximum_items) is not int or not 1 <= maximum_items <= 10_000:
+            raise IdentityStorageConflictError("Limite snapshot amministrativo non valido.")
+        expected = _encode_datetime(expected_actor_updated_at, "expected_actor_updated_at")
+        with self._transaction("read_admin_provisioning_snapshot") as connection:
+            self._require_current_admin(connection, actor_user_id, expected)
+            users = connection.execute(
+                "SELECT * FROM users WHERE role = 'pending' ORDER BY created_at, user_id LIMIT ?",
+                (maximum_items + 1,),
+            ).fetchall()
+            classes = connection.execute(
+                "SELECT * FROM classes ORDER BY class_id LIMIT ?", (maximum_items + 1,)
+            ).fetchall()
+            if len(users) > maximum_items or len(classes) > maximum_items:
+                raise IdentityStorageConflictError("Snapshot amministrativo oltre il limite.")
+            return (
+                tuple(self._user(row) for row in users),
+                tuple(self._class_group(row) for row in classes),
+            )
+
+    def create_class_as_admin(
+        self,
+        actor_user_id: str,
+        class_group: ClassGroup,
+        *,
+        expected_actor_updated_at: datetime,
+    ) -> None:
+        if type(class_group) is not ClassGroup:
+            raise IdentityStorageConflictError("Classe amministrativa non valida.")
+        expected = _encode_datetime(expected_actor_updated_at, "expected_actor_updated_at")
+        with self._transaction("create_class_as_admin") as connection:
+            self._require_current_admin(connection, actor_user_id, expected)
+            connection.execute(
+                "INSERT INTO classes VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    class_group.class_id,
+                    class_group.label,
+                    class_group.school_year,
+                    int(class_group.active),
+                    _encode_datetime(class_group.created_at, "created_at"),
+                    _encode_datetime(class_group.updated_at, "updated_at"),
+                ),
+            )
+
+    def approve_pending_user_as_admin(
+        self,
+        actor_user_id: str,
+        target_user_id: str,
+        role: str,
+        class_id: str | None,
+        updated_at: datetime,
+        *,
+        expected_actor_updated_at: datetime,
+        expected_target_updated_at: datetime,
+    ) -> tuple[UserAccount, ClassMembership | None, int]:
+        if role not in {"teacher", "student"} or (role == "student") != (class_id is not None):
+            raise IdentityStorageConflictError("Approvazione amministrativa non valida.")
+        expected_actor = _encode_datetime(expected_actor_updated_at, "expected_actor_updated_at")
+        expected_target = _encode_datetime(expected_target_updated_at, "expected_target_updated_at")
+        changed = _encode_datetime(updated_at, "updated_at")
+        if changed <= expected_target:
+            raise IdentityStorageConflictError("Revisione approvazione non crescente.")
+        with self._transaction("approve_pending_user_as_admin") as connection:
+            self._require_current_admin(connection, actor_user_id, expected_actor)
+            row = connection.execute(
+                "SELECT * FROM users WHERE user_id = ?", (target_user_id,)
+            ).fetchone()
+            if row is None:
+                raise IdentityStorageNotFoundError("Account pending non trovato.")
+            if (
+                target_user_id == actor_user_id
+                or row["role"] != "pending"
+                or row["active"] != 1
+                or row["updated_at"] != expected_target
+            ):
+                raise IdentityStorageConflictError("Account pending modificato o non approvabile.")
+            if connection.execute(
+                "SELECT 1 FROM class_memberships WHERE user_id = ? LIMIT 1",
+                (target_user_id,),
+            ).fetchone() is not None:
+                raise IdentityStorageConflictError("Account pending con membership preesistente.")
+            if role == "student":
+                class_row = connection.execute(
+                    "SELECT * FROM classes WHERE class_id = ?", (class_id,)
+                ).fetchone()
+                if class_row is None or class_row["active"] != 1:
+                    raise IdentityStorageConflictError("Classe studente assente o non attiva.")
+            stale = connection.execute(
+                """
+                SELECT 1 FROM sessions
+                WHERE user_id = ? AND revoked_at IS NULL AND expires_at > ?
+                    AND (created_at > ? OR last_seen_at > ?)
+                LIMIT 1
+                """,
+                (target_user_id, changed, changed, changed),
+            ).fetchone()
+            if stale is not None:
+                raise IdentityStorageConflictError("Clock approvazione precedente alla sessione corrente.")
+            connection.execute(
+                "UPDATE users SET role = ?, updated_at = ? WHERE user_id = ?",
+                (role, changed, target_user_id),
+            )
+            membership = None
+            if role == "student":
+                connection.execute(
+                    "INSERT INTO class_memberships VALUES (?, ?, 'student', ?, NULL, NULL)",
+                    (target_user_id, class_id, changed),
+                )
+                membership = ClassMembership(target_user_id, class_id, "student", updated_at)
+            revoked = connection.execute(
+                """
+                UPDATE sessions SET revoked_at = ?
+                WHERE user_id = ? AND revoked_at IS NULL
+                    AND created_at <= ? AND expires_at > ?
+                """,
+                (changed, target_user_id, changed, changed),
+            ).rowcount
+            connection.execute(
+                "DELETE FROM tui_pairings WHERE user_id = ? AND status = 'authorized'",
+                (target_user_id,),
+            )
+            updated_row = connection.execute(
+                "SELECT * FROM users WHERE user_id = ?", (target_user_id,)
+            ).fetchone()
+            return self._user(updated_row), membership, revoked
+
     @staticmethod
     def _reserve_external_identity_generation(
         connection: sqlite3.Connection,

--- a/tests/test_thebitlab_admin_provisioning.py
+++ b/tests/test_thebitlab_admin_provisioning.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.thebitlab_admin_provisioning import (
+    AdminProvisioningConflictError,
+    AdminProvisioningService,
+)
+from scripts.thebitlab_identity import ClassGroup, UserAccount, UserSession
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+
+NOW = datetime(2026, 9, 2, 10, 0, tzinfo=timezone.utc)
+LATER = NOW + timedelta(minutes=1)
+
+
+def user(user_id: str, role: str, *, updated_at: datetime = NOW) -> UserAccount:
+    return UserAccount(user_id, user_id, role, True, NOW, updated_at)
+
+
+def session(user_id: str) -> UserSession:
+    return UserSession(
+        f"session-{user_id}",
+        user_id,
+        "sha256:" + ("a" if user_id == "student-01" else "b") * 64,
+        NOW,
+        NOW + timedelta(hours=8),
+        NOW,
+    )
+
+
+@pytest.fixture
+def graph(tmp_path):
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3")
+    admin = user("admin-01", "admin")
+    pending_student = user("student-01", "pending")
+    pending_teacher = user("teacher-01", "pending")
+    storage.create_user(admin)
+    storage.create_user(pending_student)
+    storage.create_user(pending_teacher)
+    storage.create_session(session("student-01"))
+    service = AdminProvisioningService(storage, clock=lambda: LATER)
+    return storage, service, admin, pending_student, pending_teacher
+
+
+def test_admin_creates_class_reads_snapshot_and_approves_student_atomically(graph) -> None:
+    storage, service, admin, pending_student, _pending_teacher = graph
+
+    created = service.create_class(
+        admin, class_id="class-01", label="Classe 1", school_year="2026/2027"
+    )
+    snapshot = service.snapshot(admin)
+    approved = service.approve(
+        admin,
+        target_user_id=pending_student.user_id,
+        expected_target_updated_at=pending_student.updated_at,
+        role="student",
+        class_id=created.class_id,
+    )
+
+    assert [item.user_id for item in snapshot.pending_users] == ["student-01", "teacher-01"]
+    assert snapshot.classes == (created,)
+    assert approved.user.role == "student"
+    assert approved.membership is not None
+    assert approved.membership.class_id == "class-01"
+    assert approved.membership.source_provider is None
+    assert approved.revoked_sessions == 1
+    assert storage.read_user("student-01").role == "student"
+    assert storage.list_user_memberships("student-01") == [approved.membership]
+    assert storage.list_user_sessions("student-01")[0].revoked_at == LATER
+
+
+def test_admin_approves_teacher_without_implicit_membership(graph) -> None:
+    storage, service, admin, _pending_student, pending_teacher = graph
+
+    result = service.approve(
+        admin,
+        target_user_id=pending_teacher.user_id,
+        expected_target_updated_at=pending_teacher.updated_at,
+        role="teacher",
+    )
+
+    assert result.user.role == "teacher"
+    assert result.membership is None
+    assert result.revoked_sessions == 0
+    assert storage.list_user_memberships("teacher-01") == []
+
+
+def test_non_admin_and_stale_admin_fail_closed(graph) -> None:
+    storage, service, admin, pending_student, pending_teacher = graph
+
+    with pytest.raises(AdminProvisioningConflictError):
+        service.snapshot(pending_teacher)
+
+    changed = replace(admin, display_name="changed", updated_at=LATER)
+    storage.save_user(changed, expected_updated_at=admin.updated_at)
+    with pytest.raises(AdminProvisioningConflictError):
+        service.approve(
+            admin,
+            target_user_id=pending_student.user_id,
+            expected_target_updated_at=pending_student.updated_at,
+            role="teacher",
+        )
+    assert storage.read_user("student-01").role == "pending"
+
+
+def test_inactive_or_missing_class_rolls_back_role_membership_and_session(graph) -> None:
+    storage, service, admin, pending_student, _pending_teacher = graph
+    inactive = ClassGroup("closed", "Chiusa", "2025/2026", False, NOW, NOW)
+    storage.create_class(inactive)
+
+    for class_id in ("closed", "missing"):
+        with pytest.raises(AdminProvisioningConflictError):
+            service.approve(
+                admin,
+                target_user_id=pending_student.user_id,
+                expected_target_updated_at=pending_student.updated_at,
+                role="student",
+                class_id=class_id,
+            )
+        assert storage.read_user("student-01").role == "pending"
+        assert storage.list_user_memberships("student-01") == []
+        assert storage.list_user_sessions("student-01")[0].revoked_at is None
+
+
+def test_replay_and_target_revision_race_fail_closed(graph) -> None:
+    storage, service, admin, pending_student, _pending_teacher = graph
+    service.create_class(admin, class_id="class-01", label="Classe", school_year="2026/2027")
+    first = service.approve(
+        admin,
+        target_user_id=pending_student.user_id,
+        expected_target_updated_at=pending_student.updated_at,
+        role="student",
+        class_id="class-01",
+    )
+
+    with pytest.raises(AdminProvisioningConflictError):
+        service.approve(
+            admin,
+            target_user_id=pending_student.user_id,
+            expected_target_updated_at=pending_student.updated_at,
+            role="student",
+            class_id="class-01",
+        )
+    assert storage.read_user("student-01") == first.user
+    assert len(storage.list_user_memberships("student-01")) == 1
+
+
+def test_snapshot_bound_and_invalid_role_fail_before_mutation(graph) -> None:
+    storage, _service, admin, pending_student, _pending_teacher = graph
+    bounded = AdminProvisioningService(storage, clock=lambda: LATER, maximum_snapshot_items=1)
+
+    with pytest.raises(AdminProvisioningConflictError):
+        bounded.snapshot(admin)
+    with pytest.raises(ValueError):
+        bounded.approve(
+            admin,
+            target_user_id=pending_student.user_id,
+            expected_target_updated_at=pending_student.updated_at,
+            role="admin",
+        )
+    assert storage.read_user("student-01").role == "pending"


### PR DESCRIPTION
## Summary
- add provider-independent admin provisioning application service and storage port
- provide bounded pending/class snapshot and admin-owned class creation
- atomically approve pending teacher/student, create manual student membership, and revoke active target sessions
- fail closed on stale admin/target revisions, inactive classes, replay, preexisting memberships, and clock races
- document bootstrap/UI as separate boundaries

## Validation
- 120 focused identity/auth/mapping tests passed
- py_compile and diff checks clean

Closes #613
Relates to #535 and #292