### PR TITLE
Pilot deployment-as-code: nginx, systemd e data root

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "scripts/**"
       - "schemas/**"
+      - "deploy/**"
       - "tests/**"
       - "activities/**"
       - "doc/**"
@@ -25,6 +26,7 @@ on:
     paths:
       - "scripts/**"
       - "schemas/**"
+      - "deploy/**"
       - "tests/**"
       - "activities/**"
       - "doc/**"
@@ -52,6 +54,9 @@ jobs:
 
       - name: Install test dependencies
         run: python -m pip install -r requirements-dev.txt -r requirements-utui.txt -r requirements-auth.txt
+
+      - name: Install deployment lint tools
+        run: sudo apt-get update && sudo apt-get install -y nginx
 
       - name: Run Python tests
         run: python -m pytest

--- a/deploy/pilot/candidate.example.json
+++ b/deploy/pilot/candidate.example.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../../schemas/pilot-deployment.schema.json",
+  "schema_version": "thebitlab.pilot-deployment.v1",
+  "deployment_id": "pilot-candidate-example",
+  "release": {
+    "commit": "0123456789abcdef0123456789abcdef01234567",
+    "repository_root": "/opt/thebitlab/current",
+    "python_executable": "/opt/thebitlab/current/.venv/bin/python"
+  },
+  "service": {
+    "user": "thebitlab",
+    "group": "thebitlab",
+    "home_directory": "/home/thebitlab",
+    "bind_host": "127.0.0.1",
+    "port": 8000,
+    "environment_file": "/etc/thebitlab/secrets/pilot.env",
+    "lock_directory": "/run/thebitlab"
+  },
+  "data": {
+    "root": "/srv/thebitlab/data",
+    "auth_db_path": ".thebitlab-auth/auth.sqlite3"
+  },
+  "origin": {
+    "url": "https://candidate.example.edu",
+    "exposure": "edge_only",
+    "allowed_proxy_cidrs": [
+      "192.0.2.0/24",
+      "2001:db8::/32"
+    ],
+    "tls_certificate_file": "/etc/thebitlab/tls/origin.crt",
+    "tls_private_key_file": "/etc/thebitlab/tls/origin.key",
+    "access_log": "/var/log/nginx/thebitlab-access.log",
+    "error_log": "/var/log/nginx/thebitlab-error.log"
+  },
+  "features": {
+    "google_auth": true,
+    "github_oauth": false,
+    "github_app_token_runtime": false
+  }
+}

--- a/deploy/pilot/pilot.env.example
+++ b/deploy/pilot/pilot.env.example
@@ -1,0 +1,17 @@
+# CONTRACT TEMPLATE ONLY. Do not deploy this file and do not commit real values.
+# The real file lives at service.environment_file from the deployment manifest,
+# is owned by root:<service-group>, and has mode 0640 or stricter.
+THEBITLAB_TEACHER_TOKEN=<external-secret-at-least-32-characters>
+THEBITLAB_GOOGLE_CLIENT_ID=<external-google-client-id>
+THEBITLAB_GOOGLE_CLIENT_SECRET=<external-google-client-secret>
+THEBITLAB_AUTH_CSRF_SECRET_B64=<external-independent-base64url-secret>
+THEBITLAB_RATE_LIMIT_PEPPER_B64=<external-independent-base64url-secret>
+THEBITLAB_TUI_PAIRING_PEPPER_B64=<external-independent-base64url-secret>
+
+# Required together only when features.github_oauth=true.
+# THEBITLAB_GITHUB_CLIENT_ID=<external-github-client-id>
+# THEBITLAB_GITHUB_CLIENT_SECRET=<external-github-client-secret>
+
+# Deliberately forbidden here because the rendered unit owns them:
+# THEBITLAB_AUTH_DB_PATH, THEBITLAB_TRUSTED_PROXY_CIDRS,
+# THEBITLAB_GOOGLE_REDIRECT_URI, THEBITLAB_GITHUB_REDIRECT_URI.

--- a/deploy/pilot/pilot.env.example
+++ b/deploy/pilot/pilot.env.example
@@ -12,6 +12,7 @@ THEBITLAB_TUI_PAIRING_PEPPER_B64=<external-independent-base64url-secret>
 # THEBITLAB_GITHUB_CLIENT_ID=<external-github-client-id>
 # THEBITLAB_GITHUB_CLIENT_SECRET=<external-github-client-secret>
 
-# Deliberately forbidden here because the rendered unit owns them:
-# THEBITLAB_AUTH_DB_PATH, THEBITLAB_TRUSTED_PROXY_CIDRS,
-# THEBITLAB_GOOGLE_REDIRECT_URI, THEBITLAB_GITHUB_REDIRECT_URI.
+# Deliberately forbidden here because the rendered launcher owns them:
+# THEBITLAB_DEPLOYMENT_REVISION, THEBITLAB_LOCK_DIR, THEBITLAB_AUTH_DB_PATH,
+# THEBITLAB_TRUSTED_PROXY_CIDRS, THEBITLAB_GOOGLE_REDIRECT_URI,
+# THEBITLAB_GITHUB_REDIRECT_URI. Any other unlisted name is also rejected.

--- a/deploy/pilot/templates/thebitlab-log-format.conf.template
+++ b/deploy/pilot/templates/thebitlab-log-format.conf.template
@@ -1,0 +1,5 @@
+# Query-bearing request fields are deliberately excluded because OAuth
+# callbacks and other URLs may carry credentials.
+log_format thebitlab '$remote_addr - $remote_user [$time_local] '
+                     '"$request_method $uri $server_protocol" $status $body_bytes_sent '
+                     '"$http_user_agent" request_id=$request_id';

--- a/deploy/pilot/templates/thebitlab-nginx.conf.template
+++ b/deploy/pilot/templates/thebitlab-nginx.conf.template
@@ -1,0 +1,65 @@
+# Generated from a versioned deployment manifest. Do not edit in place.
+
+# Reject unknown SNI/Host traffic, including direct-IP probes.
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    access_log off;
+    return 444;
+}
+
+server {
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    server_name _;
+    ssl_reject_handshake on;
+    access_log off;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name @@ORIGIN_HOST@@;
+@@ORIGIN_ACCESS_RULES@@
+    access_log @@ACCESS_LOG@@ thebitlab;
+    error_log @@ERROR_LOG@@ warn;
+    return 308 https://@@ORIGIN_HOST@@$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name @@ORIGIN_HOST@@;
+@@ORIGIN_ACCESS_RULES@@
+    ssl_certificate @@TLS_CERTIFICATE_FILE@@;
+    ssl_certificate_key @@TLS_PRIVATE_KEY_FILE@@;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_cache shared:thebitlab_tls:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    access_log @@ACCESS_LOG@@ thebitlab;
+    error_log @@ERROR_LOG@@ warn;
+    server_tokens off;
+    client_max_body_size 32m;
+
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header Referrer-Policy no-referrer always;
+
+    location / {
+        proxy_pass http://127.0.0.1:@@APP_PORT@@;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        # Overwrite untrusted inbound forwarding data with one bounded hop.
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
+    }
+}

--- a/deploy/pilot/templates/thebitlab.service.template
+++ b/deploy/pilot/templates/thebitlab.service.template
@@ -1,0 +1,53 @@
+[Unit]
+Description=TheBitLab pilot application (@@DEPLOYMENT_ID@@)
+Documentation=file://@@REPOSITORY_ROOT@@/doc/PILOT_DEPLOYMENT.md
+Wants=network-online.target
+After=network-online.target
+ConditionPathIsDirectory=@@REPOSITORY_ROOT@@
+ConditionPathIsDirectory=@@DATA_ROOT@@
+ConditionPathExists=@@ENVIRONMENT_FILE@@
+
+[Service]
+Type=simple
+User=@@SERVICE_USER@@
+Group=@@SERVICE_GROUP@@
+WorkingDirectory=@@REPOSITORY_ROOT@@
+RuntimeDirectory=thebitlab
+RuntimeDirectoryMode=0700
+UMask=0077
+
+# Secrets are supplied only by this external, protected file. The explicit
+# values below come later and therefore own topology/path resolution.
+EnvironmentFile=@@ENVIRONMENT_FILE@@
+Environment=PYTHONUNBUFFERED=1
+Environment=HOME=@@HOME_DIRECTORY@@
+Environment=THEBITLAB_DEPLOYMENT_REVISION=@@RELEASE_COMMIT@@
+Environment=THEBITLAB_LOCK_DIR=@@LOCK_DIRECTORY@@
+Environment=THEBITLAB_AUTH_DB_PATH=@@AUTH_DB_PATH@@
+Environment=THEBITLAB_TRUSTED_PROXY_CIDRS=127.0.0.1/32
+Environment=THEBITLAB_GOOGLE_REDIRECT_URI=@@GOOGLE_REDIRECT_URI@@
+@@GITHUB_REDIRECT_ENV@@
+
+ExecStart=@@PYTHON_EXECUTABLE@@ scripts/course_board_server.py --host @@BIND_HOST@@ --port @@APP_PORT@@ --root @@DATA_ROOT@@ --enable-google-auth@@GITHUB_APP_FLAG@@
+Restart=on-failure
+RestartSec=5s
+TimeoutStartSec=30s
+TimeoutStopSec=45s
+KillSignal=SIGINT
+SuccessExitStatus=130
+
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=@@DATA_ROOT@@ @@LOCK_DIRECTORY@@@@GITHUB_APP_WRITE_PATH@@
+RestrictSUIDSGID=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/pilot/templates/thebitlab.service.template
+++ b/deploy/pilot/templates/thebitlab.service.template
@@ -16,19 +16,13 @@ RuntimeDirectory=thebitlab
 RuntimeDirectoryMode=0700
 UMask=0077
 
-# Secrets are supplied only by this external, protected file. The explicit
-# values below come later and therefore own topology/path resolution.
-EnvironmentFile=@@ENVIRONMENT_FILE@@
+# Do not use EnvironmentFile= here: systemd gives it precedence over
+# Environment=. The launcher validates the protected file at every start,
+# imports only allowlisted secrets, and sets manifest-owned topology itself.
 Environment=PYTHONUNBUFFERED=1
 Environment=HOME=@@HOME_DIRECTORY@@
-Environment=THEBITLAB_DEPLOYMENT_REVISION=@@RELEASE_COMMIT@@
-Environment=THEBITLAB_LOCK_DIR=@@LOCK_DIRECTORY@@
-Environment=THEBITLAB_AUTH_DB_PATH=@@AUTH_DB_PATH@@
-Environment=THEBITLAB_TRUSTED_PROXY_CIDRS=127.0.0.1/32
-Environment=THEBITLAB_GOOGLE_REDIRECT_URI=@@GOOGLE_REDIRECT_URI@@
-@@GITHUB_REDIRECT_ENV@@
 
-ExecStart=@@PYTHON_EXECUTABLE@@ scripts/course_board_server.py --host @@BIND_HOST@@ --port @@APP_PORT@@ --root @@DATA_ROOT@@ --enable-google-auth@@GITHUB_APP_FLAG@@
+ExecStart=@@PYTHON_EXECUTABLE@@ scripts/pilot_service_launcher.py --environment-file @@ENVIRONMENT_FILE@@ --deployment-revision @@RELEASE_COMMIT@@ --lock-directory @@LOCK_DIRECTORY@@ --auth-db-path @@AUTH_DB_PATH@@ --trusted-proxy-cidrs 127.0.0.1/32 --google-redirect-uri @@GOOGLE_REDIRECT_URI@@@@GITHUB_OAUTH_ARGUMENTS@@ --host @@BIND_HOST@@ --port @@APP_PORT@@ --root @@DATA_ROOT@@ --enable-google-auth@@GITHUB_APP_FLAG@@
 Restart=on-failure
 RestartSec=5s
 TimeoutStartSec=30s

--- a/doc/ARCHITETTURA_MVP.md
+++ b/doc/ARCHITETTURA_MVP.md
@@ -157,6 +157,8 @@ Riferimenti: [grading](ASSIGNMENT_GRADING.md), [sandbox](ASSIGNMENT_SANDBOX.md),
 
 ## Deployment pilot
 
+La baseline operativa versionata è definita in [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md): manifest chiuso, template nginx/systemd, root unica, riferimenti secret esterni, contratto firewall e rollback bounded. Configurazioni live o copie manuali non versionate non sono fonti architetturali.
+
 Configurazione iniziale raccomandata:
 
 - una replica applicativa;

--- a/doc/INFRASTRUTTURA_PRODUZIONE.md
+++ b/doc/INFRASTRUTTURA_PRODUZIONE.md
@@ -3,6 +3,11 @@
 > Documento operativo e didattico: cosa abbiamo costruito, perché, e come
 > rifarlo da zero. Scritto per chi vuole capire ogni passaggio, non solo
 > ripeterlo. Ultimo aggiornamento: 4 agosto 2026.
