### PR TITLE
Pilot: unify data root with backup and restore

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -1,46 +1,43 @@
 # Checkpoint operativo
 
-- **Data/ora:** 2026-08-17T05:19:38+02:00
-- **Obiettivo:** issue #702, binding autorevole `user_id` auth ↔ soggetto didattico ↔ `class_id` ↔ assignment/target.
-- **Stato:** **completato e committato** sul branch `feat/identity-binding-702`; nessun push o merge eseguito.
-- **Criterio e risultato:** contratto/source-of-truth documentati; ID server-side stabili; migrazione SQLite v12 e compatibilita legacy esplicita; validator fail-closed e fixture/test missing, duplicate, ambiguous, cross-class, membership rimossa e legacy ambiguo; nessun matching implicito o ID client usato come autorita.
+- **Data/ora:** 2026-08-18T21:44:07+02:00
+- **Obiettivo:** issue #705, singola root pilot con auth+dati e backup/restore completo verificabile.
+- **Stato:** **completato**, review completa eseguita; commit conclusivo = `HEAD` del branch indicato sotto. Nessun push, PR o modifica live.
+- **Criterio:** bootstrap da root vuota e idempotente; root/auth/binding completi e fail-closed; backup coerente deterministico e secret-safe; restore isolato con checksum, integrity/migrazioni, demo/binding/startup smoke e no-write sorgente. Tutto verificato sui dati demo.
 
-## Decisioni canoniche
+## Architettura e decisioni canoniche
 
-- ADR accettato: `doc/architecture/adr-authoritative-student-identity-binding.md`.
-- SQLite identity e source-of-truth per binding 1:1 immutabile `user_id <-> subject_id`, classi/membership e alias legacy class-scoped.
-- `subject_id` e opaco e server-generated (`subject:<uuid hex>`); `student_id`, email, username, path e repository sono attributi legacy, mai authority.
-- `class_id` deriva dalle membership auth; assignment e target sono record ricaricati dallo storage server. L'enforcement completo delle student API resta fuori scope in #706.
-- Snapshot transazionale con digest `authority_revision`; lifecycle binding CAS monotono/no-delete; alias append-only con revisione binding e membership attiva.
+- Contratto e runbook: `doc/PILOT_ROOT_BACKUP.md`; deployment e rehearsal aggiornati.
+- Una root contiene marker `.thebitlab-root.json`, auth SQLite relativo, design, calendario, roster, activity, assignment, report, tentativi, help e workspace. Classe/roster/auth/assignment condividono `3A-TPSI`; due studenti hanno account, membership, binding #702 e target `subject_id`.
+- `scripts/pilot_data_root.py`: `bootstrap`, `validate`, `backup`, `restore`; produzione deriva root/auth/deployment ID dal manifest #701, direct root solo per smoke locali.
+- Backup `thebitlab.pilot-backup.v1`: directory `payload/`, `manifest.json` deterministico con path/size/SHA-256 ordinati, `manifest.sha256`; lock esclusivo a processo fermo e SQLite backup API. Lock/cache/sidecar sono transitori; secret/symlink fanno fallire il backup.
+- Restore solo verso target inesistente e isolato; verifica completa prima/dopo, migrazioni supportate, demo existing, matrice identity/binding e server loopback su porta effimera.
+- Launcher systemd valida la root prima di leggere l'EnvironmentFile; doppia istanza sulla stessa root e seconda SQLite falliscono chiuse.
+- Target engineering governance: RPO 24h/RTO 8 ore lavorative; le misure locali non sono SLA né prova di conformità.
 
-## File principali
+## File creati/modificati
 
-- Nuovi: ADR binding, `scripts/thebitlab_identity_binding.py`, 4 fixture `tests/fixtures/identity_binding/`, test domain/storage dedicati.
-- Modificati: ADR identity/storage e `data-contracts.md`; `scripts/thebitlab_identity_sqlite.py` (schema v12, trigger, adapter/snapshot), `scripts/thebitlab_identity_ports.py`, `scripts/assignment_records.py`; fixture/test contrattuali e rehearsal migrazioni storiche.
-- `CHECKPOINT.md` sostituisce il checkpoint obsoleto di un altro worktree.
+- Creati: `doc/PILOT_ROOT_BACKUP.md`, `schemas/pilot-backup-manifest.schema.json`, `scripts/pilot_data_root.py`, `tests/test_pilot_data_root.py`.
+- Modificati: `deploy/pilot/templates/thebitlab.service.template`, `doc/PILOT_DEPLOYMENT.md`, `doc/PILOT_REHEARSAL.md`, `scripts/pilot_service_launcher.py`, `tests/test_pilot_deployment.py`, `CHECKPOINT.md`.
+- Evidence storiche #678 non toccate.
 
-## Verifiche e review
+## Verifiche
 
-- Test pertinenti finali: **170 passed, 2 skipped** (`identity_binding`, `identity_binding_sqlite`, assignment records, data fixtures, identity, identity SQLite, contracts, storage).
-- Test finali focalizzati dopo i trigger DB: **69 passed**.
-- Suite ampia senza `tests/test_student_errors.py`: **2165 passed, 67 skipped, 2 failed**; i due failure sono ambientali Windows estranei al diff (privilegio symlink WinError 1314 e launcher macOS non eseguibile WinError 193).
-- Suite completa non collezionabile per dipendenza opzionale assente `utui` in `tests/test_student_errors.py`; nessun package installato. `ruff` non disponibile nell'ambiente.
-- `compileall`: **PASS**. `git diff --check`: **PASS**. Link Markdown locali: **PASS**.
-- Review completa del diff eseguita. Finding corretti: migrazione v12 non permissiva su artefatti parziali; alias aggiungibili post-provisioning con CAS; coerenza fixture `class_id`; trigger DB contro delete/reuse/update e alias non autorevoli. Nessun finding aperto.
-- Nessun server, watcher o processo temporaneo avviato.
+- Suite integrata root/deployment/demo/binding/assignment: **67 passed, 1 skipped**; skip = smoke nginx/systemd Linux non disponibile su host Windows.
+- Lock server mirati: **2 passed, 1 skipped**; skip Windows previsto per test permessi POSIX.
+- CLI reale Windows: bootstrap `created=true`, secondo bootstrap `created=false`; `student_lab_demo_check --existing` PASS; backup **2.067245 s**, restore **2.013516 s**, 19 file, integrity/binding/startup PASS.
+- Test coprono partial root, doppia istanza, manifest/checksum deterministico, secret exclusion, tampering, target isolato, no-write sorgente/backup, schema/migrazione parziale, binding #702 e path POSIX/Windows.
+- `compileall`, `git diff --check`, schema Draft 2020-12 e link Markdown locali: PASS. `ruff` non eseguito perché non installato.
+- Warning pytest: cleanup di vecchie directory temporanee Windows con DACL intenzionalmente invalida create da test auth estranei; nessun failure.
+- Nessun server, watcher o processo temporaneo lasciato attivo.
 
-## Stato Git e prossimo passo
+## Stato Git e residui
 
-- Base iniziale: `3d785a54336e81f69efa7a6d5ee7941f9ba76675` (`origin/main`).
-- Worktree: `F:/dev/2cornot2c-702`; branch `feat/identity-binding-702`.
-- Commit dell'unita creato su `HEAD`; lo SHA definitivo e riportato nel riepilogo finale della sessione.
-- Problemi aperti in scope: nessuno. Non e stato implementato l'enforcement student API, intenzionalmente demandato a #706.
-- Prossimo lavoro distinto: issue #706, consumare `StudentBindingSnapshot`/`AssignmentTargetResolution` nelle policy student API senza accettare authority dalla request.
+- Worktree: `F:/dev/2cornot2c-705`; branch `feat/pilot-root-backup-705`; base iniziale `4f400e6896cbc1fb6ac17109d891035890b853f7`.
+- Commit conclusivo autorizzato creato su `HEAD`; repository atteso pulito dopo il commit. Nessun push/PR.
+- Finding implementativi aperti: nessuno.
+- Gate esterni non eseguiti/non autorizzati: target Linux reale, staging/VPS, cifratura/provider/retention approvati, rehearsal integrato #678 e approvazioni governance. I PASS storici non sono stati promossi.
 
-## File minimi per una ripresa
+## Prossimo passo
 
-- `AGENTS.md`
-- `CHECKPOINT.md`
-- `doc/architecture/adr-authoritative-student-identity-binding.md`
-- `scripts/thebitlab_identity_binding.py`
-- diff/commit dell'unita #702
+Controllo umano del commit/diff; quindi, in una nuova sessione e solo su autorizzazione, eventuale push/apertura PR. File minimi: `AGENTS.md`, `CHECKPOINT.md`, `doc/PILOT_ROOT_BACKUP.md`, diff di `scripts/pilot_data_root.py` e `tests/test_pilot_data_root.py`.

--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -1,43 +1,41 @@
 # Checkpoint operativo
 
-- **Data/ora:** 2026-08-18T21:44:07+02:00
-- **Obiettivo:** issue #705, singola root pilot con auth+dati e backup/restore completo verificabile.
-- **Stato:** **completato**, review completa eseguita; commit conclusivo = `HEAD` del branch indicato sotto. Nessun push, PR o modifica live.
-- **Criterio:** bootstrap da root vuota e idempotente; root/auth/binding completi e fail-closed; backup coerente deterministico e secret-safe; restore isolato con checksum, integrity/migrazioni, demo/binding/startup smoke e no-write sorgente. Tutto verificato sui dati demo.
+- **Data/ora:** 2026-08-18T22:11:15+02:00
+- **Obiettivo:** validazione Linux/POSIX finale issue #705 prima di push/PR.
+- **Stato:** **completato — READY FOR PUSH**. Validazione eseguita soltanto con dati demo/sintetici; nessun push, PR, VPS/staging/live o dato reale.
+- **Criterio:** suite integrata Linux, bootstrap root vuota, fail-closed POSIX, backup/restore verificabile e isolato, launcher ordering, render/systemd/nginx e startup loopback tutti PASS. Due difetti POSIX reali trovati, corretti, riesaminati e testati.
 
-## Architettura e decisioni canoniche
+## Ambiente Linux
 
-- Contratto e runbook: `doc/PILOT_ROOT_BACKUP.md`; deployment e rehearsal aggiornati.
-- Una root contiene marker `.thebitlab-root.json`, auth SQLite relativo, design, calendario, roster, activity, assignment, report, tentativi, help e workspace. Classe/roster/auth/assignment condividono `3A-TPSI`; due studenti hanno account, membership, binding #702 e target `subject_id`.
-- `scripts/pilot_data_root.py`: `bootstrap`, `validate`, `backup`, `restore`; produzione deriva root/auth/deployment ID dal manifest #701, direct root solo per smoke locali.
-- Backup `thebitlab.pilot-backup.v1`: directory `payload/`, `manifest.json` deterministico con path/size/SHA-256 ordinati, `manifest.sha256`; lock esclusivo a processo fermo e SQLite backup API. Lock/cache/sidecar sono transitori; secret/symlink fanno fallire il backup.
-- Restore solo verso target inesistente e isolato; verifica completa prima/dopo, migrazioni supportate, demo existing, matrice identity/binding e server loopback su porta effimera.
-- Launcher systemd valida la root prima di leggere l'EnvironmentFile; doppia istanza sulla stessa root e seconda SQLite falliscono chiuse.
-- Target engineering governance: RPO 24h/RTO 8 ore lavorative; le misure locali non sono SLA né prova di conformità.
+- Container effimero `ubuntu:24.04`, immagine `ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea`, repository host montato read-only e copiato in `/work` interno.
+- Docker Desktop engine 28.3.2 su WSL2 kernel `6.18.33.2-microsoft-standard-WSL2`.
+- Ubuntu 24.04.4 LTS; Python 3.12.3; pytest 8.4.2; nginx 1.24.0; systemd 255; OpenSSL 3.0.13.
 
-## File creati/modificati
+## Finding e correzioni
 
-- Creati: `doc/PILOT_ROOT_BACKUP.md`, `schemas/pilot-backup-manifest.schema.json`, `scripts/pilot_data_root.py`, `tests/test_pilot_data_root.py`.
-- Modificati: `deploy/pilot/templates/thebitlab.service.template`, `doc/PILOT_DEPLOYMENT.md`, `doc/PILOT_REHEARSAL.md`, `scripts/pilot_service_launcher.py`, `tests/test_pilot_deployment.py`, `CHECKPOINT.md`.
-- Evidence storiche #678 non toccate.
+1. `topology_from_paths()` risolveva il path prima del controllo e accettava una root symlink; inoltre `validate_root()` accettava symlink interni. Ora la root esplicita e l'intero albero applicativo falliscono chiusi. Test di regressione POSIX aggiunto.
+2. I lock `.course-storage.lock` e `.thebitlab-server.lock` creati dopo l'hardening avevano mode `0644`. I rispettivi lock owner applicano ora `0600` su POSIX; test specifici e controllo completo dell'albero verificano directory `0700` e file `0600`.
 
