### PR TITLE
Add first Efesto foundation hardware labs

### DIFF
--- a/activities/examples/hardware_component_placement.json
+++ b/activities/examples/hardware_component_placement.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "id": "hw-component-placement-001",
+  "titolo": "Riconosci e posiziona i componenti del PC",
+  "tipo": "laboratorio",
+  "linguaggio": "virtual-lab",
+  "language": "virtual-lab",
+  "source_name": "build.json",
+  "difficolta": "A",
+  "argomenti": ["componenti", "motherboard", "cpu", "ram", "gpu", "storage"],
+  "consegna": "Correggi la configurazione iniziale posizionando CPU, RAM, GPU, SSD NVMe e SSD SATA sull'interfaccia appropriata.",
+  "student_support_mode": "feedback-tecnico",
+  "correzione": {"compila": false, "test": true, "sandbox": true, "ai_feedback": false},
+  "metriche": {
+    "tempo_stimato_minuti": 20,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": false
+  },
+  "extensions": {
+    "thebitlab.virtual_lab": {
+      "schema_version": "virtual_lab.v1",
+      "runtime": "efesto",
+      "scenario_id": "component-placement-001",
+      "submission": {"path": "build.json", "media_type": "application/json"},
+      "capabilities": ["interactive-ui", "deterministic-grade", "headless-run"]
+    }
+  },
+  "rubrica": [
+    {"criterio": "Riconoscimento delle interfacce", "punti": 5},
+    {"criterio": "Configurazione finale completa", "punti": 3},
+    {"criterio": "Metodo e autonomia", "punti": 2}
+  ]
+}

--- a/activities/examples/hardware_cpu_socket_matching.json
+++ b/activities/examples/hardware_cpu_socket_matching.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "id": "hw-cpu-socket-matching-001",
+  "titolo": "CPU e socket: abbina le piattaforme corrette",
+  "tipo": "laboratorio",
+  "linguaggio": "virtual-lab",
+  "language": "virtual-lab",
+  "source_name": "build.json",
+  "difficolta": "A",
+  "argomenti": ["cpu", "socket", "motherboard", "compatibilita"],
+  "consegna": "Correggi la configurazione iniziale installando ogni CPU nel socket compatibile. Usa le etichette e il feedback del grader per distinguere AM5 e LGA1700.",
+  "student_support_mode": "feedback-tecnico",
+  "correzione": {"compila": false, "test": true, "sandbox": true, "ai_feedback": false},
+  "metriche": {
+    "tempo_stimato_minuti": 15,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": false
+  },
+  "extensions": {
+    "thebitlab.virtual_lab": {
+      "schema_version": "virtual_lab.v1",
+      "runtime": "efesto",
+      "scenario_id": "cpu-socket-matching-001",
+      "submission": {"path": "build.json", "media_type": "application/json"},
+      "capabilities": ["interactive-ui", "deterministic-grade", "headless-run"]
+    }
+  },
+  "rubrica": [
+    {"criterio": "Riconoscimento del socket", "punti": 5},
+    {"criterio": "Configurazione finale corretta", "punti": 3},
+    {"criterio": "Metodo e autonomia", "punti": 2}
+  ]
+}

--- a/activities/examples/hardware_ddr5_dual_channel.json
+++ b/activities/examples/hardware_ddr5_dual_channel.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "id": "hw-ddr5-dual-channel-001",
+  "titolo": "DDR5 e dual channel: scegli A2 e B2",
+  "tipo": "laboratorio",
+  "linguaggio": "virtual-lab",
+  "language": "virtual-lab",
+  "source_name": "build.json",
+  "difficolta": "B",
+  "argomenti": ["ram", "ddr5", "dual-channel", "dimm", "motherboard"],
+  "consegna": "I due moduli DDR5 entrano fisicamente in tutti i DIMM, ma la configurazione iniziale non usa gli slot consigliati. Spostali in A2 e B2 per ottenere il dual channel previsto dal laboratorio.",
+  "student_support_mode": "feedback-tecnico",
+  "correzione": {"compila": false, "test": true, "sandbox": true, "ai_feedback": false},
+  "metriche": {
+    "tempo_stimato_minuti": 20,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": false
+  },
+  "extensions": {
+    "thebitlab.virtual_lab": {
+      "schema_version": "virtual_lab.v1",
+      "runtime": "efesto",
+      "scenario_id": "ddr5-dual-channel-001",
+      "submission": {"path": "build.json", "media_type": "application/json"},
+      "capabilities": ["interactive-ui", "deterministic-grade", "headless-run"]
+    }
+  },
+  "rubrica": [
+    {"criterio": "Distinzione tra compatibilita fisica e configurazione corretta", "punti": 4},
+    {"criterio": "Uso corretto di A2/B2", "punti": 4},
+    {"criterio": "Metodo e autonomia", "punti": 2}
+  ]
+}

