### PR TITLE
Add Efesto design-by-requirement hardware labs

### DIFF
--- a/activities/examples/hardware_ai_gpu_vram.json
+++ b/activities/examples/hardware_ai_gpu_vram.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "id": "hw-ai-gpu-vram-001",
+  "titolo": "Workstation AI: scegli la GPU in base alla VRAM",
+  "tipo": "laboratorio",
+  "linguaggio": "virtual-lab",
+  "language": "virtual-lab",
+  "source_name": "build.json",
+  "difficolta": "C",
+  "argomenti": ["gpu", "vram", "ai", "llm", "pcie", "workstation"],
+  "consegna": "Il target richiede inferenza LLM locale con almeno 24 GB di VRAM. Sostituisci la GPU iniziale con una qualsiasi soluzione che soddisfi il requisito, senza cercare un modello specifico.",
+  "student_support_mode": "feedback-tecnico",
+  "correzione": {"compila": false, "test": true, "sandbox": true, "ai_feedback": false},
+  "metriche": {
+    "tempo_stimato_minuti": 20,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": false
+  },
+  "extensions": {
+    "thebitlab.virtual_lab": {
+      "schema_version": "virtual_lab.v1",
+      "runtime": "efesto",
+      "scenario_id": "ai-gpu-vram-001",
+      "submission": {"path": "build.json", "media_type": "application/json"},
+      "capabilities": ["interactive-ui", "deterministic-grade", "headless-run"]
+    }
+  },
+  "rubrica": [
+    {"criterio": "Interpretazione del requisito VRAM", "punti": 4},
+    {"criterio": "Scelta di una soluzione adeguata", "punti": 4},
+    {"criterio": "Metodo e autonomia", "punti": 2}
+  ]
+}

--- a/activities/examples/hardware_psu_headroom_design.json
+++ b/activities/examples/hardware_psu_headroom_design.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "id": "hw-psu-headroom-design-001",
+  "titolo": "PSU: calcola il margine invece di scegliere a memoria",
+  "tipo": "laboratorio",
+  "linguaggio": "virtual-lab",
+  "language": "virtual-lab",
+  "source_name": "build.json",
+  "difficolta": "C",
+  "argomenti": ["psu", "power", "watt", "headroom", "gpu", "workstation"],
+  "consegna": "Il brief fissa CPU, GPU e NVMe. Il resto del sistema vale 80 W e si richiede un margine del 20%. Sostituisci solo il PSU con una potenza sufficiente al carico calcolato.",
+  "student_support_mode": "feedback-tecnico",
+  "correzione": {"compila": false, "test": true, "sandbox": true, "ai_feedback": false},
+  "metriche": {
+    "tempo_stimato_minuti": 25,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": false
+  },
+  "extensions": {
+    "thebitlab.virtual_lab": {
+      "schema_version": "virtual_lab.v1",
+      "runtime": "efesto",
+      "scenario_id": "psu-headroom-design-001",
+      "submission": {"path": "build.json", "media_type": "application/json"},
+      "capabilities": ["interactive-ui", "deterministic-grade", "headless-run"]
+    }
+  },
+  "rubrica": [
+    {"criterio": "Calcolo del carico e del margine", "punti": 5},
+    {"criterio": "Scelta di un PSU sufficiente", "punti": 3},
+    {"criterio": "Metodo e autonomia", "punti": 2}
+  ]
+}

--- a/activities/examples/hardware_ram_upgrade_headroom.json
+++ b/activities/examples/hardware_ram_upgrade_headroom.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "id": "hw-ram-upgrade-headroom-001",
+  "titolo": "RAM: 64 GB con margine di espansione",
+  "tipo": "laboratorio",
+  "linguaggio": "virtual-lab",
+  "language": "virtual-lab",
+  "source_name": "build.json",
+  "difficolta": "C",
+  "argomenti": ["ram", "ddr5", "capacity", "upgrade", "workstation"],
+  "consegna": "La macchina deve avere almeno 64 GB di RAM oggi ma lasciare due DIMM liberi per un futuro upgrade. Sostituisci i moduli iniziali mantenendo esattamente due moduli installati.",
+  "student_support_mode": "feedback-tecnico",
+  "correzione": {"compila": false, "test": true, "sandbox": true, "ai_feedback": false},
+  "metriche": {
+    "tempo_stimato_minuti": 20,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": false
+  },
+  "extensions": {
+    "thebitlab.virtual_lab": {
+      "schema_version": "virtual_lab.v1",
+      "runtime": "efesto",
+      "scenario_id": "ram-upgrade-headroom-001",
+      "submission": {"path": "build.json", "media_type": "application/json"},
+      "capabilities": ["interactive-ui", "deterministic-grade", "headless-run"]
+    }
+  },
+  "rubrica": [
+    {"criterio": "Capacita RAM adeguata", "punti": 4},
+    {"criterio": "Margine di espansione preservato", "punti": 4},
+    {"criterio": "Metodo e autonomia", "punti": 2}
+  ]
+}