+>
+> **Autorità deployment:** questa guida storica non è una configurazione
+> riproducibile. Per ogni nuova candidate usare la baseline versionata e
+> secret-safe in [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md); non ricopiare
+> configurazioni live nel repository.
 
 ---
 

--- a/doc/PILOT_DEPLOYMENT.md
+++ b/doc/PILOT_DEPLOYMENT.md
@@ -33,7 +33,7 @@ python scripts/pilot_deployment_smoke.py \
   --config deploy/pilot/candidate.example.json
 ```
 
-Lo smoke crea root, `EnvironmentFile`, certificato e output in una directory temporanea, esegue soltanto `nginx -t` e `systemd-analyze verify`, quindi elimina tutto. Non avvia né ricarica servizi.
+Lo smoke crea root, `EnvironmentFile`, certificato e output in una directory temporanea, esegue soltanto `nginx -t` e `systemd-analyze verify`, quindi elimina tutto. Per restare eseguibile senza privilegi, la sola copia nginx temporanea usa le porte 18080/18443; il bundle firmato resta invariato su 80/443. Non avvia né ricarica servizi.
 
 ## Contratto della data root
 

--- a/doc/PILOT_DEPLOYMENT.md
+++ b/doc/PILOT_DEPLOYMENT.md
@@ -1,0 +1,146 @@
+# Baseline deployment-as-code del pilot
+
+Questo documento è il contratto canonico per preparare una nuova candidate TheBitLab con nginx e systemd. Gli artefatti sono una baseline **offline**: non modificano DNS, Cloudflare, firewall, staging o produzione. La guida storica [`INFRASTRUTTURA_PRODUZIONE.md`](INFRASTRUTTURA_PRODUZIONE.md) descrive la topologia esistente, ma non sostituisce questo contratto versionato.
+
+## Artefatti e fonti di verità
+
+| Artefatto | Scopo |
+|---|---|
+| `deploy/pilot/candidate.example.json` | manifest di esempio senza segreti né valori live |
+| `schemas/pilot-deployment.schema.json` | schema chiuso di release, servizio, root e origin |
+| `schemas/pilot-environment.schema.json` | nomi e forma dell'`EnvironmentFile` esterno |
+| `deploy/pilot/templates/` | template nginx, formato log secret-safe e unit systemd |
+| `scripts/validate_pilot_deployment.py` | validazione semantica e rendering deterministico |
+| `scripts/pilot_deployment_smoke.py` | `nginx -t` e `systemd-analyze verify` su dati sintetici temporanei |
+| `tests/test_pilot_deployment.py` | casi positivi e negativi dei contratti |
+
+Ogni ambiente deve avere un manifest versionato derivato dall'esempio. `release.commit` è uno SHA Git completo; `deployment.lock.json`, prodotto dal renderer, lega lo SHA ai digest di tutti i file renderizzati. `release.python_executable` deve appartenere alla stessa release (tipicamente `.venv/bin/python`), così anche le dipendenze tornano indietro con il codice. Non attivare un bundle se checkout, manifest, lock o CI non coincidono.
+
+Validazione e rendering offline:
+
+```bash
+python scripts/validate_pilot_deployment.py \
+  --config deploy/pilot/candidate.example.json \
+  --output build/pilot-candidate
+```
+
+La directory output deve essere nuova: il renderer non sovrascrive un bundle. Il manifest di esempio usa dominio e reti riservati alla documentazione e **non è una configurazione installabile** finché non viene derivato un manifest candidate approvato.
+
+Smoke non distruttivo su Linux, senza usare riferimenti o segreti reali:
+
+```bash
+python scripts/pilot_deployment_smoke.py \
+  --config deploy/pilot/candidate.example.json
+```
+
+Lo smoke crea root, `EnvironmentFile`, certificato e output in una directory temporanea, esegue soltanto `nginx -t` e `systemd-analyze verify`, quindi elimina tutto. Non avvia né ricarica servizi.
+
+## Contratto della data root
+
+`data.root` è l'unica root persistente autorevole dell'istanza pilot. Deve essere:
+
+- assoluta, dedicata, esterna al checkout/release e non un symlink;
+- posseduta dall'account di servizio, non accessibile ad altri utenti non autorizzati;
+- condivisa dalla sola replica applicativa, dashboard, activity, assegnazioni, report e dati didattici della candidate;
+- inclusa per intero nella procedura di backup/restore approvata, salvo i segreti esterni;
+- invariata durante un rollback del solo codice/configurazione.
+
+`data.auth_db_path` è sempre relativo alla root. Il percorso effettivo è quindi, senza fallback o seconda sorgente:
+
+```text
+<data.root>/<data.auth_db_path>
+```
+
+La baseline usa `.thebitlab-auth/auth.sqlite3`. L'unit renderizzata dichiara `THEBITLAB_AUTH_DB_PATH` **dopo** l'`EnvironmentFile`, impedendo a quest'ultimo di cambiare la risoluzione. Percorsi assoluti, traversal, root sovrapposta alla release o riferimenti secret dentro release/data root sono rifiutati. Il lock applicativo è fissato a `/run/thebitlab`; il backend ascolta solo su `127.0.0.1`.
+
+Una root diversa identifica una diversa istanza. Copie o mount manuali non documentati non costituiscono sincronizzazione autorevole; valgono i confini di [`PILOT_REHEARSAL.md`](PILOT_REHEARSAL.md).
+
+## Segreti e configurazione runtime
+
+Il repository contiene soltanto nomi, schema e path di riferimento. Il file `deploy/pilot/pilot.env.example` mostra il contratto con placeholder deliberatamente non validi: non va installato.
+
+Il vero `service.environment_file`:
+
+- vive fuori da repository, bundle renderizzato, data root ed evidenze;
+- è un file regolare non-symlink, tipicamente `root:<service-group>` e `0640` o più restrittivo;
+- non usa `export`, quoting, espansioni shell o righe multilinea;
+- contiene soltanto le variabili ammesse dallo schema;
+- non viene copiato nel bundle, nel lock, nei log o nel backup applicativo non cifrato.
+
+Per Google auth sono obbligatori token docente, client ID, client secret e tre segreti base64url indipendenti (CSRF, rate limit, pairing). Se `features.github_oauth=true`, client ID e secret GitHub sono entrambi obbligatori. Redirect URI, trusted proxy e auth DB sono invece derivati dal manifest e sono vietati nel file esterno. Il runtime GitHub App, se abilitato, usa la directory esterna protetta `$HOME/.thebitlab-secrets/github-app`; nessuna chiave o installation token entra negli artefatti.
+
+Sul target autorizzato si può validare esplicitamente il file. Il validator legge i valori soltanto per verificarne forma e indipendenza, non li stampa:
+
+```bash
+python scripts/validate_pilot_deployment.py \
+  --config <manifest-versionato.json> \
+  --environment-file <stesso-path-di-service.environment_file> \
+  --check-external-references
+```
+
+Non eseguire questo comando su file live durante review offline. La governance di issue #699 resta un gate umano: fino all'approvazione usare solo account e dati demo.
+
+## Origin exposure e firewall
+
+`origin.exposure` è una scelta esplicita:
+
+- `edge_only` richiede almeno una CIDR canonica versionata in `allowed_proxy_cidrs`;
+- `public` richiede allowlist vuota ed è una scelta diversa da approvare, non un fallback.
+
+In modalità `edge_only`, nginx applica `allow` alle CIDR dichiarate e poi `deny all` su HTTP e HTTPS. Loopback resta ammesso per diagnostica locale. Il default server chiude HTTP con `444` e rifiuta l'handshake TLS per SNI sconosciuto. Il proxy sovrascrive `X-Forwarded-For` con un solo hop e attesta `X-Forwarded-Proto: https`; l'app considera trusted soltanto nginx su `127.0.0.1/32`.
+
+Il bundle genera anche `firewall/origin-exposure.json`, contratto machine-readable per il firewall host:
+
+- porte ingress applicative: TCP 80 e 443;
+- `edge_only`: default deny su queste porte, eccezioni soltanto per le CIDR versionate;
+- `public`: accesso esplicitamente pubblico;
+- porta backend: solo il bind loopback dichiarato.
+
+L'esecutore firewall deve applicare quel file in modo idempotente e verificare il risultato prima dell'attivazione; non deve modificare SSH o altre regole di gestione. Una allowlist firewall divergente, regole manuali aggiuntive o l'accessibilità remota della porta backend sono `FAIL`. La baseline non contiene CIDR Cloudflare live: il workstream trusted-proxy deve inserirle in un manifest candidate versionato e sottoporle alla stessa validazione. Nginx è un secondo controllo, non un sostituto del firewall host.
+
+Verifiche candidate obbligatorie, da un ambiente controllato e senza pubblicare IP/evidenze sensibili:
+
+1. `nginx -t` e `systemd-analyze verify` passano sul bundle esatto;
+2. richiesta locale con host canonico raggiunge nginx;
+3. richiesta all'origin da sorgente non ammessa non arriva all'app (`403`, rifiuto TLS o timeout firewall);
+4. richiesta attraverso una sorgente edge ammessa raggiunge l'app;
+5. porta backend non è raggiungibile da rete;
+6. access log usa `$uri`, mai `$request_uri`, `$args` o `Referer`.
+
+Non trasferire automaticamente i PASS della topologia precedente.
+
+## Layout di attivazione
+
+Una candidate deve conservare separatamente release e configurazione immutabili, per esempio:
+
+```text
+/opt/thebitlab/releases/<commit>/       checkout/artifact e .venv dello SHA
+/opt/thebitlab/current -> releases/<commit>
+/etc/thebitlab/deployments/<id>-<commit>/
+/etc/thebitlab/current -> deployments/<id>-<commit>
+/etc/systemd/system/thebitlab.service -> /etc/thebitlab/current/systemd/thebitlab.service
+/etc/nginx/conf.d/thebitlab-log-format.conf -> /etc/thebitlab/current/nginx/thebitlab-log-format.conf
+/etc/nginx/sites-enabled/thebitlab.conf -> /etc/thebitlab/current/nginx/thebitlab.conf
+/etc/thebitlab/secrets/pilot.env        esterno e persistente
+/srv/thebitlab/data/                    root persistente al rollback
+```
+
+Prima dell'attivazione verificare SHA, digest del lock, metadata dei riferimenti esterni, schema dell'environment, ownership/root, contratto firewall e tool smoke. I tre symlink di integrazione nginx/systemd devono puntare **attraverso** `/etc/thebitlab/current`, non a copie o direttamente a una versione: in questo modo lo switch del bundle cambia tutti gli artifact attivi. Il formato log entra nel contesto nginx `http`; nessun file renderizzato va editato sul target. Conservare bundle, checkout e virtualenv precedenti finché termina la finestra di rollback. Qualunque differenza manuale fra bundle e host invalida il gate topologia.
+
+## Rollback bounded
+
+Target operativo: decisione e rollback tecnico entro **15 minuti**, con un solo tentativo. Il rollback è ammesso soltanto verso il bundle precedente già validato, il cui checkout e lock sono ancora presenti.
+
+1. Dichiarare rollback, bloccare nuovi deploy e registrare release corrente/precedente senza copiare environment o log sensibili.
+2. Fermare l'app se il failure mode può scrivere dati incoerenti.
+3. Ripuntare atomicamente i symlink `current` di release e configurazione al bundle precedente.
+4. Riapplicare `firewall/origin-exposure.json` precedente; se la verifica fallisce, mantenere deny e non riaprire l'origin.
+5. Eseguire `systemd-analyze verify` e `nginx -t`; solo dopo fare daemon-reload, reload nginx e restart dell'app.
+6. Verificare health locale, origin edge-only, porta backend chiusa e flusso demo minimo.
+7. Se un controllo fallisce o si supera il limite, fermare l'app, mantenere l'origin fail-closed ed escalare secondo governance/incident response. Non tentare modifiche manuali iterative.
+
+Il rollback del bundle **non** ripristina dati né segreti. Prima del deploy bisogna dichiarare la compatibilità backward dello schema auth/dati. Se la release precedente non può leggere lo schema corrente, il rollback applicativo è bloccato: mantenere il servizio fermo e usare soltanto la procedura di restore isolato approvata. Un'eventuale rotazione secret si annulla dal secret store secondo procedura separata; i valori precedenti non vengono archiviati nel repository.
+
+## Gate prima di staging o produzione
+
+Questa baseline non autorizza deploy live. Servono ancora manifest candidate reale revisionato, allowlist edge approvata, executor firewall, secret store popolato, governance #699, backup/restore e rehearsal #678 sulla nuova topologia. Cloudflare non deve essere cambiato come effetto della validazione o del rendering.

--- a/doc/PILOT_DEPLOYMENT.md
+++ b/doc/PILOT_DEPLOYMENT.md
@@ -11,6 +11,7 @@ Questo documento è il contratto canonico per preparare una nuova candidate TheB
 | `schemas/pilot-environment.schema.json` | nomi e forma dell'`EnvironmentFile` esterno |
 | `deploy/pilot/templates/` | template nginx, formato log secret-safe e unit systemd |
 | `scripts/validate_pilot_deployment.py` | validazione semantica e rendering deterministico |
+| `scripts/pilot_service_launcher.py` | import fail-closed dei secret e avvio con topologia autorevole |
 | `scripts/pilot_deployment_smoke.py` | `nginx -t` e `systemd-analyze verify` su dati sintetici temporanei |
 | `tests/test_pilot_deployment.py` | casi positivi e negativi dei contratti |
 
@@ -51,7 +52,7 @@ Lo smoke crea root, `EnvironmentFile`, certificato e output in una directory tem
 <data.root>/<data.auth_db_path>
 ```
 
