### PR TITLE
Activate macOS VMware classroom image 1.0.0

### DIFF
--- a/packer/classroom-releases.lock.json
+++ b/packer/classroom-releases.lock.json
@@ -14,8 +14,12 @@
     "macos-arm64-vmware": {
       "host": "macos-arm64",
       "provider": "vmware_desktop",
-      "candidate_version": "1.0.0",
-      "active_release": null
+      "candidate_version": null,
+      "active_release": {
+        "version": "1.0.0",
+        "manifest_url": "https://github.com/TheBitPoets/2cornot2c/releases/download/classroom-macos-arm64-vmware-v1.0.0/release-manifest.json",
+        "manifest_sha256": "9513c086e5218ab826c0a8710257750c21b9c4c59d025a215c78b46200f9505a"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- activate macOS ARM64 / VMware 1.0.0 independently
- pin the immutable release manifest URL and independently downloaded SHA-256
- clear the macOS candidate

## Evidence
- physical workflow #30762890215 passed locked toolchain validation, build, VMware acceptance, artifact round-trip and publication
- release manifest and 1.27 GB box were independently downloaded; exact size and SHA-256 match
- Windows remains independently active and unchanged

Completes #621 after merge.