### PR TITLE
Add reusable student virtual-lab UI lifecycle

### DIFF
--- a/scripts/student_virtual_lab_cli.py
+++ b/scripts/student_virtual_lab_cli.py
@@ -11,7 +11,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import efesto_ui_server, student_lab_runner, student_lab_service, student_virtual_lab
+from scripts import (
+    efesto_ui_server,
+    student_lab_runner,
+    student_virtual_lab,
+    student_virtual_lab_ui,
+)
 
 
 def add_assignment_selection(parser: argparse.ArgumentParser) -> None:
@@ -60,32 +65,32 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def assignment_ui_session(args: argparse.Namespace) -> efesto_ui_server.EfestoUiSession:
+def load_selected_assignment(args: argparse.Namespace) -> dict:
     root = args.root.resolve(strict=False)
-    assignment = student_lab_runner.load_student_assignment(
+    return student_lab_runner.load_student_assignment(
         root=root,
         student_id=args.student_id,
         assignment_id=args.assignment_id,
         activity_id=args.activity_id,
         now=args.now,
     )
-    activity = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
-    workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
-    activity_path_value = str(activity.get("path") or "").strip()
-    workspace_path_value = str(workspace.get("path") or "").strip()
-    if not activity_path_value:
-        raise ValueError("activity.path mancante nella consegna")
-    if not workspace_path_value:
-        raise ValueError("workspace.path mancante nella consegna")
-    return efesto_ui_server.EfestoUiSession.load(
-        project_root=(args.runtime_root or root).resolve(strict=False),
-        activity_path=student_lab_service.resolve_local_path(root, activity_path_value),
-        workspace_path=student_lab_service.resolve_local_path(root, workspace_path_value),
+
+
+def assignment_ui_session(args: argparse.Namespace) -> efesto_ui_server.EfestoUiSession:
+    return student_virtual_lab_ui.session_for_assignment(
+        load_selected_assignment(args),
+        root=args.root,
+        runtime_root=args.runtime_root,
     )
 
 
 def run_ui_command(args: argparse.Namespace) -> int:
-    session = assignment_ui_session(args)
+    assignment = load_selected_assignment(args)
+    session = student_virtual_lab_ui.session_for_assignment(
+        assignment,
+        root=args.root,
+        runtime_root=args.runtime_root,
+    )
     server = efesto_ui_server.create_server(session, port=args.port)
     url = efesto_ui_server.session_url(server, session)
     print(f"Efesto UI: {url}")

--- a/scripts/student_virtual_lab_ui.py
+++ b/scripts/student_virtual_lab_ui.py
@@ -1,0 +1,137 @@
+"""Student-facing lifecycle adapter for local virtual-lab browser UIs."""
+
+from __future__ import annotations
+
+import atexit
+import webbrowser
+from pathlib import Path
+from typing import Any, Callable
+
+from scripts import efesto_ui_server, student_lab_service
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+OpenBrowserFn = Callable[[str], bool]
+
+
+def clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def is_virtual_lab_assignment(assignment: dict[str, Any]) -> bool:
+    """Return whether the student assignment advertises a virtual-lab artifact."""
+
+    activity = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
+    return clean_text(activity.get("language")).lower() == "virtual-lab"
+
+
+def session_for_assignment(
+    assignment: dict[str, Any],
+    *,
+    root: Path = PROJECT_ROOT,
+    runtime_root: Path | None = None,
+) -> efesto_ui_server.EfestoUiSession:
+    """Resolve trusted local paths and build an Efesto UI session."""
+
+    if not is_virtual_lab_assignment(assignment):
+        raise ValueError("La consegna selezionata non e un virtual-lab.")
+    activity = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
+    workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+    activity_path_value = clean_text(activity.get("path"))
+    workspace_path_value = clean_text(workspace.get("path"))
+    if not activity_path_value:
+        raise ValueError("activity.path mancante nella consegna.")
+    if not workspace_path_value:
+        raise ValueError("workspace.path mancante nella consegna.")
+
+    resolved_root = root.resolve(strict=False)
+    return efesto_ui_server.EfestoUiSession.load(
+        project_root=(runtime_root or resolved_root).resolve(strict=False),
+        activity_path=student_lab_service.resolve_local_path(resolved_root, activity_path_value),
+        workspace_path=student_lab_service.resolve_local_path(resolved_root, workspace_path_value),
+    )
+
+
+class StudentVirtualLabUiRegistry:
+    """Keep one local browser server per assignment while the TUI is alive."""
+
+    def __init__(self) -> None:
+        self._running: dict[str, efesto_ui_server.RunningEfestoUi] = {}
+        self._closed = False
+
+    def assignment_key(self, assignment: dict[str, Any]) -> str:
+        return clean_text(assignment.get("assignment_id")) or clean_text(assignment.get("activity_id"))
+
+    def open(
+        self,
+        assignment: dict[str, Any],
+        *,
+        root: Path = PROJECT_ROOT,
+        runtime_root: Path | None = None,
+        port: int = 0,
+        open_browser_fn: OpenBrowserFn = webbrowser.open,
+    ) -> tuple[efesto_ui_server.RunningEfestoUi, bool, bool]:
+        """Start or reuse a local UI and try to open it in the browser.
+
+        Returns `(running, reused, browser_opened)`.
+        """
+
+        if self._closed:
+            raise ValueError("Registro UI virtual-lab gia chiuso.")
+        key = self.assignment_key(assignment)
+        if not key:
+            raise ValueError("Identificativo consegna virtual-lab mancante.")
+        running = self._running.get(key)
+        reused = running is not None
+        if running is None:
+            session = session_for_assignment(
+                assignment,
+                root=root,
+                runtime_root=runtime_root,
+            )
+            running = efesto_ui_server.start_in_background(session, port=port)
+            self._running[key] = running
+        try:
+            opened = bool(open_browser_fn(running.url))
+        except (OSError, ValueError):
+            opened = False
+        return running, reused, opened
+
+    def close(self, assignment: dict[str, Any]) -> None:
+        key = self.assignment_key(assignment)
+        running = self._running.pop(key, None)
+        if running is not None:
+            running.close()
+
+    def close_all(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        running = list(self._running.values())
+        self._running.clear()
+        for item in running:
+            item.close()
+
+    def __len__(self) -> int:
+        return len(self._running)
+
+
+_PROCESS_REGISTRY = StudentVirtualLabUiRegistry()
+atexit.register(_PROCESS_REGISTRY.close_all)
+
+
+def open_assignment_ui(
+    assignment: dict[str, Any],
+    *,
+    root: Path = PROJECT_ROOT,
+    runtime_root: Path | None = None,
+    open_browser_fn: OpenBrowserFn = webbrowser.open,
+) -> tuple[efesto_ui_server.RunningEfestoUi, bool, bool]:
+    """Convenience entry point for CLI/TUI consumers using the process registry."""
+
+    return _PROCESS_REGISTRY.open(
+        assignment,
+        root=root,
+        runtime_root=runtime_root,
+        open_browser_fn=open_browser_fn,
+    )

--- a/tests/test_student_virtual_lab_ui.py
+++ b/tests/test_student_virtual_lab_ui.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scripts import student_virtual_lab, student_virtual_lab_ui
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+ACTIVITY_SOURCE = SOURCE_ROOT / "activities/examples/hardware_pcie_lane_sharing.json"
+SCENARIO_SOURCE = SOURCE_ROOT / "virtual-labs/efesto/scenarios/pcie-lane-sharing-001.json"
+STARTER_SOURCE = SOURCE_ROOT / "virtual-labs/efesto/starters/pcie-lane-sharing-001.json"
+ACTIVITY_ID = "hw-pcie-lane-sharing-001"
+SCENARIO_ID = "pcie-lane-sharing-001"
+
+
+def prepare_assignment(tmp_path: Path) -> tuple[Path, dict]:
+    root = tmp_path / "thebitlab"
+    activity_path = root / "activities/hardware.json"
+    scenario_path = root / "virtual-labs/efesto/scenarios" / f"{SCENARIO_ID}.json"
+    starter_path = root / "virtual-labs/efesto/starters" / f"{SCENARIO_ID}.json"
+    activity_path.parent.mkdir(parents=True)
+    scenario_path.parent.mkdir(parents=True)
+    starter_path.parent.mkdir(parents=True)
+    shutil.copyfile(ACTIVITY_SOURCE, activity_path)
+    shutil.copyfile(SCENARIO_SOURCE, scenario_path)
+    shutil.copyfile(STARTER_SOURCE, starter_path)
+
+    student_repo = root / "students/rossi-mario"
+    workspace = student_virtual_lab.create_virtual_lab_scaffold(
+        activity_path=activity_path,
+        target_dir=student_repo,
+        project_root=root,
+    )
+    assignment = {
+        "assignment_id": "assignment-hw-pcie-001",
+        "activity_id": ACTIVITY_ID,
+        "student_id": "rossi-mario",
+        "activity": {
+            "path": "activities/hardware.json",
+            "language": "virtual-lab",
+            "source_name": "build.json",
+        },
+        "workspace": {
+            "path": workspace.relative_to(root).as_posix(),
+            "exists": True,
+        },
+    }
+    return root, assignment
+
+
+def test_virtual_lab_assignment_detection() -> None:
+    assert student_virtual_lab_ui.is_virtual_lab_assignment(
+        {"activity": {"language": "virtual-lab"}}
+    )
+    assert not student_virtual_lab_ui.is_virtual_lab_assignment(
+        {"activity": {"language": "python"}}
+    )
+    assert not student_virtual_lab_ui.is_virtual_lab_assignment({})
+
+
+def test_session_for_assignment_resolves_thebitlab_paths(tmp_path: Path) -> None:
+    root, assignment = prepare_assignment(tmp_path)
+
+    session = student_virtual_lab_ui.session_for_assignment(assignment, root=root)
+
+    assert session.activity["id"] == ACTIVITY_ID
+    assert session.extension["runtime"] == "efesto"
+    assert session.extension["scenario_id"] == SCENARIO_ID
+    assert session.submission_path.name == "build.json"
+    assert session.submission_path.parent == (root / assignment["workspace"]["path"]).resolve()
+
+
+def test_session_for_assignment_rejects_non_virtual_lab(tmp_path: Path) -> None:
+    root, assignment = prepare_assignment(tmp_path)
+    assignment["activity"]["language"] = "python"
+
+    with pytest.raises(ValueError, match="non e un virtual-lab"):
+        student_virtual_lab_ui.session_for_assignment(assignment, root=root)
+
+
+def test_registry_reuses_server_for_same_assignment_and_closes_it(tmp_path: Path) -> None:
+    root, assignment = prepare_assignment(tmp_path)
+    registry = student_virtual_lab_ui.StudentVirtualLabUiRegistry()
+    opened_urls: list[str] = []
+
+    try:
+        first, reused_first, browser_first = registry.open(
+            assignment,
+            root=root,
+            open_browser_fn=lambda url: opened_urls.append(url) or True,
+        )
+        second, reused_second, browser_second = registry.open(
+            assignment,
+            root=root,
+            open_browser_fn=lambda url: opened_urls.append(url) or True,
+        )
+
+        assert reused_first is False
+        assert reused_second is True
+        assert browser_first is True
+        assert browser_second is True
+        assert first is second
+        assert first.url == second.url
+        assert len(registry) == 1
+        assert opened_urls == [first.url, first.url]
+    finally:
+        registry.close_all()
+
+    assert len(registry) == 0
+    assert registry._closed is True
+
+
+def test_registry_keeps_server_when_browser_open_fails(tmp_path: Path) -> None:
+    root, assignment = prepare_assignment(tmp_path)
+    registry = student_virtual_lab_ui.StudentVirtualLabUiRegistry()
+
+    try:
+        running, reused, opened = registry.open(
+            assignment,
+            root=root,
+            open_browser_fn=lambda _url: False,
+        )
+        assert reused is False
+        assert opened is False
+        assert running.url.startswith("http://127.0.0.1:")
+        assert len(registry) == 1
+    finally:
+        registry.close_all()


### PR DESCRIPTION
SUPERSEDED. Runtime UI lifecycle now belongs to standalone Efesto; generic student launch tooling lives in TheBitLab runtime adapter/CLI. Kept closed as prototype history only.