-La baseline usa `.thebitlab-auth/auth.sqlite3`. L'unit renderizzata dichiara `THEBITLAB_AUTH_DB_PATH` **dopo** l'`EnvironmentFile`, impedendo a quest'ultimo di cambiare la risoluzione. Percorsi assoluti, traversal, root sovrapposta alla release o riferimenti secret dentro release/data root sono rifiutati. Il lock applicativo è fissato a `/run/thebitlab`; il backend ascolta solo su `127.0.0.1`.
+La baseline usa `.thebitlab-auth/auth.sqlite3`. L'unit non usa la direttiva systemd `EnvironmentFile=`: il launcher legge il file esterno a ogni avvio, ne accetta soltanto la allowlist e imposta `THEBITLAB_AUTH_DB_PATH` dalla configurazione renderizzata prima di sostituirsi al server. Percorsi assoluti, traversal, root sovrapposta alla release o riferimenti secret dentro release/data root sono rifiutati. Il lock applicativo è fissato a `/run/thebitlab`; il backend ascolta solo su `127.0.0.1`.
 
 Una root diversa identifica una diversa istanza. Copie o mount manuali non documentati non costituiscono sincronizzazione autorevole; valgono i confini di [`PILOT_REHEARSAL.md`](PILOT_REHEARSAL.md).
 
@@ -67,7 +68,9 @@ Il vero `service.environment_file`:
 - contiene soltanto le variabili ammesse dallo schema;
 - non viene copiato nel bundle, nel lock, nei log o nel backup applicativo non cifrato.
 
-Per Google auth sono obbligatori token docente, client ID, client secret e tre segreti base64url indipendenti (CSRF, rate limit, pairing). Se `features.github_oauth=true`, client ID e secret GitHub sono entrambi obbligatori. Redirect URI, trusted proxy e auth DB sono invece derivati dal manifest e sono vietati nel file esterno. Il runtime GitHub App, se abilitato, usa la directory esterna protetta `$HOME/.thebitlab-secrets/github-app`; nessuna chiave o installation token entra negli artefatti.
+Per Google auth sono obbligatori token docente, client ID, client secret e tre segreti base64url indipendenti (CSRF, rate limit, pairing). Se `features.github_oauth=true`, client ID e secret GitHub sono entrambi obbligatori. Redirect URI, trusted proxy, auth DB, lock directory e revisione sono invece derivati dal manifest e sono vietati nel file esterno. Il runtime GitHub App, se abilitato, usa la directory esterna protetta `$HOME/.thebitlab-secrets/github-app`; nessuna chiave o installation token entra negli artefatti.
+
+L'ordine delle direttive non è un controllo di sicurezza: [`systemd.exec(5)`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=) specifica che i valori di `EnvironmentFile=` prevalgono su `Environment=` e che il file viene riletto poco prima dell'esecuzione. Per questo l'unit non consegna mai direttamente il file a systemd. `pilot_service_launcher.py`, eseguito senza quel file nell'ambiente, ne ricontrolla tipo, permessi, sintassi e nomi a ogni start/restart; un nome aggiunto o riservato impedisce l'avvio. Solo dopo costruisce l'ambiente del server eliminando eventuali valori precedenti posseduti dal contratto, importa i secret consentiti e applica per ultime le impostazioni autorevoli renderizzate. Non esiste quindi precedenza configurabile dal file esterno.
 
 Sul target autorizzato si può validare esplicitamente il file. Il validator legge i valori soltanto per verificarne forma e indipendenza, non li stampa:
 
@@ -125,7 +128,7 @@ Una candidate deve conservare separatamente release e configurazione immutabili,
 /srv/thebitlab/data/                    root persistente al rollback
 ```
 
-Prima dell'attivazione verificare SHA, digest del lock, metadata dei riferimenti esterni, schema dell'environment, ownership/root, contratto firewall e tool smoke. I tre symlink di integrazione nginx/systemd devono puntare **attraverso** `/etc/thebitlab/current`, non a copie o direttamente a una versione: in questo modo lo switch del bundle cambia tutti gli artifact attivi. Il formato log entra nel contesto nginx `http`; nessun file renderizzato va editato sul target. Conservare bundle, checkout e virtualenv precedenti finché termina la finestra di rollback. Qualunque differenza manuale fra bundle e host invalida il gate topologia.
+Prima dell'attivazione verificare SHA, digest del lock, metadata dei riferimenti esterni, schema dell'environment, ownership/root, contratto firewall e tool smoke. Il launcher appartiene alla release fissata da `release.commit`; l'unit deve invocarlo e non deve contenere `EnvironmentFile=`. I tre symlink di integrazione nginx/systemd devono puntare **attraverso** `/etc/thebitlab/current`, non a copie o direttamente a una versione: in questo modo lo switch del bundle cambia tutti gli artifact attivi. Il formato log entra nel contesto nginx `http`; nessun file renderizzato va editato sul target. Conservare bundle, checkout e virtualenv precedenti finché termina la finestra di rollback. Qualunque differenza manuale fra bundle e host invalida il gate topologia.
 
 ## Rollback bounded
 

--- a/doc/PILOT_REHEARSAL.md
+++ b/doc/PILOT_REHEARSAL.md
@@ -1,6 +1,6 @@
 # Pilot rehearsal: checklist ed esito go/no-go
 
-Questo runbook definisce la prova generale obbligatoria prima della prima classe del pilot TheBitLab. La prova deve produrre evidenze ripetibili e una decisione esplicita; non sostituisce la [guida MVP](MVP_2026_2027.md), gli [scenari manuali GUI/TUI](SCENARI_TEST_MANUALI_GUI.md) o lo [smoke auth staging](AUTH_STAGING_SMOKE.md).
+Questo runbook definisce la prova generale obbligatoria prima della prima classe del pilot TheBitLab. La prova deve produrre evidenze ripetibili e una decisione esplicita; non sostituisce la [guida MVP](MVP_2026_2027.md), gli [scenari manuali GUI/TUI](SCENARI_TEST_MANUALI_GUI.md) o lo [smoke auth staging](AUTH_STAGING_SMOKE.md). La topologia della nuova candidate deve derivare dalla [baseline deployment-as-code](PILOT_DEPLOYMENT.md), con manifest, lock e rollback versionati.
 
 ## Esiti possibili
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -11,6 +11,7 @@ Usa questo file come punto di partenza per capire quale documento leggere in bas
 | Cornice didattica | [`CORNICE_DIDATTICA.md`](CORNICE_DIDATTICA.md) | docenti, coordinatori, sviluppatori |
 | Guida operativa pilot | [`MVP_2026_2027.md`](MVP_2026_2027.md) | docenti e gestori dell'installazione |
 | Pilot rehearsal e go/no-go | [`PILOT_REHEARSAL.md`](PILOT_REHEARSAL.md) | docenti, gestori e decision owner |
+| Deployment pilot versionato | [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md) | gestori tecnici e reviewer |
 | Architettura | [`ARCHITETTURA_MVP.md`](ARCHITETTURA_MVP.md) | sviluppatori e gestori tecnici |
 | Diagrammi d'architettura | [`architecture/architecture-diagrams.md`](architecture/architecture-diagrams.md) | sviluppatori e gestori tecnici |
 | Bundle corsi (ADR) | [`architecture/adr-course-bundle-format.md`](architecture/adr-course-bundle-format.md) | docenti autori, sviluppatori |
@@ -100,6 +101,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | [`CORNICE_DIDATTICA.md`](CORNICE_DIDATTICA.md) | Quando devi comprendere obiettivi, UDA, aiuti, feedback e ruolo docente |
 | [`MVP_2026_2027.md`](MVP_2026_2027.md) | Quando devi preparare o usare il pilot scolastico |
 | [`PILOT_REHEARSAL.md`](PILOT_REHEARSAL.md) | Quando devi eseguire la prova generale e decidere go/no-go |
+| [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md) | Quando devi validare, renderizzare o fare rollback di nginx/systemd/root/origin |
 | [`ARCHITETTURA_MVP.md`](ARCHITETTURA_MVP.md) | Quando devi capire GUI, API, service, storage, provider, AI e Docker |
 | [`architecture/architecture-diagrams.md`](architecture/architecture-diagrams.md) | Quando vuoi una vista visuale di deployment, componenti e flussi HTTP |
 | [`FRONTEND_ARCHITECTURE.md`](FRONTEND_ARCHITECTURE.md) | Quando devi modificare stato UI, endpoint o flussi asincroni |
@@ -113,6 +115,8 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/update_lab_outputs.py` | Compila/esegue i lab configurati e aggiorna `lab/**/output/*.txt` | [`LAB_OUTPUTS.md`](LAB_OUTPUTS.md) |
 | `scripts/course_board_server.py` | Avvia il server locale della board e del calendario | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/github_app_token_runtime.py` | Genera e rinnova installation token GitHub App protetti | [`COURSE_SOURCE_CATALOG.md`](COURSE_SOURCE_CATALOG.md) |
+| `scripts/validate_pilot_deployment.py` | Valida e renderizza la baseline deployment senza incorporare segreti | [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md) |
+| `scripts/pilot_deployment_smoke.py` | Esegue lint nginx/systemd non distruttivo su fixture sintetiche | [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md) |
 | `scripts/generate_course_plan.py` | Rigenera `doc/PERCORSO_DIDATTICO.md` dal progetto didattico corrente | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/update_course_frames.py` | Inserisce nel README le cornici didattiche presenti nel progetto | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/create_activity.py` | Crea una scheda JSON di attivita TheBitLab da prompt guidato o argomenti CLI | [`ACTIVITIES_SCHEMA.md`](ACTIVITIES_SCHEMA.md) |

--- a/doc/README.md
+++ b/doc/README.md
@@ -116,6 +116,7 @@ Se devi lavorare su esercizi, compiti a casa, verifiche, correzione automatica o
 | `scripts/course_board_server.py` | Avvia il server locale della board e del calendario | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/github_app_token_runtime.py` | Genera e rinnova installation token GitHub App protetti | [`COURSE_SOURCE_CATALOG.md`](COURSE_SOURCE_CATALOG.md) |
 | `scripts/validate_pilot_deployment.py` | Valida e renderizza la baseline deployment senza incorporare segreti | [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md) |
+| `scripts/pilot_service_launcher.py` | Importa solo i secret consentiti e avvia il pilot con topologia autorevole | [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md) |
 | `scripts/pilot_deployment_smoke.py` | Esegue lint nginx/systemd non distruttivo su fixture sintetiche | [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md) |
 | `scripts/generate_course_plan.py` | Rigenera `doc/PERCORSO_DIDATTICO.md` dal progetto didattico corrente | [`COURSE_BOARD.md`](COURSE_BOARD.md) |
 | `scripts/update_course_frames.py` | Inserisce nel README le cornici didattiche presenti nel progetto | [`COURSE_BOARD.md`](COURSE_BOARD.md) |