--- a/activities/examples/hardware_storage_tiering.json
+++ b/activities/examples/hardware_storage_tiering.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "id": "hw-storage-tiering-001",
+  "titolo": "Storage: NVMe per sistema, SATA per archivio",
+  "tipo": "laboratorio",
+  "linguaggio": "virtual-lab",
+  "language": "virtual-lab",
+  "source_name": "build.json",
+  "difficolta": "C",
+  "argomenti": ["storage", "nvme", "m2", "sata", "capacity", "server"],
+  "consegna": "Progetta lo storage con almeno 1 TB NVMe per sistema/VM e almeno 2 TB SATA per archivio/backup. Sono valide piu combinazioni che soddisfano le soglie.",
+  "student_support_mode": "feedback-tecnico",
+  "correzione": {"compila": false, "test": true, "sandbox": true, "ai_feedback": false},
+  "metriche": {
+    "tempo_stimato_minuti": 20,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": false
+  },
+  "extensions": {
+    "thebitlab.virtual_lab": {
+      "schema_version": "virtual_lab.v1",
+      "runtime": "efesto",
+      "scenario_id": "storage-tiering-001",
+      "submission": {"path": "build.json", "media_type": "application/json"},
+      "capabilities": ["interactive-ui", "deterministic-grade", "headless-run"]
+    }
+  },
+  "rubrica": [
+    {"criterio": "Scelta corretta delle tecnologie storage", "punti": 4},
+    {"criterio": "Capacita coerenti con il brief", "punti": 4},
+    {"criterio": "Metodo e autonomia", "punti": 2}
+  ]
+}

