### PR TITLE
docs: add pilot 2026/27 privacy and governance package

### DIFF
--- a/doc/governance/PILOT_APPROVAL_BRIEF_2026_2027.md
+++ b/doc/governance/PILOT_APPROVAL_BRIEF_2026_2027.md
@@ -1,0 +1,278 @@
+# TheBitLab pilot 2026/2027 — scheda sintetica per Dirigente e RPD/DPO
+
+## Stato
+
+**BOZZA PER VALUTAZIONE E APPROVAZIONE ISTITUZIONALE.**
+
+Questa scheda riassume in forma breve il pacchetto tecnico e privacy del pilot TheBitLab. Non costituisce da sola una dichiarazione di conformità GDPR, una DPIA conclusa, un atto di nomina o un parere legale. Le decisioni finali spettano all'Istituto, con il coinvolgimento del RPD/DPO e delle altre figure competenti.
+
+Documenti di dettaglio collegati:
+
+- `PILOT_GOVERNANCE_2026_2027.md`;
+- `PILOT_PRIVACY_NOTICE_DRAFT.md`;
+- `PILOT_DPIA_SCREENING.md`;
+- `PILOT_PROVIDER_REGISTER.md`;
+- issue governance `#699`, identity policy `#700`, AI boundary `#710` e roadmap AI `#711`–`#715`.
+
+---
+
+# 1. Che cos'è TheBitLab
+
+TheBitLab è una piattaforma didattica per corsi di informatica e laboratori scolastici. Nel pilot 2026/2027 il perimetro previsto comprende:
+
+- autenticazione Google;
+- associazione autorizzata studente–classe–assignment;
+- distribuzione di activity e materiali;
+- esecuzione di esercizi/lab in sandbox;
+- tentativi, report dei test e scelta del tentativo definitivo;
+- richieste di aiuto e feedback;
+- dashboard docente e registro delle consegne;
+- backup/restore e audit tecnico;
+- funzioni AI progressive, attivabili sui dati reali solo dopo il relativo gate privacy/compliance.
+
+Non è prevista, nel perimetro corrente del pilot, una piattaforma multi-scuola general purpose, una profilazione commerciale, pubblicità, vendita di dati o monitoraggio biometrico/emotivo.
+
+---
+
+# 2. Chi usa il sistema
+
+| Ruolo | Uso principale | Accesso previsto |
+|---|---|---|
+| Studente | activity, lab, tentativi, aiuto | solo classe/assignment e dati propri |
+| Docente | assegnazioni, report, feedback, grading | solo classi di competenza |
+| Amministratore tecnico | deployment, sicurezza, backup/restore | accesso minimo necessario e tracciato |
+| Dirigente/decision owner | autorizzazione pilot, rischio residuo, GO/NO-GO | documentazione e decisioni di governance |
+| RPD/DPO | supporto alla valutazione privacy | documentazione, flussi e registri necessari |
+
+Il dominio dell'account Google non attribuisce autorizzazioni didattiche: l'accesso a classi e assignment dipende sempre dai binding e dalle membership interne TheBitLab.
+
+---
+
+# 3. Account ammessi
+
+Decisione progettuale proposta/registrata:
+
+- sono ammessi sia account Google Workspace scolastici sia account Gmail personali;
+- l'account scolastico è preferibile quando disponibile e funzionante, ma non è requisito tecnico esclusivo;
+- Gmail personale è ammesso per evitare che indisponibilità o password dimenticate dell'account scolastico impediscano l'attività didattica;
+- l'Istituto deve confermare che questa scelta è compatibile con le proprie policy e con l'informativa fornita a studenti/famiglie;
+- eventuali blocchi amministrativi del tenant Workspace devono essere gestiti come problema di onboarding/supporto, non aggirati.
+
+**Decisione richiesta all'Istituto:** approvare, modificare o vietare l'uso di Gmail personale nel pilot.
+
+---
+
+# 4. Dati trattati e finalità
+
+La progettazione segue minimizzazione e separazione per finalità. Le categorie previste sono:
+
+| Categoria | Esempi | Finalità |
+|---|---|---|
+| Identità e account | user ID interno, provider, stato account | login, sicurezza, amministrazione |
+| Classe e membership | class ID, ruolo, membership | autorizzazione e isolamento |
+| Didattica | course/activity/assignment ID | distribuzione del percorso |
+| Elaborati e tentativi | codice, output test, attempt ID | laboratorio, storico, feedback |
+| Grading e feedback | esiti test, rubriche, feedback, eventuale proposta AI | valutazione e supporto docente |
+| Aiuto | domanda, contesto minimo, risposta | assistenza didattica |
+| Audit/security | eventi tecnici minimizzati | sicurezza, incidenti, troubleshooting |
+| Backup | copia coerente dello stato applicativo | continuità e disaster recovery |
+
+Principi tecnici già assunti:
+
+- niente cookie, bearer, secret, chiavi private o callback OAuth sensibili nei documenti/evidence condivisi;
+- niente ID di autorizzazione accettati dal client come authority;
+- dati di studenti diversi non devono essere mescolati;
+- hidden test e materiali teacher-only non devono essere esposti allo studente né inviati a provider AI quando non necessari/autorizzati.
+
+**Decisione richiesta all'Istituto/RPD:** confermare che le categorie e finalità siano appropriate o indicare modifiche.
+
+---
+
+# 5. Conservazione proposta
+
+Questi valori sono una **proposta tecnica iniziale** e devono essere confermati o modificati dall'Istituto/RPD in base alla finalità e alle regole interne.
+
+| Dato | Retention proposta |
+|---|---|
+| Account, membership, assignment, tentativi/report e grading del pilot | anno scolastico + 90 giorni |
+| Richieste di aiuto/tutor e relativo contesto | 30 giorni, salvo necessità didattica documentata diversa |
+| Log security/operativi minimizzati | 30 giorni, salvo evento/incidente che richieda conservazione controllata |
+| Payload AI esterni | non persistito da TheBitLab per default; eventuale retention provider da documentare |
+| Backup rolling | 30 giorni, con cifratura e controllo accessi |
+| Evidence del rehearsal | conservazione separata e ristretta secondo policy approvata |
+
+Cancellazione, rettifica, esportazione e gestione degli account devono essere documentate nella procedura operativa.
+
+**Decisione richiesta:** approvare o modificare ogni retention prima dei dati reali.
+
+---
+
+# 6. Backup e continuità
+
+Decisione progettuale registrata:
+
+- backup almeno giornaliero;
+- **RPO target 24 ore**;
+- **RTO target 8 ore lavorative**;
+- backup cifrato e separato dai secret;
+- restore periodicamente verificato in ambiente isolato;
+- manifest/checksum e controllo d'integrità;
+- nessuna scrittura nella root originale durante un restore di prova.
+
+**Decisione richiesta:** confermare RPO/RTO e autorizzare la localizzazione/provider di backup effettivi.
+
+---
+
+# 7. Provider e trasferimenti
+
+Prima dell'uso reale devono essere compilati nel `PILOT_PROVIDER_REGISTER.md` almeno:
+
+- hosting/VPS e localizzazione;
+- Google Identity/Workspace;
+- GitHub/GitLab per fonti private quando usati;
+- backup/storage;
+- provider AI eventualmente attivati;
+- ruolo privacy/contratto, subfornitori rilevanti, localizzazione, retention e condizioni di data use/training;
+- eventuali trasferimenti internazionali e relativo meccanismo giuridico da validare con l'Istituto/RPD.
+
+Nessun provider AI è autorizzato implicitamente solo perché tecnicamente integrabile.
+
+**Decisione richiesta:** approvare il registro provider effettivo e la relativa documentazione contrattuale prima dell'attivazione sui dati reali.
+
+---
+
+# 8. Intelligenza artificiale: cosa è previsto
+
+La roadmap non è limitata al tutor. Sono previste quattro famiglie di capacità:
+
+1. **ASSISTIVE** — tutor, spiegazioni, debugging guidato, feedback non valutativo;
+2. **ASSESSMENT_SUPPORT** — correzione automatica e proposta di voto/punteggio con review docente;
+3. **ASSESSMENT_AUTOMATION** — grading automatico con impatto valutativo reale;
+4. **ADAPTIVE_DECISION** — analisi progressi, remediation e percorsi personalizzati.
+
+Tutte devono passare dal boundary comune `#710`:
+
+```text
+Feature didattica
+      -> AI Policy / Privacy Boundary
+      -> Provider Adapter
+```
+
+Vincoli comuni:
+
+- minimizzazione del contesto;
+- niente accesso diretto del provider a root/database/secret;
+- esclusione per default di hidden test, soluzioni docente e dati di altri studenti;
+- provider/model/prompt/policy versionati;
+- audit bounded e secret-safe;
+- feature flag/kill switch;
+- trasparenza verso docente/studente;
+- gate distinto per ogni use case prima dell'attivazione con dati reali.
+
+Per proposta voto/correzione la prima modalità prevista è `AI proposes -> docente decide`.
+
+Grading automatico e decisioni adattive restano capability target, ma richiedono screening e approvazioni più forti prima dell'uso reale; i benchmark tecnici non costituiscono da soli autorizzazione.
+
+**Decisione richiesta all'Istituto/RPD:** definire quali use case possono essere attivati nel pilot e quali restano solo in sviluppo/simulazione con dati sintetici.
+
+---
+
+# 9. DPIA e processi automatizzati
+
+È predisposto un `PILOT_DPIA_SCREENING.md` distinto per:
+
+- core della piattaforma;
+- tutor/AI assistiva;
+- assessment support;
+- automated grading;
+- adaptive learning.
+
+La decisione sull'obbligatorietà e sul contenuto finale della DPIA deve essere assunta dall'Istituto con il RPD/DPO sulla base del trattamento effettivamente attivato. In presenza di trattamenti ad alto rischio, processi decisionali automatizzati rilevanti, minori e AI educativa, lo screening non va saltato.
+
+Non sono previste nel pilot funzioni di riconoscimento emozioni, biometria o proctoring comportamentale automatizzato.
+
+**Decisione richiesta:** esito formale dello screening e, se necessario, apertura/completamento della DPIA prima dell'attivazione interessata.
+
+---
+
+# 10. Gestione incidenti
+
+Il pacchetto governance prevede:
+
+- owner tecnico e decision owner identificati;
+- revoca account/sessioni/bearer;
+- sospensione del servizio o dell'AI tramite kill switch;
+- preservation controllata delle evidence necessarie;
+- rotazione dei secret coinvolti;
+- escalation verso Dirigente/RPD e altri soggetti previsti dalla procedura;
+- registrazione tempi di rilevazione, contenimento, ripristino e comunicazione;
+- nessuna pubblicazione di log o evidence contenenti dati/secret non necessari.
+
+**Decisione richiesta:** nominativi/ruoli, canali di escalation e procedura istituzionale di data breach/incident response.
+
+---
+
+# 11. Decisioni minime richieste prima del GO pilot con dati reali
+
+L'Istituto deve compilare il record di approvazione collegato e decidere almeno:
+
+1. Titolare del trattamento e contatti istituzionali;
+2. RPD/DPO e relativo contatto;
+3. basi giuridiche e finalità dei trattamenti core;
+4. categorie dati e retention;
+5. access matrix e ruoli operativi;
+6. account Google ammessi (Workspace/Gmail personale);
+7. provider effettivi, contratti, localizzazione e trasferimenti;
+8. backup: localizzazione, cifratura, RPO/RTO;
+9. incident response, owner ed escalation;
+10. esito DPIA screening;
+11. use case AI ammessi sui dati reali;
+12. approvazione dell'informativa studenti/famiglie;
+13. eventuali ulteriori prescrizioni interne dell'Istituto.
+
+Finché questi punti non sono approvati per il perimetro effettivo, il sistema può essere sviluppato e testato con dati demo/sintetici, ma non deve essere interpretato come autorizzato al trattamento reale.
+
+---
+
+# 12. Cosa succede dopo l'approvazione
+
+Una volta approvato il pacchetto:
+
+1. le decisioni vengono versionate nella governance del progetto;
+2. deployment, retention, backup e provider vengono configurati in coerenza con esse;
+3. i gate tecnici di #678 vengono rieseguiti sulla nuova candidate;
+4. la prima lezione viene provata end-to-end;
+5. il decision owner firma il nuovo verbale `GO pilot` oppure mantiene `NO-GO` con finding espliciti;
+6. le funzioni AI vengono abilitate progressivamente solo nei use case che hanno superato il proprio gate.
+
+---
+
+# 13. Campi istituzionali da completare
+
+```text
+Istituto:
+Codice meccanografico:
+Titolare / rappresentante:
+Contatto privacy istituzionale:
+RPD/DPO:
+Contatto RPD/DPO:
+Responsabile tecnico pilot:
+Docente/owner didattico:
+Decision owner GO/NO-GO:
+Hosting/provider:
+Localizzazione hosting:
+Backup provider/localizzazione:
+Provider AI autorizzati:
+Data approvazione governance:
+Versione/revisione approvata:
+```
+
+---
+
+## Riferimenti normativi/istituzionali da usare nella review
+
+- Regolamento (UE) 2016/679 (GDPR), in particolare principi, informativa, responsabili, sicurezza, DPIA e decisioni automatizzate;
+- Garante per la protezione dei dati personali — FAQ e vademecum `Scuola`;
+- Garante — parere 4 agosto 2025 sulle Linee guida MIM per l'introduzione dell'IA nelle istituzioni scolastiche;
+- Garante — comunicazione 3 giugno 2026 sui progetti IA a scuola e verifica di dati, fornitori e DPIA;
+- Regolamento (UE) 2024/1689 (AI Act), per la classificazione dei singoli use case AI educativi quando applicabile.

--- a/doc/governance/PILOT_APPROVAL_BRIEF_2026_2027.md
+++ b/doc/governance/PILOT_APPROVAL_BRIEF_2026_2027.md
@@ -4,250 +4,289 @@
 
 **BOZZA PER VALUTAZIONE E APPROVAZIONE ISTITUZIONALE.**
 
-Questa scheda riassume in forma breve il pacchetto tecnico e privacy del pilot TheBitLab. Non costituisce da sola una dichiarazione di conformità GDPR, una DPIA conclusa, un atto di nomina o un parere legale. Le decisioni finali spettano all'Istituto, con il coinvolgimento del RPD/DPO e delle altre figure competenti.
+Questa scheda riassume il pacchetto tecnico, privacy e AI governance del pilot TheBitLab. Non costituisce una dichiarazione di conformità GDPR, una DPIA/FRIA conclusa, un atto di nomina o un parere legale. Le decisioni finali spettano all'Istituto nel proprio ruolo, con il coinvolgimento del RPD/DPO e delle altre figure competenti.
 
-Documenti di dettaglio collegati:
+Documenti collegati:
 
-- `PILOT_GOVERNANCE_2026_2027.md`;
-- `PILOT_PRIVACY_NOTICE_DRAFT.md`;
-- `PILOT_DPIA_SCREENING.md`;
-- `PILOT_PROVIDER_REGISTER.md`;
+- `PILOT_SCHOOL_COMPLIANCE_CHECKLIST_2026_2027.md` — checklist operativa GDPR + AI Act;
+- `PILOT_GOVERNANCE_2026_2027.md` — baseline completa di governance;
+- `PILOT_APPROVAL_RECORD_2026_2027.md` — record delle decisioni istituzionali;
+- `PILOT_PRIVACY_NOTICE_DRAFT.md` — bozza informativa studenti/famiglie;
+- `PILOT_DPIA_SCREENING.md` — screening GDPR/DPIA;
+- `PILOT_PROVIDER_REGISTER.md` — registro tecnico provider/processori;
 - issue governance `#699`, identity policy `#700`, AI boundary `#710` e roadmap AI `#711`–`#715`.
 
 ---
 
 # 1. Che cos'è TheBitLab
 
-TheBitLab è una piattaforma didattica per corsi di informatica e laboratori scolastici. Nel pilot 2026/2027 il perimetro previsto comprende:
+TheBitLab è una piattaforma didattica per corsi di informatica e laboratori scolastici. Nel pilot 2026/2027 il perimetro previsto può comprendere:
 
 - autenticazione Google;
 - associazione autorizzata studente–classe–assignment;
 - distribuzione di activity e materiali;
 - esecuzione di esercizi/lab in sandbox;
-- tentativi, report dei test e scelta del tentativo definitivo;
+- tentativi, report dei test e selezione del tentativo definitivo;
 - richieste di aiuto e feedback;
 - dashboard docente e registro delle consegne;
 - backup/restore e audit tecnico;
-- funzioni AI progressive, attivabili sui dati reali solo dopo il relativo gate privacy/compliance.
+- funzioni AI progressive, attivabili sui dati reali solo dopo il relativo gate.
 
-Non è prevista, nel perimetro corrente del pilot, una piattaforma multi-scuola general purpose, una profilazione commerciale, pubblicità, vendita di dati o monitoraggio biometrico/emotivo.
+Non sono previste, nel pilot corrente, profilazione commerciale, pubblicità, vendita di dati, riconoscimento biometrico, inferenza delle emozioni o proctoring comportamentale automatizzato.
 
 ---
 
-# 2. Chi usa il sistema
+# 2. Due approvazioni distinte
+
+## 2.1 GO core
+
+L'Istituto può approvare il pilot con dati reali mantenendo **tutte le funzioni AI esterne disabilitate**. In questo perimetro il sistema può usare identity, classi, assignment, elaborati, tentativi, report, grading deterministico, feedback docente, help non-AI, dashboard, backup e audit.
+
+## 2.2 GO AI per use case
+
+L'eventuale autorizzazione AI è separata per:
+
+1. `ASSISTIVE` — tutor, spiegazioni, debugging, feedback non valutativo;
+2. `ASSESSMENT_SUPPORT` — correzione/proposta di voto o punteggio con review docente;
+3. `ASSESSMENT_AUTOMATION` — grading automatico con impatto valutativo;
+4. `ADAPTIVE_DECISION` — analisi progressi e percorso/livello adattivo.
+
+Il `GO core` non autorizza automaticamente nessuno di questi use case.
+
+---
+
+# 3. Chi usa il sistema
 
 | Ruolo | Uso principale | Accesso previsto |
 |---|---|---|
 | Studente | activity, lab, tentativi, aiuto | solo classe/assignment e dati propri |
 | Docente | assegnazioni, report, feedback, grading | solo classi di competenza |
-| Amministratore tecnico | deployment, sicurezza, backup/restore | accesso minimo necessario e tracciato |
-| Dirigente/decision owner | autorizzazione pilot, rischio residuo, GO/NO-GO | documentazione e decisioni di governance |
-| RPD/DPO | supporto alla valutazione privacy | documentazione, flussi e registri necessari |
+| Amministratore applicativo | identity/membership e configurazione necessaria | accesso bounded, non browsing indiscriminato |
+| Gestore tecnico | deployment, sicurezza, backup/restore | accesso eccezionale/minimo e tracciato quando necessario |
+| Dirigente/decision owner | autorizzazione e GO/NO-GO | documentazione e decisioni di governance |
+| RPD/DPO | consulenza/sorveglianza privacy | secondo mandato istituzionale |
+| Provider AI | solo contesto minimizzato approvato | nessun accesso diretto a root/database/secret |
 
-Il dominio dell'account Google non attribuisce autorizzazioni didattiche: l'accesso a classi e assignment dipende sempre dai binding e dalle membership interne TheBitLab.
+Il dominio dell'account Google non attribuisce autorizzazioni didattiche: classi e assignment dipendono dai binding e dalle membership interne TheBitLab.
 
 ---
 
-# 3. Account ammessi
+# 4. Account Google
 
-Decisione progettuale proposta/registrata:
+Decisione progettuale proposta:
 
-- sono ammessi sia account Google Workspace scolastici sia account Gmail personali;
+- sono tecnicamente ammessi account Google Workspace scolastici e Gmail personali;
 - l'account scolastico è preferibile quando disponibile e funzionante, ma non è requisito tecnico esclusivo;
-- Gmail personale è ammesso per evitare che indisponibilità o password dimenticate dell'account scolastico impediscano l'attività didattica;
-- l'Istituto deve confermare che questa scelta è compatibile con le proprie policy e con l'informativa fornita a studenti/famiglie;
-- eventuali blocchi amministrativi del tenant Workspace devono essere gestiti come problema di onboarding/supporto, non aggirati.
+- Gmail personale può essere ammesso per continuità operativa, ma solo se compatibile con la policy della scuola;
+- eventuali blocchi amministrativi Workspace devono essere risolti come onboarding/supporto, non aggirati;
+- l'indirizzo email non diventa mai authority di classe/ruolo.
 
-**Decisione richiesta all'Istituto:** approvare, modificare o vietare l'uso di Gmail personale nel pilot.
+**Decisione richiesta:** approvare, condizionare o vietare l'uso di Gmail personale nel pilot.
 
 ---
 
-# 4. Dati trattati e finalità
-
-La progettazione segue minimizzazione e separazione per finalità. Le categorie previste sono:
+# 5. Dati e finalità
 
 | Categoria | Esempi | Finalità |
 |---|---|---|
-| Identità e account | user ID interno, provider, stato account | login, sicurezza, amministrazione |
-| Classe e membership | class ID, ruolo, membership | autorizzazione e isolamento |
+| Identità/account | ID interno, provider, stato account | login, sicurezza, amministrazione |
+| Classe/membership | class ID, ruolo, membership | autorizzazione e isolamento |
 | Didattica | course/activity/assignment ID | distribuzione del percorso |
-| Elaborati e tentativi | codice, output test, attempt ID | laboratorio, storico, feedback |
-| Grading e feedback | esiti test, rubriche, feedback, eventuale proposta AI | valutazione e supporto docente |
-| Aiuto | domanda, contesto minimo, risposta | assistenza didattica |
+| Elaborati/tentativi | codice, output test, attempt ID | laboratorio, storico, feedback |
+| Grading/feedback | esiti test, rubriche, feedback | valutazione/supporto docente |
+| Help | domanda, contesto minimo, risposta | assistenza didattica |
 | Audit/security | eventi tecnici minimizzati | sicurezza, incidenti, troubleshooting |
-| Backup | copia coerente dello stato applicativo | continuità e disaster recovery |
+| Backup | copia coerente dello stato applicativo | continuità/disaster recovery |
+| AI, se autorizzata | contesto minimo per use case | finalità specifica approvata |
 
-Principi tecnici già assunti:
+Il core non richiede per design dati sanitari, diagnosi, disabilità o DSA. Tali informazioni non devono entrare automaticamente in help, prompt AI, log o profili; eventuali futuri trattamenti di categorie particolari richiedono un perimetro separato e approvato.
 
-- niente cookie, bearer, secret, chiavi private o callback OAuth sensibili nei documenti/evidence condivisi;
-- niente ID di autorizzazione accettati dal client come authority;
-- dati di studenti diversi non devono essere mescolati;
-- hidden test e materiali teacher-only non devono essere esposti allo studente né inviati a provider AI quando non necessari/autorizzati.
-
-**Decisione richiesta all'Istituto/RPD:** confermare che le categorie e finalità siano appropriate o indicare modifiche.
+**Decisione richiesta:** confermare categorie, finalità e minimizzazione.
 
 ---
 
-# 5. Conservazione proposta
+# 6. Base giuridica e Registro art. 30
 
-Questi valori sono una **proposta tecnica iniziale** e devono essere confermati o modificati dall'Istituto/RPD in base alla finalità e alle regole interne.
+TheBitLab non impone una base giuridica universale. L'Istituto/RPD-DPO deve documentare la base applicabile a ciascun trattamento; per il servizio core di una scuola pubblica il consenso non deve essere usato come soluzione generica quando la base corretta deriva da obblighi legali e/o compiti di interesse pubblico previsti dalla normativa applicabile.
+
+Prima del `GO core`:
+
+- il trattamento TheBitLab deve essere inserito/aggiornato nel **Registro delle attività di trattamento ex art. 30 GDPR** dell'Istituto;
+- il registro deve riportare almeno finalità, categorie di interessati/dati, destinatari, trasferimenti quando applicabili, retention/criteri e misure di sicurezza pertinenti;
+- il `PILOT_PROVIDER_REGISTER.md` è un annex tecnico e **non sostituisce** il Registro art. 30 della scuola.
+
+**Decisione richiesta:** validare basi giuridiche e riferimento alla voce/record art. 30.
+
+---
+
+# 7. Gestore tecnico e art. 28 GDPR
+
+Il modello operativo deve essere qualificato prima dei dati reali.
+
+- Se l'Istituto esegue autonomamente il software e TheBitPoets/maintainer non riceve né può accedere ai dati del pilot, il semplice sviluppo del software non rende automaticamente il progetto responsabile del trattamento dei dati della scuola.
+- Se TheBitPoets o altro soggetto esterno ospita il servizio, gestisce backup/database o svolge assistenza con possibilità di accesso ai dati per conto della scuola, il ruolo deve essere qualificato e, quando ricorrono i presupposti, disciplinato con atto/contratto ex art. 28 GDPR, incluse istruzioni, sicurezza, sub-responsabili, incidenti, diritti e fine-servizio.
+
+**Decisione richiesta:** scegliere il modello operativo, qualificare il gestore e registrare l'eventuale atto art. 28.
+
+---
+
+# 8. Conservazione proposta
+
+Questi valori sono **default tecnici iniziali** da confermare/modificare dall'Istituto/RPD-DPO:
 
 | Dato | Retention proposta |
 |---|---|
-| Account, membership, assignment, tentativi/report e grading del pilot | anno scolastico + 90 giorni |
-| Richieste di aiuto/tutor e relativo contesto | 30 giorni, salvo necessità didattica documentata diversa |
-| Log security/operativi minimizzati | 30 giorni, salvo evento/incidente che richieda conservazione controllata |
-| Payload AI esterni | non persistito da TheBitLab per default; eventuale retention provider da documentare |
-| Backup rolling | 30 giorni, con cifratura e controllo accessi |
-| Evidence del rehearsal | conservazione separata e ristretta secondo policy approvata |
+| Account, membership, assignment, tentativi/report e grading operativi | anno scolastico + 90 giorni |
+| Help/tutor content | 30 giorni |
+| Log security/operativi minimizzati | 30 giorni salvo incident/legal hold |
+| Payload AI nel gateway TheBitLab | non persistito per default |
+| AI audit metadata non soggetto a obblighi più lunghi | 30 giorni |
+| Backup rolling | 30 giorni |
+| Evidence incident | secondo procedura e necessità documentata |
 
-Cancellazione, rettifica, esportazione e gestione degli account devono essere documentate nella procedura operativa.
+**Eccezione importante AI Act:** se viene attivato un sistema AI ad alto rischio soggetto agli obblighi del deployer, i log generati automaticamente sotto il controllo del deployer devono seguire il periodo minimo previsto dall'art. 26 AI Act (**almeno sei mesi**, salvo diversa disciplina applicabile). Il default di 30 giorni non può prevalere su questo obbligo.
 
-**Decisione richiesta:** approvare o modificare ogni retention prima dei dati reali.
+I voti/atti ufficiali seguono le regole e i sistemi ufficiali dell'Istituto; TheBitLab non deve diventare automaticamente un archivio indefinito.
 
 ---
 
-# 6. Backup e continuità
+# 9. Backup e continuità
 
-Decisione progettuale registrata:
+Baseline progettuale:
 
 - backup almeno giornaliero;
 - **RPO target 24 ore**;
 - **RTO target 8 ore lavorative**;
 - backup cifrato e separato dai secret;
-- restore periodicamente verificato in ambiente isolato;
-- manifest/checksum e controllo d'integrità;
-- nessuna scrittura nella root originale durante un restore di prova.
+- restore verificato in ambiente isolato;
+- manifest/checksum e integrity check;
+- nessuna scrittura nella root originale durante restore di prova.
 
-**Decisione richiesta:** confermare RPO/RTO e autorizzare la localizzazione/provider di backup effettivi.
+**Decisione richiesta:** approvare RPO/RTO, provider/localizzazione e procedura di restore.
 
 ---
 
-# 7. Provider e trasferimenti
+# 10. Provider e trasferimenti
 
