### PR TITLE
Dashboard docente: mostra backend e attempt ID nel Quadro classe

### DIFF
--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -215,6 +215,7 @@ class AssignmentOverviewService:
                         "submitted_at": submission.get("submitted_at"),
                         "commit": submission.get("commit"),
                         "source_path": submission.get("source_path"),
+                        "report_backend": submission.get("report_backend"),
                         "attempt_id": submission.get("attempt_id"),
                         "report_selection": submission.get("report_selection"),
                         "final_selected": bool(submission.get("final_selected", False)),

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -387,6 +387,7 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         renderOverviewSummaryCards,
         renderOverviewFilters,
         filteredOverviewRows,
+        renderOverview,
         focusOverviewClassFromReport,
         summaryCounts,
         reportCounts,
@@ -735,6 +736,100 @@ def test_overview_activity_filter_limits_rows() -> None:
         const rows = tested.filteredOverviewRows();
         assert.equal(rows.length, 1);
         assert.equal(rows[0].activity_id, "somma");
+        """
+    )
+
+
+def test_overview_row_escapes_backend_and_attempt_id_and_omits_missing_values() -> None:
+    run_dashboard_js(
+        """
+        tested.state.overviewRows = [
+          {
+            class_id: "3A-TPSI",
+            student: "rossi-mario",
+            title: "Somma base",
+            activity_id: "somma",
+            kind: "lab",
+            status: "submitted_on_time",
+            submitted: true,
+            report_name: "demo/somma.json",
+            report_backend: 'docker<img src=x onerror="boom">',
+            attempt_id: "attempt-<script>boom</script>",
+            tests_passed: 2,
+            tests_total: 2,
+          },
+          {
+            student: "bianchi-luca",
+            activity_id: "somma",
+            status: "submitted_on_time",
+            submitted: true,
+            report_name: "demo/null.json",
+            report_backend: null,
+            attempt_id: null,
+          },
+          {
+            student: "verdi-anna",
+            activity_id: "somma",
+            status: "submitted_on_time",
+            submitted: true,
+            report_name: "demo/missing.json",
+          },
+        ];
+
+        tested.renderOverview();
+
+        const escapedHtml = tested.els.overviewBody.children[0].innerHTML;
+        assert.ok(escapedHtml.includes('backend docker&lt;img src=x onerror=&quot;boom&quot;&gt;'));
+        assert.ok(escapedHtml.includes('attempt-&lt;script&gt;boom&lt;/script&gt;'));
+        assert.doesNotMatch(escapedHtml, /<img|<script>/);
+        assert.doesNotMatch(tested.els.overviewBody.children[1].innerHTML, /backend |tentativo /);
+        assert.doesNotMatch(tested.els.overviewBody.children[2].innerHTML, /backend |tentativo /);
+        """
+    )
+
+
+def test_overview_row_button_still_loads_and_opens_submission() -> None:
+    run_dashboard_js(
+        """
+        (async () => {
+          tested.fetchResponses["/api/assignment-reports/load"] = {
+            report: {
+              activity_id: "somma",
+              students: [{
+                student: "rossi-mario",
+                submitted: true,
+                status: "submitted_on_time",
+                submission: { files: [{ path: "assignments/somma/main.py", role: "solution" }] },
+                grading: {},
+              }],
+            },
+          };
+          tested.fetchResponses["/api/assignment-submissions/read"] = {
+            file: { path: "assignments/somma/main.py", content: "print(3)" },
+          };
+          const button = new tested.FakeElement("button");
+          button.dataset.overviewReport = "demo/somma.json";
+          button.dataset.overviewStudent = "rossi-mario";
+          const event = {
+            target: {
+              closest(selector) {
+                return selector === "[data-overview-report]" ? button : null;
+              },
+            },
+            preventDefault() {},
+            stopPropagation() {},
+          };
+
+          await tested.els.overviewBody.listeners.click[0](event);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+
+          assert.equal(tested.state.reportName, "demo/somma.json");
+          assert.equal(tested.state.reviewStudent, "rossi-mario");
+          assert.equal(tested.state.reviewSource, "overview");
+          assert.equal(tested.state.reviewFile.path, "assignments/somma/main.py");
+          const loadCall = tested.fetchCalls.find((entry) => entry.path === "/api/assignment-reports/load");
+          assert.equal(JSON.parse(loadCall.options.body).name, "demo/somma.json");
+        })();
         """
     )
 

--- a/tests/test_thebitlab_services.py
+++ b/tests/test_thebitlab_services.py
@@ -185,6 +185,7 @@ def test_assignment_overview_lists_student_rows(tmp_path) -> None:
             "submitted_at": "2026-10-18T18:22:10+02:00",
             "commit": "abc1234",
             "source_path": None,
+            "report_backend": None,
             "attempt_id": None,
             "report_selection": None,
             "final_selected": False,
@@ -213,7 +214,12 @@ def test_assignment_overview_exposes_canonical_attempt_selection(tmp_path) -> No
                     {
                         "student": "finale",
                         "submitted": True,
-                        "submission": {"report_selection": "final", "final_selected": False},
+                        "submission": {
+                            "report_backend": "docker",
+                            "attempt_id": "attempt-20260814T141612102181Z-bf0933e7",
+                            "report_selection": "final",
+                            "final_selected": False,
+                        },
                         "grading": {"provisional": True},
                     },
                     {
@@ -236,6 +242,8 @@ def test_assignment_overview_exposes_canonical_attempt_selection(tmp_path) -> No
 
     rows = {row["student"]: row for row in service.assignment_overview()}
 
+    assert rows["finale"]["report_backend"] == "docker"
+    assert rows["finale"]["attempt_id"] == "attempt-20260814T141612102181Z-bf0933e7"
     assert rows["finale"]["report_selection"] == "final"
     assert rows["finale"]["final_selected"] is True
     assert rows["finale"]["grading_provisional"] is False

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2911,6 +2911,8 @@ function renderOverview() {
           Consegna
         </button><br>
         <small class="overviewReportName" title="${escapeHtml(row.report_name || "-")}">${escapeHtml(row.report_name || "-")}</small>
+        ${row.report_backend ? `<br><small>backend ${escapeHtml(row.report_backend)}</small>` : ""}
+        ${row.attempt_id ? `<br><small>tentativo <code>${escapeHtml(row.attempt_id)}</code></small>` : ""}
       </td>
     `;
     els.overviewBody.append(tr);


### PR DESCRIPTION
## Summary

Productizza la correzione di #707 sulla linea corrente: backend del report e attempt ID canonico vengono propagati dal service e mostrati nel Quadro classe.

### Cosa cambia
- propagazione di `report_backend` e `attempt_id` dal service;
- rendering nella vista docente;
- escaping HTML;
- gestione valori null/assenti;
- regressioni su filtri e apertura della consegna;
- vecchio worktree del rehearsal ispezionato solo in lettura e lasciato invariato.

### Verifica
- service + frontend: 143 passed;
- `compileall`: PASS;
- `node --check`: PASS;
- `git diff --check`: PASS.

### Gate residuo
Lo Scenario 3 browser E2E non è stato eseguito in questa unità. Deve essere rieseguito sulla candidate/root integrata con un report Docker prodotto dalla stessa baseline, dopo la disponibilità di #705. Il FAIL storico del rehearsal resta immutato.

Relates to #707.
Depends on #705 for final E2E acceptance.