--- a/activities/examples/hardware_psu_selection.json
+++ b/activities/examples/hardware_psu_selection.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "id": "hw-psu-selection-001",
+  "titolo": "Dimensiona l'alimentatore della workstation",
+  "tipo": "laboratorio",
+  "linguaggio": "virtual-lab",
+  "language": "virtual-lab",
+  "source_name": "build.json",
+  "difficolta": "B",
+  "argomenti": ["psu", "alimentazione", "watt", "gpu", "workstation"],
+  "consegna": "La workstation del caso di studio usa una GPU da 350 W e il progetto richiede margine operativo: sostituisci il PSU iniziale con il modello 850 W Gold previsto dal brief.",
+  "student_support_mode": "feedback-tecnico",
+  "correzione": {"compila": false, "test": true, "sandbox": true, "ai_feedback": false},
+  "metriche": {
+    "tempo_stimato_minuti": 20,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": false
+  },
+  "extensions": {
+    "thebitlab.virtual_lab": {
+      "schema_version": "virtual_lab.v1",
+      "runtime": "efesto",
+      "scenario_id": "psu-selection-001",
+      "submission": {"path": "build.json", "media_type": "application/json"},
+      "capabilities": ["interactive-ui", "deterministic-grade", "headless-run"]
+    }
+  },
+  "rubrica": [
+    {"criterio": "Interpretazione del brief energetico", "punti": 4},
+    {"criterio": "Scelta del PSU richiesto", "punti": 4},
+    {"criterio": "Metodo e autonomia", "punti": 2}
+  ]
+}

