### PR TITLE
feat(auth): stile coerente per login, account e admin

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -72,6 +72,7 @@ from scripts import (
     student_help_service,
     student_lab_service,
     thebitlab_auth_runtime,
+    thebitlab_auth_styles,
     thebitlab_grading_artifacts,
     thebitlab_google_oidc_http,
     thebitlab_github_oauth_http,
@@ -6714,16 +6715,29 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             "<meta charset='utf-8'>"
             "<meta name='viewport' content='width=device-width,initial-scale=1'>"
             "<title>Accedi - TheBitLab</title>"
-            "<style>"
-            "body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,sans-serif;background:#0f172a;color:#e2e8f0;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}"
-            "main{text-align:center;padding:2rem}"
-            "h1{font-weight:600;margin-bottom:1.5rem;font-size:1.5rem}"
-            "a{display:inline-block;background:#4285F4;color:#fff;text-decoration:none;padding:.85rem 1.6rem;border-radius:.5rem;font-weight:500}"
-            "a:hover{background:#357ae8}"
-            "</style>"
+            f"<style>{thebitlab_auth_styles.AUTH_PAGE_CSS}</style>"
             "</head><body>"
-            "<main><h1>Accedi a TheBitLab</h1>"
-            "<a href='/auth/google/login'>Accedi con Google</a></main>"
+            "<div class='login-wrap'>"
+            "<main class='login-card'>"
+            "<div class='login-brand'>"
+            "<img src='https://www.thebitpoets.com/assets/logo-400.png' "
+            "srcset='https://www.thebitpoets.com/assets/logo-400.png 400w, https://www.thebitpoets.com/assets/logo-521.png 521w' "
+            "sizes='80px' width='80' height='80' alt='TheBitLab'>"
+            "</div>"
+            "<h1>Accedi a TheBitLab</h1>"
+            "<p class='sub'>Per studenti e docenti dell'istituto</p>"
+            "<a class='btn btn-google' href='/auth/google/login'>"
+            "<svg width='18' height='18' viewBox='0 0 24 24' aria-hidden='true'>"
+            "<path fill='#fff' d='M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z'/>"
+            "<path fill='#34A853' d='M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z'/>"
+            "<path fill='#FBBC05' d='M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z'/>"
+            "<path fill='#EA4335' d='M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z'/>"
+            "</svg>"
+            "Accedi con Google"
+            "</a>"
+            "<p class='teacher'>Sei docente? <a href='/tools/course_board.html'>Accedi alla dashboard</a></p>"
+            "</main>"
+            "</div>"
             "</body></html>"
         ).encode("utf-8")
         self.send_response(200)
@@ -6733,7 +6747,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         self.send_header(
             "Content-Security-Policy",
             "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; "
-            "form-action 'none'; style-src 'unsafe-inline'",
+            "form-action 'none'; style-src 'unsafe-inline'; img-src https://www.thebitpoets.com",
         )
         self.send_header("X-Content-Type-Options", "nosniff")
         self.send_header("X-Frame-Options", "DENY")

