### PR TITLE
Accept Content Pack Standard v1

### DIFF
--- a/doc/architecture/content-pack-standard-v1.md
+++ b/doc/architecture/content-pack-standard-v1.md
@@ -2,13 +2,24 @@
 
 ## Stato
 
-**Proposto** nell'ambito di #723. Il contratto nasce dal pacchetto sperimentale TPSI quarto (#625) e viene consolidato prima di avviare TPSI quinto Full Stack e il corso SQL.
+**Accettato** il 19 agosto 2026 nell'ambito di #723, dopo adozione reale su due corsi differenti e verifica della tassonomia Activity A-E.
 
 Schema canonico:
 
 ```text
 thebitlab.content-pack.v1
 ```
+
+### Evidenze di accettazione
+
+La v1 non viene accettata sulla sola base delle fixture. Il gate ha richiesto consumer reali:
+
+- `TheBitPoets/tpsi-quarto-docente`: migrazione conservativa `content-pack.v0 -> v1`, mantenendo il manifest v0 affiancato, coverage, provenance, Course Design e Activity; PR #3 mergiata allo SHA `6e0f1e662a50e8e6feac50cd1e9c80576cd0c9f3`, con CI verde su Ubuntu Python 3.11/3.12 e Windows Python 3.11;
+- `TheBitPoets/tpsi-quinto-docente`: consumer nato direttamente in v1, con fonti locali/remoto-pinned, reference tecniche e teacher-reference licensed, Course Design da 33 settimane e Activity reali A-E; il gate finale include la milestone Bootstrap/Feisbuc mergiata allo SHA `9c333d0ebe3d0bffc133e27edcb0d3ec6293783a`, con CI verde su Ubuntu Python 3.11/3.12 e Windows Python 3.11;
+- regressione del projector per source `local` alla root: `path: ""` resta valido nel Content Pack ma viene omesso dalla proiezione `CourseDesign.sources`, risultando accettato dal `course_source_catalog` reale (#727);
+- l'intera suite `2cornot2c` resta il gate finale prima del merge dell'accettazione.
+
+L'accettazione riguarda **il contratto di authoring `thebitlab.content-pack.v1`**. Non implica che i corsi consumer siano `approved` o congelati, non sceglie framework/ORM/TypeScript per TPSI5 e non dichiara implementato il grading HTML/browser, che resta governato separatamente da #729.
 
 ## Scopo
 
@@ -192,6 +203,8 @@ Ogni source e un `source-package` e deve dichiarare almeno:
 ```
 
 Per `github`/`gitlab` restano necessari `repository` e `ref`, coerentemente con `course_source_catalog`.
+
+Una source locale puo usare `path: ""` per indicare la root del repository. Nella proiezione verso `CourseDesign.sources`, il campo `path` viene omesso quando e vuoto, cosi il risultato resta compatibile con il catalogo corrente.
 
 Un Content Pack v1 deve poter proiettare `sources` direttamente nella forma `CourseDesign.sources` senza perdere i campi necessari all'indicizzazione.
 
@@ -401,7 +414,7 @@ Course Bundle 1.0.0
 BundleReference esterno con tag/SHA
 ```
 
-La conversione automatica non fa parte del primo incremento #723; il boundary e pero vincolante per evitare che i due manifest evolvano in formati concorrenti.
+La conversione automatica non fa parte della v1; il boundary e pero vincolante per evitare che i due manifest evolvano in formati concorrenti.
 
 ## Conformance
 
@@ -432,18 +445,19 @@ I test di conformita verificano almeno:
 - provenance obbligatoria;
 - coverage quando esiste un riferimento curricolare;
 - lifecycle `approved`;
-- proiezione `sources -> CourseDesign.sources`;
+- proiezione `sources -> CourseDesign.sources`, inclusa una source locale alla root senza `path` vuoto serializzato;
 - migrazione v0 -> v1 senza perdita dei metadati legacy rilevanti.
 
 ## Evoluzioni successive
 
-Non fanno parte della v1 iniziale:
+Non fanno parte della v1 accettata:
 
 - ingestione diretta di siti/PDF/provider licensed;
 - credenziali nel manifest;
 - marketplace/licensing runtime;
 - ContentBlock/ContentVersion persistenti lato server;
 - builder automatico Content Pack -> Course Bundle;
-- modifica dell'Activity schema.
+- modifica dell'Activity schema;
+- grading HTML/browser automatico.
 
 Queste evoluzioni devono preservare gli ID e il significato editoriale della v1.

--- a/scripts/content_pack_contract.py
+++ b/scripts/content_pack_contract.py
@@ -584,7 +584,9 @@ def project_course_design_sources(pack: dict[str, Any]) -> list[dict[str, Any]]:
         }
         provider = source.get("provider")
         if provider == "local":
