### PR TITLE
feat(tui): bundle micro editor e guida configurazione

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -294,16 +294,16 @@ la selezione viene inviata a `POST /api/student-lab/final-attempt`: il server ri
 consegna e tentativo sui propri dati. Senza token, la stessa operazione applicativa lavora sulla root locale.
 
 Il comando `v` cerca un editor terminale nell'ordine `micro`, `nvim`, `vim`, `hx`, `nano` (e `notepad` su Windows).
-`micro` e' l'editor minimale di default: e' un binario piccolo, ha syntax highlighting, supporto mouse e
-keybinding intuitivi (`Ctrl+S` salva, `Ctrl+Q` esce). Per scegliere esplicitamente un editor, imposta
-`THEBITLAB_EDITOR`, per esempio `micro --clean` o `nvim`. L'editor viene eseguito nella cartella della
-consegna e apre il file sorgente indicato dall'activity.
+`micro` e' l'editor minimale di default ed e' installato automaticamente nelle immagini del lab: e' un binario
+piccolo, ha syntax highlighting, supporto mouse e keybinding intuitivi (`Ctrl+S` salva, `Ctrl+Q` esce).
+L'editor viene eseguito nella cartella della consegna e apre il file sorgente indicato dall'activity.
 
-Il comando `o` apre la cartella del workspace. Se e' configurato un editor in grado di aprire cartelle
-(come VS Code, VSCodium, Cursor o Zed), `o` apre la cartella direttamente nell'editor; in alternativa
-la apre con il file manager di sistema. Per forzare un programma diverso solo per `o`, imposta
-`THEBITLAB_WORKSPACE_EDITOR` (ad esempio `code` o `zed`). Se non e' impostato nulla, viene usato
-`THEBITLAB_EDITOR` solo se riconosciuto come editor che supporta le cartelle, altrimenti il file manager.
+Il comando `o` apre la cartella del workspace. Senza configurazione usa il file manager di sistema
+(Esplora Risorse su Windows). Se si vuole aprire la cartella direttamente in un editor che lo supporta
+(VS Code, VSCodium, Cursor, Zed, ...), impostare `THEBITLAB_WORKSPACE_EDITOR`.
+
+Per una guida dettagliata alla configurazione di editor diversi, inclusi VS Code, Notepad++ e VSCodium,
+vedi [TUI_EDITOR_SETUP.md](TUI_EDITOR_SETUP.md).
 
 Il comando `l` apre il layout della vista consegna. Ogni sezione del dettaglio diventa un pannello separato;
 la disposizione iniziale li distribuisce in due colonne. Per ora il controllo principale e' il ridimensionamento:

