### PR TITLE
fix(tui-pairing): Content-Length: 0 per POST vuote

### DIFF
--- a/scripts/thebitlab_tui_pairing_client.py
+++ b/scripts/thebitlab_tui_pairing_client.py
@@ -112,6 +112,7 @@ class TuiPairingClient:
             request = urllib.request.Request(
                 self.server_url + "/auth/tui/pairings",
                 data=b"",
+                headers={"Content-Length": "0"},
                 method="POST",
             )
             try:
@@ -193,6 +194,7 @@ class TuiPairingClient:
                     headers={
                         "Authorization": authorization,
                         "X-TUI-Logout-Proof": credential.logout_proof,
+                        "Content-Length": "0",
                     },
                     method="POST",
                 )


### PR DESCRIPTION
Corregge il pairing TUI in produzione: il server rifiutava le richieste POST vuote di /auth/tui/pairings e /auth/tui/logout perche' mancava l'header Content-Length.

Il client TUI ora include esplicitamente Content-Length: 0 per tutte le richieste POST con body vuoto.
