### PR TITLE
Add quantitative Efesto grading checks

### DIFF
--- a/doc/architecture/efesto-scenario-contract.md
+++ b/doc/architecture/efesto-scenario-contract.md
@@ -1,0 +1,286 @@
+# Contratto scenari Efesto
+
+Efesto descrive un laboratorio virtuale hardware con due documenti JSON separati:
+
+- uno **scenario trusted**, mantenuto dal docente/runtime;
+- una **build studente**, che contiene soltanto le scelte effettuate nello scenario.
+
+Questa separazione e intenzionale: specifiche, vincoli e criteri di valutazione non devono essere modificabili dallo studente.
+
+## Scenario
+
+Uno scenario usa `schema_version = "efesto.scenario.v1"` e contiene:
+
+```json
+{
+  "schema_version": "efesto.scenario.v1",
+  "id": "ai-workstation-001",
+  "title": "Scegli una GPU per inferenza locale",
+  "slots": [],
+  "components": [],
+  "checks": []
+}
+```
+
+### Slot
+
+Uno slot rappresenta una posizione/interfaccia logica della macchina virtuale:
+
+```json
+{
+  "id": "pcie1",
+  "kind": "pcie",
+  "label": "PCIe x16 principale",
+  "attributes": {
+    "pcie_gen": 5,
+    "lanes": 16
+  }
+}
+```
+
+`attributes` e opzionale. Le chiavi sono identificativi portabili e i valori possono essere stringhe, boolean o numeri finiti.
+
+### Componenti
+
+Un componente dichiara gli slot in cui puo essere inserito e, opzionalmente, le proprie specifiche:
+
+```json
+{
+  "id": "gpu-24gb",
+  "kind": "gpu",
+  "label": "GPU 24 GB",
+  "allowed_slots": ["pcie1"],
+  "attributes": {
+    "vram_gb": 24,
+    "power_w": 350,
+    "pcie_gen": 4
+  }
+}
+```
+
+Gli attributi appartengono allo scenario trusted. Non vengono letti dalla build dello studente.
+
+## Build studente
+
+La build usa `schema_version = "efesto.build.v1"`:
+
+```json
+{
+  "schema_version": "efesto.build.v1",
+  "scenario_id": "ai-workstation-001",
+  "components": [
+    {
+      "slot": "pcie1",
+      "component_id": "gpu-24gb"
+    }
+  ]
+}
+```
+
+La build esprime soltanto **quale componente viene collocato in quale slot**.
+
+Campi aggiuntivi eventualmente inseriti dallo studente non possono sovrascrivere le specifiche trusted del componente.
+
+## Check strutturali
+
+### `all-placements-compatible`
+
+Verifica che ogni componente sia collocato in uno degli `allowed_slots` dichiarati nello scenario.
+
+```json
+{
+  "id": "compatible",
+  "name": "Componenti su slot compatibili",
+  "type": "all-placements-compatible",
+  "visibility": "student"
+}
+```
+
+### `component-present`
+
+Richiede la presenza di uno specifico componente.
+
+```json
+{
+  "id": "nvme-present",
+  "name": "SSD NVMe installato",
+  "type": "component-present",
+  "component_id": "nvme-2tb",
+  "visibility": "student"
+}
+```
+
+### `component-in-slot`
+
+Richiede uno specifico componente in uno specifico slot.
+
+### `not-all-occupied`
+
+Fallisce quando tutti gli slot indicati sono occupati contemporaneamente. Serve, per esempio, a modellare lane/resource sharing.
+
+```json
+{
+  "id": "lane-sharing-safe",
+  "name": "M2_2 e PCIe2 non usati insieme",
+  "type": "not-all-occupied",
+  "slots": ["m2_2", "pcie2"],
+  "visibility": "student"
+}
+```
+
+## Check quantitativi
+
+I check quantitativi leggono sempre gli attributi trusted dei componenti installati.
+
+Il campo opzionale `unit` viene usato soltanto nel messaggio di feedback e non modifica il calcolo.
+
+### `slot-component-attribute-min`
+
+Richiede che il componente presente in uno slot abbia un attributo numerico almeno pari alla soglia.
+
+Esempio: almeno 24 GB di VRAM.
+
+```json
+{
+  "id": "vram",
+  "name": "VRAM almeno 24 GB",
+  "type": "slot-component-attribute-min",
+  "slot": "pcie1",
+  "attribute": "vram_gb",
+  "min_value": 24,
+  "unit": "GB",
+  "visibility": "student"
+}
+```
+
+### `slot-component-attribute-max`
+
+Come il precedente, ma richiede un valore minore o uguale alla soglia.
+
+Puo essere usato per limiti di potenza, lunghezza, temperatura o altri valori quantitativi.
+
+### `slot-component-attribute-equals`
+
+Confronta un attributo scalare con un valore esatto.
+
+```json
+{
+  "id": "socket-family",
+  "name": "Piattaforma AM5",
+  "type": "slot-component-attribute-equals",
+  "slot": "cpu",
+  "attribute": "socket_family",
+  "expected": "am5",
+  "visibility": "student"
+}
+```
+
+### `installed-attribute-sum-min`
+
+Somma un attributo sui componenti installati e richiede un valore minimo.
+
+Il filtro `kind` e opzionale. Se e presente, tutti i componenti installati di quel tipo devono dichiarare l'attributo, altrimenti il check fallisce invece di sottostimare silenziosamente il totale.
+
+Esempio: almeno 64 GB di RAM.
+
+```json
+{
+  "id": "ram-total",
+  "name": "RAM totale almeno 64 GB",
+  "type": "installed-attribute-sum-min",
+  "attribute": "capacity_gb",
+  "kind": "ram",
+  "min_value": 64,
+  "unit": "GB",
+  "visibility": "student"
+}
+```
+
+### `installed-attribute-sum-max`
+
+Come il precedente, ma impone un massimo.
+
+### `installed-kind-count`
+
+Conta i componenti installati di un determinato `kind`.
+
+E possibile dichiarare `min_count`, `max_count` o entrambi.
+
+Esempio: esattamente due moduli RAM.
+
+```json
+{
+  "id": "ram-count",
+  "name": "Usa due moduli RAM",
+  "type": "installed-kind-count",
+  "kind": "ram",
+  "min_count": 2,
+  "max_count": 2,
+  "visibility": "student"
+}
+```
+
+### `slot-capacity-covers-installed-sum`
+
+Confronta la capacita di un componente installato in uno slot con una domanda calcolata sulla build.
+
+La formula e:
+
+```text
+required = (sum(demand_attribute) + fixed_demand) * factor
+```
+
+Esempio PSU:
+
+```json
+{
+  "id": "psu-headroom",
+  "name": "PSU con margine del 20 percento",
+  "type": "slot-capacity-covers-installed-sum",
+  "capacity_slot": "psu",
+  "capacity_attribute": "capacity_w",
+  "demand_attribute": "power_w",
+  "fixed_demand": 100,
+  "factor": 1.2,
+  "unit": "W",
+  "visibility": "student"
+}
+```
+
+Se CPU e GPU dichiarano rispettivamente 120 W e 350 W:
+
+```text
+(120 + 350 + 100) * 1.2 = 684 W
+```
+
+Un PSU da 650 W fallisce; uno da 750 W soddisfa il requisito.
+
+Il filtro opzionale `demand_kind` limita la somma a uno specifico tipo di componente.
+
+## Visibility
+
+Ogni check usa:
+
+```json
+"visibility": "student"
+```
+
+oppure:
+
+```json
+"visibility": "teacher"
+```
+
+I check teacher-only possono contribuire al grading autorevole, ma la UI studente non riceve nomi e dettagli riservati.
+
+## Principio didattico
+
+Gli scenari dovrebbero distinguere almeno tre concetti diversi:
+
+1. **compatibilita fisica/logica** — il componente puo essere collegato;
+2. **correttezza della configurazione** — il componente e collocato/usato secondo il target;
+3. **adeguatezza progettuale** — capacita, prestazioni, margine e possibilita di upgrade soddisfano il brief.
+
+Per esempio due moduli DDR5 possono essere fisicamente compatibili con quattro DIMM, ma il laboratorio puo richiedere A2/B2; oppure piu PSU possono entrare nello stesso vano ATX, ma soltanto alcuni possono soddisfare il carico con il margine richiesto.
+
+Questa distinzione evita di ridurre il corso a un semplice gioco di drag-and-drop e permette di usare Efesto per esercizi di vera progettazione hardware.

