### PR TITLE
feat(tui): apri workspace con editor configurabile

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -294,8 +294,16 @@ la selezione viene inviata a `POST /api/student-lab/final-attempt`: il server ri
 consegna e tentativo sui propri dati. Senza token, la stessa operazione applicativa lavora sulla root locale.
 
 Il comando `v` cerca un editor terminale nell'ordine `micro`, `nvim`, `vim`, `hx`, `nano` (e `notepad` su Windows).
-Per scegliere esplicitamente un editor, imposta `THEBITLAB_EDITOR`, per esempio `micro --clean` o `nvim`.
-L'editor viene eseguito nella cartella della consegna e apre il file sorgente indicato dall'activity.
+`micro` e' l'editor minimale di default: e' un binario piccolo, ha syntax highlighting, supporto mouse e
+keybinding intuitivi (`Ctrl+S` salva, `Ctrl+Q` esce). Per scegliere esplicitamente un editor, imposta
+`THEBITLAB_EDITOR`, per esempio `micro --clean` o `nvim`. L'editor viene eseguito nella cartella della
+consegna e apre il file sorgente indicato dall'activity.
+
+Il comando `o` apre la cartella del workspace. Se e' configurato un editor in grado di aprire cartelle
+(come VS Code, VSCodium, Cursor o Zed), `o` apre la cartella direttamente nell'editor; in alternativa
+la apre con il file manager di sistema. Per forzare un programma diverso solo per `o`, imposta
+`THEBITLAB_WORKSPACE_EDITOR` (ad esempio `code` o `zed`). Se non e' impostato nulla, viene usato
+`THEBITLAB_EDITOR` solo se riconosciuto come editor che supporta le cartelle, altrimenti il file manager.
 
 Il comando `l` apre il layout della vista consegna. Ogni sezione del dettaglio diventa un pannello separato;
 la disposizione iniziale li distribuisce in due colonne. Per ora il controllo principale e' il ridimensionamento:

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -1339,19 +1339,77 @@ def supports_color(no_color: bool = False) -> bool:
     return sys.stdout.isatty()
 
 
-def open_workspace(path_value: str, root: Path = PROJECT_ROOT) -> bool:
-    """Open a workspace folder with the platform file manager."""
+_FOLDER_CAPABLE_EDITORS = frozenset(
+    {
+        "code",
+        "code-insiders",
+        "code-oss",
+        "codium",
+        "vscodium",
+        "cursor",
+        "zed",
+        "fleet",
+        "subl",
+        "atom",
+        "gedit",
+        "kate",
+        "mousepad",
+        "notepadqq",
+        "geany",
+        "brackets",
+    }
+)
+
+
+def _is_folder_capable_editor(command: list[str]) -> bool:
+    if not command:
+        return False
+    basename = Path(command[0]).stem.lower()
+    return basename in _FOLDER_CAPABLE_EDITORS
+
+
+def _open_file_manager(path: Path) -> None:
+    """Open a folder with the platform file manager."""
+
+    if os.name == "nt":
+        os.startfile(path)  # type: ignore[attr-defined]
+        return
+    opener = "open" if sys.platform == "darwin" else "xdg-open"
+    subprocess.Popen([opener, str(path)])
+
+
+def open_workspace(
+    path_value: str,
+    root: Path = PROJECT_ROOT,
+    workspace_editor: str | None = None,
+) -> tuple[bool, str]:
+    """Open a workspace folder with the configured editor or the file manager."""
 
     raw_path = Path(path_value)
     path = raw_path if raw_path.is_absolute() else (root / raw_path).resolve(strict=False)
     if not path.is_dir():
