### PR TITLE
Identity: binding autorevole tra utente, soggetto, classe e assignment

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -1,55 +1,46 @@
 # Checkpoint operativo
 
-- **Data/ora:** 2026-08-09T08:51:50+02:00
-- **Obiettivo:** pubblicare il runbook del pilot rehearsal e la correzione bloccante dello Scenario 9.
-- **Stato:** **pronto per la pubblicazione**; review completa pre-commit senza finding, autorizzazione esplicita ricevuta per commit, push e PR.
-- **Criterio e risultato:** `$DemoRoot` può ora contenere il vero `README.md`, una fonte Scenario 9 versionata, il relativo asset locale e l'activity demo; catalogo, preview, link sorgente e casi immagine sono stati verificati su una root temporanea.
+- **Data/ora:** 2026-08-17T05:19:38+02:00
+- **Obiettivo:** issue #702, binding autorevole `user_id` auth ↔ soggetto didattico ↔ `class_id` ↔ assignment/target.
+- **Stato:** **completato e committato** sul branch `feat/identity-binding-702`; nessun push o merge eseguito.
+- **Criterio e risultato:** contratto/source-of-truth documentati; ID server-side stabili; migrazione SQLite v12 e compatibilita legacy esplicita; validator fail-closed e fixture/test missing, duplicate, ambiguous, cross-class, membership rimossa e legacy ambiguo; nessun matching implicito o ID client usato come autorita.
 
-## Modifiche di questa unità
+## Decisioni canoniche
 
-- `doc/SCENARI_TEST_MANUALI_GUI.md`:
-  - Scenario 9 parametrizzato con `$ScenarioRoot`;
-  - setup distruttivo limitato all'esecuzione autonoma e vietato nel pilot sulla `$DemoRoot` già preparata;
-  - copia fail-closed di `README.md`, `doc/fixtures/scenario-9-course-source.md` e dell'asset annotato prima dell'avvio con `--root $ScenarioRoot`;
-  - fonte locale configurata con entrambi i Markdown; casi immagine e numerazione dei passi resi deterministici.
-- `doc/PILOT_REHEARSAL.md`, sezione 4: obbligo di predisporre le tre fixture nella `$DemoRoot`, saltare il setup distruttivo e riavviare il server sulla stessa root; catalogo vuoto/root divergente sono `FAIL`.
-- `doc/fixtures/scenario-9-course-source.md` (nuovo): fonte minima con paragrafo normale, asset locale valido e quattro casi negativi (mancante, fuori root, URL esterno, estensione non grafica).
-- `CHECKPOINT.md`: aggiornato.
-- Modifiche pregresse a `doc/MVP_2026_2027.md` e `doc/README.md` preservate; nessun file applicativo modificato.
+- ADR accettato: `doc/architecture/adr-authoritative-student-identity-binding.md`.
+- SQLite identity e source-of-truth per binding 1:1 immutabile `user_id <-> subject_id`, classi/membership e alias legacy class-scoped.
+- `subject_id` e opaco e server-generated (`subject:<uuid hex>`); `student_id`, email, username, path e repository sono attributi legacy, mai authority.
+- `class_id` deriva dalle membership auth; assignment e target sono record ricaricati dallo storage server. L'enforcement completo delle student API resta fuori scope in #706.
+- Snapshot transazionale con digest `authority_revision`; lifecycle binding CAS monotono/no-delete; alias append-only con revisione binding e membership attiva.
 
-## Verifiche
+## File principali
 
-- Repository/worktree verificati nuovamente: `F:/dev/2cornot2c-pilot-rehearsal`; branch `docs/pilot-rehearsal`; HEAD `021d575be4f091940cef2429fd5b757ebc6d565a`; upstream configurato `origin/main`.
-- Git richiede `safe.directory`; usata soltanto l'eccezione per-comando, senza cambiare configurazioni.
-- `git diff --check`: **PASS**; solo warning informativo LF/CRLF per `CHECKPOINT.md`.
-- Controllo finale sui 6 Markdown interessati: UTF-8, link locali, newline finali, fence e trailing whitespace **PASS**.
-- Smoke ad hoc su root temporanea con `student_lab_demo_setup.prepare_demo`: **PASS**; activity disponibile, 148 heading indicizzati, URL canonico della fixture coerente, asset valido risolto e quattro casi negativi classificati correttamente.
-- 8 test mirati richiesti (13 casi pytest parametrizzati) su source catalog e immagini backend/frontend: **PASS**.
-- Primo smoke ad hoc terminato con `KeyError: 'activity'` nella sola asserzione del test temporaneo; il riepilogo espone `activity_id`. Controllo corretto sul file activity e rieseguito con esito **PASS**; non è un errore del prodotto.
-- Full suite non rieseguita: modifica esclusivamente documentale/fixture; baseline precedente sullo stesso codice **228 passed, 2 skipped**.
-- Parser PowerShell non eseguito: `pwsh` non disponibile. Rehearsal browser/manuale non eseguito: unità operativa successiva.
-- Nessun server, watcher o processo in background avviato; le root temporanee sono state rimosse automaticamente.
+- Nuovi: ADR binding, `scripts/thebitlab_identity_binding.py`, 4 fixture `tests/fixtures/identity_binding/`, test domain/storage dedicati.
+- Modificati: ADR identity/storage e `data-contracts.md`; `scripts/thebitlab_identity_sqlite.py` (schema v12, trigger, adapter/snapshot), `scripts/thebitlab_identity_ports.py`, `scripts/assignment_records.py`; fixture/test contrattuali e rehearsal migrazioni storiche.
+- `CHECKPOINT.md` sostituisce il checkpoint obsoleto di un altro worktree.
 
-## Stato Git
+## Verifiche e review
 
-- Modificati: `CHECKPOINT.md`, `doc/MVP_2026_2027.md`, `doc/README.md`, `doc/SCENARI_TEST_MANUALI_GUI.md`.
-- Non tracciati: `doc/PILOT_REHEARSAL.md`, `doc/fixtures/scenario-9-course-source.md`.
-- Worktree intenzionalmente sporco, pronto per il commit autorizzato; nessun commit, push o PR ancora creato.
-- `origin/main` recuperato e ancora coincidente con HEAD (`021d575be4f091940cef2429fd5b757ebc6d565a`); nessuna PR esistente per `docs/pilot-rehearsal`.
-- `git worktree list` continua a segnalare come `prunable` il worktree estraneo `E:/dev/2cornot2c-main`; nessuna azione eseguita.
+- Test pertinenti finali: **170 passed, 2 skipped** (`identity_binding`, `identity_binding_sqlite`, assignment records, data fixtures, identity, identity SQLite, contracts, storage).
+- Test finali focalizzati dopo i trigger DB: **69 passed**.
+- Suite ampia senza `tests/test_student_errors.py`: **2165 passed, 67 skipped, 2 failed**; i due failure sono ambientali Windows estranei al diff (privilegio symlink WinError 1314 e launcher macOS non eseguibile WinError 193).
+- Suite completa non collezionabile per dipendenza opzionale assente `utui` in `tests/test_student_errors.py`; nessun package installato. `ruff` non disponibile nell'ambiente.
+- `compileall`: **PASS**. `git diff --check`: **PASS**. Link Markdown locali: **PASS**.
+- Review completa del diff eseguita. Finding corretti: migrazione v12 non permissiva su artefatti parziali; alias aggiungibili post-provisioning con CAS; coerenza fixture `class_id`; trigger DB contro delete/reuse/update e alias non autorevoli. Nessun finding aperto.
+- Nessun server, watcher o processo temporaneo avviato.
 
-## Problemi aperti e prossimo passo
+## Stato Git e prossimo passo
 
-- Nessun finding tecnico aperto sulla correzione dello Scenario 9.
-- Creare il commit documentale, pubblicare `docs/pilot-rehearsal` e aprire una PR verso `main`, collegandola senza chiudere issue #678.
-- Dopo la pubblicazione si applica il protocollo PR: il nuovo commit fissa HEAD e azzera i round puliti; sono richiesti due round completi consecutivi senza finding sullo stesso HEAD prima del merge.
-- Il rehearsal operativo di issue #678 resta un'unità distinta e può iniziare soltanto dopo la pubblicazione del runbook.
+- Base iniziale: `3d785a54336e81f69efa7a6d5ee7941f9ba76675` (`origin/main`).
+- Worktree: `F:/dev/2cornot2c-702`; branch `feat/identity-binding-702`.
+- Commit dell'unita creato su `HEAD`; lo SHA definitivo e riportato nel riepilogo finale della sessione.
+- Problemi aperti in scope: nessuno. Non e stato implementato l'enforcement student API, intenzionalmente demandato a #706.
+- Prossimo lavoro distinto: issue #706, consumare `StudentBindingSnapshot`/`AssignmentTargetResolution` nelle policy student API senza accettare authority dalla request.
 
-## File minimi per la ripresa
+## File minimi per una ripresa
 
 - `AGENTS.md`
 - `CHECKPOINT.md`
-- `doc/PILOT_REHEARSAL.md`, sezione 4
-- `doc/SCENARI_TEST_MANUALI_GUI.md`, Scenario 9
-- `doc/fixtures/scenario-9-course-source.md`
-- diff Git corrente
+- `doc/architecture/adr-authoritative-student-identity-binding.md`
+- `scripts/thebitlab_identity_binding.py`
+- diff/commit dell'unita #702

