### PR TITLE
Define Content Pack v1 authoring standard

### DIFF
--- a/doc/architecture/content-pack-standard-v1.md
+++ b/doc/architecture/content-pack-standard-v1.md
@@ -1,0 +1,449 @@
+# TheBitLab Content Pack Standard v1
+
+## Stato
+
+**Proposto** nell'ambito di #723. Il contratto nasce dal pacchetto sperimentale TPSI quarto (#625) e viene consolidato prima di avviare TPSI quinto Full Stack e il corso SQL.
+
+Schema canonico:
+
+```text
+thebitlab.content-pack.v1
+```
+
+## Scopo
+
+Un Content Pack descrive il **livello di authoring didattico** di un corso:
+
+- fonti indicizzabili;
+- riferimenti tecnici/curricolari/editoriali;
+- provenienza;
+- matrice di copertura;
+- contenuti originali;
+- Course Design;
+- collegamenti alle Activity;
+- policy editoriali e di pubblicazione.
+
+Il Content Pack non e il formato di esecuzione del lab e non e il formato di distribuzione del corso.
+
+## Boundary dei contratti
+
+```text
+fonti / riferimenti
+        |
+        v
+Content Pack v1
+(authoring + provenance + coverage)
+        |
+        +------> Course Design v1
+        |        (UDA, calendario, composizione)
+        |
+        +------> Activity 1.0
+        |        (assegnazione, A-F, asset, grading/runtime)
+        |
+        v
+review + freeze
+        |
+        v
+Course Bundle 1.0.0
+(snapshot immutabile distribuibile)
+        |
+        v
+TheBitLab runtime
+```
+
+Il Course Bundle Format resta governato da `doc/architecture/adr-course-bundle-format.md`. Il Content Pack non duplica `bundle.json`: prepara e documenta il materiale che puo essere pubblicato in un bundle.
+
+## Compatibilita col modello attuale
+
+La v1 consolida decisioni gia esercitate da TPSI quarto:
+
+- Markdown locale e remoto tramite `CourseDesign.sources`;
+- ID stabili indipendenti dai titoli e dal calendario;
+- Course Design separato dai contenuti;
+- Activity schema 1.0 invariato;
+- tassonomia A-F gia esistente nell'Activity (`difficolta`);
+- asset studente/docente/grading separati;
+- provenienza e stato di revisione;
+- contenuti originali distinti dalle fonti di copertura o approfondimento.
+
+Il primo incremento non introduce nuovi provider nella Course Board.
+
+## Struttura consigliata del repository autore
+
+```text
+content/<course-id>/
+  content-pack.json
+  README.md
+  COVERAGE.md
+  01_....md
+  02_....md
+
+doc/course_designs/
+  <course-id>_2026_2027.json
+
+activities/<course-id>/
+  <activity-id>/
+    activity.json
+    starter/
+    student/
+    examples/
+    fixtures/
+    tests/
+    solution/
+    teacher/
+
+bundle.json              # opzionale durante authoring; autoritativo solo per la release Course Bundle
+```
+
+La struttura fisica puo variare. I path nel manifest devono essere relativi, sicuri e confinati nel repository del pack.
+
+## Manifest v1
+
+Esempio ridotto:
+
+```json
+{
+  "schema_version": "thebitlab.content-pack.v1",
+  "id": "tpsi5-pack-fullstack-2026",
+  "title": "TPSI quinto - Full Stack Web Development",
+  "version": "0.1.0",
+  "status": "draft",
+  "language": "it",
+  "audience": {
+    "school_level": "secondaria-secondo-grado",
+    "subject": "TPSI",
+    "year": 5
+  },
+  "ownership": {
+    "content_origin": "original-course-material",
+    "redistribution_status": "project-license-to-review",
+    "editorial_copying_allowed": false
+  },
+  "references": [],
+  "sources": [],
+  "coverage": {
+    "path": "content/tpsi5/COVERAGE.md",
+    "status": "draft"
+  },
+  "content_items": [],
+  "course_designs": [],
+  "activity_roots": ["activities/tpsi5"],
+  "policies": {
+    "provenance_required": true,
+    "teacher_review_required_before_publish": true,
+    "student_teacher_asset_separation_required": true,
+    "ai_is_not_primary_source": true,
+    "restricted_source_copying_forbidden": true
+  }
+}
+```
+
+## Identita e lifecycle
+
+Campi obbligatori:
+
+- `schema_version`: esattamente `thebitlab.content-pack.v1`;
+- `id`: identificatore stabile portabile;
+- `title`: titolo umano;
+- `version`: SemVer del pack;
+- `status`: stato editoriale;
+- `language`: lingua del contenuto;
+- `audience`: metadati del pubblico;
+- `ownership`: origine/licenza editoriale;
+- `references`, `sources`, `content_items`, `course_designs`, `activity_roots`;
+- `policies`.
+
+Lifecycle editoriale:
+
+```text
+draft -> reviewed -> approved -> superseded
+                         |
+                         +-> retired
+```
+
+`approved` significa che il pack e candidato alla pubblicazione. Se `teacher_review_required_before_publish` e `true`, un pack `approved` non puo contenere content item, Course Design o coverage ancora `draft/reviewed`.
+
+La release distribuibile deve poi essere congelata tramite Course Bundle + riferimento esterno tag/SHA, secondo l'ADR del Course Bundle.
+
+## `sources`: materiale indicizzabile
+
+`sources` contiene soltanto fonti che la Course Board corrente puo indicizzare. Nella v1 iniziale:
+
+```text
+type     = markdown
+provider = local | github | gitlab
+```
+
+Ogni source e un `source-package` e deve dichiarare almeno:
+
+```json
+{
+  "id": "tpsi5-source-originali",
+  "kind": "source-package",
+  "label": "TPSI quinto - contenuti originali",
+  "type": "markdown",
+  "provider": "local",
+  "role": "approved-course-content",
+  "path": "content/tpsi5",
+  "files": ["README.md", "COVERAGE.md", "01_WEB_FOUNDATIONS.md"],
+  "license_status": "project-license-to-review",
+  "indexing_status": "ready"
+}
+```
+
+Per `github`/`gitlab` restano necessari `repository` e `ref`, coerentemente con `course_source_catalog`.
+
+Un Content Pack v1 deve poter proiettare `sources` direttamente nella forma `CourseDesign.sources` senza perdere i campi necessari all'indicizzazione.
+
+## `references`: fonti non ingerite
+
+`references` registra materiale utile alla progettazione o alla spiegazione ma **non autorizza download, scraping, copia o redistribuzione**.
+
+Ruoli standard:
+
+- `coverage-reference`: programma, indice pubblico, standard curricolare;
+- `technical-reference`: documentazione tecnica autorevole;
+- `specification`: specifica normativa/tecnica;
+- `teacher-reference`: libro/corso/materiale usato dal docente per progettare spiegazioni e attivita originali.
+
+Esempi:
+
+```json
+{
+  "id": "tpsi5-ref-mdn-flexbox",
+  "kind": "documentation",
+  "role": "technical-reference",
+  "provider": "mdn",
+  "title": "MDN - CSS flexible box layout",
+  "uri": "https://developer.mozilla.org/",
+  "access": "public",
+  "license_status": "reference-and-license-aware-reuse"
+}
+```
+
+```json
+{
+  "id": "tpsi5-ref-manning-css-depth",
+  "kind": "book",
+  "role": "teacher-reference",
+  "provider": "manning",
+  "title": "CSS in Depth, Second Edition",
+  "access": "licensed",
+  "license_status": "licensed-reference-only"
+}
+```
+
+Pluralsight segue lo stesso modello `teacher-reference`. Le credenziali non fanno mai parte del pack.
+
+MDN, WHATWG, RFC, Node.js, Express, Vue, FastAPI e altre documentazioni possono essere `technical-reference` o `specification`; un adapter di ingestione futuro richiedera un contratto separato.
+
+## Coverage
+
+Se esiste almeno una `coverage-reference`, il pack deve dichiarare:
+
+```json
+"coverage": {
+  "path": "content/tpsi5/COVERAGE.md",
+  "status": "draft"
+}
+```
+
+La matrice di coverage misura **copertura e coerenza**, non somiglianza testuale con la fonte curricolare.
+
+Una coverage approvata deve mostrare almeno:
+
+```text
+obiettivo/topic
+  -> content item
+  -> UDA / Course Design
+  -> Activity/esercizi/verifiche
+  -> stato della copertura
+```
+
+## Content item
+
+Un content item e un blocco didattico stabile, normalmente rappresentato da un Markdown indicizzabile.
+
+```json
+{
+  "id": "tpsi5-content-css-flexbox",
+  "kind": "module",
+  "path": "content/tpsi5/03_CSS_MODERNO.md",
+  "order": 3,
+  "status": "draft",
+  "curriculum_topics": ["css-flexbox", "responsive-layout"],
+  "activity_ids": ["tpsi5-activity-b-flexbox-navbar-001"],
+  "source_refs": [
+    {
+      "id": "tpsi5-source-originali",
+      "role": "content-origin",
+      "locator": "content/tpsi5/03_CSS_MODERNO.md"
+    },
+    {
+      "id": "tpsi5-ref-mdn-flexbox",
+      "role": "technical-reference",
+      "locator": "Basic concepts of flexbox"
+    }
+  ]
+}
+```
+
+Se `provenance_required` e `true`, ogni content item deve avere almeno un `source_ref` valido verso un elemento di `sources` o `references`.
+
+`source_refs` registra la relazione editoriale. Non implica che il testo della fonte sia stato copiato.
+
+## Forma raccomandata della lezione
+
+La v1 mantiene la forma sperimentata in TPSI quarto:
+
+```text
+obiettivi
+prerequisiti
+problema iniziale
+teoria
+esempio minimo
+esempio realistico
+confronto tra implementazioni (quando utile)
+errori frequenti
+esercizi A-F
+laboratorio
+verifica rapida
+sintesi inclusiva
+fonti e collegamenti
+activity correlate
+```
+
+Gli heading devono restare abbastanza autonomi da poter essere selezionati nella Course Board senza frammentare la lezione in blocchi privi di significato.
+
+## Activity e tassonomia A-F
+
+La v1 **non introduce una nuova tassonomia**. Usa quella dell'Activity schema 1.0:
+
+| Livello | Progressione |
+| --- | --- |
+| A | copia/esegui/osserva |
+| B | modifica controllata |
+| C | scrittura autonoma |
+| D | debug e diagnosi |
+| E | mini-progetto |
+| F | prodotto/progetto integrato |
+
+`content_items[].activity_ids` collega il contenuto alle Activity. L'Activity mantiene il proprio `content_ids`, `source_refs`, asset, test, rubrica, runtime e metriche.
+
+La separazione minima resta:
+
+```text
+student: starter, example, fixture, visible_test
+teacher/grading: hidden_test, runner, teacher_only, solution
+```
+
+## Course Design
+
+`course_designs` contiene riferimenti stabili ai progetti che compongono contenuti e Activity in UDA/calendario:
+
+```json
+{
+  "id": "tpsi5-course-2026-2027",
+  "path": "doc/course_designs/tpsi_quinto_2026_2027.json",
+  "status": "draft"
+}
+```
+
+Il Content Pack non duplica `years/udas/items`: il Course Design resta il contratto autorevole per la composizione temporale.
+
+Nel modello corrente le `sources` del pack e quelle del Course Design possono coesistere; la proiezione v1 serve a evitare divergenze e prepara una generazione automatica futura.
+
+## Policy minime
+
+La v1 richiede cinque policy booleane:
+
+- `provenance_required`;
+- `teacher_review_required_before_publish`;
+- `student_teacher_asset_separation_required`;
+- `ai_is_not_primary_source`;
+- `restricted_source_copying_forbidden`.
+
+Sono ammessi campi aggiuntivi specifici del corso.
+
+`restricted_source_copying_forbidden` generalizza il precedente `book_text_reproduction_forbidden`: vale per libri, corsi licensed, repository privati e qualunque materiale che non possa essere redistribuito nel pack.
+
+## Migrazione da `content-pack.v0`
+
+La migrazione e deterministica e conservativa:
+
+1. `curriculum_references[]` confluisce in `references[]` mantenendo ID, ruolo, provider, URI e metadati bibliografici;
+2. ogni source v0 riceve un `label` se mancante e resta una `source-package`;
+3. `content_items[].source_refs` viene inferito solo quando il path del content item coincide con un file dichiarato da una source;
+4. `coverage` viene inferito solo se una source dichiara `COVERAGE.md`;
+5. `book_text_reproduction_forbidden` viene generalizzato in `restricted_source_copying_forbidden` senza cancellare la policy legacy;
+6. `compatibility` v0 viene conservato sotto `extensions.v0_compatibility`;
+7. nessuna risorsa esterna viene scaricata durante la migrazione.
+
+Se non e possibile inferire la provenienza richiesta, la migrazione fallisce la validazione invece di inventare un riferimento.
+
+## Pubblicazione verso Course Bundle
+
+Il Content Pack resta mutabile durante authoring. La pubblicazione deve selezionare soltanto revisioni approvate e produrre/aggiornare un Course Bundle conforme all'ADR.
+
+```text
+Content Pack v1 (approved)
+       +
+Course Design (approved)
+       +
+Activity 1.0 validate
+       +
+materiali approvati
+       |
+       v
+Course Bundle 1.0.0
+       |
+       v
+BundleReference esterno con tag/SHA
+```
+
+La conversione automatica non fa parte del primo incremento #723; il boundary e pero vincolante per evitare che i due manifest evolvano in formati concorrenti.
+
+## Conformance
+
+Il validator dependency-free vive in:
+
+```text
+scripts/content_pack_contract.py
+```
+
+Uso previsto:
+
+```bash
+python -m scripts.content_pack_contract validate content/tpsi5/content-pack.json --root .
+```
+
+Migrazione:
+
+```bash
+python -m scripts.content_pack_contract upgrade-v0 old-manifest.json new-content-pack.json
+```
+
+I test di conformita verificano almeno:
+
+- SemVer, ID e status;
+- path confinati;
+- unicita degli ID;
+- references/source cross-reference;
+- provenance obbligatoria;
+- coverage quando esiste un riferimento curricolare;
+- lifecycle `approved`;
+- proiezione `sources -> CourseDesign.sources`;
+- migrazione v0 -> v1 senza perdita dei metadati legacy rilevanti.
+
+## Evoluzioni successive
+
+Non fanno parte della v1 iniziale:
+
+- ingestione diretta di siti/PDF/provider licensed;
+- credenziali nel manifest;
+- marketplace/licensing runtime;
+- ContentBlock/ContentVersion persistenti lato server;
+- builder automatico Content Pack -> Course Bundle;
+- modifica dell'Activity schema.
+
+Queste evoluzioni devono preservare gli ID e il significato editoriale della v1.