-## Verifiche
+File modificati dal follow-up Linux: `scripts/pilot_data_root.py`, `scripts/course_board_server.py`, `scripts/thebitlab_storage.py`, `tests/test_pilot_data_root.py`, `tests/test_course_board_server.py`, `tests/test_thebitlab_storage.py`, `CHECKPOINT.md`. La documentazione canonica `doc/PILOT_ROOT_BACKUP.md` era già coerente e non ha richiesto modifiche.
 
-- Suite integrata root/deployment/demo/binding/assignment: **67 passed, 1 skipped**; skip = smoke nginx/systemd Linux non disponibile su host Windows.
-- Lock server mirati: **2 passed, 1 skipped**; skip Windows previsto per test permessi POSIX.
-- CLI reale Windows: bootstrap `created=true`, secondo bootstrap `created=false`; `student_lab_demo_check --existing` PASS; backup **2.067245 s**, restore **2.013516 s**, 19 file, integrity/binding/startup PASS.
-- Test coprono partial root, doppia istanza, manifest/checksum deterministico, secret exclusion, tampering, target isolato, no-write sorgente/backup, schema/migrazione parziale, binding #702 e path POSIX/Windows.
-- `compileall`, `git diff --check`, schema Draft 2020-12 e link Markdown locali: PASS. `ruff` non eseguito perché non installato.
-- Warning pytest: cleanup di vecchie directory temporanee Windows con DACL intenzionalmente invalida create da test auth estranei; nessun failure.
-- Nessun server, watcher o processo temporaneo lasciato attivo.
+## Evidenze Linux/POSIX
 
-## Stato Git e residui
+- Suite finale non-root integrata #705 + binding/assignment/demo + storage + lock: **119 passed, 1 skipped, 1 deselected**; skip = primitiva solo Windows, deselected = smoke deployment eseguito separatamente come root del container.
+- Smoke controllato nginx + `systemd-analyze verify`: **1 passed**. Test focalizzati post-review: **3 passed**.
+- Windows cross-platform mirato: **4 passed, 1 skipped** (symlink POSIX); warning cleanup DACL temporanei storico/estraneo.
+- Bootstrap CLI: prima esecuzione `created=true`, seconda `created=false`, idempotenza e demo-check PASS. Account docente + 2 studenti, classe, 3 membership e binding #702 PASS; `student_lab_demo_check --existing` PASS su sorgente e restore.
+- POSIX: root/entry symlink rejection, secret rejection, lock esclusivo, doppia istanza, root parziale senza reset, DB auth multiplo fail-closed e mode `0700/0600` PASS.
+- Backup: schema `thebitlab.pilot-backup.v1`, `manifest.sha256`, schema JSON e SHA-256/dimensione di tutti i 28 payload PASS; nessun secret, symlink, cache, lock o sidecar incluso. Snapshot SQLite con dato committed in WAL verificato coerente e sidecar esclusi.
+- Restore: solo target nuovo, checksum payload, `PRAGMA integrity_check`, migrazioni 1..12, binding #702, demo-check e startup bind loopback PASS. Root sorgente invariata per insieme path, SHA-256, mode e `mtime_ns`; backup invariato dai test integrati.
+- Launcher: root incompleta fallisce prima dell'accesso all'EnvironmentFile, verificato sia con test monkeypatch call-order sia con CLI.
+- Deployment: bundle sintetico isolato renderizzato; `systemd-analyze verify` PASS sulla unit generata; smoke nginx non distruttivo PASS. Il bundle example diretto non è verificabile senza l'eseguibile `/opt/thebitlab/current/...`, quindi non ripetere quel comando senza il manifest temporaneo usato dallo smoke.
+- Misure locali Linux, **non SLA**: backup **0.063356 s**; restore finale **0.072458 s**.
+- `compileall` e `git diff --check`: PASS. Review finale completa del diff: nessun finding aperto.
 
-- Worktree: `F:/dev/2cornot2c-705`; branch `feat/pilot-root-backup-705`; base iniziale `4f400e6896cbc1fb6ac17109d891035890b853f7`.
-- Commit conclusivo autorizzato creato su `HEAD`; repository atteso pulito dopo il commit. Nessun push/PR.
-- Finding implementativi aperti: nessuno.
-- Gate esterni non eseguiti/non autorizzati: target Linux reale, staging/VPS, cifratura/provider/retention approvati, rehearsal integrato #678 e approvazioni governance. I PASS storici non sono stati promossi.
+## Stato Git e prossimo passo
 
-## Prossimo passo
-
-Controllo umano del commit/diff; quindi, in una nuova sessione e solo su autorizzazione, eventuale push/apertura PR. File minimi: `AGENTS.md`, `CHECKPOINT.md`, `doc/PILOT_ROOT_BACKUP.md`, diff di `scripts/pilot_data_root.py` e `tests/test_pilot_data_root.py`.
+- Worktree `F:/dev/2cornot2c-705`; branch `feat/pilot-root-backup-705`; commit iniziale validato `92cd2864be31a0655377509733433f8bc395824e`.
+- Il follow-up Linux deve essere il nuovo `HEAD` creato al termine di questa unità; branch atteso pulito e ahead 2 rispetto a `origin/main`. Nessun push eseguito.
+- Processi temporanei: container e Docker Desktop avviati per questa unità devono risultare arrestati nel riepilogo finale.
+- Problemi aperti in scope: nessuno.
+- **Prossimo passo distinto:** controllo umano dei due commit, quindi push/apertura PR solo su autorizzazione. File minimi: `AGENTS.md`, `CHECKPOINT.md`, `doc/PILOT_ROOT_BACKUP.md` e `git diff origin/main...HEAD`.

--- a/deploy/pilot/templates/thebitlab.service.template
+++ b/deploy/pilot/templates/thebitlab.service.template
@@ -22,7 +22,7 @@ UMask=0077
 Environment=PYTHONUNBUFFERED=1
 Environment=HOME=@@HOME_DIRECTORY@@
 
-ExecStart=@@PYTHON_EXECUTABLE@@ scripts/pilot_service_launcher.py --environment-file @@ENVIRONMENT_FILE@@ --deployment-revision @@RELEASE_COMMIT@@ --lock-directory @@LOCK_DIRECTORY@@ --auth-db-path @@AUTH_DB_PATH@@ --trusted-proxy-cidrs 127.0.0.1/32 --google-redirect-uri @@GOOGLE_REDIRECT_URI@@@@GITHUB_OAUTH_ARGUMENTS@@ --host @@BIND_HOST@@ --port @@APP_PORT@@ --root @@DATA_ROOT@@ --enable-google-auth@@GITHUB_APP_FLAG@@
+ExecStart=@@PYTHON_EXECUTABLE@@ scripts/pilot_service_launcher.py --environment-file @@ENVIRONMENT_FILE@@ --deployment-id @@DEPLOYMENT_ID@@ --deployment-revision @@RELEASE_COMMIT@@ --lock-directory @@LOCK_DIRECTORY@@ --auth-db-path @@AUTH_DB_PATH@@ --trusted-proxy-cidrs 127.0.0.1/32 --google-redirect-uri @@GOOGLE_REDIRECT_URI@@@@GITHUB_OAUTH_ARGUMENTS@@ --host @@BIND_HOST@@ --port @@APP_PORT@@ --root @@DATA_ROOT@@ --enable-google-auth@@GITHUB_APP_FLAG@@
 Restart=on-failure
 RestartSec=5s
 TimeoutStartSec=30s

--- a/doc/PILOT_DEPLOYMENT.md
+++ b/doc/PILOT_DEPLOYMENT.md
@@ -54,7 +54,7 @@ Lo smoke crea root, `EnvironmentFile`, certificato e output in una directory tem
 
 La baseline usa `.thebitlab-auth/auth.sqlite3`. L'unit non usa la direttiva systemd `EnvironmentFile=`: il launcher legge il file esterno a ogni avvio, ne accetta soltanto la allowlist e imposta `THEBITLAB_AUTH_DB_PATH` dalla configurazione renderizzata prima di sostituirsi al server. Percorsi assoluti, traversal, root sovrapposta alla release o riferimenti secret dentro release/data root sono rifiutati. Il lock applicativo è fissato a `/run/thebitlab`; il backend ascolta solo su `127.0.0.1`.
 
-Una root diversa identifica una diversa istanza. Copie o mount manuali non documentati non costituiscono sincronizzazione autorevole; valgono i confini di [`PILOT_REHEARSAL.md`](PILOT_REHEARSAL.md).
+Una root diversa identifica una diversa istanza. Copie o mount manuali non documentati non costituiscono sincronizzazione autorevole; valgono i confini di [`PILOT_REHEARSAL.md`](PILOT_REHEARSAL.md). Bootstrap, marker di completezza e procedura coerente di backup/restore sono definiti in [`PILOT_ROOT_BACKUP.md`](PILOT_ROOT_BACKUP.md). Il launcher valida questa root canonica prima di leggere i secret esterni e rifiuta root parziali, auth DB divergenti o una seconda istanza sullo stesso root.
 
 ## Segreti e configurazione runtime
 
@@ -128,7 +128,7 @@ Una candidate deve conservare separatamente release e configurazione immutabili,
 /srv/thebitlab/data/                    root persistente al rollback
 ```
 
-Prima dell'attivazione verificare SHA, digest del lock, metadata dei riferimenti esterni, schema dell'environment, ownership/root, contratto firewall e tool smoke. Il launcher appartiene alla release fissata da `release.commit`; l'unit deve invocarlo e non deve contenere `EnvironmentFile=`. I tre symlink di integrazione nginx/systemd devono puntare **attraverso** `/etc/thebitlab/current`, non a copie o direttamente a una versione: in questo modo lo switch del bundle cambia tutti gli artifact attivi. Il formato log entra nel contesto nginx `http`; nessun file renderizzato va editato sul target. Conservare bundle, checkout e virtualenv precedenti finché termina la finestra di rollback. Qualunque differenza manuale fra bundle e host invalida il gate topologia.
+Prima dell'attivazione verificare SHA, digest del lock, metadata dei riferimenti esterni, schema dell'environment, ownership/root, contratto firewall, root canonica con `pilot_data_root.py validate` e tool smoke. Il launcher appartiene alla release fissata da `release.commit`; l'unit deve invocarlo e non deve contenere `EnvironmentFile=`. I tre symlink di integrazione nginx/systemd devono puntare **attraverso** `/etc/thebitlab/current`, non a copie o direttamente a una versione: in questo modo lo switch del bundle cambia tutti gli artifact attivi. Il formato log entra nel contesto nginx `http`; nessun file renderizzato va editato sul target. Conservare bundle, checkout e virtualenv precedenti finché termina la finestra di rollback. Qualunque differenza manuale fra bundle e host invalida il gate topologia.
 
 ## Rollback bounded
 

--- a/doc/PILOT_REHEARSAL.md
+++ b/doc/PILOT_REHEARSAL.md
@@ -85,7 +85,8 @@ Eseguire da un worktree pulito sulla release candidata. Il seguente esempio Powe
 $RunId = "pilot-rehearsal-YYYYMMDD-NN"
 $Repo = "C:\path\to\2cornot2c"
 $Evidence = "D:\thebitlab-evidence\$RunId"
-$DemoRoot = "D:\thebitlab-rehearsal-data\$RunId"
+# Nome mantenuto nei passi storici: identifica ora l'unica data root canonica, non una root separata dall'auth DB.
+$DemoRoot = "D:\thebitlab-canonical-data\$RunId"
 New-Item -ItemType Directory -Path $Evidence -ErrorAction Stop | Out-Null
 Set-Location $Repo
 
@@ -125,6 +126,7 @@ Eseguire almeno i controlli mirati del percorso critico:
 
 ```powershell
 python -m pytest -q `
+  tests/test_pilot_data_root.py `
   tests/test_student_lab_demo_smoke.py `
   tests/test_student_lab_demo_check.py `
   tests/test_student_lab_attempts.py `
@@ -134,18 +136,15 @@ python -m pytest -q `
   2>&1 | Tee-Object "$Evidence\02-tests.txt"
 if ($LASTEXITCODE -ne 0) { throw "Test mirati falliti" }
 
