### PR TITLE
Fix classroom workflow runner context

### DIFF
--- a/.github/workflows/publish-classroom-boxes.yml
+++ b/.github/workflows/publish-classroom-boxes.yml
@@ -125,7 +125,21 @@ jobs:
       - name: Remove isolated Vagrant home
         if: always()
         shell: pwsh
-        run: Remove-Item -LiteralPath $env:VAGRANT_HOME -Recurse -Force -ErrorAction SilentlyContinue
+        run: |
+          $isolated = Join-Path $env:RUNNER_TEMP `
+            "2cornot2c-vagrant-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          $separator = [IO.Path]::DirectorySeparatorChar
+          $expectedParent = [IO.Path]::GetFullPath(
+            $env:RUNNER_TEMP
+          ).TrimEnd($separator)
+          $actualParent = [IO.Path]::GetFullPath(
+            (Split-Path -Parent $isolated)
+          ).TrimEnd($separator)
+          if ($actualParent -ne $expectedParent) {
+            throw 'Percorso VAGRANT_HOME isolato non valido.'
+          }
+          Remove-Item -LiteralPath $isolated -Recurse -Force `
+            -ErrorAction SilentlyContinue
 
   vmware-arm64:
     if: inputs.target == 'macos-arm64-vmware'
@@ -179,7 +193,12 @@ jobs:
           retention-days: 1
       - name: Remove isolated Vagrant home
         if: always()
-        run: rm -rf -- "$VAGRANT_HOME"
+        run: |
+          isolated="$RUNNER_TEMP/2cornot2c-vagrant-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          case "$isolated" in
+            "$RUNNER_TEMP"/2cornot2c-vagrant-*) rm -rf -- "$isolated" ;;
+            *) echo "Percorso VAGRANT_HOME isolato non valido." >&2; exit 6 ;;
+          esac
 
   release-windows:
     needs: virtualbox-amd64

--- a/.github/workflows/publish-classroom-boxes.yml
+++ b/.github/workflows/publish-classroom-boxes.yml
@@ -75,13 +75,18 @@ jobs:
     needs: validate-release
     runs-on: [self-hosted, Windows, X64, classroom-packer]
     timeout-minutes: 120
-    env:
-      VAGRANT_HOME: ${{ runner.temp }}/2cornot2c-vagrant-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+      - name: Configure isolated Vagrant home
+        shell: pwsh
+        run: |
+          $home = Join-Path $env:RUNNER_TEMP `
+            "2cornot2c-vagrant-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          "VAGRANT_HOME=$home" | Out-File -FilePath $env:GITHUB_ENV `
+            -Encoding utf8 -Append
       - name: Install checksum-locked Packer plugin
         working-directory: packer
         run: python install-locked-plugin.py --platform windows_amd64
@@ -127,13 +132,15 @@ jobs:
     needs: validate-release
     runs-on: [self-hosted, macOS, ARM64, classroom-packer]
     timeout-minutes: 120
-    env:
-      VAGRANT_HOME: ${{ runner.temp }}/2cornot2c-vagrant-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+      - name: Configure isolated Vagrant home
+        run: |
+          printf 'VAGRANT_HOME=%s/2cornot2c-vagrant-%s-%s\n' \
+            "$RUNNER_TEMP" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" >> "$GITHUB_ENV"
       - name: Install checksum-locked Packer plugin
         working-directory: packer
         run: python3 install-locked-plugin.py --platform darwin_arm64

--- a/tests/test_classroom_release_manifest.py
+++ b/tests/test_classroom_release_manifest.py
@@ -252,3 +252,7 @@ def test_packer_toolchain_and_source_are_exactly_locked() -> None:
     assert "VAGRANT_HOME: ${{ runner.temp }}" not in workflow
     assert "2cornot2c-vagrant-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT" in workflow
     assert '"$RUNNER_TEMP" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"' in workflow
+    assert "Remove-Item -LiteralPath $env:VAGRANT_HOME" not in workflow
+    assert 'rm -rf -- "$VAGRANT_HOME"' not in workflow
+    assert "Remove-Item -LiteralPath $isolated" in workflow
+    assert 'rm -rf -- "$isolated"' in workflow

--- a/tests/test_classroom_release_manifest.py
+++ b/tests/test_classroom_release_manifest.py
@@ -249,4 +249,6 @@ def test_packer_toolchain_and_source_are_exactly_locked() -> None:
     assert "install-locked-plugin.py --platform darwin_arm64" in workflow
     assert "install-locked-vagrant-plugin.py" in workflow
     assert "--require-vagrant-vmware" in workflow
-    assert "VAGRANT_HOME: ${{ runner.temp }}/2cornot2c-vagrant-" in workflow
+    assert "VAGRANT_HOME: ${{ runner.temp }}" not in workflow
+    assert "2cornot2c-vagrant-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT" in workflow
+    assert '"$RUNNER_TEMP" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"' in workflow


### PR DESCRIPTION
## Summary
- derive isolated Vagrant homes from runtime runner environment variables inside each physical job
- avoid unsupported job-level use of the `runner` expression context
- retain run/attempt-specific isolation and cleanup on both platforms

## Validation
- focused workflow tests pass
- GitHub accepted branch dispatch run `30753664975` and completed it as skipped before any physical runner job, confirming workflow parsing without consuming Windows or macOS

Follow-up to #642. Part of #621.
