### PR TITLE
Bound VirtualBox acceptance boot retry

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -108,7 +108,10 @@ Su una macchina amd64, dopo la build VirtualBox:
 ```
 
 Il test avvia la box con 2048 MB e due CPU, esegue l'health check installato
-nella VM e verifica zram, memoria, sessione grafica e cartelle condivise.
+nella VM e verifica zram, memoria, sessione grafica e cartelle condivise. Su
+VirtualBox, se la prima VM importata resta irraggiungibile durante il boot, il
+test la distrugge e la ricrea una sola volta; due boot falliti interrompono la
+release. Il retry è limitato a VirtualBox e resta visibile nei log.
 Il profilo sperimentale da 1536 MB si prova con:
 
 ```bash

--- a/packer/acceptance/test-box.sh
+++ b/packer/acceptance/test-box.sh
@@ -37,7 +37,15 @@ test -f "$box_file"
 
 vagrant box add "$box_name" "$box_file" --provider "$provider" --force
 
-vagrant up --provider "$provider"
+if ! vagrant up --provider "$provider"; then
+  if [ "$provider" != "virtualbox" ]; then
+    exit 1
+  fi
+  echo "Primo boot VirtualBox non raggiungibile: ricreo una volta la VM." >&2
+  VAGRANT_DOTFILE_PATH="$dotfile_path" vagrant destroy --force
+  rm -rf -- "$dotfile_path"
+  vagrant up --provider "$provider"
+fi
 vagrant ssh -c '
   set -eu
   sudo /usr/local/bin/2cornot2c-health-check

--- a/tests/test_classroom_release_manifest.py
+++ b/tests/test_classroom_release_manifest.py
@@ -138,6 +138,55 @@ def test_acceptance_import_uses_isolated_vagrantfile(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(os.name == "nt", reason="richiede Bash/Unix")
+def test_virtualbox_acceptance_recreates_one_failed_first_boot(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    calls = tmp_path / "vagrant-calls.txt"
+    marker = tmp_path / "first-up-failed"
+    vagrant = fake_bin / "vagrant"
+    vagrant.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '%s\\n' \"$*\" >> \"$VAGRANT_CALLS\"\n"
+        "if [ \"${1:-}\" = up ] && [ ! -e \"$VAGRANT_UP_MARKER\" ]; then\n"
+        "  : > \"$VAGRANT_UP_MARKER\"\n"
+        "  exit 1\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    vagrant.chmod(0o755)
+    box = tmp_path / "classroom.box"
+    box.write_bytes(b"box")
+
+    completed = subprocess.run(
+        (
+            "bash",
+            str(ROOT / "packer" / "acceptance" / "test-box.sh"),
+            "virtualbox",
+            str(box),
+        ),
+        cwd=ROOT,
+        env=os.environ
+        | {
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "VAGRANT_CALLS": str(calls),
+            "VAGRANT_UP_MARKER": str(marker),
+            "TMPDIR": str(tmp_path),
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    commands = calls.read_text(encoding="utf-8").splitlines()
+    assert commands.count("up --provider virtualbox") == 2
+    assert commands.count("destroy --force") == 2
+    assert "ricreo una volta" in completed.stderr
+
+
+@pytest.mark.skipif(os.name == "nt", reason="richiede Bash/Unix")
 def test_source_box_bootstrap_uses_isolated_vagrant_context(tmp_path: Path) -> None:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()


### PR DESCRIPTION
Physical run 30754616614 built the box successfully, but one imported VirtualBox VM hung during early init while a fresh import of the same immutable box booted and passed the full health check. Retry exactly one failed VirtualBox import by destroying and recreating only the acceptance VM; VMware remains fail-immediate and two failures still block release. Part of #621.