### PR TITLE
Fix classroom release download action pin

### DIFF
--- a/.github/workflows/publish-classroom-boxes.yml
+++ b/.github/workflows/publish-classroom-boxes.yml
@@ -213,7 +213,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Download verified box
-        uses: actions/download-artifact@fa0a91b85d5f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: windows-amd64-virtualbox-${{ inputs.version }}
           path: release
@@ -250,7 +250,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Download verified box
-        uses: actions/download-artifact@fa0a91b85d5f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: macos-arm64-vmware-${{ inputs.version }}
           path: release

--- a/tests/test_classroom_release_manifest.py
+++ b/tests/test_classroom_release_manifest.py
@@ -81,6 +81,9 @@ def test_release_workflow_keeps_dispatch_input_out_of_shell_source() -> None:
     assert "needs: virtualbox-amd64" in workflow
     assert "needs: vmware-arm64" in workflow
     assert "needs: [virtualbox-amd64, vmware-arm64]" not in workflow
+    assert workflow.count(
+        "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
+    ) == 2
     assert 'git ls-remote --exit-code --tags origin "refs/tags/$tag"' in workflow
     assert 'if [ "$tag_status" -ne 2 ]' in workflow
 


### PR DESCRIPTION
Replace the mistyped download-artifact commit with the verified v4.3.0 tag commit. Physical build and acceptance passed in run 30758090948, but release setup could not resolve the old SHA. Part of #621.