### PR TITLE
feat: pagina di login pubblica con bottone Google

### DIFF
--- a/doc/INFRASTRUTTURA_PRODUZIONE.md
+++ b/doc/INFRASTRUTTURA_PRODUZIONE.md
@@ -829,3 +829,172 @@ DS/digest DNSSEC. Le chiavi pubbliche e gli IP pubblici invece sì.
 - [ ] Pulizia record obsoleti (TXT placeholder OVH, CNAME ftp)
 - [ ] Sostituire la chiave SSH di backup da "account personale" a deploy key
       del solo repo `thebitlab-backups` (quando abilitato)
+
+---
+
+## 11. Avvio dell'applicazione e flussi di accesso
+
+### 11.1 Come avviare il server
+
+Il codice dell'app vive in `/opt/thebitlab/repo`, il virtualenv in
+`/opt/thebitlab/venv`, i dati in `/srv/thebitlab/data`.
+
+#### Produzione (systemd)
+
+```bash
+cd /opt/thebitlab/repo
+/opt/thebitlab/venv/bin/python scripts/course_board_server.py \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --root /srv/thebitlab/data \
+  --enable-google-auth \
+  --enable-github-app-token-runtime
+```
+
+In produzione il processo è gestito da systemd (`systemctl status thebitlab`).
+
+#### Sviluppo locale
+
+```bash
+python scripts/course_board_server.py \
+  --host 127.0.0.1 \
+  --port 8765 \
+  --root ./tmp-data
+```
+
+#### Sviluppo con Google OIDC
+
+```bash
+export THEBITLAB_TEACHER_TOKEN="..."
+export THEBITLAB_GOOGLE_CLIENT_ID="..."
+export THEBITLAB_GOOGLE_CLIENT_SECRET="..."
+export THEBITLAB_GOOGLE_REDIRECT_URI="https://app.thebitpoets.com/auth/google/callback"
+export THEBITLAB_AUTH_CSRF_SECRET_B64="..."
+export THEBITLAB_RATE_LIMIT_PEPPER_B64="..."
+export THEBITLAB_TUI_PAIRING_PEPPER_B64="..."
+export THEBITLAB_TRUSTED_PROXY_CIDRS="127.0.0.1/32,::1/128"
+
+python scripts/course_board_server.py \
+  --host 127.0.0.1 \
+  --port 8765 \
+  --root ./tmp-data \
+  --enable-google-auth
+```
+
+> **Nota**: per il login con Google il `redirect_uri` deve essere esattamente
+> quello registrato in Google Cloud Console, e l'app deve essere raggiungibile
+> via HTTPS (in locale si usa un tunnel come Cloudflare `cloudflared`).
+
+#### Flag disponibili
+
+| Flag | Effetto |
+|---|---|
+| `--host` | Indirizzo di ascolto (`127.0.0.1` in produzione dietro nginx) |
+| `--port` | Porta TCP |
+| `--root` | Directory radice per dati, report, lock e database SQLite |
+| `--enable-google-auth` | Attiva Google OIDC, login page, sessioni web e admin |
+| `--enable-github-app-token-runtime` | Attiva generazione/rinnovo token GitHub App per fonti private |
+| `--allow-insecure-network-http` | Permette HTTP su indirizzo non-loopback (solo per test protetti) |
+
+---
+
+### 11.2 Punti di accesso
+
+| URL | Tipo di accesso | Scopo |
+|---|---|---|
+| `/` | Pubblico (se `--enable-google-auth`) o docente Basic Auth | Login page o Course Board |
+| `/login` | Pubblico (se `--enable-google-auth`) | Pagina con bottone "Accedi con Google" |
+| `/tools/course_board.html` | Docente Basic Auth | Course Design Board |
+| `/auth/google/login` | Pubblico | Avvia il flusso OAuth 2.0/OIDC con Google |
+| `/auth/google/callback` | Pubblico (chiamato da Google) | Completa il login |
+| `/auth/account` | Sessione web | Landing post-login (stato pending/studente/docente/admin) |
+| `/auth/admin` | Admin (ruolo `admin`) | Gestione utenti, classi e approvazioni |
+| `/auth/tui/pair` | Studente autenticato | Accoppiamento browser ↔ terminale TUI |
+| `/api/student-lab/...` | Bearer TUI | API usate dalla CLI/TUI dello studente |
+| `/api/...` | Docente Basic Auth | API usate dalla dashboard docente |
+
+Credenziali dashboard docente:
+
+- **Username**: `teacher`
+- **Password**: token salvato in `C:\Users\antonio\.thebitlab-secrets\hetzner\teacher-token.txt`
+
+---
+
+### 11.3 Flusso di login per uno studente
+
+```text
+app.thebitpoets.com/login
+        │
+        ▼
+  ┌─────────────┐
+  │ Bottone     │
+  │ Accedi con  │──▶ /auth/google/login ──▶ Google
+  │ Google      │                              │
+  └─────────────┘                              │
+        ▲                                      │
+        │                                      ▼
+  /auth/account                         /auth/google/callback
+  (account in attesa)                         │
+        ▲                                     ▼
+        └────────── utente pending ◀──────────┘
+                     │
+                     ▼
+            admin approva ruolo/classe
+                     │
+                     ▼
+            /auth/account aggiornato
+            (studente/docente/admin)
+```
+
+Passaggi dettagliati:
+
+1. Lo studente apre `https://app.thebitpoets.com/login`.
+2. Clicca **Accedi con Google**; il browser viene rimandato a `/auth/google/login`.
+3. Il server risponde con `302 Found` a `https://accounts.google.com/...`.
+4. Lo studente inserisce le credenziali Google.
+5. Google rimanda il browser a `/auth/google/callback?code=...&state=...`.
+6. Il server verifica `state` e `nonce`, scambia il `code` con i token, verifica
+   la firma dell'`id_token`, estrae `email` e `sub`.
+7. Il server crea un utente nel database con ruolo **`pending`**.
+8. Il browser arriva su `/auth/account` con il messaggio
+   "Account in attesa".
+9. Un docente/admin accede a `/auth/admin` e approva l'utente,
+   assegnandogli ruolo (`student`/`teacher`/`admin`) e classe.
+10. Al prossimo caricamento di `/auth/account` lo studente vede la sua area
+    personale e può associare la TUI da `/auth/tui/pair`.
+
+---
+
+### 11.4 Flusso di accesso per il docente
+
+1. Il docente apre `https://app.thebitpoets.com/tools/course_board.html`.
+2. Il browser mostra il prompt HTTP Basic Auth.
+3. Inserisce:
+   - **Username**: `teacher`
+   - **Password**: il token dal file `teacher-token.txt`
+4. Accede alla Course Design Board.
+
+Il docente può anche usare `/auth/admin` (se ha ruolo admin) per gestire gli
+utenti pending.
+
+---
+
+### 11.5 Avviare un'istanza di staging sulla stessa macchina
+
+Per testare modifiche senza toccare la produzione si avvia una seconda istanza
+su una porta diversa con un data root separato:
+
+```bash
+sudo mkdir -p /srv/thebitlab/staging-data
+sudo chown thebitlab:thebitlab /srv/thebitlab/staging-data
+sudo -u thebitlab /opt/thebitlab/venv/bin/python scripts/course_board_server.py \
+  --host 127.0.0.1 \
+  --port 8001 \
+  --root /srv/thebitlab/staging-data \
+  --enable-google-auth \
+  --enable-github-app-token-runtime
+```
+
+Aggiungere poi un vhost nginx per `staging.thebitpoets.com` che punti a
+`http://127.0.0.1:8001` e un record DNS `staging` → `91.98.123.183`.
+>>>>>>> 02a30e4 (docs(INFRASTRUTTURA_PRODUZIONE): aggiungi avvio app e flussi di accesso)

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -5971,6 +5971,13 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             return
         if self.dispatch_google_oidc(parsed):
             return