-python scripts/student_lab_demo_check.py --root $DemoRoot --json `
+python scripts/pilot_data_root.py bootstrap --root $DemoRoot `
+  2>&1 | Tee-Object "$Evidence\03-root-bootstrap.json"
+if ($LASTEXITCODE -ne 0) { throw "Bootstrap root canonica fallito" }
+python scripts/student_lab_demo_check.py --root $DemoRoot --existing --json `
   2>&1 | Tee-Object "$Evidence\03-demo-check.json"
 if ($LASTEXITCODE -ne 0) { throw "Demo check fallito" }
 ```
 
-`03-demo-check.json` deve avere `ok: true` e confermare setup, scenario positivo e negativo, payload lab e API dashboard. La root indicata deve essere nuova o vuota. Durante le verifiche successive usare soltanto la modalità non distruttiva:
-
-```powershell
-python scripts/student_lab_demo_check.py --root $DemoRoot --existing --json
-```
-
-Non rilanciare setup/smoke distruttivi mentre un server usa la root.
+`03-root-bootstrap.json` e `03-demo-check.json` devono avere `ok: true`; il primo prova marker, auth, classe, membership e binding, il secondo scenario positivo/negativo, payload lab e API dashboard. La root indicata deve essere nuova o vuota. Durante le verifiche successive usare soltanto `pilot_data_root.py validate` e la modalità demo `--existing`. Non rilanciare setup/smoke distruttivi mentre un server usa la root.
 
 ## 3. Flusso TUI, Docker e coerenza dei tentativi
 
@@ -181,7 +180,7 @@ Per gli Scenari 2-4 il registro è intenzionalmente quello rigenerato alla fine 
 - negli Scenari 2 e 3 la riga `rossi-mario` deve mostrare `Definitivo`, backend Docker e `$DockerAttemptId`, non `Provvisorio` e backend locale; la riga negativa `bianchi-luca` deve restare fallita;
 - nello Scenario 4 non usare i totali seed-only `Aiuti 1` e `Aiuti AI 1`: confrontare registro, riga e modal con gli eventi realmente accettati nello Scenario 7. Devono essere presenti sia il prompt seed sia ogni nuova richiesta accettata, e i totali devono uguagliare il valore iniziale più il numero di richieste persistite; richieste annullate o input invalidi non devono aumentarlo.
 
-Completato lo Scenario 5, fermare il server ed eseguire il relativo ripristino della demo con `python scripts/student_lab_demo_setup.py --root $DemoRoot`; da questo punto non servono più le aspettative sostitutive precedenti. Prima dello Scenario 9, con il server ancora fermo, impostare `$ScenarioRoot = $DemoRoot` ed eseguire la sola copia di `README.md`, della fonte controllata e del relativo asset prevista dal passo 1 dello scenario generico; saltare invece il setup iniziale dello Scenario 9, perché la root ripristinata contiene già l'activity. Verificare che `$DemoRoot\README.md`, `$DemoRoot\doc\fixtures\scenario-9-course-source.md` e `$DemoRoot\doc\images\dashboard-guides\scenario-9-docente-percorso-colori.png` siano file, quindi riavviare con `--root $DemoRoot`. Non procedere con catalogo vuoto, fixture assenti o server su una root diversa: ognuno di questi casi è `FAIL`.
+Completato lo Scenario 5, fermare il server. Non usare `student_lab_demo_setup.py`, perché cancellerebbe auth DB e marker. Se lo scenario richiede davvero uno stato pulito, conservare la root precedente soltanto come evidence protetta, scegliere una **nuova** `$DemoRoot` isolata, eseguire `pilot_data_root.py bootstrap --root $DemoRoot` e aggiornare esplicitamente la configurazione della sola istanza di rehearsal prima di proseguire; non tenere due server attivi. Da questo punto non servono più le aspettative sostitutive precedenti. Prima dello Scenario 9, con il server ancora fermo, impostare `$ScenarioRoot = $DemoRoot` ed eseguire la sola copia di `README.md`, della fonte controllata e del relativo asset prevista dal passo 1 dello scenario generico; saltare invece il setup iniziale dello Scenario 9, perché la root canonica contiene già l'activity. Verificare che `$DemoRoot\README.md`, `$DemoRoot\doc\fixtures\scenario-9-course-source.md` e `$DemoRoot\doc\images\dashboard-guides\scenario-9-docente-percorso-colori.png` siano file, quindi riavviare con `--root $DemoRoot`. Non procedere con catalogo vuoto, fixture assenti o server su una root diversa: ognuno di questi casi è `FAIL`.
 
 La matrice minima deve provare:
 
@@ -223,71 +222,31 @@ Lo smoke CLI da solo non prova il provider E2E e non autorizza **GO pilot**.
 
 ## 6. Backup e restore isolato
 
-Con soli dati/account demo, registrare prima la matrice attesa di identità, ruoli e membership, quindi fermare in modo pulito il processo e acquisire un backup coerente secondo la procedura approvata. Lo snippet deve essere eseguito nello stesso ambiente effettivo del servizio: se `THEBITLAB_AUTH_DB_PATH` è fornita da un service manager o da configurazione esterna, caricare quel valore nella sessione senza trascriverlo nelle evidenze. Un ambiente di backup che non riproduce la configurazione del servizio è `FAIL`.
+Con soli dati/account demo, registrare prima la matrice attesa di identità, ruoli e membership, quindi fermare in modo pulito il processo e acquisire un backup coerente secondo la procedura approvata. I comandi devono usare lo stesso manifest deployment effettivo del servizio: root e `data.auth_db_path` derivano solo da quel contratto, senza override environment o fallback. Un ambiente di backup che non riproduce la configurazione del servizio è `FAIL`.
 
-Per una root file-based e un processo fermo, un esempio minimo è:
+La procedura supportata è [`PILOT_ROOT_BACKUP.md`](PILOT_ROOT_BACKUP.md). Non usare più copie separate di DemoRoot e auth DB: quella procedura ricreerebbe il finding topologico #678. Con il processo applicativo fermo e il manifest candidate effettivo:
 