--- a/tests/test_efesto_foundation_labs.py
+++ b/tests/test_efesto_foundation_labs.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import efesto_headless, efesto_ui_server, student_virtual_lab
+from scripts.thebitlab_virtual_lab_contracts import (
+    normalize_virtual_lab_extension,
+    validate_virtual_lab_extension,
+)
+from scripts.thebitlab_virtual_lab_scaffold import starter_content_for_activity
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+LABS = [
+    {
+        "activity": "activities/examples/hardware_component_placement.json",
+        "activity_id": "hw-component-placement-001",
+        "scenario_id": "component-placement-001",
+        "starter_score": 5.0,
+        "corrected": [
+            {"slot": "cpu_socket", "component_id": "cpu-basic-001"},
+            {"slot": "dimm_a2", "component_id": "ram-ddr5-001"},
+            {"slot": "pcie1", "component_id": "gpu-basic-001"},
+            {"slot": "m2_1", "component_id": "nvme-basic-001"},
+            {"slot": "sata1", "component_id": "sata-ssd-basic-001"},
+        ],
+    },
+    {
+        "activity": "activities/examples/hardware_cpu_socket_matching.json",
+        "activity_id": "hw-cpu-socket-matching-001",
+        "scenario_id": "cpu-socket-matching-001",
+        "starter_score": 0.0,
+        "corrected": [
+            {"slot": "socket_am5", "component_id": "cpu-ryzen-am5-001"},
+            {"slot": "socket_lga1700", "component_id": "cpu-core-lga1700-001"},
+        ],
+    },
+    {
+        "activity": "activities/examples/hardware_ddr5_dual_channel.json",
+        "activity_id": "hw-ddr5-dual-channel-001",
+        "scenario_id": "ddr5-dual-channel-001",
+        "starter_score": 3.33,
+        "corrected": [
+            {"slot": "dimm_a2", "component_id": "ddr5-module-a-001"},
+            {"slot": "dimm_b2", "component_id": "ddr5-module-b-001"},
+        ],
+    },
+    {
+        "activity": "activities/examples/hardware_psu_selection.json",
+        "activity_id": "hw-psu-selection-001",
+        "scenario_id": "psu-selection-001",
+        "starter_score": 6.67,
+        "corrected": [
+            {"slot": "pcie1", "component_id": "gpu-350w-001"},
+            {"slot": "psu_bay", "component_id": "psu-850-gold-001"},
+        ],
+    },
+]
+
+
+@pytest.mark.parametrize("lab", LABS, ids=[item["scenario_id"] for item in LABS])
+def test_foundation_activity_and_starter_contract(lab: dict) -> None:
+    activity_path = ROOT / lab["activity"]
+    activity = json.loads(activity_path.read_text(encoding="utf-8"))
+
+    assert activity["id"] == lab["activity_id"]
+    assert activity["language"] == "virtual-lab"
+    assert activity["source_name"] == "build.json"
+    assert validate_virtual_lab_extension(activity, str(activity_path)) == []
+
+    extension = normalize_virtual_lab_extension(activity)
+    assert extension is not None
+    assert extension["runtime"] == "efesto"
+    assert extension["scenario_id"] == lab["scenario_id"]
+    assert extension["submission"]["path"] == "build.json"
+    assert set(extension["capabilities"]) == {
+        "interactive-ui",
+        "deterministic-grade",
+        "headless-run",
+    }
+
+    provider_extension, starter_text = starter_content_for_activity(
+        activity,
+        project_root=ROOT,
+    )
+    starter = json.loads(starter_text)
+    assert provider_extension == extension
+    assert starter["schema_version"] == "efesto.build.v1"
+    assert starter["scenario_id"] == lab["scenario_id"]
+
+
+@pytest.mark.parametrize("lab", LABS, ids=[item["scenario_id"] for item in LABS])
+def test_foundation_starter_fails_and_corrected_build_passes(lab: dict) -> None:
+    scenario = efesto_headless.load_scenario(ROOT, lab["scenario_id"])
+    starter = json.loads(
+        (ROOT / "virtual-labs/efesto/starters" / f"{lab['scenario_id']}.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    initial = efesto_headless.grade_build(
+        scenario,
+        starter,
+        activity_id=lab["activity_id"],
+    )
+    corrected = {
+        "schema_version": "efesto.build.v1",
+        "scenario_id": lab["scenario_id"],
+        "components": lab["corrected"],
+    }
+    final = efesto_headless.grade_build(
+        scenario,
+        corrected,
+        activity_id=lab["activity_id"],
+    )
+
+    assert initial["passed"] is False
+    assert initial["score"] == lab["starter_score"]
+    assert any(test["passed"] is False for test in initial["tests"])
+    assert final["passed"] is True
+    assert final["score"] == 10.0
+    assert final["summary"]["passed"] == final["summary"]["total"]
+
+
+@pytest.mark.parametrize("lab", LABS, ids=[item["scenario_id"] for item in LABS])
+def test_foundation_lab_uses_same_generic_2d_ui(tmp_path: Path, lab: dict) -> None:
+    activity_path = ROOT / lab["activity"]
+    student_repo = tmp_path / lab["activity_id"]
+    workspace = student_virtual_lab.create_virtual_lab_scaffold(
+        activity_path=activity_path,
+        target_dir=student_repo,
+        project_root=ROOT,
+    )
+
+    session = efesto_ui_server.EfestoUiSession.load(
+        project_root=ROOT,
+        activity_path=activity_path,
+        workspace_path=workspace,
+    )
+    state = session.state()
+
+    assert state["activity"]["id"] == lab["activity_id"]
+    assert state["activity"]["scenario_id"] == lab["scenario_id"]
+    assert state["build"]["scenario_id"] == lab["scenario_id"]
+    assert state["grading"]["passed"] is False
+    assert state["grading"]["score"] == lab["starter_score"]
+    assert state["scenario"]["slots"]
+    assert state["scenario"]["components"]

--- a/virtual-labs/efesto/scenarios/component-placement-001.json
+++ b/virtual-labs/efesto/scenarios/component-placement-001.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "efesto.scenario.v1",
+  "id": "component-placement-001",
+  "title": "Riconosci e posiziona i componenti",
+  "slots": [
+    {"id": "cpu_socket", "kind": "cpu-socket", "label": "Socket CPU"},
+    {"id": "dimm_a2", "kind": "dimm", "label": "DIMM A2"},
+    {"id": "pcie1", "kind": "pcie", "label": "PCIe x16 principale"},
+    {"id": "m2_1", "kind": "m2", "label": "M.2 NVMe"},
+    {"id": "sata1", "kind": "sata", "label": "Porta SATA 1"}
+  ],
+  "components": [
+    {"id": "cpu-basic-001", "kind": "cpu", "label": "Processore", "allowed_slots": ["cpu_socket"]},
+    {"id": "ram-ddr5-001", "kind": "ram", "label": "Modulo RAM DDR5", "allowed_slots": ["dimm_a2"]},
+    {"id": "gpu-basic-001", "kind": "gpu", "label": "Scheda video", "allowed_slots": ["pcie1"]},
+    {"id": "nvme-basic-001", "kind": "nvme", "label": "SSD NVMe M.2", "allowed_slots": ["m2_1"]},
+    {"id": "sata-ssd-basic-001", "kind": "sata-ssd", "label": "SSD SATA 2,5 pollici", "allowed_slots": ["sata1"]}
+  ],
+  "checks": [
+    {"id": "placements-compatible", "name": "Ogni componente usa l'interfaccia corretta", "type": "all-placements-compatible", "visibility": "student"},
+    {"id": "cpu-correct", "name": "CPU installata nel socket", "type": "component-in-slot", "component_id": "cpu-basic-001", "slot": "cpu_socket", "visibility": "student"},
+    {"id": "ram-correct", "name": "RAM installata nel DIMM", "type": "component-in-slot", "component_id": "ram-ddr5-001", "slot": "dimm_a2", "visibility": "student"},
+    {"id": "gpu-correct", "name": "GPU installata nello slot PCIe x16", "type": "component-in-slot", "component_id": "gpu-basic-001", "slot": "pcie1", "visibility": "student"},
+    {"id": "nvme-correct", "name": "SSD NVMe installato nello slot M.2", "type": "component-in-slot", "component_id": "nvme-basic-001", "slot": "m2_1", "visibility": "student"},
+    {"id": "sata-correct", "name": "SSD SATA collegato alla porta SATA", "type": "component-in-slot", "component_id": "sata-ssd-basic-001", "slot": "sata1", "visibility": "student"}
+  ]
+}

