### PR TITLE
Auth: bootstrap locale one-shot del primo admin

### DIFF
--- a/doc/architecture/admin-provisioning-service.md
+++ b/doc/architecture/admin-provisioning-service.md
@@ -18,7 +18,7 @@ Gli errori applicativi sono sanitizzati e non serializzano identità provider o 
 Dopo che il primo account Google è stato creato come `pending`, un operatore locale con accesso al database protetto esegue una sola volta:
 
 ```text
-python scripts/thebitlab_admin_bootstrap_cli.py --database <auth.sqlite3> --user-id <user-id-TheBitLab>
+python -I scripts/thebitlab_admin_bootstrap_cli.py --database <auth.sqlite3> --user-id <user-id-TheBitLab>
 ```
 
-Il comando non accetta email, subject provider, cookie o token. Verifica nuovamente ACL/permessi del database, quindi promuove il target pending e revoca le sue sessioni nella stessa transazione. Fallisce se esiste già un admin, il target non è pending/attivo, possiede membership, la revisione cambia o il clock precede una sessione corrente. Le esecuzioni concorrenti producono un solo vincitore; output ed errori non mostrano lo user ID. Dopo il bootstrap l'admin deve effettuare nuovamente il login.
+Il comando rifiuta l'avvio senza la modalità Python isolata `-I`, che ignora `PYTHONPATH`, user site e variabili Python ereditate prima di caricare moduli privilegiati. Non accetta email, subject provider, cookie o token. Verifica nuovamente ACL/permessi del database, quindi promuove il target pending e revoca le sue sessioni nella stessa transazione. Fallisce se esiste già un admin, il target non è pending/attivo, possiede membership, la revisione cambia o il clock precede una sessione corrente. Le esecuzioni concorrenti producono un solo vincitore; output ed errori non mostrano lo user ID. Dopo il bootstrap l'admin deve effettuare nuovamente il login.

--- a/doc/architecture/admin-provisioning-service.md
+++ b/doc/architecture/admin-provisioning-service.md
@@ -18,7 +18,7 @@ Gli errori applicativi sono sanitizzati e non serializzano identità provider o 
 Dopo che il primo account Google è stato creato come `pending`, un operatore locale con accesso al database protetto esegue una sola volta:
 
 ```text
-python -I scripts/thebitlab_admin_bootstrap_cli.py --database <auth.sqlite3> --user-id <user-id-TheBitLab>
+python -I -S scripts/thebitlab_admin_bootstrap_cli.py --database <auth.sqlite3> --user-id <user-id-TheBitLab>
 ```
 
-Il comando rifiuta l'avvio senza la modalità Python isolata `-I`, che ignora `PYTHONPATH`, user site e variabili Python ereditate prima di caricare moduli privilegiati. Non accetta email, subject provider, cookie o token. Verifica nuovamente ACL/permessi del database, quindi promuove il target pending e revoca le sue sessioni nella stessa transazione. Fallisce se esiste già un admin, il target non è pending/attivo, possiede membership, la revisione cambia o il clock precede una sessione corrente. Le esecuzioni concorrenti producono un solo vincitore; output ed errori non mostrano lo user ID. Dopo il bootstrap l'admin deve effettuare nuovamente il login.
+Il comando rifiuta l'avvio senza `-I -S`: la modalità isolata ignora `PYTHONPATH`, user site e variabili Python, mentre `-S` impedisce il caricamento anticipato di `site` e file `.pth` globali. Non accetta email, subject provider, cookie o token. Verifica nuovamente ACL/permessi del database, quindi promuove il target pending e revoca le sue sessioni nella stessa transazione. Fallisce se esiste già un admin, il target non è pending/attivo, possiede membership, la revisione cambia o il clock precede una sessione corrente. Le esecuzioni concorrenti producono un solo vincitore; output ed errori non mostrano lo user ID. Dopo il bootstrap l'admin deve effettuare nuovamente il login.

