### PR TITLE
Activate Windows VirtualBox classroom image 1.0.0

### DIFF
--- a/packer/classroom-releases.lock.json
+++ b/packer/classroom-releases.lock.json
@@ -4,8 +4,12 @@
     "windows-amd64-virtualbox": {
       "host": "windows-amd64",
       "provider": "virtualbox",
-      "candidate_version": "1.0.0",
-      "active_release": null
+      "candidate_version": null,
+      "active_release": {
+        "version": "1.0.0",
+        "manifest_url": "https://github.com/TheBitPoets/2cornot2c/releases/download/classroom-windows-amd64-virtualbox-v1.0.0/release-manifest.json",
+        "manifest_sha256": "2f81e8ae846059187737de89ebe0a9de8a7875c2cf889c2146800298da75634b"
+      }
     },
     "macos-arm64-vmware": {
       "host": "macos-arm64",

--- a/tests/test_classroom_images.py
+++ b/tests/test_classroom_images.py
@@ -320,11 +320,16 @@ def test_vagrantfile_disables_implicit_bento_fallback() -> None:
 def test_pending_activation_refuses_official_manifest_installation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    release = classroom_images.target_release(
-        Host.WINDOWS_AMD64, Provider.VIRTUALBOX
+    release = classroom_images.TargetRelease(
+        "windows-amd64-virtualbox",
+        Host.WINDOWS_AMD64,
+        Provider.VIRTUALBOX,
+        "1.0.0",
+        None,
+        None,
+        None,
     )
     assert not release.active
-    assert release.candidate_version == "1.0.0"
     monkeypatch.setattr(classroom_images, "_target_lock", lambda *args: release)
     with pytest.raises(
         classroom_images.ClassroomImageError,


### PR DESCRIPTION
## Summary
- activate only the Windows AMD64 / VirtualBox target
- pin the immutable 1.0.0 manifest URL and its independently downloaded SHA-256
- clear the Windows candidate while leaving macOS ARM64 / VMware pending
- make the pending-state unit test independent from production lock state

## Evidence
- physical workflow run 30759588441 passed build, acceptance, artifact round-trip and release publication
- release box downloaded independently: exact size and SHA-256 match the manifest
- manifest downloaded independently: SHA-256 matches this lock
- macOS runner was skipped

Part of #621; does not close it while macOS remains pending.