### PR TITLE
Render images and icons in course paragraph previews

### DIFF
--- a/doc/SCENARI_TEST_MANUALI_GUI.md
+++ b/doc/SCENARI_TEST_MANUALI_GUI.md
@@ -814,7 +814,9 @@ della pagina Percorso. Nessun passaggio deve aprire i dialog nativi del browser 
 4a. Usa `Gestisci fonti`, verifica la proiezione delle fonti correnti e aggiungi una fonte locale `README.md`. Prova ID duplicato e file non Markdown, controllando che `Sincronizza anteprima` mostri l'errore senza modificare la board. Correggi, sincronizza, verifica il conteggio dei file/paragrafi e applica. Se un token runtime e configurato, ripeti facoltativamente con una fonte GitHub o GitLab privata e controlla il commit risolto abbreviato. Verifica che nessun campo chieda o mostri credenziali.
 5. Nel catalogo a sinistra usa il pulsante `+` su un paragrafo, poi premilo di nuovo sullo stesso paragrafo.
 5a. Clicca il titolo di un paragrafo e poi il comando `Testo`: verifica che si apra il modal con il contenuto completo.
-5b. Dentro una UDA ripeti dal titolo e dal comando `Testo`, poi usa `Apri sorgente su GitHub` e verifica l'ancora del paragrafo.
+5b. Usa un paragrafo con un'immagine Markdown relativa alla fonte: verifica un asset locale e, se disponibile, un asset GitHub al commit risolto. L'immagine deve restare entro il modal, mostrare il testo alternativo e non inviare referrer.
+5c. Prova un'immagine mancante, un percorso che esce dalla root, un URL esterno e un'estensione non grafica: il testo deve restare leggibile e deve apparire `Immagine non disponibile`, senza caricare l'asset.
+5d. Dentro una UDA ripeti dal titolo e dal comando `Testo`, poi usa `Apri sorgente su GitHub` e verifica l'ancora del paragrafo.
 5c. Nella stessa UDA usa `Collega activity`, scegli un'activity disponibile, il ruolo `Verifica`, una data pianificata e una scadenza successiva. Verifica l'errore inline provando prima una scadenza precedente. Salva, riapri `Modifica`, cambia il ruolo e controlla che una seconda aggiunta della stessa activity venga rifiutata. Mantieni il collegamento per lo Scenario 10.
 6. Modifica una cornice e premi `Ricarica`: nel dialog grafico premi `Resta qui` e verifica che la modifica
    resti visibile e che il focus torni al comando precedente. Ripeti accettando `Scarta modifiche` e verifica
@@ -835,6 +837,7 @@ Risultato atteso:
 - L'editor fonti applica soltanto anteprime sincronizzate sullo stesso snapshot della board e non espone credenziali.
 - Il collegamento activity conserva ruolo e date; la scadenza non puo precedere la pianificazione.
 - Il titolo e il comando `Testo` aprono il modal con contenuto, fonte, riga e link GitHub coerenti.
