### PR TITLE
feat: manage and synchronize Course Board sources

### DIFF
--- a/doc/COURSE_SOURCE_CATALOG.md
+++ b/doc/COURSE_SOURCE_CATALOG.md
@@ -88,7 +88,7 @@ I repository pubblici non richiedono credenziali. Per repository privati il proc
 
 ## Gestione dalla Course Board
 
-Il comando **Gestisci fonti** apre un editor provider-independent. Il docente può aggiungere, modificare o rimuovere fonti locali, GitHub e GitLab, indicare repository/ref e file Markdown, e scegliere `ready`, `pending` o `disabled`. **Sincronizza anteprima** invia soltanto la bozza in memoria a `POST /api/course-sources/preview`: il server applica gli stessi limiti del catalogo, risolve i commit e restituisce file indicizzati e heading senza scrivere il progetto. **Applica alla board** è disponibile soltanto per la stessa anteprima e lo stesso snapshot della board; il salvataggio del progetto resta un'azione separata protetta da CAS.
+Il comando **Gestisci fonti** apre un editor provider-independent. Il docente può aggiungere, modificare o rimuovere fonti locali, GitHub e GitLab, indicare repository/ref e file Markdown, e scegliere `ready`, `pending` o `disabled`. **Sincronizza anteprima** invia soltanto la bozza in memoria a `POST /api/course-sources/preview`: il server applica gli stessi limiti del catalogo, risolve i commit e restituisce file indicizzati e heading senza scrivere il progetto. Ogni heading riceve inoltre un digest d'identità che comprende livello, titolo e corpo della sezione, così rinominazioni o slittamenti non possono riallineare silenziosamente una cornice didattica. **Applica alla board** è disponibile soltanto per la stessa anteprima e lo stesso snapshot della board; il salvataggio del progetto resta un'azione separata protetta da CAS.
 
 La prima applicazione dell'editor migra intenzionalmente il vecchio `source_files` nella forma canonica `sources`. Credenziali e token non compaiono mai nei campi GUI.
 