--- a/doc/TUI_EDITOR_SETUP.md
+++ b/doc/TUI_EDITOR_SETUP.md
@@ -1,0 +1,168 @@
+# Configurare l'editor della TUI
+
+La TUI di TheBitLab integra di default l'editor **micro**:
+
+- piccolo e veloce (un solo binario);
+- syntax highlighting per C, Python, Markdown e molti altri linguaggi;
+- supporto mouse;
+- keybinding intuitivi (`Ctrl+S` salva, `Ctrl+Q` esce, `Ctrl+G` aiuto).
+
+`micro` viene installato automaticamente nelle immagini del lab (Windows e Linux).
+Lo studente non deve configurare nulla per iniziare.
+
+## Variabili d'ambiente
+
+| Variabile | Scopo |
+|-----------|-------|
+| `THEBITLAB_EDITOR` | Editor usato dal comando `v` per aprire il file sorgente della consegna. |
+| `THEBITLAB_WORKSPACE_EDITOR` | Programma usato dal comando `o` per aprire la cartella del workspace. |
+
+Se `THEBITLAB_WORKSPACE_EDITOR` non e' impostata, la TUI prova a usare `THEBITLAB_EDITOR` solo se e' un editor in grado di aprire cartelle (ad esempio VS Code, VSCodium, Cursor, Zed, Fleet, Sublime Text). Se l'editor non supporta le cartelle, `o` apre la cartella con il file manager di sistema.
+
+## Editor che supportano l'apertura di cartelle
+
+La TUI riconosce automaticamente i seguenti editor per il comando `o`:
+
+- `code`, `code-insiders`, `code-oss` (Visual Studio Code)
+- `codium`, `vscodium` (VSCodium)
+- `cursor`
+- `zed`
+- `fleet`
+- `subl` (Sublime Text)
+- `atom`
+- `gedit`
+- `kate`
+- `mousepad`
+- `notepadqq`
+- `geany`
+- `brackets`
+
+## Configurare Visual Studio Code
+
+### 1. Aggiungere `code` al PATH di Windows
+
+1. Apri **VS Code**.
+2. Premi `Ctrl+Shift+P` (o `Cmd+Shift+P` su macOS).
+3. Digita e seleziona: `Shell Command: Install 'code' command in PATH`.
+4. Chiudi e riapri il terminale.
+
+Verifica con:
+
+```powershell
+Get-Command code
+```
+
+oppure, nel Prompt dei comandi:
+
+```cmd
+where code
+```
+
+### 2. Impostare la variabile d'ambiente
+
+#### PowerShell (solo sessione corrente)
+
+```powershell
+$env:THEBITLAB_WORKSPACE_EDITOR = "code"
+$env:THEBITLAB_EDITOR = "code"
+```
+
+#### Prompt dei comandi (solo sessione corrente)
+
+```cmd
+set THEBITLAB_WORKSPACE_EDITOR=code
+set THEBITLAB_EDITOR=code
+```
+
+#### Resa permanente con `setx` (PowerShell)
+
+```powershell
+setx THEBITLAB_WORKSPACE_EDITOR "code"
+setx THEBITLAB_EDITOR "code"
+```
+
+> Dopo `setx` chiudi e riapri il terminale perche' le variabili non si applicano alla finestra corrente.
+
+#### Resa permanente dalle impostazioni Windows
+
+1. Cerca "Modifica le variabili di ambiente relative al sistema".
+2. Clicca su **Variabili d'ambiente**.
+3. Nella sezione **Variabili utente** clicca **Nuova**.
+4. Nome: `THEBITLAB_WORKSPACE_EDITOR`, Valore: `code`.
+5. Ripeti per `THEBITLAB_EDITOR` se vuoi usare VS Code anche per `v`.
+
+### 3. Usare la TUI
+
+```powershell
+cd E:\dev\2cornot2c
+python scripts\student_lab_cli.py --server-url https://app.thebitpoets.com --pair-browser
+```
+
+Dopo il pairing:
+
+- premi `v` per aprire il file sorgente in VS Code;
+- premi `o` per aprire la cartella del workspace in VS Code.
+
+## Configurare Notepad++ (Windows)
+
+Notepad++ apre file singoli, non cartelle. E' adatto al comando `v`:
+
+```cmd
+set THEBITLAB_EDITOR="C:\Program Files\Notepad++\notepad++.exe"
+```
+
+Il comando `o` continuera' a usare il file manager.
+
+## Configurare VSCodium
+
+VSCodium e' la versione open source di VS Code. Dopo averlo installato e averlo aggiunto al PATH, usa:
+
+```powershell
+$env:THEBITLAB_WORKSPACE_EDITOR = "codium"
+$env:THEBITLAB_EDITOR = "codium"
+```
+
+## Configurare editor Linux/macOS
+
+Su Linux e macOS le variabili si esportano nello shell:
+
+```bash
+export THEBITLAB_WORKSPACE_EDITOR="code"
+export THEBITLAB_EDITOR="micro"
+```
+
+Per renderle permanenti, aggiungi le due righe a `~/.bashrc` (Linux) o `~/.zshrc` (macOS).
+
+## Disabilitare l'editor personalizzato e tornare al default
+
+Rimuovi le variabili d'ambiente:
+
+```powershell
+Remove-Item Env:\THEBITLAB_WORKSPACE_EDITOR
+Remove-Item Env:\THEBITLAB_EDITOR
+```
+
+oppure, nel Prompt dei comandi:
+
+```cmd
+set THEBITLAB_WORKSPACE_EDITOR=
+set THEBITLAB_EDITOR=
+```
+
+A quel punto:
+
+- `v` tornera a cercare `micro`, `nvim`, `vim`, `hx`, `nano` (e `notepad` su Windows);
+- `o` aprira' la cartella con il file manager di sistema.
+
+## Risoluzione problemi
+
+### "Editor non avviabile: [WinError 2] Impossibile trovare il file specificato"
+
+L'eseguibile indicato non e' nel `PATH` oppure il percorso completo e' errato.
+Verifica con `where nome` (cmd) o `Get-Command nome` (PowerShell).
+
+### `o` apre il file manager invece di VS Code
+
+La variabile `THEBITLAB_WORKSPACE_EDITOR` non e' impostata oppure `THEBITLAB_EDITOR`
+punta a un editor che la TUI non riconosce come in grado di aprire cartelle.
+Imosta esplicitamente `THEBITLAB_WORKSPACE_EDITOR=code`.