+        google_runtime = getattr(self.server, "google_oidc_runtime", None)
+        if google_runtime is not None and (
+            parsed.path == "/login"
+            or (parsed.path == "/" and not self.is_teacher_authenticated())
+        ):
+            self.serve_login_page()
+            return
         if self.reject_unauthenticated_teacher_api("GET", parsed.path):
             return
         if parsed.path in {"/api/student-lab/assignments", "/api/student-lab/help-history"}:
@@ -6688,6 +6695,41 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def serve_login_page(self) -> None:
+        """Serve a public Google OIDC login page when federated auth is enabled."""
+
+        body = (
+            "<!doctype html>"
+            "<html lang='it'><head>"
+            "<meta charset='utf-8'>"
+            "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+            "<title>Accedi - TheBitLab</title>"
+            "<style>"
+            "body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,sans-serif;background:#0f172a;color:#e2e8f0;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}"
+            "main{text-align:center;padding:2rem}"
+            "h1{font-weight:600;margin-bottom:1.5rem;font-size:1.5rem}"
+            "a{display:inline-block;background:#4285F4;color:#fff;text-decoration:none;padding:.85rem 1.6rem;border-radius:.5rem;font-weight:500}"
+            "a:hover{background:#357ae8}"
+            "</style>"
+            "</head><body>"
+            "<main><h1>Accedi a TheBitLab</h1>"
+            "<a href='/auth/google/login'>Accedi con Google</a></main>"
+            "</body></html>"
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; "
+            "form-action 'none'; style-src 'unsafe-inline'",
+        )
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
         self.end_headers()
         self.wfile.write(body)
 

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -5972,12 +5972,19 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if self.dispatch_google_oidc(parsed):
             return
         google_runtime = getattr(self.server, "google_oidc_runtime", None)
