### PR TITLE
Auth admin UI: read model pending e classi

### DIFF
--- a/doc/architecture/admin-provisioning-service.md
+++ b/doc/architecture/admin-provisioning-service.md
@@ -13,6 +13,10 @@ L'approvazione avviene in una singola transazione SQLite. Sono ricontrollati ruo
 
 Gli errori applicativi sono sanitizzati e non serializzano identità provider o dettagli SQLite. La superficie HTTP/GUI amministrativa è un confine separato: questo service non consente auto-approvazione e non trasforma un pending in admin.
 
+## Read model web amministrativo
+
+`GET /auth/admin` è composto soltanto quando il runtime federato include il service. Richiede TLS e una sessione web il cui account viene riletto atomicamente come admin attivo alla revisione corrente. Restituisce HTML bounded `no-store` con utenti pending e classi; valori dinamici sono escaped e non include email, subject provider, CSRF o cookie. CSP, `nosniff` e `DENY` proteggono la pagina. Le mutazioni restano separate e richiederanno POST con CSRF.
+
 ## Bootstrap del primo admin
 
 Dopo che il primo account Google è stato creato come `pending`, un operatore locale con accesso al database protetto esegue una sola volta:

--- a/scripts/thebitlab_auth_runtime.py
+++ b/scripts/thebitlab_auth_runtime.py
@@ -91,6 +91,9 @@ class GoogleOidcRuntime:
             or type(session_routes) is not SessionHttpRoutes
             or session_routes.sessions is not routes.session_discarder
             or session_routes.proxy_resolver is not routes.proxy_resolver
+            or session_routes.admin_provisioning is None
+            or session_routes.admin_provisioning.storage
+            is not routes.session_discarder.sessions.storage
             or type(tui_pairing_routes) is not TuiPairingHttpRoutes
             or tui_pairing_routes.proxy_resolver is not routes.proxy_resolver
             or tui_pairing_routes.boundary.http_sessions is not routes.session_discarder

--- a/scripts/thebitlab_auth_runtime.py
+++ b/scripts/thebitlab_auth_runtime.py
@@ -14,6 +14,7 @@ import urllib.parse
 from collections.abc import Mapping
 from pathlib import Path
 