--- a/scripts/content_pack_contract.py
+++ b/scripts/content_pack_contract.py
@@ -1,0 +1,741 @@
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+import json
+from pathlib import Path, PurePosixPath
+import re
+from typing import Any
+
+SCHEMA_V0 = "thebitlab.content-pack.v0"
+SCHEMA_V1 = "thebitlab.content-pack.v1"
+
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
+TOKEN_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+SOURCE_ID_RE = re.compile(r"^[a-z0-9](?:[a-z0-9._-]{0,63})$")
+LANGUAGE_RE = re.compile(r"^[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$")
+
+EDITORIAL_STATUSES = frozenset(
+    {"draft", "reviewed", "approved", "superseded", "retired"}
+)
+REFERENCE_ROLES = frozenset(
+    {
+        "coverage-reference",
+        "technical-reference",
+        "teacher-reference",
+        "specification",
+    }
+)
+INDEXABLE_PROVIDERS = frozenset({"local", "github", "gitlab"})
+INDEXABLE_TYPES = frozenset({"markdown"})
+INDEXING_STATUSES = frozenset({"ready", "pending", "error", "disabled"})
+REQUIRED_POLICIES = frozenset(
+    {
+        "provenance_required",
+        "teacher_review_required_before_publish",
+        "student_teacher_asset_separation_required",
+        "ai_is_not_primary_source",
+        "restricted_source_copying_forbidden",
+    }
+)
+REQUIRED_OWNERSHIP_FIELDS = frozenset(
+    {"content_origin", "redistribution_status", "editorial_copying_allowed"}
+)
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _portable_id(value: Any, *, source_id: bool = False) -> bool:
+    text = _text(value)
+    return bool((SOURCE_ID_RE if source_id else TOKEN_RE).fullmatch(text))
+
+
+def _safe_relative_path(value: Any, *, allow_empty: bool = False) -> bool:
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    if not text:
+        return allow_empty
+    if "\\" in text or text.startswith("/"):
+        return False
+    path = PurePosixPath(text)
+    return not path.is_absolute() and all(
+        part not in {"", ".", ".."} for part in path.parts
+    )
+
+
+def _list_of_unique_strings(value: Any, *, portable: bool = False) -> bool:
+    if not isinstance(value, list):
+        return False
+    seen: set[str] = set()
+    for item in value:
+        text = _text(item)
+        if not text or text in seen:
+            return False
+        if portable and not _portable_id(text):
+            return False
+        seen.add(text)
+    return True
+
+
+def _validate_identity(pack: dict[str, Any], source: str, errors: list[str]) -> None:
+    if pack.get("schema_version") != SCHEMA_V1:
+        errors.append(f"{source}: schema_version deve essere {SCHEMA_V1}")
+    if not _portable_id(pack.get("id")):
+        errors.append(f"{source}: id deve essere un identificativo portabile")
+    if not _text(pack.get("title")):
+        errors.append(f"{source}: title deve essere una stringa non vuota")
+    version = _text(pack.get("version"))
+    if not SEMVER_RE.fullmatch(version):
+        errors.append(f"{source}: version deve essere SemVer")
+    status = _text(pack.get("status"))
+    if status not in EDITORIAL_STATUSES:
+        errors.append(
+            f"{source}: status non supportato: {status or '<mancante>'}"
+        )
+    language = _text(pack.get("language"))
+    if not LANGUAGE_RE.fullmatch(language):
+        errors.append(
+            f"{source}: language deve essere un tag lingua semplice "
+            "(es. it, en, it-IT)"
+        )
+
+
+def _validate_audience(value: Any, source: str, errors: list[str]) -> None:
+    if not isinstance(value, dict) or not value:
+        errors.append(f"{source}: audience deve essere un oggetto non vuoto")
+        return
+    for key, item in value.items():
+        if not _portable_id(key):
+            errors.append(f"{source}: audience contiene chiave non portabile: {key}")
+        if isinstance(item, dict):
+            errors.append(
+                f"{source}: audience.{key} deve essere uno scalare o una lista di scalari"
+            )
+        elif isinstance(item, list) and any(
+            isinstance(child, (dict, list)) for child in item
+        ):
+            errors.append(
+                f"{source}: audience.{key} deve contenere solo scalari"
+            )
+
+
+def _validate_ownership(value: Any, source: str, errors: list[str]) -> None:
+    if not isinstance(value, dict):
+        errors.append(f"{source}: ownership deve essere un oggetto")
+        return
+    for field in sorted(REQUIRED_OWNERSHIP_FIELDS - value.keys()):
+        errors.append(f"{source}: ownership.{field} mancante")
+    for field in ("content_origin", "redistribution_status"):
+        if field in value and not _text(value.get(field)):
+            errors.append(
+                f"{source}: ownership.{field} deve essere una stringa non vuota"
+            )
+    if "editorial_copying_allowed" in value and not isinstance(
+        value.get("editorial_copying_allowed"), bool
+    ):
+        errors.append(
+            f"{source}: ownership.editorial_copying_allowed deve essere boolean"
+        )
+
+
+def _validate_references(
+    value: Any, source: str, errors: list[str]
+) -> tuple[set[str], bool]:
+    if not isinstance(value, list):
+        errors.append(f"{source}: references deve essere una lista")
+        return set(), False
+    ids: set[str] = set()
+    has_coverage_reference = False
+    for index, item in enumerate(value):
+        prefix = f"{source}: references[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} deve essere un oggetto")
+            continue
+        reference_id = _text(item.get("id"))
+        if not _portable_id(reference_id):
+            errors.append(f"{prefix}.id deve essere un identificativo portabile")
+        elif reference_id in ids:
+            errors.append(f"{source}: reference id duplicato: {reference_id}")
+        else:
+            ids.add(reference_id)
+        for field in ("kind", "provider"):
+            if not _portable_id(item.get(field)):
+                errors.append(
+                    f"{prefix}.{field} deve essere un identificativo portabile"
+                )
+        role = _text(item.get("role"))
+        if role not in REFERENCE_ROLES:
+            errors.append(
+                f"{prefix}.role non supportato: {role or '<mancante>'}"
+            )
+        has_coverage_reference = (
+            has_coverage_reference or role == "coverage-reference"
+        )
+        if not _text(item.get("title")):
+            errors.append(f"{prefix}.title deve essere una stringa non vuota")
+        if not _text(item.get("license_status")):
+            errors.append(
+                f"{prefix}.license_status deve essere una stringa non vuota"
+            )
+        for optional in ("uri", "access", "notes"):
+            if optional in item and not isinstance(item.get(optional), str):
+                errors.append(f"{prefix}.{optional} deve essere una stringa")
+    return ids, has_coverage_reference
+
+
+def _validate_sources(value: Any, source: str, errors: list[str]) -> set[str]:
+    if not isinstance(value, list):
+        errors.append(f"{source}: sources deve essere una lista")
+        return set()
+    ids: set[str] = set()
+    for index, item in enumerate(value):
+        prefix = f"{source}: sources[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} deve essere un oggetto")
+            continue
+        source_id = _text(item.get("id"))
+        if not _portable_id(source_id, source_id=True):
+            errors.append(
+                f"{prefix}.id deve essere compatibile col Course Source Catalog"
+            )
+        elif source_id in ids:
+            errors.append(f"{source}: source id duplicato: {source_id}")
+        else:
+            ids.add(source_id)
+        if item.get("kind") != "source-package":
+            errors.append(f"{prefix}.kind deve essere source-package")
+        if not _text(item.get("label")):
+            errors.append(f"{prefix}.label deve essere una stringa non vuota")
+        source_type = _text(item.get("type"))
+        if source_type not in INDEXABLE_TYPES:
+            errors.append(
+                f"{prefix}.type non indicizzabile: {source_type or '<mancante>'}"
+            )
+        provider = _text(item.get("provider"))
+        if provider not in INDEXABLE_PROVIDERS:
+            errors.append(
+                f"{prefix}.provider non supportato dal catalogo corrente: "
+                f"{provider or '<mancante>'}"
+            )
+        if not _portable_id(item.get("role")):
+            errors.append(f"{prefix}.role deve essere un identificativo portabile")
+        if not _text(item.get("license_status")):
+            errors.append(
+                f"{prefix}.license_status deve essere una stringa non vuota"
+            )
+        indexing_status = _text(item.get("indexing_status"))
+        if indexing_status not in INDEXING_STATUSES:
+            errors.append(
+                f"{prefix}.indexing_status non supportato: "
+                f"{indexing_status or '<mancante>'}"
+            )
+        if not _safe_relative_path(item.get("path", ""), allow_empty=True):
+            errors.append(f"{prefix}.path deve essere un path relativo sicuro")
+        files = item.get("files")
+        if not _list_of_unique_strings(files):
+            errors.append(
+                f"{prefix}.files deve essere una lista di path unici non vuoti"
+            )
+        elif any(not _safe_relative_path(file) for file in files):
+            errors.append(f"{prefix}.files contiene path non sicuri")
+        if provider in {"github", "gitlab"}:
+            if not _text(item.get("repository")):
+                errors.append(f"{prefix}.repository richiesto per fonte remota")
+            if not _text(item.get("ref")):
+                errors.append(f"{prefix}.ref richiesto per fonte remota")
+    return ids
+
+
+def _validate_coverage(
+    value: Any,
+    *,
+    required: bool,
+    source: str,
+    errors: list[str],
+) -> None:
+    if value is None:
+        if required:
+            errors.append(
+                f"{source}: coverage richiesto quando esiste una coverage-reference"
+            )
+        return
+    if not isinstance(value, dict):
+        errors.append(f"{source}: coverage deve essere un oggetto")
+        return
+    if not _safe_relative_path(value.get("path")):
+        errors.append(f"{source}: coverage.path deve essere un path relativo sicuro")
+    status = _text(value.get("status"))
+    if status not in EDITORIAL_STATUSES:
+        errors.append(f"{source}: coverage.status non supportato")
+
+
+def _validate_source_refs(
+    value: Any,
+    *,
+    known_ids: set[str],
+    prefix: str,
+    errors: list[str],
+) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append(f"{prefix}.source_refs deve essere una lista non vuota")
+        return
+    seen: set[tuple[str, str]] = set()
+    for index, item in enumerate(value):
+        item_prefix = f"{prefix}.source_refs[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{item_prefix} deve essere un oggetto")
+            continue
+        ref_id = _text(item.get("id"))
+        if ref_id not in known_ids:
+            errors.append(
+                f"{item_prefix}.id sconosciuto: {ref_id or '<mancante>'}"
+            )
+        role = _text(item.get("role"))
+        if not _portable_id(role):
+            errors.append(
+                f"{item_prefix}.role deve essere un identificativo portabile"
+            )
+        locator = item.get("locator", "")
+        if locator is not None and not isinstance(locator, str):
+            errors.append(f"{item_prefix}.locator deve essere una stringa")
+        key = (ref_id, str(locator or ""))
+        if key in seen:
+            errors.append(
+                f"{prefix}.source_refs contiene riferimento duplicato: {ref_id}"
+            )
+        seen.add(key)
+
+
+def _validate_content_items(
+    value: Any,
+    *,
+    known_source_ids: set[str],
+    provenance_required: bool,
+    source: str,
+    errors: list[str],
+) -> tuple[set[str], list[str]]:
+    if not isinstance(value, list):
+        errors.append(f"{source}: content_items deve essere una lista")
+        return set(), []
+    ids: set[str] = set()
+    statuses: list[str] = []
+    for index, item in enumerate(value):
+        prefix = f"{source}: content_items[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} deve essere un oggetto")
+            continue
+        item_id = _text(item.get("id"))
+        if not _portable_id(item_id):
+            errors.append(f"{prefix}.id deve essere un identificativo portabile")
+        elif item_id in ids:
+            errors.append(f"{source}: content item id duplicato: {item_id}")
+        else:
+            ids.add(item_id)
+        if not _portable_id(item.get("kind")):
+            errors.append(f"{prefix}.kind deve essere un identificativo portabile")
+        if not _safe_relative_path(item.get("path")):
+            errors.append(f"{prefix}.path deve essere un path relativo sicuro")
+        order = item.get("order")
+        if isinstance(order, bool) or not isinstance(order, int) or order <= 0:
+            errors.append(f"{prefix}.order deve essere un intero positivo")
+        status = _text(item.get("status"))
+        if status not in EDITORIAL_STATUSES:
+            errors.append(f"{prefix}.status non supportato")
+        else:
+            statuses.append(status)
+        for field in ("curriculum_topics", "activity_ids"):
+            if field in item and not _list_of_unique_strings(
+                item.get(field), portable=True
+            ):
+                errors.append(
+                    f"{prefix}.{field} deve essere una lista di ID portabili unici"
+                )
+        if provenance_required:
+            _validate_source_refs(
+                item.get("source_refs"),
+                known_ids=known_source_ids,
+                prefix=prefix,
+                errors=errors,
+            )
+        elif "source_refs" in item:
+            _validate_source_refs(
+                item.get("source_refs"),
+                known_ids=known_source_ids,
+                prefix=prefix,
+                errors=errors,
+            )
+    return ids, statuses
+
+
+def _validate_course_designs(value: Any, source: str, errors: list[str]) -> list[str]:
+    if not isinstance(value, list):
+        errors.append(f"{source}: course_designs deve essere una lista")
+        return []
+    ids: set[str] = set()
+    statuses: list[str] = []
+    for index, item in enumerate(value):
+        prefix = f"{source}: course_designs[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} deve essere un oggetto")
+            continue
+        item_id = _text(item.get("id"))
+        if not _portable_id(item_id):
+            errors.append(f"{prefix}.id deve essere un identificativo portabile")
+        elif item_id in ids:
+            errors.append(f"{source}: course design id duplicato: {item_id}")
+        else:
+            ids.add(item_id)
+        if not _safe_relative_path(item.get("path")):
+            errors.append(f"{prefix}.path deve essere un path relativo sicuro")
+        status = _text(item.get("status"))
+        if status not in EDITORIAL_STATUSES:
+            errors.append(f"{prefix}.status non supportato")
+        else:
+            statuses.append(status)
+    return statuses
+
+
+def _validate_activity_roots(value: Any, source: str, errors: list[str]) -> None:
+    if not isinstance(value, list):
+        errors.append(f"{source}: activity_roots deve essere una lista")
+        return
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not _safe_relative_path(item):
+            errors.append(
+                f"{source}: activity_roots[{index}] deve essere un path relativo sicuro"
+            )
+            continue
+        if item in seen:
+            errors.append(f"{source}: activity_roots contiene path duplicato: {item}")
+        seen.add(item)
+
+
+def _validate_policies(value: Any, source: str, errors: list[str]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        errors.append(f"{source}: policies deve essere un oggetto")
+        return {}
+    for field in sorted(REQUIRED_POLICIES - value.keys()):
+        errors.append(f"{source}: policies.{field} mancante")
+    for field in REQUIRED_POLICIES & value.keys():
+        if not isinstance(value.get(field), bool):
+            errors.append(f"{source}: policies.{field} deve essere boolean")
+    return value
+
+
+def validate_content_pack(
+    pack: Any,
+    source: str = "<content-pack>",
+    *,
+    root: Path | None = None,
+) -> list[str]:
+    if not isinstance(pack, dict):
+        return [f"{source}: content pack deve essere un oggetto JSON"]
+
+    errors: list[str] = []
+    _validate_identity(pack, source, errors)
+    _validate_audience(pack.get("audience"), source, errors)
+    _validate_ownership(pack.get("ownership"), source, errors)
+    policies = _validate_policies(pack.get("policies"), source, errors)
+
+    reference_ids, has_coverage_reference = _validate_references(
+        pack.get("references"), source, errors
+    )
+    source_ids = _validate_sources(pack.get("sources"), source, errors)
+    collisions = reference_ids & source_ids
+    if collisions:
+        errors.append(
+            f"{source}: ID condivisi fra sources e references: "
+            f"{', '.join(sorted(collisions))}"
+        )
+    known_ids = reference_ids | source_ids
+
+    _validate_coverage(
+        pack.get("coverage"),
+        required=has_coverage_reference,
+        source=source,
+        errors=errors,
+    )
+    _, content_statuses = _validate_content_items(
+        pack.get("content_items"),
+        known_source_ids=known_ids,
+        provenance_required=policies.get("provenance_required") is True,
+        source=source,
+        errors=errors,
+    )
+    design_statuses = _validate_course_designs(
+        pack.get("course_designs"), source, errors
+    )
+    _validate_activity_roots(pack.get("activity_roots"), source, errors)
+
+    if (
+        _text(pack.get("status")) == "approved"
+        and policies.get("teacher_review_required_before_publish") is True
+    ):
+        if any(status != "approved" for status in content_statuses):
+            errors.append(
+                f"{source}: pack approved contiene content item non approved"
+            )
+        if any(status != "approved" for status in design_statuses):
+            errors.append(
+                f"{source}: pack approved contiene course design non approved"
+            )
+        coverage = pack.get("coverage")
+        if isinstance(coverage, dict) and _text(coverage.get("status")) != "approved":
+            errors.append(f"{source}: pack approved richiede coverage approved")
+
+    if root is not None:
+        errors.extend(validate_content_pack_paths(pack, root, source=source))
+    return errors
+
+
+def validate_content_pack_paths(
+    pack: dict[str, Any], root: Path, *, source: str = "<content-pack>"
+) -> list[str]:
+    errors: list[str] = []
+    root = root.resolve()
+
+    def check_file(path_value: Any, label: str) -> None:
+        if not _safe_relative_path(path_value):
+            return
+        path = (root / str(path_value)).resolve(strict=False)
+        try:
+            path.relative_to(root)
+        except ValueError:
+            errors.append(f"{source}: {label} esce dalla root")
+            return
+        if not path.is_file():
+            errors.append(f"{source}: file mancante per {label}: {path_value}")
+
+    coverage = pack.get("coverage")
+    if isinstance(coverage, dict):
+        check_file(coverage.get("path"), "coverage")
+    for item in pack.get("content_items", []):
+        if isinstance(item, dict):
+            check_file(item.get("path"), f"content item {item.get('id')}")
+    for item in pack.get("course_designs", []):
+        if isinstance(item, dict):
+            check_file(item.get("path"), f"course design {item.get('id')}")
+    for source_item in pack.get("sources", []):
+        if not isinstance(source_item, dict) or source_item.get("provider") != "local":
+            continue
+        base = _text(source_item.get("path"))
+        for filename in source_item.get("files", []):
+            relative = (
+                str(PurePosixPath(base) / filename) if base else filename
+            )
+            check_file(relative, f"source {source_item.get('id')}")
+    for index, value in enumerate(pack.get("activity_roots", [])):
+        if not _safe_relative_path(value):
+            continue
+        path = (root / value).resolve(strict=False)
+        try:
+            path.relative_to(root)
+        except ValueError:
+            errors.append(f"{source}: activity_roots[{index}] esce dalla root")
+            continue
+        if not path.is_dir():
+            errors.append(f"{source}: activity root mancante: {value}")
+    return errors
+
+
+def project_course_design_sources(pack: dict[str, Any]) -> list[dict[str, Any]]:
+    """Project v1 sources into the current CourseDesign.sources contract."""
+    projected: list[dict[str, Any]] = []
+    for source in pack.get("sources", []):
+        if not isinstance(source, dict):
+            continue
+        item = {
+            "id": source.get("id"),
+            "label": source.get("label"),
+            "type": source.get("type"),
+            "provider": source.get("provider"),
+            "path": source.get("path", ""),
+            "files": deepcopy(source.get("files", [])),
+            "indexing_status": source.get("indexing_status"),
+        }
+        for key in ("repository", "ref", "updated_at"):
+            if key in source:
+                item[key] = source.get(key)
+        projected.append(item)
+    return projected
+
+
+def _joined_source_file(source: dict[str, Any], filename: str) -> str:
+    base = _text(source.get("path"))
+    return str(PurePosixPath(base) / filename) if base else filename
+
+
+def _infer_content_source_refs(
+    item: dict[str, Any], sources: list[dict[str, Any]]
+) -> list[dict[str, str]]:
+    path = _text(item.get("path"))
+    if not path:
+        return []
+    for source in sources:
+        for filename in source.get("files", []):
+            if (
+                isinstance(filename, str)
+                and _joined_source_file(source, filename) == path
+            ):
+                return [
+                    {
+                        "id": str(source.get("id")),
+                        "role": "content-origin",
+                        "locator": path,
+                    }
+                ]
+    return []
+
+
+def _infer_coverage(sources: list[dict[str, Any]]) -> dict[str, str] | None:
+    for source in sources:
+        for filename in source.get("files", []):
+            if (
+                isinstance(filename, str)
+                and PurePosixPath(filename).name.lower() == "coverage.md"
+            ):
+                return {
+                    "path": _joined_source_file(source, filename),
+                    "status": "draft",
+                }
+    return None
+
+
+def upgrade_v0_to_v1(pack: Any) -> dict[str, Any]:
+    """Upgrade a v0 authoring manifest without fetching or inventing sources."""
+    if not isinstance(pack, dict):
+        raise ValueError("content pack v0 deve essere un oggetto")
+    if pack.get("schema_version") != SCHEMA_V0:
+        raise ValueError(f"schema_version deve essere {SCHEMA_V0}")
+
+    result = deepcopy(pack)
+    result["schema_version"] = SCHEMA_V1
+
+    references: list[dict[str, Any]] = []
+    for raw in result.pop("curriculum_references", []):
+        if not isinstance(raw, dict):
+            continue
+        reference = deepcopy(raw)
+        reference.setdefault("kind", "reference")
+        reference.setdefault("role", "coverage-reference")
+        reference.setdefault("provider", "unknown")
+        reference.setdefault("title", reference.get("id", "reference"))
+        reference.setdefault("license_status", "review-required")
+        references.append(reference)
+    result["references"] = references
+
+    sources: list[dict[str, Any]] = []
+    for raw in result.get("sources", []):
+        if not isinstance(raw, dict):
+            continue
+        source = deepcopy(raw)
+        source.setdefault("kind", "source-package")
+        source.setdefault("label", source.get("id", "source"))
+        source.setdefault("role", "approved-course-content")
+        source.setdefault("license_status", "review-required")
+        source.setdefault("indexing_status", "ready")
+        source.setdefault("path", "")
+        sources.append(source)
+    result["sources"] = sources
+
+    for item in result.get("content_items", []):
+        if not isinstance(item, dict):
+            continue
+        item.setdefault("source_refs", _infer_content_source_refs(item, sources))
+
+    if "coverage" not in result:
+        coverage = _infer_coverage(sources)
+        if coverage is not None:
+            result["coverage"] = coverage
+
+    policies = (
+        deepcopy(result.get("policies", {}))
+        if isinstance(result.get("policies"), dict)
+        else {}
+    )
+    if "restricted_source_copying_forbidden" not in policies:
+        policies["restricted_source_copying_forbidden"] = bool(
+            policies.get("book_text_reproduction_forbidden", True)
+        )
+    result["policies"] = policies
+
+    compatibility = result.pop("compatibility", None)
+    if compatibility is not None:
+        extensions = (
+            deepcopy(result.get("extensions", {}))
+            if isinstance(result.get("extensions"), dict)
+            else {}
+        )
+        extensions["v0_compatibility"] = compatibility
+        result["extensions"] = extensions
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: atteso oggetto JSON")
+    return payload
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    pack = load_json(args.path)
+    errors = validate_content_pack(pack, str(args.path), root=args.root)
+    if errors:
+        print("Content Pack validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Content Pack validation passed.")
+    return 0
+
+
+def _cmd_upgrade(args: argparse.Namespace) -> int:
+    source = load_json(args.input)
+    upgraded = upgrade_v0_to_v1(source)
+    errors = validate_content_pack(upgraded, str(args.input))
+    if errors:
+        print("Content Pack v0 -> v1 upgrade produced invalid output:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    args.output.write_text(
+        json.dumps(upgraded, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Content Pack v1 scritto in {args.output}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Valida e migra TheBitLab Content Pack."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate")
+    validate.add_argument("path", type=Path)
+    validate.add_argument("--root", type=Path)
+    validate.set_defaults(handler=_cmd_validate)
+
+    upgrade = sub.add_parser("upgrade-v0")
+    upgrade.add_argument("input", type=Path)
+    upgrade.add_argument("output", type=Path)
+    upgrade.set_defaults(handler=_cmd_upgrade)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/content_pack_contract.py
+++ b/scripts/content_pack_contract.py
@@ -56,16 +56,17 @@ def _portable_id(value: Any, *, source_id: bool = False) -> bool:
 
 
 def _safe_relative_path(value: Any, *, allow_empty: bool = False) -> bool:
-    if not isinstance(value, str):
+    if not isinstance(value, str) or value != value.strip():
         return False
-    text = value.strip()
-    if not text:
+    if not value:
         return allow_empty
-    if "\\" in text or text.startswith("/"):
+    if "\\" in value or ":" in value or value.startswith("/"):
         return False
-    path = PurePosixPath(text)
-    return not path.is_absolute() and all(
-        part not in {"", ".", ".."} for part in path.parts
+    path = PurePosixPath(value)
+    return (
+        not path.is_absolute()
+        and all(part not in {"", ".", ".."} for part in path.parts)
+        and path.as_posix() == value
     )
 
 
@@ -238,13 +239,20 @@ def _validate_sources(value: Any, source: str, errors: list[str]) -> set[str]:
         if not _safe_relative_path(item.get("path", ""), allow_empty=True):
             errors.append(f"{prefix}.path deve essere un path relativo sicuro")
         files = item.get("files")
-        if not _list_of_unique_strings(files):
+        if not isinstance(files, list) or not files or not _list_of_unique_strings(files):
             errors.append(
-                f"{prefix}.files deve essere una lista di path unici non vuoti"
+                f"{prefix}.files deve essere una lista non vuota di path unici"
             )
         elif any(not _safe_relative_path(file) for file in files):
             errors.append(f"{prefix}.files contiene path non sicuri")
-        if provider in {"github", "gitlab"}:
+        if provider == "local":
+            if item.get("repository") is not None or item.get("ref") is not None:
+                errors.append(
+                    f"{prefix}: una fonte locale non accetta repository o ref"
+                )
+        elif provider in {"github", "gitlab"}:
+            if _text(item.get("path")):
+                errors.append(f"{prefix}: una fonte remota non accetta path locale")
             if not _text(item.get("repository")):
                 errors.append(f"{prefix}.repository richiesto per fonte remota")
             if not _text(item.get("ref")):
@@ -456,6 +464,18 @@ def validate_content_pack(
         )
     known_ids = reference_ids | source_ids
 
+    if isinstance(pack.get("sources"), list):
+        try:
+            from scripts import course_source_catalog
+
+            course_source_catalog.normalize_course_sources(
+                {"sources": project_course_design_sources(pack)}
+            )
+        except (TypeError, ValueError) as error:
+            errors.append(
+                f"{source}: sources non compatibili col Course Source Catalog: {error}"
+            )
+
     _validate_coverage(
         pack.get("coverage"),
         required=has_coverage_reference,
@@ -526,10 +546,13 @@ def validate_content_pack_paths(
         if not isinstance(source_item, dict) or source_item.get("provider") != "local":
             continue
         base = _text(source_item.get("path"))
-        for filename in source_item.get("files", []):
-            relative = (
-                str(PurePosixPath(base) / filename) if base else filename
-            )
+        files = source_item.get("files", [])
+        if not isinstance(files, list):
+            continue
+        for filename in files:
+            if not isinstance(filename, str):
+                continue
+            relative = str(PurePosixPath(base) / filename) if base else filename
             check_file(relative, f"source {source_item.get('id')}")
     for index, value in enumerate(pack.get("activity_roots", [])):
         if not _safe_relative_path(value):
@@ -556,13 +579,17 @@ def project_course_design_sources(pack: dict[str, Any]) -> list[dict[str, Any]]:
             "label": source.get("label"),
             "type": source.get("type"),
             "provider": source.get("provider"),
-            "path": source.get("path", ""),
             "files": deepcopy(source.get("files", [])),
             "indexing_status": source.get("indexing_status"),
         }
-        for key in ("repository", "ref", "updated_at"):
-            if key in source:
-                item[key] = source.get(key)
+        provider = source.get("provider")
+        if provider == "local":
+            item["path"] = source.get("path", "")
+        elif provider in {"github", "gitlab"}:
+            item["repository"] = source.get("repository")
+            item["ref"] = source.get("ref")
+        if "updated_at" in source:
+            item["updated_at"] = source.get("updated_at")
         projected.append(item)
     return projected
 

--- a/tests/fixtures/content_pack_v0.json
+++ b/tests/fixtures/content_pack_v0.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "thebitlab.content-pack.v0",
+  "id": "tpsi4-pack-example-2026",
+  "title": "TPSI quarto - example migration pack",
+  "version": "0.1.0",
+  "status": "draft",
+  "language": "it",
+  "audience": {
+    "school_level": "secondaria-secondo-grado",
+    "subject": "TPSI",
+    "year": 4
+  },
+  "ownership": {
+    "content_origin": "original-course-material",
+    "redistribution_status": "project-license-to-review",
+    "editorial_copying_allowed": false
+  },
+  "curriculum_references": [
+    {
+      "id": "tpsi4-curriculum-example",
+      "kind": "bibliographic-index",
+      "role": "coverage-reference",
+      "title": "TPSI quarto - indice pubblico",
+      "provider": "publisher",
+      "uri": "https://example.invalid/catalog",
+      "license_status": "reference-only",
+      "text_imported": false
+    }
+  ],
+  "sources": [
+    {
+      "id": "tpsi4-source-originali",
+      "kind": "source-package",
+      "type": "markdown",
+      "provider": "local",
+      "role": "approved-course-content",
+      "path": "content/tpsi_quarto",
+      "files": [
+        "README.md",
+        "COVERAGE.md",
+        "01_PROCESSI.md"
+      ],
+      "license_status": "project-license-to-review",
+      "indexing_status": "ready"
+    }
+  ],
+  "content_items": [
+    {
+      "id": "tpsi4-content-processi",
+      "kind": "module",
+      "path": "content/tpsi_quarto/01_PROCESSI.md",
+      "order": 1,
+      "status": "draft",
+      "curriculum_topics": [
+        "processi"
+      ],
+      "activity_ids": [
+        "tpsi4-activity-c-processi-001"
+      ]
+    }
+  ],
+  "course_designs": [
+    {
+      "id": "tpsi4-course-2026-2027",
+      "path": "doc/course_designs/tpsi_quarto_2026_2027.json",
+      "status": "draft"
+    }
+  ],
+  "activity_roots": [
+    "activities/tpsi_quarto"
+  ],
+  "policies": {
+    "provenance_required": true,
+    "teacher_review_required_before_publish": true,
+    "student_teacher_asset_separation_required": true,
+    "ai_is_not_primary_source": true,
+    "book_text_reproduction_forbidden": true
+  },
+  "compatibility": {
+    "current": [
+      "course-source-catalog-markdown",
+      "course-design-json-v1",
+      "activity-schema-1.0"
+    ]
+  }
+}

--- a/tests/fixtures/content_pack_v1.json
+++ b/tests/fixtures/content_pack_v1.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "thebitlab.content-pack.v1",
+  "id": "tpsi5-pack-fullstack-2026",
+  "title": "TPSI quinto - Full Stack Web Development",
+  "version": "0.1.0",
+  "status": "draft",
+  "language": "it",
+  "audience": {
+    "school_level": "secondaria-secondo-grado",
+    "subject": "TPSI",
+    "year": 5
+  },
+  "ownership": {
+    "content_origin": "original-course-material",
+    "redistribution_status": "project-license-to-review",
+    "editorial_copying_allowed": false
+  },
+  "references": [
+    {
+      "id": "tpsi5-ref-curriculum",
+      "kind": "curriculum",
+      "role": "coverage-reference",
+      "provider": "school",
+      "title": "TPSI quinto - riferimento curricolare",
+      "access": "public",
+      "license_status": "reference-only"
+    },
+    {
+      "id": "tpsi5-ref-mdn-html",
+      "kind": "documentation",
+      "role": "technical-reference",
+      "provider": "mdn",
+      "title": "MDN Web Docs - HTML",
+      "uri": "https://developer.mozilla.org/en-US/docs/Web/HTML",
+      "access": "public",
+      "license_status": "reference-and-license-aware-reuse"
+    },
+    {
+      "id": "tpsi5-ref-manning-css",
+      "kind": "book",
+      "role": "teacher-reference",
+      "provider": "manning",
+      "title": "CSS in Depth, Second Edition",
+      "access": "licensed",
+      "license_status": "licensed-reference-only"
+    }
+  ],
+  "sources": [
+    {
+      "id": "tpsi5-source-originali",
+      "kind": "source-package",
+      "label": "TPSI quinto - contenuti originali",
+      "type": "markdown",
+      "provider": "local",
+      "role": "approved-course-content",
+      "path": "content/tpsi5",
+      "files": [
+        "README.md",
+        "COVERAGE.md",
+        "01_WEB_FOUNDATIONS.md"
+      ],
+      "license_status": "project-license-to-review",
+      "indexing_status": "ready"
+    }
+  ],
+  "coverage": {
+    "path": "content/tpsi5/COVERAGE.md",
+    "status": "draft"
+  },
+  "content_items": [
+    {
+      "id": "tpsi5-content-web-foundations",
+      "kind": "module",
+      "path": "content/tpsi5/01_WEB_FOUNDATIONS.md",
+      "order": 1,
+      "status": "draft",
+      "curriculum_topics": [
+        "web-platform",
+        "html-semantics"
+      ],
+      "activity_ids": [
+        "tpsi5-activity-a-html-document-001"
+      ],
+      "source_refs": [
+        {
+          "id": "tpsi5-source-originali",
+          "role": "content-origin",
+          "locator": "content/tpsi5/01_WEB_FOUNDATIONS.md"
+        },
+        {
+          "id": "tpsi5-ref-mdn-html",
+          "role": "technical-reference",
+          "locator": "HTML reference"
+        }
+      ]
+    }
+  ],
+  "course_designs": [
+    {
+      "id": "tpsi5-course-2026-2027",
+      "path": "doc/course_designs/tpsi_quinto_2026_2027.json",
+      "status": "draft"
+    }
+  ],
+  "activity_roots": [
+    "activities/tpsi5"
+  ],
+  "policies": {
+    "provenance_required": true,
+    "teacher_review_required_before_publish": true,
+    "student_teacher_asset_separation_required": true,
+    "ai_is_not_primary_source": true,
+    "restricted_source_copying_forbidden": true
+  }
+}

--- a/tests/test_content_pack_contract.py
+++ b/tests/test_content_pack_contract.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 import json
 from pathlib import Path
 
@@ -46,6 +45,57 @@ def test_sources_project_to_current_course_source_catalog() -> None:
         "README.md",
         "COVERAGE.md",
         "01_WEB_FOUNDATIONS.md",
+    )
+
+
+def test_remote_source_projects_without_local_path() -> None:
+    pack = load(V1_FIXTURE)
+    pack["sources"] = [
+        {
+            "id": "tpsi5-source-web-upstream",
+            "kind": "source-package",
+            "label": "Web course upstream",
+            "type": "markdown",
+            "provider": "github",
+            "role": "technical-reference",
+            "files": ["README.md"],
+            "repository": "TheBitPoets/web-course",
+            "ref": "main",
+            "license_status": "review-required",
+            "indexing_status": "ready"
+        }
+    ]
+    pack["content_items"][0]["source_refs"] = [
+        {
+            "id": "tpsi5-ref-mdn-html",
+            "role": "technical-reference",
+            "locator": "HTML reference"
+        }
+    ]
+
+    assert validate_content_pack(pack) == []
+    projected = project_course_design_sources(pack)
+    assert "path" not in projected[0]
+    assert projected[0]["repository"] == "TheBitPoets/web-course"
+    assert projected[0]["ref"] == "main"
+
+    normalized = course_source_catalog.normalize_course_sources(
+        {"sources": projected}
+    )
+    assert normalized[0].provider == "github"
+    assert normalized[0].repository == "TheBitPoets/web-course"
+
+
+def test_indexable_source_must_really_be_markdown() -> None:
+    pack = load(V1_FIXTURE)
+    pack["sources"][0]["files"] = ["README.txt"]
+
+    errors = validate_content_pack(pack)
+
+    assert any(
+        "sources non compatibili col Course Source Catalog" in error
+        and "Markdown" in error
+        for error in errors
     )
 
 

--- a/tests/test_content_pack_contract.py
+++ b/tests/test_content_pack_contract.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+from scripts import course_source_catalog
+from scripts.content_pack_contract import (
+    SCHEMA_V1,
+    project_course_design_sources,
+    upgrade_v0_to_v1,
+    validate_content_pack,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures"
+V1_FIXTURE = FIXTURES / "content_pack_v1.json"
+V0_FIXTURE = FIXTURES / "content_pack_v0.json"
+
+
+def load(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_canonical_v1_fixture_is_valid() -> None:
+    pack = load(V1_FIXTURE)
+
+    assert validate_content_pack(pack, str(V1_FIXTURE)) == []
+
+
+def test_sources_project_to_current_course_source_catalog() -> None:
+    pack = load(V1_FIXTURE)
+    projected = project_course_design_sources(pack)
+
+    normalized = course_source_catalog.normalize_course_sources(
+        {"sources": projected}
+    )
+
+    assert len(normalized) == 1
+    assert normalized[0].source_id == "tpsi5-source-originali"
+    assert normalized[0].provider == "local"
+    assert normalized[0].files == (
+        "README.md",
+        "COVERAGE.md",
+        "01_WEB_FOUNDATIONS.md",
+    )
+
+
+def test_coverage_is_required_when_pack_has_coverage_reference() -> None:
+    pack = load(V1_FIXTURE)
+    pack.pop("coverage")
+
+    errors = validate_content_pack(pack)
+
+    assert any("coverage richiesto" in error for error in errors)
+
+
+def test_provenance_must_reference_known_source_or_reference() -> None:
+    pack = load(V1_FIXTURE)
+    pack["content_items"][0]["source_refs"][0]["id"] = "unknown-source"
+
+    errors = validate_content_pack(pack)
+
+    assert any("source_refs[0].id sconosciuto" in error for error in errors)
+
+
+def test_source_and_reference_ids_share_one_namespace() -> None:
+    pack = load(V1_FIXTURE)
+    pack["references"][0]["id"] = "tpsi5-source-originali"
+
+    errors = validate_content_pack(pack)
+
+    assert any("ID condivisi fra sources e references" in error for error in errors)
+
+
+def test_paths_cannot_escape_pack_root() -> None:
+    pack = load(V1_FIXTURE)
+    pack["content_items"][0]["path"] = "../secret.md"
+    pack["activity_roots"] = ["activities/tpsi5", "../other"]
+
+    errors = validate_content_pack(pack)
+
+    assert any("content_items[0].path" in error for error in errors)
+    assert any("activity_roots[1]" in error for error in errors)
+
+
+def test_indexable_source_requires_at_least_one_file() -> None:
+    pack = load(V1_FIXTURE)
+    pack["sources"][0]["files"] = []
+
+    errors = validate_content_pack(pack)
+
+    assert any("sources[0].files" in error for error in errors)
+
+
+def test_approved_pack_requires_approved_content_design_and_coverage() -> None:
+    pack = load(V1_FIXTURE)
+    pack["status"] = "approved"
+
+    errors = validate_content_pack(pack)
+
+    assert any("content item non approved" in error for error in errors)
+    assert any("course design non approved" in error for error in errors)
+    assert any("coverage approved" in error for error in errors)
+
+    pack["content_items"][0]["status"] = "approved"
+    pack["course_designs"][0]["status"] = "approved"
+    pack["coverage"]["status"] = "approved"
+    assert validate_content_pack(pack) == []
+
+
+def test_v0_upgrade_is_deterministic_and_valid() -> None:
+    old = load(V0_FIXTURE)
+
+    upgraded = upgrade_v0_to_v1(old)
+
+    assert upgraded["schema_version"] == SCHEMA_V1
+    assert upgraded["references"][0]["id"] == "tpsi4-curriculum-example"
+    assert upgraded["sources"][0]["label"] == "tpsi4-source-originali"
+    assert upgraded["coverage"] == {
+        "path": "content/tpsi_quarto/COVERAGE.md",
+        "status": "draft",
+    }
+    assert upgraded["content_items"][0]["source_refs"] == [
+        {
+            "id": "tpsi4-source-originali",
+            "role": "content-origin",
+            "locator": "content/tpsi_quarto/01_PROCESSI.md",
+        }
+    ]
+    assert upgraded["policies"]["restricted_source_copying_forbidden"] is True
+    assert upgraded["extensions"]["v0_compatibility"] == old["compatibility"]
+    assert "compatibility" not in upgraded
+    assert validate_content_pack(upgraded) == []
+
+
+def test_v0_upgrade_does_not_invent_missing_provenance() -> None:
+    old = load(V0_FIXTURE)
+    old["content_items"][0]["path"] = "content/tpsi_quarto/NOT_DECLARED.md"
+
+    upgraded = upgrade_v0_to_v1(old)
+    errors = validate_content_pack(upgraded)
+
+    assert upgraded["content_items"][0]["source_refs"] == []
+    assert any("source_refs deve essere una lista non vuota" in error for error in errors)
+
+
+def test_root_validation_checks_declared_files_and_activity_roots(
+    tmp_path: Path,
+) -> None:
+    pack = load(V1_FIXTURE)
+
+    content = tmp_path / "content" / "tpsi5"
+    content.mkdir(parents=True)
+    for filename in ("README.md", "COVERAGE.md", "01_WEB_FOUNDATIONS.md"):
+        (content / filename).write_text(f"# {filename}\n", encoding="utf-8")
+
+    design = tmp_path / "doc" / "course_designs"
+    design.mkdir(parents=True)
+    (design / "tpsi_quinto_2026_2027.json").write_text("{}\n", encoding="utf-8")
+
+    (tmp_path / "activities" / "tpsi5").mkdir(parents=True)
+
+    assert validate_content_pack(pack, root=tmp_path) == []
+
+    (content / "01_WEB_FOUNDATIONS.md").unlink()
+    errors = validate_content_pack(pack, root=tmp_path)
+    assert any("01_WEB_FOUNDATIONS.md" in error for error in errors)
+
+
+def test_references_can_model_public_and_licensed_material_without_ingestion() -> None:
+    pack = load(V1_FIXTURE)
+    providers = {item["provider"]: item for item in pack["references"]}
+
+    assert providers["mdn"]["role"] == "technical-reference"
+    assert providers["mdn"]["access"] == "public"
+    assert providers["manning"]["role"] == "teacher-reference"
+    assert providers["manning"]["access"] == "licensed"
+    assert all(source["provider"] != "manning" for source in pack["sources"])


### PR DESCRIPTION
## What changed

- define `thebitlab.content-pack.v1` as the cross-course authoring/provenance standard derived from TPSI quarto #625;
- keep a strict boundary between Content Pack v1, Course Design v1, Activity schema 1.0 and Course Bundle Format 1.0.0;
- distinguish Course Board-indexable `sources` from non-ingested `references` such as MDN/WHATWG/RFC and licensed Manning/Pluralsight material;
- add a dependency-free validator with stable IDs, SemVer, editorial lifecycle, provenance, coverage and safe-path checks;
- project v1 indexable sources through the existing `course_source_catalog` contract rather than defining a competing catalog;
- add deterministic `content-pack.v0 -> v1` migration that does not fetch external resources or invent missing provenance;
- add canonical TPSI5-like and TPSI4-v0 fixtures plus conformance/regression tests.

## Why

TPSI quarto already established the right authoring concepts, but its manifest is explicitly `thebitlab.content-pack.v0` / draft. Before starting the fifth-year Full Stack course and the separate SQL course, we need one stable authoring contract so new courses do not drift into incompatible formats.

## Boundary

`Content Pack v1 -> Course Design + Activity 1.0 -> review/freeze -> Course Bundle 1.0.0 -> TheBitLab runtime`

This PR intentionally does **not** add new Course Board UI, new source providers, scraping/downloading of external course material, or a new Activity format.

## Validation target

- new tests in `tests/test_content_pack_contract.py`;
- existing Python suite/course plan/Sphinx CI must remain green;
- current `course_source_catalog` validates the projected v1 source declarations.

Closes part of #723. Context: #625, #290, #708.