-Prima dell'uso reale devono essere compilati nel `PILOT_PROVIDER_REGISTER.md` almeno:
+Prima dell'uso reale devono essere completati nel provider register almeno:
 
-- hosting/VPS e localizzazione;
+- hosting/VPS;
 - Google Identity/Workspace;
-- GitHub/GitLab per fonti private quando usati;
+- GitHub/GitLab quando usati;
 - backup/storage;
-- provider AI eventualmente attivati;
-- ruolo privacy/contratto, subfornitori rilevanti, localizzazione, retention e condizioni di data use/training;
-- eventuali trasferimenti internazionali e relativo meccanismo giuridico da validare con l'Istituto/RPD.
+- eventuale gestore tecnico esterno;
+- provider AI soltanto per gli use case attivati.
 
-Nessun provider AI è autorizzato implicitamente solo perché tecnicamente integrabile.
+Per ciascuno: ruolo privacy, DPA/contratto quando applicabile, subprocessori, localizzazione, trasferimenti, retention, data-use/training, sicurezza, owner e kill switch.
 
-**Decisione richiesta:** approvare il registro provider effettivo e la relativa documentazione contrattuale prima dell'attivazione sui dati reali.
-
----
-
-# 8. Intelligenza artificiale: cosa è previsto
-
-La roadmap non è limitata al tutor. Sono previste quattro famiglie di capacità:
-
-1. **ASSISTIVE** — tutor, spiegazioni, debugging guidato, feedback non valutativo;
-2. **ASSESSMENT_SUPPORT** — correzione automatica e proposta di voto/punteggio con review docente;
-3. **ASSESSMENT_AUTOMATION** — grading automatico con impatto valutativo reale;
-4. **ADAPTIVE_DECISION** — analisi progressi, remediation e percorsi personalizzati.
-
-Tutte devono passare dal boundary comune `#710`:
-
-```text
-Feature didattica
-      -> AI Policy / Privacy Boundary
-      -> Provider Adapter
-```
-
-Vincoli comuni:
-
-- minimizzazione del contesto;
-- niente accesso diretto del provider a root/database/secret;
-- esclusione per default di hidden test, soluzioni docente e dati di altri studenti;
-- provider/model/prompt/policy versionati;
-- audit bounded e secret-safe;
-- feature flag/kill switch;
-- trasparenza verso docente/studente;
-- gate distinto per ogni use case prima dell'attivazione con dati reali.
-
-Per proposta voto/correzione la prima modalità prevista è `AI proposes -> docente decide`.
-
-Grading automatico e decisioni adattive restano capability target, ma richiedono screening e approvazioni più forti prima dell'uso reale; i benchmark tecnici non costituiscono da soli autorizzazione.
-
-**Decisione richiesta all'Istituto/RPD:** definire quali use case possono essere attivati nel pilot e quali restano solo in sviluppo/simulazione con dati sintetici.
+Un campo `UNKNOWN` che può incidere su liceità/rischio mantiene il relativo provider disabilitato sui dati reali.
 
 ---
 
-# 9. DPIA e processi automatizzati
+# 11. DPIA GDPR
 
-È predisposto un `PILOT_DPIA_SCREENING.md` distinto per:
+È predisposto `PILOT_DPIA_SCREENING.md` per:
 
-- core della piattaforma;
+- core;
+- grading deterministico;
 - tutor/AI assistiva;
 - assessment support;
 - automated grading;
 - adaptive learning.
 
-La decisione sull'obbligatorietà e sul contenuto finale della DPIA deve essere assunta dall'Istituto con il RPD/DPO sulla base del trattamento effettivamente attivato. In presenza di trattamenti ad alto rischio, processi decisionali automatizzati rilevanti, minori e AI educativa, lo screening non va saltato.
+Con minori, valutazione sistematica, tecnologie innovative/AI e possibili effetti sulla valutazione/percorso, lo screening deve essere documentato con particolare cautela. Se emerge un rischio elevato, la DPIA deve essere completata prima del trattamento interessato.
 
-Non sono previste nel pilot funzioni di riconoscimento emozioni, biometria o proctoring comportamentale automatizzato.
-
-**Decisione richiesta:** esito formale dello screening e, se necessario, apertura/completamento della DPIA prima dell'attivazione interessata.
+**Decisione richiesta:** esito formale dello screening e, quando richiesta, DPIA completata/approvata prima dell'attivazione.
 
 ---
 
-# 10. Gestione incidenti
+# 12. AI Act 2026: cosa cambia per la scuola
 
-Il pacchetto governance prevede:
+Dal 2 agosto 2026 l'AI Act è applicabile in via generale secondo il calendario dell'art. 113, fatte salve le disposizioni con date specifiche differenti.
 
-- owner tecnico e decision owner identificati;
-- revoca account/sessioni/bearer;
-- sospensione del servizio o dell'AI tramite kill switch;
-- preservation controllata delle evidence necessarie;
-- rotazione dei secret coinvolti;
-- escalation verso Dirigente/RPD e altri soggetti previsti dalla procedura;
-- registrazione tempi di rilevazione, contenimento, ripristino e comunicazione;
-- nessuna pubblicazione di log o evidence contenenti dati/secret non necessari.
+Prima di qualunque funzione AI reale:
 
-**Decisione richiesta:** nominativi/ruoli, canali di escalation e procedura istituzionale di data breach/incident response.
+- deve essere garantita un'adeguata **AI literacy** di docenti/operatori (art. 4);
+- restano vietate le pratiche di cui all'art. 5, inclusa l'inferenza delle emozioni in ambito scolastico salvo le strette eccezioni mediche/sicurezza previste dal Regolamento;
+- ogni use case deve essere classificato rispetto all'art. 6 e all'Allegato III, punto 3 (istruzione/formazione).
+
+In particolare, sistemi usati per valutare risultati dell'apprendimento o influenzare materialmente livello/percorso possono rientrare tra i sistemi ad alto rischio. Il fatto che l'AI “proponga” e il docente confermi **non rende automaticamente il sistema non-high-risk**: va valutato l'impatto reale e, se si invoca l'art. 6(3), devono essere documentati i relativi presupposti.
 
 ---
 
-# 11. Decisioni minime richieste prima del GO pilot con dati reali
+# 13. Se l'AI è high-risk: obblighi deployer e FRIA
 
-L'Istituto deve compilare il record di approvazione collegato e decidere almeno:
+Per un use case high-risk, prima dell'attivazione reale la scuola deve chiudere gli obblighi pertinenti del deployer, inclusi quando applicabili:
 
-1. Titolare del trattamento e contatti istituzionali;
-2. RPD/DPO e relativo contatto;
-3. basi giuridiche e finalità dei trattamenti core;
-4. categorie dati e retention;
-5. access matrix e ruoli operativi;
-6. account Google ammessi (Workspace/Gmail personale);
-7. provider effettivi, contratti, localizzazione e trasferimenti;
-8. backup: localizzazione, cifratura, RPO/RTO;
-9. incident response, owner ed escalation;
-10. esito DPIA screening;
-11. use case AI ammessi sui dati reali;
-12. approvazione dell'informativa studenti/famiglie;
-13. eventuali ulteriori prescrizioni interne dell'Istituto.
+- uso secondo istruzioni del provider;
+- human oversight competente, formata, dotata di autorità e supporto;
+- controllo qualità/pertinenza dei dati di input sotto il controllo della scuola;
+- monitoraggio, sospensione e incident reporting;
+- conservazione dei log automatici sotto controllo del deployer per il periodo minimo applicabile;
+- verifica degli obblighi di registrazione nella banca dati UE per il deployer pubblico;
+- utilizzo della documentazione del provider per la DPIA GDPR.
 
-Finché questi punti non sono approvati per il perimetro effettivo, il sistema può essere sviluppato e testato con dati demo/sintetici, ma non deve essere interpretato come autorizzato al trattamento reale.
+Inoltre, per i sistemi high-risk ex art. 6(2) nei casi previsti dall'art. 27, l'Istituto pubblico deve effettuare prima dell'uso una **Fundamental Rights Impact Assessment (FRIA)**. DPIA GDPR e FRIA AI Act sono distinte, pur potendo essere integrate per le parti sovrapposte.
+
+La checklist operativa completa è `PILOT_SCHOOL_COMPLIANCE_CHECKLIST_2026_2027.md`.
 
 ---
 
-# 12. Cosa succede dopo l'approvazione
+# 14. Gestione incidenti e data breach
 
-Una volta approvato il pacchetto:
+Il pacchetto prevede revoca account/sessioni, sospensione servizio/AI, rotazione secret, preservation controllata delle evidence ed escalation.
 
-1. le decisioni vengono versionate nella governance del progetto;
-2. deployment, retention, backup e provider vengono configurati in coerenza con esse;
-3. i gate tecnici di #678 vengono rieseguiti sulla nuova candidate;
-4. la prima lezione viene provata end-to-end;
-5. il decision owner firma il nuovo verbale `GO pilot` oppure mantiene `NO-GO` con finding espliciti;
-6. le funzioni AI vengono abilitate progressivamente solo nei use case che hanno superato il proprio gate.
+La procedura dell'Istituto deve inoltre prevedere:
+
+- informazione del Titolare **senza ingiustificato ritardo** da parte dell'eventuale Responsabile quando rileva una violazione;
+- valutazione del Titolare e, quando dovuta, notifica all'autorità di controllo entro il termine dell'art. 33 GDPR;
+- comunicazione agli interessati quando ricorrono i presupposti dell'art. 34;
+- documentazione delle violazioni, decisioni e misure adottate.
 
 ---
 
-# 13. Campi istituzionali da completare
+# 15. Decisioni minime richieste prima del GO core
+
+L'Istituto deve decidere/documentare almeno:
+
+1. Titolare, contatti e RPD/DPO;
+2. finalità e basi giuridiche;
+3. voce/aggiornamento Registro art. 30;
+4. categorie dati e trattamento delle eventuali categorie particolari;
+5. retention;
+6. access matrix e ruoli;
+7. account Google ammessi;
+8. modello operativo e ruolo dell'eventuale gestore tecnico/art. 28;
+9. provider, contratti, subprocessori, localizzazione e trasferimenti;
+10. backup, cifratura, RPO/RTO;
+11. incident/data breach procedure;
+12. esito DPIA screening e DPIA quando richiesta;
+13. informativa studenti/famiglie;
+14. perimetro AI: `NESSUNA AI REALE` oppure elenco esatto degli use case autorizzati;
+15. eventuali ulteriori prescrizioni dell'Istituto.
+
+Finché questi punti non sono approvati per il perimetro effettivo, il sistema può essere sviluppato/testato con dati demo/sintetici ma non interpretato come autorizzato al trattamento reale.
+
+---
+
+# 16. Decisioni aggiuntive prima del GO di un use case AI
+
+Per ciascun use case reale:
+
+1. intended purpose e versione/release;
+2. provider e data boundary #710;
+3. AI literacy;
+4. classificazione AI Act;
+5. DPIA/FRIA quando applicabili;
+6. obblighi del deployer high-risk quando applicabili;
+7. human oversight, contestazione, override e fallback;
+8. retention/logging coerenti con la classificazione;
+9. informativa aggiornata;
+10. decisione istituzionale riferita allo specifico use case.
+
+---
+
+# 17. Campi istituzionali da completare
 
 ```text
 Istituto:
@@ -259,20 +298,28 @@ Contatto RPD/DPO:
 Responsabile tecnico pilot:
 Docente/owner didattico:
 Decision owner GO/NO-GO:
-Hosting/provider:
-Localizzazione hosting:
+Riferimento Registro art. 30:
+Modello operativo / ruolo gestore tecnico:
+Riferimento eventuale atto art. 28:
+Hosting/provider e localizzazione:
 Backup provider/localizzazione:
 Provider AI autorizzati:
+Use case AI autorizzati:
+Esito DPIA screening / riferimento DPIA:
+Riferimento eventuale FRIA:
 Data approvazione governance:
 Versione/revisione approvata:
 ```
 
 ---
 
-## Riferimenti normativi/istituzionali da usare nella review
+## Riferimenti normativi/istituzionali da riesaminare al momento dell'approvazione
 
-- Regolamento (UE) 2016/679 (GDPR), in particolare principi, informativa, responsabili, sicurezza, DPIA e decisioni automatizzate;
-- Garante per la protezione dei dati personali — FAQ e vademecum `Scuola`;
-- Garante — parere 4 agosto 2025 sulle Linee guida MIM per l'introduzione dell'IA nelle istituzioni scolastiche;
-- Garante — comunicazione 3 giugno 2026 sui progetti IA a scuola e verifica di dati, fornitori e DPIA;
-- Regolamento (UE) 2024/1689 (AI Act), per la classificazione dei singoli use case AI educativi quando applicabile.
+- Regolamento (UE) 2016/679 (GDPR), in particolare artt. 5, 6, 13, 25, 28, 30, 32, 33, 34 e 35.
+- Regolamento (UE) 2024/1689 (AI Act), in particolare artt. 4, 5, 6, 26, 27, 49 e 113 e Allegato III, punto 3.
+- Garante per la protezione dei dati personali — vademecum e materiali aggiornati per la scuola.
+- Garante — parere 4 agosto 2025 sulle Linee guida MIM per l'introduzione dell'IA nelle istituzioni scolastiche.
+- Garante — attività istruttoria/comunicazione 3 giugno 2026 sui progetti IA in ambito scolastico.
+- Garante — pareri 14 luglio 2026 sugli schemi di adeguamento nazionale al Regolamento IA, inclusi i profili relativi a istruzione e formazione.
+
+I riferimenti devono essere ricontrollati prima dell'approvazione e ogni volta che cambia materialmente il perimetro normativo o tecnico.

--- a/doc/governance/PILOT_APPROVAL_RECORD_2026_2027.md
+++ b/doc/governance/PILOT_APPROVAL_RECORD_2026_2027.md
@@ -4,9 +4,9 @@
 
 **TEMPLATE DA COMPILARE.**
 
-Questo record accompagna `PILOT_APPROVAL_BRIEF_2026_2027.md` e serve a rendere verificabili le decisioni istituzionali necessarie prima del trattamento di dati reali e dell'eventuale attivazione di funzioni AI.
+Questo record accompagna `PILOT_APPROVAL_BRIEF_2026_2027.md` e `PILOT_SCHOOL_COMPLIANCE_CHECKLIST_2026_2027.md`. Serve a rendere verificabili le decisioni istituzionali necessarie prima del trattamento di dati reali e, separatamente, prima dell'eventuale attivazione di singoli use case AI.
 
-Non sostituisce atti, informative, nomine, DPIA o pareri richiesti dall'Istituto.
+Non sostituisce registro dei trattamenti, informative, atti art. 28, DPIA, FRIA, pareri o altri adempimenti richiesti dall'Istituto.
 
 ---
 
@@ -17,6 +17,7 @@ Istituto:
 Codice meccanografico:
 Anno scolastico: 2026/2027
 Versione/revisione pacchetto governance:
+Release/candidate TheBitLab:
 Data valutazione:
 ```
 
@@ -43,51 +44,103 @@ Note:
 
 ## 3. Finalità, categorie di dati e basi giuridiche
 
-- [ ] Le finalità del pilot sono approvate.
+- [ ] Le finalità del pilot core sono approvate.
 - [ ] Le categorie di dati previste sono adeguate e minimizzate.
 - [ ] Sono state definite le basi giuridiche per i trattamenti core.
+- [ ] Il consenso non è usato come base generica del servizio core quando non appropriato.
 - [ ] Sono state definite eventuali condizioni aggiuntive per minori/studenti.
 - [ ] Sono state escluse raccolte non necessarie.
+- [ ] Dati sanitari, DSA, disabilità o altre categorie particolari non entrano nel core/help/AI per default; eventuali eccezioni sono trattamenti separati e documentati.
 
-Modifiche/prescrizioni:
+Matrice/riferimento approvato:
 
 ---
 
-## 4. Account Google
+## 4. Registro delle attività di trattamento — art. 30 GDPR
 
-Decisione progettuale corrente: Workspace scolastico e Gmail personale entrambi ammessi; l'autorizzazione interna dipende solo da binding/membership TheBitLab.
+- [ ] Il trattamento TheBitLab è stato inserito o aggiornato nel Registro delle attività di trattamento dell'Istituto.
+- [ ] Sono riportate finalità, interessati, categorie dati, destinatari, trasferimenti, retention/criteri e misure di sicurezza pertinenti.
+- [ ] La voce del Registro è coerente con la release/perimetro approvato.
+- [ ] Il `PILOT_PROVIDER_REGISTER.md` è trattato solo come annex tecnico e non come sostituto del Registro dell'Istituto.
+
+```text
+Riferimento voce/record art. 30:
+Data ultimo aggiornamento:
+Owner aggiornamento:
+```
+
+---
+
+## 5. Modello operativo, gestore tecnico e art. 28 GDPR
+
+Selezionare il modello effettivo:
+
+- [ ] **SELF-HOSTED** — l'Istituto gestisce l'istanza e TheBitPoets/maintainer non riceve né può accedere ai dati personali del pilot.
+- [ ] **SERVIZIO GESTITO / ASSISTENZA CON ACCESSO** — soggetto esterno ospita, amministra, effettua backup o assistenza con possibilità di accesso ai dati per conto della scuola.
+- [ ] **ALTRO** — descrizione sotto.
+
+Per servizi esterni che operano come Responsabili del trattamento:
+
+- [ ] ruolo privacy qualificato;
+- [ ] atto/contratto art. 28 disponibile;
+- [ ] istruzioni documentate del Titolare;
+- [ ] riservatezza/autorizzazioni del personale;
+- [ ] misure tecniche e organizzative;
+- [ ] sub-responsabili e autorizzazioni;
+- [ ] assistenza per diritti, incidenti e DPIA;
+- [ ] restituzione/cancellazione a fine servizio.
+
+```text
+Gestore tecnico:
+Ruolo privacy:
+Riferimento atto art. 28 / motivazione N/A:
+```
+
+`UNKNOWN` sul ruolo del gestore tecnico = **NO-GO dati reali**.
+
+---
+
+## 6. Account Google
+
+Decisione progettuale corrente: Workspace scolastico e Gmail personale sono tecnicamente supportati; authorization interna deriva soltanto da binding/membership TheBitLab.
 
 Selezionare:
 
 - [ ] APPROVATO senza modifiche.
 - [ ] APPROVATO con condizioni.
 - [ ] SOLO Workspace scolastico.
-- [ ] SOLO altro perimetro definito di seguito.
+- [ ] ALTRO perimetro definito sotto.
 
 Condizioni/onboarding/supporto:
 
 ---
 
-## 5. Retention
+## 7. Retention
 
 Valori tecnici proposti:
 
 ```text
-Account/membership/assignment/tentativi/report/grading: anno scolastico + 90 giorni
-Help/tutor context: 30 giorni
+Account/membership/assignment/tentativi/report/grading operativi: anno scolastico + 90 giorni
+Help/tutor content: 30 giorni
 Security/operational logs minimizzati: 30 giorni
 AI payload TheBitLab: non persistito per default
+AI audit metadata non soggetto a obblighi più lunghi: 30 giorni
 Backup rolling: 30 giorni
 ```
 
 - [ ] APPROVATI.
 - [ ] DA MODIFICARE come segue.
 
+Per eventuali sistemi AI ad alto rischio:
+
+- [ ] è verificato se l'art. 26 AI Act impone la conservazione dei log automatici sotto controllo del deployer per almeno sei mesi;
+- [ ] il periodo applicabile è configurato/documentato e prevale sul default tecnico di 30 giorni.
+
 Decisione per categoria:
 
 ---
 
-## 6. Backup e continuità
+## 8. Backup e continuità
 
 Valori progettuali:
 
@@ -101,6 +154,7 @@ RTO target: 8 ore lavorative
 - [ ] Backup cifrato approvato.
 - [ ] Provider/localizzazione backup approvati.
 - [ ] Procedura restore isolato approvata.
+- [ ] Retention/rotazione approvata.
 
 Provider/localizzazione:
 
@@ -108,80 +162,187 @@ Prescrizioni:
 
 ---
 
-## 7. Provider e responsabili/sub-responsabili
+## 9. Provider, responsabili e sub-responsabili
 
-Compilare/validare il `PILOT_PROVIDER_REGISTER.md`.
+Compilare/validare `PILOT_PROVIDER_REGISTER.md`.
 
 - [ ] Hosting/VPS verificato.
 - [ ] Google Identity/Workspace verificato.
 - [ ] GitHub/GitLab verificato quando usato.
 - [ ] Backup/storage verificato.
-- [ ] Provider AI verificati per i use case effettivamente attivati.
+- [ ] Gestore tecnico esterno verificato quando presente.
+- [ ] Provider AI verificati solo per i use case effettivamente attivati.
 - [ ] Ruoli contrattuali/responsabili verificati.
 - [ ] Retention/data-use/training verificati.
-- [ ] Eventuali trasferimenti internazionali e relativo meccanismo valutati.
+- [ ] Sub-responsabili verificati.
+- [ ] Eventuali trasferimenti internazionali e relative garanzie valutati.
 
 Provider approvati / limitazioni:
 
 ---
 
-## 8. Informativa studenti/famiglie
+## 10. Informativa studenti/famiglie
 
-- [ ] Bozza `PILOT_PRIVACY_NOTICE_DRAFT.md` revisionata.
+- [ ] `PILOT_PRIVACY_NOTICE_DRAFT.md` revisionata.
 - [ ] Titolare e contatti completati.
 - [ ] RPD/DPO completato.
 - [ ] Finalità/basi giuridiche completate.
 - [ ] Destinatari/provider completati.
+- [ ] Trasferimenti completati.
 - [ ] Retention completata.
 - [ ] Diritti e modalità di esercizio completati.
-- [ ] Informazioni sull'AI/processi automatizzati coerenti con le funzioni attive.
+- [ ] Conferimento/necessità/opzionalità completati.
+- [ ] Informazioni sull'AI/processi automatizzati coerenti con le funzioni realmente attive.
 - [ ] Modalità di pubblicazione/consegna approvata.
 
 Versione informativa approvata:
 
 ---
 
-## 9. AI — boundary comune
+## 11. DPIA screening GDPR
 
-Riferimento: #710.
+Riferimento: `PILOT_DPIA_SCREENING.md`.
 
-- [ ] `AIRequestContext`/policy di minimizzazione approvati prima dei dati reali.
-- [ ] Provider AI non hanno accesso diretto a root/database/secret.
-- [ ] Hidden test, soluzioni docente e dati di altri studenti sono esclusi per default.
-- [ ] Logging/audit AI è minimizzato.
-- [ ] Feature flag e kill switch sono obbligatori.
-- [ ] Retention e data-use del provider sono documentati.
-- [ ] Trasparenza studente/docente definita.
+### Core piattaforma
 
-Prescrizioni:
+- [ ] DPIA non richiesta — motivazione documentata.
+- [ ] DPIA richiesta e completata prima dei dati reali.
+- [ ] Valutazione da completare.
+
+### Tutor/assistive AI
+
+- [ ] N/A — non nel pilot reale.
+- [ ] DPIA non richiesta — motivazione documentata.
+- [ ] DPIA richiesta/completata.
+- [ ] Valutazione da completare.
+
+### Assessment support / proposta voto
+
+- [ ] N/A — non nel pilot reale.
+- [ ] DPIA non richiesta — motivazione documentata.
+- [ ] DPIA richiesta/completata.
+- [ ] Valutazione da completare.
+
+### Automated grading / adaptive learning
+
+- [ ] N/A — non nel pilot reale.
+- [ ] DPIA completata prima dell'uso reale.
+- [ ] Altro esito motivato formalmente da Istituto/RPD-DPO.
+
+Riferimenti/motivazioni:
 
 ---
 
-## 10. AI — use case attivabili nel pilot
+## 12. AI — decisione per il pilot iniziale
 
-Per ogni voce scegliere uno stato.
+Selezionare una sola impostazione generale:
+
+- [ ] **AI ESTERNA DISABILITATA SU DATI REALI** — il GO del pilot riguarda soltanto il core.
+- [ ] **UNO O PIÙ USE CASE AI CANDIDATI** — compilare integralmente le sezioni 13–16 per ciascuno.
+
+Il GO core non autorizza implicitamente alcun use case AI.
+
+---
+
+## 13. AI literacy e pratiche vietate — AI Act
+
+Prima di qualsiasi use case AI reale:
+
+- [ ] docenti/operatori hanno AI literacy adeguata ai sensi dell'art. 4 AI Act;
+- [ ] chi svolge human oversight ha competenza, formazione, autorità e supporto adeguati;
+- [ ] la formazione è documentata;
+- [ ] nessuna funzione di inferenza/riconoscimento delle emozioni in ambito scolastico è attiva, salvo le strette eccezioni mediche/sicurezza previste dal Regolamento;
+- [ ] non sono presenti social scoring, manipolazione o altre pratiche vietate dall'art. 5 AI Act.
+
+Riferimento evidence/formazione:
+
+---
+
+## 14. AI — classificazione per use case
+
+Per ogni use case candidato compilare una scheda:
+
+```text
+Use case:
+Intended purpose:
+Provider/system/version:
+Influenza valutazione dei risultati dell'apprendimento? SI/NO/UNKNOWN
+Influenza livello/percorso/accesso? SI/NO/UNKNOWN
+Profilazione? SI/NO/UNKNOWN
+Classificazione AI Act: NOT_APPLICABLE / NON_HIGH_RISK / HIGH_RISK_CANDIDATE / HIGH_RISK / UNKNOWN
+Eventuale art. 6(3) invocato? SI/NO
+Rationale e documentazione provider:
+Decision owner/data:
+```
+
+- [ ] È stato considerato l'Allegato III, punto 3, relativo a istruzione/formazione.
+- [ ] `AI proposes -> docente decides` non è stato usato come scorciatoia automatica per classificare il sistema non-high-risk.
+- [ ] Se viene invocato l'art. 6(3), tutti i relativi presupposti sono documentati e non è presente profilazione incompatibile con l'eccezione.
+- [ ] `UNKNOWN` mantiene il use case disabilitato sui dati reali.
+
+---
+
+## 15. High-risk AI — obblighi del deployer scuola
+
+Compilare soltanto se un use case è high-risk.
+
+- [ ] uso conforme alle istruzioni del provider;
+- [ ] human oversight effettiva e competente;
+- [ ] input data sotto controllo del deployer valutati per pertinenza/rappresentatività quando applicabile;
+- [ ] monitoraggio e procedura di sospensione;
+- [ ] incident/reporting workflow;
+- [ ] log automatici sotto controllo del deployer conservati per il periodo minimo applicabile, incluso il minimo di sei mesi previsto dall'art. 26 quando applicabile;
+- [ ] documentazione provider usata per DPIA GDPR;
+- [ ] obblighi di registrazione nella banca dati UE verificati per il deployer pubblico prima dell'uso;
+- [ ] feature flag/kill switch e fallback umano verificati;
+- [ ] informativa aggiornata.
+
+Evidence/riferimenti:
+
+---
+
+## 16. FRIA — art. 27 AI Act
+
+Per un sistema high-risk ex art. 6(2) usato da un organismo pubblico nel perimetro dell'art. 27:
+
+- [ ] FRIA non applicabile — motivazione documentata.
+- [ ] FRIA applicabile e completata **prima dell'uso**.
+- [ ] FRIA integrata operativamente con DPIA per le parti sovrapposte senza confondere i due adempimenti.
+- [ ] descritti processi, durata/frequenza, persone/gruppi interessati, rischi sui diritti fondamentali, human oversight e mitigazioni/governance.
+- [ ] eventuali adempimenti verso l'autorità di vigilanza previsti dall'art. 27 sono completati/documentati.
+
+```text
+Riferimento FRIA:
+Data:
+Owner:
+Riferimento eventuale comunicazione/adempimento:
+```
+
+---
+
+## 17. AI — use case attivabili
 
 ### Tutor / assistenza (#712)
 
-- [ ] ABILITABILE su dati reali dopo completamento gate.
+- [ ] ABILITABILE sui dati reali dopo completamento gate.
 - [ ] SOLO dati sintetici/demo.
 - [ ] NON NEL PILOT.
 
-### Correzione e proposta voto con review docente (#713)
+### Correzione e proposta voto (#713)
 
-- [ ] ABILITABILE su dati reali dopo completamento gate specifico.
+- [ ] ABILITABILE sui dati reali dopo completamento gate specifico.
 - [ ] SOLO dati sintetici/demo.
 - [ ] NON NEL PILOT.
 
 ### Grading automatico (#714)
 
-- [ ] ABILITABILE solo dopo classificazione/DPIA/approvazioni specifiche.
+- [ ] ABILITABILE solo dopo classificazione, DPIA/FRIA e obblighi high-risk applicabili.
 - [ ] SOLO dati sintetici/benchmark.
 - [ ] NON NEL PILOT.
 
 ### Adaptive learning (#715)
 
-- [ ] ABILITABILE solo dopo classificazione/DPIA/approvazioni specifiche.
+- [ ] ABILITABILE solo dopo classificazione, DPIA/FRIA e obblighi high-risk applicabili.
 - [ ] SOLO dati sintetici/simulazioni.
 - [ ] NON NEL PILOT.
 
@@ -189,50 +350,18 @@ Note/condizioni:
 
 ---
 
-## 11. DPIA screening
-
-Riferimento: `PILOT_DPIA_SCREENING.md`.
-
-### Core piattaforma
-
-- [ ] DPIA non richiesta, motivazione documentata.
-- [ ] DPIA richiesta.
-- [ ] Valutazione da completare.
-
-### Tutor/assistive AI
-
-- [ ] DPIA non richiesta, motivazione documentata.
-- [ ] DPIA richiesta.
-- [ ] Valutazione da completare.
-
-### Assessment support / proposta voto
-
-- [ ] DPIA non richiesta, motivazione documentata.
-- [ ] DPIA richiesta.
-- [ ] Valutazione da completare.
-
-### Automated grading
-
-- [ ] DPIA richiesta/da completare prima dell'uso reale.
-- [ ] Altro esito motivato dal RPD/Istituto.
-
-### Adaptive learning
-
-- [ ] DPIA richiesta/da completare prima dell'impatto reale sul percorso.
-- [ ] Altro esito motivato dal RPD/Istituto.
-
-Motivazioni/riferimenti:
-
----
-
-## 12. Incident response e sicurezza
+## 18. Incident response e data breach
 
 - [ ] Owner tecnico definito.
 - [ ] Canale di escalation definito.
 - [ ] Procedura revoca account/sessioni definita.
 - [ ] Procedura rotazione secret definita.
-- [ ] Procedura di sospensione servizio/AI definita.
+- [ ] Procedura sospensione servizio/AI definita.
 - [ ] Data breach process dell'Istituto collegato.
+- [ ] L'eventuale Responsabile informa il Titolare senza ingiustificato ritardo quando rileva una violazione.
+- [ ] Il Titolare ha una procedura per valutare/notificare all'autorità entro il termine dell'art. 33 GDPR quando dovuto.
+- [ ] È prevista la valutazione della comunicazione agli interessati ex art. 34.
+- [ ] Le violazioni e le decisioni sono documentate.
 - [ ] Policy per evidence/log sanitizzati definita.
 - [ ] Drill previsto prima del GO pilot.
 
@@ -240,20 +369,42 @@ Note:
 
 ---
 
-## 13. Decisione finale governance
+## 19. Decisione finale governance core
 
 Selezionare una sola voce:
 
-- [ ] **APPROVATO PER NUOVO REHEARSAL CON DATI DEMO**, ma non ancora per studenti reali.
-- [ ] **APPROVATO PER PILOT CON DATI REALI** nel perimetro e con le feature flag indicate sopra.
-- [ ] **APPROVATO CON PRESCRIZIONI** elencate di seguito.
+- [ ] **APPROVATO PER NUOVO REHEARSAL CON DATI DEMO**, non ancora per studenti reali.
+- [ ] **APPROVATO PER PILOT CORE CON DATI REALI**, con AI esterna disabilitata salvo autorizzazioni separate sotto.
+- [ ] **APPROVATO CON PRESCRIZIONI** elencate sotto.
 - [ ] **NON APPROVATO / DA RIVEDERE**.
 
 Prescrizioni / condizioni sospensive:
 
 ---
 
-## 14. Firme / approvazioni
+## 20. Decisione separata sui singoli use case AI
+
+Per ogni use case realmente autorizzato:
+
+```text
+Use case:
+Release/configurazione:
+Provider/system/version:
+Classificazione AI Act:
+DPIA ref:
+FRIA ref/N.A.:
+Provider approval ref:
+Informativa version:
+AI literacy evidence:
+High-risk deployer checklist ref/N.A.:
+Data autorizzazione:
+Scadenza/review date:
+Decisione: APPROVED_REAL_DATA / SYNTHETIC_ONLY / BLOCKED
+```
+
+---
+
+## 21. Firme / approvazioni
 
 ```text
 Dirigente / rappresentante del Titolare