-            item["path"] = source.get("path", "")
+            path = _text(source.get("path"))
+            if path:
+                item["path"] = path
         elif provider in {"github", "gitlab"}:
             item["repository"] = source.get("repository")
             item["ref"] = source.get("ref")

--- a/tests/test_content_pack_root_local_projection.py
+++ b/tests/test_content_pack_root_local_projection.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import course_source_catalog
+from scripts.content_pack_contract import (
+    project_course_design_sources,
+    validate_content_pack,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "content_pack_v1.json"
+
+
+def load_fixture() -> dict:
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_local_source_at_repository_root_omits_empty_path_in_projection() -> None:
+    pack = load_fixture()
+    pack["sources"] = [
+        {
+            "id": "tpsi5-source-root",
+            "kind": "source-package",
+            "label": "Root Markdown source",
+            "type": "markdown",
+            "provider": "local",
+            "role": "technical-reference",
+            "path": "",
+            "files": ["README.md"],
+            "license_status": "review-required",
+            "indexing_status": "ready",
+        }
+    ]
+    # Keep required provenance valid without claiming that the fixture content
+    # originated from the root source used only to exercise the projection edge case.
+    pack["content_items"][0]["source_refs"] = [
+        {
+            "id": "tpsi5-ref-mdn-html",
+            "role": "technical-reference",
+            "locator": "HTML reference",
+        }
+    ]
+
+    assert validate_content_pack(pack) == []
+
+    projected = project_course_design_sources(pack)
+    assert len(projected) == 1
+    assert projected[0]["provider"] == "local"
+    assert projected[0]["files"] == ["README.md"]
+    assert "path" not in projected[0]
+
+    normalized = course_source_catalog.normalize_course_sources(
+        {"sources": projected}
+    )
+    assert len(normalized) == 1
+    assert normalized[0].provider == "local"
+    assert normalized[0].path == ""
+    assert normalized[0].files == ("README.md",)


### PR DESCRIPTION
## What changed

- fix #727 by omitting `path` from `CourseDesign.sources` projection when a local Content Pack source represents the repository root with `path: ""`;
- add a regression that validates the projected root-local source through the real `course_source_catalog`;
- promote `doc/architecture/content-pack-standard-v1.md` from `Proposto` to `Accettato`;
- record real adoption evidence from TPSI4 (migrated v0 -> v1) and TPSI5 (native v1 with representative Activity A-E);
- clarify that standard acceptance freezes the authoring contract boundary, not the lifecycle state of consumer courses and not HTML/browser grading.

## Evidence

- TPSI4 consumer: `TheBitPoets/tpsi-quarto-docente` merge `6e0f1e662a50e8e6feac50cd1e9c80576cd0c9f3`, CI green on Ubuntu 3.11/3.12 and Windows 3.11;
- TPSI5 consumer: `TheBitPoets/tpsi-quinto-docente` Bootstrap/Activity E merge `9c333d0ebe3d0bffc133e27edcb0d3ec6293783a`, completing A-E; CI green on Ubuntu 3.11/3.12 and Windows 3.11;
- root-local projection regression exercises `course_source_catalog.normalize_course_sources()` rather than only inspecting raw JSON;
- final 2cornot2c gate green: Quality `32243007997`, assignment-runner Docker `32243008015`, uTUI consumer evidence `32243008008`.

## Non-scope

- TPSI5 remains draft and continues with JavaScript/DOM/HTTP/backend/DB/etc.;
- frontend framework, Node ORM and TypeScript depth remain course-level TBDs;
- HTML/browser autograding remains in #729;
- no Course Bundle or Activity schema change.

Merged as `5472eef86568a4e7ce59ad34ba937220df27efd7`.

Closes #727. Completes the acceptance gate tracked in #723.