### PR TITLE
Auth admin UI: mutazioni CSRF per classi e approvazioni

### DIFF
--- a/doc/architecture/admin-provisioning-service.md
+++ b/doc/architecture/admin-provisioning-service.md
@@ -15,7 +15,9 @@ Gli errori applicativi sono sanitizzati e non serializzano identità provider o 
 
 ## Read model web amministrativo
 
-`GET /auth/admin` è composto soltanto quando il runtime federato include il service. Richiede TLS e una sessione web il cui account viene riletto atomicamente come admin attivo alla revisione corrente. Restituisce HTML bounded `no-store` con utenti pending e classi; valori dinamici sono escaped e non include email, subject provider, CSRF o cookie. CSP, `nosniff` e `DENY` proteggono la pagina. Le mutazioni restano separate e richiederanno POST con CSRF.
+`GET /auth/admin` è composto soltanto quando il runtime federato include il service. Richiede TLS e una sessione web il cui account viene riletto atomicamente come admin attivo alla revisione corrente. Restituisce HTML bounded `no-store` con utenti pending e classi; valori dinamici sono escaped e non include email, subject provider, CSRF o cookie. CSP con hash dello script statico, `nosniff` e `DENY` proteggono la pagina.
+
+Le mutazioni usano `POST /auth/admin/classes` e `POST /auth/admin/approvals`. Richiedono cookie admin corrente e `X-CSRF-Token`; la pagina recupera il token da `/auth/session` senza serializzarlo nell'HTML e chiede conferma esplicita. Sono accettati soltanto JSON UTF-8 con `Content-Type: application/json`, schema esatto, singolo `Content-Length` canonico e body fra 1 e 4096 byte. Query, transfer coding, header duplicati, chiavi JSON duplicate, campi extra e revisioni non canoniche falliscono chiusi. La revisione target è obbligatoria; `class_id` è valorizzato solo per studenti. Successo `204`, race/replay `409`, input non valido `400`, CSRF `403`. Il socket legge il body con deadline assoluta e chiude la connessione sui framing rifiutati.
 
 ## Bootstrap del primo admin
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -4211,10 +4211,36 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.scheme or parsed.netloc or parsed.params:
             self.write_oidc_transport_error(400, "bad_auth_request")
             return True
+        body = b""
         try:
             edge = thebitlab_google_oidc_http.EdgeRequestMetadata(
                 str(self.client_address[0]), tuple(self.headers.raw_items())
             )
+            if routes.expects_body(parsed.path) and self.command != "POST":
+                self.close_connection = True
+            if routes.expects_body(parsed.path) and self.command == "POST":
+                lengths = [
+                    value.strip()
+                    for name, value in edge.headers
+                    if name.lower() == "content-length"
+                ]
+                transfers = [
+                    value
+                    for name, value in edge.headers
+                    if name.lower() == "transfer-encoding"
+                ]
+                if (
+                    transfers
+                    or len(lengths) != 1
+                    or not lengths[0].isdigit()
+                    or not 1 <= int(lengths[0]) <= 4096
+                ):
+                    raise ValueError("admin body framing")
+                body = self._read_body_with_deadline(
+                    int(lengths[0]), PAIRING_BODY_DEADLINE_SECONDS
+                )
+                if body is None:
+                    raise ValueError("admin body timeout")
             raw_query = parsed.query
             if parsed.fragment:
                 raw_query += "#" + parsed.fragment
@@ -4224,11 +4250,13 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 raw_query,
                 edge,
                 is_tls=isinstance(self.connection, ssl.SSLSocket),
+                body=body,
             )
         except (
             ValueError,
             thebitlab_google_oidc_http.EdgeClientAttributionError,
         ):
+            self.close_connection = True
             self.write_oidc_transport_error(400, "bad_auth_request")
             return True
         try:
@@ -4242,6 +4270,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             edge = None
             request = None
             raw_query = None
+            body = None
+            lengths = None
+            transfers = None
         self.write_session_http_response(response)
         return True
 