--- a/virtual-labs/efesto/scenarios/cpu-socket-matching-001.json
+++ b/virtual-labs/efesto/scenarios/cpu-socket-matching-001.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "efesto.scenario.v1",
+  "id": "cpu-socket-matching-001",
+  "title": "Abbina CPU e socket",
+  "slots": [
+    {"id": "socket_am5", "kind": "cpu-socket", "label": "Socket AMD AM5"},
+    {"id": "socket_lga1700", "kind": "cpu-socket", "label": "Socket Intel LGA1700"}
+  ],
+  "components": [
+    {"id": "cpu-ryzen-am5-001", "kind": "cpu", "label": "AMD Ryzen per AM5", "allowed_slots": ["socket_am5"]},
+    {"id": "cpu-core-lga1700-001", "kind": "cpu", "label": "Intel Core per LGA1700", "allowed_slots": ["socket_lga1700"]}
+  ],
+  "checks": [
+    {"id": "placements-compatible", "name": "Le CPU sono abbinate a socket compatibili", "type": "all-placements-compatible", "visibility": "student"},
+    {"id": "ryzen-am5", "name": "Ryzen installato su AM5", "type": "component-in-slot", "component_id": "cpu-ryzen-am5-001", "slot": "socket_am5", "visibility": "student"},
+    {"id": "core-lga1700", "name": "Intel Core installato su LGA1700", "type": "component-in-slot", "component_id": "cpu-core-lga1700-001", "slot": "socket_lga1700", "visibility": "student"}
+  ]
+}

--- a/virtual-labs/efesto/scenarios/ddr5-dual-channel-001.json
+++ b/virtual-labs/efesto/scenarios/ddr5-dual-channel-001.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "efesto.scenario.v1",
+  "id": "ddr5-dual-channel-001",
+  "title": "DDR5 e dual channel: scegli i DIMM corretti",
+  "slots": [
+    {"id": "dimm_a1", "kind": "dimm", "label": "DIMM A1"},
+    {"id": "dimm_a2", "kind": "dimm", "label": "DIMM A2 consigliato"},
+    {"id": "dimm_b1", "kind": "dimm", "label": "DIMM B1"},
+    {"id": "dimm_b2", "kind": "dimm", "label": "DIMM B2 consigliato"}
+  ],
+  "components": [
+    {
+      "id": "ddr5-module-a-001",
+      "kind": "ram",
+      "label": "Modulo DDR5 A",
+      "allowed_slots": ["dimm_a1", "dimm_a2", "dimm_b1", "dimm_b2"]
+    },
+    {
+      "id": "ddr5-module-b-001",
+      "kind": "ram",
+      "label": "Modulo DDR5 B",
+      "allowed_slots": ["dimm_a1", "dimm_a2", "dimm_b1", "dimm_b2"]
+    }
+  ],
+  "checks": [
+    {"id": "physically-compatible", "name": "I moduli sono inseriti in slot DIMM compatibili", "type": "all-placements-compatible", "visibility": "student"},
+    {"id": "module-a-a2", "name": "Primo modulo nel DIMM A2", "type": "component-in-slot", "component_id": "ddr5-module-a-001", "slot": "dimm_a2", "visibility": "student"},
+    {"id": "module-b-b2", "name": "Secondo modulo nel DIMM B2", "type": "component-in-slot", "component_id": "ddr5-module-b-001", "slot": "dimm_b2", "visibility": "student"}
+  ]
+}