--- a/scripts/thebitlab_auth_styles.py
+++ b/scripts/thebitlab_auth_styles.py
@@ -1,0 +1,175 @@
+"""Shared CSS for TheBitLab authentication and administration pages."""
+
+AUTH_PAGE_CSS = """
+:root {
+  --bg: #fafafa;
+  --ink: #1a1a1e;
+  --soft: #5a5a62;
+  --faint: #7a7a82;
+  --card: #ffffff;
+  --line: #e6e6ea;
+  --accent: #1a1a1e;
+  --accent-inverted: #ffffff;
+  --google: #4285F4;
+  --ok: #2e7d32;
+  --mono: "Cascadia Code", "JetBrains Mono", "Fira Code", Consolas, monospace;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  min-height: 100vh;
+}
+.topNav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+  padding: .65rem clamp(1rem, 3vw, 3rem);
+  border-bottom: 1px solid rgba(26, 26, 30, .12);
+  background: rgba(255, 255, 255, .94);
+  backdrop-filter: blur(10px);
+}
+.topNavBrand {
+  display: grid;
+  place-items: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  margin-right: .25rem;
+  border: 1px solid rgba(26, 26, 30, .14);
+  border-radius: .7rem;
+  background: #ffffff;
+  overflow: hidden;
+}
+.topNavBrand img { width: 100%; height: 100%; object-fit: contain; }
+.topNavTitle { font-weight: 650; font-size: .95rem; }
+.topNavTitle span { color: var(--soft); font-weight: 400; margin-left: .5rem; }
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem clamp(1rem, 3vw, 3rem);
+}
+h1 { font-size: 1.3rem; margin-bottom: 1.25rem; letter-spacing: -.02em; }
+.card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.04);
+}
+.card h2 {
+  font-size: 1.05rem;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+.badge {
+  font-size: .7rem;
+  padding: .15rem .45rem;
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--soft);
+  border: 1px solid var(--line);
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.25rem;
+  align-items: start;
+}
+table { width: 100%; border-collapse: collapse; font-size: .9rem; }
+th, td { text-align: left; padding: .55rem 0; border-bottom: 1px solid var(--line); }
+th {
+  color: var(--soft);
+  font-weight: 500;
+  font-size: .8rem;
+  text-transform: uppercase;
+  letter-spacing: .03em;
+}
+.mono { font-family: var(--mono); font-size: .85rem; }
+form.row {
+  display: flex;
+  gap: .5rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+input, select {
+  padding: .55rem .7rem;
+  border: 1px solid var(--line);
+  border-radius: .5rem;
+  background: #fff;
+  color: var(--ink);
+  font: inherit;
+}
+input.small { width: 8rem; }
+button, .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  padding: .55rem 1rem;
+  border-radius: .5rem;
+  border: none;
+  background: var(--accent);
+  color: var(--accent-inverted);
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  transition: filter .15s;
+}
+button:hover, .btn:hover { filter: brightness(0.95); }
+button.secondary { background: #fff; color: var(--ink); border: 1px solid var(--line); }
+button.ok { background: var(--ok); }
+.pending-item { padding: .9rem 0; border-bottom: 1px solid var(--line); }
+.pending-item:last-child { border-bottom: none; }
+.pending-item .email { font-weight: 500; font-size: .9rem; margin-bottom: .35rem; }
+.pending-item .meta { color: var(--soft); font-size: .8rem; margin-bottom: .6rem; }
+.hint { color: var(--faint); font-size: .8rem; margin-top: .75rem; }
+.login-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+.login-card {
+  width: min(420px, 100%);
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 1.25rem;
+  padding: 2.5rem;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.06);
+  text-align: center;
+}
+.login-brand {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto 1.25rem;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+.login-brand img { width: 100%; height: 100%; object-fit: contain; }
+.login-card h1 { font-size: 1.45rem; font-weight: 650; margin-bottom: .35rem; }
+.login-card p.sub { color: var(--soft); font-size: .95rem; margin-bottom: 1.75rem; }
+.login-card .btn-google {
+  width: 100%;
+  padding: .85rem 1rem;
+  border-radius: .65rem;
+  background: var(--google);
+  color: #fff;
+}
+.login-card .teacher {
+  margin-top: 1.25rem;
+  font-size: .85rem;
+  color: var(--faint);
+}
+.login-card .teacher a { color: var(--ink); text-underline-offset: .15rem; }
+.account-card { max-width: 520px; margin: 0 auto; text-align: center; padding-top: 3rem; }
+.account-card h1 { font-size: 1.45rem; margin-bottom: .75rem; }
+.account-card p { color: var(--soft); margin-bottom: 1.5rem; }
+.account-card .btn { margin-top: .25rem; }
+"""

--- a/scripts/thebitlab_session_http.py
+++ b/scripts/thebitlab_session_http.py
@@ -19,6 +19,7 @@ from scripts.thebitlab_edge_rate_limit import (
     EdgeRequestMetadata,
     TrustedProxyClientResolver,
 )
