### PR TITLE
Fix auth staging smoke compatibility and pairing checks

### DIFF
--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -28,12 +28,14 @@ from scripts import thebitlab_tui_pairing_client
 
 _MAX_BODY_BYTES = 32 * 1024
 _MAX_HEADER_BYTES = 32 * 1024
+_USER_AGENT = "TheBitLab-Auth-Smoke/1.0"
 _TRANSACTION_COOKIE_RE = re.compile(
     r"^__Host-thebitlab_oidc_txn-[0-9a-f]{24}=[A-Za-z0-9_-]{32,512}$"
 )
 _UNRESERVED_32_256_RE = re.compile(r"^[A-Za-z0-9_-]{32,256}$")
 _PKCE_CHALLENGE_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
 _CSP_NONCE_RE = re.compile(r"^'nonce-([A-Za-z0-9_-]{32})'$")
+_PAIRING_IMAGE_SOURCE = "https://www.thebitpoets.com"
 _GOOGLE_CLIENT_ID_RE = re.compile(
     r"^[A-Za-z0-9_-]{6,256}\.apps\.googleusercontent\.com$"
 )
@@ -338,10 +340,12 @@ def _check_pairing_page(response: ResponseSnapshot) -> None:
     if (
         csp_nonce is None
         or not parser.complete
-        or parser.script_nonces != [csp_nonce]
-        or parser.style_nonces != [csp_nonce]
-        or parser.script_ends != 1
-        or parser.style_ends != 1
+        or not parser.script_nonces
+        or any(nonce != csp_nonce for nonce in parser.script_nonces)
+        or parser.script_ends != len(parser.script_nonces)
+        or not parser.style_nonces
+        or any(nonce != csp_nonce for nonce in parser.style_nonces)
+        or parser.style_ends != len(parser.style_nonces)
         or not _repeated_header_is(response, "x-frame-options", "DENY")
         or not _repeated_header_is(
             response,
@@ -448,6 +452,7 @@ def _pairing_csp_nonce(directives: dict[str, list[str]]) -> str | None:
         "default-src",
         "script-src",
         "style-src",
+        "img-src",
         "connect-src",
         "base-uri",
         "form-action",
@@ -456,6 +461,7 @@ def _pairing_csp_nonce(directives: dict[str, list[str]]) -> str | None:
         return None
     if (
         directives["default-src"] != ["'none'"]
+        or directives["img-src"] != [_PAIRING_IMAGE_SOURCE]
         or directives["connect-src"] != ["'self'"]
         or directives["base-uri"] != ["'none'"]
         or directives["form-action"] != ["'none'"]
@@ -704,7 +710,12 @@ def _unique_object(pairs):
 
 
 def _request(method: str, url: str, timeout: float) -> ResponseSnapshot:
-    request = urllib.request.Request(url, data=b"" if method == "POST" else None, method=method)
+    request = urllib.request.Request(
+        url,
+        data=b"" if method == "POST" else None,
+        headers={"User-Agent": _USER_AGENT},
+        method=method,
+    )
     opener = urllib.request.build_opener(_NoRedirect())
     response = None
     body = None

--- a/scripts/thebitlab_auth_staging_smoke.py
+++ b/scripts/thebitlab_auth_staging_smoke.py
@@ -336,7 +336,7 @@ def _check_pairing_page(response: ResponseSnapshot) -> None:
         parser.close()
     except Exception:
         parser.invalid = True
-    visible_source = "".join(parser.data)
+    script_sources = ["".join(chunks) for chunks in parser.script_data]
     if (
         csp_nonce is None
         or not parser.complete
@@ -352,8 +352,8 @@ def _check_pairing_page(response: ResponseSnapshot) -> None:
             "x-content-type-options",
             "nosniff",
         )
-        or "/auth/session" not in visible_source
-        or "/auth/tui/pair" not in visible_source
+        or not any("/auth/session" in source for source in script_sources)
+        or not any("/auth/tui/pair" in source for source in script_sources)
     ):
         raise StagingSmokeError("Check staging pairing_page non valido.")
 
@@ -549,7 +549,7 @@ class _PairingPageParser(HTMLParser):
         self.style_nonces: list[str] = []
         self.script_ends = 0
         self.style_ends = 0
-        self.data: list[str] = []
+        self.script_data: list[list[str]] = []
         self.stack: list[str] = []
         self.seen = {"html": 0, "head": 0, "body": 0}
         self.inert_stack: list[str] = []
@@ -601,6 +601,8 @@ class _PairingPageParser(HTMLParser):
             return
         target = self.script_nonces if tag == "script" else self.style_nonces
         target.append(attrs[0][1])
+        if tag == "script":
+            self.script_data.append([])
         self.stack.append(tag)
 
     def handle_endtag(self, tag) -> None:
@@ -638,7 +640,7 @@ class _PairingPageParser(HTMLParser):
 
     def handle_data(self, data) -> None:
         if not self.inert_stack and self.stack and self.stack[-1] == "script":
-            self.data.append(data)
+            self.script_data[-1].append(data)
 
 
 def _require_response_framing(response: ResponseSnapshot) -> None:

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -169,6 +169,23 @@ def responses():
     })
 
 