--- a/doc/architecture/admin-provisioning-service.md
+++ b/doc/architecture/admin-provisioning-service.md
@@ -11,4 +11,14 @@
 
 L'approvazione avviene in una singola transazione SQLite. Sono ricontrollati ruolo/revisione dell'admin, stato/revisione del target, assenza di membership pregresse, classe attiva e monotonicità del clock. Cambio ruolo, eventuale membership e revoca di tutte le sessioni attive del target sono atomici. Replay, CAS stale, classi mancanti/inattive e sessioni temporalmente più nuove causano rollback completo.
 
-Gli errori applicativi sono sanitizzati e non serializzano identità provider o dettagli SQLite. Il bootstrap iniziale dell'admin e la superficie HTTP/GUI amministrativa sono confini separati: questo service non consente auto-approvazione e non trasforma un pending in admin.
+Gli errori applicativi sono sanitizzati e non serializzano identità provider o dettagli SQLite. La superficie HTTP/GUI amministrativa è un confine separato: questo service non consente auto-approvazione e non trasforma un pending in admin.
+
+## Bootstrap del primo admin
+
+Dopo che il primo account Google è stato creato come `pending`, un operatore locale con accesso al database protetto esegue una sola volta:
+
+```text
+python scripts/thebitlab_admin_bootstrap_cli.py --database <auth.sqlite3> --user-id <user-id-TheBitLab>
+```
+
+Il comando non accetta email, subject provider, cookie o token. Verifica nuovamente ACL/permessi del database, quindi promuove il target pending e revoca le sue sessioni nella stessa transazione. Fallisce se esiste già un admin, il target non è pending/attivo, possiede membership, la revisione cambia o il clock precede una sessione corrente. Le esecuzioni concorrenti producono un solo vincitore; output ed errori non mostrano lo user ID. Dopo il bootstrap l'admin deve effettuare nuovamente il login.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""TheBitLab application and tooling package."""

