### PR TITLE
fix(tui): editor apre file di fallback se manca source_name

### DIFF
--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -1435,6 +1435,22 @@ def editor_command(editor: str | None = None) -> list[str] | None:
     return None
 
 
+def _first_openable_source(workspace: Path) -> Path | None:
+    """Return a reasonable source file to open when no explicit source is given."""
+
+    if not workspace.is_dir():
+        return None
+    preferred = ("README.md", "readme.md", "main.c", "main.py")
+    for name in preferred:
+        candidate = workspace / name
+        if candidate.is_file():
+            return candidate
+    for candidate in sorted(workspace.iterdir()):
+        if candidate.is_file() and not candidate.name.startswith("."):
+            return candidate
+    return None
+
+
 def open_editor(
     workspace_path: str,
     source_name: str = "",
@@ -1451,9 +1467,11 @@ def open_editor(
     if command is None:
         return False, "Nessun editor disponibile. Imposta THEBITLAB_EDITOR o installa micro."
     source = clean_text(source_name, "")
-    target = workspace / source if source else workspace
-    if target != workspace and not target.is_file():
-        target = workspace
+    target = workspace / source if source else None
+    if target is None or not target.is_file():
+        target = _first_openable_source(workspace)
+    if target is None:
+        return False, "Nessun file sorgente apribile nel workspace."
     try:
         subprocess.run([*command, str(target)], cwd=str(workspace), check=False)
     except OSError as error:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -2123,6 +2123,22 @@ def test_open_editor_runs_source_in_workspace(monkeypatch, tmp_path) -> None:
     assert calls[0][1]["cwd"] == str(workspace)
 
 
+def test_open_editor_falls_back_to_first_file(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    readme = workspace / "README.md"
+    readme.write_text("# readme\n", encoding="utf-8")
+    calls = []
+    monkeypatch.setenv("THEBITLAB_EDITOR", "micro")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(student_lab_cli.subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    opened, message = student_lab_cli.open_editor(str(workspace), root=tmp_path)
+
+    assert opened is True
+    assert calls[0][0][0] == ["micro", str(readme)]
+
+
 def test_open_editor_reports_missing_editor(monkeypatch, tmp_path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()


### PR DESCRIPTION
Corregge il comando `v` quando l'activity non indica un file sorgente.

Prima passava la cartella del workspace all'editor, causando l'errore di micro "is a directory and cannot be opened". Ora `open_editor` sceglie automaticamente un file: README.md, main.c, main.py, o il primo file regolare presente.