+def _replace_pairing_body(fixtures, original: bytes, replacement: bytes) -> None:
+    key = ("GET", "https://school.test/auth/tui/pair")
+    current = fixtures[key]
+    changed_body = current.body.replace(original, replacement)
+    assert changed_body != current.body
+    fixtures[key] = smoke.ResponseSnapshot(
+        current.status,
+        tuple(
+            (name, str(len(changed_body)))
+            if name.lower() == "content-length"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        changed_body,
+    )
+
+
 def test_staging_smoke_validates_public_routes_without_exposing_secrets() -> None:
     fixtures = responses()
     calls = []
@@ -221,6 +238,66 @@ def test_staging_smoke_accepts_expected_image_source_and_multiple_nonce_styles()
     )
 
     assert all(check["ok"] for check in result["checks"])
+
+
+def test_staging_smoke_accepts_routes_in_separate_nonce_scripts() -> None:
+    fixtures = responses()
+    _replace_pairing_body(
+        fixtures,
+        b'/auth/session /auth/tui/pair</script>',
+        b'/auth/session</script>'
+        b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">'
+        b'/auth/tui/pair</script>',
+    )
+
+    result = smoke.run_smoke(
+        "https://school.test",
+        lambda method, url, timeout: fixtures[(method, url)],
+    )
+
+    assert all(check["ok"] for check in result["checks"])
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    (
+        b'/auth/ses</script>'
+        b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">'
+        b'sion /auth/tui/pair</script>',
+        b'/auth/session /auth/tui/</script>'
+        b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">pair</script>',
+    ),
+    ids=("session-split-between-scripts", "pair-split-between-scripts"),
+)
+def test_staging_smoke_rejects_route_split_between_nonce_scripts(replacement) -> None:
+    fixtures = responses()
+    _replace_pairing_body(
+        fixtures,
+        b'/auth/session /auth/tui/pair</script>',
+        replacement,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+def test_staging_smoke_rejects_duplicate_nonce_attributes() -> None:
+    fixtures = responses()
+    _replace_pairing_body(
+        fixtures,
+        b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">',
+        b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef" '
+        b'nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">',
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
 
 
 def test_staging_smoke_accepts_runtime_global_security_headers() -> None:

--- a/tests/test_thebitlab_auth_staging_smoke.py
+++ b/tests/test_thebitlab_auth_staging_smoke.py
@@ -112,7 +112,9 @@ def responses():
     )
     pairing_body = (
         b'<html><head><style nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">'
-        b'</style></head><body><script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">'
+        b'base</style><style nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">'
+        b'pairing</style></head><body>'
+        b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">'
         b'/auth/session /auth/tui/pair</script></body></html>'
     )
     return FreshResponses({
@@ -139,7 +141,7 @@ def responses():
                 ("Content-Type", "text/html; charset=utf-8"),
                 (
                     "Content-Security-Policy",
-                    "default-src 'none'; script-src 'nonce-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef'; style-src 'nonce-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef'; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+                    "default-src 'none'; script-src 'nonce-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef'; style-src 'nonce-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef'; img-src https://www.thebitpoets.com; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
                 ),
                 ("X-Frame-Options", "DENY"),
                 ("X-Content-Type-Options", "nosniff"),
@@ -204,6 +206,21 @@ def test_staging_smoke_validates_public_routes_without_exposing_secrets() -> Non
         *(key for key in fixtures if key != FreshResponses.LOGIN_KEY),
     ]
     assert all(call[2] == 30 for call in calls)
+
+
+def test_staging_smoke_accepts_expected_image_source_and_multiple_nonce_styles() -> None:
+    fixtures = responses()
+    pairing = fixtures[("GET", "https://school.test/auth/tui/pair")]
+
+    assert pairing.body.count(
+        b'<style nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">'
+    ) == 2
+    result = smoke.run_smoke(
+        "https://school.test",
+        lambda method, url, timeout: fixtures[(method, url)],
+    )
+
+    assert all(check["ok"] for check in result["checks"])
 
 
 def test_staging_smoke_accepts_runtime_global_security_headers() -> None:
@@ -556,6 +573,121 @@ def test_staging_smoke_rejects_conflicting_response_framing() -> None:
         )
 
 
+def test_staging_smoke_rejects_missing_img_src() -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/tui/pair")]
+    fixtures[("GET", "https://school.test/auth/tui/pair")] = smoke.ResponseSnapshot(
+        200,
+        tuple(
+            (
+                name,
+                value.replace(
+                    "img-src https://www.thebitpoets.com; ",
+                    "",
+                ),
+            )
+            if name.lower() == "content-security-policy"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        current.body,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+@pytest.mark.parametrize(
+    "image_sources",
+    (
+        "'self'",
+        "https://evil.test",
+        "https://www.thebitpoets.com https://evil.test",
+    ),
+)
+def test_staging_smoke_rejects_unexpected_image_sources(image_sources) -> None:
+    fixtures = responses()
+    current = fixtures[("GET", "https://school.test/auth/tui/pair")]
+    fixtures[("GET", "https://school.test/auth/tui/pair")] = smoke.ResponseSnapshot(
+        200,
+        tuple(
+            (
+                name,
+                value.replace(
+                    "img-src https://www.thebitpoets.com",
+                    f"img-src {image_sources}",
+                ),
+            )
+            if name.lower() == "content-security-policy"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        current.body,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
+@pytest.mark.parametrize(
+    ("original", "replacement"),
+    (
+        (
+            b'<style nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">pairing',
+            b"<style>pairing",
+        ),
+        (
+            b'<style nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">pairing',
+            b'<style nonce="ZYXWVUTSRQPONMLKJIHGFEDCBAabcdef">pairing',
+        ),
+        (
+            b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">',
+            b"<script>",
+        ),
+        (
+            b'<script nonce="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef">',
+            b'<script nonce="ZYXWVUTSRQPONMLKJIHGFEDCBAabcdef">',
+        ),
+    ),
+    ids=(
+        "style-without-nonce",
+        "style-with-different-nonce",
+        "script-without-nonce",
+        "script-with-different-nonce",
+    ),
+)
+def test_staging_smoke_rejects_inline_code_without_exact_csp_nonce(
+    original,
+    replacement,
+) -> None:
+    fixtures = responses()
+    key = ("GET", "https://school.test/auth/tui/pair")
+    current = fixtures[key]
+    changed_body = current.body.replace(original, replacement)
+    fixtures[key] = smoke.ResponseSnapshot(
+        200,
+        tuple(
+            (name, str(len(changed_body)))
+            if name.lower() == "content-length"
+            else (name, value)
+            for name, value in current.headers
+        ),
+        changed_body,
+    )
+
+    with pytest.raises(smoke.StagingSmokeError):
+        smoke.run_smoke(
+            "https://school.test",
+            lambda method, url, timeout: fixtures[(method, url)],
+        )
+
+
 def test_staging_smoke_rejects_csp_with_additional_sources() -> None:
     fixtures = responses()
     current = fixtures[("GET", "https://school.test/auth/tui/pair")]
@@ -703,6 +835,47 @@ def test_staging_smoke_rejects_external_script_even_with_valid_nonce() -> None:
             "https://school.test",
             lambda method, url, timeout: fixtures[(method, url)],
         )
+
+
+@pytest.mark.parametrize(("method", "expected_data"), [("GET", None), ("POST", b"")])
+def test_request_uses_explicit_stable_user_agent_for_get_and_post(
+    monkeypatch,
+    method,
+    expected_data,
+) -> None:
+    captured = []
+
+    class Response:
+        status = 204
+        headers = type("Headers", (), {"raw_items": lambda self: []})()
+
+        def read(self, size):
+            return b""
+
+        def close(self):
+            pass
+
+    class Opener:
+        def open(self, request, timeout):
+            captured.append((request, timeout))
+            return Response()
+
+    monkeypatch.setattr(
+        smoke.urllib.request,
+        "build_opener",
+        lambda *handlers: Opener(),
+    )
+
+    snapshot = smoke._request(method, "https://school.test/auth/test", 12.5)
+
+    assert snapshot.status == 204
+    assert len(captured) == 1
+    request, timeout = captured[0]
+    assert request.method == method
+    assert request.data == expected_data
+    assert request.get_header("User-agent") == "TheBitLab-Auth-Smoke/1.0"
+    assert not request.get_header("User-agent").startswith("Python-urllib/")
+    assert timeout == 12.5
 
 
 def test_staging_smoke_uses_one_absolute_deadline() -> None:


### PR DESCRIPTION
## Summary

### Explicit User-Agent / Cloudflare BIC
- Sends the stable explicit `TheBitLab-Auth-Smoke/1.0` User-Agent on both GET and POST requests so the smoke client is not classified as Python urllib by Cloudflare Browser Integrity Check.

### Fail-closed `pairing_page` checker alignment
- Aligns the pairing-page CSP contract with the released page by allowing exactly `img-src https://www.thebitpoets.com`.
- Supports multiple inline style/script tags only when every tag carries the exact expected CSP nonce; missing, different, extra, or external sources remain rejected.

## Verification

- **58 targeted tests PASS:** `python -m pytest -q tests/test_thebitlab_auth_staging_smoke.py`
- `python -m py_compile scripts/thebitlab_auth_staging_smoke.py tests/test_thebitlab_auth_staging_smoke.py` â€” PASS
- `git diff --check` â€” PASS

### Full real staging smoke
- **PASS (`ok: true`)**
- `google_login 302`
- `google_login_repeat 302`
- `anonymous_session 401`
- `pairing_page 200`
- `pairing_method 405`
- `anonymous_tui_logout 401`

## Security / scope

- No Cloudflare bypass or weakening was introduced; the client now identifies itself explicitly while Cloudflare protections remain enforced.
- VPS nginx changes are external infrastructure configuration and are intentionally not included in this repository commit.

Closes #681
Closes #682
