### PR TITLE
Quote Packer selector on Windows

### DIFF
--- a/.github/workflows/publish-classroom-boxes.yml
+++ b/.github/workflows/publish-classroom-boxes.yml
@@ -103,7 +103,7 @@ jobs:
         run: ./ensure-source-box.sh virtualbox 202510.26.0
       - name: Build VirtualBox AMD64 box
         working-directory: packer
-        run: packer build -only=classroom.vagrant.virtualbox-amd64 classroom.pkr.hcl
+        run: packer build '-only=classroom.vagrant.virtualbox-amd64' classroom.pkr.hcl
       - name: Acceptance test
         shell: bash
         run: ./packer/acceptance/test-box.sh virtualbox packer/output/virtualbox-amd64/package.box

--- a/packer/README.md
+++ b/packer/README.md
@@ -57,7 +57,7 @@ packer build -only=classroom.vagrant.vmware-arm64 classroom.pkr.hcl
 Il comando seguente deve essere eseguito su Windows o Linux amd64:
 
 ```bash
-packer build -only=classroom.vagrant.virtualbox-amd64 classroom.pkr.hcl
+packer build '-only=classroom.vagrant.virtualbox-amd64' classroom.pkr.hcl
 ```
 
 Gli artefatti vengono scritti sotto `packer/output/` e sono ignorati da Git.

--- a/tests/test_classroom_release_manifest.py
+++ b/tests/test_classroom_release_manifest.py
@@ -75,6 +75,7 @@ def test_release_workflow_keeps_dispatch_input_out_of_shell_source() -> None:
     assert run_blocks
     for run_block in run_blocks:
         assert "${{ inputs.version }}" not in run_block
+    assert "packer build '-only=classroom.vagrant.virtualbox-amd64'" in workflow
     assert "Length -ge 2GB" in workflow
     assert "stat -f %z" in workflow
     assert "needs: virtualbox-amd64" in workflow


### PR DESCRIPTION
PowerShell split the unquoted dotted `-only` value into multiple native arguments, causing physical run `30754199169` to print Packer usage before creating a VM. This PR quotes the complete selector in workflow and documentation and pins the form with a test.

Part of #621.