+from scripts.thebitlab_admin_provisioning import AdminProvisioningService
 from scripts.thebitlab_auth_services import (
     ExternalIdentityLinkService,
     FederatedIdentityService,
@@ -238,7 +239,11 @@ def compose_google_oidc_runtime(
             http_sessions,
             session_cookie_policy=cookie_policy,
         )
-        session_routes = SessionHttpRoutes(http_sessions, proxy_resolver)
+        session_routes = SessionHttpRoutes(
+            http_sessions,
+            proxy_resolver,
+            AdminProvisioningService(storage),
+        )
         pairing_service = PairingService(storage, pepper=pairing_pepper)
         pairing_sessions = TuiPairingSessionService(pairing_service)
         tui_sessions = SessionService(storage, audience="tui")

--- a/scripts/thebitlab_session_http.py
+++ b/scripts/thebitlab_session_http.py
@@ -286,14 +286,31 @@ class SessionHttpRoutes:
 
     def _admin_response(self, context) -> SessionHttpResponse:
         snapshot = self.admin_provisioning.snapshot(context.user)
-        pending = "".join(
-            f"<li><code>{html.escape(user.user_id)}</code> — {html.escape(user.display_name)}</li>"
-            for user in snapshot.pending_users
-        ) or "<li>Nessun account pending</li>"
-        classes = "".join(
-            f"<li><code>{html.escape(item.class_id)}</code> — {html.escape(item.label)}</li>"
-            for item in snapshot.classes
-        ) or "<li>Nessuna classe</li>"
+        budget = 10_000
+
+        def bounded_rows(items, render, empty):
+            nonlocal budget
+            rows = []
+            for item in items:
+                row = render(item)
+                size = len(row.encode("utf-8"))
+                if size > budget:
+                    rows.append("<li>Elenco troncato</li>")
+                    break
+                rows.append(row)
+                budget -= size
+            return "".join(rows) or empty
+
+        pending = bounded_rows(
+            snapshot.pending_users,
+            lambda user: f"<li><code>{html.escape(user.user_id)}</code> — {html.escape(user.display_name)}</li>",
+            "<li>Nessun account pending</li>",
+        )
+        classes = bounded_rows(
+            snapshot.classes,
+            lambda item: f"<li><code>{html.escape(item.class_id)}</code> — {html.escape(item.label)}</li>",
+            "<li>Nessuna classe</li>",
+        )
         body = (
             "<!doctype html><html lang=\"it\"><head><meta charset=\"utf-8\">"
             "<title>Amministrazione - TheBitLab</title></head><body><main>"

--- a/scripts/thebitlab_session_http.py
+++ b/scripts/thebitlab_session_http.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import html
 import json
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
+from scripts.thebitlab_admin_provisioning import (
+    AdminProvisioningConflictError,
+    AdminProvisioningService,
+)
 from scripts.thebitlab_edge_rate_limit import (
     EdgeClientAttributionError,
     EdgeRequestMetadata,
@@ -24,6 +29,7 @@ from scripts.thebitlab_http_auth import (
 
 _SESSION_PATH = "/auth/session"
 _ACCOUNT_PATH = "/auth/account"
+_ADMIN_PATH = "/auth/admin"
 _LOGOUT_PATH = "/auth/logout"
 _MAX_COOKIE_HEADER_BYTES = 16 * 1024
 _CSRF_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
@@ -82,6 +88,7 @@ class SessionHttpRoutes:
         self,
         sessions: HttpSessionAuthBoundary,
         proxy_resolver: TrustedProxyClientResolver,
+        admin_provisioning: AdminProvisioningService | None = None,
     ) -> None:
         if type(sessions) is not HttpSessionAuthBoundary:
             raise ValueError("Boundary sessione HTTP non valido.")
@@ -89,11 +96,16 @@ class SessionHttpRoutes:
             raise ValueError("Resolver proxy sessione non valido.")
         if not sessions.cookie_policy.secure:
             raise ValueError("Le route sessione richiedono cookie Secure.")
+        if admin_provisioning is not None and type(admin_provisioning) is not AdminProvisioningService:
+            raise ValueError("Service provisioning amministrativo non valido.")
         self.sessions = sessions
         self.proxy_resolver = proxy_resolver
+        self.admin_provisioning = admin_provisioning
 
     def handles(self, path: str) -> bool:
-        return path in {_SESSION_PATH, _ACCOUNT_PATH, _LOGOUT_PATH}
+        return path in {_SESSION_PATH, _ACCOUNT_PATH, _LOGOUT_PATH} or (
+            path == _ADMIN_PATH and self.admin_provisioning is not None
+        )
 
     def dispatch(self, request: SessionHttpRequest) -> SessionHttpResponse | None:
         if type(request) is not SessionHttpRequest:
@@ -108,7 +120,7 @@ class SessionHttpRoutes:
             self._require_https(request)
             self._require_empty_request(request)
             if (
-                request.path in {_SESSION_PATH, _ACCOUNT_PATH}
+                request.path in {_SESSION_PATH, _ACCOUNT_PATH, _ADMIN_PATH}
                 and request.method != "GET"
             ):
                 return self._method_error("GET")
@@ -118,7 +130,7 @@ class SessionHttpRoutes:
                 request.edge, "cookie", maximum_bytes=_MAX_COOKIE_HEADER_BYTES,
                 separator="; ", required=True
             )
-            if request.path in {_SESSION_PATH, _ACCOUNT_PATH}:
+            if request.path in {_SESSION_PATH, _ACCOUNT_PATH, _ADMIN_PATH}:
                 csrf_headers = _header_values(request.edge, "x-csrf-token")
                 if csrf_headers:
                     _csrf_header(csrf_headers)
@@ -127,6 +139,8 @@ class SessionHttpRoutes:
                 )
                 if request.path == _ACCOUNT_PATH:
                     return self._account_response(context)
+                if request.path == _ADMIN_PATH:
+                    return self._admin_response(context)
                 return self._session_response(context)
             csrf_token = _csrf_header(
                 _header_values(request.edge, "x-csrf-token")
@@ -147,6 +161,8 @@ class SessionHttpRoutes:
             )
         except _SessionRequestError as error:
             return self._error(error.status_code, error.error_code, error.public_message)
+        except AdminProvisioningConflictError:
+            return self._error(403, "admin_forbidden", "Accesso amministrativo non consentito.")
         except HttpAuthError as error:
             extra = (("Allow", "POST"),) if isinstance(error, HttpMethodNotAllowedError) else ()
             return self._error(error.status_code, error.error_code, error.public_message, extra)
@@ -235,13 +251,17 @@ class SessionHttpRoutes:
                 "L'account studente è autorizzato. Puoi associare la TUI da questo browser."
             )
             action = '<p><a href="/auth/tui/pair">Associa la TUI</a></p>'