--- a/packer/provision/toolchain.sh
+++ b/packer/provision/toolchain.sh
@@ -7,7 +7,33 @@ apt-get update
 apt-get install -y --no-install-recommends \
   build-essential \
   ca-certificates \
+  curl \
   gdb \
   git \
   make \
   vim
+
+MICRO_VERSION="2.0.14"
+MICRO_ARCH=""
+MICRO_SHA256=""
+case "$(uname -m)" in
+  x86_64)
+    MICRO_ARCH="linux64"
+    MICRO_SHA256="704e96add9b44e0041179f7934338d330e85230af6869f70b88720830f554786"
+    ;;
+  aarch64)
+    MICRO_ARCH="linux-arm64"
+    MICRO_SHA256="2e01b3ea62cdea3e62eb3ee99f6bffe84de06f689cf479173c4e7221b6613d06"
+    ;;
+  *)
+    echo "Architettura non supportata per micro: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+MICRO_TARBALL="micro-${MICRO_VERSION}-${MICRO_ARCH}.tar.gz"
+MICRO_URL="https://github.com/zyedidia/micro/releases/download/v${MICRO_VERSION}/${MICRO_TARBALL}"
+curl -fsSL -o "/tmp/${MICRO_TARBALL}" "${MICRO_URL}"
+echo "${MICRO_SHA256}  /tmp/${MICRO_TARBALL}" | sha256sum -c
+tar -xzf "/tmp/${MICRO_TARBALL}" -C /tmp "micro-${MICRO_VERSION}/micro"
+install -m 755 "/tmp/micro-${MICRO_VERSION}/micro" /usr/local/bin/micro
+rm -rf "/tmp/${MICRO_TARBALL}" "/tmp/micro-${MICRO_VERSION}"

--- a/scripts/bootstrap-classroom-windows.ps1
+++ b/scripts/bootstrap-classroom-windows.ps1
@@ -283,7 +283,7 @@ Write-Host "Directory: $InstallDir"
 Write-Host "[0/4] Controllo risorse..."
 Test-HostResources
 
-Write-Host "[1/4] Preparazione Git e Python 3.12..."
+Write-Host "[1/4] Preparazione Git, Python 3.12 e editor micro..."
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     Install-WingetPackage "Git.Git"
 } elseif (-not (Test-GitMinimumVersion)) {
@@ -292,6 +292,9 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
 }
 if (-not (Test-Python312)) {
     Install-WingetPackage "Python.Python.3.12"
+}
+if (-not (Get-Command micro -ErrorAction SilentlyContinue)) {
+    Install-WingetPackage "zyedidia.micro"
 }
 
 $env:Path = @(


### PR DESCRIPTION
Rende micro l'editor di default del lab e semplifica l'esperienza studente:

- micro viene installato automaticamente nelle immagini Linux (packer) e Windows (winget).
- `v` usa micro come default; `o` apre la cartella con il file manager di sistema, senza bisogno di configurazione.
- Chi vuole un editor diverso (VS Code, VSCodium, Notepad++, ...) trova la guida dettagliata in doc/TUI_EDITOR_SETUP.md.
- Aggiornato doc/STUDENT_LAB.md.
