### PR TITLE
Install checksum-locked Packer on macOS runner

### DIFF
--- a/.github/workflows/publish-classroom-boxes.yml
+++ b/.github/workflows/publish-classroom-boxes.yml
@@ -151,10 +151,17 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
-      - name: Configure isolated Vagrant home
+      - name: Configure isolated toolchain home
         run: |
-          printf 'VAGRANT_HOME=%s/2cornot2c-vagrant-%s-%s\n' \
-            "$RUNNER_TEMP" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" >> "$GITHUB_ENV"
+          isolated="$RUNNER_TEMP/2cornot2c-vagrant-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          printf 'VAGRANT_HOME=%s\n' "$isolated" >> "$GITHUB_ENV"
+          printf 'PACKER_BIN_DIR=%s/packer-bin\n' "$isolated" >> "$GITHUB_ENV"
+      - name: Install checksum-locked Packer
+        working-directory: packer
+        run: |
+          python3 install-locked-packer.py \
+            --platform darwin_arm64 --destination "$PACKER_BIN_DIR"
+          printf '%s\n' "$PACKER_BIN_DIR" >> "$GITHUB_PATH"
       - name: Install checksum-locked Packer plugin
         working-directory: packer
         run: python3 install-locked-plugin.py --platform darwin_arm64