--- a/schemas/pilot-deployment.schema.json
+++ b/schemas/pilot-deployment.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thebitlab.dev/schemas/pilot-deployment.schema.json",
+  "title": "TheBitLab pilot deployment manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "deployment_id",
+    "release",
+    "service",
+    "data",
+    "origin",
+    "features"
+  ],
+  "properties": {
+    "$schema": {"type": "string", "minLength": 1},
+    "schema_version": {"const": "thebitlab.pilot-deployment.v1"},
+    "deployment_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{2,62}$"
+    },
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit", "repository_root", "python_executable"],
+      "properties": {
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "repository_root": {"$ref": "#/$defs/absolutePath"},
+        "python_executable": {"$ref": "#/$defs/absolutePath"}
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "user",
+        "group",
+        "home_directory",
+        "bind_host",
+        "port",
+        "environment_file",
+        "lock_directory"
+      ],
+      "properties": {
+        "user": {"$ref": "#/$defs/account"},
+        "group": {"$ref": "#/$defs/account"},
+        "home_directory": {"$ref": "#/$defs/absolutePath"},
+        "bind_host": {"const": "127.0.0.1"},
+        "port": {"type": "integer", "minimum": 1024, "maximum": 65535},
+        "environment_file": {"$ref": "#/$defs/absolutePath"},
+        "lock_directory": {"const": "/run/thebitlab"}
+      }
+    },
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["root", "auth_db_path"],
+      "properties": {
+        "root": {"$ref": "#/$defs/absolutePath"},
+        "auth_db_path": {
+          "type": "string",
+          "pattern": "^(?!/)(?!.*(?:^|/)[.][.](?:/|$))[A-Za-z0-9._/-]+$"
+        }
+      }
+    },
+    "origin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "exposure",
+        "allowed_proxy_cidrs",
+        "tls_certificate_file",
+        "tls_private_key_file",
+        "access_log",
+        "error_log"
+      ],
+      "properties": {
+        "url": {"type": "string", "maxLength": 253},
+        "exposure": {"enum": ["edge_only", "public"]},
+        "allowed_proxy_cidrs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 3, "maxLength": 64}
+        },
+        "tls_certificate_file": {"$ref": "#/$defs/absolutePath"},
+        "tls_private_key_file": {"$ref": "#/$defs/absolutePath"},
+        "access_log": {"$ref": "#/$defs/absolutePath"},
+        "error_log": {"$ref": "#/$defs/absolutePath"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"exposure": {"const": "edge_only"}}},
+          "then": {"properties": {"allowed_proxy_cidrs": {"minItems": 1}}},
+          "else": {"properties": {"allowed_proxy_cidrs": {"maxItems": 0}}}
+        }
+      ]
+    },
+    "features": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["google_auth", "github_oauth", "github_app_token_runtime"],
+      "properties": {
+        "google_auth": {"const": true},
+        "github_oauth": {"type": "boolean"},
+        "github_app_token_runtime": {"type": "boolean"}
+      }
+    }
+  },
+  "$defs": {
+    "absolutePath": {
+      "type": "string",
+      "pattern": "^/(?!.*(?:^|/)[.][.](?:/|$))[A-Za-z0-9._/@+:-]+(?:/[A-Za-z0-9._@+:-]+)*$"
+    },
+    "account": {
+      "type": "string",
+      "pattern": "^[a-z_][a-z0-9_-]{0,30}$"
+    }
+  }
+}

--- a/schemas/pilot-environment.schema.json
+++ b/schemas/pilot-environment.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thebitlab.dev/schemas/pilot-environment.schema.json",
+  "title": "TheBitLab external pilot EnvironmentFile",
+  "$comment": "This schema describes names and shapes only. Real values remain outside the repository.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "THEBITLAB_TEACHER_TOKEN",
+    "THEBITLAB_GOOGLE_CLIENT_ID",
+    "THEBITLAB_GOOGLE_CLIENT_SECRET",
+    "THEBITLAB_AUTH_CSRF_SECRET_B64",
+    "THEBITLAB_RATE_LIMIT_PEPPER_B64",
+    "THEBITLAB_TUI_PAIRING_PEPPER_B64"
+  ],
+  "properties": {
+    "THEBITLAB_TEACHER_TOKEN": {"$ref": "#/$defs/opaqueSecret"},
+    "THEBITLAB_GOOGLE_CLIENT_ID": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9._~+/=-]+$"
+    },
+    "THEBITLAB_GOOGLE_CLIENT_SECRET": {"$ref": "#/$defs/opaqueSecret"},
+    "THEBITLAB_AUTH_CSRF_SECRET_B64": {"$ref": "#/$defs/base64urlSecret"},
+    "THEBITLAB_RATE_LIMIT_PEPPER_B64": {"$ref": "#/$defs/base64urlSecret"},
+    "THEBITLAB_TUI_PAIRING_PEPPER_B64": {"$ref": "#/$defs/base64urlSecret"},
+    "THEBITLAB_GITHUB_CLIENT_ID": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9._~+/=-]+$"
+    },
+    "THEBITLAB_GITHUB_CLIENT_SECRET": {"$ref": "#/$defs/opaqueSecret"}
+  },
+  "$defs": {
+    "opaqueSecret": {
+      "type": "string",
+      "minLength": 32,
+      "maxLength": 4096,
+      "pattern": "^[A-Za-z0-9._~+/=-]+$"
+    },
+    "base64urlSecret": {
+      "type": "string",
+      "minLength": 43,
+      "maxLength": 86,
+      "pattern": "^[A-Za-z0-9_-]+$"
+    }
+  }
+}