-        else:
+        elif role == "teacher":
             title = "Area docente"
             message = (
                 "L'account docente è autorizzato. "
                 "La Board mantiene una protezione docente separata."
             )
             action = '<p><a href="/tools/course_board.html">Apri la Course Design Board</a></p>'
+        else:
+            title = "Area amministratore"
+            message = "L'account amministratore è autorizzato."
+            action = '<p><a href="/auth/admin">Gestisci utenti e classi</a></p>'
         body = (
             "<!doctype html><html lang=\"it\"><head><meta charset=\"utf-8\">"
             "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
@@ -263,6 +283,29 @@ class SessionHttpRoutes:
             ),
             body,
         )
+
+    def _admin_response(self, context) -> SessionHttpResponse:
+        snapshot = self.admin_provisioning.snapshot(context.user)
+        pending = "".join(
+            f"<li><code>{html.escape(user.user_id)}</code> — {html.escape(user.display_name)}</li>"
+            for user in snapshot.pending_users
+        ) or "<li>Nessun account pending</li>"
+        classes = "".join(
+            f"<li><code>{html.escape(item.class_id)}</code> — {html.escape(item.label)}</li>"
+            for item in snapshot.classes
+        ) or "<li>Nessuna classe</li>"
+        body = (
+            "<!doctype html><html lang=\"it\"><head><meta charset=\"utf-8\">"
+            "<title>Amministrazione - TheBitLab</title></head><body><main>"
+            f"<h1>Amministrazione</h1><h2>Account pending</h2><ul>{pending}</ul>"
+            f"<h2>Classi</h2><ul>{classes}</ul></main></body></html>"
+        ).encode("utf-8")
+        return SessionHttpResponse(200, self._base_headers() + (
+            ("Content-Security-Policy", "default-src 'none'; base-uri 'none'; frame-ancestors 'none'"),
+            ("X-Content-Type-Options", "nosniff"), ("X-Frame-Options", "DENY"),
+            ("Content-Type", "text/html; charset=utf-8"),
+            ("Content-Length", str(len(body))),
+        ), body)
 
     def _method_error(self, allowed: str) -> SessionHttpResponse:
         return self._error(

--- a/tests/test_thebitlab_auth_runtime.py
+++ b/tests/test_thebitlab_auth_runtime.py
@@ -11,8 +11,10 @@ from types import SimpleNamespace
 
 import pytest
 
+from scripts.thebitlab_identity_sqlite import SqliteIdentityStorage
 from scripts.thebitlab_auth_runtime import (
     AuthRuntimeConfigurationError,
+    GoogleOidcRuntime,
     _windows_acl_tools,
     compose_google_oidc_runtime as _compose_google_oidc_runtime,
 )
@@ -130,6 +132,21 @@ def test_composition_builds_one_coherent_production_graph(tmp_path: Path) -> Non
     assert {"users", "sessions", "rate_limit_counters", "rate_limit_metadata"} <= tables
     if os.name != "nt":
         assert database.stat().st_mode & 0o777 == 0o600
+
+
+def test_runtime_rejects_admin_service_backed_by_another_storage(tmp_path: Path) -> None:
+    runtime = compose_google_oidc_runtime(valid_environment(), data_root=tmp_path)
+    runtime.session_routes.admin_provisioning.storage = SqliteIdentityStorage(
+        tmp_path / "rogue.sqlite3"
+    )
+
+    with pytest.raises(AuthRuntimeConfigurationError, match="Grafo autenticazione"):
+        GoogleOidcRuntime(
+            runtime.routes,
+            runtime.session_routes,
+            runtime.tui_pairing_routes,
+            runtime.github_routes,
+        )
 
 
 def test_composition_accepts_relative_database_and_canonical_account_landing(

--- a/tests/test_thebitlab_session_http.py
+++ b/tests/test_thebitlab_session_http.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+from scripts.thebitlab_admin_provisioning import AdminProvisioningService
 from scripts.thebitlab_auth_services import SessionService
 from scripts.thebitlab_edge_rate_limit import EdgeRequestMetadata, TrustedProxyClientResolver
 from scripts.thebitlab_http_auth import HttpSessionAuthBoundary, SessionCookiePolicy
@@ -119,7 +120,7 @@ def test_current_session_returns_minimal_snapshot_and_csrf(graph) -> None:
         ("pending", "Account in attesa", None, "/tools/course_board.html"),
         ("student", "Area studente", "/auth/tui/pair", "/tools/course_board.html"),
         ("teacher", "Area docente", "/tools/course_board.html", "/auth/tui/pair"),
-        ("admin", "Area docente", "/tools/course_board.html", "/auth/tui/pair"),
+        ("admin", "Area amministratore", "/auth/admin", "/auth/tui/pair"),
     ),
 )
 def test_account_landing_is_authenticated_and_role_aware(
@@ -146,6 +147,44 @@ def test_account_landing_is_authenticated_and_role_aware(
     assert header(response, "X-Frame-Options") == "DENY"
     assert header(response, "X-Content-Type-Options") == "nosniff"
     assert header(response, "Cache-Control") == "no-store"
+
+
+def test_admin_page_requires_current_admin_and_escapes_read_model(tmp_path) -> None:
+    storage, boundary, _routes, established = build_graph(tmp_path, "admin")
+    storage.create_user(
+        UserAccount("pending-01", "<script>alert(1)</script>", "pending", True, NOW, NOW)
+    )
+    routes = SessionHttpRoutes(
+        boundary,
+        TrustedProxyClientResolver(("127.0.0.1/32",)),
+        AdminProvisioningService(storage, clock=lambda: NOW),
+    )
+
+    response = routes.dispatch(
+        request("GET", "/auth/admin", ("Cookie", cookie(established)))
+    )
+
+    assert response.status_code == 200
+    body = response.body.decode("utf-8")
+    assert "pending-01" in body
+    assert "&lt;script&gt;" in body
+    assert "<script>" not in body
+    assert header(response, "Cache-Control") == "no-store"
+    assert header(response, "X-Frame-Options") == "DENY"
+
+    student_storage, student_boundary, _student_routes, student_session = build_graph(
+        tmp_path, "student"
+    )
+    student_routes = SessionHttpRoutes(
+        student_boundary,
+        TrustedProxyClientResolver(("127.0.0.1/32",)),
+        AdminProvisioningService(student_storage, clock=lambda: NOW),
+    )
+    forbidden = student_routes.dispatch(
+        request("GET", "/auth/admin", ("Cookie", cookie(student_session)))
+    )
+    assert forbidden.status_code == 403
+    assert json.loads(forbidden.body)["error"] == "admin_forbidden"
 
 
 def test_account_landing_rejects_non_get_query_and_body(graph) -> None:

--- a/tests/test_thebitlab_session_http.py
+++ b/tests/test_thebitlab_session_http.py
@@ -172,6 +172,24 @@ def test_admin_page_requires_current_admin_and_escapes_read_model(tmp_path) -> N
     assert header(response, "Cache-Control") == "no-store"
     assert header(response, "X-Frame-Options") == "DENY"
 
+    for index in range(40):
+        storage.create_user(
+            UserAccount(
+                f"pending-{index + 100}",
+                "<&>" * 150,
+                "pending",
+                True,
+                NOW,
+                NOW,
+            )
+        )
+    bounded = routes.dispatch(
+        request("GET", "/auth/admin", ("Cookie", cookie(established)))
+    )
+    assert bounded.status_code == 200
+    assert len(bounded.body) <= 16 * 1024
+    assert "Elenco troncato" in bounded.body.decode("utf-8")
+
     student_storage, student_boundary, _student_routes, student_session = build_graph(
         tmp_path, "student"
     )


### PR DESCRIPTION
## Summary
- add authenticated `/auth/admin` read-only page backed by AdminProvisioningService
- authorize against current active admin revision; non-admin roles fail uniformly
- render bounded escaped pending/class data without provider identities, email, CSRF, or cookies
- apply no-store, CSP, nosniff, and anti-framing headers
- link admin account landing and compose service in production runtime

## Validation
- 42 focused session/runtime tests passed, 1 skipped
- py_compile and diff checks clean

Closes #618
Part of #616
Relates to #535 and #292