--- a/tests/test_efesto_design_labs.py
+++ b/tests/test_efesto_design_labs.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import efesto_headless, efesto_ui_server, student_virtual_lab
+from scripts.thebitlab_virtual_lab_contracts import normalize_virtual_lab_extension
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+DESIGN_LABS = [
+    {
+        "activity": "activities/examples/hardware_ai_gpu_vram.json",
+        "activity_id": "hw-ai-gpu-vram-001",
+        "scenario_id": "ai-gpu-vram-001",
+        "starter_score": 5.0,
+        "solutions": [
+            [{"slot": "pcie1", "component_id": "gpu-ai-24gb"}],
+            [{"slot": "pcie1", "component_id": "gpu-ai-48gb"}],
+        ],
+    },
+    {
+        "activity": "activities/examples/hardware_ram_upgrade_headroom.json",
+        "activity_id": "hw-ram-upgrade-headroom-001",
+        "scenario_id": "ram-upgrade-headroom-001",
+        "starter_score": 6.67,
+        "solutions": [
+            [
+                {"slot": "dimm_a2", "component_id": "ram32-a"},
+                {"slot": "dimm_b2", "component_id": "ram32-b"},
+            ]
+        ],
+    },
+    {
+        "activity": "activities/examples/hardware_storage_tiering.json",
+        "activity_id": "hw-storage-tiering-001",
+        "scenario_id": "storage-tiering-001",
+        "starter_score": 3.33,
+        "solutions": [
+            [
+                {"slot": "m2_system", "component_id": "nvme-1024"},
+                {"slot": "sata_archive", "component_id": "sata-2048"},
+            ],
+            [
+                {"slot": "m2_system", "component_id": "nvme-2048"},
+                {"slot": "sata_archive", "component_id": "sata-4096"},
+            ],
+        ],
+    },
+    {
+        "activity": "activities/examples/hardware_psu_headroom_design.json",
+        "activity_id": "hw-psu-headroom-design-001",
+        "scenario_id": "psu-headroom-design-001",
+        "starter_score": 8.0,
+        "solutions": [
+            [
+                {"slot": "cpu_socket", "component_id": "cpu-workstation-120w"},
+                {"slot": "pcie1", "component_id": "gpu-workstation-350w"},
+                {"slot": "m2_1", "component_id": "nvme-workstation-15w"},
+                {"slot": "psu_bay", "component_id": "psu-design-750"},
+            ],
+            [
+                {"slot": "cpu_socket", "component_id": "cpu-workstation-120w"},
+                {"slot": "pcie1", "component_id": "gpu-workstation-350w"},
+                {"slot": "m2_1", "component_id": "nvme-workstation-15w"},
+                {"slot": "psu_bay", "component_id": "psu-design-850"},
+            ],
+        ],
+    },
+]
+
+
+def build_for(scenario_id: str, placements: list[dict]) -> dict:
+    return {
+        "schema_version": "efesto.build.v1",
+        "scenario_id": scenario_id,
+        "components": placements,
+    }
+
+
+@pytest.mark.parametrize(
+    "lab",
+    DESIGN_LABS,
+    ids=[item["scenario_id"] for item in DESIGN_LABS],
+)
+def test_design_lab_starter_fails_and_all_declared_solutions_pass(lab: dict) -> None:
+    scenario = efesto_headless.load_scenario(ROOT, lab["scenario_id"])
+    starter_path = ROOT / "virtual-labs/efesto/starters" / f"{lab['scenario_id']}.json"
+    starter = json.loads(starter_path.read_text(encoding="utf-8"))
+
+    initial = efesto_headless.grade_build(
+        scenario,
+        starter,
+        activity_id=lab["activity_id"],
+    )
+
+    assert initial["passed"] is False
+    assert initial["score"] == lab["starter_score"]
+
+    for placements in lab["solutions"]:
+        report = efesto_headless.grade_build(
+            scenario,
+            build_for(lab["scenario_id"], placements),
+            activity_id=lab["activity_id"],
+        )
+        assert report["passed"] is True
+        assert report["score"] == 10.0
+
+
+@pytest.mark.parametrize(
+    "lab",
+    DESIGN_LABS,
+    ids=[item["scenario_id"] for item in DESIGN_LABS],
+)
+def test_design_activity_points_to_quantitative_scenario(lab: dict) -> None:
+    activity = json.loads((ROOT / lab["activity"]).read_text(encoding="utf-8"))
+    extension = normalize_virtual_lab_extension(activity)
+
+    assert activity["id"] == lab["activity_id"]
+    assert activity["language"] == "virtual-lab"
+    assert activity["source_name"] == "build.json"
+    assert extension is not None
+    assert extension["runtime"] == "efesto"
+    assert extension["scenario_id"] == lab["scenario_id"]
+
+
+@pytest.mark.parametrize(
+    "lab",
+    DESIGN_LABS,
+    ids=[item["scenario_id"] for item in DESIGN_LABS],
+)
+def test_design_lab_loads_in_generic_ui_and_exposes_trusted_attributes(
+    tmp_path: Path,
+    lab: dict,
+) -> None:
+    activity_path = ROOT / lab["activity"]
+    workspace = student_virtual_lab.create_virtual_lab_scaffold(
+        activity_path=activity_path,
+        target_dir=tmp_path / lab["activity_id"],
+        project_root=ROOT,
+    )
+    session = efesto_ui_server.EfestoUiSession.load(
+        project_root=ROOT,
+        activity_path=activity_path,
+        workspace_path=workspace,
+    )
+
+    state = session.state()
+
+    assert state["activity"]["scenario_id"] == lab["scenario_id"]
+    assert state["grading"]["score"] == lab["starter_score"]
+    assert any(
+        isinstance(component.get("attributes"), dict) and component["attributes"]
+        for component in state["scenario"]["components"]
+    )
+
+
+def test_psu_lab_cannot_pass_by_removing_the_gpu_to_reduce_demand() -> None:
+    scenario = efesto_headless.load_scenario(ROOT, "psu-headroom-design-001")
+    cheating_build = build_for(
+        "psu-headroom-design-001",
+        [
+            {"slot": "cpu_socket", "component_id": "cpu-workstation-120w"},
+            {"slot": "m2_1", "component_id": "nvme-workstation-15w"},
+            {"slot": "psu_bay", "component_id": "psu-design-650"},
+        ],
+    )
+
+    report = efesto_headless.grade_build(scenario, cheating_build)
+    tests = {test["name"]: test for test in report["tests"]}
+
+    assert report["passed"] is False
+    assert tests["GPU del brief presente"]["passed"] is False
+    assert tests["PSU sufficiente con 80 W fissi e margine del 20 percento"]["passed"] is True
+
+
+def test_psu_lab_calculates_678_w_required_from_the_brief() -> None:
+    scenario = efesto_headless.load_scenario(ROOT, "psu-headroom-design-001")
+    starter = json.loads(
+        (ROOT / "virtual-labs/efesto/starters/psu-headroom-design-001.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    report = efesto_headless.grade_build(scenario, starter)
+    capacity = next(
+        test
+        for test in report["tests"]
+        if test["name"] == "PSU sufficiente con 80 W fissi e margine del 20 percento"
+    )
+
+    assert capacity["passed"] is False
+    assert "richiesti 678 W" in capacity["message"]

--- a/virtual-labs/efesto/scenarios/ai-gpu-vram-001.json
+++ b/virtual-labs/efesto/scenarios/ai-gpu-vram-001.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "efesto.scenario.v1",
+  "id": "ai-gpu-vram-001",
+  "title": "Scegli una GPU per inferenza LLM locale",
+  "slots": [
+    {"id": "pcie1", "kind": "pcie", "label": "PCIe x16 principale", "attributes": {"pcie_gen": 5, "lanes": 16}}
+  ],
+  "components": [
+    {"id": "gpu-ai-12gb", "kind": "gpu", "label": "GPU · 12 GB VRAM", "allowed_slots": ["pcie1"], "attributes": {"vram_gb": 12, "power_w": 200, "pcie_gen": 4}},
+    {"id": "gpu-ai-16gb", "kind": "gpu", "label": "GPU · 16 GB VRAM", "allowed_slots": ["pcie1"], "attributes": {"vram_gb": 16, "power_w": 250, "pcie_gen": 4}},
+    {"id": "gpu-ai-24gb", "kind": "gpu", "label": "GPU · 24 GB VRAM", "allowed_slots": ["pcie1"], "attributes": {"vram_gb": 24, "power_w": 350, "pcie_gen": 4}},
+    {"id": "gpu-ai-48gb", "kind": "gpu", "label": "GPU workstation · 48 GB VRAM", "allowed_slots": ["pcie1"], "attributes": {"vram_gb": 48, "power_w": 300, "pcie_gen": 4}}
+  ],
+  "checks": [
+    {"id": "compatible", "name": "GPU installata su uno slot compatibile", "type": "all-placements-compatible", "visibility": "student"},
+    {"id": "vram-target", "name": "VRAM almeno 24 GB", "type": "slot-component-attribute-min", "slot": "pcie1", "attribute": "vram_gb", "min_value": 24, "unit": "GB", "visibility": "student"}
+  ]
+}

--- a/virtual-labs/efesto/scenarios/psu-headroom-design-001.json
+++ b/virtual-labs/efesto/scenarios/psu-headroom-design-001.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "efesto.scenario.v1",
+  "id": "psu-headroom-design-001",
+  "title": "Dimensiona il PSU dal carico reale",
+  "slots": [
+    {"id": "cpu_socket", "kind": "cpu-socket", "label": "CPU"},
+    {"id": "pcie1", "kind": "pcie", "label": "GPU"},
+    {"id": "m2_1", "kind": "m2", "label": "NVMe"},
+    {"id": "psu_bay", "kind": "psu", "label": "PSU ATX"}
+  ],
+  "components": [
+    {"id": "cpu-workstation-120w", "kind": "cpu", "label": "CPU workstation · 120 W", "allowed_slots": ["cpu_socket"], "attributes": {"power_w": 120}},
+    {"id": "gpu-workstation-350w", "kind": "gpu", "label": "GPU workstation · 350 W", "allowed_slots": ["pcie1"], "attributes": {"power_w": 350}},
+    {"id": "nvme-workstation-15w", "kind": "nvme", "label": "NVMe · 15 W", "allowed_slots": ["m2_1"], "attributes": {"power_w": 15}},
+    {"id": "psu-design-650", "kind": "psu", "label": "PSU · 650 W", "allowed_slots": ["psu_bay"], "attributes": {"capacity_w": 650}},
+    {"id": "psu-design-750", "kind": "psu", "label": "PSU · 750 W", "allowed_slots": ["psu_bay"], "attributes": {"capacity_w": 750}},
+    {"id": "psu-design-850", "kind": "psu", "label": "PSU · 850 W", "allowed_slots": ["psu_bay"], "attributes": {"capacity_w": 850}}
+  ],
+  "checks": [
+    {"id": "compatible", "name": "Componenti installati sulle interfacce corrette", "type": "all-placements-compatible", "visibility": "student"},
+    {"id": "cpu-required", "name": "CPU del brief presente", "type": "component-in-slot", "component_id": "cpu-workstation-120w", "slot": "cpu_socket", "visibility": "student"},
+    {"id": "gpu-required", "name": "GPU del brief presente", "type": "component-in-slot", "component_id": "gpu-workstation-350w", "slot": "pcie1", "visibility": "student"},
+    {"id": "nvme-required", "name": "NVMe del brief presente", "type": "component-in-slot", "component_id": "nvme-workstation-15w", "slot": "m2_1", "visibility": "student"},
+    {
+      "id": "capacity",
+      "name": "PSU sufficiente con 80 W fissi e margine del 20 percento",
+      "type": "slot-capacity-covers-installed-sum",
+      "capacity_slot": "psu_bay",
+      "capacity_attribute": "capacity_w",
+      "demand_attribute": "power_w",
+      "fixed_demand": 80,
+      "factor": 1.2,
+      "unit": "W",
+      "visibility": "student"
+    }
+  ]
+}