-        if google_runtime is not None and (
-            parsed.path == "/login"
-            or (parsed.path == "/" and not self.is_teacher_authenticated())
-        ):
-            self.serve_login_page()
-            return
+        if google_runtime is not None:
+            if parsed.path == "/login":
+                if self.is_teacher_authenticated():
+                    self.send_response(302)
+                    self.send_header("Location", "/tools/course_board.html")
+                    self.send_header("Cache-Control", "no-store")
+                    self.end_headers()
+                    return
+                self.serve_login_page()
+                return
+            if parsed.path == "/" and not self.is_teacher_authenticated():
+                self.serve_login_page()
+                return
         if self.reject_unauthenticated_teacher_api("GET", parsed.path):
             return
         if parsed.path in {"/api/student-lab/assignments", "/api/student-lab/help-history"}:

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -6113,3 +6113,33 @@ def test_login_page_not_exposed_without_google_auth(tmp_path, monkeypatch):
         assert error.value.code == 401
     finally:
         server.shutdown()
+
+
+def test_login_page_redirects_teacher_to_dashboard(tmp_path, monkeypatch):
+    board = tmp_path / "tools" / "course_board.html"
+    board.parent.mkdir(parents=True, exist_ok=True)
+    board.write_text("<h1>Course Board</h1>", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "APP_ROOT", tmp_path)
+    server = course_board_server.BoundedThreadingHTTPServer(
+        ("127.0.0.1", 0), course_board_server.CourseBoardHandler
+    )
+    server.teacher_token = "teacher-token"
+    server.google_oidc_runtime = object()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        auth = "Basic " + base64.b64encode(
+            b"teacher:teacher-token"
+        ).decode("ascii")
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{server.server_address[1]}/login",
+            headers={"Authorization": auth},
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            # urllib segue il redirect 302 automaticamente
+            assert response.status == 200
+            assert response.url.endswith("/tools/course_board.html")
+            body = response.read().decode("utf-8")
+            assert "Course Board" in body
+    finally:
+        server.shutdown()

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -6023,3 +6023,93 @@ def test_ai_secret_status_reports_paths_and_configured_keys_without_values(tmp_p
     assert status["configured_keys"]["GEMINI_API_KEY"] is False
     assert "secret-value" not in json.dumps(status)
     assert "legacy-secret" not in json.dumps(status)
+
+
+def test_login_page_public_when_google_auth_enabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(course_board_server, "APP_ROOT", tmp_path)
+    server = course_board_server.BoundedThreadingHTTPServer(
+        ("127.0.0.1", 0), course_board_server.CourseBoardHandler
+    )
+    server.teacher_token = "teacher-token"
+    server.google_oidc_runtime = object()  # abilita la pagina di login pubblica
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/login"
+        with urllib.request.urlopen(url, timeout=5) as response:
+            assert response.status == 200
+            body = response.read().decode("utf-8")
+            assert "Accedi con Google" in body
+            assert "/auth/google/login" in body
+            assert response.headers["X-Frame-Options"] == "DENY"
+            assert response.headers["X-Content-Type-Options"] == "nosniff"
+    finally:
+        server.shutdown()
+
+
+def test_root_serves_login_page_when_google_auth_enabled_and_unauthenticated(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setattr(course_board_server, "APP_ROOT", tmp_path)
+    server = course_board_server.BoundedThreadingHTTPServer(
+        ("127.0.0.1", 0), course_board_server.CourseBoardHandler
+    )
+    server.teacher_token = "teacher-token"
+    server.google_oidc_runtime = object()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/"
+        with urllib.request.urlopen(url, timeout=5) as response:
+            assert response.status == 200
+            body = response.read().decode("utf-8")
+            assert "Accedi con Google" in body
+            assert "/auth/google/login" in body
+    finally:
+        server.shutdown()
+
+
+def test_root_serves_dashboard_when_teacher_authenticated(tmp_path, monkeypatch):
+    board = tmp_path / "tools" / "course_board.html"
+    board.parent.mkdir(parents=True, exist_ok=True)
+    board.write_text("<h1>Course Board</h1>", encoding="utf-8")
+    monkeypatch.setattr(course_board_server, "APP_ROOT", tmp_path)
+    server = course_board_server.BoundedThreadingHTTPServer(
+        ("127.0.0.1", 0), course_board_server.CourseBoardHandler
+    )
+    server.teacher_token = "teacher-token"
+    server.google_oidc_runtime = object()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        auth = "Basic " + base64.b64encode(
+            b"teacher:teacher-token"
+        ).decode("ascii")
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{server.server_address[1]}/",
+            headers={"Authorization": auth},
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            assert response.status == 200
+            body = response.read().decode("utf-8")
+            assert "Course Board" in body
+    finally:
+        server.shutdown()
+
+
+def test_login_page_not_exposed_without_google_auth(tmp_path, monkeypatch):
+    monkeypatch.setattr(course_board_server, "APP_ROOT", tmp_path)
+    server = course_board_server.BoundedThreadingHTTPServer(
+        ("127.0.0.1", 0), course_board_server.CourseBoardHandler
+    )
+    server.teacher_token = "teacher-token"
+    # google_oidc_runtime non impostato: la pagina di login non deve esistere
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/login"
+        with pytest.raises(urllib.error.HTTPError) as error:
+            urllib.request.urlopen(url, timeout=5)
+        assert error.value.code == 401
+    finally:
+        server.shutdown()


### PR DESCRIPTION
Aggiunge una pagina di accesso pubblica quando l'app viene avviata con --enable-google-auth:

- /login mostra sempre il bottone "Accedi con Google" che punta a /auth/google/login;
- / mostra la pagina di login se l'utente non è autenticato come docente, altrimenti continua a servire la dashboard;
- la pagina include header di sicurezza (CSP, X-Frame-Options, X-Content-Type-Options, no-cache).

Aggiunti 4 test in tests/test_course_board_server.py per coprire:
- login page pubblica con Google auth abilitato;
- root che serve login page quando non autenticato;
- root che serve dashboard quando il docente è autenticato;
- assenza di login page quando Google auth è disabilitato.
