### PR TITLE
Fix physical Windows runner shell

### DIFF
--- a/.github/workflows/publish-classroom-boxes.yml
+++ b/.github/workflows/publish-classroom-boxes.yml
@@ -81,11 +81,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Configure isolated Vagrant home
-        shell: pwsh
+        shell: powershell
         run: |
-          $home = Join-Path $env:RUNNER_TEMP `
+          $vagrantHome = Join-Path $env:RUNNER_TEMP `
             "2cornot2c-vagrant-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
-          "VAGRANT_HOME=$home" | Out-File -FilePath $env:GITHUB_ENV `
+          "VAGRANT_HOME=$vagrantHome" | Out-File -FilePath $env:GITHUB_ENV `
             -Encoding utf8 -Append
       - name: Install checksum-locked Packer plugin
         working-directory: packer
@@ -108,7 +108,7 @@ jobs:
         shell: bash
         run: ./packer/acceptance/test-box.sh virtualbox packer/output/virtualbox-amd64/package.box
       - name: Stage release asset
-        shell: pwsh
+        shell: powershell
         run: |
           $source = 'packer/output/virtualbox-amd64/package.box'
           if ((Get-Item -LiteralPath $source).Length -ge 2GB) {
@@ -124,7 +124,7 @@ jobs:
           retention-days: 1
       - name: Remove isolated Vagrant home
         if: always()
-        shell: pwsh
+        shell: powershell
         run: |
           $isolated = Join-Path $env:RUNNER_TEMP `
             "2cornot2c-vagrant-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"

--- a/tests/test_classroom_release_manifest.py
+++ b/tests/test_classroom_release_manifest.py
@@ -250,6 +250,9 @@ def test_packer_toolchain_and_source_are_exactly_locked() -> None:
     assert "install-locked-vagrant-plugin.py" in workflow
     assert "--require-vagrant-vmware" in workflow
     assert "VAGRANT_HOME: ${{ runner.temp }}" not in workflow
+    assert "shell: pwsh" not in workflow
+    assert workflow.count("shell: powershell") == 3
+    assert "$vagrantHome = Join-Path" in workflow
     assert "2cornot2c-vagrant-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT" in workflow
     assert '"$RUNNER_TEMP" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"' in workflow
     assert "Remove-Item -LiteralPath $env:VAGRANT_HOME" not in workflow


### PR DESCRIPTION
Use built-in Windows PowerShell instead of unavailable pwsh for the Windows classroom job, and avoid assigning the reserved HOME variable. Runtime setup/cleanup was exercised locally with Windows PowerShell. Follow-up to failed run 30753940275; part of #621.