### PR TITLE
fix(tui): aggiungi terminale alla guida rapida

### DIFF
--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -588,6 +588,7 @@ def render_assignment_detail(
         "  t  Storico e tentativo definitivo",
         "  o  Apri workspace",
         "  v  Apri editor",
+        "  c  Apri terminale",
         "  l  Modifica layout pannelli",
         "",
         "Altri comandi",


### PR DESCRIPTION
Aggiunge il comando `c` (Apri terminale) nell'elenco "Azioni principali" della guida rapida TUI.