--- a/scripts/thebitlab_admin_bootstrap.py
+++ b/scripts/thebitlab_admin_bootstrap.py
@@ -1,0 +1,67 @@
+"""One-shot local bootstrap for the first TheBitLab administrator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable
+
+from scripts.thebitlab_identity import UserAccount
+from scripts.thebitlab_identity_ports import AdminBootstrapStorage
+
+
+class AdminBootstrapError(RuntimeError):
+    """Sanitized bootstrap failure."""
+
+
+@dataclass(frozen=True)
+class AdminBootstrapResult:
+    user: UserAccount
+    revoked_sessions: int
+
+
+class AdminBootstrapService:
+    def __init__(
+        self,
+        storage: AdminBootstrapStorage,
+        *,
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        if not callable(getattr(storage, "read_user", None)) or not callable(
+            getattr(storage, "bootstrap_first_admin", None)
+        ):
+            raise ValueError("Storage bootstrap admin non valido.")
+        if not callable(clock):
+            raise ValueError("Clock bootstrap admin non valido.")
+        self.storage = storage
+        self.clock = clock
+
+    def bootstrap(self, target_user_id: str) -> AdminBootstrapResult:
+        if type(target_user_id) is not str or not target_user_id.strip():
+            raise ValueError("Target bootstrap admin non valido.")
+        try:
+            target = self.storage.read_user(target_user_id)
+            if type(target) is not UserAccount or target.role != "pending" or not target.active:
+                raise AdminBootstrapError("Bootstrap admin non disponibile.")
+            now = self.clock()
+            if type(now) is not datetime or now.tzinfo is None or now.utcoffset() is None:
+                raise AdminBootstrapError("Bootstrap admin non disponibile.")
+            user, revoked = self.storage.bootstrap_first_admin(
+                target.user_id,
+                now.astimezone(timezone.utc),
+                expected_target_updated_at=target.updated_at,
+            )
+            if (
+                type(user) is not UserAccount
+                or user.user_id != target.user_id
+                or user.role != "admin"
+                or not user.active
+                or type(revoked) is not int
+                or revoked < 0
+            ):
+                raise AdminBootstrapError("Bootstrap admin non disponibile.")
+            return AdminBootstrapResult(user, revoked)
+        except AdminBootstrapError:
+            raise
+        except Exception as error:
+            raise AdminBootstrapError("Bootstrap admin non disponibile.") from error

--- a/scripts/thebitlab_admin_bootstrap_cli.py
+++ b/scripts/thebitlab_admin_bootstrap_cli.py
@@ -11,6 +11,7 @@ if __package__ in {None, ""}:
 
 from scripts.thebitlab_admin_bootstrap import AdminBootstrapError, AdminBootstrapService
 from scripts.thebitlab_auth_runtime import AuthRuntimeConfigurationError, _prepare_database_file
+from scripts.thebitlab_identity_ports import IdentityStorageError
 from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
 
 
@@ -33,7 +34,13 @@ def main(argv: list[str] | None = None) -> int:
         result = AdminBootstrapService(SqliteIdentityStorage(database)).bootstrap(args.user_id)
         print(f"Bootstrap admin completato; sessioni revocate: {result.revoked_sessions}.")
         return 0
-    except (AdminBootstrapError, AuthRuntimeConfigurationError, OSError, ValueError):
+    except (
+        AdminBootstrapError,
+        AuthRuntimeConfigurationError,
+        IdentityStorageError,
+        OSError,
+        ValueError,
+    ):
         print("Bootstrap admin non completato.", file=sys.stderr)
         return 1
 

--- a/scripts/thebitlab_admin_bootstrap_cli.py
+++ b/scripts/thebitlab_admin_bootstrap_cli.py
@@ -1,0 +1,39 @@
+"""Local command for the one-shot first-admin bootstrap."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from scripts.thebitlab_admin_bootstrap import AdminBootstrapError, AdminBootstrapService
+from scripts.thebitlab_auth_runtime import AuthRuntimeConfigurationError, _prepare_database_file
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Promuove atomicamente un account pending come primo admin TheBitLab."
+    )
+    parser.add_argument("--database", required=True, type=Path)
+    parser.add_argument("--user-id", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        database = args.database.absolute()
+        if not database.exists() or not database.is_file():
+            raise AdminBootstrapError("Database bootstrap non disponibile.")
+        _prepare_database_file(database)
+        result = AdminBootstrapService(SqliteIdentityStorage(database)).bootstrap(args.user_id)
+        print(f"Bootstrap admin completato; sessioni revocate: {result.revoked_sessions}.")
+        return 0
+    except (AdminBootstrapError, AuthRuntimeConfigurationError, OSError, ValueError):
+        print("Bootstrap admin non completato.", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/thebitlab_admin_bootstrap_cli.py
+++ b/scripts/thebitlab_admin_bootstrap_cli.py
@@ -6,6 +6,9 @@ import argparse
 import sys
 from pathlib import Path
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from scripts.thebitlab_admin_bootstrap import AdminBootstrapError, AdminBootstrapService
 from scripts.thebitlab_auth_runtime import AuthRuntimeConfigurationError, _prepare_database_file
 from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage

--- a/scripts/thebitlab_admin_bootstrap_cli.py
+++ b/scripts/thebitlab_admin_bootstrap_cli.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import sys
 
-if __name__ == "__main__" and not sys.flags.isolated:
-    print("Avviare il bootstrap con Python in modalità isolata (-I).", file=sys.stderr)
+if __name__ == "__main__" and (not sys.flags.isolated or not sys.flags.no_site):
+    print("Avviare il bootstrap con Python isolato e senza site (-I -S).", file=sys.stderr)
     raise SystemExit(2)
 
 import argparse

--- a/scripts/thebitlab_admin_bootstrap_cli.py
+++ b/scripts/thebitlab_admin_bootstrap_cli.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
-import argparse
 import sys
+
+if __name__ == "__main__" and not sys.flags.isolated:
+    print("Avviare il bootstrap con Python in modalità isolata (-I).", file=sys.stderr)
+    raise SystemExit(2)
+
+import argparse
 from pathlib import Path
 
 if __package__ in {None, ""}:

--- a/scripts/thebitlab_auth_runtime.py
+++ b/scripts/thebitlab_auth_runtime.py
@@ -761,13 +761,21 @@ def _verify_windows_ancestor_chain(path: Path, sid: str) -> None:
 def _windows_acl_tools(
     *, acl_path: Path | None = None, acl_sid: str | None = None
 ) -> tuple[str, str, dict[str, str]]:
-    system_root = os.environ.get("SystemRoot", "")
-    if not system_root or "\x00" in system_root:
-        raise OSError("SystemRoot Windows non valido")
+    try:
+        import ctypes
+
+        buffer = ctypes.create_unicode_buffer(32_768)
+        length = ctypes.windll.kernel32.GetSystemDirectoryW(buffer, len(buffer))
+        if not 0 < length < len(buffer):
+            raise OSError("Directory sistema Windows non disponibile")
+        system_directory = Path(buffer.value)
+        system_root = str(system_directory.parent)
+    except (AttributeError, OSError, ValueError):
+        raise OSError("Directory sistema Windows non disponibile") from None
     powershell = str(
-        Path(system_root) / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+        system_directory / "WindowsPowerShell" / "v1.0" / "powershell.exe"
     )
-    icacls = str(Path(system_root) / "System32" / "icacls.exe")
+    icacls = str(system_directory / "icacls.exe")
     environment = {"SystemRoot": system_root, "WINDIR": system_root}
     if acl_path is not None and acl_sid is not None:
         environment["THEBITLAB_ACL_PATH"] = str(acl_path)

--- a/scripts/thebitlab_identity_ports.py
+++ b/scripts/thebitlab_identity_ports.py
@@ -271,6 +271,20 @@ class ClassDirectoryStorage(Protocol):
     ) -> None: ...
 
 
+class AdminBootstrapStorage(Protocol):
+    """One-shot local boundary for establishing the first administrator."""
+
+    def read_user(self, user_id: str) -> UserAccount | None: ...
+
+    def bootstrap_first_admin(
+        self,
+        target_user_id: str,
+        updated_at: datetime,
+        *,
+        expected_target_updated_at: datetime,
+    ) -> tuple[UserAccount, int]: ...
+
+
 class AdminProvisioningStorage(Protocol):
     """Atomic persistence boundary for explicit admin-owned onboarding."""
 

--- a/scripts/thebitlab_identity_sqlite.py
+++ b/scripts/thebitlab_identity_sqlite.py
@@ -716,6 +716,69 @@ class SqliteIdentityStorage:
     def list_users(self) -> list[UserAccount]:
         return [self._user(row) for row in self._query_all("SELECT * FROM users ORDER BY user_id")]
 
+    def bootstrap_first_admin(
+        self,
+        target_user_id: str,
+        updated_at: datetime,
+        *,
+        expected_target_updated_at: datetime,
+    ) -> tuple[UserAccount, int]:
+        expected = _encode_datetime(expected_target_updated_at, "expected_target_updated_at")
+        changed = _encode_datetime(updated_at, "updated_at")
+        if changed <= expected:
+            raise IdentityStorageConflictError("Revisione bootstrap non crescente.")
+        with self._transaction("bootstrap_first_admin") as connection:
+            if connection.execute(
+                "SELECT 1 FROM users WHERE role = 'admin' LIMIT 1"
+            ).fetchone() is not None:
+                raise IdentityStorageConflictError("Bootstrap admin già completato.")
+            row = connection.execute(
+                "SELECT * FROM users WHERE user_id = ?", (target_user_id,)
+            ).fetchone()
+            if row is None:
+                raise IdentityStorageNotFoundError("Target bootstrap non trovato.")
+            if (
+                row["role"] != "pending"
+                or row["active"] != 1
+                or row["updated_at"] != expected
+            ):
+                raise IdentityStorageConflictError("Target bootstrap non approvabile.")
+            if connection.execute(
+                "SELECT 1 FROM class_memberships WHERE user_id = ? LIMIT 1",
+                (target_user_id,),
+            ).fetchone() is not None:
+                raise IdentityStorageConflictError("Target bootstrap con membership preesistente.")
+            if connection.execute(
+                """
+                SELECT 1 FROM sessions
+                WHERE user_id = ? AND revoked_at IS NULL AND expires_at > ?
+                    AND (created_at > ? OR last_seen_at > ?)
+                LIMIT 1
+                """,
+                (target_user_id, changed, changed, changed),
+            ).fetchone() is not None:
+                raise IdentityStorageConflictError("Clock bootstrap precedente alla sessione corrente.")
+            connection.execute(
+                "UPDATE users SET role = 'admin', updated_at = ? WHERE user_id = ?",
+                (changed, target_user_id),
+            )
+            revoked = connection.execute(
+                """
+                UPDATE sessions SET revoked_at = ?
+                WHERE user_id = ? AND revoked_at IS NULL
+                    AND created_at <= ? AND expires_at > ?
+                """,
+                (changed, target_user_id, changed, changed),
+            ).rowcount
+            connection.execute(
+                "DELETE FROM tui_pairings WHERE user_id = ? AND status = 'authorized'",
+                (target_user_id,),
+            )
+            updated = connection.execute(
+                "SELECT * FROM users WHERE user_id = ?", (target_user_id,)
+            ).fetchone()
+            return self._user(updated), revoked
+
     @classmethod
     def _require_current_admin(
         cls,

--- a/tests/test_thebitlab_admin_bootstrap.py
+++ b/tests/test_thebitlab_admin_bootstrap.py
@@ -99,7 +99,7 @@ def test_cli_is_directly_executable_without_namespace_package_hijack(tmp_path) -
     environment = dict(os.environ)
     environment["PYTHONPATH"] = str(fake.parent)
     completed = subprocess.run(
-        [sys.executable, "scripts/thebitlab_admin_bootstrap_cli.py", "--help"],
+        [sys.executable, "-I", "scripts/thebitlab_admin_bootstrap_cli.py", "--help"],
         cwd=root,
         env=environment,
         capture_output=True,
@@ -111,6 +111,17 @@ def test_cli_is_directly_executable_without_namespace_package_hijack(tmp_path) -
     assert "--database" in completed.stdout
     assert "ModuleNotFoundError" not in completed.stderr
     assert "HIJACKED" not in completed.stderr
+
+    non_isolated = subprocess.run(
+        [sys.executable, "scripts/thebitlab_admin_bootstrap_cli.py", "--help"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert non_isolated.returncode == 2
+    assert "modalità isolata" in non_isolated.stderr
 
 
 def test_cli_sanitizes_storage_initialization_failure(tmp_path, monkeypatch, capsys) -> None:

--- a/tests/test_thebitlab_admin_bootstrap.py
+++ b/tests/test_thebitlab_admin_bootstrap.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -84,6 +87,21 @@ def test_non_pending_inactive_membership_and_stale_clock_fail_without_mutation(t
             "pending-01"
         )
     assert storage.read_user("pending-01").role == "student"
+
+
+def test_cli_is_directly_executable_from_repository_root() -> None:
+    root = Path(__file__).resolve().parents[1]
+    completed = subprocess.run(
+        [sys.executable, "scripts/thebitlab_admin_bootstrap_cli.py", "--help"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert completed.returncode == 0
+    assert "--database" in completed.stdout
+    assert "ModuleNotFoundError" not in completed.stderr
 
 
 def test_cli_reports_only_sanitized_success_and_failure(tmp_path, monkeypatch, capsys) -> None:

--- a/tests/test_thebitlab_admin_bootstrap.py
+++ b/tests/test_thebitlab_admin_bootstrap.py
@@ -99,7 +99,7 @@ def test_cli_is_directly_executable_without_namespace_package_hijack(tmp_path) -
     environment = dict(os.environ)
     environment["PYTHONPATH"] = str(fake.parent)
     completed = subprocess.run(
-        [sys.executable, "-I", "scripts/thebitlab_admin_bootstrap_cli.py", "--help"],
+        [sys.executable, "-I", "-S", "scripts/thebitlab_admin_bootstrap_cli.py", "--help"],
         cwd=root,
         env=environment,
         capture_output=True,
@@ -121,7 +121,7 @@ def test_cli_is_directly_executable_without_namespace_package_hijack(tmp_path) -
         check=False,
     )
     assert non_isolated.returncode == 2
-    assert "modalità isolata" in non_isolated.stderr
+    assert "-I -S" in non_isolated.stderr
 
 
 def test_cli_sanitizes_storage_initialization_failure(tmp_path, monkeypatch, capsys) -> None:

--- a/tests/test_thebitlab_admin_bootstrap.py
+++ b/tests/test_thebitlab_admin_bootstrap.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts import thebitlab_admin_bootstrap_cli as cli
+from scripts.thebitlab_admin_bootstrap import AdminBootstrapError, AdminBootstrapService
+from scripts.thebitlab_identity import UserAccount, UserSession
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
+
+NOW = datetime(2026, 9, 2, 12, 0, tzinfo=timezone.utc)
+LATER = NOW + timedelta(minutes=1)
+
+
+def pending(user_id="pending-01"):
+    return UserAccount(user_id, "Pending", "pending", True, NOW, NOW)
+
+
+def make_storage(tmp_path):
+    storage = SqliteIdentityStorage(tmp_path / "auth.sqlite3")
+    storage.create_user(pending())
+    storage.create_session(
+        UserSession(
+            "web-01",
+            "pending-01",
+            "sha256:" + "c" * 64,
+            NOW,
+            NOW + timedelta(hours=1),
+            NOW,
+        )
+    )
+    return storage
+
+
+def test_bootstrap_promotes_only_pending_target_and_revokes_sessions(tmp_path) -> None:
+    storage = make_storage(tmp_path)
+    result = AdminBootstrapService(storage, clock=lambda: LATER).bootstrap("pending-01")
+
+    assert result.user.role == "admin"
+    assert result.revoked_sessions == 1
+    assert storage.read_user("pending-01") == result.user
+    assert storage.list_user_sessions("pending-01")[0].revoked_at == LATER
+
+
+def test_bootstrap_is_one_shot_and_second_target_remains_pending(tmp_path) -> None:
+    storage = make_storage(tmp_path)
+    storage.create_user(pending("pending-02"))
+    service = AdminBootstrapService(storage, clock=lambda: LATER)
+    service.bootstrap("pending-01")
+
+    with pytest.raises(AdminBootstrapError):
+        service.bootstrap("pending-02")
+    assert storage.read_user("pending-02").role == "pending"
+
+
+def test_concurrent_bootstrap_has_exactly_one_winner(tmp_path) -> None:
+    storage = make_storage(tmp_path)
+    storage.create_user(pending("pending-02"))
+
+    def attempt(user_id):
+        try:
+            return AdminBootstrapService(storage, clock=lambda: LATER).bootstrap(user_id)
+        except AdminBootstrapError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(attempt, ("pending-01", "pending-02")))
+
+    assert sum(result is not None for result in results) == 1
+    assert sum(user.role == "admin" for user in storage.list_users()) == 1
+
+
+def test_non_pending_inactive_membership_and_stale_clock_fail_without_mutation(tmp_path) -> None:
+    storage = make_storage(tmp_path)
+    target = storage.read_user("pending-01")
+    storage.save_user(
+        UserAccount(target.user_id, target.display_name, "student", True, NOW, LATER),
+        expected_updated_at=NOW,
+    )
+    with pytest.raises(AdminBootstrapError):
+        AdminBootstrapService(storage, clock=lambda: LATER + timedelta(minutes=1)).bootstrap(
+            "pending-01"
+        )
+    assert storage.read_user("pending-01").role == "student"
+
+
+def test_cli_reports_only_sanitized_success_and_failure(tmp_path, monkeypatch, capsys) -> None:
+    storage = make_storage(tmp_path)
+    database = storage.database_path
+    monkeypatch.setattr(cli, "_prepare_database_file", lambda path: None)
+    monkeypatch.setattr(
+        cli,
+        "AdminBootstrapService",
+        lambda storage: AdminBootstrapService(storage, clock=lambda: LATER),
+    )
+
+    success = cli.main(["--database", str(database), "--user-id", "pending-01"])
+    second = cli.main(["--database", str(database), "--user-id", "pending-01"])
+    captured = capsys.readouterr()
+
+    assert success == 0
+    assert second == 1
+    assert "pending-01" not in captured.out + captured.err
+    assert "Bootstrap admin completato" in captured.out
+    assert "Bootstrap admin non completato" in captured.err

--- a/tests/test_thebitlab_admin_bootstrap.py
+++ b/tests/test_thebitlab_admin_bootstrap.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import os
 import subprocess
 import sys
 
@@ -11,6 +12,7 @@ import pytest
 from scripts import thebitlab_admin_bootstrap_cli as cli
 from scripts.thebitlab_admin_bootstrap import AdminBootstrapError, AdminBootstrapService
 from scripts.thebitlab_identity import UserAccount, UserSession
+from scripts.thebitlab_identity_ports import IdentityStorageError
 from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
 
 NOW = datetime(2026, 9, 2, 12, 0, tzinfo=timezone.utc)
@@ -89,11 +91,17 @@ def test_non_pending_inactive_membership_and_stale_clock_fail_without_mutation(t
     assert storage.read_user("pending-01").role == "student"
 
 
-def test_cli_is_directly_executable_from_repository_root() -> None:
+def test_cli_is_directly_executable_without_namespace_package_hijack(tmp_path) -> None:
     root = Path(__file__).resolve().parents[1]
+    fake = tmp_path / "attacker" / "scripts"
+    fake.mkdir(parents=True)
+    (fake / "__init__.py").write_text("raise RuntimeError('HIJACKED')", encoding="utf-8")
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(fake.parent)
     completed = subprocess.run(
         [sys.executable, "scripts/thebitlab_admin_bootstrap_cli.py", "--help"],
         cwd=root,
+        env=environment,
         capture_output=True,
         text=True,
         timeout=10,
@@ -102,6 +110,26 @@ def test_cli_is_directly_executable_from_repository_root() -> None:
     assert completed.returncode == 0
     assert "--database" in completed.stdout
     assert "ModuleNotFoundError" not in completed.stderr
+    assert "HIJACKED" not in completed.stderr
+
+
+def test_cli_sanitizes_storage_initialization_failure(tmp_path, monkeypatch, capsys) -> None:
+    database = tmp_path / "auth.sqlite3"
+    database.write_bytes(b"not-sqlite")
+    monkeypatch.setattr(cli, "_prepare_database_file", lambda path: None)
+    monkeypatch.setattr(
+        cli,
+        "SqliteIdentityStorage",
+        lambda path: (_ for _ in ()).throw(IdentityStorageError("raw sqlite path/details")),
+    )
+
+    result = cli.main(["--database", str(database), "--user-id", "pending-01"])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "raw sqlite" not in captured.err
+    assert "pending-01" not in captured.err
+    assert captured.err.strip() == "Bootstrap admin non completato."
 
 
 def test_cli_reports_only_sanitized_success_and_failure(tmp_path, monkeypatch, capsys) -> None:

--- a/tests/test_thebitlab_auth_runtime.py
+++ b/tests/test_thebitlab_auth_runtime.py
@@ -13,6 +13,7 @@ import pytest
 
 from scripts.thebitlab_auth_runtime import (
     AuthRuntimeConfigurationError,
+    _windows_acl_tools,
     compose_google_oidc_runtime as _compose_google_oidc_runtime,
 )
 
@@ -189,6 +190,20 @@ def test_composition_rejects_unsafe_configuration_without_echoing_values(
         "THEBITLAB_TUI_PAIRING_PEPPER_B64",
     ):
         assert environment[secret_name] not in serialized
+
+
+def test_windows_acl_tools_ignore_untrusted_systemroot_environment(monkeypatch) -> None:
+    if os.name != "nt":
+        pytest.skip("ACL Windows non disponibili")
+    monkeypatch.setenv("SystemRoot", r"C:\attacker-controlled")
+
+    powershell, icacls, environment = _windows_acl_tools()
+
+    assert "attacker-controlled" not in powershell.lower()
+    assert "attacker-controlled" not in icacls.lower()
+    assert "attacker-controlled" not in environment["SystemRoot"].lower()
+    assert Path(powershell).is_file()
+    assert Path(icacls).is_file()
 
 
 def test_windows_composition_rejects_preexisting_everyone_acl_without_repair(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add one-shot local first-admin bootstrap service and CLI
- select only an internal pending user ID; never accept provider identity or credentials
- atomically require zero existing admins, CAS target revision, reject memberships/clock races, promote, and revoke sessions
- reapply database ACL/permission verification before mutation
- sanitize CLI output and prove one winner under concurrent bootstrap

## Validation
- 43 focused bootstrap/provisioning/storage tests passed
- py_compile and diff checks clean

Closes #615
Relates to #535 and #292