--- a/virtual-labs/efesto/scenarios/ram-upgrade-headroom-001.json
+++ b/virtual-labs/efesto/scenarios/ram-upgrade-headroom-001.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "efesto.scenario.v1",
+  "id": "ram-upgrade-headroom-001",
+  "title": "64 GB oggi, spazio per l'upgrade domani",
+  "slots": [
+    {"id": "dimm_a1", "kind": "dimm", "label": "DIMM A1"},
+    {"id": "dimm_a2", "kind": "dimm", "label": "DIMM A2"},
+    {"id": "dimm_b1", "kind": "dimm", "label": "DIMM B1"},
+    {"id": "dimm_b2", "kind": "dimm", "label": "DIMM B2"}
+  ],
+  "components": [
+    {"id": "ram16-a", "kind": "ram", "label": "DDR5 · 16 GB A", "allowed_slots": ["dimm_a1", "dimm_a2", "dimm_b1", "dimm_b2"], "attributes": {"capacity_gb": 16, "speed_mt_s": 5600}},
+    {"id": "ram16-b", "kind": "ram", "label": "DDR5 · 16 GB B", "allowed_slots": ["dimm_a1", "dimm_a2", "dimm_b1", "dimm_b2"], "attributes": {"capacity_gb": 16, "speed_mt_s": 5600}},
+    {"id": "ram32-a", "kind": "ram", "label": "DDR5 · 32 GB A", "allowed_slots": ["dimm_a1", "dimm_a2", "dimm_b1", "dimm_b2"], "attributes": {"capacity_gb": 32, "speed_mt_s": 5600}},
+    {"id": "ram32-b", "kind": "ram", "label": "DDR5 · 32 GB B", "allowed_slots": ["dimm_a1", "dimm_a2", "dimm_b1", "dimm_b2"], "attributes": {"capacity_gb": 32, "speed_mt_s": 5600}}
+  ],
+  "checks": [
+    {"id": "compatible", "name": "Moduli inseriti in DIMM compatibili", "type": "all-placements-compatible", "visibility": "student"},
+    {"id": "capacity", "name": "RAM totale almeno 64 GB", "type": "installed-attribute-sum-min", "attribute": "capacity_gb", "kind": "ram", "min_value": 64, "unit": "GB", "visibility": "student"},
+    {"id": "two-modules", "name": "Usa esattamente due moduli per lasciare due DIMM liberi", "type": "installed-kind-count", "kind": "ram", "min_count": 2, "max_count": 2, "visibility": "student"}
+  ]
+}