+- Immagini e icone Markdown locali restano confinate al repository; quelle GitHub/GitLab usano il commit immutabile della fonte. Asset mancanti o non consentiti degradano a un fallback testuale leggibile.
 - Ricarica e navigazione non scartano modifiche senza conferma.
 - Un nome già esistente richiede conferma prima della sovrascrittura.
 - I dialog sono integrati nella pagina, si chiudono con `Esc`, ripristinano il focus e mostrano gli errori

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -118,8 +118,13 @@ STUDENT_API_BODY_DEADLINE_SECONDS = 15
 HTTP_HEADER_DEADLINE_SECONDS = 15
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 MARKDOWN_LINE_ENDING_RE = re.compile(r"\r\n|\r|\n")
+JAVASCRIPT_WHITESPACE = (
+    "\\u0009-\\u000d\\u0020\\u00a0\\u1680\\u2000-\\u200a"
+    "\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff"
+)
 MARKDOWN_IMAGE_RE = re.compile(
-    r"!\[[^\]\r\n]{0,500}\]\(([^)\s]+)(?:\s+(?:\"[^\"]*\"|'[^']*'))?\)"
+    rf"!\[[^\]\r\n]{{0,500}}\]\(([^){JAVASCRIPT_WHITESPACE}]+)"
+    rf"(?:[{JAVASCRIPT_WHITESPACE}]+(?:\"[^\"]*\"|'[^']*'))?\)"
 )
 JAVASCRIPT_TRIM_RE = re.compile(
     r"^[\u0009-\u000d\u0020\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]+"
@@ -3283,16 +3288,24 @@ def javascript_trim(value: str) -> str:
 def normalize_paragraph_preview_source(source: str) -> str:
     """Mirror the frontend's bounded HTML-to-Markdown preview normalization."""
 
-    text = re.sub(r"<br\s*/?\s*>", "\n", source, flags=re.IGNORECASE)
     text = re.sub(
-        r"<h([1-6])\b[^>]*>",
+        rf"<br[{JAVASCRIPT_WHITESPACE}]*/?[{JAVASCRIPT_WHITESPACE}]*>",
+        "\n",
+        source,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(
+        r"<h([1-6])(?![A-Za-z0-9_])[^>]*>",
         lambda match: f"\n{'#' * int(match.group(1))} ",
         text,
         flags=re.IGNORECASE,
     )
-    text = re.sub(r"<li\b[^>]*>", "\n- ", text, flags=re.IGNORECASE)
     text = re.sub(
-        r"</?(?:details|summary|p|div|section|article|table|thead|tbody|tr|ul|ol|li|pre|h[1-6])\b[^>]*>",
+        r"<li(?![A-Za-z0-9_])[^>]*>", "\n- ", text, flags=re.IGNORECASE
+    )
+    text = re.sub(
+        r"</?(?:details|summary|p|div|section|article|table|thead|tbody|tr|ul|ol|li|pre|h[1-6])"
+        r"(?![A-Za-z0-9_])[^>]*>",
         "\n",
         text,
         flags=re.IGNORECASE,
@@ -3633,9 +3646,9 @@ def section_text(
 
 
 def section_text_from_source(source_text: str, start_line: int, start_level: int) -> str:
-    """Extract one heading section from an already verified source snapshot."""
+    """Extract one heading section using the same CR/LF model as heading indexing."""
 
-    return section_text_from_lines(source_text.splitlines(), start_line, start_level)
+    return section_text_from_lines(list(iter_markdown_lines(source_text)), start_line, start_level)
 
 
 def section_text_from_lines(lines: list[str], start_line: int, start_level: int) -> str:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3270,12 +3270,35 @@ def normalized_heading_asset_path(source_path: str, target: str) -> str:
     return path.as_posix()
 
 
+def normalize_paragraph_preview_source(source: str) -> str:
+    """Mirror the frontend's bounded HTML-to-Markdown preview normalization."""
+
+    text = re.sub(r"<br\s*/?\s*>", "\n", source, flags=re.IGNORECASE)
+    text = re.sub(
+        r"<h([1-6])\b[^>]*>",
+        lambda match: f"\n{'#' * int(match.group(1))} ",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"<li\b[^>]*>", "\n- ", text, flags=re.IGNORECASE)
+    text = re.sub(
+        r"</?(?:details|summary|p|div|section|article|table|thead|tbody|tr|ul|ol|li|pre|h[1-6])\b[^>]*>",
+        "\n",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(r"\r\n?", "\n", text)
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
+
+
 def heading_referenced_asset_paths(source_path: str, section: str) -> set[str]:
     """Return image paths rendered by the bounded paragraph Markdown renderer."""
 
     referenced: set[str] = set()
     in_code_fence = False
-    for line in section.splitlines():
+    normalized = normalize_paragraph_preview_source(section)
+    for line in normalized.splitlines():
         if line.strip().startswith("```"):
             in_code_fence = not in_code_fence
             continue
@@ -3291,11 +3314,14 @@ def heading_referenced_asset_paths(source_path: str, section: str) -> set[str]:
 
 def _read_local_heading_asset(relative_path: str, max_bytes: int) -> bytes:
     repository_root = ROOT.resolve()
-    resolved = (repository_root / Path(relative_path)).resolve()
+    lexical = (repository_root / Path(relative_path)).absolute()
+    resolved = lexical.resolve()
     try:
         resolved.relative_to(repository_root)
     except ValueError as exc:
         raise ValueError("L'immagine esce dalla root configurata.") from exc
+    if os.path.normcase(str(resolved)) != os.path.normcase(str(lexical)):
+        raise ValueError("Symlink o reparse point non consentito nel path immagine.")
     flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -3309,12 +3335,36 @@ def _read_local_heading_asset(relative_path: str, max_bytes: int) -> bytes:
             opened_path.relative_to(repository_root)
         except (OSError, ValueError) as exc:
             raise ValueError("L'immagine aperta esce dalla root configurata.") from exc
-        metadata = os.fstat(descriptor)
-        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > max_bytes:
+        if os.path.normcase(str(opened_path)) != os.path.normcase(str(resolved)):
+            raise ValueError("Il file immagine aperto non coincide con il path verificato.")
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_size > max_bytes:
             raise ValueError("File immagine locale non valido o troppo grande.")
         with os.fdopen(descriptor, "rb", closefd=False) as stream:
             content = stream.read(max_bytes + 1)
-        if len(content) != metadata.st_size or len(content) > max_bytes:
+            stream.seek(0)
+            verification = stream.read(max_bytes + 1)
+        after = os.fstat(descriptor)
+        before_identity = (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+            before.st_ctime_ns,
+        )
+        after_identity = (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        )
+        if (
+            len(content) != before.st_size
+            or len(content) > max_bytes
+            or content != verification
+            or before_identity != after_identity
+        ):
             raise ValueError("File immagine locale instabile o troppo grande.")
         return content
     finally:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3155,7 +3155,7 @@ def headings_from_source_snapshot(
                 "line": lineno,
             }
         )
-    source_lines = source_text.splitlines()
+    source_lines = list(iter_markdown_lines(source_text))
     end_lines = [len(source_lines) + 1] * len(headings)
     open_headings: list[int] = []
     for index, heading in enumerate(headings):
@@ -3292,23 +3292,26 @@ def normalize_paragraph_preview_source(source: str) -> str:
         rf"<br[{JAVASCRIPT_WHITESPACE}]*/?[{JAVASCRIPT_WHITESPACE}]*>",
         "\n",
         source,
-        flags=re.IGNORECASE,
+        flags=re.IGNORECASE | re.ASCII,
     )
     text = re.sub(
         r"<h([1-6])(?![A-Za-z0-9_])[^>]*>",
         lambda match: f"\n{'#' * int(match.group(1))} ",
         text,
-        flags=re.IGNORECASE,
+        flags=re.IGNORECASE | re.ASCII,
     )
     text = re.sub(
-        r"<li(?![A-Za-z0-9_])[^>]*>", "\n- ", text, flags=re.IGNORECASE
+        r"<li(?![A-Za-z0-9_])[^>]*>",
+        "\n- ",
+        text,
+        flags=re.IGNORECASE | re.ASCII,
     )
     text = re.sub(
         r"</?(?:details|summary|p|div|section|article|table|thead|tbody|tr|ul|ol|li|pre|h[1-6])"
         r"(?![A-Za-z0-9_])[^>]*>",
         "\n",
         text,
-        flags=re.IGNORECASE,
+        flags=re.IGNORECASE | re.ASCII,
     )
     text = re.sub(r"<[^>]+>", "", text)
     text = re.sub(r"\r\n?", "\n", text)
@@ -3706,7 +3709,7 @@ def heading_catalog_tree(design: dict | None = None) -> list[dict]:
             raise course_source_catalog.CourseSourceCatalogError(
                 "Troppi heading per il catalogo di contesto AI."
             )
-        source_lines = source_text.splitlines()
+        source_lines = list(iter_markdown_lines(source_text))
         for heading in source_headings:
             excerpt = catalog_excerpt_from_lines(
                 source_lines,

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3298,7 +3298,7 @@ def heading_referenced_asset_paths(source_path: str, section: str) -> set[str]:
     referenced: set[str] = set()
     in_code_fence = False
     normalized = normalize_paragraph_preview_source(section)
-    for line in normalized.splitlines():
+    for line in normalized.split("\n"):
         if line.strip().startswith("```"):
             in_code_fence = not in_code_fence
             continue

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -118,6 +118,9 @@ STUDENT_API_BODY_DEADLINE_SECONDS = 15
 HTTP_HEADER_DEADLINE_SECONDS = 15
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 MARKDOWN_LINE_ENDING_RE = re.compile(r"\r\n|\r|\n")
+MARKDOWN_IMAGE_RE = re.compile(
+    r"!\[[^\]\r\n]{0,500}\]\(([^)\s]+)(?:\s+(?:\"[^\"]*\"|'[^']*'))?\)"
+)
 TAG_RE = re.compile(r"<[^>]+>")
 PUNCT_RE = re.compile(r"[^\w\s-]", re.UNICODE)
 SPACE_RE = re.compile(r"[\s_]+")
@@ -3282,6 +3285,11 @@ def _read_local_heading_asset(relative_path: str) -> bytes:
     except OSError as exc:
         raise FileNotFoundError("Immagine locale non disponibile.") from exc
     try:
+        try:
+            opened_path = course_source_catalog.opened_file_path(descriptor).resolve()
+            opened_path.relative_to(repository_root)
+        except (OSError, ValueError) as exc:
+            raise ValueError("L'immagine aperta esce dalla root configurata.") from exc
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > MAX_HEADING_IMAGE_BYTES:
             raise ValueError("File immagine locale non valido o troppo grande.")
@@ -3309,6 +3317,7 @@ def heading_asset_snapshot(
         )
     selected_file = None
     selected_heading = None
+    selected_source_text = None
     total_headings = 0
     for source_file in course_markdown_source_files(design):
         source_text = course_source_catalog.read_markdown_text(source_file, ROOT)
@@ -3322,8 +3331,9 @@ def heading_asset_snapshot(
         if match is not None:
             selected_file = source_file
             selected_heading = match
+            selected_source_text = source_text
             break
-    if selected_file is None or selected_heading is None:
+    if selected_file is None or selected_heading is None or selected_source_text is None:
         raise FileNotFoundError("Paragrafo non trovato.")
     if (
         (expected_source_commit or selected_heading["source_provider"] != "local")
@@ -3337,6 +3347,21 @@ def heading_asset_snapshot(
             "Il contenuto del paragrafo è cambiato: riallinealo prima della preview."
         )
     relative_path = normalized_heading_asset_path(selected_file.relative_path, target)
+    section = section_text_from_source(
+        selected_source_text,
+        selected_heading["line"],
+        selected_heading["level"],
+    )
+    referenced_assets = set()
+    for match in MARKDOWN_IMAGE_RE.finditer(section):
+        try:
+            referenced_assets.add(
+                normalized_heading_asset_path(selected_file.relative_path, match.group(1))
+            )
+        except ValueError:
+            continue
+    if relative_path not in referenced_assets:
+        raise ValueError("L'immagine non è referenziata dal paragrafo verificato.")
     content_type = HEADING_IMAGE_CONTENT_TYPES[PurePosixPath(relative_path).suffix.lower()]
     provider = selected_file.source.provider
     if provider == "local":

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -45,7 +45,7 @@ from copy import deepcopy
 from contextlib import ExitStack, contextmanager, nullcontext
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import parse_qs, parse_qsl, unquote, urlparse
 
@@ -141,6 +141,16 @@ MAX_HEADINGS_PER_SOURCE = 10_000
 MAX_MARKDOWN_LINES_PER_SOURCE = 250_000
 MAX_TOTAL_HEADINGS = 50_000
 MAX_HEADING_TITLE_CHARS = 512
+MAX_HEADING_IMAGE_BYTES = 8 * 1024 * 1024
+HEADING_IMAGE_CONTENT_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+}
 AI_FRAME_TIMEOUT_SECONDS = 120
 AI_COURSE_PLAN_TIMEOUT_SECONDS = 240
 MAX_AI_PROVIDER_RESPONSE_BYTES = 4 * 1024 * 1024
@@ -3207,6 +3217,165 @@ def heading_content_snapshot(
     return None
 
 
+def normalized_heading_asset_path(source_path: str, target: str) -> str:
+    """Resolve one Markdown image path without leaving the source repository."""
+
+    if (
+        not target
+        or len(target) > 2048
+        or target.startswith(("/", "//"))
+        or "\\" in target
+        or "?" in target
+        or "#" in target
+        or re.search(r"[\x00-\x1f\x7f]", target)
+        or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", target)
+        or re.search(r"%(?![0-9A-Fa-f]{2})", target)
+    ):
+        raise ValueError("Riferimento immagine non consentito.")
+    try:
+        decoded = urllib.parse.unquote(target, errors="strict")
+    except UnicodeDecodeError as exc:
+        raise ValueError("Riferimento immagine non valido.") from exc
+    if (
+        "\\" in decoded
+        or ":" in decoded
+        or "?" in decoded
+        or "#" in decoded
+        or re.search(r"[\x00-\x1f\x7f]", decoded)
+        or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", decoded)
+    ):
+        raise ValueError("Riferimento immagine non consentito.")
+    parts = list(PurePosixPath(source_path).parts[:-1])
+    if not parts or any(part in {"", ".", "..", "/"} for part in parts):
+        if "/" in source_path:
+            raise ValueError("Path fonte immagine non valido.")
+        parts = []
+    for part in decoded.split("/"):
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if not parts:
+                raise ValueError("L'immagine esce dalla root della fonte.")
+            parts.pop()
+        else:
+            parts.append(part)
+    if not parts:
+        raise ValueError("Path immagine vuoto.")
+    path = PurePosixPath(*parts)
+    if path.suffix.lower() not in HEADING_IMAGE_CONTENT_TYPES:
+        raise ValueError("Formato immagine non consentito.")
+    return path.as_posix()
+
+
+def _read_local_heading_asset(relative_path: str) -> bytes:
+    repository_root = ROOT.resolve()
+    resolved = (repository_root / Path(relative_path)).resolve()
+    try:
+        resolved.relative_to(repository_root)
+    except ValueError as exc:
+        raise ValueError("L'immagine esce dalla root configurata.") from exc
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(resolved, flags)
+    except OSError as exc:
+        raise FileNotFoundError("Immagine locale non disponibile.") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > MAX_HEADING_IMAGE_BYTES:
+            raise ValueError("File immagine locale non valido o troppo grande.")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            content = stream.read(MAX_HEADING_IMAGE_BYTES + 1)
+        if len(content) != metadata.st_size or len(content) > MAX_HEADING_IMAGE_BYTES:
+            raise ValueError("File immagine locale instabile o troppo grande.")
+        return content
+    finally:
+        os.close(descriptor)
+
+
+def heading_asset_snapshot(
+    design: dict,
+    heading_id: str,
+    expected_source_commit: str,
+    expected_content_sha256: str,
+    target: str,
+) -> dict:
+    """Return one bounded source-relative image after provenance validation."""
+
+    if re.fullmatch(r"[0-9a-f]{64}", expected_content_sha256) is None:
+        raise CourseSourceRevisionConflictError(
+            "Digest del paragrafo mancante o non valido: riallinealo prima della preview."
+        )
+    selected_file = None
+    selected_heading = None
+    total_headings = 0
+    for source_file in course_markdown_source_files(design):
+        source_text = course_source_catalog.read_markdown_text(source_file, ROOT)
+        source_headings = headings_from_source_snapshot(source_file, source_text)
+        total_headings += len(source_headings)
+        if total_headings > MAX_TOTAL_HEADINGS:
+            raise course_source_catalog.CourseSourceCatalogError(
+                "Il catalogo contiene troppi heading Markdown."
+            )
+        match = next((item for item in source_headings if item["id"] == heading_id), None)
+        if match is not None:
+            selected_file = source_file
+            selected_heading = match
+            break
+    if selected_file is None or selected_heading is None:
+        raise FileNotFoundError("Paragrafo non trovato.")
+    if (
+        (expected_source_commit or selected_heading["source_provider"] != "local")
+        and selected_heading.get("source_commit") != expected_source_commit
+    ):
+        raise CourseSourceRevisionConflictError(
+            "La fonte remota è cambiata: riallinea il paragrafo prima della preview."
+        )
+    if selected_heading.get("content_sha256") != expected_content_sha256:
+        raise CourseSourceRevisionConflictError(
+            "Il contenuto del paragrafo è cambiato: riallinealo prima della preview."
+        )
+    relative_path = normalized_heading_asset_path(selected_file.relative_path, target)
+    content_type = HEADING_IMAGE_CONTENT_TYPES[PurePosixPath(relative_path).suffix.lower()]
+    provider = selected_file.source.provider
+    if provider == "local":
+        content = _read_local_heading_asset(relative_path)
+    else:
+        repository = selected_file.source.repository
+        commit = getattr(selected_file, "resolved_ref", None)
+        if repository is None or commit is None:
+            raise CourseSourceRevisionConflictError("Provenienza immagine remota incompleta.")
+        deadline = time.monotonic() + 30.0
+        if provider == "github":
+            adapter = course_github_markdown.GitHubMarkdownAdapter(
+                course_github_markdown.GitHubApiTransport(
+                    read_github_markdown_token(deadline)
+                ),
+                blob_cache=GITHUB_MARKDOWN_BLOB_CACHE,
+            )
+        elif provider == "gitlab":
+            adapter = course_gitlab_markdown.GitLabMarkdownAdapter(
+                course_gitlab_markdown.GitLabApiTransport(
+                    read_gitlab_markdown_token(deadline)
+                ),
+                blob_cache=GITHUB_MARKDOWN_BLOB_CACHE,
+            )
+        else:
+            raise ValueError("Provider immagine non supportato.")
+        content = adapter.fetch_file_at_commit(
+            repository,
+            commit,
+            relative_path,
+            max_bytes=MAX_HEADING_IMAGE_BYTES,
+        ).content
+    return {
+        "content_type": content_type,
+        "content_base64": base64.b64encode(content).decode("ascii"),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+
+
 def markdown_source_url(
     source_file: course_source_catalog.CourseMarkdownSourceFile,
     anchor: str = "",
@@ -5964,6 +6133,38 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             heading, content = snapshot
             self.write_json({"heading": {**heading, "content": content}})
             return
+        if parsed.path == "/api/heading-asset":
+            heading_id = payload.get("id", "")
+            design = payload.get("design")
+            target = payload.get("target", "")
+            if (
+                not isinstance(heading_id, str)
+                or not isinstance(design, dict)
+                or not isinstance(target, str)
+            ):
+                self.write_error_json(400, "Richiesta immagine paragrafo non valida.")
+                return
+            try:
+                self.write_sensitive_json(
+                    heading_asset_snapshot(
+                        design,
+                        heading_id,
+                        str(payload.get("source_commit") or ""),
+                        str(payload.get("content_sha256", "")),
+                        target,
+                    )
+                )
+            except course_github_markdown.RemoteMarkdownError as error:
+                self.write_error_json(502, str(error))
+            except CourseSourceRevisionConflictError as error:
+                self.write_error_json(409, str(error))
+            except course_source_catalog.CourseSourceCatalogError as error:
+                self.write_error_json(422, str(error))
+            except FileNotFoundError as error:
+                self.write_error_json(404, str(error))
+            except ValueError as error:
+                self.write_error_json(400, str(error))
+            return
         if parsed.path == "/api/course-design":
             try:
                 if not isinstance(payload.get("design"), dict):
@@ -6343,6 +6544,16 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         body = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def write_sensitive_json(self, payload: dict) -> None:
+        body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Referrer-Policy", "no-referrer")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -3270,7 +3270,26 @@ def normalized_heading_asset_path(source_path: str, target: str) -> str:
     return path.as_posix()
 
 
-def _read_local_heading_asset(relative_path: str) -> bytes:
+def heading_referenced_asset_paths(source_path: str, section: str) -> set[str]:
+    """Return image paths rendered by the bounded paragraph Markdown renderer."""
+
+    referenced: set[str] = set()
+    in_code_fence = False
+    for line in section.splitlines():
+        if line.strip().startswith("```"):
+            in_code_fence = not in_code_fence
+            continue
+        if in_code_fence:
+            continue
+        for match in MARKDOWN_IMAGE_RE.finditer(line):
+            try:
+                referenced.add(normalized_heading_asset_path(source_path, match.group(1)))
+            except ValueError:
+                continue
+    return referenced
+
+
+def _read_local_heading_asset(relative_path: str, max_bytes: int) -> bytes:
     repository_root = ROOT.resolve()
     resolved = (repository_root / Path(relative_path)).resolve()
     try:
@@ -3291,11 +3310,11 @@ def _read_local_heading_asset(relative_path: str) -> bytes:
         except (OSError, ValueError) as exc:
             raise ValueError("L'immagine aperta esce dalla root configurata.") from exc
         metadata = os.fstat(descriptor)
-        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > MAX_HEADING_IMAGE_BYTES:
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > max_bytes:
             raise ValueError("File immagine locale non valido o troppo grande.")
         with os.fdopen(descriptor, "rb", closefd=False) as stream:
-            content = stream.read(MAX_HEADING_IMAGE_BYTES + 1)
-        if len(content) != metadata.st_size or len(content) > MAX_HEADING_IMAGE_BYTES:
+            content = stream.read(max_bytes + 1)
+        if len(content) != metadata.st_size or len(content) > max_bytes:
             raise ValueError("File immagine locale instabile o troppo grande.")
         return content
     finally:
@@ -3308,9 +3327,17 @@ def heading_asset_snapshot(
     expected_source_commit: str,
     expected_content_sha256: str,
     target: str,
+    max_bytes: int = MAX_HEADING_IMAGE_BYTES,
 ) -> dict:
     """Return one bounded source-relative image after provenance validation."""
 
+    if (
+        not isinstance(max_bytes, int)
+        or isinstance(max_bytes, bool)
+        or max_bytes <= 0
+        or max_bytes > MAX_HEADING_IMAGE_BYTES
+    ):
+        raise ValueError("Budget immagine non valido.")
     if re.fullmatch(r"[0-9a-f]{64}", expected_content_sha256) is None:
         raise CourseSourceRevisionConflictError(
             "Digest del paragrafo mancante o non valido: riallinealo prima della preview."
@@ -3352,20 +3379,16 @@ def heading_asset_snapshot(
         selected_heading["line"],
         selected_heading["level"],
     )
-    referenced_assets = set()
-    for match in MARKDOWN_IMAGE_RE.finditer(section):
-        try:
-            referenced_assets.add(
-                normalized_heading_asset_path(selected_file.relative_path, match.group(1))
-            )
-        except ValueError:
-            continue
+    referenced_assets = heading_referenced_asset_paths(
+        selected_file.relative_path,
+        section,
+    )
     if relative_path not in referenced_assets:
         raise ValueError("L'immagine non è referenziata dal paragrafo verificato.")
     content_type = HEADING_IMAGE_CONTENT_TYPES[PurePosixPath(relative_path).suffix.lower()]
     provider = selected_file.source.provider
     if provider == "local":
-        content = _read_local_heading_asset(relative_path)
+        content = _read_local_heading_asset(relative_path, max_bytes)
     else:
         repository = selected_file.source.repository
         commit = getattr(selected_file, "resolved_ref", None)
@@ -3392,7 +3415,7 @@ def heading_asset_snapshot(
             repository,
             commit,
             relative_path,
-            max_bytes=MAX_HEADING_IMAGE_BYTES,
+            max_bytes=max_bytes,
         ).content
     return {
         "content_type": content_type,
@@ -6177,6 +6200,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                         str(payload.get("source_commit") or ""),
                         str(payload.get("content_sha256", "")),
                         target,
+                        payload.get("max_bytes", MAX_HEADING_IMAGE_BYTES),
                     )
                 )
             except course_github_markdown.RemoteMarkdownError as error:

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -121,6 +121,10 @@ MARKDOWN_LINE_ENDING_RE = re.compile(r"\r\n|\r|\n")
 MARKDOWN_IMAGE_RE = re.compile(
     r"!\[[^\]\r\n]{0,500}\]\(([^)\s]+)(?:\s+(?:\"[^\"]*\"|'[^']*'))?\)"
 )
+JAVASCRIPT_TRIM_RE = re.compile(
+    r"^[\u0009-\u000d\u0020\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]+"
+    r"|[\u0009-\u000d\u0020\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]+$"
+)
 TAG_RE = re.compile(r"<[^>]+>")
 PUNCT_RE = re.compile(r"[^\w\s-]", re.UNICODE)
 SPACE_RE = re.compile(r"[\s_]+")
@@ -3270,6 +3274,12 @@ def normalized_heading_asset_path(source_path: str, target: str) -> str:
     return path.as_posix()
 
 
+def javascript_trim(value: str) -> str:
+    """Apply the ECMAScript String.trim whitespace set."""
+
+    return JAVASCRIPT_TRIM_RE.sub("", value)
+
+
 def normalize_paragraph_preview_source(source: str) -> str:
     """Mirror the frontend's bounded HTML-to-Markdown preview normalization."""
 
@@ -3289,7 +3299,7 @@ def normalize_paragraph_preview_source(source: str) -> str:
     )
     text = re.sub(r"<[^>]+>", "", text)
     text = re.sub(r"\r\n?", "\n", text)
-    return re.sub(r"\n{3,}", "\n\n", text).strip()
+    return javascript_trim(re.sub(r"\n{3,}", "\n\n", text))
 
 
 def heading_referenced_asset_paths(source_path: str, section: str) -> set[str]:
@@ -3299,7 +3309,7 @@ def heading_referenced_asset_paths(source_path: str, section: str) -> set[str]:
     in_code_fence = False
     normalized = normalize_paragraph_preview_source(section)
     for line in normalized.split("\n"):
-        if line.strip().startswith("```"):
+        if javascript_trim(line).startswith("```"):
             in_code_fence = not in_code_fence
             continue
         if in_code_fence:

--- a/scripts/course_github_markdown.py
+++ b/scripts/course_github_markdown.py
@@ -388,6 +388,73 @@ class GitHubMarkdownAdapter:
             files=tuple(snapshots),
         )
 
+    def fetch_file_at_commit(
+        self,
+        repository: str,
+        commit_sha: str,
+        relative_path: str,
+        *,
+        max_bytes: int = MAX_REMOTE_MARKDOWN_BYTES,
+    ) -> RemoteMarkdownFile:
+        """Fetch one bounded file from an already resolved immutable commit."""
+
+        path = PurePosixPath(relative_path)
+        if (
+            REPOSITORY_RE.fullmatch(repository) is None
+            or any(part in {".", ".."} for part in repository.split("/"))
+            or GIT_OBJECT_ID_RE.fullmatch(commit_sha) is None
+            or not relative_path
+            or ":" in relative_path
+            or "\\" in relative_path
+            or path.is_absolute()
+            or path.as_posix() != relative_path
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or max_bytes <= 0
+            or max_bytes > MAX_REMOTE_MARKDOWN_BYTES
+        ):
+            raise RemoteMarkdownError("File GitHub immutabile non valido.")
+        deadline = self._clock() + self._timeout_seconds
+        repository_path = "/".join(
+            parse.quote(part, safe="") for part in repository.split("/")
+        )
+        encoded_path = "/".join(
+            parse.quote(part, safe="") for part in relative_path.split("/")
+        )
+        metadata = self._get_json(
+            f"/repos/{repository_path}/contents/{encoded_path}?ref={commit_sha}",
+            deadline,
+            allow_query=True,
+        )
+        if not isinstance(metadata, dict) or metadata.get("type") != "file":
+            raise RemoteMarkdownError(f"File GitHub non valido: {relative_path}.")
+        declared_size = metadata.get("size")
+        if (
+            not isinstance(declared_size, int)
+            or isinstance(declared_size, bool)
+            or declared_size < 0
+            or declared_size > max_bytes
+        ):
+            raise RemoteMarkdownError(f"Dimensione file GitHub non valida: {relative_path}.")
+        blob_id = _required_object_id(metadata, "sha", f"file {relative_path}")
+        content = None if self._blob_cache is None else self._blob_cache.get(blob_id)
+        if content is None:
+            blob = self._get_json(
+                f"/repos/{repository_path}/git/blobs/{blob_id}", deadline
+            )
+            content = _decode_blob(blob, blob_id, relative_path)
+            if self._blob_cache is not None:
+                self._blob_cache.put(blob_id, content)
+        if len(content) != declared_size or len(content) > max_bytes:
+            raise RemoteMarkdownError(
+                f"Dimensione file GitHub incoerente: {relative_path}."
+            )
+        return RemoteMarkdownFile(
+            relative_path=relative_path,
+            git_object_id=blob_id,
+            sha256=hashlib.sha256(content).hexdigest(),
+            content=content,
+        )
+
     def _get_json(
         self,
         api_path: str,

--- a/scripts/course_gitlab_markdown.py
+++ b/scripts/course_gitlab_markdown.py
@@ -35,7 +35,13 @@ GITLAB_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+$")
 
 
 class GitLabJsonTransport(Protocol):
-    def get_json(self, api_path: str, *, timeout_seconds: float) -> Any: ...
+    def get_json(
+        self,
+        api_path: str,
+        *,
+        timeout_seconds: float,
+        max_response_bytes: int = MAX_GITHUB_RESPONSE_BYTES,
+    ) -> Any: ...
 
 
 class GitLabApiTransport:
@@ -61,7 +67,15 @@ class GitLabApiTransport:
         self._clock = clock
         self._connection_factory = connection_factory
 
-    def get_json(self, api_path: str, *, timeout_seconds: float) -> Any:
+    def get_json(
+        self,
+        api_path: str,
+        *,
+        timeout_seconds: float,
+        max_response_bytes: int = MAX_GITHUB_RESPONSE_BYTES,
+    ) -> Any:
+        if max_response_bytes <= 0 or max_response_bytes > MAX_GITHUB_RESPONSE_BYTES:
+            raise RemoteMarkdownError("Limite risposta GitLab non valido.")
         started = time.monotonic()
         operation_deadline = self._clock() + timeout_seconds
         slot_guard = GITHUB_NETWORK_SLOTS
@@ -79,7 +93,11 @@ class GitLabApiTransport:
         def worker() -> None:
             try:
                 result["value"] = self._get_json_blocking(
-                    api_path, operation_deadline, resources, lock
+                    api_path,
+                    operation_deadline,
+                    resources,
+                    lock,
+                    max_response_bytes,
                 )
             except BaseException as exc:  # noqa: BLE001
                 result["error"] = exc
@@ -124,6 +142,7 @@ class GitLabApiTransport:
         deadline: float,
         resources: dict[str, Any],
         lock: threading.Lock,
+        max_response_bytes: int,
     ) -> Any:
         parsed_path = parse.urlsplit(api_path)
         if (
@@ -176,12 +195,12 @@ class GitLabApiTransport:
                 if connection.sock is not None:
                     connection.sock.settimeout(remaining)
                 chunk = response.read(
-                    min(64 * 1024, MAX_GITHUB_RESPONSE_BYTES + 1 - len(payload))
+                    min(64 * 1024, max_response_bytes + 1 - len(payload))
                 )
                 if not chunk:
                     break
                 payload.extend(chunk)
-                if len(payload) > MAX_GITHUB_RESPONSE_BYTES:
+                if len(payload) > max_response_bytes:
                     raise RemoteMarkdownError("Risposta GitLab API troppo grande.")
         except RemoteMarkdownError:
             raise
@@ -316,10 +335,15 @@ class GitLabMarkdownAdapter:
         deadline = self._clock() + self._timeout_seconds
         project = parse.quote(repository, safe="")
         encoded_path = parse.quote(relative_path, safe="")
+        response_budget = min(
+            MAX_GITHUB_RESPONSE_BYTES,
+            ((max_bytes + 2) // 3) * 4 + 64 * 1024,
+        )
         payload = self._get_json(
             f"/api/v4/projects/{project}/repository/files/{encoded_path}"
             f"?ref={commit_sha}",
             deadline,
+            max_response_bytes=response_budget,
         )
         item = _decode_file(payload, commit_sha, relative_path)
         if len(item.content) > max_bytes:
@@ -333,11 +357,21 @@ class GitLabMarkdownAdapter:
             self._blob_cache.put(item.git_object_id, item.content)
         return item
 
-    def _get_json(self, api_path: str, deadline: float) -> Any:
+    def _get_json(
+        self,
+        api_path: str,
+        deadline: float,
+        *,
+        max_response_bytes: int = MAX_GITHUB_RESPONSE_BYTES,
+    ) -> Any:
         remaining = deadline - self._clock()
         if remaining <= 0:
             raise RemoteMarkdownError("Timeout sincronizzazione GitLab esaurito.")
-        return self._transport.get_json(api_path, timeout_seconds=remaining)
+        return self._transport.get_json(
+            api_path,
+            timeout_seconds=remaining,
+            max_response_bytes=max_response_bytes,
+        )
 
     @staticmethod
     def _validate_files(files: tuple[str, ...]) -> None:

--- a/scripts/course_gitlab_markdown.py
+++ b/scripts/course_gitlab_markdown.py
@@ -287,6 +287,52 @@ class GitLabMarkdownAdapter:
             files=tuple(snapshots),
         )
 
+    def fetch_file_at_commit(
+        self,
+        repository: str,
+        commit_sha: str,
+        relative_path: str,
+        *,
+        max_bytes: int = MAX_REMOTE_MARKDOWN_BYTES,
+    ) -> RemoteMarkdownFile:
+        """Fetch one bounded file from an already resolved immutable commit."""
+
+        path = PurePosixPath(relative_path)
+        repository_parts = repository.split("/")
+        if (
+            GITLAB_REPOSITORY_RE.fullmatch(repository) is None
+            or any(part in {".", ".."} for part in repository_parts)
+            or GITLAB_OBJECT_ID_RE.fullmatch(commit_sha) is None
+            or not relative_path
+            or ":" in relative_path
+            or "\\" in relative_path
+            or path.is_absolute()
+            or path.as_posix() != relative_path
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or max_bytes <= 0
+            or max_bytes > MAX_REMOTE_MARKDOWN_BYTES
+        ):
+            raise RemoteMarkdownError("File GitLab immutabile non valido.")
+        deadline = self._clock() + self._timeout_seconds
+        project = parse.quote(repository, safe="")
+        encoded_path = parse.quote(relative_path, safe="")
+        payload = self._get_json(
+            f"/api/v4/projects/{project}/repository/files/{encoded_path}"
+            f"?ref={commit_sha}",
+            deadline,
+        )
+        item = _decode_file(payload, commit_sha, relative_path)
+        if len(item.content) > max_bytes:
+            raise RemoteMarkdownError(
+                f"Dimensione file GitLab non valida: {relative_path}."
+            )
+        if self._blob_cache is not None:
+            cached = self._blob_cache.get(item.git_object_id)
+            if cached is not None and cached != item.content:
+                raise RemoteMarkdownError(f"Cache Git incoerente: {relative_path}.")
+            self._blob_cache.put(item.git_object_id, item.content)
+        return item
+
     def _get_json(self, api_path: str, deadline: float) -> Any:
         remaining = deadline - self._clock()
         if remaining <= 0:

--- a/scripts/course_source_catalog.py
+++ b/scripts/course_source_catalog.py
@@ -913,6 +913,12 @@ def _optional_text(value: Any, field: str) -> str | None:
     return _text(value, field, required=True)
 
 
+def opened_file_path(file_descriptor: int) -> Path:
+    """Return the final filesystem path associated with an already open handle."""
+
+    return _opened_file_path(file_descriptor)
+
+
 def _opened_file_path(file_descriptor: int) -> Path:
     if os.name == "nt":
         import ctypes

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -1695,29 +1695,29 @@ def test_paragraph_preview_resolves_local_and_commit_pinned_remote_images() -> N
     run_course_board_js(
         """
         assert.equal(
-          resolveParagraphImageSource("../images/schema rete.png", {
+          validatedParagraphImageTarget("../images/schema rete.png", {
             source: "doc/guide/chapter.md", source_provider: "local",
           }),
-          "/doc/images/schema%20rete.png",
+          "../images/schema rete.png",
         );
         const commit = "a".repeat(40);
         assert.equal(
-          resolveParagraphImageSource("assets/icon.svg", {
+          validatedParagraphImageTarget("assets/icon.svg", {
             source: "lessons/intro.md",
             source_provider: "github",
             source_repository: "TheBitPoets/materials",
             source_commit: commit,
           }),
-          "https://raw.githubusercontent.com/TheBitPoets/materials/" + commit + "/lessons/assets/icon.svg",
+          "assets/icon.svg",
         );
         assert.equal(
-          resolveParagraphImageSource("../media/map.webp", {
+          validatedParagraphImageTarget("../media/map.webp", {
             source: "course/unit/page.md",
             source_provider: "gitlab",
             source_repository: "school/group/materials",
             source_commit: commit,
           }),
-          "https://gitlab.com/school/group/materials/-/raw/" + commit + "/course/media/map.webp",
+          "../media/map.webp",
         );
         """
     )
@@ -1727,18 +1727,51 @@ def test_paragraph_preview_rejects_untrusted_or_escaping_image_references() -> N
     run_course_board_js(
         """
         const local = { source: "README.md", source_provider: "local" };
-        assert.equal(resolveParagraphImageSource("../outside.png", local), "");
-        assert.equal(resolveParagraphImageSource("https://tracker.example/pixel.png", local), "");
-        assert.equal(resolveParagraphImageSource("//tracker.example/pixel.png", local), "");
-        assert.equal(resolveParagraphImageSource("%2e%2e/secret.png", local), "");
-        assert.equal(resolveParagraphImageSource("script.html", local), "");
-        assert.equal(resolveParagraphImageSource("image.png?token=x", local), "");
-        assert.equal(resolveParagraphImageSource("image.png", {
+        assert.equal(validatedParagraphImageTarget("../outside.png", local), "");
+        assert.equal(validatedParagraphImageTarget("https://tracker.example/pixel.png", local), "");
+        assert.equal(validatedParagraphImageTarget("//tracker.example/pixel.png", local), "");
+        assert.equal(validatedParagraphImageTarget("%2e%2e/secret.png", local), "");
+        assert.equal(validatedParagraphImageTarget("script.html", local), "");
+        assert.equal(validatedParagraphImageTarget("image.png?token=x", local), "");
+        assert.equal(validatedParagraphImageTarget("image.png", {
           source: "lesson.md",
           source_provider: "github",
           source_repository: "owner/repo",
           source_commit: "main",
         }), "");
+        """
+    )
+
+
+def test_paragraph_preview_loads_assets_through_authenticated_api() -> None:
+    run_course_board_js(
+        """
+        const fallback = { hidden: true };
+        const image = {
+          dataset: { assetTarget: "../private/icon.svg" },
+          hidden: false,
+          src: "",
+          parentElement: { querySelector: () => fallback },
+          addEventListener() {},
+        };
+        const heading = {
+          id: "private:lesson.md#demo",
+          source_commit: "a".repeat(40),
+          content_sha256: "b".repeat(64),
+        };
+        state.design = { sources: [{ id: "private" }] };
+        api = async (path, options) => {
+          assert.equal(path, "/api/heading-asset");
+          const body = JSON.parse(options.body);
+          assert.equal(body.target, "../private/icon.svg");
+          assert.deepEqual(body.design, state.design);
+          return { content_type: "image/svg+xml", content_base64: "PHN2Zz48L3N2Zz4=" };
+        };
+        loadParagraphImages({ querySelectorAll: () => [image] }, heading).then(() => {
+          assert.equal(image.src, "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=");
+          assert.equal(image.hidden, false);
+          assert.equal(fallback.hidden, true);
+        });
         """
     )
 
@@ -1752,7 +1785,8 @@ def test_paragraph_preview_renders_images_and_readable_fallbacks_safely() -> Non
           heading,
         );
         assert.match(rendered, /class="paragraphImage"/);
-        assert.ok(rendered.includes('src="/doc/images/network.png"'));
+        assert.ok(rendered.includes('data-asset-target="images/network.png"'));
+        assert.equal(rendered.includes("raw.githubusercontent"), false);
         assert.ok(rendered.includes('alt="Schema **rete**"'));
         assert.match(rendered, /Immagine non disponibile: Mancante/);
         assert.doesNotMatch(rendered, /<x>/);

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -1764,6 +1764,7 @@ def test_paragraph_preview_loads_assets_through_authenticated_api() -> None:
           assert.equal(path, "/api/heading-asset");
           const body = JSON.parse(options.body);
           assert.equal(body.target, "../private/icon.svg");
+          assert.equal(body.max_bytes, 8 * 1024 * 1024);
           assert.deepEqual(body.design, state.design);
           return { content_type: "image/svg+xml", content_base64: "PHN2Zz48L3N2Zz4=" };
         };

--- a/tests/test_course_board_frontend.py
+++ b/tests/test_course_board_frontend.py
@@ -27,6 +27,7 @@ def run_course_board_js(assertions: str) -> None:
       removeAttribute(name) {{ delete this[name]; }}
       focus() {{ this.focused = true; }}
       contains() {{ return false; }}
+      querySelectorAll() {{ return []; }}
       showModal() {{ this.open = true; }}
       close() {{
         this.open = false;
@@ -1686,6 +1687,75 @@ def test_late_new_project_context_cannot_replace_newly_opened_archive() -> None:
           assert.equal(state.activeSavedDesign, "other.json");
           assert.match(els.status.textContent, /vista aperta non è stata cambiata/);
         })();
+        """
+    )
+
+
+def test_paragraph_preview_resolves_local_and_commit_pinned_remote_images() -> None:
+    run_course_board_js(
+        """
+        assert.equal(
+          resolveParagraphImageSource("../images/schema rete.png", {
+            source: "doc/guide/chapter.md", source_provider: "local",
+          }),
+          "/doc/images/schema%20rete.png",
+        );
+        const commit = "a".repeat(40);
+        assert.equal(
+          resolveParagraphImageSource("assets/icon.svg", {
+            source: "lessons/intro.md",
+            source_provider: "github",
+            source_repository: "TheBitPoets/materials",
+            source_commit: commit,
+          }),
+          "https://raw.githubusercontent.com/TheBitPoets/materials/" + commit + "/lessons/assets/icon.svg",
+        );
+        assert.equal(
+          resolveParagraphImageSource("../media/map.webp", {
+            source: "course/unit/page.md",
+            source_provider: "gitlab",
+            source_repository: "school/group/materials",
+            source_commit: commit,
+          }),
+          "https://gitlab.com/school/group/materials/-/raw/" + commit + "/course/media/map.webp",
+        );
+        """
+    )
+
+
+def test_paragraph_preview_rejects_untrusted_or_escaping_image_references() -> None:
+    run_course_board_js(
+        """
+        const local = { source: "README.md", source_provider: "local" };
+        assert.equal(resolveParagraphImageSource("../outside.png", local), "");
+        assert.equal(resolveParagraphImageSource("https://tracker.example/pixel.png", local), "");
+        assert.equal(resolveParagraphImageSource("//tracker.example/pixel.png", local), "");
+        assert.equal(resolveParagraphImageSource("%2e%2e/secret.png", local), "");
+        assert.equal(resolveParagraphImageSource("script.html", local), "");
+        assert.equal(resolveParagraphImageSource("image.png?token=x", local), "");
+        assert.equal(resolveParagraphImageSource("image.png", {
+          source: "lesson.md",
+          source_provider: "github",
+          source_repository: "owner/repo",
+          source_commit: "main",
+        }), "");
+        """
+    )
+
+
+def test_paragraph_preview_renders_images_and_readable_fallbacks_safely() -> None:
+    run_course_board_js(
+        """
+        const heading = { source: "doc/lesson.md", source_provider: "local" };
+        const rendered = renderParagraphContent(
+          "Prima ![Schema **rete**](images/network.png) dopo.\\\\n\\\\n![Mancante <x>](../bad.txt)",
+          heading,
+        );
+        assert.match(rendered, /class="paragraphImage"/);
+        assert.ok(rendered.includes('src="/doc/images/network.png"'));
+        assert.ok(rendered.includes('alt="Schema **rete**"'));
+        assert.match(rendered, /Immagine non disponibile: Mancante/);
+        assert.doesNotMatch(rendered, /<x>/);
         """
     )
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -143,6 +143,16 @@ def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, 
     assert base64.b64decode(payload["content_base64"]) == image
     assert payload["sha256"] == hashlib.sha256(image).hexdigest()
 
+    (tmp_path / "lessons" / "images" / "unreferenced.png").write_bytes(image)
+    with pytest.raises(ValueError, match="non è referenziata"):
+        course_board_server.heading_asset_snapshot(
+            design,
+            heading["id"],
+            "",
+            heading["content_sha256"],
+            "images/unreferenced.png",
+        )
+
 
 @pytest.mark.parametrize(
     "target",
@@ -151,6 +161,22 @@ def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, 
 def test_heading_asset_rejects_unsafe_or_non_image_paths(target) -> None:
     with pytest.raises(ValueError):
         course_board_server.normalized_heading_asset_path("lessons/intro.md", target)
+
+
+def test_local_heading_asset_rechecks_final_open_handle_path(tmp_path, monkeypatch) -> None:
+    (tmp_path / "images").mkdir()
+    (tmp_path / "images" / "safe.png").write_bytes(b"safe")
+    outside = tmp_path.parent / f"outside-{tmp_path.name}.png"
+    outside.write_bytes(b"outside")
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        course_board_server.course_source_catalog,
+        "opened_file_path",
+        lambda _descriptor: outside,
+    )
+
+    with pytest.raises(ValueError, match="aperta esce"):
+        course_board_server._read_local_heading_asset("images/safe.png")
 
 
 def test_markdown_line_iteration_is_streaming_and_preserves_line_endings() -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -193,6 +193,14 @@ def test_heading_asset_rejects_unsafe_or_non_image_paths(target) -> None:
         course_board_server.normalized_heading_asset_path("lessons/intro.md", target)
 
 
+def test_heading_asset_parser_uses_javascript_trim_for_code_fences() -> None:
+    section = "\ufeff```md\n![Solo codice](images/private.png)\n```"
+
+    assert course_board_server.heading_referenced_asset_paths(
+        "lessons/intro.md", section
+    ) == set()
+
+
 def test_local_heading_asset_rechecks_exact_final_open_handle_path(tmp_path, monkeypatch) -> None:
     (tmp_path / "images").mkdir()
     (tmp_path / "images" / "safe.png").write_bytes(b"safe")

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -113,12 +113,13 @@ def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, 
     (tmp_path / "lessons" / "images").mkdir(parents=True)
     markdown = tmp_path / "lessons" / "intro.md"
     markdown.write_text(
-        "# Demo\n\n![Schema](images/schema.png)\n\n<div>```md\n![Solo esempio](images/hidden.png)\n```\n",
+        "# Demo\n\n![Schema](images/schema.png)\n\n<div>```md\n![Solo esempio](images/hidden.png)\nx\u2028```\n![Separatore Unicode](images/unicode.png)\n```\n",
         encoding="utf-8",
     )
     image = b"\x89PNG\r\nverified"
     (tmp_path / "lessons" / "images" / "schema.png").write_bytes(image)
     (tmp_path / "lessons" / "images" / "hidden.png").write_bytes(image)
+    (tmp_path / "lessons" / "images" / "unicode.png").write_bytes(image)
     design = {
         "sources": [
             {
@@ -158,7 +159,10 @@ def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, 
         )
 
     (tmp_path / "lessons" / "images" / "unreferenced.png").write_bytes(image)
-    for rejected_target in ("images/unreferenced.png", "images/hidden.png"):
+    for rejected_target in (
+        "images/unreferenced.png",
+        "images/hidden.png",
+    ):
         with pytest.raises(ValueError, match="non è referenziata"):
             course_board_server.heading_asset_snapshot(
                 design,
@@ -167,6 +171,17 @@ def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, 
                 heading["content_sha256"],
                 rejected_target,
             )
+
+    # section_text_from_source normalizes Unicode line separators before both
+    # API rendering and reference authorization, so this image is visible.
+    unicode_payload = course_board_server.heading_asset_snapshot(
+        design,
+        heading["id"],
+        "",
+        heading["content_sha256"],
+        "images/unicode.png",
+    )
+    assert base64.b64decode(unicode_payload["content_base64"]) == image
 
 
 @pytest.mark.parametrize(

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -233,7 +233,12 @@ def test_section_extraction_uses_same_line_model_as_heading_index() -> None:
         expected_sha256=None,
     )
     headings = course_board_server.headings_from_source_snapshot(source_file, source)
+    changed = course_board_server.headings_from_source_snapshot(
+        source_file,
+        source.replace("same indexed line", "changed indexed line"),
+    )
 
+    assert headings[0]["content_sha256"] != changed[0]["content_sha256"]
     assert headings[1]["line"] == 3
     assert course_board_server.section_text_from_source(source, 1, 1) == (
         "body\u2028same indexed line\n## Second\ncontent"
@@ -241,11 +246,12 @@ def test_section_extraction_uses_same_line_model_as_heading_index() -> None:
     assert course_board_server.section_text_from_source(source, 3, 2) == "content"
 
 
-def test_paragraph_normalization_uses_javascript_ascii_word_boundary() -> None:
-    source = "x<divé>```\n![Visible](images/visible.png)\n```"
+@pytest.mark.parametrize("suffix", ["é", "İ", "ı", "ſ", "K"])
+def test_paragraph_normalization_uses_javascript_ascii_word_boundary(suffix) -> None:
+    source = f"x<div{suffix}>```\n![Hidden](images/private.png)\n```"
 
     assert course_board_server.normalize_paragraph_preview_source(source) == (
-        "x\n```\n![Visible](images/visible.png)\n```"
+        "x\n```\n![Hidden](images/private.png)\n```"
     )
     assert course_board_server.heading_referenced_asset_paths(
         "lesson.md", source

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -112,9 +112,13 @@ def test_extract_headings_and_section_text_include_paragraph_content(tmp_path, m
 def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, monkeypatch) -> None:
     (tmp_path / "lessons" / "images").mkdir(parents=True)
     markdown = tmp_path / "lessons" / "intro.md"
-    markdown.write_text("# Demo\n\n![Schema](images/schema.png)\n", encoding="utf-8")
+    markdown.write_text(
+        "# Demo\n\n![Schema](images/schema.png)\n\n```md\n![Solo esempio](images/hidden.png)\n```\n",
+        encoding="utf-8",
+    )
     image = b"\x89PNG\r\nverified"
     (tmp_path / "lessons" / "images" / "schema.png").write_bytes(image)
+    (tmp_path / "lessons" / "images" / "hidden.png").write_bytes(image)
     design = {
         "sources": [
             {
@@ -143,15 +147,26 @@ def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, 
     assert base64.b64decode(payload["content_base64"]) == image
     assert payload["sha256"] == hashlib.sha256(image).hexdigest()
 
-    (tmp_path / "lessons" / "images" / "unreferenced.png").write_bytes(image)
-    with pytest.raises(ValueError, match="non è referenziata"):
+    with pytest.raises(ValueError, match="troppo grande"):
         course_board_server.heading_asset_snapshot(
             design,
             heading["id"],
             "",
             heading["content_sha256"],
-            "images/unreferenced.png",
+            "images/schema.png",
+            max_bytes=4,
         )
+
+    (tmp_path / "lessons" / "images" / "unreferenced.png").write_bytes(image)
+    for rejected_target in ("images/unreferenced.png", "images/hidden.png"):
+        with pytest.raises(ValueError, match="non è referenziata"):
+            course_board_server.heading_asset_snapshot(
+                design,
+                heading["id"],
+                "",
+                heading["content_sha256"],
+                rejected_target,
+            )
 
 
 @pytest.mark.parametrize(
@@ -176,7 +191,9 @@ def test_local_heading_asset_rechecks_final_open_handle_path(tmp_path, monkeypat
     )
 
     with pytest.raises(ValueError, match="aperta esce"):
-        course_board_server._read_local_heading_asset("images/safe.png")
+        course_board_server._read_local_heading_asset(
+            "images/safe.png", course_board_server.MAX_HEADING_IMAGE_BYTES
+        )
 
 
 def test_markdown_line_iteration_is_streaming_and_preserves_line_endings() -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -113,7 +113,7 @@ def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, 
     (tmp_path / "lessons" / "images").mkdir(parents=True)
     markdown = tmp_path / "lessons" / "intro.md"
     markdown.write_text(
-        "# Demo\n\n![Schema](images/schema.png)\n\n```md\n![Solo esempio](images/hidden.png)\n```\n",
+        "# Demo\n\n![Schema](images/schema.png)\n\n<div>```md\n![Solo esempio](images/hidden.png)\n```\n",
         encoding="utf-8",
     )
     image = b"\x89PNG\r\nverified"
@@ -178,19 +178,19 @@ def test_heading_asset_rejects_unsafe_or_non_image_paths(target) -> None:
         course_board_server.normalized_heading_asset_path("lessons/intro.md", target)
 
 
-def test_local_heading_asset_rechecks_final_open_handle_path(tmp_path, monkeypatch) -> None:
+def test_local_heading_asset_rechecks_exact_final_open_handle_path(tmp_path, monkeypatch) -> None:
     (tmp_path / "images").mkdir()
     (tmp_path / "images" / "safe.png").write_bytes(b"safe")
-    outside = tmp_path.parent / f"outside-{tmp_path.name}.png"
-    outside.write_bytes(b"outside")
+    alternate = tmp_path / "images" / "alternate.png"
+    alternate.write_bytes(b"alternate")
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(
         course_board_server.course_source_catalog,
         "opened_file_path",
-        lambda _descriptor: outside,
+        lambda _descriptor: alternate,
     )
 
-    with pytest.raises(ValueError, match="aperta esce"):
+    with pytest.raises(ValueError, match="non coincide"):
         course_board_server._read_local_heading_asset(
             "images/safe.png", course_board_server.MAX_HEADING_IMAGE_BYTES
         )

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -162,6 +162,7 @@ def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, 
     for rejected_target in (
         "images/unreferenced.png",
         "images/hidden.png",
+        "images/unicode.png",
     ):
         with pytest.raises(ValueError, match="non è referenziata"):
             course_board_server.heading_asset_snapshot(
@@ -172,16 +173,6 @@ def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, 
                 rejected_target,
             )
 
-    # section_text_from_source normalizes Unicode line separators before both
-    # API rendering and reference authorization, so this image is visible.
-    unicode_payload = course_board_server.heading_asset_snapshot(
-        design,
-        heading["id"],
-        "",
-        heading["content_sha256"],
-        "images/unicode.png",
-    )
-    assert base64.b64decode(unicode_payload["content_base64"]) == image
 
 
 @pytest.mark.parametrize(
@@ -217,6 +208,48 @@ def test_local_heading_asset_rechecks_exact_final_open_handle_path(tmp_path, mon
         course_board_server._read_local_heading_asset(
             "images/safe.png", course_board_server.MAX_HEADING_IMAGE_BYTES
         )
+
+
+def test_section_extraction_uses_same_line_model_as_heading_index() -> None:
+    source = "# First\nbody\u2028same indexed line\n## Second\ncontent"
+    descriptor = course_board_server.course_source_catalog.CourseSource(
+        source_id="local",
+        label="Local",
+        source_type="markdown",
+        provider="local",
+        path="",
+        repository=None,
+        ref=None,
+        files=("lesson.md",),
+        updated_at=None,
+        indexing_status="ready",
+    )
+    source_file = course_board_server.course_source_catalog.LocalCourseSourceFile(
+        source=descriptor,
+        relative_path="lesson.md",
+        resolved_path=Path("lesson.md"),
+        expected_size=None,
+        expected_identity=None,
+        expected_sha256=None,
+    )
+    headings = course_board_server.headings_from_source_snapshot(source_file, source)
+
+    assert headings[1]["line"] == 3
+    assert course_board_server.section_text_from_source(source, 1, 1) == (
+        "body\u2028same indexed line\n## Second\ncontent"
+    )
+    assert course_board_server.section_text_from_source(source, 3, 2) == "content"
+
+
+def test_paragraph_normalization_uses_javascript_ascii_word_boundary() -> None:
+    source = "x<divé>```\n![Visible](images/visible.png)\n```"
+
+    assert course_board_server.normalize_paragraph_preview_source(source) == (
+        "x\n```\n![Visible](images/visible.png)\n```"
+    )
+    assert course_board_server.heading_referenced_asset_paths(
+        "lesson.md", source
+    ) == set()
 
 
 def test_markdown_line_iteration_is_streaming_and_preserves_line_endings() -> None:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -109,6 +109,50 @@ def test_extract_headings_and_section_text_include_paragraph_content(tmp_path, m
     )
 
 
+def test_heading_asset_uses_configured_data_root_and_verified_heading(tmp_path, monkeypatch) -> None:
+    (tmp_path / "lessons" / "images").mkdir(parents=True)
+    markdown = tmp_path / "lessons" / "intro.md"
+    markdown.write_text("# Demo\n\n![Schema](images/schema.png)\n", encoding="utf-8")
+    image = b"\x89PNG\r\nverified"
+    (tmp_path / "lessons" / "images" / "schema.png").write_bytes(image)
+    design = {
+        "sources": [
+            {
+                "id": "lesson",
+                "label": "Lesson",
+                "type": "markdown",
+                "provider": "local",
+                "path": "lessons",
+                "files": ["intro.md"],
+                "indexing_status": "ready",
+            }
+        ]
+    }
+    monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
+    heading = course_board_server.extract_headings(design)[0]
+
+    payload = course_board_server.heading_asset_snapshot(
+        design,
+        heading["id"],
+        "",
+        heading["content_sha256"],
+        "images/schema.png",
+    )
+
+    assert payload["content_type"] == "image/png"
+    assert base64.b64decode(payload["content_base64"]) == image
+    assert payload["sha256"] == hashlib.sha256(image).hexdigest()
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["../../outside.png", "%2e%2e/%2e%2e/outside.png", "https://example.test/x.png", "images/x:/pic.png", "file.txt", "x.png?token=secret"],
+)
+def test_heading_asset_rejects_unsafe_or_non_image_paths(target) -> None:
+    with pytest.raises(ValueError):
+        course_board_server.normalized_heading_asset_path("lessons/intro.md", target)
+
+
 def test_markdown_line_iteration_is_streaming_and_preserves_line_endings() -> None:
     class SplitlinesForbidden(str):
         def splitlines(self, *args, **kwargs):

--- a/tests/test_course_github_markdown.py
+++ b/tests/test_course_github_markdown.py
@@ -84,6 +84,29 @@ def test_fetches_every_file_from_one_resolved_commit() -> None:
     ]
 
 
+def test_fetches_binary_asset_from_exact_commit_with_size_bound() -> None:
+    commit = "f" * 40
+    content = b"\x89PNG\r\nverified"
+    blob_id, blob = blob_payload(content)
+    transport = FakeTransport(
+        {
+            f"/repos/owner/repo/contents/images/icon.png?ref={commit}": {
+                "type": "file",
+                "size": len(content),
+                "sha": blob_id,
+            },
+            f"/repos/owner/repo/git/blobs/{blob_id}": blob,
+        }
+    )
+
+    item = GitHubMarkdownAdapter(transport).fetch_file_at_commit(
+        "owner/repo", commit, "images/icon.png", max_bytes=len(content)
+    )
+
+    assert item.content == content
+    assert item.relative_path == "images/icon.png"
+
+
 def test_quotes_declared_ref_and_file_segments_without_changing_repository() -> None:
     commit = "b" * 40
     content = b"# Spazi\n"

--- a/tests/test_course_gitlab_markdown.py
+++ b/tests/test_course_gitlab_markdown.py
@@ -69,6 +69,26 @@ def test_fetches_nested_gitlab_project_files_from_one_commit() -> None:
     assert all(f"?ref={commit}" in call for call in transport.calls[1:])
 
 
+def test_fetches_binary_asset_from_exact_gitlab_commit() -> None:
+    commit = "f" * 40
+    content = b"GIF89a verified"
+    path = "images/icon.gif"
+    transport = FakeTransport(
+        {
+            f"/api/v4/projects/school%2Fcourse/repository/files/images%2Ficon.gif?ref={commit}": file_payload(
+                path, commit, content
+            )
+        }
+    )
+
+    item = GitLabMarkdownAdapter(transport).fetch_file_at_commit(
+        "school/course", commit, path, max_bytes=len(content)
+    )
+
+    assert item.content == content
+    assert item.relative_path == path
+
+
 def test_rejects_file_response_from_different_commit() -> None:
     commit = "b" * 40
     content = b"# Lesson\n"

--- a/tests/test_course_gitlab_markdown.py
+++ b/tests/test_course_gitlab_markdown.py
@@ -5,6 +5,7 @@ import hashlib
 
 import pytest
 
+from scripts import course_gitlab_markdown
 from scripts.course_gitlab_markdown import GitLabMarkdownAdapter
 from scripts.course_github_markdown import RemoteMarkdownError
 
@@ -17,10 +18,19 @@ class FakeTransport:
     def __init__(self, responses: dict[str, object]) -> None:
         self.responses = responses
         self.calls: list[str] = []
+        self.response_budgets: list[int] = []
 
-    def get_json(self, api_path: str, *, timeout_seconds: float):
+    def get_json(
+        self,
+        api_path: str,
+        *,
+        timeout_seconds: float,
+        max_response_bytes: int = course_gitlab_markdown.MAX_GITHUB_RESPONSE_BYTES,
+    ):
         assert timeout_seconds > 0
+        assert 0 < max_response_bytes <= course_gitlab_markdown.MAX_GITHUB_RESPONSE_BYTES
         self.calls.append(api_path)
+        self.response_budgets.append(max_response_bytes)
         return self.responses[api_path]
 
 
@@ -87,6 +97,7 @@ def test_fetches_binary_asset_from_exact_gitlab_commit() -> None:
 
     assert item.content == content
     assert item.relative_path == path
+    assert transport.response_budgets == [((len(content) + 2) // 3) * 4 + 64 * 1024]
 
 
 def test_rejects_file_response_from_different_commit() -> None:

--- a/tools/course_board.css
+++ b/tools/course_board.css
@@ -855,6 +855,31 @@ input[aria-invalid="true"] {
   font-weight: 700;
 }
 
+.paragraphImageFrame {
+  display: block;
+  margin: .8rem 0;
+}
+
+.paragraphImage {
+  display: block;
+  max-width: min(100%, 56rem);
+  max-height: 28rem;
+  border: 1px solid rgba(17, 17, 17, .12);
+  border-radius: 10px;
+  background: #fff;
+  object-fit: contain;
+}
+
+.paragraphImageFallback {
+  display: inline-block;
+  border: 1px dashed rgba(17, 17, 17, .28);
+  border-radius: 8px;
+  background: #f1f1f1;
+  color: var(--muted);
+  padding: .45rem .65rem;
+  font: .76rem/1.4 var(--mono);
+}
+
 .paragraphSourceLink {
   color: var(--ink);
   font-size: .78rem;

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -2469,12 +2469,11 @@ async function loadParagraphImages(container, heading, isCurrent = () => true) {
   const allImages = Array.from(container.querySelectorAll("img[data-preview-image]"));
   const images = allImages.slice(0, 32);
   for (const image of allImages.slice(32)) showParagraphImageFallback(image);
-  let nextIndex = 0;
-  const worker = async () => {
-    while (nextIndex < images.length) {
-      const image = images[nextIndex++];
-      image.addEventListener("error", () => showParagraphImageFallback(image), { once: true });
-      try {
+  const maxTotalBase64Chars = 22_369_624;
+  let totalBase64Chars = 0;
+  for (const image of images) {
+    image.addEventListener("error", () => showParagraphImageFallback(image), { once: true });
+    try {
         const payload = await api("/api/heading-asset", {
           method: "POST",
           body: JSON.stringify({
@@ -2490,14 +2489,14 @@ async function loadParagraphImages(container, heading, isCurrent = () => true) {
           !/^image\/(?:png|jpeg|gif|webp|svg\+xml|x-icon)$/.test(payload.content_type || "")
           || !/^[A-Za-z0-9+/]*={0,2}$/.test(payload.content_base64 || "")
           || payload.content_base64.length > 11_184_812
-        ) throw new Error("Payload immagine non valido.");
+          || totalBase64Chars + payload.content_base64.length > maxTotalBase64Chars
+        ) throw new Error("Payload immagine non valido o budget preview esaurito.");
+        totalBase64Chars += payload.content_base64.length;
         image.src = `data:${payload.content_type};base64,${payload.content_base64}`;
-      } catch (_error) {
-        if (isCurrent()) showParagraphImageFallback(image);
-      }
+    } catch (_error) {
+      if (isCurrent()) showParagraphImageFallback(image);
     }
-  };
-  await Promise.all(Array.from({ length: Math.min(4, images.length) }, worker));
+  }
 }
 
 function renderParagraphContent(source, heading = {}) {

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -2471,28 +2471,35 @@ async function loadParagraphImages(container, heading, isCurrent = () => true) {
   for (const image of allImages.slice(32)) showParagraphImageFallback(image);
   const maxTotalBase64Chars = 22_369_624;
   let totalBase64Chars = 0;
-  for (const image of images) {
+  for (const [index, image] of images.entries()) {
+    const remainingBase64Chars = maxTotalBase64Chars - totalBase64Chars;
+    const maxBytes = Math.min(8 * 1024 * 1024, Math.floor(remainingBase64Chars / 4) * 3);
+    if (maxBytes <= 0) {
+      for (const remaining of images.slice(index)) showParagraphImageFallback(remaining);
+      break;
+    }
     image.addEventListener("error", () => showParagraphImageFallback(image), { once: true });
     try {
-        const payload = await api("/api/heading-asset", {
-          method: "POST",
-          body: JSON.stringify({
-            id: heading.id,
-            source_commit: heading.source_commit || "",
-            content_sha256: heading.content_sha256 || "",
-            target: image.dataset.assetTarget || "",
-            design: state.design,
-          }),
-        });
-        if (!isCurrent()) return;
-        if (
-          !/^image\/(?:png|jpeg|gif|webp|svg\+xml|x-icon)$/.test(payload.content_type || "")
-          || !/^[A-Za-z0-9+/]*={0,2}$/.test(payload.content_base64 || "")
-          || payload.content_base64.length > 11_184_812
-          || totalBase64Chars + payload.content_base64.length > maxTotalBase64Chars
-        ) throw new Error("Payload immagine non valido o budget preview esaurito.");
-        totalBase64Chars += payload.content_base64.length;
-        image.src = `data:${payload.content_type};base64,${payload.content_base64}`;
+      const payload = await api("/api/heading-asset", {
+        method: "POST",
+        body: JSON.stringify({
+          id: heading.id,
+          source_commit: heading.source_commit || "",
+          content_sha256: heading.content_sha256 || "",
+          target: image.dataset.assetTarget || "",
+          max_bytes: maxBytes,
+          design: state.design,
+        }),
+      });
+      if (!isCurrent()) return;
+      if (
+        !/^image\/(?:png|jpeg|gif|webp|svg\+xml|x-icon)$/.test(payload.content_type || "")
+        || !/^[A-Za-z0-9+/]*={0,2}$/.test(payload.content_base64 || "")
+        || payload.content_base64.length > 11_184_812
+        || totalBase64Chars + payload.content_base64.length > maxTotalBase64Chars
+      ) throw new Error("Payload immagine non valido o budget preview esaurito.");
+      totalBase64Chars += payload.content_base64.length;
+      image.src = `data:${payload.content_type};base64,${payload.content_base64}`;
     } catch (_error) {
       if (isCurrent()) showParagraphImageFallback(image);
     }

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -2363,7 +2363,76 @@ function normalizeParagraphSource(source) {
     .trim();
 }
 
-function renderParagraphInline(value) {
+const PARAGRAPH_IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico"]);
+
+function normalizedParagraphAssetPath(sourcePath, target) {
+  const rawSource = String(sourcePath || "");
+  const rawTarget = String(target || "");
+  if (
+    !rawSource
+    || !rawTarget
+    || rawTarget.startsWith("/")
+    || rawTarget.startsWith("//")
+    || rawTarget.includes("\\")
+    || rawTarget.includes("?")
+    || rawTarget.includes("#")
+    || /[\u0000-\u001f\u007f]/.test(rawTarget)
+    || /^[a-z][a-z0-9+.-]*:/i.test(rawTarget)
+  ) return "";
+  let decodedTarget;
+  try {
+    decodedTarget = decodeURIComponent(rawTarget);
+  } catch (_error) {
+    return "";
+  }
+  if (
+    decodedTarget.includes("\\")
+    || decodedTarget.includes("?")
+    || decodedTarget.includes("#")
+    || /[\u0000-\u001f\u007f]/.test(decodedTarget)
+  ) return "";
+  const parts = rawSource.split("/").slice(0, -1);
+  if (!parts.length && rawSource.includes("/")) return "";
+  if (parts.some((part) => !part || part === "." || part === "..")) return "";
+  for (const part of decodedTarget.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (!parts.length) return "";
+      parts.pop();
+    } else {
+      parts.push(part);
+    }
+  }
+  if (!parts.length) return "";
+  const suffixMatch = parts.at(-1).toLowerCase().match(/\.[a-z0-9]+$/);
+  if (!suffixMatch || !PARAGRAPH_IMAGE_EXTENSIONS.has(suffixMatch[0])) return "";
+  return parts.map((part) => encodeURIComponent(part)).join("/");
+}
+
+function resolveParagraphImageSource(target, heading = {}) {
+  const assetPath = normalizedParagraphAssetPath(heading.source, target);
+  if (!assetPath) return "";
+  const provider = heading.source_provider || "local";
+  if (provider === "local") return `/${assetPath}`;
+  const repository = String(heading.source_repository || "");
+  const commit = String(heading.source_commit || "");
+  if (!/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/.test(commit)) return "";
+  const repositoryParts = repository.split("/");
+  if (
+    repositoryParts.length < 2
+    || repositoryParts.some((part) => !/^[A-Za-z0-9_.-]+$/.test(part) || part === "." || part === "..")
+  ) return "";
+  const encodedRepository = repositoryParts.map((part) => encodeURIComponent(part)).join("/");
+  if (provider === "github" && repositoryParts.length === 2) {
+    return `https://raw.githubusercontent.com/${encodedRepository}/${commit}/${assetPath}`;
+  }
+  if (provider === "gitlab") {
+    return `https://gitlab.com/${encodedRepository}/-/raw/${commit}/${assetPath}`;
+  }
+  return "";
+}
+
+function renderParagraphInlineText(value) {
   let html = escapeHtml(value);
   html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
   html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
@@ -2372,7 +2441,40 @@ function renderParagraphInline(value) {
   return html;
 }
 
-function renderParagraphContent(source) {
+function renderParagraphInline(value, heading = {}) {
+  const source = String(value || "");
+  const imagePattern = /!\[([^\]\r\n]{0,500})\]\(([^)\s]+)(?:\s+(?:"[^"]*"|'[^']*'))?\)/g;
+  const parts = [];
+  let start = 0;
+  for (const match of source.matchAll(imagePattern)) {
+    parts.push(renderParagraphInlineText(source.slice(start, match.index)));
+    const alt = match[1].trim() || "immagine";
+    const resolved = resolveParagraphImageSource(match[2], heading);
+    const fallback = `Immagine non disponibile: ${alt}`;
+    if (resolved) {
+      parts.push(
+        `<span class="paragraphImageFrame"><img class="paragraphImage" data-preview-image src="${escapeHtml(resolved)}" alt="${escapeHtml(alt)}" loading="lazy" decoding="async" referrerpolicy="no-referrer"><span class="paragraphImageFallback" hidden>${escapeHtml(fallback)}</span></span>`,
+      );
+    } else {
+      parts.push(`<span class="paragraphImageFallback" role="img" aria-label="${escapeHtml(fallback)}">[${escapeHtml(fallback)}]</span>`);
+    }
+    start = match.index + match[0].length;
+  }
+  parts.push(renderParagraphInlineText(source.slice(start)));
+  return parts.join("");
+}
+
+function bindParagraphImageFallbacks(container) {
+  for (const image of container.querySelectorAll("img[data-preview-image]")) {
+    image.addEventListener("error", () => {
+      image.hidden = true;
+      const fallback = image.parentElement?.querySelector(".paragraphImageFallback");
+      if (fallback) fallback.hidden = false;
+    }, { once: true });
+  }
+}
+
+function renderParagraphContent(source, heading = {}) {
   const lines = normalizeParagraphSource(source).split("\n");
   const blocks = [];
   let paragraph = [];
@@ -2382,13 +2484,13 @@ function renderParagraphContent(source) {
 
   const flushParagraph = () => {
     if (!paragraph.length) return;
-    blocks.push(`<p>${paragraph.map(renderParagraphInline).join("<br>")}</p>`);
+    blocks.push(`<p>${paragraph.map((line) => renderParagraphInline(line, heading)).join("<br>")}</p>`);
     paragraph = [];
   };
   const flushList = () => {
     if (!listItems.length) return;
     const tag = listType === "ordered" ? "ol" : "ul";
-    blocks.push(`<${tag}>${listItems.map((item) => `<li>${renderParagraphInline(item)}</li>`).join("")}</${tag}>`);
+    blocks.push(`<${tag}>${listItems.map((item) => `<li>${renderParagraphInline(item, heading)}</li>`).join("")}</${tag}>`);
     listType = "";
     listItems = [];
   };
@@ -2410,17 +2512,17 @@ function renderParagraphContent(source) {
       codeLines.push(line);
       continue;
     }
-    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
     const unordered = line.match(/^\s*[-*]\s+(.+)$/);
     const ordered = line.match(/^\s*\d+\.\s+(.+)$/);
     if (!line.trim()) {
       flushParagraph();
       flushList();
-    } else if (heading) {
+    } else if (headingMatch) {
       flushParagraph();
       flushList();
-      const level = heading[1].length;
-      blocks.push(`<h${level}>${renderParagraphInline(heading[2])}</h${level}>`);
+      const level = headingMatch[1].length;
+      blocks.push(`<h${level}>${renderParagraphInline(headingMatch[2], heading)}</h${level}>`);
     } else if (unordered || ordered) {
       flushParagraph();
       const nextType = unordered ? "unordered" : "ordered";
@@ -2476,7 +2578,8 @@ async function openParagraphPreview(paragraph) {
     const heading = payload.heading || paragraph;
     els.paragraphDialogTitle.textContent = heading.title || paragraph.title || "Testo del paragrafo";
     els.paragraphDialogMeta.textContent = `${heading.source_label || heading.source || "Sorgente n/d"} (${heading.source_provider || "local"}) · riga ${heading.line || "?"} · H${heading.level || "?"}`;
-    els.paragraphContent.innerHTML = renderParagraphContent(heading.content);
+    els.paragraphContent.innerHTML = renderParagraphContent(heading.content, heading);
+    bindParagraphImageFallbacks(els.paragraphContent);
     const sourceUrl = heading.source_url || heading.github_url;
     if (sourceUrl) {
       els.paragraphSourceLink.href = sourceUrl;

--- a/tools/course_board.js
+++ b/tools/course_board.js
@@ -2387,6 +2387,7 @@ function normalizedParagraphAssetPath(sourcePath, target) {
   }
   if (
     decodedTarget.includes("\\")
+    || decodedTarget.includes(":")
     || decodedTarget.includes("?")
     || decodedTarget.includes("#")
     || /[\u0000-\u001f\u007f]/.test(decodedTarget)
@@ -2409,11 +2410,10 @@ function normalizedParagraphAssetPath(sourcePath, target) {
   return parts.map((part) => encodeURIComponent(part)).join("/");
 }
 
-function resolveParagraphImageSource(target, heading = {}) {
-  const assetPath = normalizedParagraphAssetPath(heading.source, target);
-  if (!assetPath) return "";
+function validatedParagraphImageTarget(target, heading = {}) {
+  if (!normalizedParagraphAssetPath(heading.source, target)) return "";
   const provider = heading.source_provider || "local";
-  if (provider === "local") return `/${assetPath}`;
+  if (provider === "local") return String(target);
   const repository = String(heading.source_repository || "");
   const commit = String(heading.source_commit || "");
   if (!/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/.test(commit)) return "";
@@ -2422,13 +2422,8 @@ function resolveParagraphImageSource(target, heading = {}) {
     repositoryParts.length < 2
     || repositoryParts.some((part) => !/^[A-Za-z0-9_.-]+$/.test(part) || part === "." || part === "..")
   ) return "";
-  const encodedRepository = repositoryParts.map((part) => encodeURIComponent(part)).join("/");
-  if (provider === "github" && repositoryParts.length === 2) {
-    return `https://raw.githubusercontent.com/${encodedRepository}/${commit}/${assetPath}`;
-  }
-  if (provider === "gitlab") {
-    return `https://gitlab.com/${encodedRepository}/-/raw/${commit}/${assetPath}`;
-  }
+  if (provider === "github" && repositoryParts.length === 2) return String(target);
+  if (provider === "gitlab") return String(target);
   return "";
 }
 
@@ -2449,11 +2444,11 @@ function renderParagraphInline(value, heading = {}) {
   for (const match of source.matchAll(imagePattern)) {
     parts.push(renderParagraphInlineText(source.slice(start, match.index)));
     const alt = match[1].trim() || "immagine";
-    const resolved = resolveParagraphImageSource(match[2], heading);
+    const validatedTarget = validatedParagraphImageTarget(match[2], heading);
     const fallback = `Immagine non disponibile: ${alt}`;
-    if (resolved) {
+    if (validatedTarget) {
       parts.push(
-        `<span class="paragraphImageFrame"><img class="paragraphImage" data-preview-image src="${escapeHtml(resolved)}" alt="${escapeHtml(alt)}" loading="lazy" decoding="async" referrerpolicy="no-referrer"><span class="paragraphImageFallback" hidden>${escapeHtml(fallback)}</span></span>`,
+        `<span class="paragraphImageFrame"><img class="paragraphImage" data-preview-image data-asset-target="${escapeHtml(validatedTarget)}" alt="${escapeHtml(alt)}" loading="lazy" decoding="async" referrerpolicy="no-referrer"><span class="paragraphImageFallback" hidden>${escapeHtml(fallback)}</span></span>`,
       );
     } else {
       parts.push(`<span class="paragraphImageFallback" role="img" aria-label="${escapeHtml(fallback)}">[${escapeHtml(fallback)}]</span>`);
@@ -2464,14 +2459,45 @@ function renderParagraphInline(value, heading = {}) {
   return parts.join("");
 }
 
-function bindParagraphImageFallbacks(container) {
-  for (const image of container.querySelectorAll("img[data-preview-image]")) {
-    image.addEventListener("error", () => {
-      image.hidden = true;
-      const fallback = image.parentElement?.querySelector(".paragraphImageFallback");
-      if (fallback) fallback.hidden = false;
-    }, { once: true });
-  }
+function showParagraphImageFallback(image) {
+  image.hidden = true;
+  const fallback = image.parentElement?.querySelector(".paragraphImageFallback");
+  if (fallback) fallback.hidden = false;
+}
+
+async function loadParagraphImages(container, heading, isCurrent = () => true) {
+  const allImages = Array.from(container.querySelectorAll("img[data-preview-image]"));
+  const images = allImages.slice(0, 32);
+  for (const image of allImages.slice(32)) showParagraphImageFallback(image);
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < images.length) {
+      const image = images[nextIndex++];
+      image.addEventListener("error", () => showParagraphImageFallback(image), { once: true });
+      try {
+        const payload = await api("/api/heading-asset", {
+          method: "POST",
+          body: JSON.stringify({
+            id: heading.id,
+            source_commit: heading.source_commit || "",
+            content_sha256: heading.content_sha256 || "",
+            target: image.dataset.assetTarget || "",
+            design: state.design,
+          }),
+        });
+        if (!isCurrent()) return;
+        if (
+          !/^image\/(?:png|jpeg|gif|webp|svg\+xml|x-icon)$/.test(payload.content_type || "")
+          || !/^[A-Za-z0-9+/]*={0,2}$/.test(payload.content_base64 || "")
+          || payload.content_base64.length > 11_184_812
+        ) throw new Error("Payload immagine non valido.");
+        image.src = `data:${payload.content_type};base64,${payload.content_base64}`;
+      } catch (_error) {
+        if (isCurrent()) showParagraphImageFallback(image);
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(4, images.length) }, worker));
 }
 
 function renderParagraphContent(source, heading = {}) {
@@ -2579,7 +2605,12 @@ async function openParagraphPreview(paragraph) {
     els.paragraphDialogTitle.textContent = heading.title || paragraph.title || "Testo del paragrafo";
     els.paragraphDialogMeta.textContent = `${heading.source_label || heading.source || "Sorgente n/d"} (${heading.source_provider || "local"}) · riga ${heading.line || "?"} · H${heading.level || "?"}`;
     els.paragraphContent.innerHTML = renderParagraphContent(heading.content, heading);
-    bindParagraphImageFallbacks(els.paragraphContent);
+    await loadParagraphImages(
+      els.paragraphContent,
+      heading,
+      () => requestId === paragraphPreviewRequestId,
+    );
+    if (requestId !== paragraphPreviewRequestId) return;
     const sourceUrl = heading.source_url || heading.github_url;
     if (sourceUrl) {
       els.paragraphSourceLink.href = sourceUrl;


### PR DESCRIPTION
## Summary
- render Markdown images and didactic icons in the teacher paragraph dialog
- resolve and validate every asset relative to the verified Markdown source
- load local assets from the configured data root, not the application checkout
- fetch private/public GitHub and GitLab assets server-side through existing credentials at the immutable resolved commit
- revalidate heading commit and content digest before every asset read
- reject repository escape, external schemes, encoded traversal, Windows ADS syntax, query/fragment references and non-image extensions
- cap assets at 8 MiB, cap preview requests, use bounded concurrency, no-store responses and data URLs without referrers
- preserve escaped readable fallback text for rejected, missing or failed assets
- extend adapter/server/frontend tests and the manual checklist

## Verification
- focused GitHub/GitLab/Course Board suite: 267 passed, 3 skipped
- Python compilation, Node syntax and diff checks passed

Closes #473.