### PR TITLE
Dispatch runtime activities through plugin registry

### DIFF
--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -15,7 +15,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts import grade_activity, student_lab_attempts, student_lab_service
+from scripts import grade_activity, student_lab_attempts, student_lab_service, student_runtime
 from scripts.thebitlab_contracts import normalize_activity
 from scripts.thebitlab_technical_services import (
     DockerGradeActivityExecutionService,
@@ -508,8 +508,15 @@ def run_assignment(
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     docker_image: str = DEFAULT_DOCKER_IMAGE,
 ) -> dict[str, Any]:
-    """Run one assignment with the requested backend."""
+    """Run one assignment, delegating runtime Activities before code backends."""
 
+    activity = load_activity(root, assignment)
+    if student_runtime.activity_uses_runtime(activity):
+        return student_runtime.run_runtime_assignment(
+            assignment,
+            root=root,
+            timeout_seconds=timeout_seconds,
+        )
     if backend == "local":
         return run_local_assignment(assignment, root=root, timeout_seconds=timeout_seconds)
     if backend == "docker":

--- a/tests/test_student_runtime_dispatch.py
+++ b/tests/test_student_runtime_dispatch.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import student_lab_runner
+
+
+def test_run_assignment_dispatches_runtime_before_code_backend(monkeypatch, tmp_path: Path) -> None:
+    assignment = {"assignment_id": "a1", "activity_id": "runtime-a1", "student_id": "s1"}
+    runtime_activity = {
+        "extensions": {
+            "thebitlab.runtime": {
+                "schema_version": "runtime_activity.v1",
+                "runtime_id": "example-runtime",
+                "submission": {"artifacts": [{"id": "answer", "path": "answer.bin"}]},
+            }
+        }
+    }
+    monkeypatch.setattr(student_lab_runner, "load_activity", lambda root, item: runtime_activity)
+    calls = []
+
+    def fake_runtime(item, *, root, timeout_seconds):
+        calls.append((item, root, timeout_seconds))
+        return {"status": "passed", "passed": True, "backend": "runtime"}
+
+    monkeypatch.setattr(student_lab_runner.student_runtime, "run_runtime_assignment", fake_runtime)
+    monkeypatch.setattr(
+        student_lab_runner,
+        "run_docker_assignment",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Docker must not run")),
+    )
+
+    report = student_lab_runner.run_assignment(
+        assignment,
+        root=tmp_path,
+        backend="docker",
+        timeout_seconds=17,
+        docker_image="ignored-for-runtime",
+    )
+
+    assert report["backend"] == "runtime"
+    assert calls == [(assignment, tmp_path, 17)]
+
+
+def test_run_assignment_keeps_legacy_backend_for_non_runtime_activity(monkeypatch, tmp_path: Path) -> None:
+    assignment = {"assignment_id": "a1", "activity_id": "code-a1", "student_id": "s1"}
+    monkeypatch.setattr(student_lab_runner, "load_activity", lambda root, item: {"schema_version": "1.0"})
+    monkeypatch.setattr(
+        student_lab_runner,
+        "run_local_assignment",
+        lambda item, *, root, timeout_seconds: {"backend": "local", "passed": True},
+    )
+
+    report = student_lab_runner.run_assignment(
+        assignment,
+        root=tmp_path,
+        backend="local",
+        timeout_seconds=9,
+    )
+
+    assert report == {"backend": "local", "passed": True}


### PR DESCRIPTION
## Scope

Connect the generic runtime adapter already on `main` to the normal `student_lab_runner`.

`run_assignment()` now loads the Activity first. If it declares `extensions.thebitlab.runtime`, execution is delegated to `student_runtime.run_runtime_assignment()` before considering the historical `local/docker` code backends.

Consequences:
- runtime Activities work through the same CLI/report/Attempt path as coding labs;
- selecting `--backend docker` does not accidentally send a runtime artifact to the code runner;
- non-runtime C/Python/JS/SQL behavior is unchanged.

## Tests

Adds focused tests proving:
- runtime dispatch wins even when the caller requested Docker;
- normal Activities still use the legacy local backend.

No runtime ID (Efesto/ns-3/etc.) is hard-coded.