--- a/scripts/thebitlab_session_http.py
+++ b/scripts/thebitlab_session_http.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import html
 import json
 import re
@@ -30,9 +32,17 @@ from scripts.thebitlab_http_auth import (
 _SESSION_PATH = "/auth/session"
 _ACCOUNT_PATH = "/auth/account"
 _ADMIN_PATH = "/auth/admin"
+_ADMIN_CLASSES_PATH = "/auth/admin/classes"
+_ADMIN_APPROVALS_PATH = "/auth/admin/approvals"
+_ADMIN_MUTATION_PATHS = frozenset({_ADMIN_CLASSES_PATH, _ADMIN_APPROVALS_PATH})
 _LOGOUT_PATH = "/auth/logout"
 _MAX_COOKIE_HEADER_BYTES = 16 * 1024
+_MAX_ADMIN_BODY_BYTES = 4096
 _CSRF_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_ADMIN_SCRIPT = """const session=()=>fetch('/auth/session').then(r=>{if(!r.ok)throw Error();return r.json()});document.querySelectorAll('form[data-endpoint]').forEach(form=>form.addEventListener('submit',async event=>{event.preventDefault();if(!confirm('Confermare l’operazione amministrativa?'))return;const data=new FormData(form);let payload;if(form.dataset.endpoint.endsWith('/classes')){payload={class_id:data.get('class_id'),label:data.get('label'),school_year:data.get('school_year')}}else{const role=data.get('role');payload={target_user_id:form.dataset.user,expected_target_updated_at:form.dataset.revision,role:role,class_id:role==='student'?data.get('class_id'):null}}try{const auth=await session();const response=await fetch(form.dataset.endpoint,{method:'POST',headers:{'Content-Type':'application/json','X-CSRF-Token':auth.csrf_token},body:JSON.stringify(payload)});if(!response.ok)throw Error();location.reload()}catch(error){alert('Operazione non completata. Ricaricare e riprovare.')}}));"""
+_ADMIN_SCRIPT_HASH = base64.b64encode(
+    hashlib.sha256(_ADMIN_SCRIPT.encode("utf-8")).digest()
+).decode("ascii")
 
 
 @dataclass(frozen=True)
@@ -42,6 +52,7 @@ class SessionHttpRequest:
     raw_query: str = field(default="", repr=False)
     edge: EdgeRequestMetadata = field(default=None, repr=False)
     is_tls: bool = False
+    body: bytes = field(default=b"", repr=False)
 
     def __post_init__(self) -> None:
         if (
@@ -50,6 +61,8 @@ class SessionHttpRequest:
             or type(self.raw_query) is not str
             or type(self.edge) is not EdgeRequestMetadata
             or type(self.is_tls) is not bool
+            or type(self.body) is not bytes
+            or len(self.body) > _MAX_ADMIN_BODY_BYTES
         ):
             raise ValueError("Richiesta sessione HTTP non valida.")
 
@@ -104,8 +117,12 @@ class SessionHttpRoutes:
 
     def handles(self, path: str) -> bool:
         return path in {_SESSION_PATH, _ACCOUNT_PATH, _LOGOUT_PATH} or (
-            path == _ADMIN_PATH and self.admin_provisioning is not None
+            path in {_ADMIN_PATH, *_ADMIN_MUTATION_PATHS}
+            and self.admin_provisioning is not None
         )
+
+    def expects_body(self, path: str) -> bool:
+        return path in _ADMIN_MUTATION_PATHS and self.admin_provisioning is not None
 
     def dispatch(self, request: SessionHttpRequest) -> SessionHttpResponse | None:
         if type(request) is not SessionHttpRequest:
@@ -118,14 +135,17 @@ class SessionHttpRoutes:
         result = None
         try:
             self._require_https(request)
-            self._require_empty_request(request)
-            if (
-                request.path in {_SESSION_PATH, _ACCOUNT_PATH, _ADMIN_PATH}
-                and request.method != "GET"
-            ):
-                return self._method_error("GET")
-            if request.path == _LOGOUT_PATH and request.method != "POST":
-                return self._method_error("POST")
+            if request.path in _ADMIN_MUTATION_PATHS:
+                if request.method != "POST":
+                    return self._method_error("POST")
+                self._require_admin_json_request(request)
+            else:
+                self._require_empty_request(request)
+                if request.path in {_SESSION_PATH, _ACCOUNT_PATH, _ADMIN_PATH}:
+                    if request.method != "GET":
+                        return self._method_error("GET")
+                elif request.method != "POST":
+                    return self._method_error("POST")
             cookie_header = _combined_header(
                 request.edge, "cookie", maximum_bytes=_MAX_COOKIE_HEADER_BYTES,
                 separator="; ", required=True
@@ -145,6 +165,29 @@ class SessionHttpRoutes:
             csrf_token = _csrf_header(
                 _header_values(request.edge, "x-csrf-token")
             )
+            if request.path in _ADMIN_MUTATION_PATHS:
+                context = self.sessions.authenticate(
+                    HttpAuthRequest(
+                        "POST",
+                        cookie_header=cookie_header,
+                        csrf_token=csrf_token,
+                    )
+                )
+                if context.user.role != "admin":
+                    return self._error(
+                        403,
+                        "admin_forbidden",
+                        "Accesso amministrativo non consentito.",
+                    )
+                payload = _json_object(request.body)
+                if request.path == _ADMIN_CLASSES_PATH:
+                    self._create_admin_class(context, payload)
+                else:
+                    self._approve_admin_user(context, payload)
+                return SessionHttpResponse(
+                    204,
+                    self._base_headers() + (("Content-Length", "0"),),
+                )
             result = self.sessions.logout(
                 HttpAuthRequest(
                     "POST",
@@ -162,6 +205,12 @@ class SessionHttpRoutes:
         except _SessionRequestError as error:
             return self._error(error.status_code, error.error_code, error.public_message)
         except AdminProvisioningConflictError:
+            if request.path in _ADMIN_MUTATION_PATHS:
+                return self._error(
+                    409,
+                    "admin_conflict",
+                    "Dati amministrativi non più correnti.",
+                )
             return self._error(403, "admin_forbidden", "Accesso amministrativo non consentito.")
         except HttpAuthError as error:
             extra = (("Allow", "POST"),) if isinstance(error, HttpMethodNotAllowedError) else ()
@@ -202,6 +251,27 @@ class SessionHttpRoutes:
         transfers = _header_values(request.edge, "transfer-encoding")
         if transfers or len(lengths) > 1 or (lengths and lengths != ["0"]):
             raise _SessionRequestError(400, "bad_auth_request", "Body non consentito.")
+
+    @staticmethod
+    def _require_admin_json_request(request: SessionHttpRequest) -> None:
+        if request.raw_query:
+            raise _SessionRequestError(400, "bad_auth_request", "Query non consentita.")
+        transfers = _header_values(request.edge, "transfer-encoding")
+        lengths = _header_values(request.edge, "content-length")
+        content_types = _header_values(request.edge, "content-type")
+        content_encodings = _header_values(request.edge, "content-encoding")
+        expected = str(len(request.body))
+        if (
+            transfers
+            or lengths != [expected]
+            or expected == "0"
+            or len(request.body) > _MAX_ADMIN_BODY_BYTES
+            or content_types != ["application/json"]
+            or content_encodings
+        ):
+            raise _SessionRequestError(
+                400, "bad_auth_request", "Richiesta JSON amministrativa non valida."
+            )
 
     @staticmethod
     def _base_headers() -> tuple[tuple[str, str], ...]:
@@ -284,6 +354,63 @@ class SessionHttpRoutes:
             body,
         )
 
+    def _create_admin_class(self, context, payload: dict[str, object]) -> None:
+        if set(payload) != {"class_id", "label", "school_year"} or any(
+            type(payload[name]) is not str
+            for name in ("class_id", "label", "school_year")
+        ):
+            raise _SessionRequestError(
+                400, "invalid_admin_payload", "Payload classe non valido."
+            )
+        try:
+            self.admin_provisioning.create_class(
+                context.user,
+                class_id=payload["class_id"],
+                label=payload["label"],
+                school_year=payload["school_year"],
+            )
+        except ValueError as error:
+            raise _SessionRequestError(
+                400, "invalid_admin_payload", "Payload classe non valido."
+            ) from error
+
+    def _approve_admin_user(self, context, payload: dict[str, object]) -> None:
+        if set(payload) != {
+            "target_user_id",
+            "expected_target_updated_at",
+            "role",
+            "class_id",
+        }:
+            raise _SessionRequestError(
+                400, "invalid_admin_payload", "Payload approvazione non valido."
+            )
+        target_user_id = payload["target_user_id"]
+        revision = payload["expected_target_updated_at"]
+        role = payload["role"]
+        class_id = payload["class_id"]
+        if (
+            type(target_user_id) is not str
+            or type(revision) is not str
+            or type(role) is not str
+            or (class_id is not None and type(class_id) is not str)
+        ):
+            raise _SessionRequestError(
+                400, "invalid_admin_payload", "Payload approvazione non valido."
+            )
+        expected_revision = _parse_utc_revision(revision)
+        try:
+            self.admin_provisioning.approve(
+                context.user,
+                target_user_id=target_user_id,
+                expected_target_updated_at=expected_revision,
+                role=role,
+                class_id=class_id,
+            )
+        except ValueError as error:
+            raise _SessionRequestError(
+                400, "invalid_admin_payload", "Payload approvazione non valido."
+            ) from error
+
     def _admin_response(self, context) -> SessionHttpResponse:
         snapshot = self.admin_provisioning.snapshot(context.user)
         budget = 10_000
@@ -301,9 +428,23 @@ class SessionHttpRoutes:
                 budget -= size
             return "".join(rows) or empty
 
+        def pending_row(user):
+            user_id = html.escape(user.user_id, quote=True)
+            revision = html.escape(_utc_z(user.updated_at), quote=True)
+            name = html.escape(user.display_name)
+            return (
+                f'<li><code>{user_id}</code> — {name}'
+                f'<form data-endpoint="{_ADMIN_APPROVALS_PATH}" data-user="{user_id}" '
+                f'data-revision="{revision}"><label>Ruolo <select name="role">'
+                '<option value="student">Studente</option><option value="teacher">Docente</option>'
+                '</select></label><label>ID classe per studente '
+                '<input name="class_id" maxlength="512"></label>'
+                '<button type="submit">Approva</button></form></li>'
+            )
+
         pending = bounded_rows(
             snapshot.pending_users,
-            lambda user: f"<li><code>{html.escape(user.user_id)}</code> — {html.escape(user.display_name)}</li>",
+            pending_row,
             "<li>Nessun account pending</li>",
         )
         classes = bounded_rows(
@@ -314,15 +455,32 @@ class SessionHttpRoutes:
         body = (
             "<!doctype html><html lang=\"it\"><head><meta charset=\"utf-8\">"
             "<title>Amministrazione - TheBitLab</title></head><body><main>"
-            f"<h1>Amministrazione</h1><h2>Account pending</h2><ul>{pending}</ul>"
-            f"<h2>Classi</h2><ul>{classes}</ul></main></body></html>"
+            "<h1>Amministrazione</h1><h2>Crea classe</h2>"
+            f'<form data-endpoint="{_ADMIN_CLASSES_PATH}"><label>ID <input name="class_id" '
+            'maxlength="512" required></label><label>Nome <input name="label" maxlength="512" '
+            'required></label><label>Anno scolastico <input name="school_year" maxlength="512" '
+            'required></label><button type="submit">Crea classe</button></form>'
+            f"<h2>Account pending</h2><ul>{pending}</ul>"
+            f"<h2>Classi</h2><ul>{classes}</ul></main>"
+            f"<script>{_ADMIN_SCRIPT}</script></body></html>"
         ).encode("utf-8")
-        return SessionHttpResponse(200, self._base_headers() + (
-            ("Content-Security-Policy", "default-src 'none'; base-uri 'none'; frame-ancestors 'none'"),
-            ("X-Content-Type-Options", "nosniff"), ("X-Frame-Options", "DENY"),
-            ("Content-Type", "text/html; charset=utf-8"),
-            ("Content-Length", str(len(body))),
-        ), body)
+        return SessionHttpResponse(
+            200,
+            self._base_headers()
+            + (
+                (
+                    "Content-Security-Policy",
+                    "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; "
+                    f"script-src 'sha256-{_ADMIN_SCRIPT_HASH}'; connect-src 'self'; "
+                    "form-action 'none'",
+                ),
+                ("X-Content-Type-Options", "nosniff"),
+                ("X-Frame-Options", "DENY"),
+                ("Content-Type", "text/html; charset=utf-8"),
+                ("Content-Length", str(len(body))),
+            ),
+            body,
+        )
 
     def _method_error(self, allowed: str) -> SessionHttpResponse:
         return self._error(
@@ -360,6 +518,46 @@ class _SessionRequestError(RuntimeError):
         self.error_code = error_code
         self.public_message = public_message
         super().__init__(public_message)
+
+
+def _json_object(body: bytes) -> dict[str, object]:
+    def unique_object(pairs):
+        result = {}
+        for key, value in pairs:
+            if type(key) is not str or key in result:
+                raise ValueError("JSON duplicato")
+            result[key] = value
+        return result
+
+    try:
+        payload = json.loads(body.decode("utf-8"), object_pairs_hook=unique_object)
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as error:
+        raise _SessionRequestError(
+            400, "invalid_admin_payload", "Payload amministrativo non valido."
+        ) from error
+    if type(payload) is not dict:
+        raise _SessionRequestError(
+            400, "invalid_admin_payload", "Payload amministrativo non valido."
+        )
+    return payload
+
+
+def _parse_utc_revision(value: str) -> datetime:
+    if not value.endswith("Z"):
+        raise _SessionRequestError(
+            400, "invalid_admin_payload", "Revisione target non valida."
+        )
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as error:
+        raise _SessionRequestError(
+            400, "invalid_admin_payload", "Revisione target non valida."
+        ) from error
+    if parsed.tzinfo != timezone.utc or _utc_z(parsed) != value:
+        raise _SessionRequestError(
+            400, "invalid_admin_payload", "Revisione target non valida."
+        )
+    return parsed
 
 
 def _header_values(edge: EdgeRequestMetadata, lowered_name: str) -> list[str]:

--- a/tests/test_thebitlab_session_http.py
+++ b/tests/test_thebitlab_session_http.py
@@ -4,7 +4,7 @@ import http.client
 import json
 import socket
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -79,8 +79,8 @@ def cookie(established):
     return established.set_cookie.split(";", 1)[0]
 
 
-def request(method, path, *headers, query=""):
-    return SessionHttpRequest(method, path, query, edge(*headers))
+def request(method, path, *headers, query="", body=b""):
+    return SessionHttpRequest(method, path, query, edge(*headers), body=body)
 
 
 def header(response, name):
@@ -168,7 +168,10 @@ def test_admin_page_requires_current_admin_and_escapes_read_model(tmp_path) -> N
     body = response.body.decode("utf-8")
     assert "pending-01" in body
     assert "&lt;script&gt;" in body
-    assert "<script>" not in body
+    assert "<script>alert(1)</script>" not in body
+    assert "<script>" in body
+    assert established.context.csrf_token not in body
+    assert "script-src 'sha256-" in header(response, "Content-Security-Policy")
     assert header(response, "Cache-Control") == "no-store"
     assert header(response, "X-Frame-Options") == "DENY"
 
@@ -203,6 +206,140 @@ def test_admin_page_requires_current_admin_and_escapes_read_model(tmp_path) -> N
     )
     assert forbidden.status_code == 403
     assert json.loads(forbidden.body)["error"] == "admin_forbidden"
+
+
+def test_admin_mutations_require_csrf_and_apply_class_and_student_approval(tmp_path) -> None:
+    storage, boundary, _routes, established = build_graph(tmp_path, "admin")
+    pending_user = UserAccount(
+        "pending-01", "Pending", "pending", True, NOW, NOW
+    )
+    storage.create_user(pending_user)
+    routes = SessionHttpRoutes(
+        boundary,
+        TrustedProxyClientResolver(("127.0.0.1/32",)),
+        AdminProvisioningService(storage, clock=lambda: NOW + timedelta(seconds=1)),
+    )
+    browser_cookie = ("Cookie", cookie(established))
+
+    class_body = json.dumps(
+        {"class_id": "class-01", "label": "Classe 1", "school_year": "2026/2027"},
+        separators=(",", ":"),
+    ).encode()
+    common = (
+        browser_cookie,
+        ("Content-Type", "application/json"),
+        ("Content-Length", str(len(class_body))),
+    )
+    sensitive_request = request(
+        "POST", "/auth/admin/classes", *common, body=class_body
+    )
+    assert class_body.decode() not in repr(sensitive_request)
+    missing_csrf = routes.dispatch(sensitive_request)
+    created = routes.dispatch(
+        request(
+            "POST",
+            "/auth/admin/classes",
+            *common,
+            ("X-CSRF-Token", established.context.csrf_token),
+            body=class_body,
+        )
+    )
+
+    approval_body = json.dumps(
+        {
+            "target_user_id": "pending-01",
+            "expected_target_updated_at": "2026-09-01T08:00:00.000000Z",
+            "role": "student",
+            "class_id": "class-01",
+        },
+        separators=(",", ":"),
+    ).encode()
+    approved = routes.dispatch(
+        request(
+            "POST",
+            "/auth/admin/approvals",
+            browser_cookie,
+            ("Content-Type", "application/json"),
+            ("Content-Length", str(len(approval_body))),
+            ("X-CSRF-Token", established.context.csrf_token),
+            body=approval_body,
+        )
+    )
+    replay = routes.dispatch(
+        request(
+            "POST",
+            "/auth/admin/approvals",
+            browser_cookie,
+            ("Content-Type", "application/json"),
+            ("Content-Length", str(len(approval_body))),
+            ("X-CSRF-Token", established.context.csrf_token),
+            body=approval_body,
+        )
+    )
+
+    assert missing_csrf.status_code == 403
+    assert created.status_code == 204
+    assert approved.status_code == 204
+    assert replay.status_code == 409
+    assert storage.read_user("pending-01").role == "student"
+    memberships = storage.list_user_memberships("pending-01")
+    assert len(memberships) == 1 and memberships[0].class_id == "class-01"
+
+
+def test_admin_mutations_reject_malformed_contracts_before_service(tmp_path) -> None:
+    _storage, boundary, _routes, established = build_graph(tmp_path, "admin")
+    routes = SessionHttpRoutes(
+        boundary,
+        TrustedProxyClientResolver(("127.0.0.1/32",)),
+        AdminProvisioningService(_storage, clock=lambda: NOW + timedelta(seconds=1)),
+    )
+    cookie_header = ("Cookie", cookie(established))
+    malformed = b'{"class_id":"one","class_id":"two","label":"x","school_year":"y"}'
+
+    duplicate = routes.dispatch(
+        request(
+            "POST",
+            "/auth/admin/classes",
+            cookie_header,
+            ("Content-Type", "application/json"),
+            ("Content-Length", str(len(malformed))),
+            ("X-CSRF-Token", established.context.csrf_token),
+            body=malformed,
+        )
+    )
+    conflicting = routes.dispatch(
+        request(
+            "POST",
+            "/auth/admin/classes",
+            cookie_header,
+            ("Content-Type", "application/json"),
+            ("Content-Length", "2"),
+            ("Transfer-Encoding", "chunked"),
+            ("X-CSRF-Token", established.context.csrf_token),
+            body=b"{}",
+        )
+    )
+    encoded = routes.dispatch(
+        request(
+            "POST",
+            "/auth/admin/classes",
+            cookie_header,
+            ("Content-Type", "application/json"),
+            ("Content-Encoding", "gzip"),
+            ("Content-Length", "2"),
+            ("X-CSRF-Token", established.context.csrf_token),
+            body=b"{}",
+        )
+    )
+    wrong_method = routes.dispatch(
+        request("GET", "/auth/admin/classes", cookie_header)
+    )
+
+    assert duplicate.status_code == 400
+    assert conflicting.status_code == 400
+    assert encoded.status_code == 400
+    assert wrong_method.status_code == 405
+    assert _storage.list_classes() == []
 
 
 def test_account_landing_rejects_non_get_query_and_body(graph) -> None:
@@ -352,6 +489,76 @@ def test_duplicate_cookie_headers_are_preserved_for_boundary_rejection(graph) ->
 def test_unknown_path_is_not_claimed(graph) -> None:
     _storage, _boundary, routes, _established = graph
     assert routes.dispatch(request("GET", "/auth/other")) is None
+
+
+def test_course_board_socket_reads_bounded_admin_mutation_body(tmp_path) -> None:
+    storage, boundary, _routes, established = build_graph(tmp_path, "admin")
+    routes = SessionHttpRoutes(
+        boundary,
+        TrustedProxyClientResolver(("127.0.0.1/32",)),
+        AdminProvisioningService(storage, clock=lambda: NOW + timedelta(seconds=1)),
+    )
+    server = BoundedThreadingHTTPServer(("127.0.0.1", 0), CourseBoardHandler)
+    server.session_http_routes = routes
+    server.teacher_token = "T" * 32
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    payload = json.dumps(
+        {"class_id": "class-01", "label": "Classe", "school_year": "2026/2027"},
+        separators=(",", ":"),
+    ).encode()
+    connection = http.client.HTTPConnection(
+        "127.0.0.1", server.server_address[1], timeout=5
+    )
+    try:
+        connection.request(
+            "POST",
+            "/auth/admin/classes",
+            body=payload,
+            headers={
+                "X-Forwarded-Proto": "https",
+                "Cookie": cookie(established),
+                "X-CSRF-Token": established.context.csrf_token,
+                "Content-Type": "application/json",
+            },
+        )
+        response = connection.getresponse()
+        status = response.status
+        response.read()
+        raw = socket.create_connection(server.server_address, timeout=5)
+        try:
+            raw.sendall(
+                (
+                    "POST /auth/admin/classes HTTP/1.1\r\n"
+                    "Host: localhost\r\n"
+                    "X-Forwarded-Proto: https\r\n"
+                    f"Cookie: {cookie(established)}\r\n"
+                    f"X-CSRF-Token: {established.context.csrf_token}\r\n"
+                    "Content-Type: application/json\r\n"
+                    "Content-Length: 2\r\n"
+                    "Transfer-Encoding: chunked\r\n\r\n{}"
+                ).encode("ascii")
+            )
+            raw.settimeout(2)
+            chunks = []
+            while True:
+                chunk = raw.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            malformed = b"".join(chunks)
+        finally:
+            raw.close()
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 204
+    assert b"400" in malformed
+    assert b"bad_auth_request" in malformed
+    assert storage.read_class("class-01") is not None
 
 
 def test_course_board_socket_serves_status_and_logout_without_basic_auth(graph) -> None:


### PR DESCRIPTION
## Summary
- add strict POST APIs for class creation and pending-user approval
- require current federated admin session plus browser-bound CSRF
- enforce exact JSON schemas, canonical revisions, 4 KiB body/framing bounds, no transfer/content coding, and no queries
- connect explicit-confirmation UI forms without embedding CSRF or provider data
- preserve atomic service CAS, session revocation, replay/race rollback, and sanitized errors
- add bounded socket reads and close malformed framing connections

## Validation
- 240 focused auth/server/frontend tests passed, 2 skipped
- py_compile and diff checks clean

Closes #620
Closes #616
Relates to #535 and #292