### PR TITLE
fix(student-lab): validazione GET /api/student-lab/me

### DIFF
--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -5405,7 +5405,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 ) if parsed.query else []
             except ValueError:
                 raise thebitlab_http_auth.HttpBadRequestError() from None
-            if parsed.path == "/api/student-lab/assignments":
+            if parsed.path == "/api/student-lab/me":
+                valid = len(pairs) == 0
+            elif parsed.path == "/api/student-lab/assignments":
                 valid = len(pairs) <= 1 and all(
                     key == "now" and 0 < len(value) <= 128 for key, value in pairs
                 )


### PR DESCRIPTION
Corregge la validazione delle richieste API studente per il nuovo endpoint /api/student-lab/me.

La validazione si aspettava una query assignment_id per tutti i path tranne /assignments, quindi /api/student-lab/me senza query veniva rifiutato con 400 Bad Request. Ora /api/student-lab/me e' consentito senza parametri.