--- a/virtual-labs/efesto/scenarios/storage-tiering-001.json
+++ b/virtual-labs/efesto/scenarios/storage-tiering-001.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "efesto.scenario.v1",
+  "id": "storage-tiering-001",
+  "title": "Progetta storage di sistema e archivio",
+  "slots": [
+    {"id": "m2_system", "kind": "m2", "label": "M.2 NVMe · sistema/VM"},
+    {"id": "sata_archive", "kind": "sata", "label": "SATA · archivio/backup"}
+  ],
+  "components": [
+    {"id": "nvme-512", "kind": "nvme", "label": "NVMe · 512 GB", "allowed_slots": ["m2_system"], "attributes": {"capacity_gb": 512, "read_mb_s": 3500}},
+    {"id": "nvme-1024", "kind": "nvme", "label": "NVMe · 1 TB", "allowed_slots": ["m2_system"], "attributes": {"capacity_gb": 1024, "read_mb_s": 7000}},
+    {"id": "nvme-2048", "kind": "nvme", "label": "NVMe · 2 TB", "allowed_slots": ["m2_system"], "attributes": {"capacity_gb": 2048, "read_mb_s": 7000}},
+    {"id": "sata-1024", "kind": "sata-storage", "label": "SATA · 1 TB", "allowed_slots": ["sata_archive"], "attributes": {"capacity_gb": 1024, "read_mb_s": 550}},
+    {"id": "sata-2048", "kind": "sata-storage", "label": "SATA · 2 TB", "allowed_slots": ["sata_archive"], "attributes": {"capacity_gb": 2048, "read_mb_s": 550}},
+    {"id": "sata-4096", "kind": "sata-storage", "label": "SATA · 4 TB", "allowed_slots": ["sata_archive"], "attributes": {"capacity_gb": 4096, "read_mb_s": 550}}
+  ],
+  "checks": [
+    {"id": "compatible", "name": "Storage installato sulle interfacce corrette", "type": "all-placements-compatible", "visibility": "student"},
+    {"id": "system-capacity", "name": "Disco di sistema almeno 1 TB", "type": "slot-component-attribute-min", "slot": "m2_system", "attribute": "capacity_gb", "min_value": 1024, "unit": "GB", "visibility": "student"},
+    {"id": "archive-capacity", "name": "Archivio almeno 2 TB", "type": "slot-component-attribute-min", "slot": "sata_archive", "attribute": "capacity_gb", "min_value": 2048, "unit": "GB", "visibility": "student"}
+  ]
+}