@@ -281,8 +432,8 @@ Data:
 
 ---
 
-## 15. Regola di efficacia
+## 22. Regola di efficacia
 
-Una casella tecnica `PASS` non equivale a un'approvazione privacy. Le feature e i provider possono essere abilitati soltanto nel perimetro effettivamente approvato e nella revisione indicata in questo record.
+Una casella tecnica `PASS` non equivale a un'approvazione privacy o AI Act. Feature e provider possono essere abilitati soltanto nel perimetro effettivamente approvato e nella revisione indicata.
 
-Ogni modifica materiale a finalità, categorie dati, provider, localizzazione, retention, use case AI, automazione valutativa o topologia deve attivare una nuova review di governance e, quando applicabile, una nuova valutazione DPIA/compliance prima dell'uso reale.
+Ogni modifica materiale a finalità, categorie dati, provider, localizzazione, retention, use case AI, automazione valutativa, intended purpose, modello operativo o topologia attiva una nuova review di governance e, quando applicabile, una nuova DPIA/FRIA/classificazione prima dell'uso reale.

--- a/doc/governance/PILOT_APPROVAL_RECORD_2026_2027.md
+++ b/doc/governance/PILOT_APPROVAL_RECORD_2026_2027.md
@@ -1,0 +1,288 @@
+# TheBitLab pilot 2026/2027 — record di approvazione istituzionale
+
+## Stato
+
+**TEMPLATE DA COMPILARE.**
+
+Questo record accompagna `PILOT_APPROVAL_BRIEF_2026_2027.md` e serve a rendere verificabili le decisioni istituzionali necessarie prima del trattamento di dati reali e dell'eventuale attivazione di funzioni AI.
+
+Non sostituisce atti, informative, nomine, DPIA o pareri richiesti dall'Istituto.
+
+---
+
+## 1. Identificazione
+
+```text
+Istituto:
+Codice meccanografico:
+Anno scolastico: 2026/2027
+Versione/revisione pacchetto governance:
+Data valutazione:
+```
+
+---
+
+## 2. Ruoli
+
+```text
+Titolare del trattamento / rappresentante:
+RPD/DPO:
+Contatto RPD/DPO:
+Responsabile tecnico pilot:
+Docente / owner didattico:
+Decision owner GO/NO-GO:
+Referente incident/data breach:
+```
+
+- [ ] Ruoli e contatti sono confermati.
+- [ ] La matrice accessi è coerente con i ruoli effettivi.
+
+Note:
+
+---
+
+## 3. Finalità, categorie di dati e basi giuridiche
+
+- [ ] Le finalità del pilot sono approvate.
+- [ ] Le categorie di dati previste sono adeguate e minimizzate.
+- [ ] Sono state definite le basi giuridiche per i trattamenti core.
+- [ ] Sono state definite eventuali condizioni aggiuntive per minori/studenti.
+- [ ] Sono state escluse raccolte non necessarie.
+
+Modifiche/prescrizioni:
+
+---
+
+## 4. Account Google
+
+Decisione progettuale corrente: Workspace scolastico e Gmail personale entrambi ammessi; l'autorizzazione interna dipende solo da binding/membership TheBitLab.
+
+Selezionare:
+
+- [ ] APPROVATO senza modifiche.
+- [ ] APPROVATO con condizioni.
+- [ ] SOLO Workspace scolastico.
+- [ ] SOLO altro perimetro definito di seguito.
+
+Condizioni/onboarding/supporto:
+
+---
+
+## 5. Retention
+
+Valori tecnici proposti:
+
+```text
+Account/membership/assignment/tentativi/report/grading: anno scolastico + 90 giorni
+Help/tutor context: 30 giorni
+Security/operational logs minimizzati: 30 giorni
+AI payload TheBitLab: non persistito per default
+Backup rolling: 30 giorni
+```
+
+- [ ] APPROVATI.
+- [ ] DA MODIFICARE come segue.
+
+Decisione per categoria:
+
+---
+
+## 6. Backup e continuità
+
+Valori progettuali:
+
+```text
+Frequenza minima: giornaliera
+RPO target: 24 ore
+RTO target: 8 ore lavorative
+```
+
+- [ ] RPO/RTO approvati.
+- [ ] Backup cifrato approvato.
+- [ ] Provider/localizzazione backup approvati.
+- [ ] Procedura restore isolato approvata.
+
+Provider/localizzazione:
+
+Prescrizioni:
+
+---
+
+## 7. Provider e responsabili/sub-responsabili
+
+Compilare/validare il `PILOT_PROVIDER_REGISTER.md`.
+
+- [ ] Hosting/VPS verificato.
+- [ ] Google Identity/Workspace verificato.
+- [ ] GitHub/GitLab verificato quando usato.
+- [ ] Backup/storage verificato.
+- [ ] Provider AI verificati per i use case effettivamente attivati.
+- [ ] Ruoli contrattuali/responsabili verificati.
+- [ ] Retention/data-use/training verificati.
+- [ ] Eventuali trasferimenti internazionali e relativo meccanismo valutati.
+
+Provider approvati / limitazioni:
+
+---
+
+## 8. Informativa studenti/famiglie
+
+- [ ] Bozza `PILOT_PRIVACY_NOTICE_DRAFT.md` revisionata.
+- [ ] Titolare e contatti completati.
+- [ ] RPD/DPO completato.
+- [ ] Finalità/basi giuridiche completate.
+- [ ] Destinatari/provider completati.
+- [ ] Retention completata.
+- [ ] Diritti e modalità di esercizio completati.
+- [ ] Informazioni sull'AI/processi automatizzati coerenti con le funzioni attive.
+- [ ] Modalità di pubblicazione/consegna approvata.
+
+Versione informativa approvata:
+
+---
+
+## 9. AI — boundary comune
+
+Riferimento: #710.
+
+- [ ] `AIRequestContext`/policy di minimizzazione approvati prima dei dati reali.
+- [ ] Provider AI non hanno accesso diretto a root/database/secret.
+- [ ] Hidden test, soluzioni docente e dati di altri studenti sono esclusi per default.
+- [ ] Logging/audit AI è minimizzato.
+- [ ] Feature flag e kill switch sono obbligatori.
+- [ ] Retention e data-use del provider sono documentati.
+- [ ] Trasparenza studente/docente definita.
+
+Prescrizioni:
+
+---
+
+## 10. AI — use case attivabili nel pilot
+
+Per ogni voce scegliere uno stato.
+
+### Tutor / assistenza (#712)
+
+- [ ] ABILITABILE su dati reali dopo completamento gate.
+- [ ] SOLO dati sintetici/demo.
+- [ ] NON NEL PILOT.
+
+### Correzione e proposta voto con review docente (#713)
+
+- [ ] ABILITABILE su dati reali dopo completamento gate specifico.
+- [ ] SOLO dati sintetici/demo.
+- [ ] NON NEL PILOT.
+
+### Grading automatico (#714)
+
+- [ ] ABILITABILE solo dopo classificazione/DPIA/approvazioni specifiche.
+- [ ] SOLO dati sintetici/benchmark.
+- [ ] NON NEL PILOT.
+
+### Adaptive learning (#715)
+
+- [ ] ABILITABILE solo dopo classificazione/DPIA/approvazioni specifiche.
+- [ ] SOLO dati sintetici/simulazioni.
+- [ ] NON NEL PILOT.
+
+Note/condizioni:
+
+---
+
+## 11. DPIA screening
+
+Riferimento: `PILOT_DPIA_SCREENING.md`.
+
+### Core piattaforma
+
+- [ ] DPIA non richiesta, motivazione documentata.
+- [ ] DPIA richiesta.
+- [ ] Valutazione da completare.
+
+### Tutor/assistive AI
+
+- [ ] DPIA non richiesta, motivazione documentata.
+- [ ] DPIA richiesta.
+- [ ] Valutazione da completare.
+
+### Assessment support / proposta voto
+
+- [ ] DPIA non richiesta, motivazione documentata.
+- [ ] DPIA richiesta.
+- [ ] Valutazione da completare.
+
+### Automated grading
+
+- [ ] DPIA richiesta/da completare prima dell'uso reale.
+- [ ] Altro esito motivato dal RPD/Istituto.
+
+### Adaptive learning
+
+- [ ] DPIA richiesta/da completare prima dell'impatto reale sul percorso.
+- [ ] Altro esito motivato dal RPD/Istituto.
+
+Motivazioni/riferimenti:
+
+---
+
+## 12. Incident response e sicurezza
+
+- [ ] Owner tecnico definito.
+- [ ] Canale di escalation definito.
+- [ ] Procedura revoca account/sessioni definita.
+- [ ] Procedura rotazione secret definita.
+- [ ] Procedura di sospensione servizio/AI definita.
+- [ ] Data breach process dell'Istituto collegato.
+- [ ] Policy per evidence/log sanitizzati definita.
+- [ ] Drill previsto prima del GO pilot.
+
+Note:
+
+---
+
+## 13. Decisione finale governance
+
+Selezionare una sola voce:
+
+- [ ] **APPROVATO PER NUOVO REHEARSAL CON DATI DEMO**, ma non ancora per studenti reali.
+- [ ] **APPROVATO PER PILOT CON DATI REALI** nel perimetro e con le feature flag indicate sopra.
+- [ ] **APPROVATO CON PRESCRIZIONI** elencate di seguito.
+- [ ] **NON APPROVATO / DA RIVEDERE**.
+
+Prescrizioni / condizioni sospensive:
+
+---
+
+## 14. Firme / approvazioni
+
+```text
+Dirigente / rappresentante del Titolare
+Nome:
+Data:
+Firma/riferimento atto:
+
+RPD/DPO — parere/coinvolgimento
+Nome:
+Data:
+Riferimento:
+
+Responsabile tecnico pilot
+Nome:
+Data:
+
+Docente / owner didattico
+Nome:
+Data:
+
+Decision owner GO/NO-GO
+Nome:
+Data:
+```
+
+---
+
+## 15. Regola di efficacia
+
+Una casella tecnica `PASS` non equivale a un'approvazione privacy. Le feature e i provider possono essere abilitati soltanto nel perimetro effettivamente approvato e nella revisione indicata in questo record.
+
+Ogni modifica materiale a finalità, categorie dati, provider, localizzazione, retention, use case AI, automazione valutativa o topologia deve attivare una nuova review di governance e, quando applicabile, una nuova valutazione DPIA/compliance prima dell'uso reale.

