### PR TITLE
feat(tui): comando c per aprire terminale nel workspace

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -284,7 +284,8 @@ Comandi disponibili nella TUI minima:
 Nel dettaglio della consegna i comandi sono divisi in:
 
 - azioni principali: `e` esegue il runner e salva il report, `t` mostra lo storico e seleziona il tentativo
-  definitivo, `a` registra una richiesta di aiuto, `o` apre la cartella workspace, `v` apre l'editor;
+  definitivo, `a` registra una richiesta di aiuto, `o` apre la cartella workspace, `v` apre l'editor,
+  `c` apre un terminale nel workspace;
 - altri comandi: `h` mostra lo storico aiuti, `b` o invio torna alla lista, `q` esce.
 - navigazione `utui`: `j` scorre i pannelli verso il basso e `k` verso l'alto.
 
@@ -302,7 +303,11 @@ Il comando `o` apre la cartella del workspace. Senza configurazione usa il file 
 (Esplora Risorse su Windows). Se si vuole aprire la cartella direttamente in un editor che lo supporta
 (VS Code, VSCodium, Cursor, Zed, ...), impostare `THEBITLAB_WORKSPACE_EDITOR`.
 
-Per una guida dettagliata alla configurazione di editor diversi, inclusi VS Code, Notepad++ e VSCodium,
+Il comando `c` apre un terminale nella cartella del workspace. Su Windows preferisce Windows Terminal
+(`wt -d <cartella>`); se non e' installato apre il Prompt dei comandi. Da li lo studente puo' eseguire
+comandi come `code .` per avviare VS Code o `python main.py` per provare il programma.
+
+Per una guida dettagliata alla configurazione di editor diversi, inclusi VS Code, VSCodium, Notepad++ e VSCodium,
 vedi [TUI_EDITOR_SETUP.md](TUI_EDITOR_SETUP.md).
 
 Il comando `l` apre il layout della vista consegna. Ogni sezione del dettaglio diventa un pannello separato;

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -703,7 +703,7 @@ def render_utui_detail_commands() -> str:
     return "\n".join(
         (
             "Navigazione: j = scorri giu | k = scorri su | l = modifica layout",
-            "Azioni: e = test/report | t = tentativi | a = aiuto | o = workspace | v = editor",
+            "Azioni: e = test/report | t = tentativi | a = aiuto | o = workspace | v = editor | c = terminale",
             "Altri: h = storico aiuti | b/invio = lista | q = esci",
         )
     )
@@ -1451,6 +1451,57 @@ def _first_openable_source(workspace: Path) -> Path | None:
     return None
 
 
+def open_terminal(path_value: str, root: Path = PROJECT_ROOT) -> tuple[bool, str]:
+    """Open a terminal in the workspace directory.
+
+    On Windows prefer Windows Terminal (`wt -d <dir>`); fall back to cmd.
+    On macOS open Terminal.app; on Linux try common terminal emulators.
+    """
+
+    raw_path = Path(path_value)
+    path = raw_path if raw_path.is_absolute() else (root / raw_path).resolve(strict=False)
+    if not path.is_dir():
+        return False, "Workspace non disponibile."
+
+    if os.name == "nt":
+        wt = shutil.which("wt") or shutil.which("wt.exe")
+        if wt:
+            try:
+                subprocess.Popen([wt, "-d", str(path)])
+                return True, "Terminale Windows aperto."
+            except OSError as error:
+                return False, f"Terminale non avviabile: {error}"
+        try:
+            subprocess.Popen(["cmd", "/k", f"cd /d {path}"])
+            return True, "Prompt dei comandi aperto."
+        except OSError as error:
+            return False, f"Terminale non avviabile: {error}"
+
+    if sys.platform == "darwin":
+        try:
+            subprocess.Popen(["open", "-a", "Terminal", str(path)])
+            return True, "Terminale aperto."
+        except OSError as error:
+            return False, f"Terminale non avviabile: {error}"
+
+    candidates = [
+        ["gnome-terminal", "--working-directory", str(path)],
+        ["konsole", "--workdir", str(path)],
+        ["xfce4-terminal", "--working-directory", str(path)],
+        ["kitty", "--directory", str(path)],
+        ["alacritty", "--working-directory", str(path)],
+        ["xterm", "-cd", str(path)],
+    ]
+    for command in candidates:
+        if shutil.which(command[0]):
+            try:
+                subprocess.Popen(command)
+                return True, f"Terminale aperto ({command[0]})."
+            except OSError:
+                continue
+    return False, "Nessun terminale disponibile."
+
+
 def open_editor(
     workspace_path: str,
     source_name: str = "",
@@ -1751,6 +1802,15 @@ def run_tui(
                     root=root,
                 )
                 print_fn(message)
+                input_fn("Premi invio per continuare...")
+                continue
+            if action == "c":
+                workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+                ok, message = open_terminal(clean_text(workspace.get("path"), ""), root=root)
+                if not ok:
+                    print_fn(message or "Terminale non disponibile.")
+                else:
+                    print_fn(message)
                 input_fn("Premi invio per continuare...")
                 continue
             if action in {"l", "layout"}:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -2151,6 +2151,41 @@ def test_open_editor_reports_missing_editor(monkeypatch, tmp_path) -> None:
     assert "Nessun editor disponibile" in message
 
 
+def test_open_terminal_prefers_windows_terminal_on_windows(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(student_lab_cli.os, "name", "nt")
+    calls = []
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: str(tmp_path / name) if name == "wt" else None)
+    monkeypatch.setattr(student_lab_cli.subprocess, "Popen", lambda args: calls.append(args))
+
+    ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
+
+    assert ok is True
+    assert calls == [[str(tmp_path / "wt"), "-d", str(workspace.resolve())]]
+
+
+def test_open_terminal_falls_back_to_cmd_on_windows(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(student_lab_cli.os, "name", "nt")
+    calls = []
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(student_lab_cli.subprocess, "Popen", lambda args: calls.append(args))
+
+    ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
+
+    assert ok is True
+    assert calls[0][0] == "cmd"
+    assert calls[0][1] == "/k"
+
+
+def test_open_terminal_rejects_missing_path(tmp_path) -> None:
+    ok, message = student_lab_cli.open_terminal(str(tmp_path / "missing"))
+    assert ok is False
+    assert "non disponibile" in message
+
+
 def test_truncate_keeps_short_text_and_clips_long_text() -> None:
     assert student_lab_cli.truncate("abc", 5) == "abc"
     assert student_lab_cli.truncate("abcdef", 5) == "ab..."


### PR DESCRIPTION
Aggiunge il comando `c` nel dettaglio di una consegna: apre un terminale nella cartella del workspace.

Comportamento per piattaforma:
- Windows: Windows Terminal (`wt -d <dir>`) se disponibile, altrimenti Prompt dei comandi (`cmd /k cd /d <dir>`).
- macOS: Terminal.app.
- Linux: prova gnome-terminal, konsole, xfce4-terminal, kitty, alacritty, xterm.

Da li lo studente puo' eseguire `code .`, `python main.py`, ecc. Aggiornati doc e test.