--- a/virtual-labs/efesto/starters/ai-gpu-vram-001.json
+++ b/virtual-labs/efesto/starters/ai-gpu-vram-001.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "efesto.build.v1",
+  "scenario_id": "ai-gpu-vram-001",
+  "components": [
+    {"slot": "pcie1", "component_id": "gpu-ai-12gb"}
+  ]
+}

--- a/virtual-labs/efesto/starters/psu-headroom-design-001.json
+++ b/virtual-labs/efesto/starters/psu-headroom-design-001.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "efesto.build.v1",
+  "scenario_id": "psu-headroom-design-001",
+  "components": [
+    {"slot": "cpu_socket", "component_id": "cpu-workstation-120w"},
+    {"slot": "pcie1", "component_id": "gpu-workstation-350w"},
+    {"slot": "m2_1", "component_id": "nvme-workstation-15w"},
+    {"slot": "psu_bay", "component_id": "psu-design-650"}
+  ]
+}

--- a/virtual-labs/efesto/starters/ram-upgrade-headroom-001.json
+++ b/virtual-labs/efesto/starters/ram-upgrade-headroom-001.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "efesto.build.v1",
+  "scenario_id": "ram-upgrade-headroom-001",
+  "components": [
+    {"slot": "dimm_a2", "component_id": "ram16-a"},
+    {"slot": "dimm_b2", "component_id": "ram16-b"}
+  ]
+}

--- a/virtual-labs/efesto/starters/storage-tiering-001.json
+++ b/virtual-labs/efesto/starters/storage-tiering-001.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "efesto.build.v1",
+  "scenario_id": "storage-tiering-001",
+  "components": [
+    {"slot": "m2_system", "component_id": "nvme-512"},
+    {"slot": "sata_archive", "component_id": "sata-1024"}
+  ]
+}


### PR DESCRIPTION
SUPERSEDED. Design-by-requirement hardware labs were migrated to `TheBitPoets/thebitlab-hardware`; the quantitative evaluator lives in standalone Efesto. Kept closed as prototype history only.