--- a/doc/architecture/adr-authoritative-student-identity-binding.md
+++ b/doc/architecture/adr-authoritative-student-identity-binding.md
@@ -1,0 +1,141 @@
+# ADR: binding autorevole tra identita auth e soggetto didattico
+
+## Stato
+
+Accettato.
+
+## Contesto
+
+Il dominio auth identifica una persona con il `user_id` interno e conserva classi e membership in SQLite. Il dominio didattico storico identifica invece uno studente con `student_id`, nomi di directory, repository o username e conserva assignment e target in JSON. Questi valori legacy possono cambiare, collidere tra classi o essere forniti dal client; non possono quindi essere usati per derivare l'identita autorizzata.
+
+Questa decisione definisce il prerequisito di identita per le policy class-scoped. L'enforcement completo degli endpoint studente resta in #706.
+
+## Decisione
+
+### Namespace e identita stabili
+
+Le identita canoniche hanno responsabilita distinte:
+
+| ID | Autorita | Regole |
+|---|---|---|
+| `user_id` | directory auth SQLite | Interno, stabile, mai derivato da email o username. Arriva al resolver soltanto dal contesto di autenticazione verificato. |
+| `subject_id` | provisioning TheBitLab in SQLite | ID opaco server-generated `subject:<uuid-hex-lowercase>`. Identifica il soggetto didattico, non una credenziale o una persona provider. |
+| `class_id` | directory classi SQLite | ID interno stabile della classe/anno scolastico; team e nomi leggibili sono mapping o attributi. |
+| `assignment_id` | record Assignment caricato dallo storage server | Identifica il record sorgente; un ID nella request puo al massimo selezionare un record che il server ricarica, non provarne ownership o target. |
+| target assignment | record Assignment | Il riferimento canonico allo studente e `subject_id`; path, repository, `student_id` e display name sono attributi operativi/legacy. |
+
+Il binding canonico e una coppia 1:1 immutabile:
+
+```text
+user_id auth <-> subject_id didattico
+```
+
+`class_id` non viene copiato nel binding: deriva esclusivamente dalle `class_memberships` auth attive e dalla classe interna attiva. Questo evita due sorgenti concorrenti per l'appartenenza. Un assignment collega poi una classe e i suoi destinatari:
+
+```text
+assignment_id -> class_id + targets[].subject_id
+```
+
+### Source of truth
+
+Lo schema identity SQLite e l'unica source-of-truth transazionale per:
+
+- account `users`;
+- `student_subject_bindings`;
+- classi e `class_memberships`;
+- `legacy_student_subject_aliases` usati durante la migrazione.
+
+I vincoli SQLite rendono univoci sia `user_id` sia `subject_id` nel binding. Trigger applicativi nel database impongono provisioning su account studente attivo, coppia immutabile, revisione monotona e divieto di cancellazione/riuso. La cancellazione dell'utente e quindi bloccata finche il binding esiste; gli alias sono append-only e impediscono anche la cancellazione della classe (`ON DELETE RESTRICT`).
+
+I JSON Assignment restano sorgente didattica per assignment e target nella fase MVP. Non diventano autorita per l'utente autenticato: il consumer riceve il `user_id` soltanto dal contesto auth, legge uno snapshot identity coerente e carica l'assignment dallo storage server. Nessun campo della request sostituisce questi passaggi.
+
+### Lifecycle e revisioni
+
+Un binding nasce attivo alla `revision = 1`, con `created_at == updated_at`. `user_id`, `subject_id` e `created_at` sono immutabili. Attivazione e disattivazione avanzano esattamente di una revisione mediante compare-and-swap e richiedono un `updated_at` strettamente monotono. Reuse o reassignment degli ID non sono consentiti.
+
+`StudentBindingSnapshot` legge nella stessa transazione account, binding, membership, classi e alias. `authority_revision` e un digest SHA-256 canonico dell'intero contenuto autorevole letto, non un valore del client. Il resolver lo ricalcola prima dell'uso. I consumer devono trattare lo snapshot come una capability effimera e rileggerlo per una nuova decisione; non possono ricombinarlo con righe lette separatamente.
+
+La rimozione della membership ha effetto al successivo snapshot: il binding persona/soggetto puo restare valido, ma la risoluzione di qualunque assignment della classe fallisce chiusa.
+
+### Risoluzione fail-closed
+
+`resolve_student_identity(authenticated_user_id, snapshot)` accetta come input identitario solo il `user_id` autenticato. Rifiuta:
+
+- account mancante, non studente o disabilitato;
+- binding mancante o inattivo;
+- piu binding per lo stesso utente;
+- binding appartenente a un utente differente;
+- membership duplicate, con ruolo incoerente o verso classi mancanti/inattive;
+- snapshot con revisione non coerente.
+
+`resolve_assignment_target(...)` richiede inoltre:
+
+1. assignment caricato dal server con `id`, `class_id` e target validi;
+2. membership studente attiva nella `class_id` dell'assignment;
+3. esattamente un target con il `subject_id` risolto, oppure un solo alias legacy esplicito e non ambiguo.
+
+Missing, duplicate, cross-class, target mancante, alias legacy ambiguo e storage incoerente producono sempre un diniego. L'errore pubblico e sanitizzato (`Identita didattica non risolvibile.`); il codice di errore strutturato serve al logging server-side senza includere ID o contenuti persistiti nel messaggio esposto.
+
+Questo validator risolve identita e target ma non decide quali endpoint o operazioni siano permessi: tale policy appartiene a #706.
+
+### Compatibilita e migrazione legacy
+
+`student_id` legacy non viene mai confrontato implicitamente con `user_id`, email, username, directory o repository. La sola compatibilita consentita e un alias provisionato esplicitamente:
+
+```text
+(class_id, legacy_student_id) -> subject_id
+```
+
+La chiave e class-scoped per evitare collisioni tra anni/classi. Lo storage canonico impedisce che la stessa chiave punti a soggetti diversi. Adapter o import che presentano piu candidati devono comunque fallire chiusi prima della scrittura.
+
+Procedura di migrazione:
+
+1. provisionare server-side un `subject_id` per ogni account studente verificato;
+2. creare gli alias class-scoped dopo verifica amministrativa del roster;
+3. eseguire `migrate_legacy_assignment_targets` in dry-run su tutti i record interessati;
+4. bloccare la migrazione completa se un target e mancante, duplicato o ambiguo;
+5. scrivere `targets[].subject_id`, conservando temporaneamente `student_id`, path e repository come attributi compatibili;
+6. validare il round-trip con il reader Assignment e solo dopo pubblicare i record migrati.
+
+Lo schema Assignment `1.0` accetta in transizione il campo additivo `targets[].subject_id`. I writer legacy possono continuare a produrre record leggibili dai tool docente, ma tali record non sono utilizzabili per una risoluzione studente autorevole senza alias esplicito. Nuovi writer che conoscono il binding devono produrre `subject_id`.
+
+Gli alias non vengono creati automaticamente. Sono aggiunti in modo append-only soltanto mentre binding, revisione attesa, account, classe e membership studente sono ancora attivi. Non sono cancellati finche esistono assignment legacy che li richiedono; la loro eventuale rimozione richiedera inventario, migrazione completa verificata e una migrazione schema dedicata.
+
+## Implementazione
+
+- Contratti, validator, resolver e adapter migrazione: `scripts/thebitlab_identity_binding.py`.
+- Porta: `StudentSubjectBindingStorage` in `scripts/thebitlab_identity_ports.py`.
+- Source-of-truth e migrazione schema v12: `scripts/thebitlab_identity_sqlite.py`.
+- Compatibilita target Assignment: `scripts/assignment_records.py`.
+- Fixture contrattuali: `tests/fixtures/identity_binding/`.
+
+## Conseguenze
+
+### Positive
+
+- Nessun ID controllato dal client diventa autorita.
+- Identita auth, soggetto didattico, membership e target sono collegati con relazioni esplicite e versionate.
+- Rimozioni membership e incoerenze diventano dinieghi deterministici.
+- I dati legacy possono essere migrati senza matching euristico.
+
+### Costi
+
+- Il provisioning deve creare binding e alias verificati prima di abilitare le future student API.
+- Gli assignment legacy non migrati richiedono alias ancora presenti.
+- SQLite identity diventa dipendenza necessaria anche per risolvere il soggetto didattico.
+
+## Alternative rifiutate
+
+- `user_id == student_id`: namespace e lifecycle diversi, collisioni non rilevabili.
+- Matching per email, username, repository o path: attributi mutabili e talvolta controllabili esternamente.
+- Fidarsi di `student_id`, `class_id`, `subject_id` o target nella request: consente escalation orizzontale.
+- Copiare le membership nei JSON didattici: crea una seconda source-of-truth non transazionale.
+- Scegliere il primo match legacy: trasforma corruzione o ambiguita in accesso indebito.
+
+## Relazioni
+
+- Identity/auth storage: [`adr-identity-auth-storage.md`](adr-identity-auth-storage.md).
+- Storage didattico: [`adr-sqlite-storage-schema.md`](adr-sqlite-storage-schema.md).
+- Contratti dati: [`data-contracts.md`](data-contracts.md).
+- Remediation binding: #702.
+- Enforcement student API: #706.

--- a/doc/architecture/adr-identity-auth-storage.md
+++ b/doc/architecture/adr-identity-auth-storage.md
@@ -67,7 +67,7 @@ I JSON restano formato di export, backup leggibile e scambio, ma non sono una se
 
 Lo schema concreto e le migrazioni sono implementati da `SqliteIdentityStorage` dietro le porte definite in `scripts/thebitlab_identity_ports.py`.
 
-### Schema SQLite v1-v2
+### Schema SQLite v1-v12
 
 La prima migrazione crea:
 
@@ -80,7 +80,7 @@ La prima migrazione crea:
 - `tui_pairings`;
 - `schema_migrations`.
 
-Foreign key, ruoli, booleani e stati pairing sono vincolati anche nel database. La cancellazione di un utente elimina identita, membership, sessioni e pairing gia associati; la cancellazione di una classe elimina membership e mapping collegati. Le chiavi provider e i digest hanno vincoli univoci indicizzati.
+Foreign key, ruoli, booleani e stati pairing sono vincolati anche nel database. La cancellazione di un utente elimina identita, membership, sessioni e pairing gia associati; dalla v12 viene invece bloccata se esiste il binding didattico autorevole. La cancellazione di una classe elimina membership e mapping collegati, ma viene bloccata finche esistono alias legacy da migrare. Le chiavi provider e i digest hanno vincoli univoci indicizzati.
 
 `linked_at` e `created_at` dei mapping descrivono la creazione originale e non cambiano quando vengono aggiornati attributi leggibili come email, username o display name. Il linking verso un proprietario interno differente fallisce senza modifiche parziali.
 
@@ -91,6 +91,8 @@ Le transizioni pairing vengono applicate con compare-and-swap sullo stato persis
 `expires_at` e un limite esclusivo: `last_seen_at` e `revoked_at` devono precederlo, e una sessione con `expires_at` uguale all'istante di revoca non e piu attiva. I cleanup ricevono un cutoff esplicito e cancellano record con `expires_at` minore o uguale al cutoff; la politica di retention resta responsabilita del service chiamante.
 
 La migrazione v2 crea la tombstone ABA-safe `external_identity_generations` e la popola dalle identita v1 esistenti prima di accettare nuovi link.
+
+La migrazione v12 aggiunge `student_subject_bindings` e `legacy_student_subject_aliases`. Il binding 1:1 collega l'account auth al soggetto didattico opaco; classi e target vengono risolti dalle membership e dagli assignment autorevoli, non da ID della request. Contratto, lifecycle e migrazione legacy sono definiti in [`adr-authoritative-student-identity-binding.md`](adr-authoritative-student-identity-binding.md).
 
 Le migrazioni sono numerate, sequenziali, eseguite dentro `BEGIN IMMEDIATE` e registrate solo al commit. Il codice rifiuta sequenze mancanti e database con una versione schema piu recente, evitando downgrade impliciti.
 
@@ -127,12 +129,15 @@ I record provider-agnostici sono definiti in `scripts/thebitlab_identity.py`:
 - `UserSession`;
 - `TuiPairing`.
 