--- a/scripts/efesto_contracts.py
+++ b/scripts/efesto_contracts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 from copy import deepcopy
 from typing import Any
@@ -9,12 +10,21 @@ EFESTO_BUILD_SCHEMA_VERSION = "efesto.build.v1"
 EFESTO_SCENARIO_SCHEMA_VERSION = "efesto.scenario.v1"
 MAX_BUILD_PLACEMENTS = 256
 MAX_SCENARIO_ITEMS = 512
+MAX_ATTRIBUTES = 64
+MAX_ATTRIBUTE_STRING_LENGTH = 256
 
 _ALLOWED_CHECK_TYPES = {
     "all-placements-compatible",
     "component-present",
     "component-in-slot",
     "not-all-occupied",
+    "slot-component-attribute-min",
+    "slot-component-attribute-max",
+    "slot-component-attribute-equals",
+    "installed-attribute-sum-min",
+    "installed-attribute-sum-max",
+    "installed-kind-count",
+    "slot-capacity-covers-installed-sum",
 }
 _ALLOWED_VISIBILITIES = {"student", "teacher"}
 _PORTABLE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
@@ -30,6 +40,26 @@ def is_portable_id(value: Any) -> bool:
     """Return whether value is a stable portable identifier."""
 
     return bool(_PORTABLE_ID_RE.fullmatch(clean_text(value)))
