### PR TITLE
fix(tui): correzioni post-review PR #667 (terminale workspace)

### DIFF
--- a/doc/STUDENT_LAB.md
+++ b/doc/STUDENT_LAB.md
@@ -307,7 +307,7 @@ Il comando `c` apre un terminale nella cartella del workspace. Su Windows prefer
 (`wt -d <cartella>`); se non e' installato apre il Prompt dei comandi. Da li lo studente puo' eseguire
 comandi come `code .` per avviare VS Code o `python main.py` per provare il programma.
 
-Per una guida dettagliata alla configurazione di editor diversi, inclusi VS Code, VSCodium, Notepad++ e VSCodium,
+Per una guida dettagliata alla configurazione di editor diversi, inclusi VS Code, VSCodium e Notepad++,
 vedi [TUI_EDITOR_SETUP.md](TUI_EDITOR_SETUP.md).
 
 Il comando `l` apre il layout della vista consegna. Ogni sezione del dettaglio diventa un pannello separato;

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -1455,13 +1455,13 @@ def _first_openable_source(workspace: Path) -> Path | None:
 def _windows_terminal_command(path: Path) -> tuple[list[str], dict[str, str], str]:
     wt = shutil.which("wt") or shutil.which("wt.exe")
     if wt:
-        return [wt, "-d", str(path)], {}, "Terminale Windows aperto."
+        return [wt, "-d", str(path)], {}, "windows-terminal"
     # /k keeps the window open after changing directory.
-    return ["cmd", "/k"], {"cwd": str(path)}, "Prompt dei comandi aperto."
+    return ["cmd", "/k"], {"cwd": str(path)}, "cmd"
 
 
 def _macos_terminal_command(path: Path) -> tuple[list[str], dict[str, str], str]:
-    return ["open", "-a", "Terminal", "."], {"cwd": str(path)}, "Terminale aperto."
+    return ["open", "-a", "Terminal", "."], {"cwd": str(path)}, "Terminal"
 
 
 def _linux_terminal_commands(path: Path) -> list[tuple[list[str], dict[str, str], str]]:
