### PR TITLE
Add runtime inventory and student launch CLIs

### DIFF
--- a/scripts/student_runtime_cli.py
+++ b/scripts/student_runtime_cli.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+import json
+import webbrowser
+from pathlib import Path
+from urllib.parse import urlparse
+
+from scripts import student_lab_runner, student_runtime
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def add_assignment_selection(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--student-id", required=True)
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--assignment-id")
+    selection.add_argument("--activity-id")
+    parser.add_argument("--root", type=Path, default=PROJECT_ROOT)
+    parser.add_argument("--now")
+    parser.add_argument(
+        "--timeout",
+        type=student_lab_runner.positive_int,
+        default=30,
+        help="Timeout operativo passato al runtime, in secondi.",
+    )
+
+
+def safe_browser_endpoint(endpoint: str) -> bool:
+    """Allow automatic browser opening only for ordinary HTTP(S) endpoints."""
+
+    parsed = urlparse(str(endpoint or "").strip())
+    return parsed.scheme in {"http", "https"} and bool(parsed.hostname)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Esegue o apre una consegna TheBitLab gestita da un runtime esterno."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    launch = subparsers.add_parser("launch", help="Apre l'interfaccia interattiva del runtime.")
+    add_assignment_selection(launch)
+    launch.add_argument("--no-open-browser", action="store_true")
+
+    run = subparsers.add_parser("run", help="Esegue il grading headless tramite il normale runner TheBitLab.")
+    add_assignment_selection(run)
+    run.add_argument("--write-report", action="store_true")
+    run.add_argument("--final", action="store_true")
+    return parser.parse_args()
+
+
+def load_assignment(args: argparse.Namespace) -> dict:
+    return student_lab_runner.load_student_assignment(
+        root=args.root.resolve(strict=False),
+        student_id=args.student_id,
+        assignment_id=args.assignment_id,
+        activity_id=args.activity_id,
+        now=args.now,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve(strict=False)
+    try:
+        assignment = load_assignment(args)
+        if args.command == "launch":
+            result = student_runtime.launch_runtime_assignment(
+                assignment,
+                root=root,
+                timeout_seconds=args.timeout,
+            )
+            payload = {
+                "status": result.status,
+                "session_id": result.session_id,
+                "endpoint": result.endpoint,
+                "detail": result.detail,
+                "metadata": result.metadata,
+            }
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+            if result.endpoint and not args.no_open_browser:
+                if not safe_browser_endpoint(result.endpoint):
+                    raise ValueError(
+                        "Il runtime ha restituito un endpoint non HTTP(S); "
+                        "l'apertura automatica e stata bloccata."
+                    )
+                webbrowser.open(result.endpoint)
+            return 0 if result.status in {"started", "already_running"} else 1
+
+        if args.final and not args.write_report:
+            raise ValueError("--final richiede --write-report")
+        report = student_lab_runner.run_assignment(
+            assignment,
+            root=root,
+            timeout_seconds=args.timeout,
+        )
+        if args.write_report:
+            report_path = student_lab_runner.write_student_report(root, assignment, report)
+            if args.final:
+                student_lab_runner.finalize_report_attempt(
+                    root,
+                    assignment,
+                    report_path,
+                    student_lab_runner.clean_text(report.get("attempt_id")),
+                )
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        return 0 if report.get("passed") is True else 1
+    except ValueError as error:
+        print(f"Runtime non disponibile: {error}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/thebitlab_runtime_cli.py
+++ b/scripts/thebitlab_runtime_cli.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from scripts import thebitlab_runtime_plugins
+
+
+DEFAULT_REGISTRY = thebitlab_runtime_plugins.RuntimePluginRegistry()
+
+
+def runtime_record(
+    runtime_id: str,
+    *,
+    registry: thebitlab_runtime_plugins.RuntimePluginRegistry = DEFAULT_REGISTRY,
+) -> dict[str, Any]:
+    """Return one stable inventory record for an installed runtime plugin."""
+
+    try:
+        loaded = registry.get(runtime_id)
+        probe = thebitlab_runtime_plugins.probe_runtime(loaded)
+    except thebitlab_runtime_plugins.RuntimePluginError as error:
+        return {
+            "runtime_id": runtime_id,
+            "installed": True,
+            "available": False,
+            "status": "error",
+            "detail": str(error),
+        }
+    descriptor = loaded.descriptor
+    return {
+        "runtime_id": descriptor.runtime_id,
+        "display_name": descriptor.display_name,
+        "plugin_version": descriptor.plugin_version,
+        "api_version": descriptor.api_version,
+        "capabilities": sorted(descriptor.capabilities),
+        "vendor": descriptor.vendor,
+        "homepage": descriptor.homepage,
+        "installed": True,
+        "available": probe.available,
+        "runtime_version": probe.version,
+        "status": "available" if probe.available else "unavailable",
+        "detail": probe.detail,
+        "metadata": probe.metadata,
+    }
+
+
+def runtime_inventory(
+    *,
+    registry: thebitlab_runtime_plugins.RuntimePluginRegistry = DEFAULT_REGISTRY,
+) -> list[dict[str, Any]]:
+    """Probe every administrator-installed runtime known to this Python environment."""
+
+    return [runtime_record(runtime_id, registry=registry) for runtime_id in registry.installed_ids()]
+
+
+def render_inventory(records: list[dict[str, Any]]) -> str:
+    if not records:
+        return "Nessun runtime TheBitLab installato."
+    lines = []
+    for record in records:
+        runtime_id = str(record.get("runtime_id") or "-")
+        display_name = str(record.get("display_name") or runtime_id)
+        status = str(record.get("status") or "unknown")
+        plugin_version = str(record.get("plugin_version") or "-")
+        runtime_version = str(record.get("runtime_version") or "-")
+        capabilities = ", ".join(record.get("capabilities") or []) or "-"
+        lines.extend(
+            [
+                f"{runtime_id} · {display_name}",
+                f"  stato: {status}",
+                f"  plugin: {plugin_version} · runtime: {runtime_version}",
+                f"  capability: {capabilities}",
+            ]
+        )
+        detail = str(record.get("detail") or "").strip()
+        if detail:
+            lines.append(f"  dettaglio: {detail}")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Scopri e verifica i runtime esterni installati per TheBitLab."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="Elenca e prova tutti i runtime installati.")
+    list_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    probe_parser = subparsers.add_parser("probe", help="Verifica un runtime specifico.")
+    probe_parser.add_argument("runtime_id")
+    probe_parser.add_argument("--json", action="store_true", dest="as_json")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "list":
+        records = runtime_inventory()
+        print(json.dumps(records, ensure_ascii=False, indent=2) if args.as_json else render_inventory(records))
+        return 0 if all(record.get("available") is True for record in records) else (0 if not records else 1)
+
+    record = runtime_record(args.runtime_id)
+    print(json.dumps(record, ensure_ascii=False, indent=2) if args.as_json else render_inventory([record]))
+    return 0 if record.get("available") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_student_runtime_cli.py
+++ b/tests/test_student_runtime_cli.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from scripts import student_runtime_cli
+
+
+def test_browser_endpoint_accepts_only_http_or_https() -> None:
+    assert student_runtime_cli.safe_browser_endpoint("http://127.0.0.1:9999/session") is True
+    assert student_runtime_cli.safe_browser_endpoint("https://lab.example.test/session") is True
+    assert student_runtime_cli.safe_browser_endpoint("file:///tmp/answer") is False
+    assert student_runtime_cli.safe_browser_endpoint("javascript:alert(1)") is False
+    assert student_runtime_cli.safe_browser_endpoint("matlab:open") is False
+    assert student_runtime_cli.safe_browser_endpoint("") is False

--- a/tests/test_thebitlab_runtime_cli.py
+++ b/tests/test_thebitlab_runtime_cli.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from scripts import thebitlab_runtime_cli, thebitlab_runtime_plugins
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, factory) -> None:
+        self.name = name
+        self._factory = factory
+
+    def load(self):
+        return self._factory
+
+
+class AvailableRuntime:
+    def describe(self):
+        return {
+            "schema_version": "runtime_descriptor.v1",
+            "runtime_id": "available-runtime",
+            "display_name": "Available Runtime",
+            "plugin_version": "1.2.3",
+            "api_version": "runtime_plugin.v1",
+            "capabilities": ["headless-run", "interactive-launch"],
+            "vendor": "Example",
+        }
+
+    def probe(self):
+        return {
+            "schema_version": "runtime_probe.v1",
+            "available": True,
+            "version": "9.1",
+            "detail": "ready",
+            "metadata": {"mode": "local"},
+        }
+
+
+class MissingBackendRuntime:
+    def describe(self):
+        return {
+            "schema_version": "runtime_descriptor.v1",
+            "runtime_id": "missing-backend",
+            "display_name": "Missing Backend",
+            "plugin_version": "0.2.0",
+            "api_version": "runtime_plugin.v1",
+            "capabilities": ["headless-run"],
+        }
+
+    def probe(self):
+        return {
+            "schema_version": "runtime_probe.v1",
+            "available": False,
+            "version": "",
+            "detail": "native simulator not installed",
+            "metadata": {},
+        }
+
+
+def registry():
+    return thebitlab_runtime_plugins.RuntimePluginRegistry(
+        lambda: (
+            FakeEntryPoint("available-runtime", AvailableRuntime),
+            FakeEntryPoint("missing-backend", MissingBackendRuntime),
+        )
+    )
+
+
+def test_inventory_distinguishes_plugin_from_backend_availability() -> None:
+    records = thebitlab_runtime_cli.runtime_inventory(registry=registry())
+    assert [record["runtime_id"] for record in records] == ["available-runtime", "missing-backend"]
+    assert records[0]["available"] is True
+    assert records[0]["runtime_version"] == "9.1"
+    assert records[0]["capabilities"] == ["headless-run", "interactive-launch"]
+    assert records[1]["available"] is False
+    assert "not installed" in records[1]["detail"]
+
+
+def test_render_inventory_is_human_readable() -> None:
+    text = thebitlab_runtime_cli.render_inventory(
+        thebitlab_runtime_cli.runtime_inventory(registry=registry())
+    )
+    assert "available-runtime" in text
+    assert "headless-run" in text
+    assert "missing-backend" in text
+    assert "unavailable" in text
+
+
+def test_empty_inventory_is_explicit() -> None:
+    empty = thebitlab_runtime_plugins.RuntimePluginRegistry(lambda: ())
+    assert thebitlab_runtime_cli.runtime_inventory(registry=empty) == []
+    assert "Nessun runtime" in thebitlab_runtime_cli.render_inventory([])


### PR DESCRIPTION
Adds two generic operational CLIs on top of the runtime plugin SDK and automatic runner dispatch.

### Administrator runtime CLI
`scripts/thebitlab_runtime_cli.py`
- `list`: discovers every installed `thebitlab.runtimes` entry point and probes the actual backend;
- `probe <runtime_id>`: reports plugin version, runtime version, capabilities, availability and detail;
- supports JSON output for future installer/dashboard integration.

This explicitly distinguishes *adapter installed* from *simulator/backend available*, useful for native/licensed tools.

### Student runtime CLI
`scripts/student_runtime_cli.py`
- `launch`: opens an interactive runtime assignment via generic `launch()`;
- `run`: delegates to the normal `student_lab_runner`, with optional report/final-attempt persistence.
- automatic browser opening accepts only HTTP(S) endpoints; native/custom-protocol launch belongs to the trusted plugin itself.

Tests use fake runtimes and endpoint safety checks. No runtime-specific ID is hard-coded.