--- a/packer/install-locked-packer.py
+++ b/packer/install-locked-packer.py
@@ -1,0 +1,87 @@
+"""Install the exact checksum-pinned Packer binary in an isolated directory."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import tempfile
+from urllib.parse import urlparse
+from urllib.request import urlopen
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parent
+LOCK = ROOT / "toolchain.lock.json"
+MAX_ARCHIVE_BYTES = 100 * 1024 * 1024
+MAX_BINARY_BYTES = 200 * 1024 * 1024
+PLATFORMS = {"darwin_arm64", "windows_amd64"}
+
+
+def install(platform: str, destination: Path) -> Path:
+    payload = json.loads(LOCK.read_text(encoding="utf-8"))
+    version = str(payload["packer_version"])
+    expected = str(payload["packer_archives"][platform])
+    filename = f"packer_{version}_{platform}.zip"
+    url = f"https://releases.hashicorp.com/packer/{version}/{filename}"
+    destination.mkdir(parents=True, exist_ok=False, mode=0o700)
+
+    with tempfile.TemporaryDirectory(prefix="2cornot2c-packer-") as directory:
+        archive_path = Path(directory) / filename
+        digest = hashlib.sha256()
+        size = 0
+        with urlopen(url, timeout=30) as response, archive_path.open("wb") as output:
+            if urlparse(response.geturl()).scheme != "https":
+                raise RuntimeError("Redirect Packer fuori da HTTPS.")
+            while chunk := response.read(1024 * 1024):
+                size += len(chunk)
+                if size > MAX_ARCHIVE_BYTES:
+                    raise RuntimeError("Archivio Packer troppo grande.")
+                digest.update(chunk)
+                output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        if digest.hexdigest() != expected:
+            raise RuntimeError("Checksum Packer non corrispondente al lock.")
+
+        with zipfile.ZipFile(archive_path) as package:
+            candidates = []
+            for member in package.infolist():
+                path = PurePosixPath(member.filename)
+                if path.is_absolute() or ".." in path.parts:
+                    raise RuntimeError("Percorso non sicuro nell'archivio Packer.")
+                if path.name in {"packer", "packer.exe"} and not member.is_dir():
+                    candidates.append(member)
+            if len(candidates) != 1:
+                raise RuntimeError("Binario Packer non univoco.")
+            member = candidates[0]
+            if member.file_size <= 0 or member.file_size > MAX_BINARY_BYTES:
+                raise RuntimeError("Dimensione binario Packer non valida.")
+            binary = destination / PurePosixPath(member.filename).name
+            written = 0
+            with package.open(member) as source, binary.open("xb") as output:
+                while chunk := source.read(1024 * 1024):
+                    written += len(chunk)
+                    if written > member.file_size:
+                        raise RuntimeError("Binario Packer oltre la dimensione dichiarata.")
+                    output.write(chunk)
+                output.flush()
+                os.fsync(output.fileno())
+            if written != member.file_size:
+                raise RuntimeError("Binario Packer incompleto.")
+            binary.chmod(0o700)
+    return binary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--platform", required=True, choices=sorted(PLATFORMS))
+    parser.add_argument("--destination", required=True, type=Path)
+    arguments = parser.parse_args()
+    print(install(arguments.platform, arguments.destination))
+
+
+if __name__ == "__main__":
+    main()

--- a/packer/toolchain.lock.json
+++ b/packer/toolchain.lock.json
@@ -1,6 +1,10 @@
 {
   "schema_version": "2cornot2c.packer-toolchain.v1",
   "packer_version": "1.16.0",
+  "packer_archives": {
+    "darwin_arm64": "6530042cf8f8a1f96b6607cb22b5be298be53b400cd4a2c81ab8b946964fccda",
+    "windows_amd64": "91a378d4e7f9c5363caa196e23fd78717da31d12fc6069c8bb892cdacceb2eb8"
+  },
   "plugins": {
     "github.com/hashicorp/vagrant": {
       "version": "1.1.5",

--- a/packer/verify-toolchain.py
+++ b/packer/verify-toolchain.py
@@ -20,6 +20,7 @@ def load_lock(path: Path = LOCK) -> tuple[str, str, str]:
     if set(payload) != {
         "schema_version",
         "packer_version",
+        "packer_archives",
         "plugins",
         "vagrant_plugins",
     }:
@@ -27,6 +28,16 @@ def load_lock(path: Path = LOCK) -> tuple[str, str, str]:
     if payload["schema_version"] != "2cornot2c.packer-toolchain.v1":
         raise RuntimeError("Versione lock Packer non supportata.")
     packer_version = payload["packer_version"]
+    packer_archives = payload["packer_archives"]
+    if not isinstance(packer_archives, dict) or set(packer_archives) != {
+        "darwin_arm64",
+        "windows_amd64",
+    }:
+        raise RuntimeError("Archivi Packer non validi.")
+    if any(
+        not SHA256_RE.fullmatch(str(value)) for value in packer_archives.values()
+    ):
+        raise RuntimeError("Checksum Packer non valido.")
     plugins = payload["plugins"]
     if not isinstance(plugins, dict) or set(plugins) != {
         "github.com/hashicorp/vagrant"

--- a/tests/test_classroom_release_manifest.py
+++ b/tests/test_classroom_release_manifest.py
@@ -292,6 +292,8 @@ def test_packer_toolchain_and_source_are_exactly_locked() -> None:
     ).read_text(encoding="utf-8")
 
     assert toolchain["packer_version"] == "1.16.0"
+    assert set(toolchain["packer_archives"]) == {"darwin_arm64", "windows_amd64"}
+    assert all(len(value) == 64 for value in toolchain["packer_archives"].values())
     assert toolchain["plugins"]["github.com/hashicorp/vagrant"]["version"] == "1.1.5"
     assert toolchain["vagrant_plugins"]["vagrant-vmware-desktop"]["version"] == "3.0.5"
     assert 'required_version = "= 1.16.0"' in template
@@ -300,6 +302,8 @@ def test_packer_toolchain_and_source_are_exactly_locked() -> None:
     assert all(len(box["sha256"]) == 64 for box in sources["boxes"].values())
     assert "install-locked-plugin.py --platform windows_amd64" in workflow
     assert "install-locked-plugin.py --platform darwin_arm64" in workflow
+    assert "install-locked-packer.py" in workflow
+    assert "--platform darwin_arm64 --destination \"$PACKER_BIN_DIR\"" in workflow
     assert "install-locked-vagrant-plugin.py" in workflow
     assert "--require-vagrant-vmware" in workflow
     assert "VAGRANT_HOME: ${{ runner.temp }}" not in workflow
@@ -307,7 +311,7 @@ def test_packer_toolchain_and_source_are_exactly_locked() -> None:
     assert workflow.count("shell: powershell") == 3
     assert "$vagrantHome = Join-Path" in workflow
     assert "2cornot2c-vagrant-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT" in workflow
-    assert '"$RUNNER_TEMP" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"' in workflow
+    assert 'isolated="$RUNNER_TEMP/2cornot2c-vagrant-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"' in workflow
     assert "Remove-Item -LiteralPath $env:VAGRANT_HOME" not in workflow
     assert 'rm -rf -- "$VAGRANT_HOME"' not in workflow
     assert "Remove-Item -LiteralPath $isolated" in workflow

--- a/tests/test_packer_toolchain.py
+++ b/tests/test_packer_toolchain.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 import zipfile
@@ -26,6 +27,13 @@ def plugin_archive(member: str = "packer-plugin-vagrant_v1.1.5_x5.0.exe") -> byt
     output = io.BytesIO()
     with zipfile.ZipFile(output, "w") as archive:
         archive.writestr(member, b"verified plugin")
+    return output.getvalue()
+
+
+def packer_archive(member: str = "packer") -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.writestr(member, b"verified packer")
     return output.getvalue()
 
 
@@ -57,6 +65,57 @@ def write_lock(path: Path, archive: bytes) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def test_locked_packer_installer_verifies_and_extracts_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_script("install_locked_packer", "install-locked-packer.py")
+    archive = packer_archive()
+    lock = tmp_path / "toolchain.lock.json"
+    lock.write_text(
+        json.dumps(
+            {
+                "packer_version": "1.16.0",
+                "packer_archives": {
+                    "darwin_arm64": hashlib.sha256(archive).hexdigest()
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "LOCK", lock)
+    monkeypatch.setattr(module, "urlopen", lambda url, timeout: Response(archive))
+
+    binary = module.install("darwin_arm64", tmp_path / "bin")
+
+    assert binary.read_bytes() == b"verified packer"
+    if os.name != "nt":
+        assert binary.stat().st_mode & 0o700 == 0o700
+
+
+def test_locked_packer_installer_rejects_archive_traversal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_script("install_locked_packer_unsafe", "install-locked-packer.py")
+    archive = packer_archive("../packer")
+    lock = tmp_path / "toolchain.lock.json"
+    lock.write_text(
+        json.dumps(
+            {
+                "packer_version": "1.16.0",
+                "packer_archives": {
+                    "darwin_arm64": hashlib.sha256(archive).hexdigest()
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "LOCK", lock)
+    monkeypatch.setattr(module, "urlopen", lambda url, timeout: Response(archive))
+
+    with pytest.raises(RuntimeError, match="non sicuro"):
+        module.install("darwin_arm64", tmp_path / "bin")
 
 
 def test_locked_plugin_installer_verifies_archive_before_install(


### PR DESCRIPTION
The macOS physical run #30762634904 failed before building because the host had Packer 1.15.4 while the reviewed toolchain requires 1.16.0. Install the official Darwin ARM64 archive into the run-isolated directory, verify its pinned SHA-256 before extraction, and prepend only that directory to the job PATH. The existing cleanup removes it. Adds fail-closed schema validation and focused tests. Part of #621.