@@ -1477,7 +1477,6 @@ def _linux_terminal_commands(path: Path) -> list[tuple[list[str], dict[str, str]
 
 def _terminal_family() -> str:
     """Return the current platform family for terminal selection."""
-
     if os.name == "nt":
         return "nt"
     if sys.platform == "darwin":
@@ -1499,24 +1498,22 @@ def open_terminal(path_value: str, root: Path = PROJECT_ROOT) -> tuple[bool, str
 
     family = _terminal_family()
     if family == "nt":
-        command, kwargs, message = _windows_terminal_command(path)
+        command, kwargs, name = _windows_terminal_command(path)
     elif family == "darwin":
-        command, kwargs, message = _macos_terminal_command(path)
-    elif family == "posix":
-        for command, kwargs, message in _linux_terminal_commands(path):
+        command, kwargs, name = _macos_terminal_command(path)
+    else:
+        for command, kwargs, name in _linux_terminal_commands(path):
             if shutil.which(command[0]):
                 try:
                     subprocess.Popen(command, **kwargs)
-                    return True, f"Terminale aperto ({message})."
+                    return True, f"Terminale aperto ({name})."
                 except OSError:
                     continue
         return False, "Nessun terminale disponibile."
-    else:
-        return False, "Piattaforma non supportata."
 
     try:
         subprocess.Popen(command, **kwargs)
-        return True, message
+        return True, f"Terminale aperto ({name})."
     except OSError as error:
         return False, f"Terminale non avviabile: {error}"
 

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -1452,6 +1452,28 @@ def _first_openable_source(workspace: Path) -> Path | None:
     return None
 
 
+def _windows_terminal_command(path: Path) -> tuple[list[str], dict[str, str], str]:
+    wt = shutil.which("wt") or shutil.which("wt.exe")
+    if wt:
+        return [wt, "-d", str(path)], {}, "Terminale Windows aperto."
+    return ["cmd"], {"cwd": str(path)}, "Prompt dei comandi aperto."
+
+
+def _macos_terminal_command(path: Path) -> tuple[list[str], dict[str, str], str]:
+    return ["open", "-a", "Terminal", "."], {"cwd": str(path)}, "Terminale aperto."
+
+
+def _linux_terminal_commands(path: Path) -> list[tuple[list[str], dict[str, str], str]]:
+    return [
+        (["gnome-terminal", "--working-directory", str(path)], {"cwd": str(path)}, "gnome-terminal"),
+        (["konsole", "--workdir", str(path)], {"cwd": str(path)}, "konsole"),
+        (["xfce4-terminal", "--working-directory", str(path)], {"cwd": str(path)}, "xfce4-terminal"),
+        (["kitty", "--directory", str(path)], {"cwd": str(path)}, "kitty"),
+        (["alacritty", "--working-directory", str(path)], {"cwd": str(path)}, "alacritty"),
+        (["xterm", "-cd", str(path)], {"cwd": str(path)}, "xterm"),
+    ]
+
+
 def open_terminal(path_value: str, root: Path = PROJECT_ROOT) -> tuple[bool, str]:
     """Open a terminal in the workspace directory.
 
@@ -1465,42 +1487,24 @@ def open_terminal(path_value: str, root: Path = PROJECT_ROOT) -> tuple[bool, str
         return False, "Workspace non disponibile."
 
     if os.name == "nt":
-        wt = shutil.which("wt") or shutil.which("wt.exe")
-        if wt:
-            try:
-                subprocess.Popen([wt, "-d", str(path)])
-                return True, "Terminale Windows aperto."
-            except OSError as error:
-                return False, f"Terminale non avviabile: {error}"
-        try:
-            subprocess.Popen(["cmd", "/k", f"cd /d {path}"])
-            return True, "Prompt dei comandi aperto."
-        except OSError as error:
-            return False, f"Terminale non avviabile: {error}"
+        command, kwargs, message = _windows_terminal_command(path)
+    elif sys.platform == "darwin":
+        command, kwargs, message = _macos_terminal_command(path)
+    else:
+        for command, kwargs, message in _linux_terminal_commands(path):
+            if shutil.which(command[0]):
+                try:
+                    subprocess.Popen(command, **kwargs)
+                    return True, f"Terminale aperto ({message})."
+                except OSError:
+                    continue
+        return False, "Nessun terminale disponibile."
 
-    if sys.platform == "darwin":
-        try:
-            subprocess.Popen(["open", "-a", "Terminal", str(path)])
-            return True, "Terminale aperto."
-        except OSError as error:
-            return False, f"Terminale non avviabile: {error}"
-
-    candidates = [
-        ["gnome-terminal", "--working-directory", str(path)],
-        ["konsole", "--workdir", str(path)],
-        ["xfce4-terminal", "--working-directory", str(path)],
-        ["kitty", "--directory", str(path)],
-        ["alacritty", "--working-directory", str(path)],
-        ["xterm", "-cd", str(path)],
-    ]
-    for command in candidates:
-        if shutil.which(command[0]):
-            try:
-                subprocess.Popen(command)
-                return True, f"Terminale aperto ({command[0]})."
-            except OSError:
-                continue
-    return False, "Nessun terminale disponibile."
+    try:
+        subprocess.Popen(command, **kwargs)
+        return True, message
+    except OSError as error:
+        return False, f"Terminale non avviabile: {error}"
 
 
 def open_editor(

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -1456,7 +1456,8 @@ def _windows_terminal_command(path: Path) -> tuple[list[str], dict[str, str], st
     wt = shutil.which("wt") or shutil.which("wt.exe")
     if wt:
         return [wt, "-d", str(path)], {}, "Terminale Windows aperto."
-    return ["cmd"], {"cwd": str(path)}, "Prompt dei comandi aperto."
+    # /k keeps the window open after changing directory.
+    return ["cmd", "/k"], {"cwd": str(path)}, "Prompt dei comandi aperto."
 
 
 def _macos_terminal_command(path: Path) -> tuple[list[str], dict[str, str], str]:
@@ -1474,6 +1475,16 @@ def _linux_terminal_commands(path: Path) -> list[tuple[list[str], dict[str, str]
     ]
 
 
+def _terminal_family() -> str:
+    """Return the current platform family for terminal selection."""
+
+    if os.name == "nt":
+        return "nt"
+    if sys.platform == "darwin":
+        return "darwin"
+    return "posix"
+
+
 def open_terminal(path_value: str, root: Path = PROJECT_ROOT) -> tuple[bool, str]:
     """Open a terminal in the workspace directory.
 
@@ -1486,11 +1497,12 @@ def open_terminal(path_value: str, root: Path = PROJECT_ROOT) -> tuple[bool, str
     if not path.is_dir():
         return False, "Workspace non disponibile."
 
-    if os.name == "nt":
+    family = _terminal_family()
+    if family == "nt":
         command, kwargs, message = _windows_terminal_command(path)
-    elif sys.platform == "darwin":
+    elif family == "darwin":
         command, kwargs, message = _macos_terminal_command(path)
-    else:
+    elif family == "posix":
         for command, kwargs, message in _linux_terminal_commands(path):
             if shutil.which(command[0]):
                 try:
@@ -1499,6 +1511,8 @@ def open_terminal(path_value: str, root: Path = PROJECT_ROOT) -> tuple[bool, str
                 except OSError:
                     continue
         return False, "Nessun terminale disponibile."
+    else:
+        return False, "Piattaforma non supportata."
 
     try:
         subprocess.Popen(command, **kwargs)

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -2171,7 +2171,7 @@ def test_windows_terminal_command_falls_back_to_cmd(monkeypatch, tmp_path) -> No
 
     command, kwargs, message = student_lab_cli._windows_terminal_command(workspace)
 
-    assert command == ["cmd"]
+    assert command == ["cmd", "/k"]
     assert kwargs == {"cwd": str(workspace.resolve())}
 
 
@@ -2201,6 +2201,53 @@ def test_open_terminal_rejects_missing_path(tmp_path) -> None:
     ok, message = student_lab_cli.open_terminal(str(tmp_path / "missing"))
     assert ok is False
     assert "non disponibile" in message
+
+
+def test_open_terminal_runs_windows_command(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    calls = []
+    monkeypatch.setattr(student_lab_cli, "_terminal_family", lambda: "nt")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: str(tmp_path / name) if name == "wt" else None)
+    monkeypatch.setattr(
+        student_lab_cli.subprocess,
+        "Popen",
+        lambda args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
+
+    assert ok is True
+    assert calls == [([str(tmp_path / "wt"), "-d", str(workspace.resolve())], {})]
+
+
+def test_open_terminal_runs_macos_command(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    calls = []
+    monkeypatch.setattr(student_lab_cli, "_terminal_family", lambda: "darwin")
+    monkeypatch.setattr(
+        student_lab_cli.subprocess,
+        "Popen",
+        lambda args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
+
+    assert ok is True
+    assert calls == [(["open", "-a", "Terminal", "."], {"cwd": str(workspace.resolve())})]
+
+
+def test_open_terminal_reports_no_linux_terminal(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(student_lab_cli, "_terminal_family", lambda: "posix")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: None)
+
+    ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
+
+    assert ok is False
+    assert "Nessun terminale disponibile" in message
 
 
 def test_truncate_keeps_short_text_and_clips_long_text() -> None:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -2151,33 +2151,50 @@ def test_open_editor_reports_missing_editor(monkeypatch, tmp_path) -> None:
     assert "Nessun editor disponibile" in message
 
 
-def test_open_terminal_prefers_windows_terminal_on_windows(monkeypatch, tmp_path) -> None:
+def test_windows_terminal_command_prefers_wt(monkeypatch, tmp_path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    monkeypatch.setattr(student_lab_cli.os, "name", "nt")
-    calls = []
-    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: str(tmp_path / name) if name == "wt" else None)
-    monkeypatch.setattr(student_lab_cli.subprocess, "Popen", lambda args: calls.append(args))
+    wt_path = str(tmp_path / "wt")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: wt_path if name == "wt" else None)
 
-    ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
+    command, kwargs, message = student_lab_cli._windows_terminal_command(workspace)
 
-    assert ok is True
-    assert calls == [[str(tmp_path / "wt"), "-d", str(workspace.resolve())]]
+    assert command == [wt_path, "-d", str(workspace.resolve())]
+    assert kwargs == {}
+    assert "Windows" in message
 
 
-def test_open_terminal_falls_back_to_cmd_on_windows(monkeypatch, tmp_path) -> None:
-    workspace = tmp_path / "workspace"
+def test_windows_terminal_command_falls_back_to_cmd(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "consegna con spazi"
     workspace.mkdir()
-    monkeypatch.setattr(student_lab_cli.os, "name", "nt")
-    calls = []
     monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: None)
-    monkeypatch.setattr(student_lab_cli.subprocess, "Popen", lambda args: calls.append(args))
 
-    ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
+    command, kwargs, message = student_lab_cli._windows_terminal_command(workspace)
 
-    assert ok is True
-    assert calls[0][0] == "cmd"
-    assert calls[0][1] == "/k"
+    assert command == ["cmd"]
+    assert kwargs == {"cwd": str(workspace.resolve())}
+
+
+def test_macos_terminal_command_uses_cwd(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    command, kwargs, message = student_lab_cli._macos_terminal_command(workspace)
+
+    assert command == ["open", "-a", "Terminal", "."]
+    assert kwargs == {"cwd": str(workspace.resolve())}
+
+
+def test_linux_terminal_commands_include_common_emulators(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    candidates = student_lab_cli._linux_terminal_commands(workspace)
+    names = [cmd[0] for cmd, _, _ in candidates]
+
+    assert "gnome-terminal" in names
+    assert "xfce4-terminal" in names
+    assert all(kwargs.get("cwd") == str(workspace.resolve()) for _, kwargs, _ in candidates)
 
 
 def test_open_terminal_rejects_missing_path(tmp_path) -> None:

--- a/tests/test_student_lab_cli.py
+++ b/tests/test_student_lab_cli.py
@@ -2157,11 +2157,11 @@ def test_windows_terminal_command_prefers_wt(monkeypatch, tmp_path) -> None:
     wt_path = str(tmp_path / "wt")
     monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: wt_path if name == "wt" else None)
 
-    command, kwargs, message = student_lab_cli._windows_terminal_command(workspace)
+    command, kwargs, name = student_lab_cli._windows_terminal_command(workspace)
 
     assert command == [wt_path, "-d", str(workspace.resolve())]
     assert kwargs == {}
-    assert "Windows" in message
+    assert name == "windows-terminal"
 
 
 def test_windows_terminal_command_falls_back_to_cmd(monkeypatch, tmp_path) -> None:
@@ -2169,20 +2169,22 @@ def test_windows_terminal_command_falls_back_to_cmd(monkeypatch, tmp_path) -> No
     workspace.mkdir()
     monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: None)
 
-    command, kwargs, message = student_lab_cli._windows_terminal_command(workspace)
+    command, kwargs, name = student_lab_cli._windows_terminal_command(workspace)
 
     assert command == ["cmd", "/k"]
     assert kwargs == {"cwd": str(workspace.resolve())}
+    assert name == "cmd"
 
 
 def test_macos_terminal_command_uses_cwd(tmp_path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    command, kwargs, message = student_lab_cli._macos_terminal_command(workspace)
+    command, kwargs, name = student_lab_cli._macos_terminal_command(workspace)
 
     assert command == ["open", "-a", "Terminal", "."]
     assert kwargs == {"cwd": str(workspace.resolve())}
+    assert name == "Terminal"
 
 
 def test_linux_terminal_commands_include_common_emulators(tmp_path) -> None:
@@ -2218,6 +2220,7 @@ def test_open_terminal_runs_windows_command(monkeypatch, tmp_path) -> None:
     ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
 
     assert ok is True
+    assert "windows-terminal" in message
     assert calls == [([str(tmp_path / "wt"), "-d", str(workspace.resolve())], {})]
 
 
@@ -2235,7 +2238,28 @@ def test_open_terminal_runs_macos_command(monkeypatch, tmp_path) -> None:
     ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
 
     assert ok is True
+    assert "Terminal" in message
     assert calls == [(["open", "-a", "Terminal", "."], {"cwd": str(workspace.resolve())})]
+
+
+def test_open_terminal_runs_linux_command(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    calls = []
+    monkeypatch.setattr(student_lab_cli, "_terminal_family", lambda: "posix")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: name == "xfce4-terminal")
+    monkeypatch.setattr(
+        student_lab_cli.subprocess,
+        "Popen",
+        lambda args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
+
+    assert ok is True
+    assert "xfce4-terminal" in message
+    assert calls[0][0] == ["xfce4-terminal", "--working-directory", str(workspace.resolve())]
+    assert calls[0][1]["cwd"] == str(workspace.resolve())
 
 
 def test_open_terminal_reports_no_linux_terminal(monkeypatch, tmp_path) -> None:
@@ -2248,6 +2272,23 @@ def test_open_terminal_reports_no_linux_terminal(monkeypatch, tmp_path) -> None:
 
     assert ok is False
     assert "Nessun terminale disponibile" in message
+
+
+def test_open_terminal_reports_subprocess_error(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(student_lab_cli, "_terminal_family", lambda: "nt")
+    monkeypatch.setattr(student_lab_cli.shutil, "which", lambda name: str(tmp_path / name) if name == "wt" else None)
+
+    def failing_popen(*args, **kwargs):
+        raise OSError("nope")
+
+    monkeypatch.setattr(student_lab_cli.subprocess, "Popen", failing_popen)
+
+    ok, message = student_lab_cli.open_terminal(str(workspace), root=tmp_path)
+
+    assert ok is False
+    assert "Terminale non avviabile" in message
 
 
 def test_truncate_keeps_short_text_and_clips_long_text() -> None:


### PR DESCRIPTION
Corregge i problemi evidenziati dalla review retrospettiva di PR #667:

- fallback Windows sicuro con `cwd=` per path con spazi/metacaratteri;
- macOS apre Terminal nella directory corretta con `cwd=`;
- helper testabili per Windows, macOS e Linux;
- rimosso refuso doc (VSCodium duplicato);
- test estesi per tutte le piattaforme.