-```powershell
-$BackupRoot = "D:\thebitlab-backups\$RunId"
-$RestoreRoot = "D:\thebitlab-restore-tests\$RunId"
-$HadAuthDbPath = Test-Path Env:THEBITLAB_AUTH_DB_PATH
-$ConfiguredAuthDb = $env:THEBITLAB_AUTH_DB_PATH
-if (-not $HadAuthDbPath) {
-  $AuthDbSource = Join-Path $DemoRoot ".thebitlab-auth\auth.sqlite3"
-} elseif ([string]::IsNullOrWhiteSpace($ConfiguredAuthDb) -or $ConfiguredAuthDb -ne $ConfiguredAuthDb.Trim()) {
-  throw "THEBITLAB_AUTH_DB_PATH non valido"
-} elseif ([IO.Path]::IsPathRooted($ConfiguredAuthDb)) {
-  $AuthDbSource = [IO.Path]::GetFullPath($ConfiguredAuthDb)
-} else {
-  $AuthDbSource = [IO.Path]::GetFullPath((Join-Path $DemoRoot $ConfiguredAuthDb))
-}
-if (-not (Test-Path -LiteralPath $AuthDbSource -PathType Leaf)) {
-  throw "Database auth configurato assente: backup non valido"
-}
-
-New-Item -ItemType Directory -Force -Path (Split-Path $BackupRoot) | Out-Null
-New-Item -ItemType Directory -Force -Path (Split-Path $RestoreRoot) | Out-Null
-Copy-Item -LiteralPath $DemoRoot -Destination $BackupRoot -Recurse -ErrorAction Stop
-$BackupAuthDb = Join-Path $BackupRoot ".thebitlab-auth\auth.sqlite3"
-New-Item -ItemType Directory -Force -Path (Split-Path $BackupAuthDb) | Out-Null
-Copy-Item -LiteralPath $AuthDbSource -Destination $BackupAuthDb -Force -ErrorAction Stop
-Copy-Item -LiteralPath $BackupRoot -Destination $RestoreRoot -Recurse -ErrorAction Stop
-
-python scripts/student_lab_demo_check.py --root $RestoreRoot --existing --json `
-  2>&1 | Tee-Object "$Evidence\08-restore-demo-check.json"
-if ($LASTEXITCODE -ne 0) { throw "Restore demo non valido" }
-
-$RestoreAuthDb = Join-Path $RestoreRoot ".thebitlab-auth\auth.sqlite3"
-if (-not (Test-Path -LiteralPath $RestoreAuthDb -PathType Leaf)) {
-  throw "Database auth assente nel restore"
-}
-python -c "import sqlite3,sys; from pathlib import Path; c=sqlite3.connect(Path(sys.argv[1]).resolve().as_uri() + '?mode=ro', uri=True); r=c.execute('PRAGMA integrity_check').fetchone()[0]; print(r); raise SystemExit(r != 'ok')" $RestoreAuthDb `
-  2>&1 | Tee-Object "$Evidence\08-sqlite-integrity.txt"
-if ($LASTEXITCODE -ne 0) { throw "Integrita SQLite fallita" }
-
-$PreviousAuthDbPath = $env:THEBITLAB_AUTH_DB_PATH
-$env:THEBITLAB_AUTH_DB_PATH = $RestoreAuthDb
+```bash
+python scripts/pilot_data_root.py validate --config <manifest-candidate.json>
+python scripts/pilot_data_root.py backup \
+  --config <manifest-candidate.json> \
+  --output <directory-backup-nuova>
+python scripts/pilot_data_root.py restore \
+  --backup <directory-backup> \
+  --target <root-restore-nuova-isolata>
 ```
 
-Con `THEBITLAB_AUTH_DB_PATH` così rimappato, avviare in modo controllato il server con `--root $RestoreRoot` e la configurazione auth prevista. Dall'interfaccia amministrativa verificare identità demo, ruoli e membership attesi e registrare `PASS`; database assente, mancato avvio, integrity check diverso da `ok` o qualsiasi identità/ruolo/membership mancante o inatteso sono `FAIL` e bloccano **GO pilot**. Verificare inoltre che il server non scriva nella root originale. Solo dopo la verifica fermarlo e ripristinare l'ambiente:
-
-```powershell
-if ($HadAuthDbPath) {
-  $env:THEBITLAB_AUTH_DB_PATH = $PreviousAuthDbPath
-} else {
-  Remove-Item Env:THEBITLAB_AUTH_DB_PATH -ErrorAction SilentlyContinue
-}
-```
+Salvare come evidenza sanitizzata gli output JSON e il digest del manifest, non il payload né valori environment. I comandi devono terminare con `ok: true` e riportano durata effettiva, integrity/migrazioni, demo check, binding #702 e startup smoke. Verificare separatamente che la root sorgente e il backup non siano cambiati durante il restore. OAuth secret, private key e token non devono comparire in root, backup, manifest o evidenze.
 
 Il rehearsal deve inoltre provare:
 
 - manifest/checksum del backup e restore in directory isolata;
-- inclusione di identità, design, calendari, activity, roster, assegnazioni, report e binding;
+- inclusione di identità, design, calendari, activity, roster, assegnazioni, report, tentativi, help e binding;
 - esclusione dal backup applicativo non cifrato di OAuth secret, private key e token;
-- tempo di backup/restore entro gli obiettivi approvati;
+- tempo di backup/restore confrontato con i target approvati, senza dedurne automaticamente SLA o conformità;
 - avvio controllato sulla copia e nessuna scrittura nella root originale.
 
-Una semplice copia creata senza restore verificato non supera il gate.
+Una semplice copia creata senza lock esclusivo, snapshot SQLite coerente e restore verificato non supera il gate.
 
 ## 7. Drill incidente e arresto
 

--- a/doc/PILOT_ROOT_BACKUP.md
+++ b/doc/PILOT_ROOT_BACKUP.md
@@ -1,0 +1,99 @@
+# Root canonica e backup/restore del pilot
+
+Questo documento definisce la baseline tecnica di issue #705. Non autorizza un deploy live né l'uso di dati reali. Il contratto deployment canonico resta [`PILOT_DEPLOYMENT.md`](PILOT_DEPLOYMENT.md); governance, retention e approvazioni restano in [`governance/PILOT_GOVERNANCE_2026_2027.md`](governance/PILOT_GOVERNANCE_2026_2027.md).
+
+## Topologia supportata
+
+Una installazione pilot ha **una sola replica applicativa e una sola data root**. Il manifest deployment determina senza fallback:
+
+```text
+data.root/
+├── .thebitlab-root.json                 marker portabile dell'installazione
+├── .thebitlab-auth/auth.sqlite3         account, classi, membership, binding #702
+├── doc/
+│   ├── course_design.json               design corrente
+│   ├── calendars/*.json                 calendari
+│   └── classes/*.json                   roster locali
+├── activities/                          activity
+├── teacher-assignments/                 assignment con target subject_id
+├── teacher-reports/                     report/registro
+├── teacher-help-events/                 stato help
+└── examples/assignment_tracking/
+    └── student_repos/...                elaborati, report e tentativi immutabili
+```
+
+`data.auth_db_path` è un path relativo POSIX canonico; il DB effettivo è sempre `<data.root>/<data.auth_db_path>`. Path assoluti, backslash, `.`/`..`, una seconda SQLite, marker divergente, root parziale, symlink e root in uso falliscono chiusi. File environment, OAuth secret, private key e token restano esterni alla root. Il launcher systemd valida marker, completezza, schema, account e binding prima di leggere l'EnvironmentFile o avviare il server.
+
+Il profilo bootstrap contiene soltanto dati demo: docente, due studenti, classe e membership, binding immutabili `user_id <-> subject_id`, alias legacy espliciti e target assignment `subject_id`. Non implementa la policy student API di #706 e non supporta sincronizzazione fra host o due repliche.
+
+## Bootstrap e validazione
+
+Sul target autorizzato, a servizio fermo, usare il manifest candidate reale:
+
+```bash
+python scripts/pilot_data_root.py bootstrap --config /etc/thebitlab/candidate.json
+python scripts/pilot_data_root.py validate --config /etc/thebitlab/candidate.json
+python scripts/student_lab_demo_check.py \
+  --root /srv/thebitlab/data --existing --json
+```
+
+Il primo comando accetta una root nuova/vuota e scrive il marker soltanto dopo il provisioning completo. Una seconda esecuzione valida lo stato senza rigenerarlo o modificarlo (`created: false`). Una root popolata senza marker non viene cancellata. Per smoke locali Windows/Linux è disponibile `--root <path-assoluto>` con `--auth-db-path <relativo>`; in deployment `--config` è obbligatorio come source of truth.
+
+## Backup coerente
+
+Il backup applicativo deve essere esterno alla data root e su storage protetto/cifrato secondo la decisione di governance. Fermare prima il processo applicativo, quindi:
+
+```bash
+python scripts/pilot_data_root.py backup \
+  --config /etc/thebitlab/candidate.json \
+  --output /var/backups/thebitlab/<run-id>
+```
+
+Il tool acquisisce lo stesso lock cross-process del server: se una replica è attiva, il backup fallisce. Mentre mantiene il lock:
+
+1. valida root, demo, account, ruoli, membership e binding;
+2. enumera tutti i file regolari e rifiuta symlink o path riconducibili a secret/credenziali;
+3. copia lo stato file-based;
+4. crea l'auth DB con `sqlite3.Connection.backup`, dopo `PRAGMA integrity_check`, invece di copiare un DB live o troncato;
+5. esclude soltanto lock/cache runtime e sidecar SQLite transitori già assorbiti nello snapshot coerente;
+6. pubblica atomicamente la directory nuova dopo aver scritto manifest e checksum.
+
+Il formato `thebitlab.pilot-backup.v1`, descritto da [`../schemas/pilot-backup-manifest.schema.json`](../schemas/pilot-backup-manifest.schema.json), è:
+
+```text
+<backup>/
+├── manifest.json       metadata deterministica e file ordinati
+├── manifest.sha256     SHA-256 esatto di manifest.json
+└── payload/            snapshot con path relativi alla root
+```
+
+Ogni entry contiene soltanto `path`, `size` e `sha256`. Il manifest non contiene path assoluti, timestamp, valori environment o secret. A parità di root, manifest e relativo checksum sono deterministici. La durata è riportata nell'output del comando, non nel manifest.
+
+## Restore isolato e verifica
+
+Il target deve essere inesistente, esterno al backup e diverso dalla root sorgente:
+
+```bash
+python scripts/pilot_data_root.py restore \
+  --backup /var/backups/thebitlab/<run-id> \
+  --target /srv/thebitlab-restore-tests/<run-id>
+```
+
+Il restore:
+
+1. verifica checksum del manifest, contratto chiuso, ordine/unicità/path portabili e checksum/dimensione di ogni file;
+2. rifiuta file non dichiarati, symlink e path secret;
+3. copia in una staging directory e rinomina solo a copia completa;
+4. applica le migrazioni SQLite supportate e riesegue `PRAGMA integrity_check`;
+5. verifica account, ruoli, classe, membership, binding #702 e target assignment;
+6. esegue l'equivalente di `student_lab_demo_check --existing`;
+7. acquisisce il lock e crea/chiude un server HTTP su loopback con porta effimera come startup smoke controllato;
+8. non apre in scrittura né la root originaria né il backup.
+
+Qualunque errore rimuove la root restore parziale. EnvironmentFile e secret devono essere forniti separatamente solo per un successivo avvio auth autorizzato; non vanno copiati dal backup.
+
+## RPO, RTO, retention ed evidenze
+
+La baseline di engineering usa backup almeno giornaliero, **RPO target 24 ore**, **RTO target 8 ore lavorative** e retention backup rolling proposta di 30 giorni. I comandi riportano `duration_seconds` per backup e restore e la dicitura esplicita che la misura locale non costituisce SLA, conformità o approvazione. Provider, localizzazione, cifratura, rotazione e RPO/RTO devono essere approvati dall'Istituto/RPD-DPO e verificati nel rehearsal reale.
+
+Le evidenze storiche #678 restano component-level e non vengono modificate né promosse a PASS integrato. Dopo una modifica a root, storage, auth o restore vanno rieseguiti i gate integrati indicati da [`PILOT_REHEARSAL.md`](PILOT_REHEARSAL.md).

--- a/schemas/pilot-backup-manifest.schema.json
+++ b/schemas/pilot-backup-manifest.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thebitlab.dev/schemas/pilot-backup-manifest.schema.json",
+  "title": "TheBitLab canonical pilot root backup manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "root_schema_version",
+    "deployment_id",
+    "auth_db_path",
+    "consistency",
+    "files"
+  ],
+  "properties": {
+    "schema_version": {"const": "thebitlab.pilot-backup.v1"},
+    "root_schema_version": {"const": "thebitlab.pilot-root.v1"},
+    "deployment_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{2,62}$"
+    },
+    "auth_db_path": {"$ref": "#/$defs/relativePath"},
+    "consistency": {
+      "const": "application-stopped-exclusive-root-lock+sqlite-backup-api"
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "size", "sha256"],
+        "properties": {
+          "path": {"$ref": "#/$defs/relativePath"},
+          "size": {"type": "integer", "minimum": 0},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "relativePath": {
+      "type": "string",
+      "pattern": "^(?!/)(?!.*(?:^|/)[.][.]?(?:/|$))(?!.*\\\\)[A-Za-z0-9._@+:-]+(?:/[A-Za-z0-9._@+:-]+)*$"
+    }
+  }
+}

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -245,6 +245,8 @@ class DataRootProcessLock:
     def _acquire_handle(path: Path):
         handle = path.open("a+b")
         try:
+            if os.name != "nt":
+                os.fchmod(handle.fileno(), 0o600)
             handle.seek(0, os.SEEK_END)
             if handle.tell() == 0:
                 handle.write(b"\0")

--- a/scripts/pilot_data_root.py
+++ b/scripts/pilot_data_root.py
@@ -1,0 +1,853 @@
+#!/usr/bin/env python3
+"""Bootstrap, validate, back up, and restore one canonical pilot data root."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import sqlite3
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterator, Mapping
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import (  # noqa: E402
+    course_board_server,
+    student_lab_demo_check,
+    student_lab_demo_smoke,
+    validate_pilot_deployment,
+)
+from scripts.thebitlab_identity import (  # noqa: E402
+    ClassGroup,
+    ClassMembership,
+    UserAccount,
+)
+from scripts.thebitlab_identity_binding import (  # noqa: E402
+    LegacySubjectAlias,
+    StudentBindingResolutionError,
+    StudentSubjectBinding,
+    resolve_assignment_target,
+)
+from scripts.thebitlab_identity_ports import IdentityStorageError  # noqa: E402
+from scripts.thebitlab_identity_sqlite import (  # noqa: E402
+    SCHEMA_VERSION,
+    SqliteIdentityStorage,
+)
+
+ROOT_SCHEMA = "thebitlab.pilot-root.v1"
+BACKUP_SCHEMA = "thebitlab.pilot-backup.v1"
+ROOT_MARKER = ".thebitlab-root.json"
+BACKUP_MANIFEST = "manifest.json"
+BACKUP_MANIFEST_CHECKSUM = "manifest.sha256"
+BACKUP_PAYLOAD = "payload"
+DEFAULT_AUTH_DB_PATH = ".thebitlab-auth/auth.sqlite3"
+DEMO_CLASS_ID = "3A-TPSI"
+DEMO_TIMESTAMP = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+DEMO_IDENTITIES = (
+    {
+        "user_id": "demo-student-rossi-mario",
+        "student_id": student_lab_demo_smoke.STUDENT_ID,
+        "display_name": "Rossi Mario",
+        "subject_id": "subject:11111111111111111111111111111111",
+    },
+    {
+        "user_id": "demo-student-bianchi-luca",
+        "student_id": student_lab_demo_smoke.FAILING_STUDENT_ID,
+        "display_name": "Bianchi Luca",
+        "subject_id": "subject:22222222222222222222222222222222",
+    },
+)
+REQUIRED_EXACT_PATHS = (
+    "activities/python-demo-somma-001.json",
+    "doc/calendars/as_2026_2027.json",
+    "doc/classes/demo-3a.json",
+    "doc/course_design.json",
+    "teacher-reports/demo/python-demo-somma-001.json",
+)
+REQUIRED_GLOBS = (
+    "teacher-assignments/*.json",
+    "teacher-help-events/*/*/events.json",
+    "examples/assignment_tracking/student_repos/rossi-mario/reports/python-demo-somma-001/latest.json",
+    "examples/assignment_tracking/student_repos/rossi-mario/reports/"
+    "python-demo-somma-001/assignments/*/attempts/*.json",
+    "examples/assignment_tracking/student_repos/bianchi-luca/reports/python-demo-somma-001/latest.json",
+    "examples/assignment_tracking/student_repos/bianchi-luca/reports/"
+    "python-demo-somma-001/assignments/*/attempts/*.json",
+)
+TRANSIENT_NAMES = {".thebitlab-server.lock"}
+SECRET_COMPONENTS = {".secrets", "secrets"}
+SECRET_SUFFIXES = {".env", ".key", ".pem", ".p12", ".pfx"}
+DEPLOYMENT_ID_PATTERN = re.compile(r"^[a-z][a-z0-9-]{2,62}$")
+
+
+class PilotRootError(RuntimeError):
+    """Raised when the supported single-root pilot contract is not satisfied."""
+
+
+@dataclass(frozen=True)
+class PilotTopology:
+    root: Path
+    auth_db_relative: str
+    deployment_id: str
+
+    @property
+    def auth_db_path(self) -> Path:
+        return self.root.joinpath(*PurePosixPath(self.auth_db_relative).parts)
+
+
+def _canonical_json(payload: Mapping[str, Any]) -> bytes:
+    return (json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2) + "\n").encode("utf-8")
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_canonical_json(payload))
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _relative_path(value: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip() or "\\" in value or "\x00" in value:
+        raise PilotRootError("Il path auth deve essere relativo POSIX canonico.")
+    raw_parts = value.split("/")
+    path = PurePosixPath(value)
+    if path.is_absolute() or path == PurePosixPath(".") or any(part in {"", ".", ".."} for part in raw_parts):
+        raise PilotRootError("Il path auth deve restare nella root canonica.")
+    if path.suffix not in {".db", ".sqlite", ".sqlite3"}:
+        raise PilotRootError("Il path auth deve identificare un database SQLite.")
+    return path.as_posix()
+
+
+def topology_from_paths(
+    root: Path,
+    auth_db_path: str = DEFAULT_AUTH_DB_PATH,
+    *,
+    deployment_id: str = "pilot-demo-local",
+) -> PilotTopology:
+    expanded = root.expanduser()
+    if not expanded.is_absolute():
+        raise PilotRootError("La data root deve essere espressa come path assoluto.")
+    resolved = expanded.resolve(strict=False)
+    if resolved == resolved.parent:
+        raise PilotRootError("La data root deve essere una directory assoluta dedicata.")
+    if resolved.is_symlink():
+        raise PilotRootError("La data root non puo essere un symlink.")
+    if not isinstance(deployment_id, str) or DEPLOYMENT_ID_PATTERN.fullmatch(deployment_id) is None:
+        raise PilotRootError("deployment_id non valido.")
+    return PilotTopology(resolved, _relative_path(auth_db_path), deployment_id)
+
+
+def topology_from_manifest(path: Path) -> PilotTopology:
+    manifest = validate_pilot_deployment.load_json(path)
+    validate_pilot_deployment.validate_manifest(manifest)
+    return topology_from_paths(
+        Path(manifest["data"]["root"]),
+        manifest["data"]["auth_db_path"],
+        deployment_id=manifest["deployment_id"],
+    )
+
+
+def _root_marker(topology: PilotTopology) -> dict[str, Any]:
+    return {
+        "schema_version": ROOT_SCHEMA,
+        "profile": "pilot-demo",
+        "deployment_id": topology.deployment_id,
+        "auth_db_path": topology.auth_db_relative,
+        "identity_schema_version": SCHEMA_VERSION,
+        "class_id": DEMO_CLASS_ID,
+        "students": [
+            {
+                "user_id": item["user_id"],
+                "student_id": item["student_id"],
+                "subject_id": item["subject_id"],
+            }
+            for item in DEMO_IDENTITIES
+        ],
+    }
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise PilotRootError(f"{label} contiene chiavi duplicate.")
+            result[key] = value
+        return result
+
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicates,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise PilotRootError(f"{label} assente o non valido.") from error
+    if not isinstance(payload, dict):
+        raise PilotRootError(f"{label} deve essere un oggetto JSON.")
+    return payload
+
+
+@contextmanager
+def _stopped_root_lock(root: Path) -> Iterator[None]:
+    lock = course_board_server.DataRootProcessLock(root)
+    try:
+        lock.acquire()
+    except RuntimeError as error:
+        raise PilotRootError("Root in uso: la topologia a doppia istanza non e supportata.") from error
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+def _copy_demo_documents(root: Path) -> None:
+    calendar_source = PROJECT_ROOT / "doc" / "calendars" / "as_2026_2027.json"
+    calendar_destination = root / "doc" / "calendars" / "as_2026_2027.json"
+    calendar_destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(calendar_source, calendar_destination)
+
+    design = _load_object(PROJECT_ROOT / "doc" / "course_design.json", "Design demo")
+    years = design.get("years")
+    if not isinstance(years, list) or not years or not isinstance(years[0], dict):
+        raise PilotRootError("Design demo senza anno scolastico.")
+    years[0]["audience"] = {"class_ids": [DEMO_CLASS_ID]}
+    _write_json(root / "doc" / "course_design.json", design)
+
+    roster = _load_object(PROJECT_ROOT / "doc" / "classes" / "demo-3a.json", "Roster demo")
+    expected_student_ids = {item["student_id"] for item in DEMO_IDENTITIES}
+    students = roster.get("students")
+    if not isinstance(students, list):
+        raise PilotRootError("Roster demo senza studenti.")
+    roster["id"] = DEMO_CLASS_ID
+    roster["label"] = "3A TPSI"
+    roster["students"] = [
+        student
+        for student in students
+        if isinstance(student, dict) and student.get("id") in expected_student_ids
+    ]
+    if {student.get("id") for student in roster["students"]} != expected_student_ids:
+        raise PilotRootError("Roster demo incompleto.")
+    _write_json(root / "doc" / "classes" / "demo-3a.json", roster)
+
+
+def _provision_identity(topology: PilotTopology) -> None:
+    storage = SqliteIdentityStorage(topology.auth_db_path)
+    storage.create_user(
+        UserAccount(
+            "demo-teacher",
+            "Docente Demo",
+            "teacher",
+            True,
+            DEMO_TIMESTAMP,
+            DEMO_TIMESTAMP,
+        )
+    )
+    storage.create_class(
+        ClassGroup(
+            DEMO_CLASS_ID,
+            "3A TPSI",
+            "2026-2027",
+            True,
+            DEMO_TIMESTAMP,
+            DEMO_TIMESTAMP,
+        )
+    )
+    storage.save_membership(
+        ClassMembership("demo-teacher", DEMO_CLASS_ID, "teacher", DEMO_TIMESTAMP)
+    )
+    for identity in DEMO_IDENTITIES:
+        storage.create_user(
+            UserAccount(
+                identity["user_id"],
+                identity["display_name"],
+                "student",
+                True,
+                DEMO_TIMESTAMP,
+                DEMO_TIMESTAMP,
+            )
+        )
+        storage.save_membership(
+            ClassMembership(identity["user_id"], DEMO_CLASS_ID, "student", DEMO_TIMESTAMP)
+        )
+        storage.create_student_subject_binding(
+            StudentSubjectBinding(
+                identity["subject_id"],
+                identity["user_id"],
+                True,
+                1,
+                DEMO_TIMESTAMP,
+                DEMO_TIMESTAMP,
+            ),
+            (
+                LegacySubjectAlias(
+                    DEMO_CLASS_ID,
+                    identity["student_id"],
+                    identity["subject_id"],
+                    DEMO_TIMESTAMP,
+                ),
+            ),
+        )
+
+
+def _add_assignment_subjects(root: Path) -> None:
+    paths = sorted((root / "teacher-assignments").glob("*.json"))
+    if len(paths) != 1:
+        raise PilotRootError("Il bootstrap demo deve produrre una sola consegna autorevole.")
+    assignment = _load_object(paths[0], "Consegna demo")
+    subjects = {item["student_id"]: item["subject_id"] for item in DEMO_IDENTITIES}
+    targets = assignment.get("targets")
+    if not isinstance(targets, list):
+        raise PilotRootError("Target della consegna demo non validi.")
+    for target in targets:
+        if not isinstance(target, dict) or target.get("student_id") not in subjects:
+            raise PilotRootError("Target della consegna demo inatteso.")
+        target["subject_id"] = subjects[target["student_id"]]
+    _write_json(paths[0], assignment)
+
+
+def _remove_runtime_caches(root: Path) -> None:
+    for directory in sorted(root.rglob("__pycache__"), reverse=True):
+        if directory.is_dir() and not directory.is_symlink():
+            shutil.rmtree(directory)
+    for path in root.rglob("*.pyc"):
+        path.unlink()
+
+
+def _harden_tree_permissions(root: Path) -> None:
+    """Apply private baseline modes on POSIX; Windows ACLs remain deployment-owned."""
+
+    if os.name == "nt":
+        return
+    root.chmod(0o700)
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise PilotRootError("Symlink non supportato nello stato applicativo.")
+        path.chmod(0o700 if path.is_dir() else 0o600)
+
+
+def bootstrap(topology: PilotTopology) -> dict[str, Any]:
+    """Create a complete demo installation, or validate the existing one unchanged."""
+
+    root = topology.root
+    existed = root.exists()
+    root.mkdir(parents=True, exist_ok=True)
+    cleanup_on_failure = not existed
+    try:
+        with _stopped_root_lock(root):
+            entries = [item for item in root.iterdir() if item.name not in TRANSIENT_NAMES]
+            if entries:
+                if not (root / ROOT_MARKER).is_file():
+                    raise PilotRootError("Root parziale o non gestita: bootstrap rifiutato.")
+                result = validate_root(topology, run_demo_check=True, lock=False)
+                return {**result, "created": False, "idempotent": True}
+            cleanup_on_failure = True
+            student_lab_demo_smoke.run_smoke(root)
+            _remove_runtime_caches(root)
+            _copy_demo_documents(root)
+            _provision_identity(topology)
+            _add_assignment_subjects(root)
+            _write_json(root / ROOT_MARKER, _root_marker(topology))
+            _harden_tree_permissions(root)
+            result = validate_root(topology, run_demo_check=True, lock=False)
+            return {**result, "created": True, "idempotent": True}
+    except Exception:
+        if cleanup_on_failure:
+            shutil.rmtree(root, ignore_errors=True)
+        raise
+
+
+def _sqlite_integrity(database_path: Path) -> None:
+    if not database_path.is_file() or database_path.is_symlink():
+        raise PilotRootError("Database auth canonico assente o non regolare.")
+    connection: sqlite3.Connection | None = None
+    try:
+        connection = sqlite3.connect(database_path.resolve().as_uri() + "?mode=ro", uri=True)
+        result = connection.execute("PRAGMA integrity_check").fetchone()
+        versions = [row[0] for row in connection.execute("SELECT version FROM schema_migrations ORDER BY version")]
+    except sqlite3.DatabaseError as error:
+        raise PilotRootError("Integrity/schema check SQLite non riuscito.") from error
+    finally:
+        if connection is not None:
+            connection.close()
+    if result != ("ok",):
+        raise PilotRootError("SQLite integrity_check non riuscito.")
+    if versions != list(range(1, SCHEMA_VERSION + 1)):
+        raise PilotRootError("Migrazioni auth incomplete o non supportate.")
+
+
+def _verify_identity(topology: PilotTopology) -> None:
+    storage = SqliteIdentityStorage(topology.auth_db_path)
+    users = storage.list_users()
+    expected_users = {"demo-teacher", *(item["user_id"] for item in DEMO_IDENTITIES)}
+    if {user.user_id for user in users} != expected_users or any(not user.active for user in users):
+        raise PilotRootError("Matrice account demo incoerente.")
+    classes = storage.list_classes()
+    if len(classes) != 1 or classes[0].class_id != DEMO_CLASS_ID or not classes[0].active:
+        raise PilotRootError("Classe demo auth incoerente.")
+    roster = _load_object(topology.root / "doc/classes/demo-3a.json", "Roster demo")
+    roster_students = roster.get("students")
+    expected_student_ids = {item["student_id"] for item in DEMO_IDENTITIES}
+    if (
+        roster.get("id") != DEMO_CLASS_ID
+        or not isinstance(roster_students, list)
+        or {
+            student.get("id")
+            for student in roster_students
+            if isinstance(student, dict) and student.get("active") is True
+        }
+        != expected_student_ids
+    ):
+        raise PilotRootError("Roster demo incoerente con classe e account auth.")
+    expected_memberships = {
+        ("demo-teacher", "teacher"),
+        *((item["user_id"], "student") for item in DEMO_IDENTITIES),
+    }
+    memberships = {
+        (membership.user_id, membership.role)
+        for membership in storage.list_class_memberships(DEMO_CLASS_ID)
+    }
+    if memberships != expected_memberships:
+        raise PilotRootError("Membership demo auth incoerenti.")
+    assignment_paths = sorted((topology.root / "teacher-assignments").glob("*.json"))
+    if len(assignment_paths) != 1:
+        raise PilotRootError("Consegna demo autorevole mancante o ambigua.")
+    assignment = _load_object(assignment_paths[0], "Consegna demo")
+    for identity in DEMO_IDENTITIES:
+        snapshot = storage.read_student_binding_snapshot(identity["user_id"])
+        resolution = resolve_assignment_target(identity["user_id"], snapshot, assignment)
+        if resolution.subject_id != identity["subject_id"] or resolution.used_legacy_alias:
+            raise PilotRootError("Binding #702 o target subject_id demo incoerente.")
+
+
+def _check_required_state(root: Path, auth_relative: str) -> None:
+    required = (*REQUIRED_EXACT_PATHS, auth_relative)
+    missing = [relative for relative in required if not root.joinpath(*PurePosixPath(relative).parts).is_file()]
+    missing.extend(pattern for pattern in REQUIRED_GLOBS if not any(root.glob(pattern)))
+    if missing:
+        raise PilotRootError("Root parziale: stato richiesto mancante.")
+    sqlite_files = {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".db", ".sqlite", ".sqlite3"}
+    }
+    if sqlite_files != {auth_relative}:
+        raise PilotRootError("Topologia auth ambigua: database SQLite inatteso o mancante.")
+
+
+def validate_root(
+    topology: PilotTopology,
+    *,
+    run_demo_check: bool = True,
+    lock: bool = True,
+) -> dict[str, Any]:
+    """Fail closed unless the root, auth database, demo state, and binding agree."""
+
+    def perform() -> dict[str, Any]:
+        root = topology.root
+        if not root.is_dir() or root.is_symlink():
+            raise PilotRootError("Data root canonica assente, non-directory o symlink.")
+        marker = _load_object(root / ROOT_MARKER, "Marker root canonica")
+        if marker != _root_marker(topology):
+            raise PilotRootError("Marker root incoerente con deployment/auth configurati.")
+        _check_required_state(root, topology.auth_db_relative)
+        _sqlite_integrity(topology.auth_db_path)
+        try:
+            _verify_identity(topology)
+        except (IdentityStorageError, StudentBindingResolutionError) as error:
+            raise PilotRootError("Account, membership o binding #702 incoerenti.") from error
+        if run_demo_check:
+            try:
+                result = student_lab_demo_check.run_guided_check(root, prepare=False)
+            except RuntimeError as error:
+                raise PilotRootError("student_lab_demo_check --existing non riuscito.") from error
+            if result.get("ok") is not True:
+                raise PilotRootError("student_lab_demo_check --existing non riuscito.")
+        return {
+            "ok": True,
+            "root": str(root),
+            "auth_db_path": topology.auth_db_relative,
+            "deployment_id": topology.deployment_id,
+            "identity_schema_version": SCHEMA_VERSION,
+            "demo_check": run_demo_check,
+        }
+
+    if lock:
+        if not topology.root.is_dir() or topology.root.is_symlink():
+            raise PilotRootError("Data root canonica assente, non-directory o symlink.")
+        with _stopped_root_lock(topology.root):
+            return perform()
+    return perform()
+
+
+def _paths_overlap(first: Path, second: Path) -> bool:
+    first_resolved = first.resolve(strict=False)
+    second_resolved = second.resolve(strict=False)
+    return (
+        first_resolved == second_resolved
+        or first_resolved in second_resolved.parents
+        or second_resolved in first_resolved.parents
+    )
+
+
+def _secret_path(relative: PurePosixPath) -> bool:
+    lowered = [part.lower() for part in relative.parts]
+    name = lowered[-1]
+    return (
+        any(part in SECRET_COMPONENTS for part in lowered)
+        or Path(name).suffix in SECRET_SUFFIXES
+        or "secret" in name
+        or ("token" in name and name != "auth.sqlite3")
+    )
+
+
+def _root_files(
+    root: Path, auth_db_relative: str
+) -> list[tuple[Path, PurePosixPath]]:
+    files: list[tuple[Path, PurePosixPath]] = []
+    auth_sidecars = {
+        f"{auth_db_relative}-journal",
+        f"{auth_db_relative}-shm",
+        f"{auth_db_relative}-wal",
+    }
+    for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
+        relative = PurePosixPath(path.relative_to(root).as_posix())
+        if (
+            relative.name in TRANSIENT_NAMES
+            or relative.as_posix() in auth_sidecars
+            or relative.suffix in {".lock", ".pyc"}
+            or "__pycache__" in relative.parts
+        ):
+            continue
+        if path.is_symlink():
+            raise PilotRootError("Symlink non supportato nella root applicativa.")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise PilotRootError("Entry non regolare nella root applicativa.")
+        if _secret_path(relative):
+            raise PilotRootError("Secret o credenziale rilevata nella root: backup rifiutato.")
+        files.append((path, relative))
+    return files
+
+
+def _copy_sqlite_snapshot(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    source_connection: sqlite3.Connection | None = None
+    destination_connection: sqlite3.Connection | None = None
+    try:
+        source_connection = sqlite3.connect(source.resolve().as_uri() + "?mode=ro", uri=True)
+        if source_connection.execute("PRAGMA integrity_check").fetchone() != ("ok",):
+            raise PilotRootError("SQLite sorgente non integro: backup rifiutato.")
+        destination_connection = sqlite3.connect(destination)
+        source_connection.backup(destination_connection)
+    except sqlite3.DatabaseError as error:
+        raise PilotRootError("Snapshot SQLite coerente non riuscito.") from error
+    finally:
+        if destination_connection is not None:
+            destination_connection.close()
+        if source_connection is not None:
+            source_connection.close()
+
+
+def create_backup(topology: PilotTopology, output: Path) -> dict[str, Any]:
+    """Create a deterministic manifest and a stopped-process coherent snapshot."""
+
+    started = time.perf_counter()
+    if not topology.root.is_dir() or topology.root.is_symlink():
+        raise PilotRootError("Data root canonica assente, non-directory o symlink.")
+    output = output.expanduser().resolve(strict=False)
+    if _paths_overlap(topology.root, output):
+        raise PilotRootError("Il backup deve essere esterno e isolato dalla root sorgente.")
+    if output.exists():
+        raise PilotRootError("La directory backup deve essere nuova.")
+    staging = output.with_name(f".{output.name}.partial-{os.getpid()}")
+    if staging.exists():
+        raise PilotRootError("Directory staging backup gia presente.")
+    try:
+        with _stopped_root_lock(topology.root):
+            validate_root(topology, run_demo_check=True, lock=False)
+            files = _root_files(topology.root, topology.auth_db_relative)
+            payload_root = staging / BACKUP_PAYLOAD
+            for source, relative in files:
+                destination = payload_root.joinpath(*relative.parts)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                if relative.as_posix() == topology.auth_db_relative:
+                    _copy_sqlite_snapshot(source, destination)
+                else:
+                    shutil.copyfile(source, destination)
+            manifest_files = [
+                {
+                    "path": relative.as_posix(),
+                    "size": payload_root.joinpath(*relative.parts).stat().st_size,
+                    "sha256": _sha256(payload_root.joinpath(*relative.parts)),
+                }
+                for _, relative in files
+            ]
+            manifest = {
+                "schema_version": BACKUP_SCHEMA,
+                "root_schema_version": ROOT_SCHEMA,
+                "deployment_id": topology.deployment_id,
+                "auth_db_path": topology.auth_db_relative,
+                "consistency": "application-stopped-exclusive-root-lock+sqlite-backup-api",
+                "files": manifest_files,
+            }
+            manifest_bytes = _canonical_json(manifest)
+            (staging / BACKUP_MANIFEST).write_bytes(manifest_bytes)
+            checksum = hashlib.sha256(manifest_bytes).hexdigest()
+            (staging / BACKUP_MANIFEST_CHECKSUM).write_text(
+                f"{checksum}  {BACKUP_MANIFEST}\n", encoding="ascii"
+            )
+            _harden_tree_permissions(staging)
+            staging.rename(output)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    duration = time.perf_counter() - started
+    return {
+        "ok": True,
+        "backup": str(output),
+        "files": len(manifest_files),
+        "manifest_sha256": checksum,
+        "duration_seconds": round(duration, 6),
+        "rpo_target_hours": 24,
+        "rto_target_business_hours": 8,
+        "target_assessment": "local measurement only; not an SLA or compliance claim",
+    }
+
+
+def _validated_backup(backup: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    if not backup.is_dir() or backup.is_symlink():
+        raise PilotRootError("Directory backup assente o non regolare.")
+    manifest_path = backup / BACKUP_MANIFEST
+    checksum_path = backup / BACKUP_MANIFEST_CHECKSUM
+    try:
+        checksum_line = checksum_path.read_text(encoding="ascii")
+    except (OSError, UnicodeError) as error:
+        raise PilotRootError("Checksum manifest assente o non valido.") from error
+    expected_line = f"{_sha256(manifest_path)}  {BACKUP_MANIFEST}\n"
+    if checksum_line != expected_line:
+        raise PilotRootError("Checksum del manifest non valido.")
+    manifest = _load_object(manifest_path, "Manifest backup")
+    required_keys = {
+        "schema_version",
+        "root_schema_version",
+        "deployment_id",
+        "auth_db_path",
+        "consistency",
+        "files",
+    }
+    if (
+        set(manifest) != required_keys
+        or manifest.get("schema_version") != BACKUP_SCHEMA
+        or manifest.get("root_schema_version") != ROOT_SCHEMA
+        or manifest.get("consistency")
+        != "application-stopped-exclusive-root-lock+sqlite-backup-api"
+        or not isinstance(manifest.get("deployment_id"), str)
+        or DEPLOYMENT_ID_PATTERN.fullmatch(manifest["deployment_id"]) is None
+    ):
+        raise PilotRootError("Contratto manifest backup non supportato.")
+    auth_relative = _relative_path(manifest.get("auth_db_path"))
+    raw_files = manifest.get("files")
+    if not isinstance(raw_files, list) or not raw_files:
+        raise PilotRootError("Elenco file del backup assente.")
+    paths: list[str] = []
+    files: list[dict[str, Any]] = []
+    for item in raw_files:
+        if not isinstance(item, dict) or set(item) != {"path", "size", "sha256"}:
+            raise PilotRootError("Entry manifest backup non valida.")
+        relative_text = item.get("path")
+        try:
+            relative = PurePosixPath(relative_text)
+        except TypeError as error:
+            raise PilotRootError("Path manifest backup non valido.") from error
+        if (
+            relative.is_absolute()
+            or relative == PurePosixPath(".")
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or "\\" in relative_text
+        ):
+            raise PilotRootError("Path manifest backup non portabile.")
+        if _secret_path(relative):
+            raise PilotRootError("Manifest backup contiene un path secret vietato.")
+        source = backup / BACKUP_PAYLOAD / Path(*relative.parts)
+        if source.is_symlink() or not source.is_file():
+            raise PilotRootError("Payload backup incompleto o non regolare.")
+        if type(item.get("size")) is not int or item["size"] < 0 or source.stat().st_size != item["size"]:
+            raise PilotRootError("Dimensione payload backup non valida.")
+        digest = item.get("sha256")
+        if not isinstance(digest, str) or len(digest) != 64 or _sha256(source) != digest:
+            raise PilotRootError("Checksum payload backup non valido.")
+        paths.append(relative.as_posix())
+        files.append(item)
+    if paths != sorted(paths) or len(paths) != len(set(paths)) or auth_relative not in paths:
+        raise PilotRootError("Ordine, unicita o database auth del manifest non validi.")
+    payload_entries = list((backup / BACKUP_PAYLOAD).rglob("*"))
+    if any(
+        path.is_symlink() or (not path.is_file() and not path.is_dir())
+        for path in payload_entries
+    ):
+        raise PilotRootError("Payload backup contiene entry non regolari.")
+    actual = {
+        path.relative_to(backup / BACKUP_PAYLOAD).as_posix()
+        for path in payload_entries
+        if path.is_file()
+    }
+    if actual != set(paths):
+        raise PilotRootError("Payload backup contiene file non dichiarati.")
+    return manifest, files
+
+
+def _controlled_startup_smoke(root: Path) -> None:
+    original_root = course_board_server.ROOT
+    lock = course_board_server.DataRootProcessLock(root)
+    server = None
+    try:
+        lock.acquire()
+        course_board_server.configure_data_root(root)
+        server = course_board_server.BoundedThreadingHTTPServer(
+            ("127.0.0.1", 0), course_board_server.CourseBoardHandler
+        )
+        server.teacher_token = "controlled-restore-smoke-only"
+    except (OSError, RuntimeError) as error:
+        raise PilotRootError("Startup smoke controllato del restore non riuscito.") from error
+    finally:
+        try:
+            if server is not None:
+                server.server_close()
+        finally:
+            try:
+                course_board_server.configure_data_root(original_root)
+            finally:
+                lock.release()
+
+
+def restore_backup(backup: Path, target: Path) -> dict[str, Any]:
+    """Verify and restore a backup into a new isolated root, never into its source."""
+
+    started = time.perf_counter()
+    backup = backup.expanduser().resolve(strict=True)
+    target = target.expanduser().resolve(strict=False)
+    if target.exists():
+        raise PilotRootError("La root restore deve essere nuova e isolata.")
+    if _paths_overlap(backup, target):
+        raise PilotRootError("La root restore non puo sovrapporsi al backup.")
+    manifest, files = _validated_backup(backup)
+    topology = topology_from_paths(
+        target,
+        manifest["auth_db_path"],
+        deployment_id=manifest["deployment_id"],
+    )
+    staging = target.with_name(f".{target.name}.partial-{os.getpid()}")
+    if staging.exists():
+        raise PilotRootError("Directory staging restore gia presente.")
+    try:
+        for item in files:
+            relative = PurePosixPath(item["path"])
+            source = backup / BACKUP_PAYLOAD / Path(*relative.parts)
+            destination = staging / Path(*relative.parts)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+        _harden_tree_permissions(staging)
+        staging.rename(target)
+        try:
+            SqliteIdentityStorage(topology.auth_db_path)
+        except IdentityStorageError as error:
+            raise PilotRootError("Migrazione schema identity del restore non riuscita.") from error
+        result = validate_root(topology, run_demo_check=True)
+        _controlled_startup_smoke(target)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(target, ignore_errors=True)
+        raise
+    duration = time.perf_counter() - started
+    return {
+        **result,
+        "restore": str(target),
+        "source_backup": str(backup),
+        "files": len(files),
+        "sqlite_integrity": True,
+        "migrations": SCHEMA_VERSION,
+        "binding_702": True,
+        "startup_smoke": True,
+        "duration_seconds": round(duration, 6),
+        "rpo_target_hours": 24,
+        "rto_target_business_hours": 8,
+        "target_assessment": "local measurement only; not an SLA or compliance claim",
+    }
+
+
+def _topology_arguments(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--config", type=Path, help="Manifest deployment pilot autorevole.")
+    group.add_argument("--root", type=Path, help="Root assoluta per smoke locali/demo.")
+    parser.add_argument("--auth-db-path", default=DEFAULT_AUTH_DB_PATH)
+    parser.add_argument("--deployment-id", default="pilot-demo-local")
+
+
+def _args_topology(args: argparse.Namespace) -> PilotTopology:
+    if args.config is not None:
+        if args.auth_db_path != DEFAULT_AUTH_DB_PATH or args.deployment_id != "pilot-demo-local":
+            raise PilotRootError("Con --config root, auth e deployment_id derivano soltanto dal manifest.")
+        return topology_from_manifest(args.config)
+    return topology_from_paths(
+        args.root,
+        args.auth_db_path,
+        deployment_id=args.deployment_id,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    bootstrap_parser = subparsers.add_parser("bootstrap", help="Bootstrap idempotente della root vuota.")
+    _topology_arguments(bootstrap_parser)
+    validate_parser = subparsers.add_parser("validate", help="Validazione fail-closed della root.")
+    _topology_arguments(validate_parser)
+    backup_parser = subparsers.add_parser("backup", help="Snapshot coerente a processo fermo.")
+    _topology_arguments(backup_parser)
+    backup_parser.add_argument("--output", type=Path, required=True)
+    restore_parser = subparsers.add_parser("restore", help="Restore verificato in root nuova isolata.")
+    restore_parser.add_argument("--backup", type=Path, required=True)
+    restore_parser.add_argument("--target", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "restore":
+            result = restore_backup(args.backup, args.target)
+        else:
+            topology = _args_topology(args)
+            if args.command == "bootstrap":
+                result = bootstrap(topology)
+            elif args.command == "validate":
+                result = validate_root(topology)
+            else:
+                result = create_backup(topology, args.output)
+    except (RuntimeError, OSError, ValueError) as error:
+        print(f"ERRORE: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pilot_data_root.py
+++ b/scripts/pilot_data_root.py
@@ -144,11 +144,11 @@ def topology_from_paths(
     expanded = root.expanduser()
     if not expanded.is_absolute():
         raise PilotRootError("La data root deve essere espressa come path assoluto.")
+    if expanded.is_symlink():
+        raise PilotRootError("La data root non puo essere un symlink.")
     resolved = expanded.resolve(strict=False)
     if resolved == resolved.parent:
         raise PilotRootError("La data root deve essere una directory assoluta dedicata.")
-    if resolved.is_symlink():
-        raise PilotRootError("La data root non puo essere un symlink.")
     if not isinstance(deployment_id, str) or DEPLOYMENT_ID_PATTERN.fullmatch(deployment_id) is None:
         raise PilotRootError("deployment_id non valido.")
     return PilotTopology(resolved, _relative_path(auth_db_path), deployment_id)
@@ -437,6 +437,8 @@ def _verify_identity(topology: PilotTopology) -> None:
 
 
 def _check_required_state(root: Path, auth_relative: str) -> None:
+    if any(path.is_symlink() for path in root.rglob("*")):
+        raise PilotRootError("Symlink non supportato nella root applicativa.")
     required = (*REQUIRED_EXACT_PATHS, auth_relative)
     missing = [relative for relative in required if not root.joinpath(*PurePosixPath(relative).parts).is_file()]
     missing.extend(pattern for pattern in REQUIRED_GLOBS if not any(root.glob(pattern)))

--- a/scripts/pilot_service_launcher.py
+++ b/scripts/pilot_service_launcher.py
@@ -14,6 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts import pilot_data_root  # noqa: E402
 from scripts.pilot_environment import (  # noqa: E402
     ALLOWED_EXTERNAL_NAMES,
     DeploymentValidationError,
@@ -59,6 +60,7 @@ def build_effective_environment(
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--environment-file", type=Path, required=True)
+    parser.add_argument("--deployment-id", required=True)
     parser.add_argument("--deployment-revision", required=True)
     parser.add_argument("--lock-directory", required=True)
     parser.add_argument("--auth-db-path", required=True)
@@ -110,6 +112,14 @@ def _server_command(args: argparse.Namespace) -> list[str]:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
+        pilot_data_root.validate_root(
+            pilot_data_root.topology_from_paths(
+                args.root,
+                args.auth_db_path,
+                deployment_id=args.deployment_id,
+            ),
+            run_demo_check=False,
+        )
         check_environment_file(args.environment_file)
         external = parse_environment_file(args.environment_file)
         environment = build_effective_environment(
@@ -120,7 +130,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         command = _server_command(args)
         os.execve(command[0], command, environment)
-    except (DeploymentValidationError, OSError) as exc:
+    except (DeploymentValidationError, pilot_data_root.PilotRootError, OSError) as exc:
         print(f"ERRORE: {exc}", file=sys.stderr)
         return 2
     return 0

--- a/scripts/thebitlab_storage.py
+++ b/scripts/thebitlab_storage.py
@@ -41,6 +41,12 @@ class CourseStorageLock:
     def _acquire_process_lock(self):
         self.path.parent.mkdir(parents=True, exist_ok=True)
         handle = self.path.open("a+b")
+        try:
+            if os.name != "nt":
+                os.fchmod(handle.fileno(), 0o600)
+        except OSError:
+            handle.close()
+            raise
         handle.seek(0, os.SEEK_END)
         if handle.tell() == 0:
             handle.write(b"\0")

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -1655,6 +1655,9 @@ def test_data_root_process_lock_rejects_a_second_server(tmp_path) -> None:
 
     second_lock.acquire()
     second_lock.release()
+    if os.name != "nt":
+        assert first_lock.path.stat().st_mode & 0o777 == 0o600
+        assert first_lock.legacy_path.stat().st_mode & 0o777 == 0o600
 
 
 def test_data_root_process_lock_rejects_a_legacy_server(tmp_path) -> None:

--- a/tests/test_pilot_data_root.py
+++ b/tests/test_pilot_data_root.py
@@ -1,0 +1,299 @@
+"""Integrated contract tests for the canonical pilot root and backup/restore."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts import course_board_server, pilot_data_root, pilot_service_launcher
+from scripts.thebitlab_identity_sqlite import SCHEMA_VERSION, SqliteIdentityStorage
+
+
+def tree_digest(root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+@pytest.fixture(scope="module")
+def prepared_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    root = tmp_path_factory.mktemp("pilot-root") / "data"
+    topology = pilot_data_root.topology_from_paths(root)
+    result = pilot_data_root.bootstrap(topology)
+    assert result["ok"] is True
+    return root
+
+
+@pytest.fixture
+def canonical_root(prepared_root: Path, tmp_path: Path) -> Path:
+    root = tmp_path / "data"
+    shutil.copytree(prepared_root, root)
+    return root
+
+
+def test_bootstrap_from_empty_root_is_complete_and_idempotent(tmp_path: Path) -> None:
+    root = tmp_path / "canonical"
+    topology = pilot_data_root.topology_from_paths(root)
+
+    first = pilot_data_root.bootstrap(topology)
+    before = tree_digest(root)
+    second = pilot_data_root.bootstrap(topology)
+
+    assert first["created"] is True
+    assert second["created"] is False
+    assert second["idempotent"] is True
+    assert second["demo_check"] is True
+    assert tree_digest(root) == before
+    assert (root / "doc/course_design.json").is_file()
+    assert (root / "doc/calendars/as_2026_2027.json").is_file()
+    roster = json.loads((root / "doc/classes/demo-3a.json").read_text(encoding="utf-8"))
+    assert roster["id"] == pilot_data_root.DEMO_CLASS_ID
+    assert {student["id"] for student in roster["students"]} == {
+        "rossi-mario",
+        "bianchi-luca",
+    }
+    assert list(root.glob("teacher-help-events/*/*/events.json"))
+    assert list(root.glob("examples/**/attempts/*.json"))
+
+
+def test_partial_or_incoherent_root_fails_closed_without_reset(tmp_path: Path) -> None:
+    root = tmp_path / "partial"
+    root.mkdir()
+    sentinel = root / "do-not-delete.txt"
+    sentinel.write_text("preserve", encoding="utf-8")
+
+    with pytest.raises(pilot_data_root.PilotRootError, match="parziale"):
+        pilot_data_root.bootstrap(pilot_data_root.topology_from_paths(root))
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve"
+
+
+def test_missing_required_state_and_ambiguous_auth_database_fail_closed(canonical_root: Path) -> None:
+    topology = pilot_data_root.topology_from_paths(canonical_root)
+    report = canonical_root / "teacher-reports/demo/python-demo-somma-001.json"
+    report_bytes = report.read_bytes()
+    report.unlink()
+    with pytest.raises(pilot_data_root.PilotRootError, match="parziale"):
+        pilot_data_root.validate_root(topology)
+    report.write_bytes(report_bytes)
+
+    shutil.copyfile(
+        canonical_root / pilot_data_root.DEFAULT_AUTH_DB_PATH,
+        canonical_root / "second.sqlite3",
+    )
+    with pytest.raises(pilot_data_root.PilotRootError, match="ambigua"):
+        pilot_data_root.validate_root(topology)
+
+
+def test_same_root_double_instance_is_rejected(canonical_root: Path, tmp_path: Path) -> None:
+    topology = pilot_data_root.topology_from_paths(canonical_root)
+    lock = course_board_server.DataRootProcessLock(canonical_root)
+    lock.acquire()
+    try:
+        with pytest.raises(pilot_data_root.PilotRootError, match="doppia istanza"):
+            pilot_data_root.validate_root(topology)
+        with pytest.raises(pilot_data_root.PilotRootError, match="doppia istanza"):
+            pilot_data_root.create_backup(topology, tmp_path / "backup")
+    finally:
+        lock.release()
+
+
+def test_auth_path_is_root_relative_portable_and_unambiguous(tmp_path: Path) -> None:
+    nested = pilot_data_root.topology_from_paths(
+        tmp_path / "root", "state/auth/identity.sqlite3"
+    )
+
+    assert nested.auth_db_path == (tmp_path / "root/state/auth/identity.sqlite3").resolve()
+    with pytest.raises(pilot_data_root.PilotRootError, match="assoluto"):
+        pilot_data_root.topology_from_paths(Path("relative-root"))
+    for invalid in (
+        "../identity.sqlite3",
+        "/var/lib/identity.sqlite3",
+        r"state\auth\identity.sqlite3",
+        "state/./identity.sqlite3",
+        "state/auth.txt",
+    ):
+        with pytest.raises(pilot_data_root.PilotRootError):
+            pilot_data_root.topology_from_paths(tmp_path / "root", invalid)
+
+
+def test_backup_manifest_and_payload_are_deterministic_and_secret_free(
+    canonical_root: Path, tmp_path: Path
+) -> None:
+    topology = pilot_data_root.topology_from_paths(canonical_root)
+    first = tmp_path / "backup-first"
+    second = tmp_path / "backup-second"
+
+    first_result = pilot_data_root.create_backup(topology, first)
+    second_result = pilot_data_root.create_backup(topology, second)
+
+    assert (first / "manifest.json").read_bytes() == (second / "manifest.json").read_bytes()
+    assert (first / "manifest.sha256").read_bytes() == (second / "manifest.sha256").read_bytes()
+    manifest = json.loads((first / "manifest.json").read_text(encoding="utf-8"))
+    schema = json.loads(
+        (Path(__file__).parents[1] / "schemas/pilot-backup-manifest.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    Draft202012Validator(schema).validate(manifest)
+    assert manifest["consistency"].endswith("sqlite-backup-api")
+    assert manifest["files"] == sorted(manifest["files"], key=lambda item: item["path"])
+    assert not any(item["path"].endswith(".lock") for item in manifest["files"])
+    assert not any(
+        item["path"].endswith(("-journal", "-shm", "-wal"))
+        for item in manifest["files"]
+    )
+    serialized = (first / "manifest.json").read_text(encoding="utf-8").lower()
+    assert "client_secret" not in serialized
+    assert "teacher_token" not in serialized
+    assert first_result["duration_seconds"] >= 0
+    assert first_result["target_assessment"].startswith("local measurement only")
+
+
+def test_secret_inside_root_causes_backup_to_fail_instead_of_leaking(
+    canonical_root: Path, tmp_path: Path
+) -> None:
+    secret = canonical_root / ".secrets/oauth-token.txt"
+    secret.parent.mkdir()
+    secret.write_text("DO-NOT-BACK-UP", encoding="utf-8")
+    output = tmp_path / "backup"
+
+    with pytest.raises(pilot_data_root.PilotRootError, match="Secret"):
+        pilot_data_root.create_backup(
+            pilot_data_root.topology_from_paths(canonical_root), output
+        )
+
+    assert not output.exists()
+
+
+def test_restore_is_isolated_checks_integrity_binding_demo_and_startup(
+    canonical_root: Path, tmp_path: Path
+) -> None:
+    topology = pilot_data_root.topology_from_paths(canonical_root)
+    backup = tmp_path / "backup"
+    target = tmp_path / "restored"
+    pilot_data_root.create_backup(topology, backup)
+    source_before = tree_digest(canonical_root)
+    backup_before = tree_digest(backup)
+
+    result = pilot_data_root.restore_backup(backup, target)
+
+    assert result["ok"] is True
+    assert result["sqlite_integrity"] is True
+    assert result["migrations"] == SCHEMA_VERSION
+    assert result["binding_702"] is True
+    assert result["demo_check"] is True
+    assert result["startup_smoke"] is True
+    assert result["duration_seconds"] >= 0
+    assert tree_digest(canonical_root) == source_before
+    assert tree_digest(backup) == backup_before
+    storage = SqliteIdentityStorage(target / pilot_data_root.DEFAULT_AUTH_DB_PATH)
+    assert len(storage.list_users()) == 3
+    assert len(storage.list_class_memberships(pilot_data_root.DEMO_CLASS_ID)) == 3
+
+
+def test_restore_rejects_checksum_tampering_and_existing_target(
+    canonical_root: Path, tmp_path: Path
+) -> None:
+    backup = tmp_path / "backup"
+    pilot_data_root.create_backup(
+        pilot_data_root.topology_from_paths(canonical_root), backup
+    )
+    target = tmp_path / "target"
+    target.mkdir()
+    with pytest.raises(pilot_data_root.PilotRootError, match="nuova"):
+        pilot_data_root.restore_backup(backup, target)
+
+    target.rmdir()
+    payload_file = next(
+        path
+        for path in (backup / "payload").rglob("*")
+        if path.is_file() and path.suffix == ".json"
+    )
+    payload_file.write_bytes(payload_file.read_bytes() + b"tampered")
+    with pytest.raises(pilot_data_root.PilotRootError, match="Dimensione|Checksum"):
+        pilot_data_root.restore_backup(backup, target)
+    assert not target.exists()
+
+
+def test_restore_rejects_partial_identity_migration_artifact(
+    canonical_root: Path, tmp_path: Path
+) -> None:
+    backup = tmp_path / "backup"
+    pilot_data_root.create_backup(
+        pilot_data_root.topology_from_paths(canonical_root), backup
+    )
+    database = backup / "payload" / pilot_data_root.DEFAULT_AUTH_DB_PATH
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "DELETE FROM schema_migrations WHERE version = ?", (SCHEMA_VERSION,)
+        )
+    manifest_path = backup / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    relative = pilot_data_root.DEFAULT_AUTH_DB_PATH
+    entry = next(item for item in manifest["files"] if item["path"] == relative)
+    entry["size"] = database.stat().st_size
+    entry["sha256"] = hashlib.sha256(database.read_bytes()).hexdigest()
+    manifest_path.write_bytes(pilot_data_root._canonical_json(manifest))
+    digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    (backup / "manifest.sha256").write_text(
+        f"{digest}  manifest.json\n", encoding="ascii"
+    )
+
+    target = tmp_path / "restored"
+    with pytest.raises(pilot_data_root.PilotRootError, match="Migrazione"):
+        pilot_data_root.restore_backup(backup, target)
+
+    assert not target.exists()
+
+
+def test_launcher_validates_canonical_root_before_reading_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    def reject_root(*_args, **_kwargs) -> None:
+        calls.append("root")
+        raise pilot_data_root.PilotRootError("root incompleta")
+
+    def unexpected_secret_read(_path: Path) -> None:
+        calls.append("secret")
+
+    monkeypatch.setattr(pilot_service_launcher.pilot_data_root, "validate_root", reject_root)
+    monkeypatch.setattr(pilot_service_launcher, "check_environment_file", unexpected_secret_read)
+    result = pilot_service_launcher.main(
+        [
+            "--environment-file",
+            str(tmp_path / "missing.env"),
+            "--deployment-id",
+            "pilot-test",
+            "--deployment-revision",
+            "a" * 40,
+            "--lock-directory",
+            str(tmp_path / "locks"),
+            "--auth-db-path",
+            pilot_data_root.DEFAULT_AUTH_DB_PATH,
+            "--trusted-proxy-cidrs",
+            "127.0.0.1/32",
+            "--google-redirect-uri",
+            "https://candidate.example.edu/auth/google/callback",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8000",
+            "--root",
+            str(tmp_path / "data"),
+            "--enable-google-auth",
+        ]
+    )
+
+    assert result == 2
+    assert calls == ["root"]

--- a/tests/test_pilot_data_root.py
+++ b/tests/test_pilot_data_root.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 import sqlite3
 from pathlib import Path
@@ -62,6 +63,10 @@ def test_bootstrap_from_empty_root_is_complete_and_idempotent(tmp_path: Path) ->
     }
     assert list(root.glob("teacher-help-events/*/*/events.json"))
     assert list(root.glob("examples/**/attempts/*.json"))
+    if os.name != "nt":
+        for path in (root, *root.rglob("*")):
+            expected_mode = 0o700 if path.is_dir() else 0o600
+            assert path.stat().st_mode & 0o777 == expected_mode
 
 
 def test_partial_or_incoherent_root_fails_closed_without_reset(tmp_path: Path) -> None:
@@ -91,6 +96,26 @@ def test_missing_required_state_and_ambiguous_auth_database_fail_closed(canonica
     )
     with pytest.raises(pilot_data_root.PilotRootError, match="ambigua"):
         pilot_data_root.validate_root(topology)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Symlink POSIX non disponibile su Windows.")
+def test_symlinked_root_and_entries_fail_closed(canonical_root: Path, tmp_path: Path) -> None:
+    root_alias = tmp_path / "root-alias"
+    root_alias.symlink_to(canonical_root, target_is_directory=True)
+    with pytest.raises(pilot_data_root.PilotRootError, match="symlink"):
+        pilot_data_root.topology_from_paths(root_alias)
+
+    report = canonical_root / "teacher-reports/demo/python-demo-somma-001.json"
+    external_report = tmp_path / "external-report.json"
+    report.replace(external_report)
+    report.symlink_to(external_report)
+    topology = pilot_data_root.topology_from_paths(canonical_root)
+    with pytest.raises(pilot_data_root.PilotRootError, match="Symlink"):
+        pilot_data_root.validate_root(topology)
+    backup = tmp_path / "backup"
+    with pytest.raises(pilot_data_root.PilotRootError, match="Symlink"):
+        pilot_data_root.create_backup(topology, backup)
+    assert not backup.exists()
 
 
 def test_same_root_double_instance_is_rejected(canonical_root: Path, tmp_path: Path) -> None:

--- a/tests/test_pilot_deployment.py
+++ b/tests/test_pilot_deployment.py
@@ -42,7 +42,11 @@ def valid_environment() -> dict[str, str]:
 
 
 def test_deployment_schemas_are_closed_valid_draft_2020_12_documents() -> None:
-    for name in ("pilot-deployment.schema.json", "pilot-environment.schema.json"):
+    for name in (
+        "pilot-deployment.schema.json",
+        "pilot-environment.schema.json",
+        "pilot-backup-manifest.schema.json",
+    ):
         schema = deployment.load_json(ROOT / "schemas" / name)
         assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
         assert schema["additionalProperties"] is False
@@ -76,6 +80,7 @@ def test_rendered_service_pins_root_auth_resolution_and_generated_topology(tmp_p
 
     assert "\nEnvironmentFile=" not in unit
     assert "scripts/pilot_service_launcher.py" in unit
+    assert "--deployment-id pilot-candidate-example" in unit
     assert "--auth-db-path .thebitlab-auth/auth.sqlite3" in unit
     assert "--trusted-proxy-cidrs 127.0.0.1/32" in unit
     assert "--host 127.0.0.1 --port 8000 --root /srv/thebitlab/data" in unit

--- a/tests/test_thebitlab_storage.py
+++ b/tests/test_thebitlab_storage.py
@@ -577,6 +577,9 @@ def test_course_storage_lock_serializes_different_processes(tmp_path) -> None:
     assert process.returncode == 0, stderr
     assert stdout.strip() == "completed"
     assert storage.read_design() == {"title": "child"}
+    if os.name != "nt":
+        lock_path = tmp_path / "doc" / ".course-storage.lock"
+        assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
 
 
 def test_uncommitted_delete_transaction_is_restored_on_next_adapter(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Completa la remediation #705 del finding bloccante `FINDING-678-TOPOLOGY-001`, introducendo una singola root canonica per auth + dati didattici e un flusso completo, verificabile e fail-closed di backup/restore.

### Architettura della root
La root canonica contiene:
- `.thebitlab-root.json`;
- `.thebitlab-auth/auth.sqlite3`;
- design, calendario e roster;
- activity e workspace;
- assignment con `subject_id`;
- report, tentativi e help;
- account, classe, membership e binding #702.

Il launcher valida la root prima di leggere i secret. Root parziali, auth DB multipli, symlink inattesi e doppie istanze falliscono chiusi.

### Backup/restore
Formato `thebitlab.pilot-backup.v1`:
- `manifest.json` deterministico;
- `manifest.sha256`;
- payload con checksum SHA-256 per ogni file;
- snapshot SQLite mediante backup API sotto lock esclusivo;
- secret, symlink, cache, lock e sidecar transitori esclusi o rifiutati.

Restore:
- solo verso root nuova e isolata;
- verifica checksum e manifest;
- `PRAGMA integrity_check`;
- migrazioni/schema;
- binding #702;
- `student_lab_demo_check --existing`;
- startup smoke loopback;
- nessuna scrittura alla root sorgente.

### Verifica Windows/integrata
- suite integrata: 67 passed, 1 skipped;
- lock concorrente: 2 passed, 1 skipped;
- `compileall`, schema, link Markdown e `git diff --check`: PASS;
- `student_lab_demo_check --existing`: PASS;
- misure locali iniziali: backup 2.067245 s, restore 2.013516 s.

### Validazione Linux finale
Ambiente effimero Ubuntu 24.04.4 LTS su Docker Desktop/WSL2, repository montato read-only e lavoro su copia interna con soli dati sintetici.

- 119 passed, 1 skipped Windows-only; zero failure finali;
- smoke nginx/systemd separato: PASS;
- bootstrap da root vuota: `created=true`; seconda esecuzione idempotente `created=false`;
- account, classe, 3 membership e binding #702: PASS;
- demo-check `--existing`: PASS su sorgente e restore;
- symlink root/interni rifiutati;
- mode directory `0700`, file/lock `0600`;
- secret exclusion, lock esclusivo, doppia istanza, partial-root e auth DB multiplo: PASS;
- backup con checksum di tutti i 28 payload: PASS;
- WAL SQLite acquisito coerentemente; sidecar esclusi;
- restore isolato, migrazioni 1..12, binding, demo-check e startup loopback: PASS;
- no-write-to-source verificato su path, SHA-256, mode e `mtime_ns`;
- `PRAGMA integrity_check = ok`;
- root incompleta fallisce prima della lettura dell'EnvironmentFile;
- deployment render: PASS;
- `systemd-analyze verify`: PASS;
- smoke nginx non distruttivo: PASS.

Misure Linux locali, non SLA: backup 0.063356 s; restore 0.072458 s.

### Difetti trovati durante la validazione Linux
Sono stati corretti prima della pubblicazione:
1. root symlink e symlink interni potevano essere accettati;
2. `.course-storage.lock` e `.thebitlab-server.lock` potevano avere mode `0644`.

Fix finale: `7dc50a46` (`fix(pilot): enforce POSIX root safety`).

Nessun VPS/live, dato reale o secret è stato modificato. Le evidenze storiche #678 restano baseline di regressione e non vengono reinterpretate come PASS della nuova root unificata.

Closes #705.