-        return False
-    if os.name == "nt":
-        os.startfile(path)  # type: ignore[attr-defined]
-        return True
-    opener = "open" if sys.platform == "darwin" else "xdg-open"
-    subprocess.Popen([opener, str(path)])
-    return True
+        return False, "Workspace non disponibile."
+
+    explicit_workspace_editor = str(
+        workspace_editor or os.environ.get("THEBITLAB_WORKSPACE_EDITOR", "")
+    ).strip()
+    explicit_editor = str(os.environ.get("THEBITLAB_EDITOR", "")).strip()
+
+    for candidate in (explicit_workspace_editor, explicit_editor):
+        if not candidate:
+            continue
+        command = editor_command(candidate)
+        if command is None:
+            continue
+        if _is_folder_capable_editor(command):
+            try:
+                subprocess.run([*command, str(path)], cwd=str(path), check=False)
+                return True, f"Aperto in {command[0]}."
+            except OSError as error:
+                return False, f"Editor non avviabile: {error}"
+
+    _open_file_manager(path)
+    return True, "Cartella aperta."
 
 
 EDITOR_CANDIDATES = ("micro", "nvim", "vim", "hx", "nano")
@@ -1659,8 +1717,11 @@ def run_tui(
                 continue
             if action == "o":
                 workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
-                if not open_workspace(clean_text(workspace.get("path"), ""), root=root):
-                    print_fn("Workspace non disponibile.")
+                ok, message = open_workspace(clean_text(workspace.get("path"), ""), root=root)
+                if not ok:
+                    print_fn(message or "Workspace non disponibile.")
+                else:
+                    print_fn(message)
                 input_fn("Premi invio per continuare...")
                 continue
             if action == "v":

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -2051,7 +2051,9 @@ def test_run_tui_keeps_saved_runner_result_when_remote_refresh_fails(monkeypatch
 
 
 def test_open_workspace_rejects_missing_path(tmp_path) -> None:
-    assert student_lab_cli.open_workspace(str(tmp_path / "missing")) is False
+    ok, message = student_lab_cli.open_workspace(str(tmp_path / "missing"))
+    assert ok is False
+    assert "non disponibile" in message
 
 
 def test_open_workspace_resolves_relative_path_from_root(monkeypatch, tmp_path) -> None:
@@ -2059,13 +2061,40 @@ def test_open_workspace_resolves_relative_path_from_root(monkeypatch, tmp_path) 
     workspace.mkdir(parents=True)
     opened = []
 
-    monkeypatch.setattr(
-        student_lab_cli,
-        "os",
-        SimpleNamespace(name="nt", startfile=opened.append),
-    )
+    monkeypatch.setattr(student_lab_cli, "_open_file_manager", opened.append)
 
-    assert student_lab_cli.open_workspace("student/assignments/python-base-somma-001", root=tmp_path) is True
+    ok, message = student_lab_cli.open_workspace("student/assignments/python-base-somma-001", root=tmp_path)
+    assert ok is True
+    assert opened == [workspace.resolve()]
+
+
+def test_open_workspace_uses_configured_folder_editor(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("THEBITLAB_WORKSPACE_EDITOR", "code")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+    monkeypatch.setattr(student_lab_cli.subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    ok, message = student_lab_cli.open_workspace(str(workspace), root=tmp_path)
+
+    assert ok is True
+    assert "code" in message
+    assert calls[0][0][0] == ["code", str(workspace.resolve())]
+    assert calls[0][1]["cwd"] == str(workspace.resolve())
+
+
+def test_open_workspace_falls_back_to_file_manager_when_editor_is_terminal(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("THEBITLAB_EDITOR", "micro")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: f"/bin/{name}")
+    opened = []
+    monkeypatch.setattr(student_lab_cli, "_open_file_manager", opened.append)
+
+    ok, message = student_lab_cli.open_workspace(str(workspace), root=tmp_path)
+
+    assert ok is True
     assert opened == [workspace.resolve()]
 
 


### PR DESCRIPTION
Permette di configurare l'apertura del workspace (`o` nella TUI):

- Nuova variabile `THEBITLAB_WORKSPACE_EDITOR` (es. `code`, `zed`) per aprire la cartella della consegna nell'editor preferito.
- Se non impostata, viene usata `THEBITLAB_EDITOR` solo se riconosciuto come editor che supporta cartelle (VS Code, VSCodium, Cursor, Zed, ...).
- Se l'editor configurato e' terminale (es. `micro`), `o` continua a usare il file manager di sistema.
- Default per editare file (`v`) resta `micro` come editor minimale.

Aggiornati test e `doc/STUDENT_LAB.md`.