+Il binding didattico usa i record `StudentSubjectBinding`, `LegacySubjectAlias` e `StudentBindingSnapshot` definiti in `scripts/thebitlab_identity_binding.py`.
+
 Le porte di persistenza sono definite in `scripts/thebitlab_identity_ports.py`:
 
 - `UserDirectoryStorage`;
 - `ClassDirectoryStorage`;
 - `SessionStorage`;
-- `TuiPairingStorage`.
+- `TuiPairingStorage`;
+- `StudentSubjectBindingStorage`.
 
 ## Conseguenze
 
@@ -163,6 +168,7 @@ Le porte di persistenza sono definite in `scripts/thebitlab_identity_ports.py`:
 
 - Epic MVP: #535.
 - Contratti iniziali: #537.
+- Binding autorevole studente: [`adr-authoritative-student-identity-binding.md`](adr-authoritative-student-identity-binding.md), #702.
 - Servizi applicativi: [`auth-application-services.md`](auth-application-services.md).
 - Roadmap MVP: #292.
 - Roadmap architetturale: #282.

--- a/doc/architecture/adr-sqlite-storage-schema.md
+++ b/doc/architecture/adr-sqlite-storage-schema.md
@@ -12,7 +12,7 @@ La dashboard consegne e le future viste docente/studente hanno pero bisogno di q
 
 La decisione precedente e documentata in [`storage-sqlite-evaluation.md`](storage-sqlite-evaluation.md): introdurre porte di storage prima di SQLite e usare SQLite prima come indice/prototipo isolato.
 
-Questo ADR riguarda i dati didattici indicizzabili. Utenti, identita federate, classi di autorizzazione, sessioni e pairing sono invece sorgente primaria transazionale nello schema separato definito da [`adr-identity-auth-storage.md`](adr-identity-auth-storage.md); non devono essere ricostruiti dai JSON didattici.
+Questo ADR riguarda i dati didattici indicizzabili. Utenti, identita federate, classi di autorizzazione, sessioni, pairing e binding auth-soggetto didattico sono invece sorgente primaria transazionale nello schema separato definito da [`adr-identity-auth-storage.md`](adr-identity-auth-storage.md); non devono essere ricostruiti dai JSON didattici. Il confine autorevole verso assignment e target e specificato in [`adr-authoritative-student-identity-binding.md`](adr-authoritative-student-identity-binding.md).
 
 ## Decisione
 
@@ -187,6 +187,7 @@ Note:
 
 - Quando l'entita Assignment non esiste ancora nei JSON, l'id puo essere derivato da `activity_id`, `class_id` e `due_at`.
 - In futuro i registri dovranno collegarsi a `assignment_id`, non solo ad `activity_id`.
+- I target studente canonici referenziano il `subject_id` identity; `student_id`, repository e path legacy non sono autorita e richiedono l'adapter di migrazione esplicito.
 
 ### `registers`
 

--- a/doc/architecture/data-contracts.md
+++ b/doc/architecture/data-contracts.md
@@ -81,11 +81,20 @@ Campi minimi:
 | Campo | Tipo | Note |
 |---|---|---|
 | `schema_version` | string | Versione del contratto dati. |
-| `id` | string | Identificativo stabile, per esempio `rossi-mario`. |
+| `subject_id` | string | Identificativo didattico canonico opaco `subject:<uuid-hex>`; assegnato server-side. |
+| `id` | string | Alias `student_id` legacy (per esempio `rossi-mario`), non autorita per auth/authz. |
 | `display_name` | string | Nome leggibile. |
-| `class_ids` | array | Classi associate. |
+| `class_ids` | array | Proiezione didattica/legacy delle classi; non sostituisce le membership auth autorevoli. |
 | `provider_accounts` | object | Account per GitHub/GitLab/local. |
 | `repo_refs` | array | Repository collegati. |
+
+Il collegamento con auth non viene serializzato o inferito dal roster. La source-of-truth e il binding SQLite `user_id <-> subject_id`; le classi derivano dalle membership auth. Vedi [`adr-authoritative-student-identity-binding.md`](adr-authoritative-student-identity-binding.md).
+
+Compatibilita attuale:
+
+- roster e registri possono contenere soltanto `id`/`student_id`;
+- un record legacy diventa utilizzabile da un consumer studente solo tramite alias esplicito `(class_id, legacy_student_id) -> subject_id`;
+- email, username, repository e path non sono alias impliciti.
 
 ### Activity
 
@@ -130,6 +139,28 @@ Fase di transizione:
 - I lettori operativi devono usare `scripts/thebitlab_contracts.py` per normalizzare verso i campi canonici senza rompere i dati esistenti.
 - Scaffold, assegnazione, tracking e storage consegne usano gia helper condivisi per activity canoniche/legacy.
 - Gli asset con visibilita studente entrano nello scaffold; asset nascosti, runner e `teacher_only` restano riservati a docente/grader.
+
+### Assignment
+
+Rappresenta una activity assegnata a una classe o a un insieme di soggetti didattici.
+
+Campi minimi:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `schema_version` | string | Versione contratto assignment. |
+| `id` | string | `assignment_id` stabile del record caricato dal server. |
+| `activity_id` | string | Activity collegata. |
+| `class_id` | string | Classe interna dell'assignment. |
+| `assigned_at` | string | Istante ISO di assegnazione. |
+| `due_at` | string | Scadenza ISO. |
+| `targets` | array | Destinatari; il riferimento canonico e `subject_id`. |
+
+Compatibilita attuale:
+
+- lo schema `1.0` accetta `targets[].subject_id` come campo additivo e preserva ancora `student_id`, `repo_ref`, `path` e `target`;
+- per una decisione studente il server ricarica il record tramite storage e risolve `subject_id` dal binding auth; nessun ID nella request prova classe o ownership;
+- target senza `subject_id` richiedono migrazione o alias legacy esplicito e univoco; missing, duplicate o ambiguous falliscono chiusi.
 
 ### AssignmentRegister
 