--- a/doc/COURSE_SOURCE_CATALOG.md
+++ b/doc/COURSE_SOURCE_CATALOG.md
@@ -86,9 +86,15 @@ Gli adapter usano esclusivamente `https://api.github.com` e `https://gitlab.com/
 
 I repository pubblici non richiedono credenziali. Per repository privati il processo riceve un installation token GitHub App a vita breve tramite `THEBITLAB_GITHUB_TOKEN_FILE`, oppure un project/group access token GitLab tramite `THEBITLAB_GITLAB_TOKEN_FILE`; entrambi indicano un file esterno al repository. Il path deve essere assoluto e il file regolare e non collegato. Su POSIX deve appartenere all'utente corrente con permessi owner-only; su Windows deve avere una DACL protetta che conceda accesso completo soltanto all'utente corrente e a `SYSTEM`. Il token non compare nel design, negli URL, nei log, nella cache o nelle risposte HTTP. Il rinnovo o la rotazione del token è responsabilità del runtime provider.
 
+## Gestione dalla Course Board
+
+Il comando **Gestisci fonti** apre un editor provider-independent. Il docente può aggiungere, modificare o rimuovere fonti locali, GitHub e GitLab, indicare repository/ref e file Markdown, e scegliere `ready`, `pending` o `disabled`. **Sincronizza anteprima** invia soltanto la bozza in memoria a `POST /api/course-sources/preview`: il server applica gli stessi limiti del catalogo, risolve i commit e restituisce file indicizzati e heading senza scrivere il progetto. **Applica alla board** è disponibile soltanto per la stessa anteprima e lo stesso snapshot della board; il salvataggio del progetto resta un'azione separata protetta da CAS.
+
+La prima applicazione dell'editor migra intenzionalmente il vecchio `source_files` nella forma canonica `sources`. Credenziali e token non compaiono mai nei campi GUI.
+
 ## Limiti attuali
 
 - Nessun clone o pull Git: gli adapter usano le API repository dei provider.
 - La cache è locale al processo; installazioni replicate richiederanno uno snapshot store condiviso.
 - Il Markdown generato conserva repository, ref, commit risolto, stato e timestamp dichiarato della fonte.
-- Modifica GUI del catalogo e conflitti semantici sono incrementi successivi di #290.
+- I conflitti semantici tra contenuti equivalenti di fonti differenti richiedono ancora una decisione del docente.

--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -811,6 +811,7 @@ della pagina Percorso. Nessun passaggio deve aprire i dialog nativi del browser 
    Riaprilo, conferma, lascia vuoto il nome e verifica l'errore inline; inserisci infine
    `test-manuale-percorso.json` e crea il progetto.
 4. Aggiungi un percorso con settimane e ore valide. Prova poi a crearne uno con `0` settimane e verifica il bordo rosso e il messaggio di errore.
+4a. Usa `Gestisci fonti`, verifica la proiezione delle fonti correnti e aggiungi una fonte locale `README.md`. Prova ID duplicato e file non Markdown, controllando che `Sincronizza anteprima` mostri l'errore senza modificare la board. Correggi, sincronizza, verifica il conteggio dei file/paragrafi e applica. Se un token runtime e configurato, ripeti facoltativamente con una fonte GitHub o GitLab privata e controlla il commit risolto abbreviato. Verifica che nessun campo chieda o mostri credenziali.
 5. Nel catalogo a sinistra usa il pulsante `+` su un paragrafo, poi premilo di nuovo sullo stesso paragrafo.
 5a. Clicca il titolo di un paragrafo e poi il comando `Testo`: verifica che si apra il modal con il contenuto completo.
 5b. Dentro una UDA ripeti dal titolo e dal comando `Testo`, poi usa `Apri sorgente su GitHub` e verifica l'ancora del paragrafo.
@@ -831,6 +832,7 @@ Risultato atteso:
 
 - I dati non validi non entrano nel progetto.
 - Lo stesso paragrafo e la stessa activity non vengono duplicati nella medesima UDA.
+- L'editor fonti applica soltanto anteprime sincronizzate sullo stesso snapshot della board e non espone credenziali.
 - Il collegamento activity conserva ruolo e date; la scadenza non puo precedere la pianificazione.
 - Il titolo e il comando `Testo` aprono il modal con contenuto, fonte, riga e link GitHub coerenti.
 - Ricarica e navigazione non scartano modifiche senza conferma.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3271,6 +3271,7 @@ def section_text(
     heading_id: str = "",
     source_commit: str = "",
     content_sha256: str = "",
+    expected_title: str = "",
 ) -> str:
     """Extract local Markdown text for one heading section."""
 
@@ -3339,6 +3340,10 @@ def section_text(
                     "Il paragrafo è stato rinominato, rimosso o spostato: riallinealo prima di usare l'AI."
                 )
             return ""
+        if expected_title and matching_heading.get("title") != expected_title:
+            raise CourseSourceRevisionConflictError(
+                "Il titolo del paragrafo è cambiato: riallinealo prima di usare l'AI."
+            )
         if (
             content_sha256
             and matching_heading.get("content_sha256") != content_sha256
@@ -3537,6 +3542,7 @@ def topic_summary(
             str(item.get("id", "")),
             str(item.get("source_commit") or ""),
             str(item.get("content_sha256", "")),
+            str(item.get("title", "")),
         )
     return summary
 
@@ -3597,9 +3603,38 @@ def board_item_from_heading(heading: dict) -> dict:
     }
 
 
-def compact_design(design: dict) -> dict:
+def validate_course_item_provenance(design: dict) -> None:
+    """Reject board items whose immutable heading provenance is incomplete or stale."""
+
+    headings = {heading["id"]: heading for heading in extract_headings(design)}
+    keys = (
+        "title", "source", "source_id", "source_provider", "source_repository",
+        "source_ref", "source_commit", "content_sha256", "level", "line", "href",
+    )
+
+    def validate(items: list[dict]) -> None:
+        for item in items:
+            heading = headings.get(str(item.get("id", "")))
+            if not item.get("content_sha256") or heading is None:
+                raise CourseSourceRevisionConflictError(
+                    "Un paragrafo del corso non ha una provenienza verificabile: riallinealo prima di usare l'AI."
+                )
+            if any(item.get(key) != heading.get(key) for key in keys):
+                raise CourseSourceRevisionConflictError(
+                    "Un paragrafo del corso non coincide più con la fonte: riallinealo prima di usare l'AI."
+                )
+            validate(item.get("children", []))
+
+    for year in design.get("years", []):
+        for uda in year.get("udas", []):
+            validate(uda.get("items", []))
+
+
+def compact_design(design: dict, *, verify_provenance: bool = False) -> dict:
     """Return the full course structure without verbose frame text."""
 
+    if verify_provenance:
+        validate_course_item_provenance(design)
     return {
         "years": [
             {
@@ -6232,7 +6267,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/ai-frame":
             try:
                 context = {
-                    "course": compact_design(payload.get("design", {})),
+                    "course": compact_design(payload.get("design", {}), verify_provenance=True),
                     "target": target_context(
                         payload.get("design", {}),
                         payload.get("year_id", ""),
@@ -6275,7 +6310,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                     "selection_objectives": brief.get("description", ""),
                     "selection_rule": "Usa selection_objectives come criterio principale per scegliere quali paragrafi e sottoparagrafi inserire nelle UDA.",
                     "target_year_id": year_id,
-                    "current_course": compact_design(design),
+                    "current_course": compact_design(design, verify_provenance=True),
                     "available_topics": available_topics,
                     "constraints": {
                         "use_only_available_topic_ids": True,

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3322,6 +3322,10 @@ def section_text(
             or matching_heading["line"] != start_line
             or matching_heading["level"] != start_level
         ):
+            if content_sha256:
+                raise CourseSourceRevisionConflictError(
+                    "Il paragrafo è stato rinominato, rimosso o spostato: riallinealo prima di usare l'AI."
+                )
             return ""
         if (
             content_sha256
@@ -3506,6 +3510,10 @@ def topic_summary(
         ],
     }
     if include_text:
+        if not item.get("content_sha256"):
+            raise CourseSourceRevisionConflictError(
+                "Il paragrafo non ha una provenienza verificabile: riallinealo prima di usare l'AI."
+            )
         summary["text"] = section_text(
             item.get("source", ""),
             item.get("line", ""),

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3164,6 +3164,7 @@ def heading_content_snapshot(
     design: dict,
     heading_id: str,
     expected_source_commit: str = "",
+    expected_content_sha256: str = "",
 ) -> tuple[dict, str] | None:
     """Return heading content only when immutable remote provenance still matches."""
 
@@ -3184,6 +3185,13 @@ def heading_content_snapshot(
                 ) and heading.get("source_commit") != expected_source_commit:
                     raise CourseSourceRevisionConflictError(
                         "La fonte remota è cambiata: riallinea il paragrafo prima della preview."
+                    )
+                if (
+                    expected_content_sha256
+                    and heading.get("content_sha256") != expected_content_sha256
+                ):
+                    raise CourseSourceRevisionConflictError(
+                        "Il contenuto del paragrafo è cambiato: riallinealo prima della preview."
                     )
                 return heading, section_text_from_source(
                     source_text,
@@ -3258,6 +3266,7 @@ def section_text(
     source_id: str = "",
     heading_id: str = "",
     source_commit: str = "",
+    content_sha256: str = "",
 ) -> str:
     """Extract local Markdown text for one heading section."""
 
@@ -3312,6 +3321,10 @@ def section_text(
             matching_heading is None
             or matching_heading["line"] != start_line
             or matching_heading["level"] != start_level
+            or (
+                content_sha256
+                and matching_heading.get("content_sha256") != content_sha256
+            )
         ):
             return ""
     return section_text_from_source(source_text, start_line, start_level)
@@ -3500,6 +3513,7 @@ def topic_summary(
             str(item.get("source_id", "")),
             str(item.get("id", "")),
             str(item.get("source_commit", "")),
+            str(item.get("content_sha256", "")),
         )
     return summary
 
@@ -5696,10 +5710,14 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             query = parse_qs(parsed.query)
             heading_id = query.get("id", [""])[0]
             expected_source_commit = query.get("source_commit", [""])[0]
+            expected_content_sha256 = query.get("content_sha256", [""])[0]
             try:
                 design = source_request_design(parsed.query)
                 snapshot = heading_content_snapshot(
-                    design, heading_id, expected_source_commit
+                    design,
+                    heading_id,
+                    expected_source_commit,
+                    expected_content_sha256,
                 )
             except course_github_markdown.RemoteMarkdownError as error:
                 self.write_error_json(502, str(error))
@@ -5870,6 +5888,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                     design,
                     heading_id,
                     str(payload.get("source_commit", "")),
+                    str(payload.get("content_sha256", "")),
                 )
             except course_github_markdown.RemoteMarkdownError as error:
                 self.write_error_json(502, str(error))

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3166,8 +3166,12 @@ def heading_content_snapshot(
     expected_source_commit: str = "",
     expected_content_sha256: str = "",
 ) -> tuple[dict, str] | None:
-    """Return heading content only when immutable remote provenance still matches."""
+    """Return heading content only when immutable provenance still matches."""
 
+    if re.fullmatch(r"[0-9a-f]{64}", expected_content_sha256) is None:
+        raise CourseSourceRevisionConflictError(
+            "Digest del paragrafo mancante o non valido: riallinealo prima della preview."
+        )
     total_headings = 0
     for source_file in course_markdown_source_files(design):
         source_text = course_source_catalog.read_markdown_text(source_file, ROOT)
@@ -3295,12 +3299,20 @@ def section_text(
         None,
     )
     if source_file is None:
+        if content_sha256:
+            raise CourseSourceRevisionConflictError(
+                "La fonte del paragrafo non è disponibile: riattivala o riallinea l'item prima di usare l'AI."
+            )
         return ""
     resolved_ref = getattr(source_file, "resolved_ref", None)
     if (
         (source_commit or source_file.source.provider != "local")
         and source_commit != resolved_ref
     ):
+        if content_sha256:
+            raise CourseSourceRevisionConflictError(
+                "Il commit della fonte è cambiato: riallinea il paragrafo prima di usare l'AI."
+            )
         return ""
     snapshot_key = f"{source_id}\0{source}"
     source_text = None if source_snapshots is None else source_snapshots.get(snapshot_key)
@@ -3523,7 +3535,7 @@ def topic_summary(
             source_files,
             str(item.get("source_id", "")),
             str(item.get("id", "")),
-            str(item.get("source_commit", "")),
+            str(item.get("source_commit") or ""),
             str(item.get("content_sha256", "")),
         )
     return summary
@@ -5898,7 +5910,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 snapshot = heading_content_snapshot(
                     design,
                     heading_id,
-                    str(payload.get("source_commit", "")),
+                    str(payload.get("source_commit") or ""),
                     str(payload.get("content_sha256", "")),
                 )
             except course_github_markdown.RemoteMarkdownError as error:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3321,12 +3321,15 @@ def section_text(
             matching_heading is None
             or matching_heading["line"] != start_line
             or matching_heading["level"] != start_level
-            or (
-                content_sha256
-                and matching_heading.get("content_sha256") != content_sha256
-            )
         ):
             return ""
+        if (
+            content_sha256
+            and matching_heading.get("content_sha256") != content_sha256
+        ):
+            raise CourseSourceRevisionConflictError(
+                "Il contenuto del paragrafo è cambiato: riallinealo prima di usare l'AI."
+            )
     return section_text_from_source(source_text, start_line, start_level)
 
 
@@ -6218,6 +6221,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                     ),
                 }
                 self.write_json({"frame": call_ai_didactic_frame(context)})
+            except CourseSourceRevisionConflictError as error:
+                self.write_error_json(409, str(error))
             except Exception as error:  # noqa: BLE001
                 self.send_response(500)
                 self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -980,6 +980,25 @@ def uda_actual_revisions(design: dict) -> dict[str, str]:
     return revisions
 
 
+def preview_course_sources(design: object) -> dict:
+    """Resolve an in-memory source catalog without persisting the design."""
+
+    if not isinstance(design, dict):
+        raise ValueError("design deve essere un oggetto.")
+    validate_course_source_catalog(design)
+    source_files = course_markdown_source_files(design)
+    catalog = course_source_catalog.course_source_catalog_payload(
+        design,
+        ROOT,
+        default_files=DEFAULT_SOURCES,
+        local_files=source_files,
+    )
+    return {
+        "sources": catalog["sources"],
+        "headings": extract_headings(design, source_files),
+    }
+
+
 def course_calendar_context(raw_query: str) -> dict:
     """Return one design and its derived activity events from one snapshot."""
 
@@ -5785,6 +5804,16 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return
         payload = self.read_teacher_json()
         if payload is None:
+            return
+        if parsed.path == "/api/course-sources/preview":
+            try:
+                self.write_json(preview_course_sources(payload.get("design")))
+            except course_github_markdown.RemoteMarkdownError as error:
+                self.write_error_json(502, str(error))
+            except course_source_catalog.CourseSourceCatalogError as error:
+                self.write_error_json(422, str(error))
+            except ValueError as error:
+                self.write_error_json(400, str(error))
             return
         if parsed.path == "/api/heading-content":
             heading_id = payload.get("id", "")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3124,6 +3124,7 @@ def headings_from_source_snapshot(
                 "source_commit": resolved_ref,
                 "level": len(match.group(1)),
                 "title": TAG_RE.sub("", title).strip(),
+                "_identity_title": title,
                 "anchor": anchor,
                 "href": source_url if descriptor.provider in {"github", "gitlab"} else f"../{source}#{anchor}",
                 "source_url": source_url,
@@ -3145,8 +3146,9 @@ def headings_from_source_snapshot(
         section = "\n".join(
             source_lines[heading["line"] : end_lines[index] - 1]
         ).strip()
+        identity_title = heading.pop("_identity_title")
         identity_text = (
-            f"{heading['level']}\0{heading['title']}\0{section}"
+            f"{heading['level']}\0{identity_title}\0{section}"
         )
         heading["content_sha256"] = hashlib.sha256(
             identity_text.encode("utf-8")

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -993,9 +993,28 @@ def preview_course_sources(design: object) -> dict:
         default_files=DEFAULT_SOURCES,
         local_files=source_files,
     )
+    snapshot_manifest = [
+        {
+            "source_id": item.source.source_id,
+            "provider": item.source.provider,
+            "path": item.relative_path,
+            "resolved_ref": getattr(item, "resolved_ref", None),
+            "sha256": item.expected_sha256,
+        }
+        for item in source_files
+    ]
+    snapshot_revision = hashlib.sha256(
+        json.dumps(
+            snapshot_manifest,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
     return {
         "sources": catalog["sources"],
         "headings": extract_headings(design, source_files),
+        "snapshot_revision": snapshot_revision,
     }
 
 
@@ -3112,6 +3131,23 @@ def headings_from_source_snapshot(
                 "line": lineno,
             }
         )
+    source_lines = source_text.splitlines()
+    end_lines = [len(source_lines) + 1] * len(headings)
+    open_headings: list[int] = []
+    for index, heading in enumerate(headings):
+        while (
+            open_headings
+            and heading["level"] <= headings[open_headings[-1]]["level"]
+        ):
+            end_lines[open_headings.pop()] = heading["line"]
+        open_headings.append(index)
+    for index, heading in enumerate(headings):
+        section = "\n".join(
+            source_lines[heading["line"] : end_lines[index] - 1]
+        ).strip()
+        heading["content_sha256"] = hashlib.sha256(
+            section.encode("utf-8")
+        ).hexdigest()
     return headings
 
 
@@ -3376,6 +3412,7 @@ def heading_catalog_tree(design: dict | None = None) -> list[dict]:
             "source_repository": heading.get("source_repository"),
             "source_ref": heading.get("source_ref"),
             "source_commit": heading.get("source_commit"),
+            "content_sha256": heading.get("content_sha256"),
             "level": heading["level"],
             "line": heading["line"],
             "anchor": heading["anchor"],
@@ -3423,6 +3460,7 @@ def topic_summary(
         "source_repository": item.get("source_repository"),
         "source_ref": item.get("source_ref"),
         "source_commit": item.get("source_commit"),
+        "content_sha256": item.get("content_sha256"),
         "level": item.get("level", ""),
         "href": item.get("href", ""),
         "source_url": (
@@ -3509,6 +3547,7 @@ def board_item_from_heading(heading: dict) -> dict:
         "source_repository": heading.get("source_repository"),
         "source_ref": heading.get("source_ref"),
         "source_commit": heading.get("source_commit"),
+        "content_sha256": heading.get("content_sha256"),
         "href": heading["href"],
         "level": heading["level"],
         "line": heading["line"],

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3145,8 +3145,11 @@ def headings_from_source_snapshot(
         section = "\n".join(
             source_lines[heading["line"] : end_lines[index] - 1]
         ).strip()
+        identity_text = (
+            f"{heading['level']}\0{heading['title']}\0{section}"
+        )
         heading["content_sha256"] = hashlib.sha256(
-            section.encode("utf-8")
+            identity_text.encode("utf-8")
         ).hexdigest()
     return headings
 

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -326,7 +326,7 @@ def test_source_editor_migrates_legacy_item_ids_without_detaching_topics() -> No
         }];
         const design = { years: [{ udas: [{ items: [{
           id: "README.md#intro", title: "Intro", source: "README.md",
-          line: 1, level: 1, frame: { status: "done" },
+          line: 99, level: 3, frame: { status: "done" },
         }] }] }] };
         const preview = [{
           id: "legacy-abc:README.md#intro", title: "Intro", source: "README.md",
@@ -340,6 +340,8 @@ def test_source_editor_migrates_legacy_item_ids_without_detaching_topics() -> No
         const item = design.years[0].udas[0].items[0];
         assert.equal(item.id, "legacy-abc:README.md#intro");
         assert.equal(item.source_id, "legacy-abc");
+        assert.equal(item.line, 1);
+        assert.equal(item.level, 1);
         assert.equal(item.frame.status, "done");
         """
     )
@@ -353,6 +355,7 @@ def test_source_editor_requires_preview_and_context_before_apply() -> None:
     assert "delete nextDesign.source_files" in source
     assert "sourcePreviewSignature(sources) !== editor.preview.signature" in source
     assert "isBoardContextUnchanged(editor.boardContext)" in source
+    assert "state.isNewDesign || hasUnsavedChanges()" in source
     assert "editor.pendingPreviewRequests = Math.max" in source
 
 

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -335,7 +335,7 @@ def test_source_editor_migrates_legacy_item_ids_without_detaching_topics() -> No
           anchor: "intro", line: 1, level: 1, href: "../README.md#intro",
         }];
 
-        migrateLegacySourceItems(design, preview);
+        reconcileSourceItems(design, preview);
 
         const item = design.years[0].udas[0].items[0];
         assert.equal(item.id, "legacy-abc:README.md#intro");
@@ -343,6 +343,36 @@ def test_source_editor_migrates_legacy_item_ids_without_detaching_topics() -> No
         assert.equal(item.line, 1);
         assert.equal(item.level, 1);
         assert.equal(item.frame.status, "done");
+        """
+    )
+
+
+def test_source_editor_updates_assigned_remote_commit_from_preview() -> None:
+    run_course_board_js(
+        """
+        state.sources = [{ id: "remote", legacy: false }];
+        state.headings = [{
+          id: "remote:README.md#intro", source_id: "remote", source: "README.md",
+          anchor: "intro", line: 1, level: 1, source_commit: "a".repeat(40),
+        }];
+        const design = { years: [{ udas: [{ items: [{
+          id: "remote:README.md#intro", source_id: "remote", source: "README.md",
+          source_commit: "a".repeat(40), line: 1, level: 1,
+        }] }] }] };
+        const preview = [{
+          id: "remote:README.md#intro", title: "Intro", source: "README.md",
+          source_id: "remote", source_label: "Remote", source_provider: "github",
+          source_repository: "school/course", source_ref: "main",
+          source_commit: "b".repeat(40), anchor: "intro", line: 2, level: 1,
+          href: "https://example.invalid/" + "b".repeat(40) + "/README.md#intro",
+        }];
+
+        reconcileSourceItems(design, preview);
+
+        const item = design.years[0].udas[0].items[0];
+        assert.equal(item.source_commit, "b".repeat(40));
+        assert.equal(item.line, 2);
+        assert.match(item.href, /bbbbbbbbbbbb/);
         """
     )
 

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -294,6 +294,25 @@ def test_catalog_paragraph_preview_uses_keyboard_accessible_button() -> None:
     assert ".headingPreviewTrigger" in css
 
 
+def test_loaded_legacy_item_hydrates_missing_content_digest() -> None:
+    run_course_board_js(
+        """
+        const design = { years: [{ udas: [{ items: [{
+          id: "README.md#intro", source: "README.md",
+        }] }] }] };
+        const headings = [{
+          id: "README.md#intro", source: "README.md", source_id: "legacy",
+          content_sha256: "d".repeat(64),
+        }];
+
+        const hydrated = hydrateMissingItemContentDigests(design, headings);
+
+        assert.equal(hydrated, 1);
+        assert.equal(design.years[0].udas[0].items[0].content_sha256, "d".repeat(64));
+        """
+    )
+
+
 def test_source_editor_projects_catalog_without_runtime_fields() -> None:
     run_course_board_js(
         """

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -335,6 +335,14 @@ def test_source_editor_migrates_legacy_item_ids_without_detaching_topics() -> No
           content_sha256: "c".repeat(64), anchor: "intro", line: 1, level: 1, href: "../README.md#intro",
         }];
 
+        assert.throws(
+          () => reconcileSourceItems(
+            JSON.parse(JSON.stringify(design)),
+            [],
+            [{ id: "legacy-abc", indexing_status: "pending" }],
+          ),
+          /deve restare ready/,
+        );
         reconcileSourceItems(design, preview, [{ id: "legacy-abc", indexing_status: "ready" }]);
 
         const item = design.years[0].udas[0].items[0];

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -526,6 +526,7 @@ def test_source_editor_requires_preview_and_context_before_apply() -> None:
     assert "state.isNewDesign || hasUnsavedChanges()" in source
     assert "editor.pendingPreviewRequests = Math.max" in source
     assert "verified.snapshot_revision !== editor.preview.snapshotRevision" in source
+    assert "sourcePreviewSignature(collectSourceEditorSources()) !== sourcePreviewSignature(sources)" in source
     assert "applied.ref = resolvedRef" in source
 
 

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -379,6 +379,32 @@ def test_source_editor_updates_assigned_remote_commit_from_preview() -> None:
     )
 
 
+def test_source_editor_keeps_direct_id_when_heading_content_digests_repeat() -> None:
+    run_course_board_js(
+        """
+        const emptyHash = "e".repeat(64);
+        state.sources = [{ id: "course" }];
+        state.headings = [
+          { id: "course:README.md#one", source_id: "course", source: "README.md", content_sha256: emptyHash },
+          { id: "course:README.md#two", source_id: "course", source: "README.md", content_sha256: emptyHash },
+        ];
+        const design = { years: [{ udas: [{ items: [{
+          id: "course:README.md#two", source_id: "course", source: "README.md",
+          content_sha256: emptyHash,
+        }] }] }] };
+        const preview = [
+          { id: "course:README.md#one", source_id: "course", source: "README.md", content_sha256: emptyHash, title: "One" },
+          { id: "course:README.md#two", source_id: "course", source: "README.md", content_sha256: emptyHash, title: "Two" },
+        ];
+
+        reconcileSourceItems(design, preview, [{ id: "course", indexing_status: "ready" }]);
+
+        assert.equal(design.years[0].udas[0].items[0].id, "course:README.md#two");
+        assert.equal(design.years[0].udas[0].items[0].title, "Two");
+        """
+    )
+
+
 def test_source_editor_blocks_removed_used_source_but_allows_pending_source() -> None:
     run_course_board_js(
         """

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -302,6 +302,7 @@ def test_loaded_legacy_item_hydrates_missing_content_digest() -> None:
         }] }] }] };
         const headings = [{
           id: "README.md#intro", title: "Intro", source: "README.md", source_id: "legacy",
+          source_provider: "local", href: "README.md#intro",
           line: 1, level: 1, content_sha256: "d".repeat(64),
         }];
 
@@ -309,6 +310,7 @@ def test_loaded_legacy_item_hydrates_missing_content_digest() -> None:
 
         assert.equal(hydrated, 1);
         assert.equal(design.years[0].udas[0].items[0].content_sha256, "d".repeat(64));
+        assert.equal(design.years[0].udas[0].items[0].source_id, "legacy");
         """
     )
 

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -294,6 +294,38 @@ def test_catalog_paragraph_preview_uses_keyboard_accessible_button() -> None:
     assert ".headingPreviewTrigger" in css
 
 
+def test_source_editor_projects_catalog_without_runtime_fields() -> None:
+    run_course_board_js(
+        """
+        state.sources = [{
+          id: "remote", label: "Remote", provider: "gitlab", path: "",
+          repository: "school/course", ref: "main", files: ["README.md"],
+          updated_at: null, indexing_status: "ready", resolved_ref: "a".repeat(40),
+          indexed_files: ["README.md"], legacy: false,
+        }];
+
+        const editable = editableCourseSources();
+
+        assert.deepEqual(JSON.parse(JSON.stringify(editable)), [{
+          id: "remote", label: "Remote", type: "markdown", provider: "gitlab",
+          path: "", repository: "school/course", ref: "main", files: ["README.md"],
+          updated_at: null, indexing_status: "ready",
+        }]);
+        assert.equal(nextSourceId(editable), "source-2");
+        """
+    )
+
+
+def test_source_editor_requires_preview_and_context_before_apply() -> None:
+    source = Path("tools/course_board.js").read_text(encoding="utf-8")
+
+    assert 'api("/api/course-sources/preview"' in source
+    assert "delete candidate.source_files" in source
+    assert "delete state.design.source_files" in source
+    assert "sourcePreviewSignature(sources) !== editor.preview.signature" in source
+    assert "isBoardContextUnchanged(editor.boardContext)" in source
+
+
 def test_item_from_heading_preserves_source_provenance() -> None:
     run_course_board_js(
         """

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -322,7 +322,7 @@ def test_source_editor_migrates_legacy_item_ids_without_detaching_topics() -> No
         state.sources = [{ id: "legacy-abc", legacy: true }];
         state.headings = [{
           id: "README.md#intro", source_id: "legacy-abc", source: "README.md",
-          anchor: "intro", line: 1, level: 1,
+          anchor: "intro", line: 1, level: 1, content_sha256: "c".repeat(64),
         }];
         const design = { years: [{ udas: [{ items: [{
           id: "README.md#intro", title: "Intro", source: "README.md",
@@ -332,10 +332,10 @@ def test_source_editor_migrates_legacy_item_ids_without_detaching_topics() -> No
           id: "legacy-abc:README.md#intro", title: "Intro", source: "README.md",
           source_id: "legacy-abc", source_label: "README.md", source_provider: "local",
           source_repository: null, source_ref: null, source_commit: null,
-          anchor: "intro", line: 1, level: 1, href: "../README.md#intro",
+          content_sha256: "c".repeat(64), anchor: "intro", line: 1, level: 1, href: "../README.md#intro",
         }];
 
-        reconcileSourceItems(design, preview);
+        reconcileSourceItems(design, preview, [{ id: "legacy-abc", indexing_status: "ready" }]);
 
         const item = design.years[0].udas[0].items[0];
         assert.equal(item.id, "legacy-abc:README.md#intro");
@@ -354,6 +354,7 @@ def test_source_editor_updates_assigned_remote_commit_from_preview() -> None:
         state.headings = [{
           id: "remote:README.md#intro", source_id: "remote", source: "README.md",
           anchor: "intro", line: 1, level: 1, source_commit: "a".repeat(40),
+          content_sha256: "c".repeat(64),
         }];
         const design = { years: [{ udas: [{ items: [{
           id: "remote:README.md#intro", source_id: "remote", source: "README.md",
@@ -363,16 +364,41 @@ def test_source_editor_updates_assigned_remote_commit_from_preview() -> None:
           id: "remote:README.md#intro", title: "Intro", source: "README.md",
           source_id: "remote", source_label: "Remote", source_provider: "github",
           source_repository: "school/course", source_ref: "main",
-          source_commit: "b".repeat(40), anchor: "intro", line: 2, level: 1,
+          source_commit: "b".repeat(40), content_sha256: "c".repeat(64),
+          anchor: "intro", line: 2, level: 1,
           href: "https://example.invalid/" + "b".repeat(40) + "/README.md#intro",
         }];
 
-        reconcileSourceItems(design, preview);
+        reconcileSourceItems(design, preview, [{ id: "remote", indexing_status: "ready" }]);
 
         const item = design.years[0].udas[0].items[0];
         assert.equal(item.source_commit, "b".repeat(40));
         assert.equal(item.line, 2);
         assert.match(item.href, /bbbbbbbbbbbb/);
+        """
+    )
+
+
+def test_source_editor_blocks_removed_used_source_but_allows_pending_source() -> None:
+    run_course_board_js(
+        """
+        state.sources = [{ id: "remote" }];
+        state.headings = [{
+          id: "remote:README.md#intro", source_id: "remote", source: "README.md",
+          content_sha256: "a".repeat(64),
+        }];
+        const design = { years: [{ udas: [{ items: [{
+          id: "remote:README.md#intro", source_id: "remote", source: "README.md",
+          content_sha256: "a".repeat(64), source_commit: "b".repeat(40),
+        }] }] }] };
+
+        assert.throws(
+          () => reconcileSourceItems(JSON.parse(JSON.stringify(design)), [], []),
+          /rimossa o rinominata/,
+        );
+        const pending = JSON.parse(JSON.stringify(design));
+        reconcileSourceItems(pending, [], [{ id: "remote", indexing_status: "pending" }]);
+        assert.equal(pending.years[0].udas[0].items[0].source_commit, "b".repeat(40));
         """
     )
 
@@ -387,6 +413,8 @@ def test_source_editor_requires_preview_and_context_before_apply() -> None:
     assert "isBoardContextUnchanged(editor.boardContext)" in source
     assert "state.isNewDesign || hasUnsavedChanges()" in source
     assert "editor.pendingPreviewRequests = Math.max" in source
+    assert "verified.snapshot_revision !== editor.preview.snapshotRevision" in source
+    assert "applied.ref = resolvedRef" in source
 
 
 def test_item_from_heading_preserves_source_provenance() -> None:

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -379,6 +379,36 @@ def test_source_editor_updates_assigned_remote_commit_from_preview() -> None:
     )
 
 
+def test_source_editor_rejects_pre_digest_item_from_stale_remote_commit() -> None:
+    run_course_board_js(
+        """
+        state.sources = [{ id: "remote" }];
+        state.headings = [{
+          id: "remote:README.md#intro", source_id: "remote", source: "README.md",
+          source_provider: "github", source_commit: "b".repeat(40),
+          content_sha256: "c".repeat(64),
+        }];
+        const design = { years: [{ udas: [{ items: [{
+          id: "remote:README.md#intro", source_id: "remote", source: "README.md",
+          source_provider: "github", source_commit: "a".repeat(40),
+        }] }] }] };
+
+        assert.throws(
+          () => reconcileSourceItems(
+            design,
+            [{
+              id: "remote:README.md#intro", source_id: "remote", source: "README.md",
+              source_provider: "github", source_commit: "b".repeat(40),
+              content_sha256: "c".repeat(64),
+            }],
+            [{ id: "remote", indexing_status: "ready" }],
+          ),
+          /vecchio commit senza digest/,
+        );
+        """
+    )
+
+
 def test_source_editor_keeps_direct_id_when_heading_content_digests_repeat() -> None:
     run_course_board_js(
         """

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -298,11 +298,11 @@ def test_loaded_legacy_item_hydrates_missing_content_digest() -> None:
     run_course_board_js(
         """
         const design = { years: [{ udas: [{ items: [{
-          id: "README.md#intro", source: "README.md",
+          id: "README.md#intro", title: "Intro", source: "README.md", line: 1, level: 1,
         }] }] }] };
         const headings = [{
-          id: "README.md#intro", source: "README.md", source_id: "legacy",
-          content_sha256: "d".repeat(64),
+          id: "README.md#intro", title: "Intro", source: "README.md", source_id: "legacy",
+          line: 1, level: 1, content_sha256: "d".repeat(64),
         }];
 
         const hydrated = hydrateMissingItemContentDigests(design, headings);
@@ -1702,7 +1702,7 @@ def test_detached_draft_preview_posts_its_in_memory_design() -> None:
           return { heading: { title: "Draft", content: "Detached content" } };
         };
 
-        openParagraphPreview({ id: "draft-heading", title: "Draft", source: "draft.md" })
+        openParagraphPreview({ id: "draft-heading", title: "Draft", source: "draft.md", content_sha256: "d".repeat(64) })
           .then(() => assert.match(els.paragraphContent.innerHTML, /Detached content/));
         """
     )
@@ -1721,8 +1721,8 @@ def test_late_paragraph_preview_cannot_overwrite_newer_dialog() -> None:
             else resolveSecond = resolve;
           });
         };
-        const first = openParagraphPreview({ id: "first", title: "Primo", source: "a.md" });
-        const second = openParagraphPreview({ id: "second", title: "Secondo", source: "b.md" });
+        const first = openParagraphPreview({ id: "first", title: "Primo", source: "a.md", content_sha256: "a".repeat(64) });
+        const second = openParagraphPreview({ id: "second", title: "Secondo", source: "b.md", content_sha256: "b".repeat(64) });
         resolveSecond({ heading: { title: "Secondo", content: "Nuovo" } });
         second.then(() => {
           assert.equal(els.paragraphDialogTitle.textContent, "Secondo");

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -316,14 +316,44 @@ def test_source_editor_projects_catalog_without_runtime_fields() -> None:
     )
 
 
+def test_source_editor_migrates_legacy_item_ids_without_detaching_topics() -> None:
+    run_course_board_js(
+        """
+        state.sources = [{ id: "legacy-abc", legacy: true }];
+        state.headings = [{
+          id: "README.md#intro", source_id: "legacy-abc", source: "README.md",
+          anchor: "intro", line: 1, level: 1,
+        }];
+        const design = { years: [{ udas: [{ items: [{
+          id: "README.md#intro", title: "Intro", source: "README.md",
+          line: 1, level: 1, frame: { status: "done" },
+        }] }] }] };
+        const preview = [{
+          id: "legacy-abc:README.md#intro", title: "Intro", source: "README.md",
+          source_id: "legacy-abc", source_label: "README.md", source_provider: "local",
+          source_repository: null, source_ref: null, source_commit: null,
+          anchor: "intro", line: 1, level: 1, href: "../README.md#intro",
+        }];
+
+        migrateLegacySourceItems(design, preview);
+
+        const item = design.years[0].udas[0].items[0];
+        assert.equal(item.id, "legacy-abc:README.md#intro");
+        assert.equal(item.source_id, "legacy-abc");
+        assert.equal(item.frame.status, "done");
+        """
+    )
+
+
 def test_source_editor_requires_preview_and_context_before_apply() -> None:
     source = Path("tools/course_board.js").read_text(encoding="utf-8")
 
     assert 'api("/api/course-sources/preview"' in source
     assert "delete candidate.source_files" in source
-    assert "delete state.design.source_files" in source
+    assert "delete nextDesign.source_files" in source
     assert "sourcePreviewSignature(sources) !== editor.preview.signature" in source
     assert "isBoardContextUnchanged(editor.boardContext)" in source
+    assert "editor.pendingPreviewRequests = Math.max" in source
 
 
 def test_item_from_heading_preserves_source_provenance() -> None:

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -355,6 +355,33 @@ def test_source_editor_migrates_legacy_item_ids_without_detaching_topics() -> No
     )
 
 
+def test_source_editor_detects_orphaned_legacy_item_after_heading_rename() -> None:
+    run_course_board_js(
+        """
+        state.sources = [{
+          id: "legacy-abc", legacy: true, path: "", files: ["README.md"],
+        }];
+        state.headings = [];
+        const design = { years: [{ udas: [{ items: [{
+          id: "README.md#old", source: "README.md", href: "../README.md#old",
+        }] }] }] };
+        const preview = [{
+          id: "legacy-abc:README.md#new", source_id: "legacy-abc", source: "README.md",
+          content_sha256: "a".repeat(64),
+        }];
+
+        assert.throws(
+          () => reconcileSourceItems(
+            design,
+            preview,
+            [{ id: "legacy-abc", indexing_status: "ready" }],
+          ),
+          /non è presente/,
+        );
+        """
+    )
+
+
 def test_source_editor_updates_assigned_remote_commit_from_preview() -> None:
     run_course_board_js(
         """

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -603,9 +603,10 @@ def test_heading_content_digest_includes_title_identity(tmp_path) -> None:
 
     headings = course_board_server.headings_from_source_snapshot(
         source_file,
-        "# Allow anonymous access\n\nSame body.\n\n# Deny anonymous access\n\nSame body.\n",
+        "# Include <stdio.h>\n\nSame body.\n\n# Include <stdlib.h>\n\nSame body.\n",
     )
 
+    assert headings[0]["title"] == headings[1]["title"] == "Include"
     assert headings[0]["content_sha256"] != headings[1]["content_sha256"]
 
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -649,18 +649,19 @@ def test_source_preview_resolves_in_memory_design_without_persisting(tmp_path, m
             topic["content_sha256"],
         )
     changed_files = course_board_server.course_markdown_source_files(design)
-    assert course_board_server.section_text(
-        topic["source"],
-        topic["line"],
-        topic["level"],
-        design,
-        {},
-        changed_files,
-        topic["source_id"],
-        topic["id"],
-        "",
-        topic["content_sha256"],
-    ) == ""
+    with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
+        course_board_server.section_text(
+            topic["source"],
+            topic["line"],
+            topic["level"],
+            design,
+            {},
+            changed_files,
+            topic["source_id"],
+            topic["id"],
+            "",
+            topic["content_sha256"],
+        )
     assert not (tmp_path / "doc" / "course_design.json").exists()
 
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -579,6 +579,36 @@ def test_course_sources_endpoint_returns_normalized_legacy_catalog(tmp_path, mon
         thread.join(timeout=5)
 
 
+def test_heading_content_digest_includes_title_identity(tmp_path) -> None:
+    descriptor = course_board_server.course_source_catalog.CourseSource(
+        source_id="course",
+        label="Course",
+        source_type="markdown",
+        provider="local",
+        path="",
+        repository=None,
+        ref=None,
+        files=("lesson.md",),
+        updated_at=None,
+        indexing_status="ready",
+    )
+    source_file = course_board_server.course_source_catalog.LocalCourseSourceFile(
+        source=descriptor,
+        relative_path="lesson.md",
+        resolved_path=tmp_path / "lesson.md",
+        expected_size=None,
+        expected_identity=None,
+        expected_sha256=None,
+    )
+
+    headings = course_board_server.headings_from_source_snapshot(
+        source_file,
+        "# Allow anonymous access\n\nSame body.\n\n# Deny anonymous access\n\nSame body.\n",
+    )
+
+    assert headings[0]["content_sha256"] != headings[1]["content_sha256"]
+
+
 def test_source_preview_resolves_in_memory_design_without_persisting(tmp_path, monkeypatch) -> None:
     lesson = tmp_path / "lesson.md"
     lesson.write_text("# Preview\n\n## Topic\n\nText.\n", encoding="utf-8")

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -685,6 +685,12 @@ def test_target_context_reads_each_source_from_one_shared_snapshot(tmp_path, mon
             }],
         }],
     }
+    heading_digests = {
+        heading["id"]: heading["content_sha256"]
+        for heading in course_board_server.extract_headings(design)
+    }
+    for item in design["years"][0]["udas"][0]["items"]:
+        item["content_sha256"] = heading_digests[item["id"]]
     original_read = course_board_server.course_source_catalog.read_markdown_text
     reads = []
 
@@ -734,24 +740,22 @@ def test_target_context_rejects_stale_source_id_on_reused_path(tmp_path, monkeyp
         }],
     }
 
-    context = course_board_server.target_context(
-        design,
-        "year",
-        "uda",
-        "source-a:lesson.md#current",
-    )
-
-    assert context["target_topic"]["source_id"] == "source-a"
-    assert context["target_topic"]["text"] == ""
+    with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
+        course_board_server.target_context(
+            design,
+            "year",
+            "uda",
+            "source-a:lesson.md#current",
+        )
 
     design["years"][0]["udas"][0]["items"][0].pop("source_id")
-    missing_provenance = course_board_server.target_context(
-        design,
-        "year",
-        "uda",
-        "source-a:lesson.md#current",
-    )
-    assert missing_provenance["target_topic"]["text"] == ""
+    with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
+        course_board_server.target_context(
+            design,
+            "year",
+            "uda",
+            "source-a:lesson.md#current",
+        )
 
     stale_item = design["years"][0]["udas"][0]["items"][0]
     stale_item.update({
@@ -759,13 +763,13 @@ def test_target_context_rejects_stale_source_id_on_reused_path(tmp_path, monkeyp
         "source_id": "source-b",
         "line": 2,
     })
-    shifted = course_board_server.target_context(
-        design,
-        "year",
-        "uda",
-        "source-b:lesson.md#current",
-    )
-    assert shifted["target_topic"]["text"] == ""
+    with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
+        course_board_server.target_context(
+            design,
+            "year",
+            "uda",
+            "source-b:lesson.md#current",
+        )
 
 
 def test_ai_catalog_rejects_excessive_heading_count(tmp_path, monkeypatch) -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -640,6 +640,27 @@ def test_source_preview_resolves_in_memory_design_without_persisting(tmp_path, m
     lesson.write_text("# Preview\n\n## Topic\n\nChanged.\n", encoding="utf-8")
     changed = course_board_server.preview_course_sources(design)
     assert changed["snapshot_revision"] != payload["snapshot_revision"]
+    topic = next(heading for heading in payload["headings"] if heading["title"] == "Topic")
+    with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
+        course_board_server.heading_content_snapshot(
+            design,
+            topic["id"],
+            "",
+            topic["content_sha256"],
+        )
+    changed_files = course_board_server.course_markdown_source_files(design)
+    assert course_board_server.section_text(
+        topic["source"],
+        topic["line"],
+        topic["level"],
+        design,
+        {},
+        changed_files,
+        topic["source_id"],
+        topic["id"],
+        "",
+        topic["content_sha256"],
+    ) == ""
     assert not (tmp_path / "doc" / "course_design.json").exists()
 
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -604,6 +604,11 @@ def test_source_preview_resolves_in_memory_design_without_persisting(tmp_path, m
         "Preview",
         "Topic",
     ]
+    assert len(payload["snapshot_revision"]) == 64
+    assert all(len(heading["content_sha256"]) == 64 for heading in payload["headings"])
+    lesson.write_text("# Preview\n\n## Topic\n\nChanged.\n", encoding="utf-8")
+    changed = course_board_server.preview_course_sources(design)
+    assert changed["snapshot_revision"] != payload["snapshot_revision"]
     assert not (tmp_path / "doc" / "course_design.json").exists()
 
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -579,6 +579,34 @@ def test_course_sources_endpoint_returns_normalized_legacy_catalog(tmp_path, mon
         thread.join(timeout=5)
 
 
+def test_source_preview_resolves_in_memory_design_without_persisting(tmp_path, monkeypatch) -> None:
+    lesson = tmp_path / "lesson.md"
+    lesson.write_text("# Preview\n\n## Topic\n\nText.\n", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    design = {
+        "sources": [
+            {
+                "id": "preview-source",
+                "label": "Preview source",
+                "type": "markdown",
+                "provider": "local",
+                "files": ["lesson.md"],
+                "indexing_status": "ready",
+            }
+        ],
+        "years": [],
+    }
+
+    payload = course_board_server.preview_course_sources(design)
+
+    assert payload["sources"][0]["indexed_files"] == ["lesson.md"]
+    assert [heading["title"] for heading in payload["headings"]] == [
+        "Preview",
+        "Topic",
+    ]
+    assert not (tmp_path / "doc" / "course_design.json").exists()
+
+
 def test_target_context_reads_each_source_from_one_shared_snapshot(tmp_path, monkeypatch) -> None:
     (tmp_path / "lesson.md").write_text(
         "## Before\n\nOne.\n\n## Target\n\nTwo.\n\n## After\n\nThree.\n",

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -713,6 +713,12 @@ def test_target_context_reads_each_source_from_one_shared_snapshot(tmp_path, mon
     assert context["next_topics"][0]["text"] == "Three."
     assert reads == ["lesson.md"]
 
+    design["years"][0]["udas"][0]["items"][1]["title"] = "Forged title"
+    with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
+        course_board_server.target_context(design, "year", "uda", "lesson.md#target")
+    with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
+        course_board_server.compact_design(design, verify_provenance=True)
+
 
 def test_target_context_rejects_stale_source_id_on_reused_path(tmp_path, monkeypatch) -> None:
     (tmp_path / "lesson.md").write_text("## Current\n\nNew content.\n", encoding="utf-8")

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -642,6 +642,8 @@ def test_source_preview_resolves_in_memory_design_without_persisting(tmp_path, m
     assert changed["snapshot_revision"] != payload["snapshot_revision"]
     topic = next(heading for heading in payload["headings"] if heading["title"] == "Topic")
     with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
+        course_board_server.heading_content_snapshot(design, topic["id"])
+    with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
         course_board_server.heading_content_snapshot(
             design,
             topic["id"],
@@ -873,13 +875,13 @@ def test_ai_course_helpers_use_the_supplied_design_source_catalog(tmp_path, monk
             }
         ],
     }
-    context = course_board_server.target_context(
-        framed_design,
-        "year",
-        "uda-1",
-        "archive:archived.md#archived",
-    )
-    assert context["target_topic"]["text"] == ""
+    with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
+        course_board_server.target_context(
+            framed_design,
+            "year",
+            "uda-1",
+            "archive:archived.md#archived",
+        )
 
 
 def test_local_catalog_does_not_read_configured_github_token(tmp_path, monkeypatch) -> None:
@@ -1040,11 +1042,11 @@ def test_github_heading_uses_commit_pinned_snapshot_and_rejects_stale_item(
         + "/lessons/intro.md#private-lesson"
     )
     assert course_board_server.heading_content_snapshot(
-        design, heading["id"], heading["source_commit"]
+        design, heading["id"], heading["source_commit"], heading["content_sha256"]
     )[1] == "Pinned content."
     with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
         course_board_server.heading_content_snapshot(
-            design, heading["id"], "c" * 40
+            design, heading["id"], "c" * 40, heading["content_sha256"]
         )
 
     (tmp_path / "lessons").mkdir()
@@ -1064,7 +1066,7 @@ def test_github_heading_uses_commit_pinned_snapshot_and_rejects_stale_item(
     }
     with pytest.raises(course_board_server.CourseSourceRevisionConflictError):
         course_board_server.heading_content_snapshot(
-            local_replacement, heading["id"], heading["source_commit"]
+            local_replacement, heading["id"], heading["source_commit"], heading["content_sha256"]
         )
     local_files = course_board_server.course_markdown_source_files(local_replacement)
     assert course_board_server.section_text(
@@ -1163,7 +1165,7 @@ def test_gitlab_heading_uses_commit_pinned_snapshot(tmp_path, monkeypatch) -> No
         + "/README.md#lesson"
     )
     assert course_board_server.heading_content_snapshot(
-        design, heading["id"], heading["source_commit"]
+        design, heading["id"], heading["source_commit"], heading["content_sha256"]
     )[1] == "Private GitLab content."
     summary = course_board_server.topic_summary(
         course_board_server.board_item_from_heading(heading)
@@ -1201,8 +1203,12 @@ def test_heading_content_endpoint_returns_selected_section(tmp_path, monkeypatch
         )
         authorization = "Basic " + base64.b64encode(f"teacher:{teacher_token}".encode("utf-8")).decode("ascii")
         request = urllib.request.Request(
-            "http://127.0.0.1:%s/api/heading-content?id=%s"
-            % (server.server_address[1], urllib.parse.quote(heading["id"], safe="")),
+            "http://127.0.0.1:%s/api/heading-content?id=%s&content_sha256=%s"
+            % (
+                server.server_address[1],
+                urllib.parse.quote(heading["id"], safe=""),
+                heading["content_sha256"],
+            ),
             headers={"Authorization": authorization},
         )
         with urllib.request.urlopen(request, timeout=5) as response:
@@ -1213,6 +1219,7 @@ def test_heading_content_endpoint_returns_selected_section(tmp_path, monkeypatch
             "http://127.0.0.1:%s/api/heading-content" % server.server_address[1],
             data=json.dumps({
                 "id": heading["id"],
+                "content_sha256": heading["content_sha256"],
                 "design": {"source_files": ["lesson.md"]},
             }).encode("utf-8"),
             headers={

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -973,12 +973,34 @@ input[aria-invalid="true"] {
   font-size: .72rem;
 }
 
+.sourceCatalogActions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .6rem;
+  margin-bottom: .8rem;
+}
+
+.sourceCatalogActions .sourceCatalogSummary { margin: 0; }
+
+.sourceDialog { width: min(980px, calc(100vw - 2rem)); }
+.sourceDialog .courseAiPanel { max-width: none; }
+.sourceDialogHelp { color: var(--muted); font-size: .8rem; }
+.sourceEditorList { display: grid; gap: .8rem; max-height: 58vh; overflow: auto; padding-right: .25rem; }
+.sourceEditorCard { border: 1px solid var(--line); border-radius: .8rem; background: #fafafa; padding: .8rem; }
+.sourceEditorCard > header { display: flex; align-items: center; justify-content: space-between; gap: .8rem; margin-bottom: .7rem; }
+.sourceEditorGrid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .65rem; }
+.sourceEditorGrid label { display: grid; gap: .3rem; font-size: .72rem; font-weight: 700; }
+.sourceEditorGrid input, .sourceEditorGrid select, .sourceEditorGrid textarea { width: 100%; }
+.sourceEditorGrid label:last-child { grid-column: 1 / -1; }
+.sourceSyncMeta { margin: .65rem 0 0; color: var(--muted); font-size: .72rem; }
+
 @media (max-width: 860px) {
   .hero { align-items: flex-start; flex-direction: column; }
   .board { grid-template-columns: 1fr; }
   .panel { min-height: auto; }
   .headingList, .courseTree { height: auto; max-height: 60vh; }
   .frameGrid { grid-template-columns: 1fr; }
-  .briefGrid { grid-template-columns: 1fr; }
+  .briefGrid, .sourceEditorGrid { grid-template-columns: 1fr; }
   .courseAiHead, .courseAiActions { align-items: flex-start; flex-direction: column; }
 }

--- a/tools/course_board.html
+++ b/tools/course_board.html
@@ -56,7 +56,10 @@
           <option value="4">H4</option>
         </select>
       </div>
-      <p id="sourceCatalogSummary" class="status sourceCatalogSummary">Catalogo fonti non caricato.</p>
+      <div class="sourceCatalogActions">
+        <p id="sourceCatalogSummary" class="status sourceCatalogSummary">Catalogo fonti non caricato.</p>
+        <button id="manageSourcesBtn" type="button">Gestisci fonti</button>
+      </div>
       <div id="headingList" class="headingList"></div>
     </section>
 
@@ -240,6 +243,28 @@
       <div class="courseAiActions">
         <button id="activityLinkSaveBtn" type="submit" class="primary">Salva collegamento</button>
         <button id="activityLinkCancelBtn" type="button">Annulla</button>
+      </div>
+    </form>
+  </dialog>
+
+  <dialog id="sourceDialog" class="courseAiDialog sourceDialog" aria-labelledby="sourceDialogTitle">
+    <form id="sourceForm" class="courseAiPanel">
+      <header class="courseAiHead">
+        <div>
+          <p class="eyebrow">Catalogo Markdown</p>
+          <h2 id="sourceDialogTitle">Gestisci fonti</h2>
+        </div>
+        <button id="sourceCloseBtn" type="button">Chiudi</button>
+      </header>
+      <p class="sourceDialogHelp">Le credenziali restano nel runtime del server e non vengono salvate nel progetto.</p>
+      <div id="sourceEditorList" class="sourceEditorList"></div>
+      <p id="sourceDialogError" class="dialogInlineError" role="alert" hidden></p>
+      <p id="sourcePreviewStatus" class="status" role="status">Sincronizza per verificare file e commit prima di applicare.</p>
+      <div class="courseAiActions sourceDialogActions">
+        <button id="sourceAddBtn" type="button">Aggiungi fonte</button>
+        <button id="sourcePreviewBtn" type="button">Sincronizza anteprima</button>
+        <button id="sourceApplyBtn" type="submit" class="primary" disabled>Applica alla board</button>
+        <button id="sourceCancelBtn" type="button">Annulla</button>
       </div>
     </form>
   </dialog>

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1163,6 +1163,9 @@ function hydrateMissingItemContentDigests(design = state.design, headings = stat
         && (!item.source || item.source === heading.source)
         && (!item.source_id || item.source_id === heading.source_id)
         && (!item.source_commit || item.source_commit === heading.source_commit)
+        && item.title === heading.title
+        && Number(item.line) === Number(heading.line)
+        && Number(item.level) === Number(heading.level)
       ) {
         item.content_sha256 = heading.content_sha256;
         hydrated += 1;
@@ -2431,6 +2434,10 @@ async function openParagraphPreview(paragraph) {
   els.paragraphContent.textContent = "Caricamento del contenuto...";
   els.paragraphSourceLink.hidden = true;
   els.paragraphDialog.showModal();
+  if (!paragraph.content_sha256) {
+    els.paragraphContent.textContent = "Contenuto non disponibile: riallinea il paragrafo dal catalogo fonti prima della preview.";
+    return;
+  }
   try {
     const payload = state.isNewDesign || hasUnsavedChanges()
       ? await api("/api/heading-content", {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1390,7 +1390,7 @@ function migrateLegacySourceItems(design, previewHeadings) {
   const oldById = new Map((state.headings || []).map((heading) => [heading.id, heading]));
   const newByKey = new Map(
     previewHeadings.map((heading) => [
-      JSON.stringify([heading.source_id, heading.source, heading.anchor, heading.line, heading.level]),
+      JSON.stringify([heading.source_id, heading.source, heading.anchor]),
       heading,
     ]),
   );
@@ -1403,8 +1403,6 @@ function migrateLegacySourceItems(design, previewHeadings) {
           sourceId,
           item.source || oldHeading?.source || "",
           oldHeading?.anchor || String(item.href || "").split("#").at(-1),
-          Number(item.line || oldHeading?.line || 0),
-          Number(item.level || oldHeading?.level || 0),
         ]);
         const replacement = newByKey.get(key);
         if (!replacement) {
@@ -2316,7 +2314,7 @@ async function openParagraphPreview(paragraph) {
   els.paragraphSourceLink.hidden = true;
   els.paragraphDialog.showModal();
   try {
-    const payload = state.isNewDesign
+    const payload = state.isNewDesign || hasUnsavedChanges()
       ? await api("/api/heading-content", {
           method: "POST",
           body: JSON.stringify({

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1401,7 +1401,13 @@ function reconcileSourceItems(design, previewHeadings, nextSources) {
   const visit = (items) => {
     for (const item of items || []) {
       const oldHeading = oldById.get(item.id);
-      const sourceId = item.source_id || oldHeading?.source_id || "";
+      const legacyMatches = (state.sources || []).filter((source) =>
+        source.legacy
+        && (source.files || []).some((file) => `${source.path ? `${source.path}/` : ""}${file}` === item.source),
+      );
+      const sourceId = item.source_id
+        || oldHeading?.source_id
+        || (legacyMatches.length === 1 ? legacyMatches[0].id : "");
       if (oldHeading || managedSourceIds.has(sourceId)) {
         const nextSource = nextSourceById.get(sourceId);
         if (!nextSource) {
@@ -2403,11 +2409,12 @@ async function openParagraphPreview(paragraph) {
           body: JSON.stringify({
             id: paragraph.id,
             source_commit: paragraph.source_commit || "",
+            content_sha256: paragraph.content_sha256 || "",
             design: state.design,
           }),
         })
       : await api(
-          `/api/heading-content?id=${encodeURIComponent(paragraph.id)}&source_commit=${encodeURIComponent(paragraph.source_commit || "")}${
+          `/api/heading-content?id=${encodeURIComponent(paragraph.id)}&source_commit=${encodeURIComponent(paragraph.source_commit || "")}&content_sha256=${encodeURIComponent(paragraph.content_sha256 || "")}${
             state.activeSavedDesign ? `&design=${encodeURIComponent(state.activeSavedDesign)}` : ""
           }`,
         );

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -19,6 +19,7 @@
   courseAiProposal: null,
   activeFrameTextarea: null,
   activityLinkEditor: null,