+
+
+def is_finite_number(value: Any) -> bool:
+    """Return whether value is a finite int/float and not a boolean."""
+
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
+
+
+def is_attribute_scalar(value: Any) -> bool:
+    """Return whether value is an allowed scenario attribute scalar."""
+
+    if isinstance(value, bool):
+        return True
+    if is_finite_number(value):
+        return True
+    return isinstance(value, str) and len(value) <= MAX_ATTRIBUTE_STRING_LENGTH
 
 
 def normalize_build(payload: dict[str, Any]) -> dict[str, Any]:
@@ -131,6 +161,43 @@ def _validate_unique_ids(
     return errors, identifiers
 
 
+def _validate_attributes(value: Any, prefix: str) -> list[str]:
+    """Validate optional scalar attributes attached to slots/components."""
+
+    if value is None:
+        return []
+    if not isinstance(value, dict):
+        return [f"{prefix}.attributes deve essere un oggetto"]
+    errors: list[str] = []
+    if len(value) > MAX_ATTRIBUTES:
+        errors.append(
+            f"{prefix}.attributes supera il limite di {MAX_ATTRIBUTES} attributi"
+        )
+    for key, attribute_value in list(value.items())[:MAX_ATTRIBUTES]:
+        if not is_portable_id(key):
+            errors.append(f"{prefix}.attributes contiene una chiave non portabile: {key}")
+            continue
+        if not is_attribute_scalar(attribute_value):
+            errors.append(
+                f"{prefix}.attributes.{key} deve essere stringa, boolean o numero finito"
+            )
+    return errors
+
+
+def _require_slot(check: dict[str, Any], slot_ids: set[str], prefix: str, field: str = "slot") -> list[str]:
+    slot_id = clean_text(check.get(field))
+    return [] if slot_id in slot_ids else [f"{prefix}.{field} sconosciuto: {slot_id}"]
+
+
+def _require_attribute(check: dict[str, Any], prefix: str, field: str = "attribute") -> list[str]:
+    value = clean_text(check.get(field))
+    return [] if is_portable_id(value) else [f"{prefix}.{field} deve essere un identificativo portabile"]
+
+
+def _require_number(check: dict[str, Any], prefix: str, field: str) -> list[str]:
+    return [] if is_finite_number(check.get(field)) else [f"{prefix}.{field} deve essere un numero finito"]
+
+
 def validate_scenario(payload: Any, source: str = "<scenario>") -> list[str]:
     """Validate the trusted `efesto.scenario.v1` format."""
 
@@ -163,20 +230,25 @@ def validate_scenario(payload: Any, source: str = "<scenario>") -> list[str]:
     for index, slot in enumerate(slots[:MAX_SCENARIO_ITEMS]):
         if not isinstance(slot, dict):
             continue
+        prefix = f"{source}: slots[{index}]"
         if not is_portable_id(slot.get("kind")):
-            errors.append(
-                f"{source}: slots[{index}].kind deve essere un identificativo portabile"
-            )
+            errors.append(f"{prefix}.kind deve essere un identificativo portabile")
+        errors.extend(_validate_attributes(slot.get("attributes"), prefix))
 
     components = (
         payload.get("components") if isinstance(payload.get("components"), list) else []
     )
+    component_kinds: set[str] = set()
     for index, component in enumerate(components[:MAX_SCENARIO_ITEMS]):
         if not isinstance(component, dict):
             continue
         prefix = f"{source}: components[{index}]"
-        if not is_portable_id(component.get("kind")):
+        kind = clean_text(component.get("kind"))
+        if not is_portable_id(kind):
             errors.append(f"{prefix}.kind deve essere un identificativo portabile")
+        else:
+            component_kinds.add(kind)
+        errors.extend(_validate_attributes(component.get("attributes"), prefix))
         allowed_slots = component.get("allowed_slots")
         if not isinstance(allowed_slots, list) or not allowed_slots:
             errors.append(f"{prefix}.allowed_slots deve essere una lista non vuota")
@@ -205,9 +277,7 @@ def validate_scenario(payload: Any, source: str = "<scenario>") -> list[str]:
             if component_id not in component_ids:
                 errors.append(f"{prefix}.component_id sconosciuto: {component_id}")
         if check_type == "component-in-slot":
-            slot_id = clean_text(check.get("slot"))
-            if slot_id not in slot_ids:
-                errors.append(f"{prefix}.slot sconosciuto: {slot_id}")
+            errors.extend(_require_slot(check, slot_ids, prefix))
         if check_type == "not-all-occupied":
             check_slots = check.get("slots")
             if not isinstance(check_slots, list) or len(check_slots) < 2:
@@ -216,6 +286,69 @@ def validate_scenario(payload: Any, source: str = "<scenario>") -> list[str]:
                 for slot_id in check_slots:
                     if clean_text(slot_id) not in slot_ids:
                         errors.append(f"{prefix}.slots contiene slot sconosciuto: {slot_id}")
+
+        if check_type in {
+            "slot-component-attribute-min",
+            "slot-component-attribute-max",
+            "slot-component-attribute-equals",
+        }:
+            errors.extend(_require_slot(check, slot_ids, prefix))
+            errors.extend(_require_attribute(check, prefix))
+        if check_type == "slot-component-attribute-min":
+            errors.extend(_require_number(check, prefix, "min_value"))
+        if check_type == "slot-component-attribute-max":
+            errors.extend(_require_number(check, prefix, "max_value"))
+        if check_type == "slot-component-attribute-equals":
+            if "expected" not in check or not is_attribute_scalar(check.get("expected")):
+                errors.append(f"{prefix}.expected deve essere uno scalare valido")
+
+        if check_type in {"installed-attribute-sum-min", "installed-attribute-sum-max"}:
+            errors.extend(_require_attribute(check, prefix))
+            if check_type.endswith("-min"):
+                errors.extend(_require_number(check, prefix, "min_value"))
+            else:
+                errors.extend(_require_number(check, prefix, "max_value"))
+            kind = clean_text(check.get("kind"))
+            if kind and kind not in component_kinds:
+                errors.append(f"{prefix}.kind sconosciuto: {kind}")
+
+        if check_type == "installed-kind-count":
+            kind = clean_text(check.get("kind"))
+            if kind not in component_kinds:
+                errors.append(f"{prefix}.kind sconosciuto: {kind}")
+            has_min = check.get("min_count") is not None
+            has_max = check.get("max_count") is not None
+            if not has_min and not has_max:
+                errors.append(f"{prefix} richiede min_count e/o max_count")
+            for field in ("min_count", "max_count"):
+                if check.get(field) is not None:
+                    value = check.get(field)
+                    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                        errors.append(f"{prefix}.{field} deve essere un intero non negativo")
+            if (
+                isinstance(check.get("min_count"), int)
+                and not isinstance(check.get("min_count"), bool)
+                and isinstance(check.get("max_count"), int)
+                and not isinstance(check.get("max_count"), bool)
+                and check["min_count"] > check["max_count"]
+            ):
+                errors.append(f"{prefix}.min_count non puo superare max_count")
+
+        if check_type == "slot-capacity-covers-installed-sum":
+            errors.extend(_require_slot(check, slot_ids, prefix, "capacity_slot"))
+            errors.extend(_require_attribute(check, prefix, "capacity_attribute"))
+            errors.extend(_require_attribute(check, prefix, "demand_attribute"))
+            if check.get("fixed_demand") is not None:
+                errors.extend(_require_number(check, prefix, "fixed_demand"))
+                if is_finite_number(check.get("fixed_demand")) and float(check["fixed_demand"]) < 0:
+                    errors.append(f"{prefix}.fixed_demand deve essere non negativo")
+            if check.get("factor") is not None:
+                errors.extend(_require_number(check, prefix, "factor"))
+                if is_finite_number(check.get("factor")) and float(check["factor"]) <= 0:
+                    errors.append(f"{prefix}.factor deve essere maggiore di zero")
+            kind = clean_text(check.get("demand_kind"))
+            if kind and kind not in component_kinds:
+                errors.append(f"{prefix}.demand_kind sconosciuto: {kind}")
 
     if len(check_ids) == 0 and isinstance(payload.get("checks"), list):
         errors.append(f"{source}: checks deve contenere almeno un controllo valido")

--- a/scripts/efesto_headless.py
+++ b/scripts/efesto_headless.py
@@ -98,20 +98,71 @@ def _placements(build: dict[str, Any]) -> dict[str, str]:
     return result
 
 
+def _component_map(scenario: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        efesto_contracts.clean_text(item.get("id")): item
+        for item in scenario.get("components", [])
+        if isinstance(item, dict) and efesto_contracts.clean_text(item.get("id"))
+    }
+
+
+def _slot_map(scenario: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        efesto_contracts.clean_text(item.get("id")): item
+        for item in scenario.get("slots", [])
+        if isinstance(item, dict) and efesto_contracts.clean_text(item.get("id"))
+    }
+
+
+def _component_in_slot(
+    scenario: dict[str, Any], placements: dict[str, str], slot_id: str
+) -> dict[str, Any] | None:
+    component_id = placements.get(slot_id)
+    return _component_map(scenario).get(component_id or "")
+
+
+def _attribute(component: dict[str, Any] | None, name: str) -> Any:
+    if not isinstance(component, dict):
+        return None
+    attributes = component.get("attributes")
+    return attributes.get(name) if isinstance(attributes, dict) else None
+
+
+def _number_attribute(component: dict[str, Any] | None, name: str) -> float | None:
+    value = _attribute(component, name)
+    return float(value) if efesto_contracts.is_finite_number(value) else None
+
+
+def _display_number(value: float) -> str:
+    return str(int(value)) if float(value).is_integer() else f"{value:.2f}".rstrip("0").rstrip(".")
+
+
+def _unit_suffix(check: dict[str, Any]) -> str:
+    unit = efesto_contracts.clean_text(check.get("unit"))
+    return f" {unit}" if unit else ""
+
+
+def _installed_components(
+    scenario: dict[str, Any], placements: dict[str, str], *, kind: str = ""
+) -> list[dict[str, Any]]:
+    components = _component_map(scenario)
+    installed: list[dict[str, Any]] = []
+    for component_id in placements.values():
+        component = components.get(component_id)
+        if component is None:
+            continue
+        if kind and efesto_contracts.clean_text(component.get("kind")) != kind:
+            continue
+        installed.append(component)
+    return installed
+
+
 def _compatibility_detail(
     scenario: dict[str, Any],
     placements: dict[str, str],
 ) -> tuple[bool, str]:
-    slots = {
-        efesto_contracts.clean_text(item.get("id")): item
-        for item in scenario.get("slots", [])
-        if isinstance(item, dict)
-    }
-    components = {
-        efesto_contracts.clean_text(item.get("id")): item
-        for item in scenario.get("components", [])
-        if isinstance(item, dict)
-    }
+    slots = _slot_map(scenario)
+    components = _component_map(scenario)
     problems: list[str] = []
     for slot_id, component_id in placements.items():
         if slot_id not in slots:
@@ -125,6 +176,141 @@ def _compatibility_detail(
         if slot_id not in allowed_slots:
             problems.append(f"{component_id} non e compatibile con {slot_id}")
     return not problems, "; ".join(problems)
+
+
+def _slot_attribute_check(
+    check: dict[str, Any],
+    scenario: dict[str, Any],
+    placements: dict[str, str],
+    *,
+    mode: str,
+) -> tuple[bool, str]:
+    slot_id = efesto_contracts.clean_text(check.get("slot"))
+    attribute = efesto_contracts.clean_text(check.get("attribute"))
+    component = _component_in_slot(scenario, placements, slot_id)
+    component_id = placements.get(slot_id, "")
+    if component is None:
+        return False, f"Lo slot {slot_id} e vuoto o contiene un componente sconosciuto."
+    actual = _attribute(component, attribute)
+    suffix = _unit_suffix(check)
+
+    if mode == "equals":
+        expected = check.get("expected")
+        passed = actual == expected
+        return passed, (
+            f"{component_id}: {attribute} = {actual!s}, valore richiesto {expected!s}."
+            if not passed
+            else f"{component_id}: {attribute} = {actual!s}, requisito soddisfatto."
+        )
+
+    if not efesto_contracts.is_finite_number(actual):
+        return False, f"{component_id} non dichiara un valore numerico per {attribute}."
+    actual_number = float(actual)
+    if mode == "min":
+        threshold = float(check["min_value"])
+        passed = actual_number >= threshold
+        operator = ">="
+    else:
+        threshold = float(check["max_value"])
+        passed = actual_number <= threshold
+        operator = "<="
+    return passed, (
+        f"{component_id}: {attribute} {_display_number(actual_number)}{suffix}; "
+        f"richiesto {operator} {_display_number(threshold)}{suffix}."
+    )
+
+
+def _installed_sum_check(
+    check: dict[str, Any],
+    scenario: dict[str, Any],
+    placements: dict[str, str],
+    *,
+    mode: str,
+) -> tuple[bool, str]:
+    attribute = efesto_contracts.clean_text(check.get("attribute"))
+    kind = efesto_contracts.clean_text(check.get("kind"))
+    installed = _installed_components(scenario, placements, kind=kind)
+    values: list[float] = []
+    missing: list[str] = []
+    for component in installed:
+        value = _attribute(component, attribute)
+        if efesto_contracts.is_finite_number(value):
+            values.append(float(value))
+        elif kind:
+            missing.append(efesto_contracts.clean_text(component.get("id")))
+    if missing:
+        return False, f"Attributo {attribute} mancante per: {', '.join(missing)}."
+    total = sum(values)
+    suffix = _unit_suffix(check)
+    if mode == "min":
+        threshold = float(check["min_value"])
+        passed = total >= threshold
+        operator = ">="
+    else:
+        threshold = float(check["max_value"])
+        passed = total <= threshold
+        operator = "<="
+    kind_label = f" sui componenti {kind}" if kind else ""
+    return passed, (
+        f"Somma {attribute}{kind_label}: {_display_number(total)}{suffix}; "
+        f"richiesto {operator} {_display_number(threshold)}{suffix}."
+    )
+
+
+def _kind_count_check(
+    check: dict[str, Any],
+    scenario: dict[str, Any],
+    placements: dict[str, str],
+) -> tuple[bool, str]:
+    kind = efesto_contracts.clean_text(check.get("kind"))
+    count = len(_installed_components(scenario, placements, kind=kind))
+    min_count = check.get("min_count")
+    max_count = check.get("max_count")
+    passed = True
+    requirements: list[str] = []
+    if isinstance(min_count, int) and not isinstance(min_count, bool):
+        passed = passed and count >= min_count
+        requirements.append(f">= {min_count}")
+    if isinstance(max_count, int) and not isinstance(max_count, bool):
+        passed = passed and count <= max_count
+        requirements.append(f"<= {max_count}")
+    return passed, (
+        f"Componenti di tipo {kind} installati: {count}; richiesto {' e '.join(requirements)}."
+    )
+
+
+def _capacity_check(
+    check: dict[str, Any],
+    scenario: dict[str, Any],
+    placements: dict[str, str],
+) -> tuple[bool, str]:
+    capacity_slot = efesto_contracts.clean_text(check.get("capacity_slot"))
+    capacity_attribute = efesto_contracts.clean_text(check.get("capacity_attribute"))
+    demand_attribute = efesto_contracts.clean_text(check.get("demand_attribute"))
+    demand_kind = efesto_contracts.clean_text(check.get("demand_kind"))
+    capacity_component = _component_in_slot(scenario, placements, capacity_slot)
+    capacity_id = placements.get(capacity_slot, "")
+    capacity = _number_attribute(capacity_component, capacity_attribute)
+    if capacity is None:
+        return False, (
+            f"Il componente in {capacity_slot} non dichiara {capacity_attribute} numerico."
+        )
+
+    demand = 0.0
+    for component in _installed_components(scenario, placements, kind=demand_kind):
+        value = _attribute(component, demand_attribute)
+        if efesto_contracts.is_finite_number(value):
+            demand += float(value)
+    fixed = float(check.get("fixed_demand", 0) or 0)
+    factor = float(check.get("factor", 1) or 1)
+    required = (demand + fixed) * factor
+    passed = capacity >= required
+    suffix = _unit_suffix(check)
+    return passed, (
+        f"{capacity_id}: capacita {_display_number(capacity)}{suffix}; "
+        f"carico {_display_number(demand)}{suffix} + fisso {_display_number(fixed)}{suffix}, "
+        f"fattore {_display_number(factor)} => richiesti {_display_number(required)}{suffix}."
+    )
 
 
 def _evaluate_check(
@@ -170,6 +356,21 @@ def _evaluate_check(
             if passed
             else f"Conflitto: gli slot {', '.join(slot_ids)} sono occupati contemporaneamente."
         )
+
+    if check_type == "slot-component-attribute-min":
+        return _slot_attribute_check(check, scenario, placements, mode="min")
+    if check_type == "slot-component-attribute-max":
+        return _slot_attribute_check(check, scenario, placements, mode="max")
+    if check_type == "slot-component-attribute-equals":
+        return _slot_attribute_check(check, scenario, placements, mode="equals")
+    if check_type == "installed-attribute-sum-min":
+        return _installed_sum_check(check, scenario, placements, mode="min")
+    if check_type == "installed-attribute-sum-max":
+        return _installed_sum_check(check, scenario, placements, mode="max")
+    if check_type == "installed-kind-count":
+        return _kind_count_check(check, scenario, placements)
+    if check_type == "slot-capacity-covers-installed-sum":
+        return _capacity_check(check, scenario, placements)
 
     return False, f"Tipo di controllo non supportato: {check_type}."
 

--- a/tests/test_efesto_quantitative_checks.py
+++ b/tests/test_efesto_quantitative_checks.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from scripts import efesto_contracts, efesto_headless
+
+
+SCENARIO = {
+    "schema_version": "efesto.scenario.v1",
+    "id": "quantitative-test-001",
+    "title": "Scenario quantitativo di test",
+    "slots": [
+        {"id": "cpu", "kind": "cpu-socket", "label": "CPU"},
+        {"id": "gpu", "kind": "pcie", "label": "GPU"},
+        {"id": "ram1", "kind": "dimm", "label": "RAM 1"},
+        {"id": "ram2", "kind": "dimm", "label": "RAM 2"},
+        {"id": "psu", "kind": "psu", "label": "PSU"},
+    ],
+    "components": [
+        {
+            "id": "cpu-120w",
+            "kind": "cpu",
+            "label": "CPU 120 W",
+            "allowed_slots": ["cpu"],
+            "attributes": {"power_w": 120, "socket_family": "am5"},
+        },
+        {
+            "id": "gpu-12gb",
+            "kind": "gpu",
+            "label": "GPU 12 GB",
+            "allowed_slots": ["gpu"],
+            "attributes": {"vram_gb": 12, "power_w": 350},
+        },
+        {
+            "id": "gpu-24gb",
+            "kind": "gpu",
+            "label": "GPU 24 GB",
+            "allowed_slots": ["gpu"],
+            "attributes": {"vram_gb": 24, "power_w": 350},
+        },
+        {
+            "id": "ram16-a",
+            "kind": "ram",
+            "label": "RAM 16 GB A",
+            "allowed_slots": ["ram1", "ram2"],
+            "attributes": {"capacity_gb": 16},
+        },
+        {
+            "id": "ram16-b",
+            "kind": "ram",
+            "label": "RAM 16 GB B",
+            "allowed_slots": ["ram1", "ram2"],
+            "attributes": {"capacity_gb": 16},
+        },
+        {
+            "id": "ram32-a",
+            "kind": "ram",
+            "label": "RAM 32 GB A",
+            "allowed_slots": ["ram1", "ram2"],
+            "attributes": {"capacity_gb": 32},
+        },
+        {
+            "id": "ram32-b",
+            "kind": "ram",
+            "label": "RAM 32 GB B",
+            "allowed_slots": ["ram1", "ram2"],
+            "attributes": {"capacity_gb": 32},
+        },
+        {
+            "id": "psu650",
+            "kind": "psu",
+            "label": "PSU 650 W",
+            "allowed_slots": ["psu"],
+            "attributes": {"capacity_w": 650},
+        },
+        {
+            "id": "psu750",
+            "kind": "psu",
+            "label": "PSU 750 W",
+            "allowed_slots": ["psu"],
+            "attributes": {"capacity_w": 750},
+        },
+    ],
+    "checks": [
+        {
+            "id": "compatible",
+            "name": "Posizionamenti compatibili",
+            "type": "all-placements-compatible",
+            "visibility": "student",
+        },
+        {
+            "id": "gpu-vram",
+            "name": "VRAM almeno 24 GB",
+            "type": "slot-component-attribute-min",
+            "slot": "gpu",
+            "attribute": "vram_gb",
+            "min_value": 24,
+            "unit": "GB",
+            "visibility": "student",
+        },
+        {
+            "id": "cpu-power",
+            "name": "CPU entro 150 W",
+            "type": "slot-component-attribute-max",
+            "slot": "cpu",
+            "attribute": "power_w",
+            "max_value": 150,
+            "unit": "W",
+            "visibility": "student",
+        },
+        {
+            "id": "cpu-socket",
+            "name": "CPU AM5",
+            "type": "slot-component-attribute-equals",
+            "slot": "cpu",
+            "attribute": "socket_family",
+            "expected": "am5",
+            "visibility": "student",
+        },
+        {
+            "id": "ram-total",
+            "name": "RAM totale almeno 64 GB",
+            "type": "installed-attribute-sum-min",
+            "attribute": "capacity_gb",
+            "kind": "ram",
+            "min_value": 64,
+            "unit": "GB",
+            "visibility": "student",
+        },
+        {
+            "id": "power-total",
+            "name": "Carico componenti entro 500 W",
+            "type": "installed-attribute-sum-max",
+            "attribute": "power_w",
+            "max_value": 500,
+            "unit": "W",
+            "visibility": "student",
+        },
+        {
+            "id": "ram-count",
+            "name": "Esattamente due moduli RAM",
+            "type": "installed-kind-count",
+            "kind": "ram",
+            "min_count": 2,
+            "max_count": 2,
+            "visibility": "student",
+        },
+        {
+            "id": "psu-headroom",
+            "name": "PSU con margine del 20 percento",
+            "type": "slot-capacity-covers-installed-sum",
+            "capacity_slot": "psu",
+            "capacity_attribute": "capacity_w",
+            "demand_attribute": "power_w",
+            "fixed_demand": 100,
+            "factor": 1.2,
+            "unit": "W",
+            "visibility": "student",
+        },
+    ],
+}
+
+
+def build(*, gpu: str, ram_a: str, ram_b: str, psu: str) -> dict:
+    return {
+        "schema_version": "efesto.build.v1",
+        "scenario_id": "quantitative-test-001",
+        "components": [
+            {"slot": "cpu", "component_id": "cpu-120w"},
+            {"slot": "gpu", "component_id": gpu},
+            {"slot": "ram1", "component_id": ram_a},
+            {"slot": "ram2", "component_id": ram_b},
+            {"slot": "psu", "component_id": psu},
+        ],
+    }
+
+
+def result_by_name(report: dict) -> dict[str, dict]:
+    return {test["name"]: test for test in report["tests"]}
+
+
+def test_quantitative_scenario_contract_is_valid() -> None:
+    assert efesto_contracts.validate_scenario(SCENARIO, "scenario") == []
+
+
+def test_quantitative_checks_reject_under_spec_build_and_accept_target() -> None:
+    starter = build(gpu="gpu-12gb", ram_a="ram16-a", ram_b="ram16-b", psu="psu650")
+    target = build(gpu="gpu-24gb", ram_a="ram32-a", ram_b="ram32-b", psu="psu750")
+
+    initial = efesto_headless.grade_build(SCENARIO, starter)
+    final = efesto_headless.grade_build(SCENARIO, target)
+    tests = result_by_name(initial)
+
+    assert initial["passed"] is False
+    assert tests["VRAM almeno 24 GB"]["passed"] is False
+    assert tests["RAM totale almeno 64 GB"]["passed"] is False
+    assert tests["PSU con margine del 20 percento"]["passed"] is False
+    assert tests["CPU entro 150 W"]["passed"] is True
+    assert tests["CPU AM5"]["passed"] is True
+    assert tests["Carico componenti entro 500 W"]["passed"] is True
+    assert tests["Esattamente due moduli RAM"]["passed"] is True
+
+    assert final["passed"] is True
+    assert final["score"] == 10.0
+    assert final["summary"] == {"passed": 8, "total": 8}
+
+
+def test_student_build_cannot_override_trusted_component_attributes() -> None:
+    malicious = build(gpu="gpu-12gb", ram_a="ram32-a", ram_b="ram32-b", psu="psu750")
+    gpu_placement = next(item for item in malicious["components"] if item["slot"] == "gpu")
+    gpu_placement["attributes"] = {"vram_gb": 999, "power_w": 1}
+
+    report = efesto_headless.grade_build(SCENARIO, malicious)
+    tests = result_by_name(report)
+
+    assert tests["VRAM almeno 24 GB"]["passed"] is False
+    assert "12 GB" in tests["VRAM almeno 24 GB"]["message"]
+
+
+def test_invalid_quantitative_contract_values_are_rejected() -> None:
+    invalid = deepcopy(SCENARIO)
+    invalid["components"][0]["attributes"]["power_w"] = float("nan")
+    invalid["checks"][1]["min_value"] = "24"
+    invalid["checks"][6]["min_count"] = 3
+    invalid["checks"][6]["max_count"] = 2
+    invalid["checks"][7]["factor"] = 0
+
+    errors = efesto_contracts.validate_scenario(invalid, "scenario")
+
+    assert any("attributes.power_w" in error for error in errors)
+    assert any("min_value deve essere un numero finito" in error for error in errors)
+    assert any("min_count non puo superare max_count" in error for error in errors)
+    assert any("factor deve essere maggiore di zero" in error for error in errors)
+
+
+def test_missing_numeric_attribute_fails_filtered_sum_instead_of_undercounting() -> None:
+    scenario = deepcopy(SCENARIO)
+    del scenario["components"][3]["attributes"]["capacity_gb"]
+    starter = build(gpu="gpu-24gb", ram_a="ram16-a", ram_b="ram32-b", psu="psu750")
+
+    report = efesto_headless.grade_build(scenario, starter)
+    tests = result_by_name(report)
+
+    assert tests["RAM totale almeno 64 GB"]["passed"] is False
+    assert "Attributo capacity_gb mancante" in tests["RAM totale almeno 64 GB"]["message"]


### PR DESCRIPTION
SUPERSEDED. Quantitative hardware grading primitives are now implemented and tested in standalone `TheBitPoets/efesto`. Kept closed as prototype history only.