--- a/virtual-labs/efesto/scenarios/psu-selection-001.json
+++ b/virtual-labs/efesto/scenarios/psu-selection-001.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "efesto.scenario.v1",
+  "id": "psu-selection-001",
+  "title": "Scegli l'alimentatore per la workstation",
+  "slots": [
+    {"id": "pcie1", "kind": "pcie", "label": "PCIe x16 principale"},
+    {"id": "psu_bay", "kind": "psu", "label": "Vano alimentatore ATX"}
+  ],
+  "components": [
+    {"id": "gpu-350w-001", "kind": "gpu", "label": "GPU target · 350 W", "allowed_slots": ["pcie1"]},
+    {"id": "psu-650-bronze-001", "kind": "psu", "label": "PSU 650 W Bronze", "allowed_slots": ["psu_bay"]},
+    {"id": "psu-750-gold-001", "kind": "psu", "label": "PSU 750 W Gold", "allowed_slots": ["psu_bay"]},
+    {"id": "psu-850-gold-001", "kind": "psu", "label": "PSU 850 W Gold", "allowed_slots": ["psu_bay"]}
+  ],
+  "checks": [
+    {"id": "placements-compatible", "name": "GPU e PSU sono installati nei rispettivi alloggiamenti", "type": "all-placements-compatible", "visibility": "student"},
+    {"id": "gpu-installed", "name": "GPU target installata", "type": "component-in-slot", "component_id": "gpu-350w-001", "slot": "pcie1", "visibility": "student"},
+    {"id": "psu-target", "name": "Scelto il PSU 850 W Gold richiesto dal progetto", "type": "component-in-slot", "component_id": "psu-850-gold-001", "slot": "psu_bay", "visibility": "student"}
+  ]
+}

--- a/virtual-labs/efesto/starters/component-placement-001.json
+++ b/virtual-labs/efesto/starters/component-placement-001.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "efesto.build.v1",
+  "scenario_id": "component-placement-001",
+  "components": [
+    {"slot": "cpu_socket", "component_id": "cpu-basic-001"},
+    {"slot": "dimm_a2", "component_id": "ram-ddr5-001"},
+    {"slot": "m2_1", "component_id": "gpu-basic-001"},
+    {"slot": "pcie1", "component_id": "nvme-basic-001"},
+    {"slot": "sata1", "component_id": "sata-ssd-basic-001"}
+  ]
+}

--- a/virtual-labs/efesto/starters/cpu-socket-matching-001.json
+++ b/virtual-labs/efesto/starters/cpu-socket-matching-001.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "efesto.build.v1",
+  "scenario_id": "cpu-socket-matching-001",
+  "components": [
+    {"slot": "socket_lga1700", "component_id": "cpu-ryzen-am5-001"},
+    {"slot": "socket_am5", "component_id": "cpu-core-lga1700-001"}
+  ]
+}

--- a/virtual-labs/efesto/starters/ddr5-dual-channel-001.json
+++ b/virtual-labs/efesto/starters/ddr5-dual-channel-001.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "efesto.build.v1",
+  "scenario_id": "ddr5-dual-channel-001",
+  "components": [
+    {"slot": "dimm_a1", "component_id": "ddr5-module-a-001"},
+    {"slot": "dimm_b1", "component_id": "ddr5-module-b-001"}
+  ]
+}

--- a/virtual-labs/efesto/starters/psu-selection-001.json
+++ b/virtual-labs/efesto/starters/psu-selection-001.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "efesto.build.v1",
+  "scenario_id": "psu-selection-001",
+  "components": [
+    {"slot": "pcie1", "component_id": "gpu-350w-001"},
+    {"slot": "psu_bay", "component_id": "psu-650-bronze-001"}
+  ]
+}


### PR DESCRIPTION
SUPERSEDED. Foundation hardware Activities/scenarios/starters were migrated to `TheBitPoets/thebitlab-hardware`; engine semantics live in standalone Efesto. Kept closed as prototype history only.