+  sourceEditor: null,
 };
 
 const ACTIVE_COURSE_DESIGN_KEY = "2cornot2c.activeCourseDesign";
@@ -32,6 +33,17 @@ const els = {
   levelFilter: document.querySelector("#levelFilter"),
   searchInput: document.querySelector("#searchInput"),
   sourceCatalogSummary: document.querySelector("#sourceCatalogSummary"),
+  manageSourcesBtn: document.querySelector("#manageSourcesBtn"),
+  sourceDialog: document.querySelector("#sourceDialog"),
+  sourceForm: document.querySelector("#sourceForm"),
+  sourceCloseBtn: document.querySelector("#sourceCloseBtn"),
+  sourceEditorList: document.querySelector("#sourceEditorList"),
+  sourceDialogError: document.querySelector("#sourceDialogError"),
+  sourcePreviewStatus: document.querySelector("#sourcePreviewStatus"),
+  sourceAddBtn: document.querySelector("#sourceAddBtn"),
+  sourcePreviewBtn: document.querySelector("#sourcePreviewBtn"),
+  sourceApplyBtn: document.querySelector("#sourceApplyBtn"),
+  sourceCancelBtn: document.querySelector("#sourceCancelBtn"),
   courseTree: document.querySelector("#courseTree"),
   projectTitle: document.querySelector("#projectTitle"),
   status: document.querySelector("#status"),
@@ -1133,6 +1145,264 @@ function populateFilters() {
     els.sourceFilter.append(option);
   }
   els.sourceFilter.value = selected;
+}
+
+function editableCourseSources() {
+  return (state.sources || []).map((source) => ({
+    id: source.id || "",
+    label: source.label || source.id || "",
+    type: "markdown",
+    provider: source.provider || "local",
+    path: source.path || "",
+    repository: source.repository || "",
+    ref: source.ref || "",
+    files: [...(source.files || [])],
+    updated_at: source.updated_at || null,
+    indexing_status: source.indexing_status || "ready",
+  }));
+}
+
+function nextSourceId(sources) {
+  const used = new Set(sources.map((source) => source.id));
+  let index = sources.length + 1;
+  while (used.has(`source-${index}`)) index += 1;
+  return `source-${index}`;
+}
+
+function sourceEditorField(label, control) {
+  const wrapper = document.createElement("label");
+  const title = document.createElement("span");
+  title.textContent = label;
+  wrapper.append(title, control);
+  return wrapper;
+}
+
+function renderSourceEditor() {
+  els.sourceEditorList.innerHTML = "";
+  const sources = state.sourceEditor?.draft || [];
+  sources.forEach((source, index) => {
+    const card = document.createElement("article");
+    card.className = "sourceEditorCard";
+    card.dataset.index = String(index);
+    card.dataset.updatedAt = source.updated_at || "";
+
+    const head = document.createElement("header");
+    const title = document.createElement("strong");
+    title.textContent = source.label || source.id || `Fonte ${index + 1}`;
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.className = "danger";
+    remove.textContent = "Rimuovi";
+    remove.addEventListener("click", () => {
+      const current = collectSourceEditorSources();
+      current.splice(index, 1);
+      state.sourceEditor.draft = current;
+      invalidateSourcePreview();
+      renderSourceEditor();
+    });
+    head.append(title, remove);
+
+    const grid = document.createElement("div");
+    grid.className = "sourceEditorGrid";
+    const textInput = (field, value) => {
+      const input = document.createElement("input");
+      input.type = "text";
+      input.value = value || "";
+      input.dataset.field = field;
+      return input;
+    };
+    const provider = document.createElement("select");
+    provider.dataset.field = "provider";
+    for (const value of ["local", "github", "gitlab"]) {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = value;
+      provider.append(option);
+    }
+    provider.value = source.provider;
+    provider.addEventListener("change", () => {
+      state.sourceEditor.draft = collectSourceEditorSources();
+      invalidateSourcePreview();
+      renderSourceEditor();
+    });
+    const status = document.createElement("select");
+    status.dataset.field = "indexing_status";
+    for (const value of ["ready", "pending", "error", "disabled"]) {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = value;
+      status.append(option);
+    }
+    status.value = source.indexing_status;
+    const files = document.createElement("textarea");
+    files.rows = 3;
+    files.value = (source.files || []).join("\n");
+    files.dataset.field = "files";
+
+    grid.append(
+      sourceEditorField("ID", textInput("id", source.id)),
+      sourceEditorField("Etichetta", textInput("label", source.label)),
+      sourceEditorField("Provider", provider),
+      sourceEditorField("Stato", status),
+    );
+    if (source.provider === "local") {
+      grid.append(sourceEditorField("Directory locale", textInput("path", source.path)));
+    } else {
+      grid.append(
+        sourceEditorField("Repository", textInput("repository", source.repository)),
+        sourceEditorField("Ref", textInput("ref", source.ref)),
+      );
+    }
+    grid.append(sourceEditorField("File Markdown (uno per riga)", files));
+    const syncMeta = document.createElement("p");
+    syncMeta.className = "sourceSyncMeta";
+    syncMeta.textContent = "Non verificata.";
+    card.append(head, grid, syncMeta);
+    els.sourceEditorList.append(card);
+  });
+  if (!sources.length) {
+    const empty = document.createElement("p");
+    empty.className = "empty";
+    empty.textContent = "Nessuna fonte configurata.";
+    els.sourceEditorList.append(empty);
+  }
+}
+
+function collectSourceEditorSources() {
+  return [...els.sourceEditorList.querySelectorAll(".sourceEditorCard")].map((card) => {
+    const value = (field) => card.querySelector(`[data-field="${field}"]`)?.value.trim() || "";
+    const provider = value("provider") || "local";
+    const source = {
+      id: value("id"),
+      label: value("label"),
+      type: "markdown",
+      provider,
+      files: value("files").split(/[\n,]/).map((item) => item.trim()).filter(Boolean),
+      updated_at: card.dataset.updatedAt || null,
+      indexing_status: value("indexing_status") || "ready",
+    };
+    if (provider === "local") {
+      const path = value("path");
+      if (path) source.path = path;
+    } else {
+      source.repository = value("repository");
+      source.ref = value("ref");
+    }
+    return source;
+  });
+}
+
+function sourcePreviewSignature(sources) {
+  return JSON.stringify(sources);
+}
+
+function invalidateSourcePreview() {
+  if (!state.sourceEditor) return;
+  state.sourceEditor.requestId += 1;
+  state.sourceEditor.preview = null;
+  els.sourceApplyBtn.disabled = true;
+  els.sourcePreviewStatus.textContent = "Modifiche da sincronizzare.";
+}
+
+function showSourceDialogError(message = "") {
+  els.sourceDialogError.textContent = message;
+  els.sourceDialogError.hidden = !message;
+}
+
+function openSourceDialog() {
+  state.sourceEditor = {
+    draft: editableCourseSources(),
+    preview: null,
+    requestId: 0,
+    boardContext: captureBoardContext(),
+  };
+  showSourceDialogError();
+  els.sourceApplyBtn.disabled = true;
+  els.sourcePreviewStatus.textContent = "Sincronizza per verificare file e commit prima di applicare.";
+  renderSourceEditor();
+  els.sourceDialog.showModal();
+}
+
+function closeSourceDialog() {
+  if (state.sourceEditor) state.sourceEditor.requestId += 1;
+  state.sourceEditor = null;
+  if (els.sourceDialog.open) els.sourceDialog.close();
+}
+
+async function previewSourceEditor() {
+  const editor = state.sourceEditor;
+  if (!editor) return;
+  const sources = collectSourceEditorSources();
+  editor.draft = sources;
+  editor.preview = null;
+  showSourceDialogError();
+  els.sourceApplyBtn.disabled = true;
+  els.sourcePreviewBtn.disabled = true;
+  els.sourcePreviewStatus.textContent = "Sincronizzazione in corso...";
+  const requestId = ++editor.requestId;
+  const candidate = JSON.parse(JSON.stringify(state.design));
+  candidate.sources = sources;
+  delete candidate.source_files;
+  try {
+    const payload = await api("/api/course-sources/preview", {
+      method: "POST",
+      body: JSON.stringify({ design: candidate }),
+    });
+    if (state.sourceEditor !== editor || requestId !== editor.requestId) return;
+    if (!isBoardContextUnchanged(editor.boardContext)) {
+      throw new Error("La board è cambiata durante la sincronizzazione: riapri il dialog.");
+    }
+    editor.preview = {
+      signature: sourcePreviewSignature(sources),
+      sources: payload.sources || [],
+      headings: payload.headings || [],
+    };
+    for (const card of els.sourceEditorList.querySelectorAll(".sourceEditorCard")) {
+      const source = editor.preview.sources.find((item) => item.id === card.querySelector('[data-field="id"]').value.trim());
+      const commit = source?.resolved_ref ? ` · commit ${source.resolved_ref.slice(0, 12)}` : "";
+      card.querySelector(".sourceSyncMeta").textContent = source
+        ? `${(source.indexed_files || []).length} file indicizzati${commit}`
+        : "Fonte non restituita dal catalogo.";
+    }
+    els.sourcePreviewStatus.textContent = `${editor.preview.sources.length} fonti verificate · ${editor.preview.headings.length} paragrafi.`;
+    els.sourceApplyBtn.disabled = false;
+  } catch (error) {
+    if (state.sourceEditor === editor && requestId === editor.requestId) {
+      showSourceDialogError(error.message);
+      els.sourcePreviewStatus.textContent = "Sincronizzazione non riuscita.";
+    }
+  } finally {
+    if (state.sourceEditor === editor && requestId === editor.requestId) {
+      els.sourcePreviewBtn.disabled = false;
+    }
+  }
+}
+
+function applySourceEditor(event) {
+  event.preventDefault();
+  const editor = state.sourceEditor;
+  if (!editor?.preview) return;
+  const sources = collectSourceEditorSources();
+  if (sourcePreviewSignature(sources) !== editor.preview.signature) {
+    invalidateSourcePreview();
+    showSourceDialogError("Le fonti sono cambiate: sincronizza di nuovo prima di applicare.");
+    return;
+  }
+  if (!isBoardContextUnchanged(editor.boardContext)) {
+    showSourceDialogError("La board è cambiata: chiudi e riapri il dialog.");
+    return;
+  }
+  state.design.sources = JSON.parse(JSON.stringify(sources));
+  delete state.design.source_files;
+  state.sources = editor.preview.sources;
+  state.headings = editor.preview.headings;
+  closeSourceDialog();
+  populateFilters();
+  renderSourceCatalogSummary();
+  renderHeadings();
+  renderCourse();
+  renderCourseActions();
+  setStatus("Catalogo fonti applicato alla board. Salva il progetto per renderlo persistente.");
 }
 
 function renderSourceCatalogSummary() {
@@ -3193,6 +3463,32 @@ els.saveArchiveBtn.addEventListener("click", () => runAsyncAction(saveArchiveDes
 els.saveArchiveAsBtn.addEventListener("click", () => runAsyncAction(saveArchiveDesignAs, "Salvataggio copia"));
 els.deleteArchiveBtn.addEventListener("click", () => runAsyncAction(deleteArchiveDesign, "Cancellazione progetto"));
 els.addYearBtn.addEventListener("click", openYearDialog);
+els.manageSourcesBtn.addEventListener("click", openSourceDialog);
+els.sourceAddBtn.addEventListener("click", () => {
+  const sources = collectSourceEditorSources();
+  const id = nextSourceId(sources);
+  sources.push({
+    id,
+    label: `Fonte ${sources.length + 1}`,
+    type: "markdown",
+    provider: "local",
+    path: "",
+    repository: "",
+    ref: "",
+    files: [],
+    updated_at: null,
+    indexing_status: "ready",
+  });
+  state.sourceEditor.draft = sources;
+  invalidateSourcePreview();
+  renderSourceEditor();
+});
+els.sourcePreviewBtn.addEventListener("click", () => runAsyncAction(previewSourceEditor, "Sincronizzazione fonti"));
+els.sourceForm.addEventListener("submit", applySourceEditor);
+els.sourceCloseBtn.addEventListener("click", closeSourceDialog);
+els.sourceCancelBtn.addEventListener("click", closeSourceDialog);
+els.sourceDialog.addEventListener("close", closeSourceDialog);
+els.sourceEditorList.addEventListener("input", invalidateSourcePreview);
 els.yearCloseBtn.addEventListener("click", () => els.yearDialog.close());
 els.yearCancelBtn.addEventListener("click", () => els.yearDialog.close());
 els.yearCreateBtn.addEventListener("click", createYearFromDialog);

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1387,6 +1387,7 @@ function reconcileSourceItems(design, previewHeadings, nextSources) {
   const managedSourceIds = new Set((state.sources || []).map((source) => source.id));
   const nextSourceById = new Map(nextSources.map((source) => [source.id, source]));
   const oldById = new Map((state.headings || []).map((heading) => [heading.id, heading]));
+  const newById = new Map(previewHeadings.map((heading) => [heading.id, heading]));
   const newByKey = new Map();
   for (const heading of previewHeadings) {
     const key = JSON.stringify([
@@ -1409,12 +1410,15 @@ function reconcileSourceItems(design, previewHeadings, nextSources) {
           visit(item.children);
           continue;
         }
-        const key = JSON.stringify([
-          sourceId,
-          item.source || oldHeading?.source || "",
-          item.content_sha256 || oldHeading?.content_sha256 || "",
-        ]);
-        const replacement = newByKey.get(key);
+        const sourcePath = item.source || oldHeading?.source || "";
+        const contentSha256 = item.content_sha256 || oldHeading?.content_sha256 || "";
+        const direct = newById.get(item.id);
+        const directMatches = direct
+          && direct.source_id === sourceId
+          && direct.source === sourcePath
+          && direct.content_sha256 === contentSha256;
+        const key = JSON.stringify([sourceId, sourcePath, contentSha256]);
+        const replacement = directMatches ? direct : newByKey.get(key);
         if (!replacement) {
           throw new Error(`Il paragrafo assegnato ${item.id} non è presente nell'anteprima sincronizzata.`);
         }

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1359,6 +1359,7 @@ async function previewSourceEditor() {
       signature: sourcePreviewSignature(sources),
       sources: payload.sources || [],
       headings: payload.headings || [],
+      snapshotRevision: payload.snapshot_revision || "",
     };
     for (const card of els.sourceEditorList.querySelectorAll(".sourceEditorCard")) {
       const source = editor.preview.sources.find((item) => item.id === card.querySelector('[data-field="id"]').value.trim());
@@ -1382,24 +1383,36 @@ async function previewSourceEditor() {
   }
 }
 
-function reconcileSourceItems(design, previewHeadings) {
+function reconcileSourceItems(design, previewHeadings, nextSources) {
   const managedSourceIds = new Set((state.sources || []).map((source) => source.id));
+  const nextSourceById = new Map(nextSources.map((source) => [source.id, source]));
   const oldById = new Map((state.headings || []).map((heading) => [heading.id, heading]));
-  const newByKey = new Map(
-    previewHeadings.map((heading) => [
-      JSON.stringify([heading.source_id, heading.source, heading.anchor]),
-      heading,
-    ]),
-  );
+  const newByKey = new Map();
+  for (const heading of previewHeadings) {
+    const key = JSON.stringify([
+      heading.source_id,
+      heading.source,
+      heading.content_sha256,
+    ]);
+    newByKey.set(key, newByKey.has(key) ? null : heading);
+  }
   const visit = (items) => {
     for (const item of items || []) {
       const oldHeading = oldById.get(item.id);
       const sourceId = item.source_id || oldHeading?.source_id || "";
       if (oldHeading || managedSourceIds.has(sourceId)) {
+        const nextSource = nextSourceById.get(sourceId);
+        if (!nextSource) {
+          throw new Error(`La fonte usata dal paragrafo ${item.id} è stata rimossa o rinominata.`);
+        }
+        if (nextSource.indexing_status !== "ready") {
+          visit(item.children);
+          continue;
+        }
         const key = JSON.stringify([
           sourceId,
           item.source || oldHeading?.source || "",
-          oldHeading?.anchor || String(item.href || "").split("#").at(-1),
+          item.content_sha256 || oldHeading?.content_sha256 || "",
         ]);
         const replacement = newByKey.get(key);
         if (!replacement) {
@@ -1415,6 +1428,7 @@ function reconcileSourceItems(design, previewHeadings) {
           source_repository: replacement.source_repository,
           source_ref: replacement.source_ref,
           source_commit: replacement.source_commit,
+          content_sha256: replacement.content_sha256,
           href: replacement.href,
           level: replacement.level,
           line: replacement.line,
@@ -1428,7 +1442,7 @@ function reconcileSourceItems(design, previewHeadings) {
   }
 }
 
-function applySourceEditor(event) {
+async function applySourceEditor(event) {
   event.preventDefault();
   const editor = state.sourceEditor;
   if (!editor?.preview) return;
@@ -1442,25 +1456,77 @@ function applySourceEditor(event) {
     showSourceDialogError("La board è cambiata: chiudi e riapri il dialog.");
     return;
   }
-  const nextDesign = JSON.parse(JSON.stringify(state.design));
+
+  const candidate = JSON.parse(JSON.stringify(state.design));
+  candidate.sources = sources;
+  delete candidate.source_files;
+  const requestId = ++editor.requestId;
+  editor.pendingPreviewRequests += 1;
+  els.sourceApplyBtn.disabled = true;
+  els.sourcePreviewBtn.disabled = true;
+  els.sourcePreviewStatus.textContent = "Verifica finale dello snapshot...";
   try {
-    reconcileSourceItems(nextDesign, editor.preview.headings);
+    const verified = await api("/api/course-sources/preview", {
+      method: "POST",
+      body: JSON.stringify({ design: candidate }),
+    });
+    if (state.sourceEditor !== editor || requestId !== editor.requestId) return;
+    if (!isBoardContextUnchanged(editor.boardContext)) {
+      throw new Error("La board è cambiata durante la verifica finale.");
+    }
+    if (
+      !verified.snapshot_revision
+      || verified.snapshot_revision !== editor.preview.snapshotRevision
+    ) {
+      editor.preview = null;
+      els.sourceApplyBtn.disabled = true;
+      throw new Error("Lo snapshot delle fonti è cambiato: sincronizza di nuovo.");
+    }
+
+    const verifiedById = new Map((verified.sources || []).map((source) => [source.id, source]));
+    const appliedSources = sources.map((source) => {
+      const applied = JSON.parse(JSON.stringify(source));
+      if (source.provider !== "local" && source.indexing_status === "ready") {
+        const resolvedRef = verifiedById.get(source.id)?.resolved_ref;
+        if (!resolvedRef) throw new Error(`Commit risolto non disponibile per ${source.id}.`);
+        applied.ref = resolvedRef;
+      }
+      return applied;
+    });
+    const appliedHeadings = (verified.headings || []).map((heading) => ({
+      ...heading,
+      source_ref: appliedSources.find((source) => source.id === heading.source_id)?.ref || heading.source_ref,
+    }));
+    const appliedCatalog = (verified.sources || []).map((source) => ({
+      ...source,
+      ref: appliedSources.find((item) => item.id === source.id)?.ref || source.ref,
+    }));
+    const nextDesign = JSON.parse(JSON.stringify(state.design));
+    reconcileSourceItems(nextDesign, appliedHeadings, appliedSources);
+    nextDesign.sources = JSON.parse(JSON.stringify(appliedSources));
+    delete nextDesign.source_files;
+    state.design = nextDesign;
+    state.sources = appliedCatalog;
+    state.headings = appliedHeadings;
+    closeSourceDialog();
+    populateFilters();
+    renderSourceCatalogSummary();
+    renderHeadings();
+    renderCourse();
+    renderCourseActions();
+    setStatus("Catalogo fonti applicato e fissato allo snapshot verificato. Salva il progetto per renderlo persistente.");
   } catch (error) {
-    showSourceDialogError(error.message);
-    return;
+    if (state.sourceEditor === editor && requestId === editor.requestId) {
+      showSourceDialogError(error.message);
+      els.sourcePreviewStatus.textContent = "Applicazione non riuscita.";
+      els.sourceApplyBtn.disabled = !editor.preview;
+    }
+  } finally {
+    if (state.sourceEditor === editor) {
+      editor.pendingPreviewRequests = Math.max(0, editor.pendingPreviewRequests - 1);
+      els.sourcePreviewBtn.disabled = editor.pendingPreviewRequests > 0;
+    }
   }
-  nextDesign.sources = JSON.parse(JSON.stringify(sources));
-  delete nextDesign.source_files;
-  state.design = nextDesign;
-  state.sources = editor.preview.sources;
-  state.headings = editor.preview.headings;
-  closeSourceDialog();
-  populateFilters();
-  renderSourceCatalogSummary();
-  renderHeadings();
-  renderCourse();
-  renderCourseActions();
-  setStatus("Catalogo fonti applicato alla board. Salva il progetto per renderlo persistente.");
 }
 
 function renderSourceCatalogSummary() {
@@ -1672,6 +1738,7 @@ function itemFromHeading(heading) {
     source_repository: heading.source_repository,
     source_ref: heading.source_ref,
     source_commit: heading.source_commit,
+    content_sha256: heading.content_sha256,
     href: heading.href,
     level: heading.level,
     line: heading.line,
@@ -1700,6 +1767,7 @@ function childItemsFromHeading(parentHeading) {
       source_repository: heading.source_repository,
       source_ref: heading.source_ref,
       source_commit: heading.source_commit,
+      content_sha256: heading.content_sha256,
       href: heading.href,
       level: heading.level,
       line: heading.line,

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1543,6 +1543,11 @@ async function applySourceEditor(event) {
     if (!isBoardContextUnchanged(editor.boardContext)) {
       throw new Error("La board è cambiata durante la verifica finale.");
     }
+    if (sourcePreviewSignature(collectSourceEditorSources()) !== sourcePreviewSignature(sources)) {
+      editor.preview = null;
+      els.sourceApplyBtn.disabled = true;
+      throw new Error("Le fonti sono cambiate durante la verifica finale: sincronizza di nuovo.");
+    }
     if (
       !verified.snapshot_revision
       || verified.snapshot_revision !== editor.preview.snapshotRevision

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1382,11 +1382,8 @@ async function previewSourceEditor() {
   }
 }
 
-function migrateLegacySourceItems(design, previewHeadings) {
-  const legacySourceIds = new Set(
-    (state.sources || []).filter((source) => source.legacy).map((source) => source.id),
-  );
-  if (!legacySourceIds.size) return;
+function reconcileSourceItems(design, previewHeadings) {
+  const managedSourceIds = new Set((state.sources || []).map((source) => source.id));
   const oldById = new Map((state.headings || []).map((heading) => [heading.id, heading]));
   const newByKey = new Map(
     previewHeadings.map((heading) => [
@@ -1398,7 +1395,7 @@ function migrateLegacySourceItems(design, previewHeadings) {
     for (const item of items || []) {
       const oldHeading = oldById.get(item.id);
       const sourceId = item.source_id || oldHeading?.source_id || "";
-      if (legacySourceIds.has(sourceId)) {
+      if (oldHeading || managedSourceIds.has(sourceId)) {
         const key = JSON.stringify([
           sourceId,
           item.source || oldHeading?.source || "",
@@ -1406,7 +1403,7 @@ function migrateLegacySourceItems(design, previewHeadings) {
         ]);
         const replacement = newByKey.get(key);
         if (!replacement) {
-          throw new Error(`Il paragrafo legacy ${item.id} non è presente nell'anteprima sincronizzata.`);
+          throw new Error(`Il paragrafo assegnato ${item.id} non è presente nell'anteprima sincronizzata.`);
         }
         Object.assign(item, {
           id: replacement.id,
@@ -1447,7 +1444,7 @@ function applySourceEditor(event) {
   }
   const nextDesign = JSON.parse(JSON.stringify(state.design));
   try {
-    migrateLegacySourceItems(nextDesign, editor.preview.headings);
+    reconcileSourceItems(nextDesign, editor.preview.headings);
   } catch (error) {
     showSourceDialogError(error.message);
     return;

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1411,6 +1411,16 @@ function reconcileSourceItems(design, previewHeadings, nextSources) {
           continue;
         }
         const sourcePath = item.source || oldHeading?.source || "";
+        const provider = item.source_provider || oldHeading?.source_provider || "local";
+        if (
+          provider !== "local"
+          && item.source_commit
+          && !item.content_sha256
+          && oldHeading?.source_commit
+          && item.source_commit !== oldHeading.source_commit
+        ) {
+          throw new Error(`Il paragrafo ${item.id} appartiene a un vecchio commit senza digest: rimuovilo o ripristina la ref prima di riallinearlo.`);
+        }
         const contentSha256 = item.content_sha256 || oldHeading?.content_sha256 || "";
         const direct = newById.get(item.id);
         const directMatches = direct

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -456,6 +456,8 @@ async function loadAll() {
     state.activityCatalogError = "";
   }
   state.design = courseContext.design;
+  markDesignClean();
+  hydrateMissingItemContentDigests();
   state.designRevision = courseContext.revision;
   state.designEditableRevision = courseContext.editableRevision;
   state.currentDesignRevision = courseContext.revision;
@@ -477,7 +479,6 @@ async function loadAll() {
   renderProjectTitle();
   renderHeadings();
   renderCourse();
-  markDesignClean();
   if (state.activityCatalogError) {
     setStatus(`Catalogo activity non disponibile: ${state.activityCatalogError}. Usa Ricarica per riprovare.`);
   } else if (state.activeSavedDesign || state.isNewDesign) {
@@ -600,6 +601,7 @@ async function loadCurrentDesign() {
   state.activeSavedDesign = "";
   state.isNewDesign = false;
   markDesignClean();
+  hydrateMissingItemContentDigests();
   localStorage.removeItem(ACTIVE_COURSE_DESIGN_KEY);
   sessionStorage.removeItem(ACTIVE_COURSE_SESSION_KEY);
   renderSavedDesigns();
@@ -643,6 +645,7 @@ async function loadSavedDesignByName(name, options = {}) {
   state.activeSavedDesign = name;
   state.isNewDesign = false;
   markDesignClean();
+  hydrateMissingItemContentDigests();
   localStorage.setItem(ACTIVE_COURSE_DESIGN_KEY, name);
   sessionStorage.setItem(ACTIVE_COURSE_SESSION_KEY, "true");
   if (render) {
@@ -992,6 +995,7 @@ async function deleteArchiveDesignOnce() {
   state.activeSavedDesign = "";
   state.isNewDesign = false;
   markDesignClean();
+  hydrateMissingItemContentDigests();
   renderSavedDesigns();
   renderProjectTitle();
   populateFilters();
@@ -1145,6 +1149,31 @@ function populateFilters() {
     els.sourceFilter.append(option);
   }
   els.sourceFilter.value = selected;
+}
+
+function hydrateMissingItemContentDigests(design = state.design, headings = state.headings) {
+  const byId = new Map((headings || []).map((heading) => [heading.id, heading]));
+  let hydrated = 0;
+  const visit = (items) => {
+    for (const item of items || []) {
+      const heading = byId.get(item.id);
+      if (
+        !item.content_sha256
+        && heading?.content_sha256
+        && (!item.source || item.source === heading.source)
+        && (!item.source_id || item.source_id === heading.source_id)
+        && (!item.source_commit || item.source_commit === heading.source_commit)
+      ) {
+        item.content_sha256 = heading.content_sha256;
+        hydrated += 1;
+      }
+      visit(item.children);
+    }
+  };
+  for (const year of design?.years || []) {
+    for (const uda of year.udas || []) visit(uda.items);
+  }
+  return hydrated;
 }
 
 function editableCourseSources() {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1314,10 +1314,12 @@ function openSourceDialog() {
     draft: editableCourseSources(),
     preview: null,
     requestId: 0,
+    pendingPreviewRequests: 0,
     boardContext: captureBoardContext(),
   };
   showSourceDialogError();
   els.sourceApplyBtn.disabled = true;
+  els.sourcePreviewBtn.disabled = false;
   els.sourcePreviewStatus.textContent = "Sincronizza per verificare file e commit prima di applicare.";
   renderSourceEditor();
   els.sourceDialog.showModal();
@@ -1337,6 +1339,7 @@ async function previewSourceEditor() {
   editor.preview = null;
   showSourceDialogError();
   els.sourceApplyBtn.disabled = true;
+  editor.pendingPreviewRequests += 1;
   els.sourcePreviewBtn.disabled = true;
   els.sourcePreviewStatus.textContent = "Sincronizzazione in corso...";
   const requestId = ++editor.requestId;
@@ -1372,9 +1375,61 @@ async function previewSourceEditor() {
       els.sourcePreviewStatus.textContent = "Sincronizzazione non riuscita.";
     }
   } finally {
-    if (state.sourceEditor === editor && requestId === editor.requestId) {
-      els.sourcePreviewBtn.disabled = false;
+    if (state.sourceEditor === editor) {
+      editor.pendingPreviewRequests = Math.max(0, editor.pendingPreviewRequests - 1);
+      els.sourcePreviewBtn.disabled = editor.pendingPreviewRequests > 0;
     }
+  }
+}
+
+function migrateLegacySourceItems(design, previewHeadings) {
+  const legacySourceIds = new Set(
+    (state.sources || []).filter((source) => source.legacy).map((source) => source.id),
+  );
+  if (!legacySourceIds.size) return;
+  const oldById = new Map((state.headings || []).map((heading) => [heading.id, heading]));
+  const newByKey = new Map(
+    previewHeadings.map((heading) => [
+      JSON.stringify([heading.source_id, heading.source, heading.anchor, heading.line, heading.level]),
+      heading,
+    ]),
+  );
+  const visit = (items) => {
+    for (const item of items || []) {
+      const oldHeading = oldById.get(item.id);
+      const sourceId = item.source_id || oldHeading?.source_id || "";
+      if (legacySourceIds.has(sourceId)) {
+        const key = JSON.stringify([
+          sourceId,
+          item.source || oldHeading?.source || "",
+          oldHeading?.anchor || String(item.href || "").split("#").at(-1),
+          Number(item.line || oldHeading?.line || 0),
+          Number(item.level || oldHeading?.level || 0),
+        ]);
+        const replacement = newByKey.get(key);
+        if (!replacement) {
+          throw new Error(`Il paragrafo legacy ${item.id} non è presente nell'anteprima sincronizzata.`);
+        }
+        Object.assign(item, {
+          id: replacement.id,
+          title: replacement.title,
+          source: replacement.source,
+          source_id: replacement.source_id,
+          source_label: replacement.source_label,
+          source_provider: replacement.source_provider,
+          source_repository: replacement.source_repository,
+          source_ref: replacement.source_ref,
+          source_commit: replacement.source_commit,
+          href: replacement.href,
+          level: replacement.level,
+          line: replacement.line,
+        });
+      }
+      visit(item.children);
+    }
+  };
+  for (const year of design.years || []) {
+    for (const uda of year.udas || []) visit(uda.items);
   }
 }
 
@@ -1392,8 +1447,16 @@ function applySourceEditor(event) {
     showSourceDialogError("La board è cambiata: chiudi e riapri il dialog.");
     return;
   }
-  state.design.sources = JSON.parse(JSON.stringify(sources));
-  delete state.design.source_files;
+  const nextDesign = JSON.parse(JSON.stringify(state.design));
+  try {
+    migrateLegacySourceItems(nextDesign, editor.preview.headings);
+  } catch (error) {
+    showSourceDialogError(error.message);
+    return;
+  }
+  nextDesign.sources = JSON.parse(JSON.stringify(sources));
+  delete nextDesign.source_files;
+  state.design = nextDesign;
   state.sources = editor.preview.sources;
   state.headings = editor.preview.headings;
   closeSourceDialog();

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1158,7 +1158,7 @@ function hydrateMissingItemContentDigests(design = state.design, headings = stat
     for (const item of items || []) {
       const heading = byId.get(item.id);
       if (
-        !item.content_sha256
+        (!item.content_sha256 || !item.source_id || !item.source_provider || !item.href)
         && heading?.content_sha256
         && (!item.source || item.source === heading.source)
         && (!item.source_id || item.source_id === heading.source_id)
@@ -1167,7 +1167,20 @@ function hydrateMissingItemContentDigests(design = state.design, headings = stat
         && Number(item.line) === Number(heading.line)
         && Number(item.level) === Number(heading.level)
       ) {
-        item.content_sha256 = heading.content_sha256;
+        Object.assign(item, {
+          title: heading.title,
+          source: heading.source,
+          source_id: heading.source_id,
+          source_label: heading.source_label,
+          source_provider: heading.source_provider,
+          source_repository: heading.source_repository,
+          source_ref: heading.source_ref,
+          source_commit: heading.source_commit,
+          content_sha256: heading.content_sha256,
+          href: heading.href,
+          level: heading.level,
+          line: heading.line,
+        });
         hydrated += 1;
       }
       visit(item.children);

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -1385,6 +1385,7 @@ async function previewSourceEditor() {
 
 function reconcileSourceItems(design, previewHeadings, nextSources) {
   const managedSourceIds = new Set((state.sources || []).map((source) => source.id));
+  const currentSourceById = new Map((state.sources || []).map((source) => [source.id, source]));
   const nextSourceById = new Map(nextSources.map((source) => [source.id, source]));
   const oldById = new Map((state.headings || []).map((heading) => [heading.id, heading]));
   const newById = new Map(previewHeadings.map((heading) => [heading.id, heading]));
@@ -1407,6 +1408,9 @@ function reconcileSourceItems(design, previewHeadings, nextSources) {
           throw new Error(`La fonte usata dal paragrafo ${item.id} è stata rimossa o rinominata.`);
         }
         if (nextSource.indexing_status !== "ready") {
+          if (currentSourceById.get(sourceId)?.legacy) {
+            throw new Error(`La fonte legacy ${sourceId} deve restare ready durante la migrazione iniziale.`);
+          }
           visit(item.children);
           continue;
         }


### PR DESCRIPTION
## Summary
- add a Course Board “Gestisci fonti” dialog for local, GitHub, and GitLab catalogs
- support source creation, editing, status changes, migration, preview, synchronization, and immutable remote ref pinning
- add non-persistent `POST /api/course-sources/preview` with bounded catalog/file/heading output
- reconcile assigned topics without silent detach, removal, rename, stale-commit, duplicate-content, or board-snapshot loss
- propagate and enforce heading content digests across preview and AI boundaries
- fail closed on stale source, commit, heading structure, title, or content before provider-backed AI calls
- hydrate legacy topics only when structural identity still matches, then preserve complete verified provenance

## Validation
- focused Course Board frontend/server suites pass (3 expected skips; known Windows protected-DACL cleanup warnings only)
- JavaScript syntax, Python compilation, and `git diff --check` pass
- full GitHub Actions matrix green at `827d03c`
- two consecutive independent read-only reviews at `827d03c`: `Nessun finding.`

Closes #633
Part of #290