--- a/scripts/pilot_deployment_smoke.py
+++ b/scripts/pilot_deployment_smoke.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Run a non-destructive nginx/systemd smoke for the pilot deployment bundle."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import copy
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import validate_pilot_deployment as deployment  # noqa: E402
+
+
+def _secret(byte: int) -> str:
+    return base64.urlsafe_b64encode(bytes([byte]) * 32).rstrip(b"=").decode("ascii")
+
+
+def _run(command: list[str], *, environment: dict[str, str] | None = None) -> None:
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=environment,
+    )
+    if result.returncode:
+        output = "\n".join((result.stdout + result.stderr).splitlines()[-20:])
+        raise RuntimeError(f"Comando smoke fallito ({command[0]}):\n{output}")
+
+
+def _verify_lock(bundle: Path) -> None:
+    lock = json.loads((bundle / "deployment.lock.json").read_text(encoding="utf-8"))
+    for name, expected in lock["files"].items():
+        actual = hashlib.sha256((bundle / name).read_bytes()).hexdigest()
+        if actual != expected:
+            raise RuntimeError(f"Digest bundle non valido: {name}")
+
+
+def run_smoke(config: Path) -> None:
+    nginx = shutil.which("nginx")
+    systemd_analyze = shutil.which("systemd-analyze")
+    openssl = shutil.which("openssl")
+    missing = [name for name, value in (("nginx", nginx), ("systemd-analyze", systemd_analyze), ("openssl", openssl)) if value is None]
+    if missing:
+        raise RuntimeError("Tool smoke mancanti: " + ", ".join(missing))
+
+    source_manifest = deployment.load_json(config)
+    deployment.validate_manifest(source_manifest)
+    with tempfile.TemporaryDirectory(prefix="thebitlab-deployment-smoke-") as temporary_name:
+        temporary = Path(temporary_name)
+        data_root = temporary / "data"
+        data_root.mkdir(mode=0o700)
+        release_root = temporary / "release"
+        release_root.mkdir()
+        release_python = release_root / "python"
+        release_python.symlink_to(sys.executable)
+        environment_file = temporary / "pilot.env"
+        environment_file.write_text(
+            "\n".join(
+                (
+                    "THEBITLAB_TEACHER_TOKEN=" + "T" * 32,
+                    "THEBITLAB_GOOGLE_CLIENT_ID=synthetic-client-id.example",
+                    "THEBITLAB_GOOGLE_CLIENT_SECRET=" + "G" * 32,
+                    "THEBITLAB_AUTH_CSRF_SECRET_B64=" + _secret(1),
+                    "THEBITLAB_RATE_LIMIT_PEPPER_B64=" + _secret(2),
+                    "THEBITLAB_TUI_PAIRING_PEPPER_B64=" + _secret(3),
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        environment_file.chmod(0o600)
+        certificate = temporary / "origin.crt"
+        private_key = temporary / "origin.key"
+        _run(
+            [
+                openssl,
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-nodes",
+                "-days",
+                "1",
+                "-subj",
+                "/CN=candidate.example.edu",
+                "-keyout",
+                str(private_key),
+                "-out",
+                str(certificate),
+            ]
+        )
+        private_key.chmod(0o600)
+
+        manifest = copy.deepcopy(source_manifest)
+        manifest["release"]["repository_root"] = str(release_root)
+        manifest["release"]["python_executable"] = str(release_python)
+        manifest["service"]["environment_file"] = str(environment_file)
+        manifest["data"]["root"] = str(data_root)
+        manifest["origin"]["tls_certificate_file"] = str(certificate)
+        manifest["origin"]["tls_private_key_file"] = str(private_key)
+        manifest["origin"]["access_log"] = str(temporary / "access.log")
+        manifest["origin"]["error_log"] = str(temporary / "error.log")
+        deployment.validate_manifest(manifest)
+        values = deployment.parse_environment_file(environment_file)
+        deployment.validate_environment(values, github_oauth=False)
+        deployment.check_external_references(manifest)
+
+        bundle = temporary / "bundle"
+        deployment.render_bundle(manifest, bundle)
+        _verify_lock(bundle)
+
+        nginx_config = temporary / "nginx-smoke.conf"
+        nginx_config.write_text(
+            "\n".join(
+                (
+                    f"pid {temporary / 'nginx.pid'};",
+                    f"error_log {temporary / 'nginx-global.log'};",
+                    "events {}",
+                    "http {",
+                    "    include /etc/nginx/mime.types;",
+                    f"    include {bundle / 'nginx/thebitlab-log-format.conf'};",
+                    f"    include {bundle / 'nginx/thebitlab.conf'};",
+                    "}",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        _run([nginx, "-t", "-p", str(temporary), "-c", str(nginx_config)])
+
+        tool_environment = dict(os.environ)
+        tool_environment["SYSTEMD_LOG_LEVEL"] = "warning"
+        _run(
+            [systemd_analyze, "verify", str(bundle / "systemd/thebitlab.service")],
+            environment=tool_environment,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=ROOT / "deploy" / "pilot" / "candidate.example.json",
+    )
+    args = parser.parse_args(argv)
+    try:
+        run_smoke(args.config)
+    except (deployment.DeploymentValidationError, OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        print(f"ERRORE: {exc}", file=sys.stderr)
+        return 2
+    print("PASS: smoke deployment non distruttivo (nginx -t, systemd-analyze verify)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pilot_deployment_smoke.py
+++ b/scripts/pilot_deployment_smoke.py
@@ -9,6 +9,7 @@ import copy
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -47,6 +48,22 @@ def _verify_lock(bundle: Path) -> None:
         actual = hashlib.sha256((bundle / name).read_bytes()).hexdigest()
         if actual != expected:
             raise RuntimeError(f"Digest bundle non valido: {name}")
+
+
+def _nginx_site_for_unprivileged_smoke(site: str) -> str:
+    ports = {"80": "18080", "443": "18443"}
+    counts = {port: 0 for port in ports}
+    listen = re.compile(r"(?m)^(\s*listen\s+(?:\[::\]:)?)(80|443)(?=[\s;])")
+
+    def replace(match: re.Match[str]) -> str:
+        port = match.group(2)
+        counts[port] += 1
+        return match.group(1) + ports[port]
+
+    smoke_site = listen.sub(replace, site)
+    if counts != {"80": 4, "443": 4}:
+        raise RuntimeError(f"Direttive listen nginx inattese per lo smoke: {counts}")
+    return smoke_site
 
 
 def run_smoke(config: Path) -> None:
@@ -123,6 +140,13 @@ def run_smoke(config: Path) -> None:
         deployment.render_bundle(manifest, bundle)
         _verify_lock(bundle)
 
+        nginx_smoke_site = temporary / "nginx-smoke-site.conf"
+        nginx_smoke_site.write_text(
+            _nginx_site_for_unprivileged_smoke(
+                (bundle / "nginx/thebitlab.conf").read_text(encoding="utf-8")
+            ),
+            encoding="utf-8",
+        )
         nginx_config = temporary / "nginx-smoke.conf"
         nginx_config.write_text(
             "\n".join(
@@ -133,7 +157,7 @@ def run_smoke(config: Path) -> None:
                     "http {",
                     "    include /etc/nginx/mime.types;",
                     f"    include {bundle / 'nginx/thebitlab-log-format.conf'};",
-                    f"    include {bundle / 'nginx/thebitlab.conf'};",
+                    f"    include {nginx_smoke_site};",
                     "}",
                     "",
                 )

--- a/scripts/pilot_environment.py
+++ b/scripts/pilot_environment.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Shared, stdlib-only contract for the external pilot environment file."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Mapping
+
+
+REQUIRED_EXTERNAL_NAMES = frozenset(
+    {
+        "THEBITLAB_TEACHER_TOKEN",
+        "THEBITLAB_GOOGLE_CLIENT_ID",
+        "THEBITLAB_GOOGLE_CLIENT_SECRET",
+        "THEBITLAB_AUTH_CSRF_SECRET_B64",
+        "THEBITLAB_RATE_LIMIT_PEPPER_B64",
+        "THEBITLAB_TUI_PAIRING_PEPPER_B64",
+    }
+)
+GITHUB_EXTERNAL_NAMES = frozenset(
+    {
+        "THEBITLAB_GITHUB_CLIENT_ID",
+        "THEBITLAB_GITHUB_CLIENT_SECRET",
+    }
+)
+ALLOWED_EXTERNAL_NAMES = REQUIRED_EXTERNAL_NAMES | GITHUB_EXTERNAL_NAMES
+OPAQUE_SECRET_NAMES = frozenset(
+    {
+        "THEBITLAB_TEACHER_TOKEN",
+        "THEBITLAB_GOOGLE_CLIENT_SECRET",
+        "THEBITLAB_GITHUB_CLIENT_SECRET",
+    }
+)
+BASE64URL_SECRET_NAMES = (
+    "THEBITLAB_AUTH_CSRF_SECRET_B64",
+    "THEBITLAB_RATE_LIMIT_PEPPER_B64",
+    "THEBITLAB_TUI_PAIRING_PEPPER_B64",
+)
+_IDENTIFIER_VALUE_RE = re.compile(r"^[A-Za-z0-9._~+/=-]+$")
+_BASE64URL_VALUE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class DeploymentValidationError(ValueError):
+    """A safe configuration error that never needs to include secret values."""
+
+
+def check_environment_file(path: Path) -> None:
+    """Require a regular, non-symlink environment file with private permissions."""
+
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise DeploymentValidationError(
+            f"Riferimento esterno assente o non accessibile: {path}"
+        ) from exc
+    if path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+        raise DeploymentValidationError(f"Riferimento esterno non regolare: {path}")
+    if os.name != "nt" and metadata.st_mode & 0o027:
+        raise DeploymentValidationError(
+            f"Permessi troppo ampi sul riferimento esterno: {path}"
+        )
+
+
+def parse_environment_file(path: Path) -> dict[str, str]:
+    """Parse the deliberately small, unquoted external-file contract."""
+
+    try:
+        lines = path.read_text(encoding="utf-8-sig").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise DeploymentValidationError("EnvironmentFile non leggibile.") from exc
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(lines, start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export ") or "=" not in line:
+            raise DeploymentValidationError(
+                f"EnvironmentFile: sintassi non valida alla riga {line_number}."
+            )
+        key, value = line.split("=", 1)
+        if (
+            not key
+            or key != key.strip()
+            or not key.replace("_", "A").isalnum()
+            or not key[0].isalpha()
+        ):
+            raise DeploymentValidationError(
+                f"EnvironmentFile: nome non valido alla riga {line_number}."
+            )
+        if key in values:
+            raise DeploymentValidationError(
+                f"EnvironmentFile: variabile duplicata alla riga {line_number}."
+            )
+        if (
+            not value
+            or value != value.strip()
+            or any(ord(character) < 0x21 or ord(character) > 0x7E for character in value)
+        ):
+            raise DeploymentValidationError(
+                f"EnvironmentFile: valore non valido alla riga {line_number}."
+            )
+        values[key] = value
+    return values
+
+
+def validate_environment_names(
+    values: Mapping[str, str], *, github_oauth: bool
+) -> None:
+    """Fail closed unless the external file has exactly the enabled name contract."""
+
+    errors: list[str] = []
+    missing = REQUIRED_EXTERNAL_NAMES.difference(values)
+    unexpected = set(values).difference(ALLOWED_EXTERNAL_NAMES)
+    present_github = GITHUB_EXTERNAL_NAMES.intersection(values)
+    if missing:
+        errors.append("variabili obbligatorie omesse: " + ", ".join(sorted(missing)))
+    if unexpected:
+        errors.append("variabili non ammesse: " + ", ".join(sorted(unexpected)))
+    if github_oauth and present_github != GITHUB_EXTERNAL_NAMES:
+        errors.append("GitHub OAuth: client ID e client secret esterni sono entrambi obbligatori")
+    if not github_oauth and present_github:
+        errors.append("GitHub OAuth: credenziali presenti ma feature disabilitata")
+    if errors:
+        raise DeploymentValidationError(
+            "EnvironmentFile non valido (valori omessi):\n- " + "\n- ".join(errors)
+        )
+
+
+def validate_external_environment(
+    values: Mapping[str, str], *, github_oauth: bool
+) -> None:
+    """Validate the complete runtime contract without deployment-only dependencies."""
+
+    validate_environment_names(values, github_oauth=github_oauth)
+    errors: list[str] = []
+    for name in OPAQUE_SECRET_NAMES.intersection(values):
+        value = values[name]
+        if not 32 <= len(value) <= 4096 or _IDENTIFIER_VALUE_RE.fullmatch(value) is None:
+            errors.append(f"{name}: forma non valida")
+
+    client_id_lengths = {
+        "THEBITLAB_GOOGLE_CLIENT_ID": (6, 255),
+        "THEBITLAB_GITHUB_CLIENT_ID": (1, 255),
+    }
+    for name, (minimum, maximum) in client_id_lengths.items():
+        value = values.get(name)
+        if value is not None and (
+            not minimum <= len(value) <= maximum
+            or _IDENTIFIER_VALUE_RE.fullmatch(value) is None
+        ):
+            errors.append(f"{name}: forma non valida")
+
+    decoded_secrets: list[bytes] = []
+    for name in BASE64URL_SECRET_NAMES:
+        value = values[name]
+        if not 43 <= len(value) <= 86 or _BASE64URL_VALUE_RE.fullmatch(value) is None:
+            errors.append(f"{name}: forma non valida")
+            continue
+        try:
+            decoded = base64.b64decode(
+                value + "=" * (-len(value) % 4),
+                altchars=b"-_",
+                validate=True,
+            )
+        except (binascii.Error, ValueError):
+            errors.append(f"{name}: base64url non valida")
+            continue
+        if not 32 <= len(decoded) <= 64:
+            errors.append(f"{name}: deve rappresentare 32-64 byte")
+        decoded_secrets.append(decoded)
+    if len(decoded_secrets) != len(set(decoded_secrets)):
+        errors.append("I segreti CSRF, rate limit e pairing devono essere indipendenti")
+
+    if errors:
+        raise DeploymentValidationError(
+            "EnvironmentFile non valido (valori omessi):\n- " + "\n- ".join(errors)
+        )

--- a/scripts/pilot_service_launcher.py
+++ b/scripts/pilot_service_launcher.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Validate pilot secrets and exec the service with manifest-owned topology."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.pilot_environment import (  # noqa: E402
+    ALLOWED_EXTERNAL_NAMES,
+    DeploymentValidationError,
+    check_environment_file,
+    parse_environment_file,
+    validate_external_environment,
+)
+
+
+AUTHORITATIVE_NAMES = frozenset(
+    {
+        "THEBITLAB_DEPLOYMENT_REVISION",
+        "THEBITLAB_LOCK_DIR",
+        "THEBITLAB_AUTH_DB_PATH",
+        "THEBITLAB_TRUSTED_PROXY_CIDRS",
+        "THEBITLAB_GOOGLE_REDIRECT_URI",
+        "THEBITLAB_GITHUB_REDIRECT_URI",
+    }
+)
+OWNED_NAMES = ALLOWED_EXTERNAL_NAMES | AUTHORITATIVE_NAMES
+
+
+def build_effective_environment(
+    base: Mapping[str, str],
+    external: Mapping[str, str],
+    authoritative: Mapping[str, str],
+    *,
+    github_oauth: bool,
+) -> dict[str, str]:
+    """Return an environment where external values cannot own topology."""
+
+    validate_external_environment(external, github_oauth=github_oauth)
+    if set(authoritative) != AUTHORITATIVE_NAMES - (
+        set() if github_oauth else {"THEBITLAB_GITHUB_REDIRECT_URI"}
+    ):
+        raise DeploymentValidationError("Configurazione autorevole del launcher incompleta.")
+    effective = {name: value for name, value in base.items() if name not in OWNED_NAMES}
+    effective.update(external)
+    effective.update(authoritative)
+    return effective
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--environment-file", type=Path, required=True)
+    parser.add_argument("--deployment-revision", required=True)
+    parser.add_argument("--lock-directory", required=True)
+    parser.add_argument("--auth-db-path", required=True)
+    parser.add_argument("--trusted-proxy-cidrs", required=True)
+    parser.add_argument("--google-redirect-uri", required=True)
+    parser.add_argument("--github-redirect-uri")
+    parser.add_argument("--enable-github-oauth", action="store_true")
+    parser.add_argument("--host", required=True)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--enable-google-auth", action="store_true")
+    parser.add_argument("--enable-github-app-token-runtime", action="store_true")
+    return parser
+
+
+def _authoritative_environment(args: argparse.Namespace) -> dict[str, str]:
+    if args.enable_github_oauth != (args.github_redirect_uri is not None):
+        raise DeploymentValidationError("Configurazione GitHub OAuth del launcher incoerente.")
+    values = {
+        "THEBITLAB_DEPLOYMENT_REVISION": args.deployment_revision,
+        "THEBITLAB_LOCK_DIR": args.lock_directory,
+        "THEBITLAB_AUTH_DB_PATH": args.auth_db_path,
+        "THEBITLAB_TRUSTED_PROXY_CIDRS": args.trusted_proxy_cidrs,
+        "THEBITLAB_GOOGLE_REDIRECT_URI": args.google_redirect_uri,
+    }
+    if args.github_redirect_uri is not None:
+        values["THEBITLAB_GITHUB_REDIRECT_URI"] = args.github_redirect_uri
+    return values
+
+
+def _server_command(args: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        str(ROOT / "scripts" / "course_board_server.py"),
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--root",
+        str(args.root),
+    ]
+    if args.enable_google_auth:
+        command.append("--enable-google-auth")
+    if args.enable_github_app_token_runtime:
+        command.append("--enable-github-app-token-runtime")
+    return command
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        check_environment_file(args.environment_file)
+        external = parse_environment_file(args.environment_file)
+        environment = build_effective_environment(
+            os.environ,
+            external,
+            _authoritative_environment(args),
+            github_oauth=args.enable_github_oauth,
+        )
+        command = _server_command(args)
+        os.execve(command[0], command, environment)
+    except (DeploymentValidationError, OSError) as exc:
+        print(f"ERRORE: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_pilot_deployment.py
+++ b/scripts/validate_pilot_deployment.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Validate and render the secret-safe TheBitLab pilot deployment baseline."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOYMENT_SCHEMA = ROOT / "schemas" / "pilot-deployment.schema.json"
+ENVIRONMENT_SCHEMA = ROOT / "schemas" / "pilot-environment.schema.json"
+TEMPLATE_ROOT = ROOT / "deploy" / "pilot" / "templates"
+_ORIGIN_HOST_RE = re.compile(
+    r"^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?[.])+"
+    r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+)
+GENERATED_FILES = (
+    "nginx/thebitlab-log-format.conf",
+    "nginx/thebitlab.conf",
+    "systemd/thebitlab.service",
+    "firewall/origin-exposure.json",
+    "manifest.normalized.json",
+)
+
+
+class DeploymentValidationError(ValueError):
+    """A safe configuration error that never needs to include secret values."""
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DeploymentValidationError(f"Chiave JSON duplicata: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8-sig"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except DeploymentValidationError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise DeploymentValidationError(f"JSON non valido: {path}") from exc
+    if not isinstance(payload, dict):
+        raise DeploymentValidationError(f"Oggetto JSON richiesto: {path}")
+    return payload
+
+
+def _schema_errors(instance: Mapping[str, Any], schema_path: Path, *, redact: bool) -> list[str]:
+    schema = load_json(schema_path)
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(instance),
+        key=lambda item: tuple(str(part) for part in item.absolute_path),
+    )
+    messages = []
+    for error in errors:
+        location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        detail = "vincolo non soddisfatto" if redact else error.message
+        messages.append(f"{location}: {detail}")
+    return messages
+
+
+def _posix_path(value: str) -> PurePosixPath:
+    return PurePosixPath(value)
+
+
+def _is_within(candidate: PurePosixPath, parent: PurePosixPath) -> bool:
+    return candidate == parent or parent in candidate.parents
+
+
+def _semantic_manifest_errors(manifest: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    release = manifest["release"]
+    service = manifest["service"]
+    data = manifest["data"]
+    origin = manifest["origin"]
+
+    repository_root = _posix_path(release["repository_root"])
+    python_executable = _posix_path(release["python_executable"])
+    data_root = _posix_path(data["root"])
+    environment_file = _posix_path(service["environment_file"])
+    home_directory = _posix_path(service["home_directory"])
+    tls_certificate = _posix_path(origin["tls_certificate_file"])
+    tls_private_key = _posix_path(origin["tls_private_key_file"])
+
+    if service["user"] in {"root", "nobody"} or service["group"] in {"root", "nogroup"}:
+        errors.append("service: usare un account dedicato non privilegiato")
+    if home_directory != PurePosixPath("/home") / service["user"]:
+        errors.append("service.home_directory: deve essere /home/<service.user>")
+    if _is_within(data_root, repository_root) or _is_within(repository_root, data_root):
+        errors.append("data.root: deve essere separata dalla release applicativa")
+    if not _is_within(python_executable, repository_root):
+        errors.append("release.python_executable: deve appartenere alla release applicativa")
+
+    auth_relative = _posix_path(data["auth_db_path"])
+    auth_resolved = data_root / auth_relative
+    if auth_relative.is_absolute() or auth_relative == PurePosixPath("."):
+        errors.append("data.auth_db_path: deve essere un file relativo alla data root")
+    if auth_relative.suffix not in {".db", ".sqlite", ".sqlite3"}:
+        errors.append("data.auth_db_path: estensione SQLite richiesta")
+    if not _is_within(auth_resolved, data_root) or auth_resolved == data_root:
+        errors.append("data.auth_db_path: risoluzione fuori dalla data root")
+
+    external_paths = {
+        "service.environment_file": environment_file,
+        "origin.tls_certificate_file": tls_certificate,
+        "origin.tls_private_key_file": tls_private_key,
+    }
+    for name, path in external_paths.items():
+        if _is_within(path, repository_root) or _is_within(path, data_root):
+            errors.append(f"{name}: il riferimento esterno non può stare nella release o nella data root")
+    if len(set(external_paths.values())) != len(external_paths):
+        errors.append("secret references: environment, certificato e chiave devono avere path distinti")
+
+    try:
+        parsed_origin = urlsplit(origin["url"])
+        parsed_hostname = parsed_origin.hostname
+        parsed_port = parsed_origin.port
+    except ValueError:
+        parsed_origin = None
+        parsed_hostname = None
+        parsed_port = -1
+    canonical_origin = f"https://{parsed_hostname}" if parsed_hostname is not None else None
+    if (
+        parsed_origin is None
+        or parsed_origin.scheme != "https"
+        or not parsed_hostname
+        or _ORIGIN_HOST_RE.fullmatch(parsed_hostname) is None
+        or parsed_hostname.rsplit(".", 1)[-1].isdigit()
+        or parsed_origin.username is not None
+        or parsed_origin.password is not None
+        or parsed_port is not None
+        or parsed_origin.path
+        or parsed_origin.query
+        or parsed_origin.fragment
+        or origin["url"] != canonical_origin
+    ):
+        errors.append("origin.url: deve essere una origin HTTPS canonica senza porta, path, query o credenziali")
+
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for index, raw_network in enumerate(origin["allowed_proxy_cidrs"]):
+        try:
+            network = ipaddress.ip_network(raw_network, strict=True)
+        except ValueError:
+            errors.append(f"origin.allowed_proxy_cidrs.{index}: CIDR canonica richiesta")
+            continue
+        if network.prefixlen == 0 or network.is_loopback or network.is_unspecified or network.is_multicast:
+            errors.append(f"origin.allowed_proxy_cidrs.{index}: rete non ammessa")
+        networks.append(network)
+    for index, network in enumerate(networks):
+        if any(
+            index != other
+            and network.version == candidate.version
+            and network.subnet_of(candidate)
+            for other, candidate in enumerate(networks)
+        ):
+            errors.append(f"origin.allowed_proxy_cidrs.{index}: rete ridondante o sovrapposta")
+
+    return errors
+
+
+def validate_manifest(manifest: Mapping[str, Any]) -> None:
+    errors = _schema_errors(manifest, DEPLOYMENT_SCHEMA, redact=False)
+    if not errors:
+        errors.extend(_semantic_manifest_errors(manifest))
+    if errors:
+        raise DeploymentValidationError("Manifest deployment non valido:\n- " + "\n- ".join(errors))
+
+
+def parse_environment_file(path: Path) -> dict[str, str]:
+    """Parse the deliberately small, unquoted EnvironmentFile contract."""
+
+    try:
+        lines = path.read_text(encoding="utf-8-sig").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise DeploymentValidationError("EnvironmentFile non leggibile.") from exc
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(lines, start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export ") or "=" not in line:
+            raise DeploymentValidationError(f"EnvironmentFile: sintassi non valida alla riga {line_number}.")
+        key, value = line.split("=", 1)
+        if not key or key != key.strip() or not key.replace("_", "A").isalnum() or not key[0].isalpha():
+            raise DeploymentValidationError(f"EnvironmentFile: nome non valido alla riga {line_number}.")
+        if key in values:
+            raise DeploymentValidationError(f"EnvironmentFile: variabile duplicata alla riga {line_number}.")
+        if not value or value != value.strip() or any(ord(character) < 0x21 or ord(character) > 0x7E for character in value):
+            raise DeploymentValidationError(f"EnvironmentFile: valore non valido alla riga {line_number}.")
+        values[key] = value
+    return values
+
+
+def validate_environment(values: Mapping[str, str], *, github_oauth: bool) -> None:
+    errors = _schema_errors(values, ENVIRONMENT_SCHEMA, redact=True)
+    github_names = {"THEBITLAB_GITHUB_CLIENT_ID", "THEBITLAB_GITHUB_CLIENT_SECRET"}
+    present_github = github_names.intersection(values)
+    if github_oauth and present_github != github_names:
+        errors.append("GitHub OAuth: client ID e client secret esterni sono entrambi obbligatori")
+    if not github_oauth and present_github:
+        errors.append("GitHub OAuth: credenziali presenti ma feature disabilitata")
+
+    decoded_secrets: list[bytes] = []
+    for name in (
+        "THEBITLAB_AUTH_CSRF_SECRET_B64",
+        "THEBITLAB_RATE_LIMIT_PEPPER_B64",
+        "THEBITLAB_TUI_PAIRING_PEPPER_B64",
+    ):
+        value = values.get(name)
+        if value is None:
+            continue
+        try:
+            decoded = base64.b64decode(
+                value + "=" * (-len(value) % 4),
+                altchars=b"-_",
+                validate=True,
+            )
+        except (binascii.Error, ValueError):
+            errors.append(f"{name}: base64url non valida")
+            continue
+        if not 32 <= len(decoded) <= 64:
+            errors.append(f"{name}: deve rappresentare 32-64 byte")
+        decoded_secrets.append(decoded)
+    if len(decoded_secrets) != len(set(decoded_secrets)):
+        errors.append("I segreti CSRF, rate limit e pairing devono essere indipendenti")
+
+    if errors:
+        raise DeploymentValidationError("EnvironmentFile non valido (valori omessi):\n- " + "\n- ".join(errors))
+
+
+def _check_external_file(
+    path: Path, *, private: bool, allow_group_read: bool = False
+) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise DeploymentValidationError(f"Riferimento esterno assente o non accessibile: {path}") from exc
+    if path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+        raise DeploymentValidationError(f"Riferimento esterno non regolare: {path}")
+    forbidden_mode = 0o027 if allow_group_read else 0o077
+    if private and os.name != "nt" and metadata.st_mode & forbidden_mode:
+        raise DeploymentValidationError(f"Permessi troppo ampi sul riferimento esterno: {path}")
+
+
+def check_external_references(manifest: Mapping[str, Any]) -> None:
+    """Check metadata only; this function never opens or reads referenced files."""
+
+    service = manifest["service"]
+    origin = manifest["origin"]
+    _check_external_file(
+        Path(service["environment_file"]), private=True, allow_group_read=True
+    )
+    _check_external_file(Path(origin["tls_certificate_file"]), private=False)
+    _check_external_file(Path(origin["tls_private_key_file"]), private=True)
+
+
+def _render_template(name: str, replacements: Mapping[str, str]) -> str:
+    template = (TEMPLATE_ROOT / name).read_text(encoding="utf-8")
+    rendered = template
+    for token, value in replacements.items():
+        rendered = rendered.replace(f"@@{token}@@", value)
+    if "@@" in rendered:
+        raise DeploymentValidationError(f"Template incompleto: {name}")
+    return rendered
+
+
+def _origin_access_rules(manifest: Mapping[str, Any]) -> str:
+    if manifest["origin"]["exposure"] == "public":
+        return "    # Public origin exposure explicitly selected by the manifest."
+    rules = ["    # Local diagnostics remain possible; Internet traffic must come from the edge."]
+    rules.extend(("    allow 127.0.0.1;", "    allow ::1;"))
+    rules.extend(f"    allow {network};" for network in manifest["origin"]["allowed_proxy_cidrs"])
+    rules.append("    deny all;")
+    return "\n".join(rules)
+
+
+def normalized_manifest_bytes(manifest: Mapping[str, Any]) -> bytes:
+    return (json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=True) + "\n").encode("utf-8")
+
+
+def render_bundle(manifest: Mapping[str, Any], output: Path) -> None:
+    validate_manifest(manifest)
+    if output.exists():
+        raise DeploymentValidationError(f"La directory output esiste già: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    origin = manifest["origin"]
+    service = manifest["service"]
+    release = manifest["release"]
+    features = manifest["features"]
+    origin_host = urlsplit(origin["url"]).hostname
+    assert origin_host is not None
+    github_app_directory = PurePosixPath(service["home_directory"]) / ".thebitlab-secrets/github-app"
+    replacements = {
+        "DEPLOYMENT_ID": manifest["deployment_id"],
+        "REPOSITORY_ROOT": release["repository_root"],
+        "PYTHON_EXECUTABLE": release["python_executable"],
+        "RELEASE_COMMIT": release["commit"],
+        "SERVICE_USER": service["user"],
+        "SERVICE_GROUP": service["group"],
+        "HOME_DIRECTORY": service["home_directory"],
+        "BIND_HOST": service["bind_host"],
+        "APP_PORT": str(service["port"]),
+        "ENVIRONMENT_FILE": service["environment_file"],
+        "LOCK_DIRECTORY": service["lock_directory"],
+        "DATA_ROOT": manifest["data"]["root"],
+        "AUTH_DB_PATH": manifest["data"]["auth_db_path"],
+        "GOOGLE_REDIRECT_URI": f"{origin['url'].rstrip('/')}/auth/google/callback",
+        "GITHUB_REDIRECT_ENV": (
+            f"Environment=THEBITLAB_GITHUB_REDIRECT_URI={origin['url'].rstrip('/')}/auth/github/callback"
+            if features["github_oauth"]
+            else "# GitHub OAuth disabled by the deployment manifest."
+        ),
+        "GITHUB_APP_FLAG": " --enable-github-app-token-runtime" if features["github_app_token_runtime"] else "",
+        "GITHUB_APP_WRITE_PATH": f" -{github_app_directory}" if features["github_app_token_runtime"] else "",
+        "ORIGIN_HOST": origin_host,
+        "ORIGIN_ACCESS_RULES": _origin_access_rules(manifest),
+        "TLS_CERTIFICATE_FILE": origin["tls_certificate_file"],
+        "TLS_PRIVATE_KEY_FILE": origin["tls_private_key_file"],
+        "ACCESS_LOG": origin["access_log"],
+        "ERROR_LOG": origin["error_log"],
+    }
+    firewall_contract = {
+        "schema_version": "thebitlab.origin-exposure.v1",
+        "mode": origin["exposure"],
+        "default_for_tcp_ports": "deny" if origin["exposure"] == "edge_only" else "allow",
+        "tcp_ports": [80, 443],
+        "allowed_source_cidrs": origin["allowed_proxy_cidrs"],
+        "backend_bind": f"{service['bind_host']}:{service['port']}",
+    }
+    contents = {
+        "nginx/thebitlab-log-format.conf": _render_template("thebitlab-log-format.conf.template", replacements),
+        "nginx/thebitlab.conf": _render_template("thebitlab-nginx.conf.template", replacements),
+        "systemd/thebitlab.service": _render_template("thebitlab.service.template", replacements),
+        "firewall/origin-exposure.json": json.dumps(firewall_contract, indent=2, sort_keys=True) + "\n",
+        "manifest.normalized.json": normalized_manifest_bytes(manifest).decode("utf-8"),
+    }
+
+    temporary = Path(tempfile.mkdtemp(prefix=f".{output.name}-", dir=output.parent))
+    try:
+        for relative_name in GENERATED_FILES:
+            target = temporary / relative_name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(contents[relative_name], encoding="utf-8", newline="\n")
+        hashes = {
+            name: hashlib.sha256((temporary / name).read_bytes()).hexdigest()
+            for name in GENERATED_FILES
+        }
+        lock = {
+            "schema_version": "thebitlab.pilot-deployment-lock.v1",
+            "deployment_id": manifest["deployment_id"],
+            "release_commit": release["commit"],
+            "files": hashes,
+        }
+        (temporary / "deployment.lock.json").write_text(
+            json.dumps(lock, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        temporary.replace(output)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True, help="Manifest JSON versionato.")
+    parser.add_argument("--output", type=Path, help="Directory nuova in cui renderizzare gli artifact.")
+    parser.add_argument(
+        "--environment-file",
+        type=Path,
+        help="Valida esplicitamente un EnvironmentFile esterno senza stamparne i valori.",
+    )
+    parser.add_argument(
+        "--check-external-references",
+        action="store_true",
+        help="Controlla esistenza/tipo/permessi dei riferimenti esterni senza leggerli.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        manifest = load_json(args.config)
+        validate_manifest(manifest)
+        if args.environment_file is not None:
+            expected = Path(manifest["service"]["environment_file"])
+            if args.environment_file.absolute() != expected.absolute():
+                raise DeploymentValidationError("EnvironmentFile diverso dal riferimento nel manifest.")
+            _check_external_file(
+                args.environment_file, private=True, allow_group_read=True
+            )
+            values = parse_environment_file(args.environment_file)
+            validate_environment(values, github_oauth=manifest["features"]["github_oauth"])
+        if args.check_external_references:
+            check_external_references(manifest)
+        if args.output is not None:
+            render_bundle(manifest, args.output)
+    except DeploymentValidationError as exc:
+        print(f"ERRORE: {exc}", file=os.sys.stderr)
+        return 2
+    print("PASS: baseline deployment valida" + (" e renderizzata" if args.output else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_pilot_deployment.py
+++ b/scripts/validate_pilot_deployment.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import base64
-import binascii
 import hashlib
 import ipaddress
 import json
@@ -22,6 +20,17 @@ from jsonschema import Draft202012Validator
 
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in os.sys.path:
+    os.sys.path.insert(0, str(ROOT))
+
+from scripts.pilot_environment import (  # noqa: E402
+    DeploymentValidationError,
+    check_environment_file,
+    parse_environment_file,
+    validate_external_environment,
+)
+
+
 DEPLOYMENT_SCHEMA = ROOT / "schemas" / "pilot-deployment.schema.json"
 ENVIRONMENT_SCHEMA = ROOT / "schemas" / "pilot-environment.schema.json"
 TEMPLATE_ROOT = ROOT / "deploy" / "pilot" / "templates"
@@ -36,10 +45,6 @@ GENERATED_FILES = (
     "firewall/origin-exposure.json",
     "manifest.normalized.json",
 )
-
-
-class DeploymentValidationError(ValueError):
-    """A safe configuration error that never needs to include secret values."""
 
 
 def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -188,66 +193,13 @@ def validate_manifest(manifest: Mapping[str, Any]) -> None:
         raise DeploymentValidationError("Manifest deployment non valido:\n- " + "\n- ".join(errors))
 
 
-def parse_environment_file(path: Path) -> dict[str, str]:
-    """Parse the deliberately small, unquoted EnvironmentFile contract."""
-
-    try:
-        lines = path.read_text(encoding="utf-8-sig").splitlines()
-    except (OSError, UnicodeError) as exc:
-        raise DeploymentValidationError("EnvironmentFile non leggibile.") from exc
-    values: dict[str, str] = {}
-    for line_number, raw_line in enumerate(lines, start=1):
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("export ") or "=" not in line:
-            raise DeploymentValidationError(f"EnvironmentFile: sintassi non valida alla riga {line_number}.")
-        key, value = line.split("=", 1)
-        if not key or key != key.strip() or not key.replace("_", "A").isalnum() or not key[0].isalpha():
-            raise DeploymentValidationError(f"EnvironmentFile: nome non valido alla riga {line_number}.")
-        if key in values:
-            raise DeploymentValidationError(f"EnvironmentFile: variabile duplicata alla riga {line_number}.")
-        if not value or value != value.strip() or any(ord(character) < 0x21 or ord(character) > 0x7E for character in value):
-            raise DeploymentValidationError(f"EnvironmentFile: valore non valido alla riga {line_number}.")
-        values[key] = value
-    return values
-
-
 def validate_environment(values: Mapping[str, str], *, github_oauth: bool) -> None:
     errors = _schema_errors(values, ENVIRONMENT_SCHEMA, redact=True)
-    github_names = {"THEBITLAB_GITHUB_CLIENT_ID", "THEBITLAB_GITHUB_CLIENT_SECRET"}
-    present_github = github_names.intersection(values)
-    if github_oauth and present_github != github_names:
-        errors.append("GitHub OAuth: client ID e client secret esterni sono entrambi obbligatori")
-    if not github_oauth and present_github:
-        errors.append("GitHub OAuth: credenziali presenti ma feature disabilitata")
-
-    decoded_secrets: list[bytes] = []
-    for name in (
-        "THEBITLAB_AUTH_CSRF_SECRET_B64",
-        "THEBITLAB_RATE_LIMIT_PEPPER_B64",
-        "THEBITLAB_TUI_PAIRING_PEPPER_B64",
-    ):
-        value = values.get(name)
-        if value is None:
-            continue
-        try:
-            decoded = base64.b64decode(
-                value + "=" * (-len(value) % 4),
-                altchars=b"-_",
-                validate=True,
-            )
-        except (binascii.Error, ValueError):
-            errors.append(f"{name}: base64url non valida")
-            continue
-        if not 32 <= len(decoded) <= 64:
-            errors.append(f"{name}: deve rappresentare 32-64 byte")
-        decoded_secrets.append(decoded)
-    if len(decoded_secrets) != len(set(decoded_secrets)):
-        errors.append("I segreti CSRF, rate limit e pairing devono essere indipendenti")
-
     if errors:
-        raise DeploymentValidationError("EnvironmentFile non valido (valori omessi):\n- " + "\n- ".join(errors))
+        raise DeploymentValidationError(
+            "EnvironmentFile non valido (valori omessi):\n- " + "\n- ".join(errors)
+        )
+    validate_external_environment(values, github_oauth=github_oauth)
 
 
 def _check_external_file(
@@ -269,9 +221,7 @@ def check_external_references(manifest: Mapping[str, Any]) -> None:
 
     service = manifest["service"]
     origin = manifest["origin"]
-    _check_external_file(
-        Path(service["environment_file"]), private=True, allow_group_read=True
-    )
+    check_environment_file(Path(service["environment_file"]))
     _check_external_file(Path(origin["tls_certificate_file"]), private=False)
     _check_external_file(Path(origin["tls_private_key_file"]), private=True)
 
@@ -328,10 +278,10 @@ def render_bundle(manifest: Mapping[str, Any], output: Path) -> None:
         "DATA_ROOT": manifest["data"]["root"],
         "AUTH_DB_PATH": manifest["data"]["auth_db_path"],
         "GOOGLE_REDIRECT_URI": f"{origin['url'].rstrip('/')}/auth/google/callback",
-        "GITHUB_REDIRECT_ENV": (
-            f"Environment=THEBITLAB_GITHUB_REDIRECT_URI={origin['url'].rstrip('/')}/auth/github/callback"
+        "GITHUB_OAUTH_ARGUMENTS": (
+            f" --enable-github-oauth --github-redirect-uri {origin['url'].rstrip('/')}/auth/github/callback"
             if features["github_oauth"]
-            else "# GitHub OAuth disabled by the deployment manifest."
+            else ""
         ),
         "GITHUB_APP_FLAG": " --enable-github-app-token-runtime" if features["github_app_token_runtime"] else "",
         "GITHUB_APP_WRITE_PATH": f" -{github_app_directory}" if features["github_app_token_runtime"] else "",
@@ -411,9 +361,7 @@ def main(argv: list[str] | None = None) -> int:
             expected = Path(manifest["service"]["environment_file"])
             if args.environment_file.absolute() != expected.absolute():
                 raise DeploymentValidationError("EnvironmentFile diverso dal riferimento nel manifest.")
-            _check_external_file(
-                args.environment_file, private=True, allow_group_read=True
-            )
+            check_environment_file(args.environment_file)
             values = parse_environment_file(args.environment_file)
             validate_environment(values, github_oauth=manifest["features"]["github_oauth"])
         if args.check_external_references:

--- a/tests/test_pilot_deployment.py
+++ b/tests/test_pilot_deployment.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator
 
+from scripts import pilot_deployment_smoke as smoke
 from scripts import validate_pilot_deployment as deployment
 
 
@@ -237,6 +238,21 @@ def test_github_features_render_only_the_explicit_contract(tmp_path: Path) -> No
     assert "--enable-github-app-token-runtime" in unit
     assert "-/home/thebitlab/.thebitlab-secrets/github-app" in unit
     assert "private-key.pem" not in unit
+
+
+def test_nginx_smoke_uses_unprivileged_ports_without_mutating_bundle(tmp_path: Path) -> None:
+    output = tmp_path / "bundle"
+    deployment.render_bundle(manifest(), output)
+    site = (output / "nginx/thebitlab.conf").read_text(encoding="utf-8")
+
+    smoke_site = smoke._nginx_site_for_unprivileged_smoke(site)
+
+    assert smoke_site.count("18080") == 4
+    assert smoke_site.count("18443") == 4
+    assert smoke_site.replace("18080", "80").replace("18443", "443") == site
+    assert (output / "nginx/thebitlab.conf").read_text(encoding="utf-8") == site
+    with pytest.raises(RuntimeError, match="Direttive listen nginx inattese"):
+        smoke._nginx_site_for_unprivileged_smoke("server { listen 80; }")
 
 
 def test_smoke_cli_entrypoint_resolves_repository_package() -> None:

--- a/tests/test_pilot_deployment.py
+++ b/tests/test_pilot_deployment.py
@@ -1,0 +1,283 @@
+"""Contract, renderer and tool smoke tests for the pilot deployment baseline."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts import validate_pilot_deployment as deployment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE = ROOT / "deploy" / "pilot" / "candidate.example.json"
+
+
+def manifest() -> dict:
+    return deployment.load_json(CANDIDATE)
+
+
+def encoded_secret(byte: int) -> str:
+    return base64.urlsafe_b64encode(bytes([byte]) * 32).rstrip(b"=").decode("ascii")
+
+
+def valid_environment() -> dict[str, str]:
+    return {
+        "THEBITLAB_TEACHER_TOKEN": "T" * 32,
+        "THEBITLAB_GOOGLE_CLIENT_ID": "client-id.example",
+        "THEBITLAB_GOOGLE_CLIENT_SECRET": "G" * 32,
+        "THEBITLAB_AUTH_CSRF_SECRET_B64": encoded_secret(1),
+        "THEBITLAB_RATE_LIMIT_PEPPER_B64": encoded_secret(2),
+        "THEBITLAB_TUI_PAIRING_PEPPER_B64": encoded_secret(3),
+    }
+
+
+def test_deployment_schemas_are_closed_valid_draft_2020_12_documents() -> None:
+    for name in ("pilot-deployment.schema.json", "pilot-environment.schema.json"):
+        schema = deployment.load_json(ROOT / "schemas" / name)
+        assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        assert schema["additionalProperties"] is False
+        Draft202012Validator.check_schema(schema)
+
+
+def test_candidate_manifest_renders_reproducible_secret_free_bundle(tmp_path: Path) -> None:
+    payload = manifest()
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+
+    deployment.render_bundle(payload, first)
+    deployment.render_bundle(payload, second)
+
+    for relative_name in (*deployment.GENERATED_FILES, "deployment.lock.json"):
+        assert (first / relative_name).read_bytes() == (second / relative_name).read_bytes()
+    rendered = "\n".join(
+        path.read_text(encoding="utf-8") for path in first.rglob("*") if path.is_file()
+    )
+    assert "<external-" not in rendered
+    assert "GOOGLE_CLIENT_SECRET=" not in rendered
+    assert payload["service"]["environment_file"] in rendered
+    assert payload["release"]["commit"] in rendered
+
+
+def test_rendered_service_pins_root_auth_resolution_and_generated_topology(tmp_path: Path) -> None:
+    payload = manifest()
+    output = tmp_path / "bundle"
+    deployment.render_bundle(payload, output)
+    unit = (output / "systemd/thebitlab.service").read_text(encoding="utf-8")
+
+    environment_index = unit.index("EnvironmentFile=")
+    auth_index = unit.index("Environment=THEBITLAB_AUTH_DB_PATH=")
+    assert environment_index < auth_index
+    assert "Environment=THEBITLAB_AUTH_DB_PATH=.thebitlab-auth/auth.sqlite3" in unit
+    assert "Environment=THEBITLAB_TRUSTED_PROXY_CIDRS=127.0.0.1/32" in unit
+    assert "--host 127.0.0.1 --port 8000 --root /srv/thebitlab/data" in unit
+    assert "--enable-google-auth" in unit
+    assert "--enable-github-app-token-runtime" not in unit
+    assert "User=thebitlab" in unit
+    assert "ProtectSystem=strict" in unit
+
+
+def test_edge_only_nginx_blocks_direct_origin_and_does_not_log_queries(tmp_path: Path) -> None:
+    output = tmp_path / "bundle"
+    deployment.render_bundle(manifest(), output)
+    site = (output / "nginx/thebitlab.conf").read_text(encoding="utf-8")
+    log_format = (output / "nginx/thebitlab-log-format.conf").read_text(encoding="utf-8")
+
+    assert "listen 443 ssl default_server;" in site
+    assert "ssl_reject_handshake on;" in site
+    assert "allow 192.0.2.0/24;" in site
+    assert "allow 2001:db8::/32;" in site
+    assert site.count("deny all;") == 2
+    assert "proxy_set_header X-Forwarded-For $remote_addr;" in site
+    assert "$request_uri" not in log_format
+    assert "$args" not in log_format
+    assert "$http_referer" not in log_format
+    firewall = json.loads((output / "firewall/origin-exposure.json").read_text(encoding="utf-8"))
+    assert firewall == {
+        "schema_version": "thebitlab.origin-exposure.v1",
+        "mode": "edge_only",
+        "default_for_tcp_ports": "deny",
+        "tcp_ports": [80, 443],
+        "allowed_source_cidrs": ["192.0.2.0/24", "2001:db8::/32"],
+        "backend_bind": "127.0.0.1:8000",
+    }
+
+
+def test_public_origin_requires_explicit_empty_allowlist(tmp_path: Path) -> None:
+    payload = manifest()
+    payload["origin"]["exposure"] = "public"
+    payload["origin"]["allowed_proxy_cidrs"] = []
+    output = tmp_path / "public"
+
+    deployment.render_bundle(payload, output)
+
+    site = (output / "nginx/thebitlab.conf").read_text(encoding="utf-8")
+    assert "Public origin exposure explicitly selected" in site
+    assert "deny all;" not in site
+
+
+def test_manifest_rejects_incomplete_ambiguous_or_unsafe_root_configuration() -> None:
+    cases = []
+    missing = manifest()
+    del missing["service"]["environment_file"]
+    cases.append(missing)
+    absolute_auth = manifest()
+    absolute_auth["data"]["auth_db_path"] = "/srv/other/auth.sqlite3"
+    cases.append(absolute_auth)
+    escaped_auth = manifest()
+    escaped_auth["data"]["auth_db_path"] = "../auth.sqlite3"
+    cases.append(escaped_auth)
+    release_data_overlap = manifest()
+    release_data_overlap["data"]["root"] = "/opt/thebitlab/current/data"
+    cases.append(release_data_overlap)
+    secret_in_release = manifest()
+    secret_in_release["service"]["environment_file"] = "/opt/thebitlab/current/pilot.env"
+    cases.append(secret_in_release)
+    mutable_runtime = manifest()
+    mutable_runtime["release"]["python_executable"] = "/opt/thebitlab/venv/bin/python"
+    cases.append(mutable_runtime)
+    public_with_allowlist = manifest()
+    public_with_allowlist["origin"]["exposure"] = "public"
+    cases.append(public_with_allowlist)
+
+    for payload in cases:
+        with pytest.raises(deployment.DeploymentValidationError):
+            deployment.validate_manifest(payload)
+
+
+def test_edge_only_manifest_rejects_missing_invalid_or_redundant_proxy_ranges() -> None:
+    for ranges in ([], ["0.0.0.0/0"], ["192.0.2.1/24"], ["192.0.2.0/24", "192.0.2.0/25"]):
+        payload = manifest()
+        payload["origin"]["allowed_proxy_cidrs"] = ranges
+        with pytest.raises(deployment.DeploymentValidationError):
+            deployment.validate_manifest(payload)
+
+
+def test_manifest_rejects_noncanonical_or_template_unsafe_origins() -> None:
+    for origin in (
+        "https://candidate.example.edu/",
+        "https://Candidate.example.edu",
+        "https://candidate.example.edu:443",
+        "https://candidate.example.edu\\nbad.example.edu",
+        "https://127.0.0.1",
+        "https://[broken",
+    ):
+        payload = manifest()
+        payload["origin"]["url"] = origin
+        with pytest.raises(deployment.DeploymentValidationError):
+            deployment.validate_manifest(payload)
+
+
+def test_environment_contract_accepts_only_complete_independent_external_values() -> None:
+    deployment.validate_environment(valid_environment(), github_oauth=False)
+    github = valid_environment()
+    github.update(
+        {
+            "THEBITLAB_GITHUB_CLIENT_ID": "github-client",
+            "THEBITLAB_GITHUB_CLIENT_SECRET": "H" * 32,
+        }
+    )
+    deployment.validate_environment(github, github_oauth=True)
+
+    incomplete = valid_environment()
+    del incomplete["THEBITLAB_GOOGLE_CLIENT_SECRET"]
+    with pytest.raises(deployment.DeploymentValidationError):
+        deployment.validate_environment(incomplete, github_oauth=False)
+
+    ambiguous = valid_environment()
+    ambiguous["THEBITLAB_AUTH_DB_PATH"] = "/somewhere/else.sqlite3"
+    with pytest.raises(deployment.DeploymentValidationError):
+        deployment.validate_environment(ambiguous, github_oauth=False)
+
+    repeated = valid_environment()
+    repeated["THEBITLAB_RATE_LIMIT_PEPPER_B64"] = repeated["THEBITLAB_AUTH_CSRF_SECRET_B64"]
+    with pytest.raises(deployment.DeploymentValidationError, match="indipendenti"):
+        deployment.validate_environment(repeated, github_oauth=False)
+
+    quoted = valid_environment()
+    quoted["THEBITLAB_GOOGLE_CLIENT_SECRET"] = '"' + "G" * 32 + '"'
+    with pytest.raises(deployment.DeploymentValidationError) as captured:
+        deployment.validate_environment(quoted, github_oauth=False)
+    assert quoted["THEBITLAB_GOOGLE_CLIENT_SECRET"] not in str(captured.value)
+
+
+def test_environment_parser_rejects_duplicate_or_shell_syntax_without_echoing_values(tmp_path: Path) -> None:
+    secret_marker = "DO-NOT-ECHO-THIS-SECRET"
+    path = tmp_path / "pilot.env"
+    path.write_text(
+        f"THEBITLAB_TEACHER_TOKEN={secret_marker}\nTHEBITLAB_TEACHER_TOKEN={secret_marker}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(deployment.DeploymentValidationError) as captured:
+        deployment.parse_environment_file(path)
+    assert secret_marker not in str(captured.value)
+
+    path.write_text("export THEBITLAB_TEACHER_TOKEN=value\n", encoding="utf-8")
+    with pytest.raises(deployment.DeploymentValidationError):
+        deployment.parse_environment_file(path)
+
+
+def test_github_features_render_only_the_explicit_contract(tmp_path: Path) -> None:
+    payload = manifest()
+    payload["features"]["github_oauth"] = True
+    payload["features"]["github_app_token_runtime"] = True
+    output = tmp_path / "github"
+
+    deployment.render_bundle(payload, output)
+
+    unit = (output / "systemd/thebitlab.service").read_text(encoding="utf-8")
+    assert "THEBITLAB_GITHUB_REDIRECT_URI=https://candidate.example.edu/auth/github/callback" in unit
+    assert "--enable-github-app-token-runtime" in unit
+    assert "-/home/thebitlab/.thebitlab-secrets/github-app" in unit
+    assert "private-key.pem" not in unit
+
+
+def test_smoke_cli_entrypoint_resolves_repository_package() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/pilot_deployment_smoke.py", "--help"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "non-destructive nginx/systemd smoke" in result.stdout
+    assert "Traceback" not in result.stderr
+
+
+def test_cli_validates_example_without_touching_external_references() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/validate_pilot_deployment.py", "--config", str(CANDIDATE)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "PASS: baseline deployment valida"
+
+
+@pytest.mark.skipif(
+    not all(shutil.which(tool) for tool in ("nginx", "systemd-analyze", "openssl")),
+    reason="nginx/systemd-analyze/openssl non disponibili su questo host",
+)
+def test_controlled_nginx_and_systemd_smoke() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/pilot_deployment_smoke.py", "--config", str(CANDIDATE)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS: smoke deployment non distruttivo" in result.stdout

--- a/tests/test_pilot_deployment.py
+++ b/tests/test_pilot_deployment.py
@@ -14,6 +14,7 @@ import pytest
 from jsonschema import Draft202012Validator
 
 from scripts import pilot_deployment_smoke as smoke
+from scripts import pilot_service_launcher as service_launcher
 from scripts import validate_pilot_deployment as deployment
 
 
@@ -73,11 +74,10 @@ def test_rendered_service_pins_root_auth_resolution_and_generated_topology(tmp_p
     deployment.render_bundle(payload, output)
     unit = (output / "systemd/thebitlab.service").read_text(encoding="utf-8")
 
-    environment_index = unit.index("EnvironmentFile=")
-    auth_index = unit.index("Environment=THEBITLAB_AUTH_DB_PATH=")
-    assert environment_index < auth_index
-    assert "Environment=THEBITLAB_AUTH_DB_PATH=.thebitlab-auth/auth.sqlite3" in unit
-    assert "Environment=THEBITLAB_TRUSTED_PROXY_CIDRS=127.0.0.1/32" in unit
+    assert "\nEnvironmentFile=" not in unit
+    assert "scripts/pilot_service_launcher.py" in unit
+    assert "--auth-db-path .thebitlab-auth/auth.sqlite3" in unit
+    assert "--trusted-proxy-cidrs 127.0.0.1/32" in unit
     assert "--host 127.0.0.1 --port 8000 --root /srv/thebitlab/data" in unit
     assert "--enable-google-auth" in unit
     assert "--enable-github-app-token-runtime" not in unit
@@ -209,6 +209,51 @@ def test_environment_contract_accepts_only_complete_independent_external_values(
     assert quoted["THEBITLAB_GOOGLE_CLIENT_SECRET"] not in str(captured.value)
 
 
+def test_service_launcher_rejects_reserved_external_names_and_pins_effective_topology(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "pilot.env"
+    external = valid_environment()
+    external["THEBITLAB_AUTH_DB_PATH"] = "/tmp/attacker.sqlite3"
+    path.write_text(
+        "".join(f"{name}={value}\n" for name, value in external.items()),
+        encoding="utf-8",
+    )
+    parsed = deployment.parse_environment_file(path)
+    authoritative = {
+        "THEBITLAB_DEPLOYMENT_REVISION": "a" * 40,
+        "THEBITLAB_LOCK_DIR": "/run/thebitlab",
+        "THEBITLAB_AUTH_DB_PATH": ".thebitlab-auth/auth.sqlite3",
+        "THEBITLAB_TRUSTED_PROXY_CIDRS": "127.0.0.1/32",
+        "THEBITLAB_GOOGLE_REDIRECT_URI": "https://candidate.example.edu/auth/google/callback",
+    }
+
+    with pytest.raises(deployment.DeploymentValidationError, match="variabili non ammesse"):
+        service_launcher.build_effective_environment(
+            {}, parsed, authoritative, github_oauth=False
+        )
+
+    malformed = valid_environment()
+    malformed["THEBITLAB_TEACHER_TOKEN"] = "!" * 32
+    with pytest.raises(deployment.DeploymentValidationError, match="forma non valida"):
+        service_launcher.build_effective_environment(
+            {}, malformed, authoritative, github_oauth=False
+        )
+
+    base = {
+        "PATH": "/usr/bin",
+        "THEBITLAB_AUTH_DB_PATH": "/tmp/stale.sqlite3",
+        "THEBITLAB_GITHUB_CLIENT_SECRET": "stale-secret",
+    }
+    effective = service_launcher.build_effective_environment(
+        base, valid_environment(), authoritative, github_oauth=False
+    )
+    assert effective["THEBITLAB_AUTH_DB_PATH"] == ".thebitlab-auth/auth.sqlite3"
+    assert effective["THEBITLAB_TRUSTED_PROXY_CIDRS"] == "127.0.0.1/32"
+    assert "THEBITLAB_GITHUB_CLIENT_SECRET" not in effective
+    assert effective["PATH"] == "/usr/bin"
+
+
 def test_environment_parser_rejects_duplicate_or_shell_syntax_without_echoing_values(tmp_path: Path) -> None:
     secret_marker = "DO-NOT-ECHO-THIS-SECRET"
     path = tmp_path / "pilot.env"
@@ -234,7 +279,8 @@ def test_github_features_render_only_the_explicit_contract(tmp_path: Path) -> No
     deployment.render_bundle(payload, output)
 
     unit = (output / "systemd/thebitlab.service").read_text(encoding="utf-8")
-    assert "THEBITLAB_GITHUB_REDIRECT_URI=https://candidate.example.edu/auth/github/callback" in unit
+    assert "--enable-github-oauth --github-redirect-uri https://candidate.example.edu/auth/github/callback" in unit
+    assert "Environment=THEBITLAB_GITHUB_REDIRECT_URI=" not in unit
     assert "--enable-github-app-token-runtime" in unit
     assert "-/home/thebitlab/.thebitlab-secrets/github-app" in unit
     assert "private-key.pem" not in unit


### PR DESCRIPTION
## Summary

Completa la remediation di #701 introducendo una baseline deployment-as-code riproducibile e secret-safe per il pilot.

### Cosa cambia
- manifest candidate e template nginx/systemd/environment in `deploy/pilot/`;
- schema `pilot-*.schema.json` per deployment ed EnvironmentFile;
- validator/rendering deterministico con `scripts/validate_pilot_deployment.py`;
- smoke non distruttivo nginx/systemd con `scripts/pilot_deployment_smoke.py`;
- test positivi e fail-closed;
- documentazione su data root, secret references, origin/firewall e rollback bounded;
- aggiornamenti a documentazione architetturale, rehearsal e CI.

### Verifica
- test mirati/documentali: 22 passed, 1 skipped;
- smoke Debian: PASS (`nginx -t`, `systemd-analyze verify`);
- Sphinx con warning fatali: PASS;
- piano generato, `py_compile`, `git diff --check`, secret scan e review: PASS;
- full suite: 2 failure ambientali Windows estranee al diff (privilegio symlink e script macOS eseguito come Win32).

### Limiti / follow-up
Nessun ambiente live, segreto o configurazione Cloudflare è stato toccato. Prima del deploy servono manifest reale revisionato, allowlist edge, executor firewall, secret store, governance #699, backup/restore e nuovo rehearsal #678.

Closes #701.