--- a/doc/governance/PILOT_DPIA_SCREENING.md
+++ b/doc/governance/PILOT_DPIA_SCREENING.md
@@ -1,0 +1,290 @@
+# TheBitLab pilot 2026/2027 — DPIA screening
+
+## Stato
+
+**DRAFT DA COMPILARE DAL TITOLARE CON IL SUPPORTO DEL RPD/DPO PRIMA DELL'USO CON DATI REALI.**
+
+Questo documento non decide autonomamente se una DPIA completa sia giuridicamente obbligatoria. Serve a rendere la decisione esplicita, motivata e versionata.
+
+Principio del progetto:
+
+> Se il trattamento può presentare un rischio elevato per diritti e libertà degli studenti, il pilot non procede con dati reali finché la valutazione richiesta non è stata completata e le misure di mitigazione non sono state approvate.
+
+---
+
+# 1. Scope della screening
+
+- Progetto: TheBitLab / 2cornot2c pilot 2026/2027
+- Istituto: `[________]`
+- Titolare: `[________]`
+- RPD/DPO: `[________]`
+- Owner tecnico: `[________]`
+- Owner didattico: `[________]`
+- Versione/release valutata: `[________]`
+- Topologia: `[________]`
+- Data: `[________]`
+
+Use case incluso nella screening:
+
+- [ ] core identity/classi/assignment
+- [ ] tentativi/report/grading deterministico
+- [ ] help non-AI
+- [ ] AI tutor/assistiva (#712)
+- [ ] AI correction/grade proposal (#713)
+- [ ] AI automated grading (#714)
+- [ ] AI adaptive learning (#715)
+- [ ] altro: `________`
+
+---
+
+# 2. Descrizione sintetica del trattamento
+
+Compilare:
+
+- finalità: `[________]`
+- interessati: `[________]`
+- categorie dati: `[________]`
+- origine dati: `[________]`
+- destinatari/provider: `[________]`
+- retention: `[________]`
+- trasferimenti: `[________]`
+- decisioni prodotte: `[________]`
+- human oversight: `[________]`
+- possibilità di contestazione/review: `[________]`
+
+---
+
+# 3. Trigger di rischio
+
+Per ciascun criterio indicare `NO`, `YES`, `UNKNOWN` e rationale.
+
+| Trigger | Stato | Rationale/evidence |
+|---|---|---|
+| interessati minori | | |
+| nuova tecnologia/AI | | |
+| valutazione sistematica di persone | | |
+| scoring/grading/profilazione | | |
+| decisione automatizzata con impatto significativo | | |
+| adattamento di percorso/livello/accesso | | |
+| monitoraggio sistematico | | |
+| dati su larga scala | | |
+| combinazione di dataset/fonti | | |
+| dati sensibili/art. 9 | | |
+| interessati vulnerabili | | |
+| impossibilità/difficoltà di sottrarsi al trattamento | | |
+| trasferimenti verso paesi terzi | | |
+| provider multipli/sub-responsabili | | |
+| rischio cross-student/cross-class | | |
+| uso di elaborati/codice come input AI | | |
+| uso di feedback/voto per future decisioni | | |
+| rischio di bias/discriminazione | | |
+| rischio di errore sistematico di grading | | |
+| rischio di leakage di hidden test/soluzioni docente | | |
+
+`UNKNOWN` è un blocker della decisione, non equivale a `NO`.
+
+---
+
+# 4. Classificazione conservativa per use case
+
+Questa tabella è una **policy interna di screening**, non una classificazione legale automatica.
+
+| Use case | Default screening TheBitLab | Attivazione reale |
+|---|---|---|
+| core identity/assignment | DPIA screening obbligatoria | dopo governance e screening approvate |
+| grading deterministico Docker/test | DPIA screening obbligatoria | dopo governance e security gate |
+| AI tutor/assistiva | screening specifica + review RPD/DPO | solo dopo #710 e gate use-case |
+| AI correction/grade proposal | **presunzione interna: DPIA completa da valutare come necessaria** | solo dopo decisione documentata |
+| AI automated grading | **presunzione interna forte: DPIA completa** | disabilitato finché gate legali/didattici non sono chiusi |
+| AI adaptive path | **presunzione interna forte: DPIA completa** | disabilitato finché gate legali/didattici non sono chiusi |
+
+La scuola/RPD-DPO può concludere diversamente solo con rationale documentata riferita allo scope reale.
+
+---
+
+# 5. Necessità e proporzionalità
+
+Per ogni trattamento/use case rispondere:
+
+1. Quale problema didattico/operativo risolve?
+2. Il dato è strettamente necessario?
+3. È possibile ottenere lo stesso risultato con meno dati?
+4. È possibile usare dati sintetici o anonimizzati?
+5. Il trattamento è facoltativo o necessario al servizio core?
+6. È possibile mantenere la decisione al docente senza perdita sostanziale di utilità?
+7. Il provider deve ricevere tutto l'elaborato o basta un frammento?
+8. È necessario conservare il prompt/response?
+9. È necessario mantenere lo storico completo o basta un aggregate?
+10. È possibile tenere hidden test/teacher solution completamente fuori dal provider?
+11. È possibile disabilitare il use case senza impedire l'attività didattica?
+
+Outcome:
+
+- [ ] proporzionato
+- [ ] proporzionato solo con mitigazioni
+- [ ] non proporzionato
+- [ ] informazioni insufficienti
+
+Rationale: `[________]`
+
+---
+
+# 6. Rischi da valutare
+
+## Privacy/security
+
+- account takeover;
+- accesso cross-class/cross-student;
+- esposizione email/identity mapping;
+- leakage di elaborati;
+- leakage di log/query/secret;
+- backup non cifrato/incompleto;
+- provider AI che riceve campi eccedenti;
+- retention superiore al necessario;
+- trasferimenti/provider non governati;
+- coding agent con accesso improprio a produzione.
+
+## Didattica/assessment
+
+- falso positivo/falso negativo del grading;
+- feedback AI errato o fuorviante;
+- bias sistematico verso categorie di studenti;
+- proposal/voto AI accettato senza review reale;
+- automation bias del docente;
+- impossibilità per lo studente di capire/contestare la valutazione;
+- variazione non tracciata di modello/prompt/rubrica;
+- drift del provider/modello;
+- uso di dati storici oltre la finalità originaria.
+
+## Minori
+
+- linguaggio non comprensibile;
+- pressione a fornire dati non necessari;
+- profilazione eccedente;
+- esposizione a output inappropriati;
+- decisioni adattive opache;
+- monitoraggio comportamentale invasivo.
+
+---
+
+# 7. Misure di mitigazione baseline
+
+- root unica e authorization class-scoped (#702/#705/#706);
+- secret fuori repository/log;
+- trusted proxy e logging secret-safe (#703/#704);
+- retention bounded;
+- least privilege;
+- backup giornaliero + RPO 24h + RTO 8h;
+- AI Privacy/Provider Boundary (#710);
+- synthetic-first;
+- field allow/deny;
+- no cross-student context;
+- no direct DB/root access per AI;
+- hidden test/teacher solution excluded by default;
+- model/prompt/policy/rubric versioning;
+- human oversight configurabile;
+- rationale/evidence separate dall'output AI;
+- contestazione/override;
+- quality/bias/drift gates per assessment;
+- feature flag e kill switch;
+- incident response con escalation a Titolare/RPD-DPO;
+- informativa comprensibile e specifica per use case.
+
+Misure ulteriori richieste: `[________]`
+
+---
+
+# 8. Automated decision-making / assessment screening
+
+Compilare per #713–#715:
+
+- L'AI propone soltanto o decide? `[________]`
+- Il docente deve confermare? `[________]`
+- Il docente può modificare/rifiutare? `[________]`
+- L'override è effettivo o solo formale? `[________]`
+- L'output incide su voto ufficiale? `[________]`
+- L'output incide su accesso/livello/percorso? `[________]`
+- Esiste diritto/processo di contestazione? `[________]`
+- Esistono explanation/evidence sufficienti? `[________]`
+- Esistono soglie di accuracy/error/bias? `[________]`
+- È possibile tornare a workflow interamente umano? `[________]`
+
+Se l'AI produce una decisione autonoma con impatto significativo, la screening non può concludersi con un generico `low risk` senza analisi giuridica specifica.
+
+---
+
+# 9. AI Act screening
+
+Per ogni use case AI registrare:
+
+- intended purpose;
+- provider/deployer roles;
+- whether the system evaluates learning outcomes;
+- whether the output determines/influences access, level or educational path;
+- whether the use falls within an Annex III education category;
+- whether an exclusion/non-high-risk rationale is claimed;
+- source/version of the legal guidance used for classification;
+- decision owner/date.
+
+Classificazione: `[NOT_APPLICABLE | NON_HIGH_RISK | HIGH_RISK_CANDIDATE | HIGH_RISK | UNKNOWN]`
+
+Rationale: `[________]`
+
+`UNKNOWN` mantiene la capability disabilitata sui dati reali.
+
+---
+
+# 10. Decisione DPIA
+
+Una delle seguenti:
+
+- [ ] **FULL DPIA REQUIRED**
+- [ ] **FULL DPIA NOT REQUIRED — rationale documentata**
+- [ ] **SCOPE MUST CHANGE BEFORE DECISION**
+- [ ] **BLOCKED — informazioni/provider/contratti insufficienti**
+
+Rationale: `[________]`
+
+Misure obbligatorie prima dell'attivazione: `[________]`
+
+Residual risk: `[LOW | MEDIUM | HIGH | UNKNOWN]`
+
+Se resta un rischio elevato non mitigato, il Titolare/RPD-DPO determina il passo successivo previsto dalla normativa; il software non può auto-approvare il rischio.
+
+---
+
+# 11. Firme e review
+
+Titolare/decision owner: `[________]`
+
+Data: `[________]`
+
+RPD/DPO review: `[________]`
+
+Data: `[________]`
+
+Owner tecnico: `[________]`
+
+Owner didattico: `[________]`
+
+Next review date: `[________]`
+
+Release/use-case scope: `[________]`
+
+---
+
+# 12. Invariante di rollout
+
+Una modifica a uno dei seguenti elementi invalida almeno la relativa screening e richiede review:
+
+- intended purpose;
+- categorie dati;
+- provider/subprocessor;
+- trasferimenti;
+- retention;
+- modello/prompt/policy per use case valutativi;
+- authority/human oversight;
+- topologia;
+- identity/authz;
+- output che diventa voto/decisione ufficiale;
+- percorso adattivo che cambia materialmente opportunità/accesso.

--- a/doc/governance/PILOT_DPIA_SCREENING.md
+++ b/doc/governance/PILOT_DPIA_SCREENING.md
@@ -1,14 +1,16 @@
-# TheBitLab pilot 2026/2027 — DPIA screening
+# TheBitLab pilot 2026/2027 — DPIA & AI risk screening
 
 ## Stato
 
 **DRAFT DA COMPILARE DAL TITOLARE CON IL SUPPORTO DEL RPD/DPO PRIMA DELL'USO CON DATI REALI.**
 
-Questo documento non decide autonomamente se una DPIA completa sia giuridicamente obbligatoria. Serve a rendere la decisione esplicita, motivata e versionata.
+Questo documento non decide autonomamente se una DPIA completa sia giuridicamente obbligatoria. Serve a rendere la decisione esplicita, motivata e versionata e a coordinare, per gli use case AI, la classificazione AI Act e l'eventuale FRIA.
 
 Principio del progetto:
 
 > Se il trattamento può presentare un rischio elevato per diritti e libertà degli studenti, il pilot non procede con dati reali finché la valutazione richiesta non è stata completata e le misure di mitigazione non sono state approvate.
+
+**DPIA GDPR e FRIA AI Act sono valutazioni distinte.** Possono essere integrate operativamente per le parti sovrapposte, ma una non viene considerata automaticamente sostitutiva dell'altra.
 
 ---
 
@@ -24,7 +26,7 @@ Principio del progetto:
 - Topologia: `[________]`
 - Data: `[________]`
 
-Use case incluso nella screening:
+Use case incluso:
 
 - [ ] core identity/classi/assignment
 - [ ] tentativi/report/grading deterministico
@@ -44,8 +46,10 @@ Compilare:
 - finalità: `[________]`
 - interessati: `[________]`
 - categorie dati: `[________]`
+- eventuali categorie particolari art. 9: `[NESSUNA / DESCRIZIONE E BASE]`
 - origine dati: `[________]`
 - destinatari/provider: `[________]`
+- ruolo gestore tecnico/processori: `[________]`
 - retention: `[________]`
 - trasferimenti: `[________]`
 - decisioni prodotte: `[________]`
@@ -54,13 +58,14 @@ Compilare:
 
 ---
 
-# 3. Trigger di rischio
+# 3. Trigger di rischio GDPR
 
 Per ciascun criterio indicare `NO`, `YES`, `UNKNOWN` e rationale.
 
 | Trigger | Stato | Rationale/evidence |
 |---|---|---|
 | interessati minori | | |
+| interessati vulnerabili | | |
 | nuova tecnologia/AI | | |
 | valutazione sistematica di persone | | |
 | scoring/grading/profilazione | | |
@@ -70,7 +75,6 @@ Per ciascun criterio indicare `NO`, `YES`, `UNKNOWN` e rationale.
 | dati su larga scala | | |
 | combinazione di dataset/fonti | | |
 | dati sensibili/art. 9 | | |
-| interessati vulnerabili | | |
 | impossibilità/difficoltà di sottrarsi al trattamento | | |
 | trasferimenti verso paesi terzi | | |
 | provider multipli/sub-responsabili | | |
@@ -83,22 +87,24 @@ Per ciascun criterio indicare `NO`, `YES`, `UNKNOWN` e rationale.
 
 `UNKNOWN` è un blocker della decisione, non equivale a `NO`.
 
+La presenza contemporanea di minori/vulnerabilità, valutazione sistematica e tecnologia innovativa/AI richiede una valutazione particolarmente conservativa della necessità di DPIA.
+
 ---
 
-# 4. Classificazione conservativa per use case
+# 4. Default interno per use case
 
-Questa tabella è una **policy interna di screening**, non una classificazione legale automatica.
+Questa tabella è una **policy interna di gate**, non una classificazione legale automatica.
 
-| Use case | Default screening TheBitLab | Attivazione reale |
+| Use case | Default TheBitLab | Attivazione reale |
 |---|---|---|
-| core identity/assignment | DPIA screening obbligatoria | dopo governance e screening approvate |
+| core identity/assignment | DPIA screening obbligatoria | dopo governance e screening |
 | grading deterministico Docker/test | DPIA screening obbligatoria | dopo governance e security gate |
 | AI tutor/assistiva | screening specifica + review RPD/DPO | solo dopo #710 e gate use-case |
-| AI correction/grade proposal | **presunzione interna: DPIA completa da valutare come necessaria** | solo dopo decisione documentata |
-| AI automated grading | **presunzione interna forte: DPIA completa** | disabilitato finché gate legali/didattici non sono chiusi |
-| AI adaptive path | **presunzione interna forte: DPIA completa** | disabilitato finché gate legali/didattici non sono chiusi |
+| AI correction/grade proposal | **DPIA completa come gate interno salvo conclusione contraria formalmente motivata dal Titolare/RPD-DPO** | solo dopo decisione documentata |
+| AI automated grading | **DPIA completa come gate interno** | disabilitato finché gate legali/didattici non sono chiusi |
+| AI adaptive path con impatto materiale | **DPIA completa come gate interno** | disabilitato finché gate legali/didattici non sono chiusi |
 
-La scuola/RPD-DPO può concludere diversamente solo con rationale documentata riferita allo scope reale.
+La scuola/RPD-DPO può definire un esito diverso soltanto con rationale documentata riferita allo scope reale.
 
 ---
 
@@ -109,14 +115,15 @@ Per ogni trattamento/use case rispondere:
 1. Quale problema didattico/operativo risolve?
 2. Il dato è strettamente necessario?
 3. È possibile ottenere lo stesso risultato con meno dati?
-4. È possibile usare dati sintetici o anonimizzati?
+4. È possibile usare dati sintetici o realmente anonimizzati?
 5. Il trattamento è facoltativo o necessario al servizio core?
 6. È possibile mantenere la decisione al docente senza perdita sostanziale di utilità?
 7. Il provider deve ricevere tutto l'elaborato o basta un frammento?
-8. È necessario conservare il prompt/response?
+8. È necessario conservare prompt/response?
 9. È necessario mantenere lo storico completo o basta un aggregate?
 10. È possibile tenere hidden test/teacher solution completamente fuori dal provider?
-11. È possibile disabilitare il use case senza impedire l'attività didattica?
+11. È possibile disabilitare il use case senza impedire l'attività didattica core?
+12. Possono comparire incidentalmente dati sanitari/DSA/disabilità nel contesto? Come vengono esclusi?
 
 Outcome:
 
@@ -136,13 +143,14 @@ Rationale: `[________]`
 - account takeover;
 - accesso cross-class/cross-student;
 - esposizione email/identity mapping;
-- leakage di elaborati;
+- leakage di elaborati o categorie particolari;
 - leakage di log/query/secret;
 - backup non cifrato/incompleto;
 - provider AI che riceve campi eccedenti;
 - retention superiore al necessario;
 - trasferimenti/provider non governati;
-- coding agent con accesso improprio a produzione.
+- coding agent con accesso improprio a produzione;
+- ruolo controller/processor non qualificato.
 
 ## Didattica/assessment
 
@@ -163,7 +171,8 @@ Rationale: `[________]`
 - profilazione eccedente;
 - esposizione a output inappropriati;
 - decisioni adattive opache;
-- monitoraggio comportamentale invasivo.
+- monitoraggio comportamentale invasivo;
+- inferenza delle emozioni o pratiche vietate.
 
 ---
 
@@ -181,20 +190,22 @@ Rationale: `[________]`
 - no cross-student context;
 - no direct DB/root access per AI;
 - hidden test/teacher solution excluded by default;
+- categorie particolari escluse dal contesto AI per default;
 - model/prompt/policy/rubric versioning;
-- human oversight configurabile;
+- human oversight configurabile ed effettiva;
 - rationale/evidence separate dall'output AI;
 - contestazione/override;
 - quality/bias/drift gates per assessment;
 - feature flag e kill switch;
 - incident response con escalation a Titolare/RPD-DPO;
-- informativa comprensibile e specifica per use case.
+- informativa comprensibile e specifica per use case;
+- AI literacy del personale interessato.
 
 Misure ulteriori richieste: `[________]`
 
 ---
 
-# 8. Automated decision-making / assessment screening
+# 8. Automated decision-making / assessment screening GDPR
 
 Compilare per #713–#715:
 
@@ -209,7 +220,7 @@ Compilare per #713–#715:
 - Esistono soglie di accuracy/error/bias? `[________]`
 - È possibile tornare a workflow interamente umano? `[________]`
 
-Se l'AI produce una decisione autonoma con impatto significativo, la screening non può concludersi con un generico `low risk` senza analisi giuridica specifica.
+Se l'AI produce una decisione autonoma con impatto significativo, la screening non può concludersi con un generico `low risk` senza analisi giuridica specifica del GDPR e delle garanzie applicabili.
 
 ---
 
@@ -218,23 +229,76 @@ Se l'AI produce una decisione autonoma con impatto significativo, la screening n
 Per ogni use case AI registrare:
 
 - intended purpose;
+- provider, sistema, versione e modello;
 - provider/deployer roles;
 - whether the system evaluates learning outcomes;
 - whether the output determines/influences access, level or educational path;
+- whether profiling occurs;
 - whether the use falls within an Annex III education category;
-- whether an exclusion/non-high-risk rationale is claimed;
-- source/version of the legal guidance used for classification;
+- whether an Article 6(3) non-high-risk rationale is claimed;
+- source/version of provider/legal documentation used for classification;
 - decision owner/date.
 
 Classificazione: `[NOT_APPLICABLE | NON_HIGH_RISK | HIGH_RISK_CANDIDATE | HIGH_RISK | UNKNOWN]`
 
 Rationale: `[________]`
 
-`UNKNOWN` mantiene la capability disabilitata sui dati reali.
+Regole di gate:
+
+- `UNKNOWN` mantiene la capability disabilitata sui dati reali;
+- `AI proposes -> docente decides` non costituisce da solo una ragione sufficiente per escludere l'high-risk;
+- se viene invocato l'art. 6(3), documentare i presupposti applicabili e verificare che il sistema non effettui profilazione incompatibile con l'eccezione;
+- use case che valutano risultati dell'apprendimento o influenzano materialmente livello/percorso sono trattati come `HIGH_RISK_CANDIDATE` finché la classificazione non è conclusa.
 
 ---
 
-# 10. Decisione DPIA
+# 10. High-risk deployer screening — art. 26 AI Act
+
+Se classificazione = `HIGH_RISK`, verificare almeno:
+
+- [ ] istruzioni del provider disponibili e applicate;
+- [ ] human oversight con persone competenti, formate, dotate di autorità e supporto;
+- [ ] input data sotto controllo del deployer valutati per pertinenza/rappresentatività quando applicabile;
+- [ ] monitoraggio del sistema e procedura di sospensione;
+- [ ] reporting di rischi/incidenti secondo gli obblighi applicabili;
+- [ ] log automatici sotto controllo del deployer conservati per il periodo minimo applicabile, incluso **almeno sei mesi** quando richiesto dall'art. 26;
+- [ ] informazioni del provider utilizzate per DPIA GDPR quando applicabile;
+- [ ] obblighi di registrazione nella banca dati UE verificati per il deployer pubblico;
+- [ ] feature flag/kill switch e fallback umano testati;
+- [ ] AI literacy evidence disponibile.
+
+Riferimenti/evidence: `[________]`
+
+---
+
+# 11. FRIA screening — art. 27 AI Act
+
+Per sistemi high-risk ex art. 6(2), verificare se l'Istituto rientra nel perimetro dell'art. 27 quale organismo di diritto pubblico/deployer.
+
+Esito:
+
+- [ ] FRIA NOT APPLICABLE — rationale documentata.
+- [ ] FRIA REQUIRED.
+- [ ] UNKNOWN / BLOCKED.
+
+Se richiesta, la FRIA deve coprire almeno:
+
+- processi e intended purpose;
+- durata/frequenza d'uso;
+- categorie di persone e gruppi interessati;
+- rischi specifici di danno ai diritti fondamentali nel contesto reale;
+- implementazione concreta della human oversight;
+- mitigazioni, governance e meccanismi di reclamo/ricorso pertinenti.
+
+- [ ] FRIA completata prima dell'uso.
+- [ ] eventuale integrazione con DPIA documentata senza confondere i due adempimenti.
+- [ ] eventuali adempimenti verso l'autorità di vigilanza previsti dall'art. 27 completati/documentati.
+
+Riferimento FRIA: `[________]`
+
+---
+
+# 12. Decisione DPIA GDPR
 
 Una delle seguenti:
 
@@ -249,11 +313,24 @@ Misure obbligatorie prima dell'attivazione: `[________]`
 
 Residual risk: `[LOW | MEDIUM | HIGH | UNKNOWN]`
 
-Se resta un rischio elevato non mitigato, il Titolare/RPD-DPO determina il passo successivo previsto dalla normativa; il software non può auto-approvare il rischio.
+Se resta un rischio elevato non mitigato, il Titolare/RPD-DPO determina il passo successivo previsto dalla normativa; il software non auto-approva il rischio.
 
 ---
 
-# 11. Firme e review
+# 13. Decisione AI Act
+
+- Classificazione use case: `[________]`
+- High-risk deployer checklist: `[N.A. / COMPLETA / BLOCCATA]`
+- FRIA: `[N.A. / COMPLETA / BLOCCATA]`
+- AI literacy: `[COMPLETA / BLOCCATA]`
+- Provider evidence: `[COMPLETA / BLOCCATA]`
+- Real student data: `[ENABLED / SYNTHETIC_ONLY / BLOCKED]`
+
+Rationale/condizioni: `[________]`
+
+---
+
+# 14. Firme e review
 
 Titolare/decision owner: `[________]`
 
@@ -273,13 +350,14 @@ Release/use-case scope: `[________]`
 
 ---
 
-# 12. Invariante di rollout
+# 15. Invariante di rollout
 
 Una modifica a uno dei seguenti elementi invalida almeno la relativa screening e richiede review:
 
 - intended purpose;
-- categorie dati;
+- categorie dati, incluse categorie particolari;
 - provider/subprocessor;
+- ruolo controller/processor;
 - trasferimenti;
 - retention;
 - modello/prompt/policy per use case valutativi;
@@ -287,4 +365,6 @@ Una modifica a uno dei seguenti elementi invalida almeno la relativa screening e
 - topologia;
 - identity/authz;
 - output che diventa voto/decisione ufficiale;
-- percorso adattivo che cambia materialmente opportunità/accesso.
+- percorso adattivo che cambia materialmente opportunità/accesso;
+- classificazione AI Act;
+- condizioni che rendevano non applicabile DPIA o FRIA.

--- a/doc/governance/PILOT_GOVERNANCE_2026_2027.md
+++ b/doc/governance/PILOT_GOVERNANCE_2026_2027.md
@@ -1,0 +1,589 @@
+# TheBitLab pilot 2026/2027 — Privacy & Governance Baseline
+
+## Stato
+
+**DRAFT PER APPROVAZIONE DELLA SCUOLA/RPD-DPO — non costituisce parere legale né attestazione di conformità.**
+
+Questo documento è il pacchetto operativo di governance richiesto da #699 e dal gate `Governance` del pilot rehearsal #678.
+
+Il documento:
+
+- traduce in regole operative i principi privacy/security del pilot;
+- registra le decisioni già prese per il pilot 2026/27;
+- separa le decisioni di prodotto dalle decisioni che spettano al titolare del trattamento/RPD-DPO;
+- fornisce una baseline verificabile per deployment, backup/restore, logging, identity e AI;
+- non autorizza da solo l'uso di dati reali.
+
+Prima dell'uso con studenti reali devono essere compilate le sezioni `APPROVAL REQUIRED`, completata la DPIA screening e ottenute le approvazioni previste dall'istituto.
+
+---
+
+# 1. Decisioni già congelate
+
+## 1.1 Account Google ammessi
+
+Per il pilot sono ammessi:
+
+- account Google Workspace scolastici;
+- account Gmail personali.
+
+Quando disponibile e funzionante, l'account scolastico può essere preferito, ma non è requisito tecnico esclusivo.
+
+Il dominio/provider dell'account **non attribuisce autorizzazioni interne**. Classe, membership, assignment, target e accesso sono determinati esclusivamente da binding e policy TheBitLab (#702/#706).
+
+Il gap `access_not_configured` osservato sul tenant Workspace resta un problema di onboarding/supporto del tenant, non una prova di errore del callback applicativo e non blocca l'intero pilot quando Gmail personale è ammesso dalla governance.
+
+## 1.2 Continuità operativa
+
+Baseline approvata:
+
+- backup almeno giornaliero;
+- RPO target: **24 ore**;
+- RTO target: **8 ore lavorative**;
+- restore sempre verificato in ambiente isolato;
+- segreti esclusi dal backup applicativo non cifrato;
+- implementazione tecnica e rehearsal del restore: #705.
+
+## 1.3 Roadmap AI
+
+Le capacità AI previste non vengono eliminate:
+
+- tutor/assistente;
+- feedback e debugging;
+- correzione automatica;
+- proposta di voto/punteggio;
+- grading automatico;
+- analisi progressi e remediation;
+- percorsi adattivi.
+
+L'implementazione può iniziare con dati sintetici/fixture. L'attivazione su dati reali dipende dal relativo gate di governance/privacy/compliance.
+
+Boundary comune: #710. Roadmap: #711. Capability separate: #712–#715.
+
+---
+
+# 2. Principi non negoziabili
+
+Il pilot applica come requisiti di engineering e governance:
+
+1. **purpose limitation** — ogni dato ha una finalità dichiarata;
+2. **data minimisation** — si raccoglie e si espone solo ciò che serve;
+3. **storage limitation** — ogni categoria ha retention o criterio esplicito;
+4. **integrity & confidentiality** — accesso, cifratura, backup e audit sono proporzionati al rischio;
+5. **accountability** — decisioni, owner, policy e revisioni devono essere ricostruibili;
+6. **least privilege** — l'accesso deriva dal ruolo e dal perimetro necessario;
+7. **no silent authority** — autenticazione, provider identity o AI output non diventano automaticamente autorizzazione o decisione didattica;
+8. **synthetic-first** — sviluppo, benchmark e rehearsal usano dati sintetici/demo finché il trattamento reale non è approvato;
+9. **fail closed** — ambiguity su identity, membership, root, policy o data scope non diventa accesso;
+10. **student vulnerability** — il design assume che gli interessati siano anche minori e richiede protezioni rafforzate e comunicazioni comprensibili.
+
+Riferimenti normativi/istituzionali da riesaminare al momento dell'approvazione:
+
+- GDPR, Regolamento (UE) 2016/679, in particolare artt. 5, 6, 13, 28, 32, 33, 34, 35 e 22;
+- Garante per la protezione dei dati personali, area Scuola e vademecum aggiornati;
+- Regolamento (UE) 2024/1689 (AI Act) e calendario/applicazione vigente;
+- regole nazionali/scolastiche applicabili al trattamento e alla valutazione.
+
+---
+
+# 3. Ruoli privacy e responsabilità
+
+## 3.1 Titolare
+
+Baseline organizzativa da sottoporre alla scuola:
+
+> Per il pilot didattico svolto da un'istituzione scolastica, l'istituto determina finalità e mezzi del trattamento relativo alla propria utenza e viene trattato come **Titolare del trattamento**, salvo diversa qualificazione documentata per uno specifico servizio.
+
+`APPROVAL REQUIRED`
+
+- Istituto/Titolare: `____________________________`
+- Dirigente / legale rappresentante: `____________________________`
+- Contatti privacy: `____________________________`
+- RPD/DPO: `____________________________`
+- Contatto RPD/DPO: `____________________________`
+
+## 3.2 Responsabili e sub-responsabili
+
+Per ciascun servizio esterno che tratta dati per conto del Titolare deve essere registrato almeno:
+
+- provider/organizzazione;
+- servizio e finalità;
+- ruolo privacy;
+- contratto/DPA art. 28 quando applicabile;
+- sub-responsabili rilevanti;
+- localizzazione/trattamento e trasferimenti extra SEE quando applicabili;
+- retention/data-use/training policy;
+- misure di sicurezza;
+- data di approvazione e owner.
+
+Il ruolo del gestore tecnico/TheBitLab rispetto alla scuola deve essere **esplicitamente qualificato** prima dell'uso reale. Nessun maintainer/coding agent ottiene accesso ai dati reali solo perché sviluppa il software.
+
+## 3.3 Ruoli operativi TheBitLab
+
+| Ruolo | Responsabilità | Authority sui dati |
+|---|---|---|
+| Studente | attività, tentativi, aiuti, selezione definitivo | solo propri dati/assignment autorizzati |
+| Docente | classe, assignment, review, feedback, grading | solo classi/perimetro assegnato |
+| Admin TheBitLab | identity, membership, configurazione applicativa | amministrazione necessaria; no browsing didattico indiscriminato |
+| Gestore tecnico | deployment, backup, security, incident response | accesso eccezionale e tracciato quando necessario |
+| Decision owner | GO/NO-GO e rischio residuo non bloccante | nessun accesso implicito ai contenuti personali |
+| RPD/DPO | consulenza/sorveglianza privacy | secondo mandato istituzionale |
+| AI provider | solo contesto minimizzato autorizzato | nessun accesso diretto a root/database |
+| Coding agent/LLM di sviluppo | sviluppo su codice e dati sintetici | **nessun accesso ai dati reali di produzione** |
+
+---
+
+# 4. Base giuridica — decisione del Titolare, non del software
+
+TheBitLab non codifica una base giuridica universale.
+
+Per i trattamenti necessari all'attività didattica di una scuola pubblica, la scuola/RPD-DPO deve mappare e documentare la base applicabile, tipicamente nel quadro di obblighi legali e/o compiti di interesse pubblico previsti dalla normativa nazionale ed europea.
+
+Regole di prodotto:
+
+- il **consenso non viene usato come catch-all** per rendere lecito il funzionamento core della piattaforma;
+- feature opzionali con finalità ulteriori richiedono una valutazione separata;
+- ogni use case AI con dati reali possiede una voce distinta nel registro dei trattamenti/use case;
+- se una finalità cambia, il dato non viene silenziosamente riutilizzato.
+
+`APPROVAL REQUIRED`
+
+La scuola/RPD-DPO deve completare una matrice:
+
+| Trattamento | Finalità | Base giuridica | Necessità/proporzionalità | Note |
+|---|---|---|---|---|
+| Identity/login | | | | |
+| Membership/classi | | | | |
+| Assignment/activity | | | | |
+| Tentativi/report | | | | |
+| Feedback/grading | | | | |
+| Help/tutor | | | | |
+| Security/audit logs | | | | |
+| Backup/restore | | | | |
+| AI assistiva | | | | |
+| AI assessment support | | | | |
+| AI grading/adaptive | | | | |
+
+---
+
+# 5. Inventario dati e finalità
+
+## 5.1 Identity e autenticazione
+
+Dati possibili:
+
+- `user_id` interno;
+- provider e subject federato necessario al login;
+- email/display name quando necessari per onboarding e riconoscibilità operativa;
+- ruolo, stato account e membership;
+- session metadata minimizzati;
+- eventi di revoca/security.
+
+Finalità:
+
+- autenticazione;
+- associazione dell'account al soggetto didattico;
+- access control;
+- audit security e revoca.
+
+Vincoli:
+
+- email/dominio non sono authorization authority;
+- cookie, bearer, pairing proof, OAuth code/state e secret non vanno in issue, screenshot o evidence condivise;
+- identifier interno stabile preferito nei collegamenti applicativi.
+
+## 5.2 Dati didattici strutturali
+
+- classe/roster/binding;
+- course design/UDA;
+- activity e assignment;
+- calendario;
+- fingerprint/versione activity/test/rubrica.
+
+Finalità:
+
+- erogazione della didattica;
+- attribuzione corretta di attività e verifiche;
+- riproducibilità della valutazione.
+
+## 5.3 Elaborati, tentativi e report
+
+- codice/elaborato consegnato;
+- `attempt_id`;
+- timestamp necessari;
+- backend/runner;
+- esito test e report strutturato;
+- selezione del tentativo definitivo.
+
+Finalità:
+
+- esecuzione del laboratorio;
+- feedback;
+- grading/review;
+- ricostruzione del tentativo valutato.
+
+## 5.4 Aiuti e interazioni tutor
+
+- domanda dello studente;
+- frammento di codice/context necessario;
+- risposta/feedback;
+- contatori/policy di aiuto;
+- metadati minimi per audit.
+
+Finalità:
+
+- supporto didattico;
+- verifica delle policy di aiuto;
+- eventuale review docente.
+
+Non raccogliere automaticamente dati personali non necessari, conversazioni esterne o cronologie eccedenti.
+
+## 5.5 Grading e feedback
+
+- evidence deterministica;
+- rubrica/revisione;
+- feedback docente;
+- eventuale proposta AI;
+- eventuale voto/punteggio e decisione finale;
+- audit di override/review.
+
+Finalità:
+
+- valutazione didattica nel perimetro autorizzato;
+- spiegabilità e contestabilità della decisione.
+
+L'output AI deve restare distinguibile da evidence deterministica e decisione umana.
+
+## 5.6 Log tecnici e security
+
+- timestamp;
+- endpoint/path canonico;
+- status/timing;
+- correlation identifier non sensibile;
+- security event essenziale;
+- client attribution solo quando necessaria e correttamente derivata.
+
+Da escludere per default:
+
+- query OAuth sensibili;
+- cookie;
+- bearer/proof;
+- secret;
+- body contenenti elaborati salvo logging esplicitamente approvato;
+- dump database.
+
+## 5.7 Backup
+
+Contiene soltanto dati applicativi necessari al restore coerente.
+
+Non contiene nel backup applicativo non cifrato:
+
+- OAuth client secret;
+- private key GitHub App;
+- bearer/token runtime;
+- credenziali infrastrutturali.
+
+---
+
+# 6. Retention baseline proposta
+
+**Questi periodi sono default di engineering da approvare/modificare con la scuola/RPD-DPO. Non sostituiscono obblighi di conservazione scolastici o normativi.**
+
+TheBitLab distingue sempre la copia operativa della piattaforma dall'eventuale registro/archivio scolastico ufficiale.
+
+| Categoria | Default pilot proposto | Fine periodo |
+|---|---:|---|
+| Account/binding/membership | anno scolastico + 90 giorni | delete/deactivate o retention motivata |
+| Assignment/activity mapping per studente | anno scolastico + 90 giorni | delete/de-identify se non più necessario |
+| Elaborati/tentativi/report operativi | anno scolastico + 90 giorni | export necessario + delete/de-identify |
+| Feedback/grading operativi | anno scolastico + 90 giorni | il record ufficiale segue i sistemi/policy della scuola |
+| Help/tutor interaction content | 30 giorni | delete; mantenere solo metriche realmente anonime se utili |
+| AI request/response payload nel gateway | **0 giorni per default** | non persistere payload; audit solo metadata bounded |
+| AI audit metadata | 30 giorni | delete salvo incident/legal hold |
+| Access/security log ordinario | 30 giorni | delete/rotate salvo incident/legal hold |
+| Evidence di incident | secondo procedura incidente | closure + retention approvata caso per caso |
+| Backup applicativi | rolling 30 giorni | rotazione verificata; legal/incident hold separato |
+| Evidence rehearsal demo/sintetica | secondo progetto/release policy | nessun dato reale nel rehearsal finché non autorizzato |
+
+Regole:
+
+- nessuna retention `forever` implicita;
+- estensioni richiedono finalità/owner/scadenza;
+- un incident/legal hold congela solo gli artifact necessari e viene tracciato;
+- se dati valutativi devono essere conservati più a lungo per obblighi scolastici, la retention va definita dall'istituto e preferibilmente affidata al sistema ufficiale invece di trasformare TheBitLab in archivio indefinito.
+
+---
+
+# 7. Access matrix
+
+Legenda: `R` read, `W` write, `A` admin, `N` no access, `E` eccezionale/incident-only.
+
+| Dato | Studente | Docente | Admin app | Gestore tecnico | AI provider | Coding agent |
+|---|---|---|---|---|---|---|
+| Proprio profilo minimo | R | R se nella classe | A | E | N | N |
+| Membership/classi | propria R | R classi assegnate | A | E | N | N |
+| Assignment | propri R | RW classi assegnate | A bounded | E | context minimo se use case approvato | N |
+| Proprio elaborato | RW secondo workflow | R classi assegnate | N default | E | frammento minimo se approvato | N |
+| Elaborati altri studenti | N | R solo propria classe | N default | E | N | N |
+| Hidden tests/teacher solution | N | R | A bounded | E | **N default** | sintetici/dev only |
+| Grading/feedback | proprio R | RW classi assegnate | N default | E | proposal context solo se approvato | N |
+| Security logs | N | N default | bounded | R/E | N | N |
+| Backup | N | N | N | E/A | N | N |
+| Secret/credentials | N | N | N | E/A secondo ruolo | N | N |
+
+Qualunque eccezione deve essere motivata, temporanea e auditabile.
+
+---
+
+# 8. Account personali Gmail e Workspace
+
+L'informativa deve spiegare che:
+
+- il pilot consente entrambi i tipi di account;
+- l'email usata per il login può essere personale o scolastica;
+- il provider Google prova l'identità federata ma **non determina** classe o autorizzazione TheBitLab;
+- lo studente viene collegato a un `user_id` interno e a membership autorizzate dalla scuola;
+- eventuali problemi del tenant Workspace sono gestiti come supporto/onboarding;
+- l'uso di un account personale non autorizza il riuso dell'email per finalità estranee al pilot.
+
+---
+
+# 9. Provider esterni e registry
+
+Prima dell'attivazione reale ogni provider deve avere una scheda:
+
+```text
+provider:
+service:
+purpose:
+data_categories:
+role: processor | independent_controller | other
+DPA_or_contract_ref:
+subprocessors_ref:
+processing_locations:
+third_country_transfer_basis:
+provider_retention:
+training_data_use:
+security_measures_ref:
+kill_switch:
+approved_by:
+approved_at:
+review_due:
+```
+
+Provider iniziali potenziali:
+
+- Google OIDC;
+- GitHub/GitLab per fonti didattiche;
+- infrastruttura hosting/backup;
+- provider AI solo dopo #710 e gate use-case.
+
+Il registry non contiene secret.
+
+---
+
+# 10. AI privacy/governance boundary
+
+Tutte le feature AI seguono:
+
+```text
+Feature didattica
+   ↓
+UseCasePolicy
+   ↓
+AI Privacy/Provider Boundary (#710)
+   ↓
+Provider Adapter
+```
+
+Regole:
+
+- synthetic-only fino al gate reale;
+- niente accesso diretto a root/database;
+- niente cookie/bearer/secret;
+- niente cross-student context;
+- hidden test/teacher solution esclusi per default;
+- contesto minimo necessario;
+- provider/model/policy/use-case versionati;
+- payload non persistito nel gateway per default;
+- audit metadata bounded;
+- feature flag e kill switch;
+- transparency verso studente/docente;
+- grading/proposta voto/adaptive path hanno gate più forti del tutor.
+
+Un gate tecnico #710 superato non rende automaticamente conforme ogni use case.
+
+---
+
+# 11. Informativa e diritti
+
+Prima dell'uso reale deve esistere un'informativa comprensibile anche agli studenti/minori che includa almeno:
+
+- identità/contatti del Titolare;
+- contatto RPD/DPO;
+- finalità e base giuridica per categoria;
+- categorie/destinatari;
+- eventuali trasferimenti extra SEE e garanzie;
+- retention o criteri;
+- diritti esercitabili;
+- diritto di reclamo al Garante;
+- obbligatorietà/conseguenze del conferimento quando pertinenti;
+- processi decisionali automatizzati/profilazione e informazioni richieste, quando applicabili;
+- presenza e ruolo dell'AI quando attiva.
+
+Template: `PILOT_PRIVACY_NOTICE_DRAFT.md`.
+
+Workflow diritti:
+
+1. richiesta ricevuta dal Titolare/RPD-DPO;
+2. autenticazione del richiedente secondo procedura della scuola;
+3. lookup bounded dei dati TheBitLab;
+4. export/rettifica/restriction/delete secondo istruzione e base giuridica;
+5. propagazione ai responsabili quando dovuta;
+6. audit della richiesta senza duplicare dati personali;
+7. chiusura entro le scadenze normative applicabili.
+
+---
+
+# 12. Sicurezza minima
+
+Prima dei dati reali:
+
+- HTTPS origin e trusted proxy verificati;
+- origin non esposto oltre il contratto approvato;
+- secret fuori dal repository e fuori dai log;
+- sessioni/bearer revocabili;
+- membership e authorization fail-closed;
+- Docker sandbox per codice studente non fidato;
+- job senza secret e network secondo policy;
+- backup cifrato e restore testato;
+- access log path-only/secret-safe;
+- logging applicativo minimizzato;
+- least privilege per GitHub App/provider;
+- patching e owner operativo definiti;
+- nessun accesso diretto di coding agent/AI di sviluppo ai dati reali.
+
+Issue tecniche collegate: #701–#706, #710.
+
+---
+
+# 13. Incident & personal data breach response
+
+## 13.1 Classi di incidente
+
+- credential/session compromise;
+- accesso cross-student/cross-class;
+- esposizione log/query/secret;
+- perdita/corruzione dati;
+- backup/restore failure;
+- provider breach/outage;
+- invio AI di dati oltre policy;
+- grading/assessment errato con impatto sistematico;
+- configurazione che espone origin o dati.
+
+## 13.2 Procedura minima
+
+1. **detect** — registra timestamp e source senza copiare dati eccedenti;
+2. **contain** — kill switch, disable provider, revoke session, blocca account/route, ferma release quando necessario;
+3. **preserve** — conserva evidence minima e cifrata con accesso ristretto;
+4. **assess** — categorie dati, interessati, volume, rischio e impatto;
+5. **escalate** — gestore tecnico → Titolare/dirigente → RPD-DPO/decision owner;
+6. **notify** — il Titolare valuta gli obblighi GDPR, inclusa notifica all'autorità senza ingiustificato ritardo e, ove possibile, entro 72 ore quando applicabile; comunicazione agli interessati quando richiesta;
+7. **recover** — restore/patch/revoke/redeploy;
+8. **verify** — test del controllo corretto;
+9. **close** — root cause, corrective action, owner, retention dell'evidence e follow-up.
+
+Nessun maintainer decide autonomamente se un evento è o non è un data breach notificabile.
+
+---
+
+# 14. DPIA screening
+
+Prima del GO con dati reali va completato `PILOT_DPIA_SCREENING.md`.
+
+Regola conservativa del progetto:
+
+- il pilot core senza AI richiede **screening DPIA documentato**;
+- AI assistiva su dati reali richiede screening specifico e decisione RPD-DPO/Titolare;
+- assessment support, grading automatico e adaptive decision sono trattati come **presuntivamente candidati a DPIA completa** finché il Titolare/RPD-DPO non documenta diversamente;
+- la decisione `DPIA not required` deve avere rationale, autore/data e scope, non una checkbox senza motivazione.
+
+Trigger forti:
+
+- minori;
+- nuova tecnologia;
+- valutazione/profilazione sistematica;
+- trattamento su larga scala o combinazione di fonti;
+- decisioni automatizzate con effetti significativi;
+- dati sensibili/special categories se introdotti;
+- monitoraggio sistematico;
+- uso AI che modifica materially grading/percorso/accesso.
+
+Il pilot **non deve introdurre** riconoscimento emozioni, biometria o proctoring comportamentale come scorciatoia di controllo.
+
+---
+
+# 15. Data protection by design gates
+
+Ogni nuova feature che tratta dati studente deve dichiarare:
+
+```text
+purpose:
+data_subjects:
+data_categories:
+minimum_fields:
+source:
+recipients:
+retention:
+authority:
+security_boundary:
+AI_use_case: none | ...
+DPIA_ref_or_screening:
+privacy_notice_impact:
+delete/export_path:
+```
+
+PR/issue senza questa informazione non può introdurre un nuovo trattamento reale silenziosamente.
+
+---
+
+# 16. Approval package
+
+Prima del nuovo rehearsal #678 con dati reali devono essere compilati/approvati:
+
+- [ ] identità del Titolare;
+- [ ] RPD/DPO e contatti;
+- [ ] mappa base giuridica/finalità;
+- [ ] data inventory;
+- [ ] retention matrix definitiva;
+- [ ] access matrix definitiva;
+- [ ] provider registry e contratti/DPA pertinenti;
+- [ ] decisione trasferimenti extra SEE dove applicabile;
+- [ ] informativa Art. 13 approvata;
+- [ ] workflow diritti interessati;
+- [ ] backup RPO/RTO e restore evidence;
+- [ ] incident response ed escalation;
+- [ ] DPIA screening e DPIA completa quando richiesta;
+- [ ] AI use case gates per qualunque AI attivata;
+- [ ] owner e firme/approvazioni;
+- [ ] data di revisione della governance.
+
+Il fatto che il software passi i test non sostituisce queste approvazioni.
+
+---
+
+# 17. Stato per #699
+
+Con questo documento il pacchetto governance passa da `missing` a **DRAFT STRUCTURED**.
+
+Non è ancora `APPROVED` perché restano da compilare e approvare almeno:
+
+- Titolare/dirigente/RPD-DPO;
+- basi giuridiche specifiche;
+- retention definitiva;
+- provider registry/contratti;
+- informativa;
+- DPIA screening;
+- firme e data di revisione.
+
+Fino a quel momento #699 resta aperta e i dati reali restano bloccati dal gate governance.

--- a/doc/governance/PILOT_GOVERNANCE_2026_2027.md
+++ b/doc/governance/PILOT_GOVERNANCE_2026_2027.md
@@ -4,151 +4,185 @@
 
 **DRAFT PER APPROVAZIONE DELLA SCUOLA/RPD-DPO — non costituisce parere legale né attestazione di conformità.**
 
-Questo documento è il pacchetto operativo di governance richiesto da #699 e dal gate `Governance` del pilot rehearsal #678.
+Questo documento è la baseline canonica di governance richiesta da #699 e dal gate `Governance` del pilot rehearsal #678.
 
 Il documento:
 
-- traduce in regole operative i principi privacy/security del pilot;
-- registra le decisioni già prese per il pilot 2026/27;
-- separa le decisioni di prodotto dalle decisioni che spettano al titolare del trattamento/RPD-DPO;
-- fornisce una baseline verificabile per deployment, backup/restore, logging, identity e AI;
+- traduce i principi privacy/security in regole operative;
+- separa le decisioni di prodotto dalle decisioni del Titolare/RPD-DPO;
+- definisce i gate per uso di dati reali;
+- coordina GDPR, sicurezza, provider e AI Act per il pilot 2026/2027;
 - non autorizza da solo l'uso di dati reali.
 
-Prima dell'uso con studenti reali devono essere compilate le sezioni `APPROVAL REQUIRED`, completata la DPIA screening e ottenute le approvazioni previste dall'istituto.
+Documenti operativi collegati:
+
+- `PILOT_SCHOOL_COMPLIANCE_CHECKLIST_2026_2027.md`;
+- `PILOT_APPROVAL_BRIEF_2026_2027.md`;
+- `PILOT_APPROVAL_RECORD_2026_2027.md`;
+- `PILOT_PRIVACY_NOTICE_DRAFT.md`;
+- `PILOT_DPIA_SCREENING.md`;
+- `PILOT_PROVIDER_REGISTER.md`.
+
+Prima dell'uso con studenti reali devono essere completati i campi istituzionali, il Registro art. 30, la qualificazione dei provider/gestore tecnico, la DPIA screening e gli altri gate applicabili.
 
 ---
 
-# 1. Decisioni già congelate
+# 1. Perimetro e due gate distinti
 
-## 1.1 Account Google ammessi
+## 1.1 GO core
 
-Per il pilot sono ammessi:
+Il pilot core può includere:
+
+- autenticazione e identity binding;
+- classi e membership;
+- activity e assignment;
+- elaborati, tentativi e report;
+- grading deterministico/test runner;
+- feedback docente;
+- help non-AI;
+- dashboard docente;
+- backup/restore;
+- audit, sicurezza e incident response.
+
+Il `GO core` può essere concesso mantenendo **tutta l'AI esterna disabilitata sui dati reali**.
+
+## 1.2 GO AI per singolo use case
+
+L'AI è autorizzata separatamente per use case:
+
+- `TUTOR_ASSISTANCE`;
+- `FEEDBACK`;
+- `CORRECTION`;
+- `GRADE_PROPOSAL`;
+- `AUTOMATED_GRADING`;
+- `ADAPTIVE_PATH`.
+
+Il `GO core` non autorizza implicitamente alcun provider o use case AI.
+
+---
+
+# 2. Decisioni progettuali già congelate
+
+## 2.1 Account Google
+
+TheBitLab supporta tecnicamente:
 
 - account Google Workspace scolastici;
 - account Gmail personali.
 
-Quando disponibile e funzionante, l'account scolastico può essere preferito, ma non è requisito tecnico esclusivo.
+Quando disponibile, l'account scolastico può essere preferito. L'Istituto decide se Gmail personale è ammesso nel proprio pilot.
 
-Il dominio/provider dell'account **non attribuisce autorizzazioni interne**. Classe, membership, assignment, target e accesso sono determinati esclusivamente da binding e policy TheBitLab (#702/#706).
+Il provider/dominio dell'account **non attribuisce autorizzazioni interne**. Classe, membership, assignment e target derivano da binding e policy TheBitLab (#702/#706).
 
-Il gap `access_not_configured` osservato sul tenant Workspace resta un problema di onboarding/supporto del tenant, non una prova di errore del callback applicativo e non blocca l'intero pilot quando Gmail personale è ammesso dalla governance.
+## 2.2 Continuità operativa
 
-## 1.2 Continuità operativa
-
-Baseline approvata:
+Baseline tecnica:
 
 - backup almeno giornaliero;
 - RPO target: **24 ore**;
 - RTO target: **8 ore lavorative**;
-- restore sempre verificato in ambiente isolato;
+- restore verificato in ambiente isolato;
 - segreti esclusi dal backup applicativo non cifrato;
-- implementazione tecnica e rehearsal del restore: #705.
+- implementazione tecnica e rehearsal: #705.
 
-## 1.3 Roadmap AI
+## 2.3 Roadmap AI
 
-Le capacità AI previste non vengono eliminate:
+Restano previste:
 
 - tutor/assistente;
 - feedback e debugging;
-- correzione automatica;
+- correzione;
 - proposta di voto/punteggio;
 - grading automatico;
-- analisi progressi e remediation;
+- analisi progressi/remediation;
 - percorsi adattivi.
 
-L'implementazione può iniziare con dati sintetici/fixture. L'attivazione su dati reali dipende dal relativo gate di governance/privacy/compliance.
-
-Boundary comune: #710. Roadmap: #711. Capability separate: #712–#715.
+Sviluppo e benchmark possono usare dati sintetici. L'attivazione su dati reali dipende dal relativo gate. Boundary comune: #710; roadmap #711; capability #712–#715.
 
 ---
 
-# 2. Principi non negoziabili
+# 3. Principi non negoziabili
 
-Il pilot applica come requisiti di engineering e governance:
+Il pilot applica:
 
-1. **purpose limitation** — ogni dato ha una finalità dichiarata;
-2. **data minimisation** — si raccoglie e si espone solo ciò che serve;
-3. **storage limitation** — ogni categoria ha retention o criterio esplicito;
-4. **integrity & confidentiality** — accesso, cifratura, backup e audit sono proporzionati al rischio;
-5. **accountability** — decisioni, owner, policy e revisioni devono essere ricostruibili;
-6. **least privilege** — l'accesso deriva dal ruolo e dal perimetro necessario;
-7. **no silent authority** — autenticazione, provider identity o AI output non diventano automaticamente autorizzazione o decisione didattica;
-8. **synthetic-first** — sviluppo, benchmark e rehearsal usano dati sintetici/demo finché il trattamento reale non è approvato;
-9. **fail closed** — ambiguity su identity, membership, root, policy o data scope non diventa accesso;
-10. **student vulnerability** — il design assume che gli interessati siano anche minori e richiede protezioni rafforzate e comunicazioni comprensibili.
-
-Riferimenti normativi/istituzionali da riesaminare al momento dell'approvazione:
-
-- GDPR, Regolamento (UE) 2016/679, in particolare artt. 5, 6, 13, 28, 32, 33, 34, 35 e 22;
-- Garante per la protezione dei dati personali, area Scuola e vademecum aggiornati;
-- Regolamento (UE) 2024/1689 (AI Act) e calendario/applicazione vigente;
-- regole nazionali/scolastiche applicabili al trattamento e alla valutazione.
+1. **purpose limitation** — finalità esplicite e separate;
+2. **data minimisation** — solo dati necessari;
+3. **storage limitation** — retention/criterio per categoria;
+4. **integrity & confidentiality** — protezioni proporzionate al rischio;
+5. **privacy by design/default** — default più restrittivo;
+6. **accountability** — decisioni, owner, versioni ed evidence ricostruibili;
+7. **least privilege** — accesso solo al perimetro necessario;
+8. **no silent authority** — identity provider e AI output non diventano authorization/decisione didattica;
+9. **synthetic-first** — dati demo/sintetici finché il trattamento reale non è approvato;
+10. **fail closed** — ambiguità su identity, membership, root, provider o policy produce diniego;
+11. **student vulnerability** — minori/interessati vulnerabili richiedono protezioni e linguaggio adeguati;
+12. **human accountability** — decisioni istituzionali e valutative restano attribuite a soggetti identificati.
 
 ---
 
-# 3. Ruoli privacy e responsabilità
+# 4. Ruoli privacy
 
-## 3.1 Titolare
+## 4.1 Titolare
 
-Baseline organizzativa da sottoporre alla scuola:
+Baseline da sottoporre all'Istituto:
 
-> Per il pilot didattico svolto da un'istituzione scolastica, l'istituto determina finalità e mezzi del trattamento relativo alla propria utenza e viene trattato come **Titolare del trattamento**, salvo diversa qualificazione documentata per uno specifico servizio.
+> Per il pilot didattico svolto da una scuola, l'Istituto determina finalità e mezzi del trattamento relativo alla propria utenza e viene trattato come Titolare nel proprio perimetro, salvo diversa qualificazione documentata per specifici trattamenti.
 
 `APPROVAL REQUIRED`
 
-- Istituto/Titolare: `____________________________`
-- Dirigente / legale rappresentante: `____________________________`
-- Contatti privacy: `____________________________`
-- RPD/DPO: `____________________________`
-- Contatto RPD/DPO: `____________________________`
+```text
+Istituto/Titolare:
+Dirigente/rappresentante:
+Contatto privacy:
+RPD/DPO:
+Contatto RPD/DPO:
+```
 
-## 3.2 Responsabili e sub-responsabili
+## 4.2 Gestore tecnico e Responsabili
 
-Per ciascun servizio esterno che tratta dati per conto del Titolare deve essere registrato almeno:
+Il modello operativo deve essere esplicito.
 
-- provider/organizzazione;
-- servizio e finalità;
-- ruolo privacy;
-- contratto/DPA art. 28 quando applicabile;
-- sub-responsabili rilevanti;
-- localizzazione/trattamento e trasferimenti extra SEE quando applicabili;
-- retention/data-use/training policy;
-- misure di sicurezza;
-- data di approvazione e owner.
+### Self-hosted senza accesso esterno ai dati
 
-Il ruolo del gestore tecnico/TheBitLab rispetto alla scuola deve essere **esplicitamente qualificato** prima dell'uso reale. Nessun maintainer/coding agent ottiene accesso ai dati reali solo perché sviluppa il software.
+Se l'Istituto gestisce l'istanza e TheBitPoets/maintainer non riceve né può accedere ai dati personali del pilot, il semplice sviluppo/pubblicazione del software non attribuisce automaticamente al progetto il ruolo di Responsabile per i dati della scuola.
 
-## 3.3 Ruoli operativi TheBitLab
+### Servizio gestito/assistenza con accesso
+
+Se un soggetto esterno ospita, amministra, effettua backup/database o assistenza con possibilità di accesso ai dati per conto della scuola:
+
+- ruolo privacy qualificato;
+- atto/contratto art. 28 GDPR quando applicabile;
+- istruzioni documentate;
+- obblighi di riservatezza;
+- misure tecniche/organizzative;
+- sub-responsabili e autorizzazioni;
+- assistenza su diritti, incidenti, DPIA;
+- restituzione/cancellazione a fine rapporto.
+
+`UNKNOWN` sul ruolo del gestore tecnico è **NO-GO dati reali**.
+
+## 4.3 Ruoli operativi
 
 | Ruolo | Responsabilità | Authority sui dati |
 |---|---|---|
-| Studente | attività, tentativi, aiuti, selezione definitivo | solo propri dati/assignment autorizzati |
-| Docente | classe, assignment, review, feedback, grading | solo classi/perimetro assegnato |
-| Admin TheBitLab | identity, membership, configurazione applicativa | amministrazione necessaria; no browsing didattico indiscriminato |
-| Gestore tecnico | deployment, backup, security, incident response | accesso eccezionale e tracciato quando necessario |
-| Decision owner | GO/NO-GO e rischio residuo non bloccante | nessun accesso implicito ai contenuti personali |
-| RPD/DPO | consulenza/sorveglianza privacy | secondo mandato istituzionale |
-| AI provider | solo contesto minimizzato autorizzato | nessun accesso diretto a root/database |
-| Coding agent/LLM di sviluppo | sviluppo su codice e dati sintetici | **nessun accesso ai dati reali di produzione** |
+| Studente | activity, tentativi, help | solo propri dati/assignment autorizzati |
+| Docente | assignment, report, feedback, grading | solo classi assegnate |
+| Admin applicativo | identity/membership/config | amministrazione bounded |
+| Gestore tecnico | deployment, backup, security | accesso eccezionale/minimo e tracciato |
+| Decision owner | GO/NO-GO | documentazione/governance |
+| RPD/DPO | consulenza/sorveglianza | secondo mandato |
+| AI provider | contesto minimizzato autorizzato | nessun accesso diretto a root/database |
+| Coding agent/LLM dev | sviluppo | **nessun dato reale produzione** |
 
 ---
 
-# 4. Base giuridica — decisione del Titolare, non del software
+# 5. Basi giuridiche e Registro art. 30
 
 TheBitLab non codifica una base giuridica universale.
 
-Per i trattamenti necessari all'attività didattica di una scuola pubblica, la scuola/RPD-DPO deve mappare e documentare la base applicabile, tipicamente nel quadro di obblighi legali e/o compiti di interesse pubblico previsti dalla normativa nazionale ed europea.
-
-Regole di prodotto:
-
-- il **consenso non viene usato come catch-all** per rendere lecito il funzionamento core della piattaforma;
-- feature opzionali con finalità ulteriori richiedono una valutazione separata;
-- ogni use case AI con dati reali possiede una voce distinta nel registro dei trattamenti/use case;
-- se una finalità cambia, il dato non viene silenziosamente riutilizzato.
+Per i trattamenti core di una scuola pubblica, Istituto/RPD-DPO devono mappare la base applicabile nel quadro degli obblighi legali e/o compiti di interesse pubblico o altra base pertinente. Il consenso non viene usato come `catch-all` per rendere lecito il servizio core.
 
 `APPROVAL REQUIRED`
-
-La scuola/RPD-DPO deve completare una matrice:
 
 | Trattamento | Finalità | Base giuridica | Necessità/proporzionalità | Note |
 |---|---|---|---|---|
@@ -157,433 +191,476 @@ La scuola/RPD-DPO deve completare una matrice:
 | Assignment/activity | | | | |
 | Tentativi/report | | | | |
 | Feedback/grading | | | | |
-| Help/tutor | | | | |
-| Security/audit logs | | | | |
+| Help non-AI | | | | |
+| Security/audit | | | | |
 | Backup/restore | | | | |
-| AI assistiva | | | | |
-| AI assessment support | | | | |
-| AI grading/adaptive | | | | |
+| AI use case, se attivo | | | | |
+
+Prima del `GO core` il trattamento TheBitLab deve essere inserito/aggiornato nel **Registro delle attività di trattamento ex art. 30 GDPR** dell'Istituto.
+
+Il record deve essere coerente con almeno:
+
+- finalità;
+- categorie interessati/dati;
+- destinatari/processori;
+- trasferimenti quando applicabili;
+- retention/criteri;
+- misure di sicurezza pertinenti.
+
+`PILOT_PROVIDER_REGISTER.md` è un annex tecnico e **non sostituisce** il Registro art. 30.
 
 ---
 
-# 5. Inventario dati e finalità
+# 6. Inventario dati e finalità
 
-## 5.1 Identity e autenticazione
+## 6.1 Identity/auth
 
-Dati possibili:
+Possibili dati:
 
 - `user_id` interno;
-- provider e subject federato necessario al login;
-- email/display name quando necessari per onboarding e riconoscibilità operativa;
-- ruolo, stato account e membership;
+- provider subject necessario al login;
+- email/display name quando necessari per onboarding;
+- ruolo, stato account, membership;
 - session metadata minimizzati;
-- eventi di revoca/security.
+- revoca/security events.
 
-Finalità:
+Finalità: autenticazione, binding, access control, security/revoca.
 
-- autenticazione;
-- associazione dell'account al soggetto didattico;
-- access control;
-- audit security e revoca.
-
-Vincoli:
-
-- email/dominio non sono authorization authority;
-- cookie, bearer, pairing proof, OAuth code/state e secret non vanno in issue, screenshot o evidence condivise;
-- identifier interno stabile preferito nei collegamenti applicativi.
-
-## 5.2 Dati didattici strutturali
+## 6.2 Dati didattici strutturali
 
 - classe/roster/binding;
-- course design/UDA;
-- activity e assignment;
+- course/activity/assignment;
 - calendario;
-- fingerprint/versione activity/test/rubrica.
+- fingerprint/versioni test/rubrica.
 
-Finalità:
+Finalità: erogazione didattica e riproducibilità.
 
-- erogazione della didattica;
-- attribuzione corretta di attività e verifiche;
-- riproducibilità della valutazione.
+## 6.3 Elaborati/tentativi/report
 
-## 5.3 Elaborati, tentativi e report
-
-- codice/elaborato consegnato;
-- `attempt_id`;
-- timestamp necessari;
+- codice/elaborato;
+- attempt ID e timestamp necessari;
 - backend/runner;
-- esito test e report strutturato;
-- selezione del tentativo definitivo.
+- test/report;
+- selezione tentativo definitivo.
 
-Finalità:
+Finalità: laboratorio, feedback, grading/review.
 
-- esecuzione del laboratorio;
-- feedback;
-- grading/review;
-- ricostruzione del tentativo valutato.
+## 6.4 Help
 
-## 5.4 Aiuti e interazioni tutor
-
-- domanda dello studente;
+- domanda;
 - frammento di codice/context necessario;
 - risposta/feedback;
-- contatori/policy di aiuto;
-- metadati minimi per audit.
+- metadati minimi.
 
-Finalità:
+Non raccogliere conversazioni esterne, cronologie eccedenti o dati personali non necessari.
 
-- supporto didattico;
-- verifica delle policy di aiuto;
-- eventuale review docente.
-
-Non raccogliere automaticamente dati personali non necessari, conversazioni esterne o cronologie eccedenti.
-
-## 5.5 Grading e feedback
+## 6.5 Grading/feedback
 
 - evidence deterministica;
-- rubrica/revisione;
+- rubrica;
 - feedback docente;
 - eventuale proposta AI;
-- eventuale voto/punteggio e decisione finale;
-- audit di override/review.
+- voto/punteggio e decisione finale nel perimetro approvato;
+- audit override/review.
 
-Finalità:
+AI output, evidence deterministica e decisione umana restano distinguibili.
 
-- valutazione didattica nel perimetro autorizzato;
-- spiegabilità e contestabilità della decisione.
+## 6.6 Log tecnici/security
 
-L'output AI deve restare distinguibile da evidence deterministica e decisione umana.
-
-## 5.6 Log tecnici e security
+Ammessi per default:
 
 - timestamp;
 - endpoint/path canonico;
 - status/timing;
 - correlation identifier non sensibile;
-- security event essenziale;
-- client attribution solo quando necessaria e correttamente derivata.
+- security event essenziale.
 
-Da escludere per default:
+Esclusi per default:
 
 - query OAuth sensibili;
 - cookie;
 - bearer/proof;
 - secret;
-- body contenenti elaborati salvo logging esplicitamente approvato;
+- body con elaborati salvo trattamento esplicito;
 - dump database.
 
-## 5.7 Backup
+## 6.7 Backup
 
-Contiene soltanto dati applicativi necessari al restore coerente.
-
-Non contiene nel backup applicativo non cifrato:
-
-- OAuth client secret;
-- private key GitHub App;
-- bearer/token runtime;
-- credenziali infrastrutturali.
+Contiene solo lo stato applicativo necessario al restore coerente. Secret infrastrutturali e credenziali rimangono in secret store separati.
 
 ---
 
-# 6. Retention baseline proposta
+# 7. Categorie particolari e inclusione
 
-**Questi periodi sono default di engineering da approvare/modificare con la scuola/RPD-DPO. Non sostituiscono obblighi di conservazione scolastici o normativi.**
-
-TheBitLab distingue sempre la copia operativa della piattaforma dall'eventuale registro/archivio scolastico ufficiale.
-
-| Categoria | Default pilot proposto | Fine periodo |
-|---|---:|---|
-| Account/binding/membership | anno scolastico + 90 giorni | delete/deactivate o retention motivata |
-| Assignment/activity mapping per studente | anno scolastico + 90 giorni | delete/de-identify se non più necessario |
-| Elaborati/tentativi/report operativi | anno scolastico + 90 giorni | export necessario + delete/de-identify |
-| Feedback/grading operativi | anno scolastico + 90 giorni | il record ufficiale segue i sistemi/policy della scuola |
-| Help/tutor interaction content | 30 giorni | delete; mantenere solo metriche realmente anonime se utili |
-| AI request/response payload nel gateway | **0 giorni per default** | non persistere payload; audit solo metadata bounded |
-| AI audit metadata | 30 giorni | delete salvo incident/legal hold |
-| Access/security log ordinario | 30 giorni | delete/rotate salvo incident/legal hold |
-| Evidence di incident | secondo procedura incidente | closure + retention approvata caso per caso |
-| Backup applicativi | rolling 30 giorni | rotazione verificata; legal/incident hold separato |
-| Evidence rehearsal demo/sintetica | secondo progetto/release policy | nessun dato reale nel rehearsal finché non autorizzato |
+Il core non richiede per design dati sanitari, diagnosi, disabilità, DSA, informazioni psicologiche o altre categorie particolari ex art. 9 GDPR.
 
 Regole:
 
-- nessuna retention `forever` implicita;
-- estensioni richiedono finalità/owner/scadenza;
-- un incident/legal hold congela solo gli artifact necessari e viene tracciato;
-- se dati valutativi devono essere conservati più a lungo per obblighi scolastici, la retention va definita dall'istituto e preferibilmente affidata al sistema ufficiale invece di trasformare TheBitLab in archivio indefinito.
+- nessun dato particolare automatico in profili/help/prompt AI/log;
+- quando possibile gli adattamenti didattici sono rappresentati tramite configurazioni funzionali minimizzate senza esporre diagnosi;
+- se una futura feature richiede dati particolari, si apre trattamento/use case separato con base normativa, accessi, retention, informativa e DPIA/risk review;
+- i provider AI non ricevono dati particolari incidentalmente presenti nel contesto.
 
 ---
 
-# 7. Access matrix
+# 8. Retention baseline
+
+**Default tecnici da approvare/modificare con Istituto/RPD-DPO.**
+
+| Categoria | Default pilot | Fine periodo |
+|---|---:|---|
+| Account/binding/membership | anno scolastico + 90 giorni | delete/deactivate o retention motivata |
+| Assignment mapping studente | anno scolastico + 90 giorni | delete/de-identify |
+| Elaborati/tentativi/report operativi | anno scolastico + 90 giorni | export necessario + delete/de-identify |
+| Feedback/grading operativi | anno scolastico + 90 giorni | record ufficiale nei sistemi della scuola |
+| Help/tutor content | 30 giorni | delete |
+| AI payload gateway | **0 giorni default** | non persistere payload |
+| AI audit metadata ordinario | 30 giorni | salvo obblighi più lunghi |
+| Access/security log ordinario | 30 giorni | salvo incident/legal hold |
+| Evidence incidente | secondo procedura | retention motivata |
+| Backup | rolling 30 giorni | rotazione verificata |
+
+## 8.1 Eccezione high-risk AI
+
+Se viene attivato un sistema AI ad alto rischio soggetto agli obblighi del deployer, i log generati automaticamente sotto controllo del deployer seguono il periodo previsto dalla disciplina applicabile. Quando si applica l'art. 26 AI Act, la baseline minima è **almeno sei mesi**, salvo diversa disciplina applicabile.
+
+Il default `30 giorni` non può prevalere su un obbligo più lungo.
+
+Nessuna retention `forever` implicita. Estensioni richiedono finalità, owner e scadenza/review.
+
+---
+
+# 9. Access matrix
 
 Legenda: `R` read, `W` write, `A` admin, `N` no access, `E` eccezionale/incident-only.
 
 | Dato | Studente | Docente | Admin app | Gestore tecnico | AI provider | Coding agent |
 |---|---|---|---|---|---|---|
-| Proprio profilo minimo | R | R se nella classe | A | E | N | N |
+| Profilo minimo | R proprio | R se necessario | A | E | N | N |
 | Membership/classi | propria R | R classi assegnate | A | E | N | N |
-| Assignment | propri R | RW classi assegnate | A bounded | E | context minimo se use case approvato | N |
-| Proprio elaborato | RW secondo workflow | R classi assegnate | N default | E | frammento minimo se approvato | N |
-| Elaborati altri studenti | N | R solo propria classe | N default | E | N | N |
+| Assignment | propri R | RW classi assegnate | A bounded | E | context minimo approvato | N |
+| Elaborato | RW proprio | R classe | N default | E | frammento minimo approvato | N |
+| Elaborati altri | N | R propria classe | N default | E | N | N |
 | Hidden tests/teacher solution | N | R | A bounded | E | **N default** | sintetici/dev only |
-| Grading/feedback | proprio R | RW classi assegnate | N default | E | proposal context solo se approvato | N |
+| Grading/feedback | proprio R | RW classe | N default | E | proposal context approvato | N |
 | Security logs | N | N default | bounded | R/E | N | N |
 | Backup | N | N | N | E/A | N | N |
-| Secret/credentials | N | N | N | E/A secondo ruolo | N | N |
+| Secret | N | N | N | E/A secondo ruolo | N | N |
 
-Qualunque eccezione deve essere motivata, temporanea e auditabile.
-
----
-
-# 8. Account personali Gmail e Workspace
-
-L'informativa deve spiegare che:
-
-- il pilot consente entrambi i tipi di account;
-- l'email usata per il login può essere personale o scolastica;
-- il provider Google prova l'identità federata ma **non determina** classe o autorizzazione TheBitLab;
-- lo studente viene collegato a un `user_id` interno e a membership autorizzate dalla scuola;
-- eventuali problemi del tenant Workspace sono gestiti come supporto/onboarding;
-- l'uso di un account personale non autorizza il riuso dell'email per finalità estranee al pilot.
+Eccezioni devono essere motivate, temporanee e auditabili.
 
 ---
 
-# 9. Provider esterni e registry
+# 10. Provider e trasferimenti
 
-Prima dell'attivazione reale ogni provider deve avere una scheda:
+Per ciascun provider effettivo registrare:
 
-```text
-provider:
-service:
-purpose:
-data_categories:
-role: processor | independent_controller | other
-DPA_or_contract_ref:
-subprocessors_ref:
-processing_locations:
-third_country_transfer_basis:
-provider_retention:
-training_data_use:
-security_measures_ref:
-kill_switch:
-approved_by:
-approved_at:
-review_due:
-```
+- servizio/finalità;
+- categorie/campi minimi;
+- ruolo privacy;
+- DPA/atto art. 28 quando applicabile;
+- sub-responsabili;
+- localizzazione;
+- trasferimenti e garanzie;
+- retention;
+- data use/training/product improvement;
+- sicurezza;
+- incident contact;
+- owner/review date;
+- kill switch.
 
-Provider iniziali potenziali:
+Provider minimi da valutare:
 
-- Google OIDC;
-- GitHub/GitLab per fonti didattiche;
-- infrastruttura hosting/backup;
-- provider AI solo dopo #710 e gate use-case.
+- gestore tecnico esterno, se presente;
+- Google OIDC/Workspace;
+- GitHub/GitLab quando usati;
+- hosting/VPS;
+- backup storage;
+- provider/sistemi AI per gli use case autorizzati.
 
-Il registry non contiene secret.
+`UNKNOWN` materiale = provider disabilitato sui dati reali.
 
 ---
 
-# 10. AI privacy/governance boundary
+# 11. Sicurezza e incident response
 
-Tutte le feature AI seguono:
+Baseline:
+
+- HTTPS;
+- authorization server-side class-scoped;
+- isolamento cross-student;
+- secret store esterno;
+- logging secret-safe;
+- sandbox per codice non fidato;
+- least privilege;
+- backup cifrato e restore verificato;
+- revoca sessioni/credenziali;
+- audit operazioni sensibili;
+- feature flag/kill switch.
+
+## 11.1 Data breach
+
+La procedura del pilot deve collegarsi a quella istituzionale.
+
+- eventuale Responsabile informa il Titolare **senza ingiustificato ritardo** dopo aver rilevato una violazione;
+- il Titolare valuta la notifica all'autorità ai sensi dell'art. 33 GDPR e il relativo termine quando applicabile;
+- valuta la comunicazione agli interessati ex art. 34 quando ricorrono i presupposti;
+- documenta violazione, effetti, decisioni e misure;
+- TheBitLab conserva soltanto evidence necessarie, sanitizzate e con accesso ristretto.
+
+Il software non decide autonomamente la notificabilità di un breach.
+
+---
+
+# 12. Informativa e diritti
+
+Prima del `GO core` la scuola completa e approva `PILOT_PRIVACY_NOTICE_DRAFT.md` con:
+
+- Titolare/RPD-DPO;
+- finalità/basi;
+- categorie dati;
+- destinatari/processori;
+- trasferimenti;
+- retention;
+- conferimento/necessità/opzionalità;
+- diritti e canali di esercizio;
+- reclamo al Garante;
+- informazioni su processi automatizzati quando applicabili.
+
+Ogni use case AI reale richiede informativa coerente con provider, intended purpose, retention e ruolo della human review.
+
+---
+
+# 13. AI Privacy/Provider Boundary
+
+Architettura obbligatoria:
 
 ```text
 Feature didattica
-   ↓
-UseCasePolicy
-   ↓
-AI Privacy/Provider Boundary (#710)
-   ↓
-Provider Adapter
+    -> AI Policy / Privacy Boundary (#710)
+    -> Provider Adapter
 ```
 
-Regole:
+Nessuna feature AI accede direttamente a root/database/secret.
 
-- synthetic-only fino al gate reale;
-- niente accesso diretto a root/database;
-- niente cookie/bearer/secret;
-- niente cross-student context;
-- hidden test/teacher solution esclusi per default;
-- contesto minimo necessario;
-- provider/model/policy/use-case versionati;
-- payload non persistito nel gateway per default;
-- audit metadata bounded;
-- feature flag e kill switch;
-- transparency verso studente/docente;
-- grading/proposta voto/adaptive path hanno gate più forti del tutor.
+Default:
 
-Un gate tecnico #710 superato non rende automaticamente conforme ogni use case.
-
----
-
-# 11. Informativa e diritti
-
-Prima dell'uso reale deve esistere un'informativa comprensibile anche agli studenti/minori che includa almeno:
-
-- identità/contatti del Titolare;
-- contatto RPD/DPO;
-- finalità e base giuridica per categoria;
-- categorie/destinatari;
-- eventuali trasferimenti extra SEE e garanzie;
-- retention o criteri;
-- diritti esercitabili;
-- diritto di reclamo al Garante;
-- obbligatorietà/conseguenze del conferimento quando pertinenti;
-- processi decisionali automatizzati/profilazione e informazioni richieste, quando applicabili;
-- presenza e ruolo dell'AI quando attiva.
-
-Template: `PILOT_PRIVACY_NOTICE_DRAFT.md`.
-
-Workflow diritti:
-
-1. richiesta ricevuta dal Titolare/RPD-DPO;
-2. autenticazione del richiedente secondo procedura della scuola;
-3. lookup bounded dei dati TheBitLab;
-4. export/rettifica/restriction/delete secondo istruzione e base giuridica;
-5. propagazione ai responsabili quando dovuta;
-6. audit della richiesta senza duplicare dati personali;
-7. chiusura entro le scadenze normative applicabili.
+- contesto minimizzato per use case;
+- field allow/deny;
+- no cross-student context;
+- no hidden test/teacher solution salvo decisione specifica compatibile;
+- categorie particolari vietate per default;
+- payload gateway non persistito per default;
+- provider/model/prompt/policy versionati;
+- audit bounded;
+- kill switch;
+- trasparenza;
+- synthetic-first.
 
 ---
 
-# 12. Sicurezza minima
+# 14. AI Act — baseline 2026/2027
 
-Prima dei dati reali:
+Dal 2 agosto 2026 il Regolamento (UE) 2024/1689 è applicabile in via generale secondo il calendario dell'art. 113, fatte salve le disposizioni con date specifiche differenti.
 
-- HTTPS origin e trusted proxy verificati;
-- origin non esposto oltre il contratto approvato;
-- secret fuori dal repository e fuori dai log;
-- sessioni/bearer revocabili;
-- membership e authorization fail-closed;
-- Docker sandbox per codice studente non fidato;
-- job senza secret e network secondo policy;
-- backup cifrato e restore testato;
-- access log path-only/secret-safe;
-- logging applicativo minimizzato;
-- least privilege per GitHub App/provider;
-- patching e owner operativo definiti;
-- nessun accesso diretto di coding agent/AI di sviluppo ai dati reali.
+## 14.1 AI literacy — art. 4
 
-Issue tecniche collegate: #701–#706, #710.
+Prima dell'uso AI:
 
----
+- docenti/operatori formati in modo proporzionato al use case;
+- chi svolge oversight comprende output, limiti, rischi e procedure;
+- admin/gestori conoscono configurazione, logging, kill switch e incident workflow;
+- evidence della formazione disponibile.
 
-# 13. Incident & personal data breach response
+## 14.2 Pratiche vietate — art. 5
 
-## 13.1 Classi di incidente
+TheBitLab vieta per design:
 
-- credential/session compromise;
-- accesso cross-student/cross-class;
-- esposizione log/query/secret;
-- perdita/corruzione dati;
-- backup/restore failure;
-- provider breach/outage;
-- invio AI di dati oltre policy;
-- grading/assessment errato con impatto sistematico;
-- configurazione che espone origin o dati.
-
-## 13.2 Procedura minima
-
-1. **detect** — registra timestamp e source senza copiare dati eccedenti;
-2. **contain** — kill switch, disable provider, revoke session, blocca account/route, ferma release quando necessario;
-3. **preserve** — conserva evidence minima e cifrata con accesso ristretto;
-4. **assess** — categorie dati, interessati, volume, rischio e impatto;
-5. **escalate** — gestore tecnico → Titolare/dirigente → RPD-DPO/decision owner;
-6. **notify** — il Titolare valuta gli obblighi GDPR, inclusa notifica all'autorità senza ingiustificato ritardo e, ove possibile, entro 72 ore quando applicabile; comunicazione agli interessati quando richiesta;
-7. **recover** — restore/patch/revoke/redeploy;
-8. **verify** — test del controllo corretto;
-9. **close** — root cause, corrective action, owner, retention dell'evidence e follow-up.
-
-Nessun maintainer decide autonomamente se un evento è o non è un data breach notificabile.
+- inferenza/riconoscimento delle emozioni in ambito scolastico, salvo le strette eccezioni mediche/sicurezza previste dal Regolamento;
+- social scoring;
+- manipolazione/sfruttamento della vulnerabilità nei casi vietati;
+- profilazione comportamentale generalizzata non necessaria alla finalità didattica.
 
 ---
 
-# 14. DPIA screening
+# 15. Classificazione AI per l'istruzione
 
-Prima del GO con dati reali va completato `PILOT_DPIA_SCREENING.md`.
+La classificazione si basa su sistema + intended purpose reale.
 
-Regola conservativa del progetto:
+| Use case | Default di governance |
+|---|---|
+| Tutor/debugging non valutativo | `NON_HIGH_RISK_CANDIDATE` solo se non valuta/profila/influenza materialmente decisioni |
+| Feedback formativo non valutativo | `NON_HIGH_RISK_CANDIDATE`, da rivalutare se entra nell'assessment |
+| Correzione/proposta voto | `HIGH_RISK_CANDIDATE` |
+| Automated grading | `HIGH_RISK_CANDIDATE / presumptive HIGH_RISK` |
+| Adaptive path con impatto materiale | `HIGH_RISK_CANDIDATE / presumptive HIGH_RISK` |
+| Accesso/ammissione/livello | `HIGH_RISK_CANDIDATE / presumptive HIGH_RISK` |
 
-- il pilot core senza AI richiede **screening DPIA documentato**;
-- AI assistiva su dati reali richiede screening specifico e decisione RPD-DPO/Titolare;
-- assessment support, grading automatico e adaptive decision sono trattati come **presuntivamente candidati a DPIA completa** finché il Titolare/RPD-DPO non documenta diversamente;
-- la decisione `DPIA not required` deve avere rationale, autore/data e scope, non una checkbox senza motivazione.
+I sistemi che valutano risultati dell'apprendimento o influenzano materialmente livello/percorso possono rientrare nell'Allegato III, punto 3.
 
-Trigger forti:
+`AI proposes -> docente decides` **non è automaticamente un'esclusione dall'high-risk**.
 
-- minori;
-- nuova tecnologia;
-- valutazione/profilazione sistematica;
-- trattamento su larga scala o combinazione di fonti;
-- decisioni automatizzate con effetti significativi;
-- dati sensibili/special categories se introdotti;
-- monitoraggio sistematico;
-- uso AI che modifica materially grading/percorso/accesso.
+Se si invoca l'art. 6(3):
 
-Il pilot **non deve introdurre** riconoscimento emozioni, biometria o proctoring comportamentale come scorciatoia di controllo.
+- presupposti documentati;
+- impatto reale sulla decisione valutato;
+- provider evidence versionata;
+- assenza di profilazione incompatibile con l'eccezione;
+- decision owner/date.
+
+`UNKNOWN` = capability disabilitata sui dati reali.
 
 ---
 
-# 15. Data protection by design gates
+# 16. Obblighi del deployer per high-risk AI — art. 26
 
-Ogni nuova feature che tratta dati studente deve dichiarare:
+Se un use case è `HIGH_RISK`, prima dell'uso reale l'Istituto verifica quando applicabile:
+
+- uso secondo istruzioni provider;
+- human oversight con competenza, formazione, autorità e supporto;
+- qualità/pertinenza degli input sotto il proprio controllo;
+- monitoring;
+- sospensione in caso di rischio;
+- incident/risk reporting;
+- conservazione log automatici sotto proprio controllo per il periodo minimo applicabile;
+- documentazione provider utile alla DPIA GDPR;
+- obblighi di registrazione nella banca dati UE per il deployer pubblico;
+- transparency/informativa;
+- fallback umano e kill switch.
+
+Evidence in `PILOT_PROVIDER_REGISTER.md` e `PILOT_APPROVAL_RECORD_2026_2027.md`.
+
+---
+
+# 17. DPIA GDPR e FRIA AI Act
+
+## 17.1 DPIA
+
+`PILOT_DPIA_SCREENING.md` valuta:
+
+- minori/vulnerabilità;
+- valutazione/scoring;
+- decisioni automatizzate;
+- tecnologia innovativa/AI;
+- dati particolari;
+- larga scala/matching;
+- provider/trasferimenti;
+- rischio cross-student;
+- bias/errori/leakage.
+
+Se il trattamento è suscettibile di presentare rischio elevato, la DPIA viene completata **prima** dell'attivazione.
+
+## 17.2 FRIA — art. 27 AI Act
+
+Per high-risk AI ex art. 6(2), quando l'Istituto pubblico rientra nel perimetro dell'art. 27, prima dell'uso viene eseguita una Fundamental Rights Impact Assessment che copre almeno:
+
+- processi/intended purpose;
+- durata/frequenza;
+- persone/gruppi interessati;
+- rischi specifici sui diritti fondamentali;
+- human oversight concreta;
+- mitigazioni/governance e meccanismi di reclamo/ricorso pertinenti.
+
+DPIA e FRIA possono essere integrate operativamente per le parti sovrapposte, ma **non sono automaticamente sostitutive**.
+
+Eventuali adempimenti verso l'autorità di vigilanza previsti dall'art. 27 sono responsabilità del deployer e devono essere documentati.
+
+---
+
+# 18. Go/no-go governance
+
+## 18.1 GO core con dati reali
+
+Richiede:
+
+- [ ] Titolare/RPD-DPO identificati;
+- [ ] finalità/basi giuridiche approvate;
+- [ ] Registro art. 30 aggiornato;
+- [ ] categorie dati/retention approvate;
+- [ ] categorie particolari escluse o separatamente governate;
+- [ ] modello operativo e gestore tecnico/art. 28 qualificati;
+- [ ] provider/contratti/subprocessori/trasferimenti verificati;
+- [ ] informativa approvata;
+- [ ] DPIA screening e DPIA quando richiesta;
+- [ ] authorization/security/logging gate PASS;
+- [ ] backup/restore gate PASS;
+- [ ] incident/data breach workflow definito;
+- [ ] AI non autorizzata tecnicamente disabilitata.
+
+## 18.2 GO use case AI
+
+Richiede inoltre:
+
+- [ ] intended purpose/versione;
+- [ ] #710 privacy boundary;
+- [ ] provider approval;
+- [ ] AI literacy;
+- [ ] classificazione AI Act;
+- [ ] DPIA/FRIA quando applicabili;
+- [ ] high-risk deployer obligations quando applicabili;
+- [ ] human oversight/contestazione/fallback;
+- [ ] retention/logging coerenti;
+- [ ] informativa aggiornata;
+- [ ] decisione istituzionale riferita allo specifico use case/release.
+
+---
+
+# 19. Change control
+
+Richiedono nuova review almeno:
+
+- finalità/intended purpose;
+- categorie dati;
+- introduzione di categorie particolari;
+- provider/subprocessor;
+- ruolo controller/processor;
+- trasferimenti;
+- retention;
+- modello/prompt/policy per assessment;
+- livello di automazione/human oversight;
+- topologia;
+- identity/authz;
+- output che diventa voto/decisione ufficiale;
+- percorso adattivo con impatto materiale;
+- classificazione AI Act;
+- condizioni che rendevano non applicabile DPIA/FRIA.
+
+---
+
+# 20. Approval required
 
 ```text
-purpose:
-data_subjects:
-data_categories:
-minimum_fields:
-source:
-recipients:
-retention:
-authority:
-security_boundary:
-AI_use_case: none | ...
-DPIA_ref_or_screening:
-privacy_notice_impact:
-delete/export_path:
+Istituto/Titolare:
+Dirigente/rappresentante:
+RPD/DPO e contatto:
+Responsabile tecnico:
+Docente/owner didattico:
+Decision owner:
+Riferimento Registro art. 30:
+Modello operativo / gestore tecnico:
+Riferimento eventuale art. 28:
+Provider approvati:
+Hosting/localizzazione:
+Backup/localizzazione:
+Retention approvata:
+Esito DPIA screening / DPIA ref:
+AI reale nel pilot: NESSUNA / ELENCO
+Classificazione AI Act per use case:
+FRIA ref/N.A.:
+Data approvazione:
+Versione/release approvata:
+Next review:
 ```
 
-PR/issue senza questa informazione non può introdurre un nuovo trattamento reale silenziosamente.
-
 ---
 
-# 16. Approval package
+## Riferimenti normativi/istituzionali per la review
 
-Prima del nuovo rehearsal #678 con dati reali devono essere compilati/approvati:
+- Regolamento (UE) 2016/679 (GDPR), in particolare artt. 5, 6, 13, 25, 28, 30, 32, 33, 34 e 35.
+- Regolamento (UE) 2024/1689 (AI Act), in particolare artt. 4, 5, 6, 26, 27, 49 e 113 e Allegato III, punto 3.
+- Garante per la protezione dei dati personali — materiali e vademecum aggiornati per la scuola.
+- Garante — parere 4 agosto 2025 sulle Linee guida MIM per l'introduzione dell'IA nelle istituzioni scolastiche.
+- Garante — attività istruttoria/comunicazione 3 giugno 2026 sui progetti IA in ambito scolastico.
+- Garante — pareri 14 luglio 2026 sugli schemi nazionali di adeguamento al Regolamento IA, inclusi i profili relativi a istruzione e formazione.
 
-- [ ] identità del Titolare;
-- [ ] RPD/DPO e contatti;
-- [ ] mappa base giuridica/finalità;
-- [ ] data inventory;
-- [ ] retention matrix definitiva;
-- [ ] access matrix definitiva;
-- [ ] provider registry e contratti/DPA pertinenti;
-- [ ] decisione trasferimenti extra SEE dove applicabile;
-- [ ] informativa Art. 13 approvata;
-- [ ] workflow diritti interessati;
-- [ ] backup RPO/RTO e restore evidence;
-- [ ] incident response ed escalation;
-- [ ] DPIA screening e DPIA completa quando richiesta;
-- [ ] AI use case gates per qualunque AI attivata;
-- [ ] owner e firme/approvazioni;
-- [ ] data di revisione della governance.
-
-Il fatto che il software passi i test non sostituisce queste approvazioni.
-
----
-
-# 17. Stato per #699
-
-Con questo documento il pacchetto governance passa da `missing` a **DRAFT STRUCTURED**.
-
-Non è ancora `APPROVED` perché restano da compilare e approvare almeno:
-
-- Titolare/dirigente/RPD-DPO;
-- basi giuridiche specifiche;
-- retention definitiva;
-- provider registry/contratti;
-- informativa;
-- DPIA screening;
-- firme e data di revisione.
-
-Fino a quel momento #699 resta aperta e i dati reali restano bloccati dal gate governance.
+I riferimenti devono essere ricontrollati al momento dell'approvazione istituzionale e dopo modifiche normative o di perimetro.

--- a/doc/governance/PILOT_PRIVACY_NOTICE_DRAFT.md
+++ b/doc/governance/PILOT_PRIVACY_NOTICE_DRAFT.md
@@ -1,0 +1,214 @@
+# TheBitLab pilot 2026/2027 — Informativa privacy (bozza)
+
+## Stato
+
+**DRAFT DA COMPLETARE E APPROVARE DAL TITOLARE/RPD-DPO PRIMA DELL'USO CON STUDENTI REALI.**
+
+Questa bozza serve a trasformare la governance tecnica del pilot in un'informativa comprensibile a studenti e famiglie. Non va pubblicata finché i campi mancanti non sono compilati e la scuola non ha verificato base giuridica, destinatari, trasferimenti e retention.
+
+---
+
+# 1. Chi tratta i dati
+
+**Titolare del trattamento**
+
+`[ISTITUTO SCOLASTICO]`
+
+Indirizzo: `[________]`
+
+Contatti: `[________]`
+
+**Responsabile della protezione dei dati (RPD/DPO)**
+
+`[NOME/ORGANIZZAZIONE]`
+
+Contatto: `[________]`
+
+TheBitLab è la piattaforma software usata nel pilot. Il ruolo privacy dell'eventuale gestore tecnico esterno e dei provider viene definito nei relativi accordi e nel registro fornitori della scuola.
+
+---
+
+# 2. Perché vengono trattati i dati
+
+TheBitLab viene usato per supportare attività didattiche e laboratoriali, in particolare per:
+
+- permettere l'accesso autenticato dello studente;
+- associare lo studente alle classi e alle attività autorizzate;
+- distribuire activity e consegne;
+- eseguire laboratori e test;
+- registrare tentativi e selezionare, quando previsto, il tentativo definitivo;
+- permettere al docente di visualizzare report e fornire feedback;
+- gestire richieste di aiuto;
+- proteggere account, sessioni e servizio;
+- effettuare backup e ripristino;
+- usare eventuali funzioni AI soltanto quando specificamente approvate e attivate.
+
+**Base giuridica:** `[DA COMPILARE DALLA SCUOLA/RPD-DPO PER CIASCUNA FINALITÀ]`.
+
+L'uso del consenso non deve essere indicato automaticamente come base del servizio core se la base appropriata è un obbligo legale/compito di interesse pubblico o altra base prevista dalla normativa applicabile.
+
+---
+
+# 3. Quali dati possono essere trattati
+
+A seconda delle funzioni effettivamente abilitate:
+
+- identificatore interno TheBitLab;
+- account Google usato per il login e dati minimi necessari al riconoscimento/onboarding;
+- ruolo e membership di classe;
+- attività, assignment e calendario;
+- codice/elaborati, tentativi e report dei test;
+- feedback, correzioni e grading;
+- richieste di aiuto;
+- log tecnici/security minimizzati;
+- metadati necessari a backup/restore;
+- per funzioni AI approvate: solo il contesto minimo previsto dalla policy dello specifico use case.
+
+TheBitLab non usa il dominio dell'email come autorizzazione alla classe: l'accesso è determinato dalle membership interne autorizzate dalla scuola.
+
+---
+
+# 4. Account scolastico o Gmail personale
+
+Nel pilot sono ammessi sia account Google Workspace scolastici sia account Gmail personali.
+
+L'account scolastico può essere preferito quando disponibile e funzionante, ma l'account Gmail personale può essere usato quando previsto dalla policy della scuola.
+
+L'indirizzo email non viene usato per autorizzare automaticamente l'accesso a classi o consegne e non deve essere riutilizzato per finalità estranee al pilot.
+
+---
+
+# 5. Chi può vedere i dati
+
+In base al ruolo e al principio di necessità:
+
+- lo studente accede soltanto ai propri dati e alle proprie attività autorizzate;
+- il docente accede alle classi e alle attività di propria competenza;
+- gli amministratori applicativi gestiscono account/membership e configurazioni strettamente necessarie;
+- il gestore tecnico accede ai dati soltanto quando necessario per sicurezza, backup, ripristino o incident response e secondo procedure tracciate;
+- coding agent e strumenti AI usati per sviluppare il software non hanno accesso ai dati reali di produzione;
+- eventuali provider AI ricevono soltanto il contesto minimo previsto dal relativo gate e non hanno accesso diretto al database/root TheBitLab.
+
+Destinatari/responsabili esterni effettivi: `[ELENCO/REGISTRO DA COMPILARE]`.
+
+---
+
+# 6. Per quanto tempo vengono conservati
+
+La retention definitiva è stabilita dalla scuola. La baseline tecnica proposta per il pilot è:
+
+- account, membership, assignment, tentativi, report e feedback: anno scolastico + 90 giorni, salvo obblighi diversi approvati dalla scuola;
+- contenuto delle interazioni help/tutor: 30 giorni;
+- log tecnici/security ordinari: 30 giorni;
+- payload AI nel gateway TheBitLab: non persistiti per default;
+- metadati audit AI: 30 giorni;
+- backup: rotazione di 30 giorni con backup almeno giornaliero;
+- incident evidence: retention definita caso per caso dal Titolare/RPD-DPO.
+
+`APPROVAL REQUIRED`: questi valori devono essere confermati o sostituiti prima della pubblicazione.
+
+I voti/atti che devono essere conservati come documentazione scolastica ufficiale seguono le regole e i sistemi ufficiali dell'istituto; TheBitLab non deve diventare automaticamente un archivio indefinito.
+
+---
+
+# 7. Sicurezza
+
+Sono previste, tra le altre, misure quali:
+
+- HTTPS;
+- autenticazione federata e revoca sessioni;
+- authorization per ruolo/membership;
+- sandbox Docker per codice non fidato;
+- segreti esterni al repository e ai log;
+- log minimizzati e secret-safe;
+- backup cifrato e restore verificato;
+- least privilege;
+- audit delle operazioni sensibili;
+- feature flag/kill switch per provider e funzioni AI.
+
+Nessun sistema può garantire rischio zero; le misure vengono riesaminate in base ai rischi del trattamento.
+
+---
+
+# 8. Intelligenza artificiale
+
+Quando una funzione AI è abilitata, l'interfaccia deve indicarlo chiaramente.
+
+Le funzionalità previste includono tutor, feedback, correzione, proposta di voto, grading automatico e percorsi adattivi, ma non sono necessariamente tutte attive nello stesso momento.
+
+Regole del pilot:
+
+- nessun use case AI usa dati reali prima del proprio gate di governance/privacy/compliance;
+- il provider non riceve accesso diretto a root/database/credenziali;
+- vengono inviati solo i dati strettamente necessari allo specifico scopo;
+- hidden test, soluzioni docente e dati di altri studenti sono esclusi per default;
+- output AI, evidence deterministica e decisione docente restano distinguibili;
+- per funzioni valutative/adattive sono previste policy e controlli più forti, inclusa human oversight quando richiesta.
+
+Use case AI attivi in questo pilot: `[NESSUNO / ELENCO APPROVATO]`.
+
+Provider AI attivi: `[NESSUNO / ELENCO APPROVATO]`.
+
+Informazioni specifiche su logica/importanza/conseguenze del processo automatizzato, quando dovute: `[DA COMPILARE PER USE CASE]`.
+
+---
+
+# 9. Trasferimenti verso paesi extra SEE
+
+`[DA COMPILARE]`
+
+Per ciascun provider che tratta dati fuori dallo Spazio Economico Europeo devono essere indicate le condizioni e le garanzie applicabili, oppure deve essere dichiarato che non sono previsti tali trasferimenti.
+
+---
+
+# 10. Diritti
+
+Nei limiti e secondo le condizioni previste dalla normativa applicabile, l'interessato può esercitare i diritti relativi ai propri dati, inclusi accesso e rettifica e, quando applicabili, cancellazione, limitazione/opposizione e altri diritti previsti dal GDPR.
+
+Le richieste vanno indirizzate al Titolare/RPD-DPO ai contatti indicati sopra.
+
+È possibile proporre reclamo al Garante per la protezione dei dati personali.
+
+Per processi decisionali automatizzati/profilazione, quando applicabili, l'informativa deve descrivere i diritti e le garanzie specifiche previste dalla normativa e dalla policy della scuola.
+
+---
+
+# 11. Conferimento dei dati
+
+`[DA COMPILARE PER TRATTAMENTO]`
+
+L'informativa definitiva deve distinguere:
+
+- dati necessari per il servizio didattico core;
+- dati/funzioni opzionali;
+- conseguenze della mancata disponibilità quando pertinenti.
+
+---
+
+# 12. Contatti e revisione
+
+Versione informativa: `[________]`
+
+Data approvazione: `[________]`
+
+Data prossima revisione: `[________]`
+
+Titolare approvazione: `[________]`
+
+RPD/DPO review: `[________]`
+
+---
+
+## Note di drafting
+
+Prima della pubblicazione verificare almeno:
+
+- coerenza con `PILOT_GOVERNANCE_2026_2027.md`;
+- basi giuridiche;
+- provider registry e relativi ruoli;
+- trasferimenti;
+- retention definitiva;
+- DPIA screening;
+- funzioni AI realmente abilitate;
+- linguaggio comprensibile agli studenti/minori;
+- modalità con cui l'informativa viene resa a studenti e famiglie.

--- a/doc/governance/PILOT_PRIVACY_NOTICE_DRAFT.md
+++ b/doc/governance/PILOT_PRIVACY_NOTICE_DRAFT.md
@@ -4,7 +4,7 @@
 
 **DRAFT DA COMPLETARE E APPROVARE DAL TITOLARE/RPD-DPO PRIMA DELL'USO CON STUDENTI REALI.**
 
-Questa bozza serve a trasformare la governance tecnica del pilot in un'informativa comprensibile a studenti e famiglie. Non va pubblicata finché i campi mancanti non sono compilati e la scuola non ha verificato base giuridica, destinatari, trasferimenti e retention.
+Questa bozza serve a trasformare la governance tecnica del pilot in un'informativa comprensibile a studenti e famiglie. Non va pubblicata finché i campi mancanti non sono compilati e la scuola non ha verificato base giuridica, destinatari, trasferimenti, retention, perimetro AI e risultati delle valutazioni di impatto applicabili.
 
 ---
 
@@ -45,7 +45,7 @@ TheBitLab viene usato per supportare attività didattiche e laboratoriali, in pa
 
 **Base giuridica:** `[DA COMPILARE DALLA SCUOLA/RPD-DPO PER CIASCUNA FINALITÀ]`.
 
-L'uso del consenso non deve essere indicato automaticamente come base del servizio core se la base appropriata è un obbligo legale/compito di interesse pubblico o altra base prevista dalla normativa applicabile.
+L'uso del consenso non deve essere indicato automaticamente come base del servizio core se la base appropriata è un obbligo legale, un compito di interesse pubblico o altra base prevista dalla normativa applicabile.
 
 ---
 
@@ -66,13 +66,17 @@ A seconda delle funzioni effettivamente abilitate:
 
 TheBitLab non usa il dominio dell'email come autorizzazione alla classe: l'accesso è determinato dalle membership interne autorizzate dalla scuola.
 
+## Dati particolari
+
+Il core TheBitLab non richiede per design dati sanitari, diagnosi, disabilità, DSA, informazioni psicologiche o altre categorie particolari di dati. Tali informazioni non devono essere inserite automaticamente nei profili, nelle richieste di aiuto, nei prompt AI o nei log. Se l'Istituto attiva in futuro una funzione che richiede dati di questa natura, essa deve essere descritta e autorizzata come trattamento separato con le condizioni e le garanzie applicabili.
+
 ---
 
 # 4. Account scolastico o Gmail personale
 
-Nel pilot sono ammessi sia account Google Workspace scolastici sia account Gmail personali.
+Nel pilot sono tecnicamente supportati sia account Google Workspace scolastici sia account Gmail personali.
 
-L'account scolastico può essere preferito quando disponibile e funzionante, ma l'account Gmail personale può essere usato quando previsto dalla policy della scuola.
+L'account scolastico può essere preferito quando disponibile e funzionante; l'account Gmail personale può essere usato soltanto se previsto dalla policy approvata dall'Istituto.
 
 L'indirizzo email non viene usato per autorizzare automaticamente l'accesso a classi o consegne e non deve essere riutilizzato per finalità estranee al pilot.
 
@@ -91,19 +95,23 @@ In base al ruolo e al principio di necessità:
 
 Destinatari/responsabili esterni effettivi: `[ELENCO/REGISTRO DA COMPILARE]`.
 
+Ruolo dell'eventuale gestore tecnico esterno e riferimento all'atto/contratto applicabile: `[DA COMPILARE]`.
+
 ---
 
 # 6. Per quanto tempo vengono conservati
 
-La retention definitiva è stabilita dalla scuola. La baseline tecnica proposta per il pilot è:
+La retention definitiva è stabilita dalla scuola. La baseline tecnica proposta per il pilot core è:
 
 - account, membership, assignment, tentativi, report e feedback: anno scolastico + 90 giorni, salvo obblighi diversi approvati dalla scuola;
 - contenuto delle interazioni help/tutor: 30 giorni;
 - log tecnici/security ordinari: 30 giorni;
 - payload AI nel gateway TheBitLab: non persistiti per default;
-- metadati audit AI: 30 giorni;
+- metadati audit AI ordinari: 30 giorni, **salvo obblighi di conservazione più lunghi applicabili allo specifico sistema/use case**;
 - backup: rotazione di 30 giorni con backup almeno giornaliero;
 - incident evidence: retention definita caso per caso dal Titolare/RPD-DPO.
+
+Se viene attivato un sistema AI ad alto rischio soggetto agli obblighi del deployer previsti dall'AI Act, i log generati automaticamente sotto il controllo del deployer sono conservati per il periodo previsto dalla disciplina applicabile; l'art. 26 AI Act prevede, quando applicabile, un periodo di almeno sei mesi. L'informativa pubblicata deve indicare il periodo effettivamente adottato per il use case attivo.
 
 `APPROVAL REQUIRED`: questi valori devono essere confermati o sostituiti prima della pubblicazione.
 
@@ -118,7 +126,7 @@ Sono previste, tra le altre, misure quali:
 - HTTPS;
 - autenticazione federata e revoca sessioni;
 - authorization per ruolo/membership;
-- sandbox Docker per codice non fidato;
+- sandbox per codice non fidato;
 - segreti esterni al repository e ai log;
 - log minimizzati e secret-safe;
 - backup cifrato e restore verificato;
@@ -132,9 +140,11 @@ Nessun sistema può garantire rischio zero; le misure vengono riesaminate in bas
 
 # 8. Intelligenza artificiale
 
-Quando una funzione AI è abilitata, l'interfaccia deve indicarlo chiaramente.
+Il pilot può essere approvato con **AI esterna completamente disabilitata sui dati reali**. In tal caso il trattamento core non implica l'uso di provider AI.
 
-Le funzionalità previste includono tutor, feedback, correzione, proposta di voto, grading automatico e percorsi adattivi, ma non sono necessariamente tutte attive nello stesso momento.
+Quando una funzione AI è abilitata, l'interfaccia e la documentazione devono indicarlo chiaramente.
+
+Le funzionalità previste possono includere tutor, feedback, correzione, proposta di voto, grading automatico e percorsi adattivi, ma non sono necessariamente tutte attive nello stesso momento.
 
 Regole del pilot:
 
@@ -143,27 +153,45 @@ Regole del pilot:
 - vengono inviati solo i dati strettamente necessari allo specifico scopo;
 - hidden test, soluzioni docente e dati di altri studenti sono esclusi per default;
 - output AI, evidence deterministica e decisione docente restano distinguibili;
-- per funzioni valutative/adattive sono previste policy e controlli più forti, inclusa human oversight quando richiesta.
+- per funzioni valutative/adattive sono previste classificazione AI Act, valutazioni di impatto e human oversight quando applicabili;
+- funzioni di inferenza/riconoscimento delle emozioni in ambito scolastico non fanno parte del pilot, salvo eventuali future eccezioni strettamente previste dalla legge per ragioni mediche o di sicurezza.
 
 Use case AI attivi in questo pilot: `[NESSUNO / ELENCO APPROVATO]`.
 
-Provider AI attivi: `[NESSUNO / ELENCO APPROVATO]`.
+Provider/sistema/versione AI attivi: `[NESSUNO / ELENCO APPROVATO]`.
 
-Informazioni specifiche su logica/importanza/conseguenze del processo automatizzato, quando dovute: `[DA COMPILARE PER USE CASE]`.
+Classificazione AI Act del use case: `[N/A / NON_HIGH_RISK / HIGH_RISK / ALTRO ESITO MOTIVATO]`.
+
+Riferimento DPIA/FRIA quando applicabili: `[________]`.
 
 ---
 
-# 9. Trasferimenti verso paesi extra SEE
+# 9. Decisioni automatizzate, human review e contestazione
+
+Per ogni funzione che produce o influenza una valutazione, un livello, un percorso o un'altra decisione rilevante, l'informativa definitiva deve descrivere in modo coerente con il trattamento reale:
+
+- se l'AI propone soltanto o decide;
+- quale ruolo ha il docente;
+- se il docente può accettare, modificare o rifiutare l'output;
+- come lo studente può chiedere chiarimenti/review o contestare il risultato quando previsto;
+- le informazioni su logica, importanza e conseguenze del trattamento automatizzato richieste dal GDPR nei casi applicabili;
+- le misure di human oversight e fallback previste.
+
+Informazioni specifiche sul use case attivo: `[DA COMPILARE / N.A.]`.
+
+---
+
+# 10. Trasferimenti verso paesi extra SEE
 
 `[DA COMPILARE]`
 
-Per ciascun provider che tratta dati fuori dallo Spazio Economico Europeo devono essere indicate le condizioni e le garanzie applicabili, oppure deve essere dichiarato che non sono previsti tali trasferimenti.
+Per ciascun provider che comporta trattamenti o trasferimenti verso paesi terzi devono essere indicate le condizioni e le garanzie applicabili, oppure deve essere dichiarato che non sono previsti tali trasferimenti.
 
 ---
 
-# 10. Diritti
+# 11. Diritti
 
-Nei limiti e secondo le condizioni previste dalla normativa applicabile, l'interessato può esercitare i diritti relativi ai propri dati, inclusi accesso e rettifica e, quando applicabili, cancellazione, limitazione/opposizione e altri diritti previsti dal GDPR.
+Nei limiti e secondo le condizioni previste dalla normativa applicabile, l'interessato può esercitare i diritti relativi ai propri dati, inclusi accesso e rettifica e, quando applicabili, cancellazione, limitazione/opposizione e gli altri diritti previsti dal GDPR.
 
 Le richieste vanno indirizzate al Titolare/RPD-DPO ai contatti indicati sopra.
 
@@ -173,7 +201,7 @@ Per processi decisionali automatizzati/profilazione, quando applicabili, l'infor
 
 ---
 
-# 11. Conferimento dei dati
+# 12. Conferimento dei dati
 
 `[DA COMPILARE PER TRATTAMENTO]`
 
@@ -181,11 +209,20 @@ L'informativa definitiva deve distinguere:
 
 - dati necessari per il servizio didattico core;
 - dati/funzioni opzionali;
-- conseguenze della mancata disponibilità quando pertinenti.
+- conseguenze della mancata disponibilità quando pertinenti;
+- eventuali use case AI facoltativi o separatamente autorizzati.
 
 ---
 
-# 12. Contatti e revisione
+# 13. Data breach e contatti
+
+In caso di incidente che coinvolga dati personali, l'Istituto applica la propria procedura di data breach. Gli eventuali Responsabili del trattamento informano il Titolare senza ingiustificato ritardo secondo gli accordi applicabili; il Titolare valuta gli adempimenti previsti dagli artt. 33 e 34 GDPR.
+
+Canale istituzionale per segnalazioni privacy/security: `[________]`.
+
+---
+
+# 14. Contatti e revisione
 
 Versione informativa: `[________]`
 
@@ -197,18 +234,22 @@ Titolare approvazione: `[________]`
 
 RPD/DPO review: `[________]`
 
+Release/use-case AI coperti: `[________]`
+
 ---
 
 ## Note di drafting
 
 Prima della pubblicazione verificare almeno:
 
-- coerenza con `PILOT_GOVERNANCE_2026_2027.md`;
+- coerenza con `PILOT_GOVERNANCE_2026_2027.md` e `PILOT_SCHOOL_COMPLIANCE_CHECKLIST_2026_2027.md`;
 - basi giuridiche;
 - provider registry e relativi ruoli;
+- eventuale ruolo/atto art. 28 del gestore tecnico;
 - trasferimenti;
 - retention definitiva;
-- DPIA screening;
-- funzioni AI realmente abilitate;
+- DPIA screening ed eventuale DPIA;
+- funzioni AI realmente abilitate e relativa classificazione;
+- eventuale FRIA/obblighi high-risk;
 - linguaggio comprensibile agli studenti/minori;
 - modalità con cui l'informativa viene resa a studenti e famiglie.

--- a/doc/governance/PILOT_PROVIDER_REGISTER.md
+++ b/doc/governance/PILOT_PROVIDER_REGISTER.md
@@ -1,0 +1,146 @@
+# TheBitLab pilot 2026/2027 — Provider & Processing Register
+
+## Stato
+
+**DRAFT OPERATIVO — da completare/approvare con il Titolare e RPD/DPO. Non contiene segreti.**
+
+Questo registro raccoglie i servizi esterni che possono trattare dati o supportare il pilot. Non sostituisce il registro dei trattamenti dell'istituto né i contratti/DPA; fornisce un annex tecnico verificabile per #699.
+
+---
+
+# 1. Regole
+
+Per ogni provider prima dell'uso reale devono essere noti:
+
+- servizio e finalità;
+- categorie di dati;
+- interessati;
+- ruolo privacy;
+- contratto/DPA art. 28 quando applicabile;
+- sub-responsabili rilevanti;
+- localizzazione e trasferimenti extra SEE;
+- retention/data-use/training;
+- misure di sicurezza;
+- secret/config owner;
+- kill switch / disabilitazione;
+- approvazione e review date.
+
+Un campo `UNKNOWN` blocca l'attivazione del trattamento che dipende da quel provider.
+
+---
+
+# 2. Registro
+
+| ID | Provider/servizio | Finalità | Dati potenziali | Ruolo privacy | Trasferimenti | Retention/data-use | Contratto/DPA | Stato |
+|---|---|---|---|---|---|---|---|---|
+| P-01 | Google OIDC | login federato | identity provider data minima per auth/onboarding | `TBD` | `TBD` | `TBD` | `TBD` | REVIEW REQUIRED |
+| P-02 | GitHub App | fonti didattiche private read-only | repository/content metadata; nessun dato studente previsto per design | `TBD` | `TBD` | `TBD` | `TBD` | REVIEW REQUIRED |
+| P-03 | GitLab (se usato) | fonti didattiche | repository/content metadata | `TBD` | `TBD` | `TBD` | `TBD` | OPTIONAL / REVIEW REQUIRED |
+| P-04 | Hosting/VPS | esecuzione TheBitLab | dati applicativi del pilot secondo root/deployment | `TBD` | `TBD` | `TBD` | `TBD` | BLOCKED UNTIL COMPLETED |
+| P-05 | Backup storage | disaster recovery | snapshot applicativo cifrato | `TBD` | `TBD` | rolling 30d proposto | `TBD` | BLOCKED UNTIL COMPLETED |
+| P-AI-* | Provider AI | use case #712–#715 | solo `AIRequestContext` minimizzato | `TBD per provider` | `TBD` | `TBD; no training/retention assumptions without evidence` | `TBD` | DISABLED ON REAL DATA |
+
+---
+
+# 3. Scheda provider
+
+Duplicare per ciascun provider effettivo.
+
+```yaml
+provider_id:
+provider_name:
+service:
+intended_purpose:
+owner:
+
+privacy_role:
+controller_ref:
+processor_agreement_ref:
+subprocessor_list_ref:
+
+subjects: []
+data_categories: []
+minimum_fields: []
+prohibited_fields: []
+
+processing_locations: []
+third_country_transfer:
+  present: UNKNOWN
+  mechanism_ref: null
+
+retention:
+provider_training_or_product_improvement_use:
+  status: UNKNOWN
+  evidence_ref: null
+
+security_measures_ref:
+incident_contact_ref:
+
+secret_storage_ref:
+kill_switch:
+
+enabled_environments:
+  demo_synthetic: false
+  staging_real: false
+  production_real: false
+
+approved_by:
+approved_at:
+review_due:
+status: DRAFT | APPROVED_SYNTHETIC_ONLY | APPROVED_REAL_DATA | BLOCKED | RETIRED
+```
+
+---
+
+# 4. AI provider addendum
+
+Per un provider AI, oltre alla scheda generale, registrare per ogni use case:
+
+```yaml
+use_case: TUTOR_ASSISTANCE | FEEDBACK | CORRECTION | GRADE_PROPOSAL | AUTOMATED_GRADING | ADAPTIVE_PATH
+policy_ref:
+DPIA_screening_ref:
+AI_Act_classification_ref:
+allowed_context_fields: []
+forbidden_context_fields: []
+payload_persistence_gateway: false
+provider_retention:
+provider_training_use:
+human_oversight:
+quality_gate_ref:
+real_student_data_enabled: false
+```
+
+Un provider approvato per `TUTOR_ASSISTANCE` non è automaticamente approvato per `GRADE_PROPOSAL` o `AUTOMATED_GRADING`.
+
+---
+
+# 5. Evidence richiesta
+
+Non salvare secret nel registro. Evidence accettabile:
+
+- link/versione contrattuale;
+- DPA/reference;
+- elenco subprocessor/versione;
+- regione/localizzazione dichiarata;
+- policy retention/data use;
+- configurazione account/tenant rilevante;
+- screenshot sanitizzato solo se necessario;
+- test secret-safe e provider adapter contract.
+
+---
+
+# 6. Gate
+
+Prima del GO pilot con dati reali:
+
+- [ ] P-01 Google OIDC review completata;
+- [ ] provider hosting completato;
+- [ ] provider backup completato;
+- [ ] GitHub/GitLab review completata per i servizi effettivamente usati;
+- [ ] eventuali provider AI restano disabilitati oppure possiedono approval per il use case reale;
+- [ ] trasferimenti e garanzie sono documentati;
+- [ ] contratti/DPA richiesti sono registrati;
+- [ ] review date e owner sono assegnati.
+
+Se il nuovo rehearsal #678 esclude formalmente l'AI esterna, i provider AI possono restare `DISABLED ON REAL DATA` senza bloccare il GO del perimetro non-AI; non possono però essere invocati durante il run reale.

--- a/doc/governance/PILOT_PROVIDER_REGISTER.md
+++ b/doc/governance/PILOT_PROVIDER_REGISTER.md
@@ -4,7 +4,7 @@
 
 **DRAFT OPERATIVO — da completare/approvare con il Titolare e RPD/DPO. Non contiene segreti.**
 
-Questo registro raccoglie i servizi esterni che possono trattare dati o supportare il pilot. Non sostituisce il registro dei trattamenti dell'istituto né i contratti/DPA; fornisce un annex tecnico verificabile per #699.
+Questo registro raccoglie i servizi esterni che possono trattare dati o supportare il pilot. Non sostituisce il Registro delle attività di trattamento dell'Istituto né i contratti/DPA; fornisce un annex tecnico verificabile per #699.
 
 ---
 
@@ -13,19 +13,31 @@ Questo registro raccoglie i servizi esterni che possono trattare dati o supporta
 Per ogni provider prima dell'uso reale devono essere noti:
 
 - servizio e finalità;
-- categorie di dati;
+- categorie di dati e campi minimi;
 - interessati;
 - ruolo privacy;
 - contratto/DPA art. 28 quando applicabile;
-- sub-responsabili rilevanti;
+- sub-responsabili rilevanti e relativa governance;
 - localizzazione e trasferimenti extra SEE;
-- retention/data-use/training;
+- retention/data-use/training/product improvement;
 - misure di sicurezza;
+- incident/data breach contact;
 - secret/config owner;
 - kill switch / disabilitazione;
 - approvazione e review date.
 
-Un campo `UNKNOWN` blocca l'attivazione del trattamento che dipende da quel provider.
+Per provider/sistemi AI devono inoltre essere noti, per use case:
+
+- intended purpose;
+- classificazione AI Act e relativa evidence;
+- eventuale documentazione high-risk;
+- obblighi di registrazione applicabili;
+- DPIA/FRIA references;
+- human oversight;
+- log/retention applicabili;
+- policy di input/output, quality e incident reporting.
+
+Un campo `UNKNOWN` che può incidere su liceità, ruolo, trasferimenti, data use, classificazione o rischio blocca l'attivazione del trattamento che dipende dal provider.
 
 ---
 
@@ -33,16 +45,19 @@ Un campo `UNKNOWN` blocca l'attivazione del trattamento che dipende da quel prov
 
 | ID | Provider/servizio | Finalità | Dati potenziali | Ruolo privacy | Trasferimenti | Retention/data-use | Contratto/DPA | Stato |
 |---|---|---|---|---|---|---|---|---|
+| P-00 | Gestore tecnico TheBitLab/TheBitPoets, se esterno | hosting/amministrazione/supporto secondo modello reale | solo se il servizio gli consente accesso a dati del pilot | `TBD / N.A. self-hosted` | `TBD` | `TBD` | `TBD / N.A.` | BLOCKED UNTIL QUALIFIED |
 | P-01 | Google OIDC | login federato | identity provider data minima per auth/onboarding | `TBD` | `TBD` | `TBD` | `TBD` | REVIEW REQUIRED |
 | P-02 | GitHub App | fonti didattiche private read-only | repository/content metadata; nessun dato studente previsto per design | `TBD` | `TBD` | `TBD` | `TBD` | REVIEW REQUIRED |
-| P-03 | GitLab (se usato) | fonti didattiche | repository/content metadata | `TBD` | `TBD` | `TBD` | `TBD` | OPTIONAL / REVIEW REQUIRED |
+| P-03 | GitLab, se usato | fonti didattiche | repository/content metadata | `TBD` | `TBD` | `TBD` | `TBD` | OPTIONAL / REVIEW REQUIRED |
 | P-04 | Hosting/VPS | esecuzione TheBitLab | dati applicativi del pilot secondo root/deployment | `TBD` | `TBD` | `TBD` | `TBD` | BLOCKED UNTIL COMPLETED |
 | P-05 | Backup storage | disaster recovery | snapshot applicativo cifrato | `TBD` | `TBD` | rolling 30d proposto | `TBD` | BLOCKED UNTIL COMPLETED |
-| P-AI-* | Provider AI | use case #712–#715 | solo `AIRequestContext` minimizzato | `TBD per provider` | `TBD` | `TBD; no training/retention assumptions without evidence` | `TBD` | DISABLED ON REAL DATA |
+| P-AI-* | Provider/sistema AI | use case #712–#715 | solo `AIRequestContext` minimizzato | `TBD per provider/use case` | `TBD` | `TBD; no training/retention assumptions without evidence` | `TBD` | DISABLED ON REAL DATA |
+
+Se il pilot iniziale esclude formalmente l'AI esterna, le righe `P-AI-*` possono restare `DISABLED ON REAL DATA` senza bloccare il GO core.
 
 ---
 
-# 3. Scheda provider
+# 3. Scheda provider generale
 
 Duplicare per ciascun provider effettivo.
 
@@ -57,11 +72,13 @@ privacy_role:
 controller_ref:
 processor_agreement_ref:
 subprocessor_list_ref:
+subprocessor_authorisation_model:
 
 subjects: []
 data_categories: []
 minimum_fields: []
 prohibited_fields: []
+special_category_data_allowed: false
 
 processing_locations: []
 third_country_transfer:
@@ -75,6 +92,7 @@ provider_training_or_product_improvement_use:
 
 security_measures_ref:
 incident_contact_ref:
+data_breach_notification_commitment_ref:
 
 secret_storage_ref:
 kill_switch:
@@ -92,55 +110,146 @@ status: DRAFT | APPROVED_SYNTHETIC_ONLY | APPROVED_REAL_DATA | BLOCKED | RETIRED
 
 ---
 
-# 4. AI provider addendum
+# 4. Scheda gestore tecnico / art. 28
 
-Per un provider AI, oltre alla scheda generale, registrare per ogni use case:
+Compilare `P-00` quando un soggetto esterno può trattare dati per conto dell'Istituto.
+
+```yaml
+operating_model: SELF_HOSTED_NO_EXTERNAL_DATA_ACCESS | MANAGED_SERVICE | SUPPORT_WITH_POSSIBLE_ACCESS | OTHER
+technical_operator:
+privacy_role:
+role_rationale:
+article_28_required: UNKNOWN
+article_28_ref:
+documented_instructions_ref:
+confidentiality_ref:
+security_measures_ref:
+subprocessors_ref:
+data_subject_rights_assistance_ref:
+data_breach_assistance_ref:
+dpia_assistance_ref:
+end_of_service_return_delete_ref:
+```
+
+`privacy_role: UNKNOWN` o `article_28_required: UNKNOWN` blocca i dati reali quando il gestore ha accesso o tratta dati del pilot.
+
+---
+
+# 5. AI provider/system addendum
+
+Per un provider/sistema AI, oltre alla scheda generale, registrare **separatamente per ogni use case**:
 
 ```yaml
 use_case: TUTOR_ASSISTANCE | FEEDBACK | CORRECTION | GRADE_PROPOSAL | AUTOMATED_GRADING | ADAPTIVE_PATH
+intended_purpose:
+system_name:
+system_version:
+model_or_model_family:
+provider_documentation_version:
 policy_ref:
+
 DPIA_screening_ref:
-AI_Act_classification_ref:
+DPIA_ref:
+AI_Act_classification: NOT_APPLICABLE | NON_HIGH_RISK | HIGH_RISK_CANDIDATE | HIGH_RISK | UNKNOWN
+AI_Act_classification_rationale_ref:
+article_6_3_exception_claimed: false
+article_6_3_evidence_ref:
+FRIA_ref:
+AI_literacy_evidence_ref:
+EU_database_registration_ref:
+provider_high_risk_documentation_ref:
+
 allowed_context_fields: []
 forbidden_context_fields: []
+special_category_data_allowed: false
+cross_student_context_allowed: false
+hidden_tests_allowed: false
+teacher_solution_allowed: false
+
 payload_persistence_gateway: false
 provider_retention:
 provider_training_use:
+automatic_log_retention_deployer:
 human_oversight:
 quality_gate_ref:
+monitoring_ref:
+incident_reporting_ref:
+kill_switch:
 real_student_data_enabled: false
 ```
 
 Un provider approvato per `TUTOR_ASSISTANCE` non è automaticamente approvato per `GRADE_PROPOSAL` o `AUTOMATED_GRADING`.
 
+Un workflow `AI proposes -> docente decides` non è evidence sufficiente, da solo, per classificare il sistema non-high-risk.
+
 ---
 
-# 5. Evidence richiesta
+# 6. High-risk AI evidence
+
+Se `AI_Act_classification = HIGH_RISK`, prima dell'uso reale registrare almeno:
+
+- [ ] intended purpose e classificazione versionati;
+- [ ] istruzioni/documentazione del provider;
+- [ ] human oversight implementation;
+- [ ] AI literacy evidence;
+- [ ] input data governance applicabile;
+- [ ] monitoring/suspension procedure;
+- [ ] incident/risk reporting procedure;
+- [ ] log automatic retention sotto il controllo del deployer coerente con l'art. 26 e con l'eventuale disciplina applicabile;
+- [ ] DPIA reference quando applicabile;
+- [ ] FRIA reference quando applicabile;
+- [ ] registrazione/obblighi banca dati UE verificati per il deployer pubblico;
+- [ ] transparency/informativa reference;
+- [ ] fallback/kill switch testato.
+
+Per i log high-risk sotto controllo del deployer non usare automaticamente il default `30d`: quando si applica l'art. 26 AI Act, la baseline deve rispettare il minimo di **sei mesi**, salvo diversa disciplina applicabile.
+
+---
+
+# 7. Evidence richiesta
 
 Non salvare secret nel registro. Evidence accettabile:
 
 - link/versione contrattuale;
-- DPA/reference;
-- elenco subprocessor/versione;
+- DPA/reference art. 28;
+- elenco subprocessor/versione e modello di autorizzazione;
 - regione/localizzazione dichiarata;
-- policy retention/data use;
+- transfer mechanism reference;
+- policy retention/data use/training;
 - configurazione account/tenant rilevante;
+- provider AI classification/high-risk documentation;
+- FRIA/DPIA references;
+- EU database registration evidence quando applicabile;
 - screenshot sanitizzato solo se necessario;
 - test secret-safe e provider adapter contract.
 
 ---
 
-# 6. Gate
+# 8. Gate provider prima del GO core
 
-Prima del GO pilot con dati reali:
+- [ ] P-00 gestore tecnico qualificato o marcato N.A. con rationale self-hosted.
+- [ ] P-01 Google OIDC review completata.
+- [ ] P-04 hosting completato.
+- [ ] P-05 backup completato.
+- [ ] GitHub/GitLab review completata per i servizi effettivamente usati.
+- [ ] trasferimenti e garanzie documentati.
+- [ ] contratti/DPA richiesti registrati.
+- [ ] review date e owner assegnati.
+- [ ] eventuali provider AI non approvati restano tecnicamente disabilitati sui dati reali.
 
-- [ ] P-01 Google OIDC review completata;
-- [ ] provider hosting completato;
-- [ ] provider backup completato;
-- [ ] GitHub/GitLab review completata per i servizi effettivamente usati;
-- [ ] eventuali provider AI restano disabilitati oppure possiedono approval per il use case reale;
-- [ ] trasferimenti e garanzie sono documentati;
-- [ ] contratti/DPA richiesti sono registrati;
-- [ ] review date e owner sono assegnati.
+---
 
-Se il nuovo rehearsal #678 esclude formalmente l'AI esterna, i provider AI possono restare `DISABLED ON REAL DATA` senza bloccare il GO del perimetro non-AI; non possono però essere invocati durante il run reale.
+# 9. Gate provider prima del GO di un use case AI
+
+- [ ] provider generale `APPROVED_REAL_DATA`;
+- [ ] use-case addendum completo;
+- [ ] data minimisation/forbidden fields policy completa;
+- [ ] provider retention/training use verificati;
+- [ ] classificazione AI Act chiusa;
+- [ ] DPIA/FRIA references chiusi quando applicabili;
+- [ ] high-risk deployer evidence completa quando applicabile;
+- [ ] AI literacy, human oversight e quality gates completi;
+- [ ] kill switch testato;
+- [ ] informativa coerente con provider/use case/versione.
+
+Se il nuovo rehearsal #678 esclude formalmente l'AI esterna, questi gate AI non bloccano il GO del perimetro non-AI; nessun provider AI può però essere invocato con dati reali durante quel run.

--- a/doc/governance/PILOT_SCHOOL_COMPLIANCE_CHECKLIST_2026_2027.md
+++ b/doc/governance/PILOT_SCHOOL_COMPLIANCE_CHECKLIST_2026_2027.md
@@ -1,0 +1,320 @@
+# TheBitLab pilot 2026/2027 — School GDPR & AI Act compliance checklist
+
+## Stato
+
+**BOZZA OPERATIVA PER DIRIGENTE, RPD/DPO E RESPONSABILI DEL PILOT.**
+
+Questa checklist integra il pacchetto governance del pilot TheBitLab alla luce del quadro applicabile al 18 agosto 2026. Non costituisce parere legale, non sostituisce gli atti dell'Istituto e non dichiara automaticamente la conformità del trattamento.
+
+La checklist serve a decidere in modo verificabile se il pilot può passare da dati demo/sintetici a dati reali e, separatamente, se uno specifico use case di intelligenza artificiale può essere attivato.
+
+Documenti collegati:
+
+- `PILOT_APPROVAL_BRIEF_2026_2027.md`;
+- `PILOT_APPROVAL_RECORD_2026_2027.md`;
+- `PILOT_GOVERNANCE_2026_2027.md`;
+- `PILOT_PRIVACY_NOTICE_DRAFT.md`;
+- `PILOT_DPIA_SCREENING.md`;
+- `PILOT_PROVIDER_REGISTER.md`;
+- issue governance `#699`, AI boundary `#710`, use case AI `#712`–`#715`.
+
+---
+
+# 1. Due gate distinti: core e AI
+
+TheBitLab distingue due autorizzazioni indipendenti.
+
+## Gate A — pilot core con dati reali
+
+Può comprendere:
+
+- autenticazione e identity binding;
+- classi e membership;
+- activity e assignment;
+- elaborati, tentativi e report;
+- grading deterministico/test runner;
+- feedback docente;
+- help non-AI;
+- dashboard docente;
+- backup/restore;
+- audit e incident response.
+
+Il `GO core` **non autorizza automaticamente alcun provider o use case AI esterno**.
+
+## Gate B — singolo use case AI con dati reali
+
+Ogni use case AI ha un gate separato:
+
+- `TUTOR_ASSISTANCE`;
+- `FEEDBACK`;
+- `CORRECTION`;
+- `GRADE_PROPOSAL`;
+- `AUTOMATED_GRADING`;
+- `ADAPTIVE_PATH`.
+
+Se il pilot iniziale mantiene tutti i provider AI disabilitati sui dati reali, gli obblighi specifici relativi all'impiego concreto di un sistema AI ad alto rischio non bloccano il `GO core`. Restano applicabili gli obblighi GDPR e le altre regole pertinenti al trattamento core.
+
+---
+
+# 2. Accountability della scuola — GDPR
+
+Prima del `GO core`:
+
+- [ ] L'Istituto è identificato quale Titolare del trattamento per il perimetro di propria competenza, salvo diversa qualificazione documentata per specifici trattamenti.
+- [ ] Sono registrati Dirigente/rappresentante, contatto privacy e RPD/DPO.
+- [ ] Finalità e basi giuridiche sono definite per ciascun trattamento effettivamente attivato.
+- [ ] L'informativa ex art. 13 GDPR è completata, approvata e resa agli interessati con modalità documentata.
+- [ ] Il trattamento TheBitLab è inserito o aggiornato nel **Registro delle attività di trattamento ex art. 30 GDPR** dell'Istituto, con finalità, interessati, categorie dati, destinatari, trasferimenti, retention e misure di sicurezza pertinenti.
+- [ ] La DPIA screening è completata sul perimetro reale.
+- [ ] Se la screening conclude per rischio elevato, la DPIA è completata **prima** dell'inizio del trattamento interessato.
+- [ ] Le categorie di dati e le retention sono state approvate dal Titolare/RPD-DPO.
+- [ ] Sono definite le procedure per accesso, rettifica, limitazione/opposizione/cancellazione quando applicabili e per le altre richieste degli interessati.
+
+Il registro provider TheBitLab è un annex tecnico: **non sostituisce** il Registro delle attività di trattamento dell'Istituto.
+
+---
+
+# 3. Gestore tecnico, hosting e art. 28 GDPR
+
+Prima dell'uso con dati reali deve essere esplicitamente qualificato il modello operativo.
+
+## Modello 1 — self-hosted senza accesso del progetto ai dati
+
+Se l'Istituto gestisce l'istanza e TheBitPoets/maintainer non riceve né può accedere ai dati personali del pilot, il semplice sviluppo/pubblicazione del software non rende automaticamente il progetto responsabile del trattamento per i dati dell'Istituto. Restano da qualificare i provider effettivamente usati dalla scuola.
+
+## Modello 2 — servizio gestito o assistenza con accesso ai dati
+
+Se TheBitPoets, un gestore tecnico o altro soggetto esterno ospita il servizio, gestisce backup o database, effettua assistenza con possibilità di accesso ai dati o tratta comunque dati per conto della scuola:
+
+- [ ] il ruolo privacy è qualificato;
+- [ ] se opera come Responsabile del trattamento, esiste un contratto/atto conforme all'art. 28 GDPR;
+- [ ] sono definite istruzioni documentate del Titolare;
+- [ ] riservatezza e autorizzazioni del personale sono definite;
+- [ ] misure tecniche e organizzative sono documentate;
+- [ ] sub-responsabili e relativa autorizzazione sono governati;
+- [ ] assistenza per diritti, incidenti, DPIA e fine-servizio è prevista;
+- [ ] restituzione/cancellazione dei dati a fine rapporto è definita.
+
+`UNKNOWN` sul ruolo del gestore tecnico è un **NO-GO per dati reali**.
+
+---
+
+# 4. Dati particolari, inclusione e minimizzazione
+
+Il core TheBitLab non richiede per design dati sanitari, diagnosi, disabilità, DSA, informazioni psicologiche o altre categorie particolari ex art. 9 GDPR.
+
+Regole del pilot:
+
+- [ ] dati sanitari/DSA/disabilità non vengono inseriti automaticamente in profili, help, prompt AI, log o elaborati;
+- [ ] adattamenti didattici possono essere rappresentati, quando possibile, tramite configurazioni funzionali minimizzate che non espongono la diagnosi sottostante;
+- [ ] se una futura funzione richiede categorie particolari, viene aperto un trattamento/use case separato con base normativa, access matrix, informativa, retention e DPIA/risk review dedicate;
+- [ ] nessun provider AI riceve dati particolari solo perché presenti incidentalmente nel contesto.
+
+---
+
+# 5. Provider, trasferimenti e data use
+
+Per ogni provider effettivamente usato:
+
+- [ ] finalità e servizio sono documentati;
+- [ ] categorie dati e campi minimi sono noti;
+- [ ] ruolo privacy è qualificato;
+- [ ] DPA/atto art. 28 è disponibile quando applicabile;
+- [ ] subprocessori rilevanti sono documentati;
+- [ ] localizzazione del trattamento è nota;
+- [ ] eventuali trasferimenti verso paesi terzi e relative garanzie sono valutati;
+- [ ] retention del provider è nota;
+- [ ] data use/training/product improvement è noto e compatibile con il trattamento;
+- [ ] misure di sicurezza sono valutate;
+- [ ] esistono owner, review date e procedura di disabilitazione/kill switch.
+
+Un campo `UNKNOWN` che può modificare la liceità o il rischio del trattamento mantiene il provider disabilitato sui dati reali.
+
+---
+
+# 6. Sicurezza e data breach
+
+Prima del `GO core`:
+
+- [ ] authorization class-scoped e isolamento cross-student sono verificati;
+- [ ] HTTPS e gestione dei secret sono configurati;
+- [ ] query OAuth, cookie, bearer, proof e secret non vengono persistiti nei log applicativi/proxy;
+- [ ] backup è cifrato, bounded e sottoposto a restore periodico verificato;
+- [ ] accessi amministrativi/tecnici sono least-privilege e tracciabili;
+- [ ] esiste una procedura di revoca account/sessioni/credenziali;
+- [ ] esiste un processo di incident response collegato a quello dell'Istituto;
+- [ ] il Responsabile del trattamento, quando presente, informa il Titolare **senza ingiustificato ritardo** dopo essere venuto a conoscenza di una violazione di dati personali;
+- [ ] il Titolare dispone della procedura per valutare e, quando dovuto, notificare la violazione all'autorità di controllo entro il termine previsto dall'art. 33 GDPR, nonché per la comunicazione agli interessati quando applicabile;
+- [ ] ogni data breach e relative decisioni vengono documentati.
+
+TheBitLab non decide automaticamente se una violazione debba essere notificata: prepara evidence minimizzata e tempi sufficienti affinché il Titolare possa assumere la decisione prevista dalla normativa.
+
+---
+
+# 7. AI Act — baseline applicabile al pilot 2026/2027
+
+Dal 2 agosto 2026 si applica in via generale il Regolamento (UE) 2024/1689 secondo il calendario dell'art. 113, fatte salve le disposizioni con date specifiche differenti.
+
+Per TheBitLab valgono almeno questi invarianti:
+
+## 7.1 AI literacy — art. 4
+
+Prima dell'uso di funzioni AI:
+
+- [ ] docenti che interpretano output AI ricevono formazione adeguata al use case;
+- [ ] admin/gestori tecnici conoscono limiti, configurazioni, rischi e procedure di sospensione;
+- [ ] chi svolge human oversight su sistemi ad alto rischio possiede competenza, formazione, autorità e supporto adeguati;
+- [ ] la formazione è documentata e aggiornata quando cambiano sistema/use case/rischi.
+
+## 7.2 Pratiche vietate
+
+Il pilot vieta per design:
+
+- inferenza/riconoscimento delle emozioni in ambito scolastico salvo lo stretto perimetro delle eccezioni previste dal Regolamento per ragioni mediche o di sicurezza;
+- social scoring o profilazione comportamentale generalizzata non necessaria alla finalità didattica;
+- manipolazione o sfruttamento della vulnerabilità degli studenti nei casi vietati dall'art. 5 AI Act.
+
+Nessuna feature può essere attivata solo perché tecnicamente disponibile presso un provider.
+
+---
+
+# 8. Classificazione AI per use case educativo
+
+La classificazione è effettuata sul **sistema e intended purpose effettivi**, non sul nome commerciale del modello.
+
+| Use case TheBitLab | Default di governance | Nota |
+|---|---|---|
+| Tutor/spiegazioni/debugging non valutativo | `NON_HIGH_RISK_CANDIDATE` | solo se non valuta risultati, non profila e non influenza materialmente livello/percorso/decisioni |
+| Feedback formativo non valutativo | `NON_HIGH_RISK_CANDIDATE` | riesaminare se entra nella decisione valutativa |
+| Correzione/proposta di punteggio o voto | `HIGH_RISK_CANDIDATE` | può ricadere nell'Allegato III, istruzione, quando valuta risultati dell'apprendimento |
+| Grading automatico con impatto reale | `HIGH_RISK_CANDIDATE / presumptive HIGH_RISK` | attivazione reale bloccata fino a classificazione e obblighi completi |
+| Adaptive learning che orienta materialmente percorso/livello | `HIGH_RISK_CANDIDATE / presumptive HIGH_RISK` | valutare Allegato III istruzione e impatto concreto |
+| Decisioni su accesso/ammissione/livello | `HIGH_RISK_CANDIDATE / presumptive HIGH_RISK` | gate più forte |
+
+Un workflow `AI proposes -> docente decides` **non determina da solo** una classificazione non-high-risk. Occorre valutare se il sistema valuta i risultati dell'apprendimento o influenza materialmente la decisione e, se viene invocata l'eccezione dell'art. 6(3), documentarne tutti i presupposti applicabili. La profilazione impedisce di usare l'eccezione prevista dall'art. 6(3).
+
+`UNKNOWN` mantiene il use case disabilitato sui dati reali.
+
+---
+
+# 9. High-risk AI — obblighi del deployer scuola
+
+Se uno use case è classificato come sistema AI ad alto rischio ai sensi dell'art. 6(2)/Allegato III, prima dell'uso reale l'Istituto, quale deployer nel proprio perimetro, verifica e documenta almeno:
+
+- [ ] sistema/provider e intended purpose approvati;
+- [ ] istruzioni d'uso e documentazione del provider disponibili;
+- [ ] human oversight affidata a persone con competenza, formazione, autorità e supporto necessari;
+- [ ] dati di input sotto il controllo del deployer pertinenti e sufficientemente rappresentativi rispetto alla finalità, quando l'obbligo è applicabile;
+- [ ] monitoraggio del funzionamento e procedura di sospensione in caso di rischio/incidente;
+- [ ] procedura di segnalazione al provider/distributore e alle autorità competenti quando richiesta;
+- [ ] log generati automaticamente sotto il controllo del deployer conservati per **almeno sei mesi**, salvo diversa disciplina applicabile;
+- [ ] uso delle informazioni del provider per completare/aggiornare la DPIA GDPR quando applicabile;
+- [ ] obblighi di registrazione nella banca dati UE verificati prima dell'uso da parte dell'autorità/organismo pubblico e stato della registrazione documentato;
+- [ ] obblighi di informazione/trasparenza verso persone interessate e personale rispettati;
+- [ ] feature flag/kill switch e fallback a workflow umano disponibili e collaudati.
+
+La retention tecnica `AI audit metadata = 30 giorni` prevista come default del gateway vale quindi solo quando non confligge con obblighi più lunghi applicabili. Per un sistema high-risk soggetto all'art. 26, i log automatici sotto il controllo del deployer seguono il minimo di sei mesi previsto dal Regolamento, salvo diversa disciplina applicabile.
+
+---
+
+# 10. FRIA AI Act e DPIA GDPR sono valutazioni distinte
+
+Per un sistema AI ad alto rischio di cui all'art. 6(2), quando la scuola rientra tra i deployer pubblici soggetti all'art. 27 AI Act, prima dell'uso deve essere effettuata una **Fundamental Rights Impact Assessment (FRIA)**.
+
+La FRIA deve descrivere almeno, secondo l'art. 27:
+
+- processi in cui il sistema viene utilizzato e intended purpose;
+- durata e frequenza d'uso;
+- categorie di persone/gruppi interessati;
+- rischi specifici di danno ai diritti fondamentali nel contesto reale;
+- implementazione concreta della human oversight;
+- misure di mitigazione e governance, inclusi meccanismi di reclamo/ricorso pertinenti.
+
+Regole TheBitLab:
+
+- [ ] `PILOT_DPIA_SCREENING.md` decide il gate GDPR/DPIA;
+- [ ] classificazione AI Act decide se si applica il gate high-risk;
+- [ ] quando applicabile, viene compilata una FRIA prima dell'attivazione;
+- [ ] DPIA e FRIA possono essere integrate operativamente per le parti sovrapposte, ma nessuna delle due viene considerata automaticamente sostitutiva dell'altra;
+- [ ] l'esito e gli eventuali adempimenti verso l'autorità di vigilanza previsti dall'art. 27 sono documentati dal deployer.
+
+---
+
+# 11. Informativa e processi automatizzati
+
+Se un use case AI è attivato con dati reali, l'informativa deve essere aggiornata alla configurazione effettiva e indicare almeno, quando dovuto:
+
+- presenza e finalità della funzione AI;
+- categorie di dati inviate;
+- provider/destinatari e trasferimenti;
+- retention pertinente;
+- distinzione tra suggerimento AI, evidence deterministica e decisione docente;
+- logica, importanza e conseguenze previste dei processi automatizzati nei casi previsti dal GDPR;
+- modalità di human review, contestazione e override applicabili.
+
+---
+
+# 12. Decisione GO/NO-GO
+
+## GO core con dati reali
+
+Può essere firmato solo se:
+
+- [ ] governance GDPR approvata;
+- [ ] Registro art. 30 aggiornato;
+- [ ] informativa approvata e pronta alla pubblicazione;
+- [ ] ruoli controller/processor/provider definiti;
+- [ ] contratti/DPA e trasferimenti verificati;
+- [ ] retention approvate;
+- [ ] DPIA screening chiusa e DPIA completata quando richiesta;
+- [ ] security/authz/logging/backup/restore gate tecnici PASS;
+- [ ] incident response e data breach workflow collegati all'Istituto;
+- [ ] eventuali categorie particolari escluse o separatamente governate;
+- [ ] tutti gli use case AI non approvati sono tecnicamente disabilitati sui dati reali.
+
+## GO use case AI con dati reali
+
+Richiede inoltre:
+
+- [ ] use case e intended purpose versionati;
+- [ ] provider e data boundary #710 approvati;
+- [ ] AI literacy adeguata;
+- [ ] classificazione AI Act documentata;
+- [ ] DPIA/FRIA completate quando applicabili;
+- [ ] obblighi deployer high-risk completati quando applicabili;
+- [ ] human oversight e contestazione testate;
+- [ ] retention/logging coerenti con la classificazione;
+- [ ] informativa aggiornata;
+- [ ] decisione istituzionale riferita alla release/use-case esatti.
+
+---
+
+# 13. Evidence da allegare al fascicolo della scuola
+
+Il fascicolo istituzionale dovrebbe poter referenziare senza segreti:
+
+1. versione del pacchetto governance;
+2. estratto/riferimento del Registro art. 30 aggiornato;
+3. informativa approvata;
+4. DPIA screening ed eventuale DPIA;
+5. provider register + DPA/contratti/riferimenti ai subprocessor;
+6. decisione su ruolo del gestore tecnico;
+7. retention policy;
+8. incident/data breach procedure;
+9. evidence di backup/restore e security rehearsal sanitizzate;
+10. per AI: classificazione, AI literacy, eventuale FRIA, documentazione high-risk/deployer e provider evidence;
+11. `PILOT_APPROVAL_RECORD_2026_2027.md` firmato/riferimento all'atto istituzionale;
+12. verbale finale `GO/NO-GO` del pilot.
+
+---
+
+## Riferimenti normativi/istituzionali per la review
+
+- Regolamento (UE) 2016/679 (GDPR), in particolare artt. 5, 6, 13, 25, 28, 30, 32, 33, 34 e 35.
+- Regolamento (UE) 2024/1689 (AI Act), in particolare artt. 4, 5, 6, 26, 27, 49 e 113 e Allegato III, punto 3.
+- Garante per la protezione dei dati personali, vademecum e materiali aggiornati per la scuola.
+- Garante, parere 4 agosto 2025 sulle Linee guida MIM per l'introduzione dell'IA nelle istituzioni scolastiche.
+- Garante, attività istruttoria/comunicazione 3 giugno 2026 sui progetti di IA in ambito scolastico.
+- Garante, pareri 14 luglio 2026 sugli schemi nazionali di adeguamento al Regolamento IA, inclusi i profili relativi a istruzione e formazione.
+
+Questi riferimenti devono essere ricontrollati al momento dell'approvazione istituzionale e ogni volta che cambia materialmente il perimetro normativo o tecnico.


### PR DESCRIPTION
Implements the structured school/DPO governance package required by #699 without claiming legal approval or automatic GDPR compliance.

Current package:
- `doc/governance/PILOT_SCHOOL_COMPLIANCE_CHECKLIST_2026_2027.md`: operational school checklist integrating GDPR accountability and the AI Act framework applicable to the 2026/27 pilot;
- `doc/governance/PILOT_APPROVAL_BRIEF_2026_2027.md`: concise brief for Dirigente and RPD/DPO;
- `doc/governance/PILOT_APPROVAL_RECORD_2026_2027.md`: institutional decision/sign-off record;
- `doc/governance/PILOT_GOVERNANCE_2026_2027.md`: canonical privacy/governance baseline aligned with the 2026 GDPR + AI Act gates;
- `doc/governance/PILOT_PRIVACY_NOTICE_DRAFT.md`: Article-13-oriented student/family notice template;
- `doc/governance/PILOT_DPIA_SCREENING.md`: GDPR DPIA screening coordinated with AI Act classification and FRIA screening;
- `doc/governance/PILOT_PROVIDER_REGISTER.md`: provider/processor/subprocessor/transfer/retention register with AI-system evidence fields.

Governance decisions already recorded from #699/#700:
- Workspace school accounts and personal Gmail are technically supported; the school decides the allowed policy and Google identity is never internal authorization;
- daily backup, RPO 24h, RTO 8 working hours;
- all planned AI capabilities remain on the roadmap, but real-student activation is gated per use case through #710–#715;
- the initial real-data pilot may obtain `GO core` with all external AI disabled, keeping AI authorization as a separate use-case gate.

2026 compliance review additions:
- explicit school Record of Processing Activities / GDPR Article 30 gate;
- explicit technical-operator qualification and Article 28 processor decision when applicable;
- special-category data excluded from core/help/AI by default;
- GDPR breach workflow linkage (processor -> controller without undue delay; controller decision under Articles 33–34);
- AI Act Article 4 literacy and Article 5 prohibited-practice guardrails;
- Annex III education/high-risk classification gate; `AI proposes -> teacher decides` is not treated as an automatic non-high-risk exception;
- deployer obligations for high-risk AI, including applicable logging/registration duties and the Article 26 minimum logging period when applicable;
- explicit distinction between GDPR DPIA and AI Act Article 27 FRIA, with integration allowed only for overlapping content.

Important: the package remains `DRAFT FOR SCHOOL/DPO APPROVAL`. It does not close #699 and does not authorize real-student data until legal bases, RoPA, provider roles/contracts, final retention, DPIA screening/required DPIA, institutional approvals and the applicable technical gates are completed.

Before merge this PR still requires a clean documentation/consistency review and green CI on the current head.