+from scripts.thebitlab_auth_styles import AUTH_PAGE_CSS
 from scripts.thebitlab_http_auth import (
     HttpAuthError,
     HttpAuthRequest,
@@ -320,23 +321,41 @@ class SessionHttpRoutes:
             message = (
                 "L'account studente è autorizzato. Puoi associare la TUI da questo browser."
             )
-            action = '<p><a href="/auth/tui/pair">Associa la TUI</a></p>'
+            action = '<p><a class="btn" href="/auth/tui/pair">Associa la TUI</a></p>'
         elif role == "teacher":
             title = "Area docente"
             message = (
                 "L'account docente è autorizzato. "
                 "La Board mantiene una protezione docente separata."
             )
-            action = '<p><a href="/tools/course_board.html">Apri la Course Design Board</a></p>'
+            action = '<p><a class="btn" href="/tools/course_board.html">Apri la Course Design Board</a></p>'
         else:
             title = "Area amministratore"
             message = "L'account amministratore è autorizzato."
-            action = '<p><a href="/auth/admin">Gestisci utenti e classi</a></p>'
+            action = '<p><a class="btn" href="/auth/admin">Gestisci utenti e classi</a></p>'
+        logo_url = "https://www.thebitpoets.com/assets/logo-400.png"
+        logo_srcset = (
+            "https://www.thebitpoets.com/assets/logo-400.png 400w, "
+            "https://www.thebitpoets.com/assets/logo-521.png 521w"
+        )
         body = (
-            "<!doctype html><html lang=\"it\"><head><meta charset=\"utf-8\">"
-            "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
-            f"<title>{title} - TheBitLab</title></head><body><main><h1>{title}</h1>"
-            f"<p>{message}</p>{action}</main></body></html>"
+            "<!doctype html>"
+            "<html lang='it'><head>"
+            "<meta charset='utf-8'>"
+            "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+            f"<title>{title} - TheBitLab</title>"
+            f"<style>{AUTH_PAGE_CSS}</style>"
+            "</head><body>"
+            "<nav class='topNav'>"
+            f"<a class='topNavBrand' href='/'><img src='{logo_url}' "
+            f"srcset='{logo_srcset}' sizes='40px' width='40' height='40' alt='TheBitLab'></a>"
+            "<div class='topNavTitle'>TheBitLab</div>"
+            "</nav>"
+            "<main><div class='account-card card'>"
+            f"<h1>{title}</h1>"
+            f"<p>{message}</p>{action}"
+            "</div></main>"
+            "</body></html>"
         ).encode("utf-8")
         return SessionHttpResponse(
             200,
@@ -344,7 +363,8 @@ class SessionHttpRoutes:
                 (
                     "Content-Security-Policy",
                     "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; "
-                    "form-action 'none'",
+                    "form-action 'none'; style-src 'unsafe-inline'; "
+                    "img-src https://www.thebitpoets.com",
                 ),
                 ("X-Content-Type-Options", "nosniff"),
                 ("X-Frame-Options", "DENY"),
@@ -422,7 +442,7 @@ class SessionHttpRoutes:
                 row = render(item)
                 size = len(row.encode("utf-8"))
                 if size > budget:
-                    rows.append("<li>Elenco troncato</li>")
+                    rows.append('<p class="hint">Elenco troncato</p>')
                     break
                 rows.append(row)
                 budget -= size
@@ -433,35 +453,66 @@ class SessionHttpRoutes:
             revision = html.escape(_utc_z(user.updated_at), quote=True)
             name = html.escape(user.display_name)
             return (
-                f'<li><code>{user_id}</code> — {name}'
-                f'<form data-endpoint="{_ADMIN_APPROVALS_PATH}" data-user="{user_id}" '
-                f'data-revision="{revision}"><label>Ruolo <select name="role">'
-                '<option value="student">Studente</option><option value="teacher">Docente</option>'
-                '</select></label><label>ID classe per studente '
-                '<input name="class_id" maxlength="512"></label>'
-                '<button type="submit">Approva</button></form></li>'
+                '<div class="pending-item">'
+                f'<div class="email">{name}</div>'
+                f'<div class="meta">Google • ID <span class="mono">{user_id}</span></div>'
+                f'<form class="row" data-endpoint="{_ADMIN_APPROVALS_PATH}" data-user="{user_id}" '
+                f'data-revision="{revision}">'
+                '<select name="role">'
+                '<option value="student">Studente</option>'
+                '<option value="teacher">Docente</option>'
+                '<option value="admin">Amministratore</option>'
+                '</select>'
+                '<input name="class_id" maxlength="512" placeholder="ID classe per studente">'
+                '<button class="ok" type="submit">Approva</button></form></div>'
             )
 
+        pending_users = list(snapshot.pending_users)
+        class_list = list(snapshot.classes)
         pending = bounded_rows(
-            snapshot.pending_users,
+            pending_users,
             pending_row,
-            "<li>Nessun account pending</li>",
+            '<p class="hint">Nessun account pending</p>',
         )
         classes = bounded_rows(
-            snapshot.classes,
-            lambda item: f"<li><code>{html.escape(item.class_id)}</code> — {html.escape(item.label)}</li>",
-            "<li>Nessuna classe</li>",
+            class_list,
+            lambda item: (
+                "<tr>"
+                f'<td class="mono">{html.escape(item.class_id)}</td>'
+                f'<td>{html.escape(item.label)}</td>'
+                f'<td>{html.escape(getattr(item, "school_year", ""))}</td>'
+                "</tr>"
+            ),
+            '<tr><td colspan="3" class="hint">Nessuna classe</td></tr>',
+        )
+        logo_url = "https://www.thebitpoets.com/assets/logo-400.png"
+        logo_srcset = (
+            "https://www.thebitpoets.com/assets/logo-400.png 400w, "
+            "https://www.thebitpoets.com/assets/logo-521.png 521w"
         )
         body = (
-            "<!doctype html><html lang=\"it\"><head><meta charset=\"utf-8\">"
-            "<title>Amministrazione - TheBitLab</title></head><body><main>"
-            "<h1>Amministrazione</h1><h2>Crea classe</h2>"
-            f'<form data-endpoint="{_ADMIN_CLASSES_PATH}"><label>ID <input name="class_id" '
-            'maxlength="512" required></label><label>Nome <input name="label" maxlength="512" '
-            'required></label><label>Anno scolastico <input name="school_year" maxlength="512" '
-            'required></label><button type="submit">Crea classe</button></form>'
-            f"<h2>Account pending</h2><ul>{pending}</ul>"
-            f"<h2>Classi</h2><ul>{classes}</ul></main>"
+            "<!doctype html><html lang='it'><head><meta charset='utf-8'>"
+            "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+            "<title>Amministrazione - TheBitLab</title>"
+            f"<style>{AUTH_PAGE_CSS}</style></head><body>"
+            "<nav class='topNav'>"
+            f"<a class='topNavBrand' href='/'><img src='{logo_url}' "
+            f"srcset='{logo_srcset}' sizes='40px' width='40' height='40' alt='TheBitLab'></a>"
+            "<div class='topNavTitle'>TheBitLab<span>Gestione utenti e classi</span></div>"
+            "</nav>"
+            "<main><h1>Amministrazione</h1><div class='grid'>"
+            f'<section class="card"><h2>Classi <span class="badge">{len(class_list)}</span></h2>'
+            "<table><thead><tr><th>ID</th><th>Nome</th><th>Anno</th></tr></thead>"
+            f"<tbody>{classes}</tbody></table>"
+            f'<form class="row" data-endpoint="{_ADMIN_CLASSES_PATH}">'
+            '<input class="small" name="class_id" maxlength="512" placeholder="ID classe" required>'
+            '<input name="label" maxlength="512" placeholder="Nome classe" required>'
+            '<input class="small" name="school_year" maxlength="512" placeholder="Anno scolastico" required>'
+            '<button type="submit">Crea classe</button></form></section>'
+            f'<section class="card"><h2>Utenti in attesa <span class="badge">{len(pending_users)}</span></h2>'
+            f"{pending}"
+            '<p class="hint">Gli utenti approvati ricevono il ruolo e la classe selezionati.</p></section>'
+            "</div></main>"
             f"<script>{_ADMIN_SCRIPT}</script></body></html>"
         ).encode("utf-8")
         return SessionHttpResponse(
@@ -472,7 +523,8 @@ class SessionHttpRoutes:
                     "Content-Security-Policy",
                     "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; "
                     f"script-src 'sha256-{_ADMIN_SCRIPT_HASH}'; connect-src 'self'; "
-                    "form-action 'none'",
+                    "form-action 'none'; style-src 'unsafe-inline'; "
+                    "img-src https://www.thebitpoets.com",
                 ),
                 ("X-Content-Type-Options", "nosniff"),
                 ("X-Frame-Options", "DENY"),


### PR DESCRIPTION
Unifica lo stile grafico delle pagine di autenticazione e amministrazione con il design del sito statico e della dashboard.

Cambiamenti:
- nuovo modulo scripts/thebitlab_auth_styles.py con CSS condiviso (palette chiara, card, top navigation, bottoni);
- pagina /login rinnovata: card centrata con logo, titolo, bottone "Accedi con Google", link per docenti;
- pagina /auth/account rinnovata per tutti i ruoli (pending, studente, docente, amministratore);
- pagina /auth/admin rinnovata: top navigation, card Classi (tabella + form creazione) e card Utenti pending;
- CSP aggiornate per permettere style inline e il caricamento del logo dal sito statico;
- test esistenti passano.