--- a/scripts/assignment_records.py
+++ b/scripts/assignment_records.py
@@ -106,11 +106,12 @@ def require_same_timezone_kind(left: datetime, right: datetime, left_name: str, 
         raise ValueError(f"{left_name} e {right_name} devono usare timezone coerenti.")
 
 
-def target_sort_key(target: dict[str, str]) -> tuple[str, str, str, str, str]:
+def target_sort_key(target: dict[str, str]) -> tuple[str, str, str, str, str, str]:
     """Return a stable sort key for assignment targets."""
 
     serialized = json.dumps(target, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return (
+        target.get("subject_id", ""),
         target.get("student_id", ""),
         target.get("target", ""),
         target.get("repo_ref", ""),
@@ -131,7 +132,7 @@ def normalize_target(target: dict[str, Any] | str) -> dict[str, str]:
         raise ValueError("Target non valido.")
     normalized = {
         key: str(target.get(key, "")).strip()
-        for key in ("student_id", "display_name", "repo_ref", "path", "target")
+        for key in ("subject_id", "student_id", "display_name", "repo_ref", "path", "target")
         if str(target.get(key, "")).strip()
     }
     if not normalized:

--- a/scripts/thebitlab_identity_binding.py
+++ b/scripts/thebitlab_identity_binding.py
@@ -1,0 +1,467 @@
+"""Authoritative auth-user to educational-subject binding contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Literal
+
+from scripts.thebitlab_identity import ClassGroup, ClassMembership, UserAccount
+
+
+SUBJECT_BINDING_SCHEMA_VERSION = "identity_subject_binding.v1"
+SUBJECT_ID_PATTERN = re.compile(r"^subject:[0-9a-f]{32}$")
+REVISION_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+BindingFailureCode = Literal[
+    "missing",
+    "duplicate",
+    "ambiguous",
+    "incoherent",
+    "class_mismatch",
+    "target_missing",
+    "legacy_missing",
+    "legacy_ambiguous",
+]
+
+
+class StudentBindingResolutionError(RuntimeError):
+    """Fail-closed resolution error with a sanitized public message."""
+
+    PUBLIC_MESSAGE = "Identita didattica non risolvibile."
+
+    def __init__(self, code: BindingFailureCode) -> None:
+        self.code = code
+        super().__init__(self.PUBLIC_MESSAGE)
+
+
+def _text(value: str, field_name: str) -> str:
+    if type(value) is not str:
+        raise ValueError(f"{field_name} deve essere una stringa.")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > 512
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in normalized
+        )
+    ):
+        raise ValueError(f"{field_name} non valido.")
+    return normalized
+
+
+def _subject_id(value: str) -> str:
+    normalized = _text(value, "subject_id")
+    if SUBJECT_ID_PATTERN.fullmatch(normalized) is None:
+        raise ValueError("subject_id non valido.")
+    return normalized
+
+
+def _utc(value: datetime, field_name: str) -> datetime:
+    if type(value) is not datetime or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} deve includere il timezone.")
+    return value.astimezone(timezone.utc)
+
+
+def generate_subject_id() -> str:
+    """Generate an opaque server-side educational subject identifier."""
+
+    return f"subject:{uuid.uuid4().hex}"
+
+
+@dataclass(frozen=True)
+class StudentSubjectBinding:
+    """Immutable ownership pair with a monotonic lifecycle revision."""
+
+    subject_id: str
+    user_id: str
+    active: bool
+    revision: int
+    created_at: datetime
+    updated_at: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "subject_id", _subject_id(self.subject_id))
+        object.__setattr__(self, "user_id", _text(self.user_id, "user_id"))
+        if type(self.active) is not bool:
+            raise ValueError("active deve essere booleano.")
+        if type(self.revision) is not int or self.revision < 1:
+            raise ValueError("revision deve essere un intero positivo.")
+        created_at = _utc(self.created_at, "created_at")
+        updated_at = _utc(self.updated_at, "updated_at")
+        if updated_at < created_at:
+            raise ValueError("updated_at non puo precedere created_at.")
+        object.__setattr__(self, "created_at", created_at)
+        object.__setattr__(self, "updated_at", updated_at)
+
+
+@dataclass(frozen=True)
+class LegacySubjectAlias:
+    """Explicit class-scoped bridge from a legacy student ID to a subject."""
+
+    class_id: str
+    legacy_student_id: str
+    subject_id: str
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "class_id", _text(self.class_id, "class_id"))
+        object.__setattr__(
+            self,
+            "legacy_student_id",
+            _text(self.legacy_student_id, "legacy_student_id"),
+        )
+        object.__setattr__(self, "subject_id", _subject_id(self.subject_id))
+        object.__setattr__(self, "created_at", _utc(self.created_at, "created_at"))
+
+
+@dataclass(frozen=True)
+class StudentBindingSnapshot:
+    """One coherent authoritative read used by a binding decision."""
+
+    account: UserAccount | None
+    bindings: tuple[StudentSubjectBinding, ...]
+    memberships: tuple[ClassMembership, ...]
+    classes: tuple[ClassGroup, ...]
+    legacy_aliases: tuple[LegacySubjectAlias, ...]
+    authority_revision: str
+
+    def __post_init__(self) -> None:
+        for field_name in ("bindings", "memberships", "classes", "legacy_aliases"):
+            if type(getattr(self, field_name)) is not tuple:
+                raise ValueError(f"{field_name} deve essere una tupla.")
+        if REVISION_PATTERN.fullmatch(self.authority_revision) is None:
+            raise ValueError("authority_revision non valida.")
+
+
+@dataclass(frozen=True)
+class ResolvedStudentIdentity:
+    """Minimal server-derived identity capability for downstream policy code."""
+
+    user_id: str
+    subject_id: str
+    class_ids: tuple[str, ...]
+    authority_revision: str
+
+
+@dataclass(frozen=True)
+class AssignmentTargetResolution:
+    """Authoritative subject/class/assignment target resolution result."""
+
+    assignment_id: str
+    class_id: str
+    user_id: str
+    subject_id: str
+    target: dict[str, Any]
+    authority_revision: str
+    used_legacy_alias: bool
+
+
+def _timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _snapshot_payload(
+    account: UserAccount | None,
+    bindings: tuple[StudentSubjectBinding, ...],
+    memberships: tuple[ClassMembership, ...],
+    classes: tuple[ClassGroup, ...],
+    legacy_aliases: tuple[LegacySubjectAlias, ...],
+) -> dict[str, Any]:
+    account_payload = None
+    if account is not None:
+        account_payload = {
+            "user_id": account.user_id,
+            "role": account.role,
+            "active": account.active,
+            "created_at": _timestamp(account.created_at),
+            "updated_at": _timestamp(account.updated_at),
+        }
+    return {
+        "schema_version": SUBJECT_BINDING_SCHEMA_VERSION,
+        "account": account_payload,
+        "bindings": sorted(
+            (
+                {
+                    "subject_id": item.subject_id,
+                    "user_id": item.user_id,
+                    "active": item.active,
+                    "revision": item.revision,
+                    "created_at": _timestamp(item.created_at),
+                    "updated_at": _timestamp(item.updated_at),
+                }
+                for item in bindings
+            ),
+            key=lambda item: (item["subject_id"], item["user_id"], item["revision"]),
+        ),
+        "memberships": sorted(
+            (
+                {
+                    "user_id": item.user_id,
+                    "class_id": item.class_id,
+                    "role": item.role,
+                    "joined_at": _timestamp(item.joined_at),
+                    "source_provider": item.source_provider,
+                    "source_group_subject": item.source_group_subject,
+                }
+                for item in memberships
+            ),
+            key=lambda item: (item["class_id"], item["role"], item["user_id"]),
+        ),
+        "classes": sorted(
+            (
+                {
+                    "class_id": item.class_id,
+                    "active": item.active,
+                    "created_at": _timestamp(item.created_at),
+                    "updated_at": _timestamp(item.updated_at),
+                }
+                for item in classes
+            ),
+            key=lambda item: item["class_id"],
+        ),
+        "legacy_aliases": sorted(
+            (
+                {
+                    "class_id": item.class_id,
+                    "legacy_student_id": item.legacy_student_id,
+                    "subject_id": item.subject_id,
+                    "created_at": _timestamp(item.created_at),
+                }
+                for item in legacy_aliases
+            ),
+            key=lambda item: (
+                item["class_id"],
+                item["legacy_student_id"],
+                item["subject_id"],
+            ),
+        ),
+    }
+
+
+def build_student_binding_snapshot(
+    *,
+    account: UserAccount | None,
+    bindings: Iterable[StudentSubjectBinding] = (),
+    memberships: Iterable[ClassMembership] = (),
+    classes: Iterable[ClassGroup] = (),
+    legacy_aliases: Iterable[LegacySubjectAlias] = (),
+) -> StudentBindingSnapshot:
+    """Build a content-versioned snapshot from one adapter read transaction."""
+
+    values = (
+        tuple(bindings),
+        tuple(memberships),
+        tuple(classes),
+        tuple(legacy_aliases),
+    )
+    serialized = json.dumps(
+        _snapshot_payload(account, *values),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    revision = f"sha256:{hashlib.sha256(serialized).hexdigest()}"
+    return StudentBindingSnapshot(account, *values, revision)
+
+
+def _fail(code: BindingFailureCode) -> None:
+    raise StudentBindingResolutionError(code)
+
+
+def resolve_student_identity(
+    authenticated_user_id: str,
+    snapshot: StudentBindingSnapshot,
+) -> ResolvedStudentIdentity:
+    """Resolve only from an authenticated user ID and an authoritative snapshot."""
+
+    try:
+        user_id = _text(authenticated_user_id, "authenticated_user_id")
+        rebuilt = build_student_binding_snapshot(
+            account=snapshot.account,
+            bindings=snapshot.bindings,
+            memberships=snapshot.memberships,
+            classes=snapshot.classes,
+            legacy_aliases=snapshot.legacy_aliases,
+        )
+    except (TypeError, ValueError):
+        _fail("incoherent")
+    if rebuilt.authority_revision != snapshot.authority_revision:
+        _fail("incoherent")
+    account = snapshot.account
+    if account is None or not account.active or account.role != "student":
+        _fail("missing")
+    if account.user_id != user_id:
+        _fail("ambiguous")
+    if not snapshot.bindings:
+        _fail("missing")
+    if len(snapshot.bindings) != 1:
+        _fail("duplicate")
+    binding = snapshot.bindings[0]
+    if binding.user_id != user_id:
+        _fail("ambiguous")
+    if not binding.active:
+        _fail("missing")
+
+    classes_by_id: dict[str, ClassGroup] = {}
+    for class_group in snapshot.classes:
+        if class_group.class_id in classes_by_id:
+            _fail("ambiguous")
+        classes_by_id[class_group.class_id] = class_group
+    class_ids: list[str] = []
+    for membership in snapshot.memberships:
+        if membership.user_id != user_id or membership.role != "student":
+            _fail("ambiguous")
+        if membership.class_id in class_ids:
+            _fail("duplicate")
+        class_group = classes_by_id.get(membership.class_id)
+        if class_group is None or not class_group.active:
+            _fail("incoherent")
+        class_ids.append(membership.class_id)
+    if set(classes_by_id) != set(class_ids):
+        _fail("incoherent")
+    return ResolvedStudentIdentity(
+        user_id=user_id,
+        subject_id=binding.subject_id,
+        class_ids=tuple(sorted(class_ids)),
+        authority_revision=snapshot.authority_revision,
+    )
+
+
+def _assignment_parts(assignment: dict[str, Any]) -> tuple[str, str, list[dict[str, Any]]]:
+    if type(assignment) is not dict:
+        _fail("incoherent")
+    try:
+        assignment_id = _text(assignment.get("id"), "assignment_id")
+        class_id = _text(assignment.get("class_id"), "class_id")
+    except (TypeError, ValueError):
+        _fail("incoherent")
+    targets = assignment.get("targets")
+    if type(targets) is not list or not targets or any(type(item) is not dict for item in targets):
+        _fail("incoherent")
+    return assignment_id, class_id, targets
+
+
+def _alias_subjects(
+    aliases: Iterable[LegacySubjectAlias],
+    class_id: str,
+    legacy_student_id: str,
+) -> tuple[str, ...]:
+    return tuple(
+        alias.subject_id
+        for alias in aliases
+        if alias.class_id == class_id and alias.legacy_student_id == legacy_student_id
+    )
+
+
+def resolve_assignment_target(
+    authenticated_user_id: str,
+    snapshot: StudentBindingSnapshot,
+    assignment: dict[str, Any],
+) -> AssignmentTargetResolution:
+    """Resolve a server-loaded assignment target without trusting request IDs."""
+
+    identity = resolve_student_identity(authenticated_user_id, snapshot)
+    assignment_id, class_id, targets = _assignment_parts(assignment)
+    if class_id not in identity.class_ids:
+        _fail("class_mismatch")
+
+    canonical_matches: list[dict[str, Any]] = []
+    seen_subjects: set[str] = set()
+    for target in targets:
+        raw_subject_id = target.get("subject_id")
+        if raw_subject_id is None or raw_subject_id == "":
+            continue
+        try:
+            target_subject_id = _subject_id(raw_subject_id)
+        except (TypeError, ValueError):
+            _fail("incoherent")
+        if target_subject_id in seen_subjects:
+            _fail("duplicate")
+        seen_subjects.add(target_subject_id)
+        if target_subject_id == identity.subject_id:
+            canonical_matches.append(target)
+    if len(canonical_matches) > 1:
+        _fail("duplicate")
+    if canonical_matches:
+        return AssignmentTargetResolution(
+            assignment_id,
+            class_id,
+            identity.user_id,
+            identity.subject_id,
+            deepcopy(canonical_matches[0]),
+            identity.authority_revision,
+            False,
+        )
+
+    legacy_matches: list[dict[str, Any]] = []
+    for target in targets:
+        raw_legacy_id = target.get("student_id")
+        if raw_legacy_id is None or raw_legacy_id == "":
+            continue
+        try:
+            legacy_id = _text(raw_legacy_id, "student_id")
+        except (TypeError, ValueError):
+            _fail("incoherent")
+        subjects = _alias_subjects(snapshot.legacy_aliases, class_id, legacy_id)
+        if len(subjects) > 1:
+            _fail("legacy_ambiguous")
+        if subjects == (identity.subject_id,):
+            legacy_matches.append(target)
+    if len(legacy_matches) > 1:
+        _fail("legacy_ambiguous")
+    if not legacy_matches:
+        _fail("target_missing")
+    return AssignmentTargetResolution(
+        assignment_id,
+        class_id,
+        identity.user_id,
+        identity.subject_id,
+        deepcopy(legacy_matches[0]),
+        identity.authority_revision,
+        True,
+    )
+
+
+def migrate_legacy_assignment_targets(
+    assignment: dict[str, Any],
+    aliases: Iterable[LegacySubjectAlias],
+) -> dict[str, Any]:
+    """Return a canonical copy; never infer aliases from mutable or client data."""
+
+    _, class_id, targets = _assignment_parts(assignment)
+    authoritative_aliases = tuple(aliases)
+    migrated = deepcopy(assignment)
+    migrated_targets = migrated["targets"]
+    seen_subjects: set[str] = set()
+    for target in migrated_targets:
+        raw_subject_id = target.get("subject_id")
+        if raw_subject_id:
+            try:
+                subject_id = _subject_id(raw_subject_id)
+            except (TypeError, ValueError):
+                _fail("incoherent")
+        else:
+            raw_legacy_id = target.get("student_id")
+            try:
+                legacy_id = _text(raw_legacy_id, "student_id")
+            except (TypeError, ValueError):
+                _fail("legacy_missing")
+            subjects = _alias_subjects(authoritative_aliases, class_id, legacy_id)
+            if not subjects:
+                _fail("legacy_missing")
+            if len(subjects) != 1:
+                _fail("legacy_ambiguous")
+            subject_id = subjects[0]
+            target["subject_id"] = subject_id
+        if subject_id in seen_subjects:
+            _fail("legacy_ambiguous")
+        seen_subjects.add(subject_id)
+    return migrated

--- a/scripts/thebitlab_identity_ports.py
+++ b/scripts/thebitlab_identity_ports.py
@@ -12,6 +12,11 @@ from scripts.thebitlab_identity import (
     UserAccount,
     UserSession,
 )
+from scripts.thebitlab_identity_binding import (
+    LegacySubjectAlias,
+    StudentBindingSnapshot,
+    StudentSubjectBinding,
+)
 
 
 class IdentityStorageError(RuntimeError):
@@ -269,6 +274,44 @@ class ClassDirectoryStorage(Protocol):
         future_skew: timedelta,
         expected_class_updated_at: datetime,
     ) -> None: ...
+
+
+class StudentSubjectBindingStorage(Protocol):
+    """Authoritative persistence port for auth-to-educational-subject binding."""
+
+    def create_student_subject_binding(
+        self,
+        binding: StudentSubjectBinding,
+        aliases: tuple[LegacySubjectAlias, ...] = (),
+    ) -> None: ...
+
+    def read_student_subject_binding(
+        self, subject_id: str
+    ) -> StudentSubjectBinding | None: ...
+
+    def list_user_subject_bindings(self, user_id: str) -> list[StudentSubjectBinding]: ...
+
+    def save_student_subject_binding(
+        self,
+        binding: StudentSubjectBinding,
+        *,
+        expected_revision: int,
+    ) -> None: ...
+
+    def save_legacy_subject_alias(
+        self,
+        alias: LegacySubjectAlias,
+        *,
+        expected_binding_revision: int,
+    ) -> None: ...
+
+    def list_legacy_subject_aliases(
+        self, class_id: str | None = None
+    ) -> list[LegacySubjectAlias]: ...
+
+    def read_student_binding_snapshot(self, user_id: str) -> StudentBindingSnapshot:
+        """Read the complete binding authority in one coherent transaction."""
+        ...
 
 
 class AdminBootstrapStorage(Protocol):

--- a/scripts/thebitlab_identity_sqlite.py
+++ b/scripts/thebitlab_identity_sqlite.py
@@ -18,6 +18,12 @@ from scripts.thebitlab_identity import (
     UserAccount,
     UserSession,
 )
+from scripts.thebitlab_identity_binding import (
+    LegacySubjectAlias,
+    StudentBindingSnapshot,
+    StudentSubjectBinding,
+    build_student_binding_snapshot,
+)
 from scripts.thebitlab_dashboard_auth_ports import DashboardAuthorizationSnapshot
 from scripts.thebitlab_identity_ports import (
     IdentityStorageConflictError,
@@ -31,7 +37,7 @@ from scripts.thebitlab_identity_ports import (
 )
 
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 _T = TypeVar("_T")
 
 
@@ -298,6 +304,102 @@ _MIGRATION_11 = (
     _MIGRATION_10[1],
 )
 
+_MIGRATION_12 = (
+    """
+    CREATE TABLE student_subject_bindings (
+        subject_id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL UNIQUE REFERENCES users(user_id) ON DELETE RESTRICT,
+        active INTEGER NOT NULL CHECK (active IN (0, 1)),
+        revision INTEGER NOT NULL CHECK (revision >= 1),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        CHECK (length(subject_id) = 40),
+        CHECK (substr(subject_id, 1, 8) = 'subject:'),
+        CHECK (substr(subject_id, 9) NOT GLOB '*[^0-9a-f]*'),
+        CHECK (updated_at >= created_at)
+    )
+    """,
+    "CREATE INDEX idx_student_subject_bindings_active ON student_subject_bindings(active)",
+    """
+    CREATE TABLE legacy_student_subject_aliases (
+        class_id TEXT NOT NULL REFERENCES classes(class_id) ON DELETE RESTRICT,
+        legacy_student_id TEXT NOT NULL,
+        subject_id TEXT NOT NULL REFERENCES student_subject_bindings(subject_id) ON DELETE RESTRICT,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (class_id, legacy_student_id),
+        CHECK (length(trim(legacy_student_id)) > 0)
+    )
+    """,
+    "CREATE INDEX idx_legacy_student_subject_aliases_subject "
+    "ON legacy_student_subject_aliases(subject_id)",
+    """
+    CREATE TRIGGER trg_student_subject_bindings_validate_insert
+    BEFORE INSERT ON student_subject_bindings
+    WHEN NEW.active != 1 OR NEW.revision != 1 OR NEW.updated_at != NEW.created_at
+        OR NOT EXISTS (
+            SELECT 1 FROM users
+            WHERE user_id = NEW.user_id AND active = 1 AND role = 'student'
+        )
+    BEGIN
+        SELECT RAISE(ABORT, 'invalid student subject binding provision');
+    END
+    """,
+    """
+    CREATE TRIGGER trg_student_subject_bindings_validate_update
+    BEFORE UPDATE ON student_subject_bindings
+    WHEN NEW.subject_id != OLD.subject_id OR NEW.user_id != OLD.user_id
+        OR NEW.created_at != OLD.created_at OR NEW.revision != OLD.revision + 1
+        OR NEW.updated_at <= OLD.updated_at
+        OR (NEW.active = 1 AND NOT EXISTS (
+            SELECT 1 FROM users
+            WHERE user_id = NEW.user_id AND active = 1 AND role = 'student'
+        ))
+    BEGIN
+        SELECT RAISE(ABORT, 'invalid student subject binding revision');
+    END
+    """,
+    """
+    CREATE TRIGGER trg_student_subject_bindings_no_delete
+    BEFORE DELETE ON student_subject_bindings
+    BEGIN
+        SELECT RAISE(ABORT, 'immutable student subject binding');
+    END
+    """,
+    """
+    CREATE TRIGGER trg_legacy_student_subject_aliases_validate_insert
+    BEFORE INSERT ON legacy_student_subject_aliases
+    WHEN NOT EXISTS (
+        SELECT 1 FROM student_subject_bindings AS bindings
+        JOIN users ON users.user_id = bindings.user_id
+        JOIN class_memberships AS memberships
+            ON memberships.user_id = bindings.user_id
+            AND memberships.class_id = NEW.class_id
+            AND memberships.role = 'student'
+        JOIN classes ON classes.class_id = memberships.class_id
+        WHERE bindings.subject_id = NEW.subject_id AND bindings.active = 1
+            AND users.active = 1 AND users.role = 'student'
+            AND classes.active = 1
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'invalid legacy student subject alias');
+    END
+    """,
+    """
+    CREATE TRIGGER trg_legacy_student_subject_aliases_no_update
+    BEFORE UPDATE ON legacy_student_subject_aliases
+    BEGIN
+        SELECT RAISE(ABORT, 'immutable legacy student subject alias');
+    END
+    """,
+    """
+    CREATE TRIGGER trg_legacy_student_subject_aliases_no_delete
+    BEFORE DELETE ON legacy_student_subject_aliases
+    BEGIN
+        SELECT RAISE(ABORT, 'immutable legacy student subject alias');
+    END
+    """,
+)
+
 _MIGRATION_4 = (
     """
     CREATE TABLE external_group_mapping_generations (
@@ -419,6 +521,7 @@ class SqliteIdentityStorage:
                 (9, _MIGRATION_9),
                 (10, _MIGRATION_10),
                 (11, _MIGRATION_11),
+                (12, _MIGRATION_12),
             )
             for version, statements in migrations:
                 if version in versions:
@@ -573,6 +676,30 @@ class SqliteIdentityStorage:
             created_at=_decode_datetime(row["created_at"]),
             display_name=row["display_name"],
             updated_at=_decode_datetime(row["updated_at"]),
+        )
+
+    @classmethod
+    def _subject_binding(cls, row: sqlite3.Row) -> StudentSubjectBinding:
+        return cls._hydrate(
+            StudentSubjectBinding,
+            row,
+            subject_id=row["subject_id"],
+            user_id=row["user_id"],
+            active=bool(row["active"]),
+            revision=row["revision"],
+            created_at=_decode_datetime(row["created_at"]),
+            updated_at=_decode_datetime(row["updated_at"]),
+        )
+
+    @classmethod
+    def _legacy_subject_alias(cls, row: sqlite3.Row) -> LegacySubjectAlias:
+        return cls._hydrate(
+            LegacySubjectAlias,
+            row,
+            class_id=row["class_id"],
+            legacy_student_id=row["legacy_student_id"],
+            subject_id=row["subject_id"],
+            created_at=_decode_datetime(row["created_at"]),
         )
 
     @classmethod
@@ -1595,6 +1722,270 @@ class SqliteIdentityStorage:
                 (user_id, class_id, role.lower()),
             )
             return cursor.rowcount == 1
+
+    def create_student_subject_binding(
+        self,
+        binding: StudentSubjectBinding,
+        aliases: tuple[LegacySubjectAlias, ...] = (),
+    ) -> None:
+        """Provision one immutable user/subject pair and its explicit legacy aliases."""
+
+        if (
+            not binding.active
+            or binding.revision != 1
+            or binding.updated_at != binding.created_at
+        ):
+            raise IdentityStorageConflictError(
+                "Un nuovo binding didattico deve essere attivo e iniziare dalla revisione 1."
+            )
+        if any(alias.subject_id != binding.subject_id for alias in aliases):
+            raise IdentityStorageConflictError(
+                "Gli alias legacy devono appartenere al binding provisionato."
+            )
+        with self._transaction("create_student_subject_binding") as connection:
+            owner = connection.execute(
+                "SELECT active, role FROM users WHERE user_id = ?",
+                (binding.user_id,),
+            ).fetchone()
+            if owner is None or tuple(owner) != (1, "student"):
+                raise IdentityStorageConflictError(
+                    "Il binding didattico richiede un account studente attivo."
+                )
+            for alias in aliases:
+                eligible_class = connection.execute(
+                    """
+                    SELECT 1 FROM classes
+                    JOIN class_memberships
+                        ON class_memberships.class_id = classes.class_id
+                    WHERE classes.class_id = ? AND classes.active = 1
+                        AND class_memberships.user_id = ?
+                        AND class_memberships.role = 'student'
+                    """,
+                    (alias.class_id, binding.user_id),
+                ).fetchone()
+                if eligible_class is None:
+                    raise IdentityStorageConflictError(
+                        "Un alias legacy richiede una membership studente attiva nella classe."
+                    )
+            connection.execute(
+                """
+                INSERT INTO student_subject_bindings
+                    (subject_id, user_id, active, revision, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    binding.subject_id,
+                    binding.user_id,
+                    int(binding.active),
+                    binding.revision,
+                    _encode_datetime(binding.created_at, "created_at"),
+                    _encode_datetime(binding.updated_at, "updated_at"),
+                ),
+            )
+            connection.executemany(
+                """
+                INSERT INTO legacy_student_subject_aliases
+                    (class_id, legacy_student_id, subject_id, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                [
+                    (
+                        alias.class_id,
+                        alias.legacy_student_id,
+                        alias.subject_id,
+                        _encode_datetime(alias.created_at, "created_at"),
+                    )
+                    for alias in aliases
+                ],
+            )
+
+    def read_student_subject_binding(
+        self, subject_id: str
+    ) -> StudentSubjectBinding | None:
+        row = self._query_one(
+            "SELECT * FROM student_subject_bindings WHERE subject_id = ?",
+            (subject_id,),
+        )
+        return None if row is None else self._subject_binding(row)
+
+    def list_user_subject_bindings(self, user_id: str) -> list[StudentSubjectBinding]:
+        rows = self._query_all(
+            "SELECT * FROM student_subject_bindings WHERE user_id = ? ORDER BY subject_id",
+            (user_id,),
+        )
+        return [self._subject_binding(row) for row in rows]
+
+    def save_student_subject_binding(
+        self,
+        binding: StudentSubjectBinding,
+        *,
+        expected_revision: int,
+    ) -> None:
+        """Advance only the active flag and monotonic revision of an existing pair."""
+
+        if binding.revision != expected_revision + 1:
+            raise IdentityStorageConflictError(
+                "La revisione del binding didattico deve avanzare di uno."
+            )
+        updated_at = _encode_datetime(binding.updated_at, "updated_at")
+        created_at = _encode_datetime(binding.created_at, "created_at")
+        with self._transaction("save_student_subject_binding") as connection:
+            cursor = connection.execute(
+                """
+                UPDATE student_subject_bindings
+                SET active = ?, revision = ?, updated_at = ?
+                WHERE subject_id = ? AND user_id = ? AND created_at = ?
+                    AND revision = ? AND updated_at < ?
+                """,
+                (
+                    int(binding.active),
+                    binding.revision,
+                    updated_at,
+                    binding.subject_id,
+                    binding.user_id,
+                    created_at,
+                    expected_revision,
+                    updated_at,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise IdentityStorageConflictError(
+                    "Binding didattico mancante, immutabile o con revisione stale."
+                )
+
+    def save_legacy_subject_alias(
+        self,
+        alias: LegacySubjectAlias,
+        *,
+        expected_binding_revision: int,
+    ) -> None:
+        """Append an alias while binding ownership and class membership still match."""
+
+        with self._transaction("save_legacy_subject_alias") as connection:
+            authority = connection.execute(
+                """
+                SELECT 1 FROM student_subject_bindings AS bindings
+                JOIN users ON users.user_id = bindings.user_id
+                JOIN class_memberships AS memberships
+                    ON memberships.user_id = bindings.user_id
+                    AND memberships.class_id = ?
+                    AND memberships.role = 'student'
+                JOIN classes ON classes.class_id = memberships.class_id
+                WHERE bindings.subject_id = ? AND bindings.active = 1
+                    AND bindings.revision = ?
+                    AND users.active = 1 AND users.role = 'student'
+                    AND classes.active = 1
+                """,
+                (alias.class_id, alias.subject_id, expected_binding_revision),
+            ).fetchone()
+            if authority is None:
+                raise IdentityStorageConflictError(
+                    "Alias legacy non coerente con binding, revisione o membership attivi."
+                )
+            connection.execute(
+                """
+                INSERT INTO legacy_student_subject_aliases
+                    (class_id, legacy_student_id, subject_id, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    alias.class_id,
+                    alias.legacy_student_id,
+                    alias.subject_id,
+                    _encode_datetime(alias.created_at, "created_at"),
+                ),
+            )
+
+    def list_legacy_subject_aliases(
+        self, class_id: str | None = None
+    ) -> list[LegacySubjectAlias]:
+        if class_id is None:
+            rows = self._query_all(
+                """
+                SELECT * FROM legacy_student_subject_aliases
+                ORDER BY class_id, legacy_student_id, subject_id
+                """
+            )
+        else:
+            rows = self._query_all(
+                """
+                SELECT * FROM legacy_student_subject_aliases
+                WHERE class_id = ? ORDER BY legacy_student_id, subject_id
+                """,
+                (class_id,),
+            )
+        return [self._legacy_subject_alias(row) for row in rows]
+
+    def read_student_binding_snapshot(self, user_id: str) -> StudentBindingSnapshot:
+        """Read account, binding, memberships, classes, and aliases atomically."""
+
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN")
+            account_row = connection.execute(
+                "SELECT * FROM users WHERE user_id = ?", (user_id,)
+            ).fetchone()
+            binding_rows = connection.execute(
+                """
+                SELECT * FROM student_subject_bindings
+                WHERE user_id = ? ORDER BY subject_id
+                """,
+                (user_id,),
+            ).fetchall()
+            membership_rows = connection.execute(
+                """
+                SELECT * FROM class_memberships
+                WHERE user_id = ? ORDER BY class_id, role
+                """,
+                (user_id,),
+            ).fetchall()
+            class_rows = connection.execute(
+                """
+                SELECT DISTINCT classes.* FROM classes
+                JOIN class_memberships
+                    ON class_memberships.class_id = classes.class_id
+                WHERE class_memberships.user_id = ?
+                ORDER BY classes.class_id
+                """,
+                (user_id,),
+            ).fetchall()
+            alias_rows = connection.execute(
+                """
+                SELECT aliases.* FROM legacy_student_subject_aliases AS aliases
+                JOIN student_subject_bindings AS bindings
+                    ON bindings.subject_id = aliases.subject_id
+                WHERE bindings.user_id = ?
+                ORDER BY aliases.class_id, aliases.legacy_student_id
+                """,
+                (user_id,),
+            ).fetchall()
+            snapshot = build_student_binding_snapshot(
+                account=None if account_row is None else self._user(account_row),
+                bindings=(self._subject_binding(row) for row in binding_rows),
+                memberships=(self._membership(row) for row in membership_rows),
+                classes=(self._class_group(row) for row in class_rows),
+                legacy_aliases=(self._legacy_subject_alias(row) for row in alias_rows),
+            )
+            connection.commit()
+            return snapshot
+        except IdentityStorageCorruptionError:
+            connection.rollback()
+            raise
+        except (TypeError, ValueError) as error:
+            connection.rollback()
+            raise IdentityStorageCorruptionError(
+                "Snapshot binding didattico persistito non valido."
+            ) from error
+        except sqlite3.DatabaseError as error:
+            connection.rollback()
+            raise IdentityStorageError(
+                "Errore SQLite durante la lettura del binding didattico."
+            ) from error
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
 
     def save_external_group_mapping(
         self,

--- a/tests/fixtures/contracts/assignment.json
+++ b/tests/fixtures/contracts/assignment.json
@@ -4,18 +4,20 @@
   "activity_id": "python-base-somma-001",
   "activity_path": "activities/python-base-somma-001.json",
   "target_type": "class",
-  "class_id": "3A-TPSI",
+  "class_id": "3a-tpsi-2026",
   "class_label": "3A TPSI",
   "github_team": "team-3a-tpsi",
   "assigned_at": "2026-10-12T09:00:00+02:00",
   "due_at": "2026-10-19T23:59:00+02:00",
   "targets": [
     {
+      "subject_id": "subject:11111111111111111111111111111111",
       "student_id": "rossi-mario",
       "display_name": "Rossi Mario",
       "repo_ref": "TheBitPoets/rossi-mario"
     },
     {
+      "subject_id": "subject:22222222222222222222222222222222",
       "student_id": "bianchi-luca",
       "display_name": "Bianchi Luca",
       "path": "studenti/bianchi-luca"

--- a/tests/fixtures/contracts/class_group.json
+++ b/tests/fixtures/contracts/class_group.json
@@ -9,6 +9,7 @@
   "students": [
     {
       "schema_version": "1.0",
+      "subject_id": "subject:11111111111111111111111111111111",
       "id": "rossi-mario",
       "display_name": "Mario Rossi",
       "class_ids": [

--- a/tests/fixtures/identity_binding/cross-class.json
+++ b/tests/fixtures/identity_binding/cross-class.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "identity_subject_binding.v1",
+  "user_id": "auth-user-001",
+  "subject_id": "subject:11111111111111111111111111111111",
+  "class_ids": ["class:3a-tpsi:2026-2027"],
+  "assignment": {
+    "schema_version": "1.0",
+    "id": "assignment:python-array:4a:001",
+    "class_id": "class:4a-tpsi:2026-2027",
+    "targets": [
+      {"subject_id": "subject:11111111111111111111111111111111"}
+    ]
+  }
+}

--- a/tests/fixtures/identity_binding/legacy-ambiguous.json
+++ b/tests/fixtures/identity_binding/legacy-ambiguous.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "identity_subject_binding.v1",
+  "user_id": "auth-user-001",
+  "subject_id": "subject:11111111111111111111111111111111",
+  "class_ids": ["class:3a-tpsi:2026-2027"],
+  "assignment": {
+    "schema_version": "1.0",
+    "id": "assignment:legacy:3a:001",
+    "class_id": "class:3a-tpsi:2026-2027",
+    "targets": [{"student_id": "rossi-mario"}]
+  },
+  "legacy_aliases": [
+    {
+      "class_id": "class:3a-tpsi:2026-2027",
+      "legacy_student_id": "rossi-mario",
+      "subject_id": "subject:11111111111111111111111111111111"
+    },
+    {
+      "class_id": "class:3a-tpsi:2026-2027",
+      "legacy_student_id": "rossi-mario",
+      "subject_id": "subject:22222222222222222222222222222222"
+    }
+  ]
+}

--- a/tests/fixtures/identity_binding/membership-removed.json
+++ b/tests/fixtures/identity_binding/membership-removed.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "identity_subject_binding.v1",
+  "user_id": "auth-user-001",
+  "subject_id": "subject:11111111111111111111111111111111",
+  "class_ids": [],
+  "assignment": {
+    "schema_version": "1.0",
+    "id": "assignment:python-somma:3a:001",
+    "class_id": "class:3a-tpsi:2026-2027",
+    "targets": [
+      {"subject_id": "subject:11111111111111111111111111111111"}
+    ]
+  }
+}

--- a/tests/fixtures/identity_binding/positive.json
+++ b/tests/fixtures/identity_binding/positive.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "identity_subject_binding.v1",
+  "user_id": "auth-user-001",
+  "subject_id": "subject:11111111111111111111111111111111",
+  "class_ids": ["class:3a-tpsi:2026-2027"],
+  "assignment": {
+    "schema_version": "1.0",
+    "id": "assignment:python-somma:3a:001",
+    "class_id": "class:3a-tpsi:2026-2027",
+    "targets": [
+      {
+        "subject_id": "subject:11111111111111111111111111111111",
+        "student_id": "rossi-mario",
+        "repo_ref": "TheBitPoets/rossi-mario"
+      }
+    ]
+  }
+}

--- a/tests/test_data_contract_fixtures.py
+++ b/tests/test_data_contract_fixtures.py
@@ -33,7 +33,8 @@ def test_class_group_contract_fixture() -> None:
 
     assert_required(payload, {"schema_version", "id", "label", "school_year", "provider", "provider_ref", "students"})
     student = payload["students"][0]
-    assert_required(student, {"schema_version", "id", "display_name", "class_ids", "provider_accounts", "repo_refs"})
+    assert_required(student, {"schema_version", "subject_id", "id", "display_name", "class_ids", "provider_accounts", "repo_refs"})
+    assert student["subject_id"] == "subject:11111111111111111111111111111111"
     assert student["id"] == "rossi-mario"
     assert student["class_ids"] == ["3a-tpsi-2026"]
     assert student["provider_accounts"]["github"] == "rossi-mario"
@@ -110,5 +111,7 @@ def test_assignment_contract_fixture() -> None:
         },
     )
     assert payload["target_type"] == "class"
+    assert payload["class_id"] == load_fixture("class_group.json")["id"]
+    assert payload["targets"][0]["subject_id"] == "subject:11111111111111111111111111111111"
     assert payload["targets"][0]["student_id"] == "rossi-mario"
     assert payload["targets"][0]["repo_ref"] == "TheBitPoets/rossi-mario"

--- a/tests/test_thebitlab_identity_binding.py
+++ b/tests/test_thebitlab_identity_binding.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts import assignment_records
+from scripts.thebitlab_identity import ClassGroup, ClassMembership, UserAccount
+from scripts.thebitlab_identity_binding import (
+    LegacySubjectAlias,
+    StudentBindingResolutionError,
+    StudentSubjectBinding,
+    build_student_binding_snapshot,
+    generate_subject_id,
+    migrate_legacy_assignment_targets,
+    resolve_assignment_target,
+    resolve_student_identity,
+)
+
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+FIXTURES = Path("tests/fixtures/identity_binding")
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def snapshot_from_fixture(payload: dict, *, include_binding: bool = True):
+    user_id = payload["user_id"]
+    subject_id = payload["subject_id"]
+    account = UserAccount(user_id, "Mario Rossi", "student", True, NOW, NOW)
+    bindings = (
+        (StudentSubjectBinding(subject_id, user_id, True, 1, NOW, NOW),)
+        if include_binding
+        else ()
+    )
+    memberships = tuple(
+        ClassMembership(user_id, class_id, "student", NOW)
+        for class_id in payload["class_ids"]
+    )
+    classes = tuple(
+        ClassGroup(class_id, class_id, "2026-2027", True, NOW, NOW)
+        for class_id in payload["class_ids"]
+    )
+    aliases = tuple(
+        LegacySubjectAlias(
+            item["class_id"],
+            item["legacy_student_id"],
+            item["subject_id"],
+            NOW,
+        )
+        for item in payload.get("legacy_aliases", [])
+    )
+    return build_student_binding_snapshot(
+        account=account,
+        bindings=bindings,
+        memberships=memberships,
+        classes=classes,
+        legacy_aliases=aliases,
+    )
+
+
+def assert_failure(code: str, operation) -> None:
+    with pytest.raises(StudentBindingResolutionError) as captured:
+        operation()
+    assert captured.value.code == code
+    assert str(captured.value) == "Identita didattica non risolvibile."
+    assert "auth-user" not in str(captured.value)
+
+
+def test_subject_ids_are_server_generated_opaque_and_namespaced() -> None:
+    first = generate_subject_id()
+    second = generate_subject_id()
+
+    assert first.startswith("subject:")
+    assert len(first) == 40
+    assert first != second
+
+
+def test_positive_fixture_resolves_auth_user_to_subject_class_and_target() -> None:
+    payload = load_fixture("positive.json")
+    snapshot = snapshot_from_fixture(payload)
+
+    identity = resolve_student_identity(payload["user_id"], snapshot)
+    target = resolve_assignment_target(
+        payload["user_id"], snapshot, payload["assignment"]
+    )
+
+    assert identity.subject_id == payload["subject_id"]
+    assert identity.class_ids == tuple(payload["class_ids"])
+    assert target.subject_id == payload["subject_id"]
+    assert target.class_id == payload["assignment"]["class_id"]
+    assert target.used_legacy_alias is False
+    assert target.authority_revision == snapshot.authority_revision
+
+
+def test_missing_and_duplicate_bindings_fail_closed_with_sanitized_error() -> None:
+    payload = load_fixture("positive.json")
+    missing = snapshot_from_fixture(payload, include_binding=False)
+    original = snapshot_from_fixture(payload)
+    duplicate = build_student_binding_snapshot(
+        account=original.account,
+        bindings=(
+            original.bindings[0],
+            StudentSubjectBinding(
+                "subject:22222222222222222222222222222222",
+                payload["user_id"],
+                True,
+                1,
+                NOW,
+                NOW,
+            ),
+        ),
+        memberships=original.memberships,
+        classes=original.classes,
+    )
+
+    assert_failure("missing", lambda: resolve_student_identity(payload["user_id"], missing))
+    assert_failure("duplicate", lambda: resolve_student_identity(payload["user_id"], duplicate))
+
+
+def test_mismatched_auth_user_and_tampered_revision_fail_closed() -> None:
+    payload = load_fixture("positive.json")
+    snapshot = snapshot_from_fixture(payload)
+
+    assert_failure("ambiguous", lambda: resolve_student_identity("other-user", snapshot))
+    assert_failure(
+        "incoherent",
+        lambda: resolve_student_identity(
+            payload["user_id"],
+            replace(snapshot, authority_revision="sha256:" + "0" * 64),
+        ),
+    )
+
+
+@pytest.mark.parametrize("fixture_name", ["cross-class.json", "membership-removed.json"])
+def test_cross_class_and_removed_membership_fixtures_fail_closed(fixture_name: str) -> None:
+    payload = load_fixture(fixture_name)
+    snapshot = snapshot_from_fixture(payload)
+
+    assert_failure(
+        "class_mismatch",
+        lambda: resolve_assignment_target(
+            payload["user_id"], snapshot, payload["assignment"]
+        ),
+    )
+
+
+def test_client_style_student_id_never_becomes_authority() -> None:
+    payload = load_fixture("positive.json")
+    snapshot = snapshot_from_fixture(payload)
+    assignment = {
+        "id": "assignment:untrusted-id:001",
+        "class_id": payload["class_ids"][0],
+        "targets": [{"student_id": payload["user_id"]}],
+    }
+
+    assert_failure(
+        "target_missing",
+        lambda: resolve_assignment_target(payload["user_id"], snapshot, assignment),
+    )
+
+
+def test_explicit_legacy_alias_migrates_and_round_trips_assignment() -> None:
+    payload = load_fixture("positive.json")
+    class_id = payload["class_ids"][0]
+    alias = LegacySubjectAlias(class_id, "rossi-mario", payload["subject_id"], NOW)
+    legacy = assignment_records.build_assignment_record(
+        activity_id="python-base-somma-001",
+        activity_path="activities/python-base-somma-001.json",
+        target_type="class",
+        class_id=class_id,
+        assigned_at="2026-10-12T09:00:00+02:00",
+        due_at="2026-10-19T23:59:00+02:00",
+        targets=[{"student_id": "rossi-mario"}],
+    )
+
+    migrated = migrate_legacy_assignment_targets(legacy, [alias])
+    round_trip = assignment_records.validate_assignment_record(migrated)
+
+    assert round_trip["targets"][0]["subject_id"] == payload["subject_id"]
+    snapshot = build_student_binding_snapshot(
+        account=snapshot_from_fixture(payload).account,
+        bindings=snapshot_from_fixture(payload).bindings,
+        memberships=snapshot_from_fixture(payload).memberships,
+        classes=snapshot_from_fixture(payload).classes,
+        legacy_aliases=(alias,),
+    )
+    resolution = resolve_assignment_target(payload["user_id"], snapshot, legacy)
+    assert resolution.used_legacy_alias is True
+
+
+def test_legacy_ambiguous_and_missing_aliases_fail_closed() -> None:
+    payload = load_fixture("legacy-ambiguous.json")
+    snapshot = snapshot_from_fixture(payload)
+
+    assert_failure(
+        "legacy_ambiguous",
+        lambda: resolve_assignment_target(
+            payload["user_id"], snapshot, payload["assignment"]
+        ),
+    )
+    assert_failure(
+        "legacy_ambiguous",
+        lambda: migrate_legacy_assignment_targets(
+            payload["assignment"], snapshot.legacy_aliases
+        ),
+    )
+    assert_failure(
+        "legacy_missing",
+        lambda: migrate_legacy_assignment_targets(payload["assignment"], ()),
+    )

--- a/tests/test_thebitlab_identity_binding_sqlite.py
+++ b/tests/test_thebitlab_identity_binding_sqlite.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.thebitlab_identity import ClassGroup, ClassMembership, UserAccount
+from scripts.thebitlab_identity_binding import (
+    LegacySubjectAlias,
+    StudentSubjectBinding,
+    resolve_assignment_target,
+)
+from scripts.thebitlab_identity_ports import (
+    IdentityStorageConflictError,
+    IdentityStorageCorruptionError,
+)
+from scripts.thebitlab_identity_sqlite import SCHEMA_VERSION, SqliteIdentityStorage
+
+
+NOW = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+SUBJECT_ID = "subject:11111111111111111111111111111111"
+CLASS_ID = "class:3a-tpsi:2026-2027"
+
+
+def provision(storage: SqliteIdentityStorage) -> StudentSubjectBinding:
+    storage.create_user(
+        UserAccount("auth-user-001", "Mario Rossi", "student", True, NOW, NOW)
+    )
+    storage.create_class(
+        ClassGroup(CLASS_ID, "3A TPSI", "2026-2027", True, NOW, NOW)
+    )
+    storage.save_membership(
+        ClassMembership("auth-user-001", CLASS_ID, "student", NOW)
+    )
+    binding = StudentSubjectBinding(
+        SUBJECT_ID, "auth-user-001", True, 1, NOW, NOW
+    )
+    storage.create_student_subject_binding(
+        binding,
+        (LegacySubjectAlias(CLASS_ID, "rossi-mario", SUBJECT_ID, NOW),),
+    )
+    return binding
+
+
+def test_sqlite_binding_alias_and_coherent_snapshot_round_trip(tmp_path) -> None:
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3")
+    binding = provision(storage)
+
+    assert storage.read_student_subject_binding(SUBJECT_ID) == binding
+    assert storage.list_user_subject_bindings("auth-user-001") == [binding]
+    assert storage.list_legacy_subject_aliases(CLASS_ID) == [
+        LegacySubjectAlias(CLASS_ID, "rossi-mario", SUBJECT_ID, NOW)
+    ]
+
+    snapshot = storage.read_student_binding_snapshot("auth-user-001")
+    resolution = resolve_assignment_target(
+        "auth-user-001",
+        snapshot,
+        {
+            "id": "assignment:legacy:001",
+            "class_id": CLASS_ID,
+            "targets": [{"student_id": "rossi-mario"}],
+        },
+    )
+    assert resolution.subject_id == SUBJECT_ID
+    assert resolution.used_legacy_alias is True
+
+
+def test_sqlite_binding_uniqueness_and_alias_ambiguity_are_atomic(tmp_path) -> None:
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3")
+    original = provision(storage)
+    duplicate_for_user = StudentSubjectBinding(
+        "subject:22222222222222222222222222222222",
+        original.user_id,
+        True,
+        1,
+        NOW,
+        NOW,
+    )
+
+    with pytest.raises(IdentityStorageConflictError):
+        storage.create_student_subject_binding(duplicate_for_user)
+
+    storage.create_user(
+        UserAccount("auth-user-002", "Luca Bianchi", "student", True, NOW, NOW)
+    )
+    other = StudentSubjectBinding(
+        "subject:22222222222222222222222222222222",
+        "auth-user-002",
+        True,
+        1,
+        NOW,
+        NOW,
+    )
+    with pytest.raises(IdentityStorageConflictError):
+        storage.create_student_subject_binding(
+            other,
+            (LegacySubjectAlias(CLASS_ID, "rossi-mario", other.subject_id, NOW),),
+        )
+
+    assert storage.read_student_subject_binding(other.subject_id) is None
+    assert storage.read_student_subject_binding(original.subject_id) == original
+
+
+def test_alias_can_be_appended_only_for_current_binding_and_membership(tmp_path) -> None:
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3")
+    provision(storage)
+    before = storage.read_student_binding_snapshot("auth-user-001")
+    alias = LegacySubjectAlias(CLASS_ID, "m.rossi", SUBJECT_ID, NOW)
+
+    storage.save_legacy_subject_alias(alias, expected_binding_revision=1)
+    after = storage.read_student_binding_snapshot("auth-user-001")
+
+    assert alias in storage.list_legacy_subject_aliases(CLASS_ID)
+    assert before.authority_revision != after.authority_revision
+    with pytest.raises(IdentityStorageConflictError):
+        storage.save_legacy_subject_alias(
+            LegacySubjectAlias(CLASS_ID, "stale", SUBJECT_ID, NOW),
+            expected_binding_revision=2,
+        )
+    storage.delete_membership("auth-user-001", CLASS_ID, "student")
+    with pytest.raises(IdentityStorageConflictError):
+        storage.save_legacy_subject_alias(
+            LegacySubjectAlias(CLASS_ID, "removed", SUBJECT_ID, NOW),
+            expected_binding_revision=1,
+        )
+
+
+def test_binding_lifecycle_uses_monotonic_compare_and_swap(tmp_path) -> None:
+    storage = SqliteIdentityStorage(tmp_path / "identity.sqlite3")
+    original = provision(storage)
+    disabled = replace(
+        original,
+        active=False,
+        revision=2,
+        updated_at=NOW + timedelta(seconds=1),
+    )
+
+    storage.save_student_subject_binding(disabled, expected_revision=1)
+    with pytest.raises(IdentityStorageConflictError):
+        storage.save_student_subject_binding(
+            replace(disabled, active=True, revision=3, updated_at=NOW + timedelta(seconds=2)),
+            expected_revision=1,
+        )
+
+    assert storage.read_student_subject_binding(SUBJECT_ID) == disabled
+    with sqlite3.connect(storage.database_path) as connection:
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            connection.execute(
+                "DELETE FROM student_subject_bindings WHERE subject_id = ?",
+                (SUBJECT_ID,),
+            )
+    assert storage.read_student_subject_binding(SUBJECT_ID) == disabled
+
+
+def test_migration_v12_upgrades_existing_identity_database(tmp_path) -> None:
+    database_path = tmp_path / "identity.sqlite3"
+    SqliteIdentityStorage(database_path)
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("DROP TABLE legacy_student_subject_aliases")
+        connection.execute("DROP TABLE student_subject_bindings")
+        connection.execute("DELETE FROM schema_migrations WHERE version = 12")
+
+    upgraded = SqliteIdentityStorage(database_path)
+    with sqlite3.connect(database_path) as connection:
+        versions = connection.execute(
+            "SELECT version FROM schema_migrations ORDER BY version"
+        ).fetchall()
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+
+    assert versions == [(version,) for version in range(1, SCHEMA_VERSION + 1)]
+    assert "student_subject_bindings" in tables
+    assert "legacy_student_subject_aliases" in tables
+    assert upgraded.list_user_subject_bindings("missing") == []
+
+
+def test_incoherent_storage_failure_is_sanitized(tmp_path) -> None:
+    database_path = tmp_path / "identity.sqlite3"
+    storage = SqliteIdentityStorage(database_path)
+    provision(storage)
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            "UPDATE classes SET updated_at = 'secret-malformed-value' WHERE class_id = ?",
+            (CLASS_ID,),
+        )
+
+    with pytest.raises(IdentityStorageCorruptionError) as captured:
+        storage.read_student_binding_snapshot("auth-user-001")
+
+    assert str(captured.value) == "Timestamp persistito non valido."
+    assert "secret-malformed-value" not in str(captured.value)
+    assert "auth-user-001" not in str(captured.value)

--- a/tests/test_thebitlab_identity_sqlite.py
+++ b/tests/test_thebitlab_identity_sqlite.py
@@ -106,6 +106,13 @@ def storage(database_path):
     return SqliteIdentityStorage(database_path)
 
 
+def drop_subject_binding_schema(connection: sqlite3.Connection) -> None:
+    """Remove v12 artifacts when rehearsing an older schema migration."""
+
+    connection.execute("DROP TABLE legacy_student_subject_aliases")
+    connection.execute("DROP TABLE student_subject_bindings")
+
+
 def test_in_memory_database_is_rejected_instead_of_losing_schema_between_connections() -> None:
     with pytest.raises(IdentityStorageError, match="file temporaneo"):
         SqliteIdentityStorage(":memory:")
@@ -148,6 +155,7 @@ def test_migration_v2_upgrades_and_backfills_existing_v1_identity(database_path)
         connection.execute("DROP TABLE external_identity_link_conflicts")
         connection.execute("DROP TABLE external_identity_generations")
         connection.execute("DROP TABLE external_group_mapping_generations")
+        drop_subject_binding_schema(connection)
         connection.execute("DELETE FROM schema_migrations WHERE version >= 2")
 
     upgraded = SqliteIdentityStorage(database_path)
@@ -240,7 +248,8 @@ def test_migration_v11_rechecks_correlations_after_earlier_v10(
                 .replace("+00:00", "Z"),
             ),
         )
-        connection.execute("DELETE FROM schema_migrations WHERE version = 11")
+        drop_subject_binding_schema(connection)
+        connection.execute("DELETE FROM schema_migrations WHERE version >= 11")
 
     upgraded = SqliteIdentityStorage(database_path)
     assert upgraded.read_session("session-01") is None
@@ -287,6 +296,7 @@ def test_migration_v8_removes_uncorrelated_legacy_tui_sessions(database_path) ->
                 NOW.isoformat().replace("+00:00", "Z"),
             ),
         )
+        drop_subject_binding_schema(connection)
         connection.execute("DELETE FROM schema_migrations WHERE version >= 7")
 
     upgraded = SqliteIdentityStorage(database_path)
@@ -299,6 +309,7 @@ def test_migration_v6_backfills_existing_sessions_as_web(database_path) -> None:
     storage.create_user(account())
     storage.create_session(session())
     with sqlite3.connect(database_path) as connection:
+        drop_subject_binding_schema(connection)
         connection.execute("DELETE FROM schema_migrations WHERE version >= 6")
 
     upgraded = SqliteIdentityStorage(database_path)
@@ -316,6 +327,7 @@ def test_migration_v5_backfills_mapping_revision(database_path) -> None:
         connection.execute(
             "UPDATE external_group_mappings SET updated_at = NULL"
         )
+        drop_subject_binding_schema(connection)
         connection.execute("DELETE FROM schema_migrations WHERE version >= 5")
 
     upgraded = SqliteIdentityStorage(database_path)
@@ -333,6 +345,7 @@ def test_migration_v4_backfills_external_group_mapping_generations(database_path
     storage.save_external_group_mapping(mapping, expected_updated_at=None)
     with sqlite3.connect(database_path) as connection:
         connection.execute("DROP TABLE external_group_mapping_generations")
+        drop_subject_binding_schema(connection)
         connection.execute("DELETE FROM schema_migrations WHERE version >= 4")
 
     upgraded = SqliteIdentityStorage(database_path)
@@ -351,6 +364,7 @@ def test_migration_v3_quarantines_ambiguous_provider_links(database_path) -> Non
         connection.execute("DROP INDEX uq_external_identities_user_provider")
         connection.execute("DROP TABLE external_identity_link_conflicts")
         connection.execute("DROP TABLE external_group_mapping_generations")
+        drop_subject_binding_schema(connection)
         connection.execute("DELETE FROM schema_migrations WHERE version >= 3")
         connection.execute(
             """


### PR DESCRIPTION
## Summary

Completa #702 introducendo il binding autorevole e fail-closed tra identità auth e soggetto didattico.

### Cosa cambia
- contratto `user_id ↔ subject_id ↔ class_id ↔ assignment target`;
- ADR dedicato e source of truth documentata;
- migrazione SQLite v12 con trigger fail-closed;
- snapshot revisionati e adapter legacy;
- fixture per binding positivo, mancante, duplicato, ambiguo e casi cross-class;
- nessun ID fornito dal client viene usato come authority.

### Verifica
- test pertinenti: 170 passed, 2 skipped;
- suite ampia: 2165 passed, 67 skipped;
- 2 failure ambientali Windows estranee al diff;
- suite completa bloccata solo dalla dipendenza opzionale `utui`;
- `compileall`, `git diff --check` e link Markdown: PASS;
- review completa: nessun finding aperto.

### Confine di scope
L'enforcement completo sulle Student API resta intenzionalmente separato in #706, che deve consumare questo contratto invece di duplicarlo.

Closes #702.