### PR TITLE
feat(runtime): broker plugin execution through sandbox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ docker/assignment-runner/*
 !scripts/
 scripts/*
 !scripts/grade_activity.py
+!scripts/thebitlab_sandbox_boundary.py

--- a/CHECKPOINT-runtime-sandbox.md
+++ b/CHECKPOINT-runtime-sandbox.md
@@ -1,0 +1,52 @@
+# Checkpoint runtime sandbox TheBitLab
+
+- **Data:** 2026-08-21
+- **Obiettivo:** estendere il boundary Docker ufficiale alle Activity runtime mantenendo
+  submission e grading host separati.
+- **Stato:** implementazione upstream completata e integrata con Romeo; nessun commit o push.
+- **Worktree:** `F:\dev\romeo\.worktrees\2cornot2c-runtime`, base
+  `5472eef86568a4e7ce59ad34ba937220df27efd7`.
+
+## Risultato
+
+- API v1 `describe/probe/launch/run/close` compatibile; `run()` locale e marcato non
+  autorevole.
+- Estensione `sandbox-plan.v1` con `prepare_sandbox` e `finalize_sandbox`.
+- Broker Docker comune con lo stesso profilo hardened di `grade_activity.py`.
+- Input submission e Activity copiati solo per lista esplicita, con containment e rifiuto
+  symlink; scenario, rubrica e grader non sono montati automaticamente.
+- Backend `docker` fail-closed senza capability; nessun fallback locale.
+- `confined_regular_input` corretto per verificare symlink sul percorso lessicale.
+- Target confrontati senza distinzione maiuscole/minuscole per evitare overwrite su
+  Windows; `worker_request` limitata a 64 KiB.
+- Errori di file Activity e assenza di Docker restano distinti nel report studente.
+
+## File
+
+Nuovi:
+
+- `scripts/thebitlab_runtime_sandbox.py`
+- `tests/test_thebitlab_runtime_sandbox.py`
+
+Modificati: contratti/dispatch runtime, helper Docker in `grade_activity.py`, test runtime e
+documentazione sandbox/adapter/servizi tecnici. Vedere `git status --short` per l'elenco esatto.
+
+## Verifiche
+
+- Suite mirata runtime, grading e technical services: passata, con 5 skip host-specific.
+- `compileall`: passato.
+- Ruff `F` sui file Python modificati: passato.
+- Ruff completo non e baseline-clean per errori preesistenti di stile.
+- `git diff --check`: passato.
+- Suite completa: non raccolta per dipendenza opzionale `utui` assente in
+  ambiente standard. Eseguita anche con la release uTUI locale: raggiunge il 100%; restano
+  due failure host-specific preesistenti (privilegio symlink Windows e lancio diretto di uno
+  script macOS `.sh` su Windows), nessuno nei moduli runtime/sandbox.
+- Piano Romeo Y2 validato direttamente con `sandbox_plan_from_payload()` upstream.
+
+## Prossimo passo
+
+Pubblicare l'immagine Romeo da base OCI per digest e wheelhouse verificata, quindi eseguire il
+smoke test Docker reale. Scenario, rubrica e grader geometrico restano fuori dal piano sandbox.
+Il behavioural test montato read-only non e segreto rispetto al codice nello stesso container e
+non deve contenere credenziali o expected outcome sensibili.

--- a/CHECKPOINT-runtime-sandbox.md
+++ b/CHECKPOINT-runtime-sandbox.md
@@ -3,7 +3,7 @@
 - **Data:** 2026-08-21
 - **Obiettivo:** estendere il boundary Docker ufficiale alle Activity runtime mantenendo
   submission e grading host separati.
-- **Stato:** implementazione upstream completata e integrata con Romeo; nessun commit o push.
+- **Stato:** implementazione upstream completata e integrata con Romeo nella PR draft #732.
 - **Worktree:** `F:\dev\romeo\.worktrees\2cornot2c-runtime`, base
   `5472eef86568a4e7ce59ad34ba937220df27efd7`.
 
@@ -43,6 +43,8 @@ documentazione sandbox/adapter/servizi tecnici. Vedere `git status --short` per 
   due failure host-specific preesistenti (privilegio symlink Windows e lancio diretto di uno
   script macOS `.sh` su Windows), nessuno nei moduli runtime/sandbox.
 - Piano Romeo Y2 validato direttamente con `sandbox_plan_from_payload()` upstream.
+- CI Docker build e smoke test verificati dopo aver preservato l'entry point diretto di
+  `grade_activity.py` e incluso il boundary condiviso nell'immagine.
 
 ## Prossimo passo
 

--- a/doc/ASSIGNMENT_SANDBOX.md
+++ b/doc/ASSIGNMENT_SANDBOX.md
@@ -204,3 +204,29 @@ Il grading Docker e la strada consigliata per codice studente, perche prepara il
 - runner senza segreti;
 - report raccolti in modo uniforme;
 - futuri runner multi-linguaggio.
+
+## Runtime plugin
+
+Le Activity `extensions.thebitlab.runtime` usano lo stesso profilo Docker tramite il broker
+comune. Il dispatcher conserva `run()` per il backend locale formativo; con backend `docker`
+richiede invece la capability `sandbox-plan.v1` e orchestra:
+
+```text
+prepare_sandbox trusted -> worker Docker untrusted -> finalize_sandbox trusted
+```
+
+Il worker riceve soltanto gli artifact submission e gli eventuali file Activity elencati
+esplicitamente nel piano, copiati dopo verifica di containment e assenza di symlink. I file
+Activity servono, per esempio, a hidden test comportamentali eseguiti dentro il container.
+Scenario, rubrica e grader possono e devono restare sull'host quando il runtime puo produrre
+una trace tecnica sufficiente. Il payload restituito dal worker non e una decisione di voto:
+il plugin trusted lo valida e ricostruisce `runtime_execution.v1` sull'host.
+
+Read-only non rende segreto un hidden test al programma nello stesso container: questi file
+non devono contenere credenziali o expected outcome sensibili. La parte che deve restare
+segreta e autorevole non viene montata e rimane nel finalize host.
+
+Il piano plugin non puo modificare rete, mount, environment, comando, utente, capability o
+limiti del container. L'immagine deve essere indicata con digest OCI immutabile. Mancanza
+dell'estensione sandbox, timeout e failure infrastrutturali falliscono chiusi e non provocano
+fallback all'esecuzione locale.

--- a/doc/architecture/runtime-adapter-template.md
+++ b/doc/architecture/runtime-adapter-template.md
@@ -171,6 +171,41 @@ Quando non lo supporta, l'Activity non deve richiedere `deterministic-grade`; Th
 
 ## Strategie per runtime diversi
 
+## Grading sandbox di codice non affidabile
+
+`run()` e sufficiente per esecuzioni locali formative. Un adapter che vuole supportare grading
+autorevole di codice non affidabile dichiara `sandbox-plan.v1` e aggiunge due metodi senza
+importare moduli interni TheBitLab:
+
+```python
+def prepare_sandbox(self, request):
+    return {
+        "schema_version": "runtime_sandbox_plan.v1",
+        "profile": {
+            "image": "ghcr.io/example/runtime@sha256:<64 cifre esadecimali>",
+            "platform": "linux/amd64",
+            "worker_schema": "example.trace.v1",
+        },
+        "inputs": [
+            {"source": "submission", "artifact_id": "primary", "target": "main.py"},
+            {"source": "activity", "path": "hidden_tests.py", "target": "hidden_tests.py"},
+        ],
+        "worker_request": {"schema_version": "example.worker.v1"},
+    }
+
+def finalize_sandbox(self, request, sandbox_result):
+    # sandbox_result e untrusted: validare la trace e ricostruire test/voto lato host.
+    return {
+        "schema_version": "runtime_execution.v1",
+        "status": "passed",
+        "tests": [{"name": "comportamento", "passed": True}],
+    }
+```
+
+Il worker non deve ricevere scenario, rubriche o expected outcome se questi possono restare
+nel grader host. Un hidden test eseguito nel container puo osservare il comportamento del
+codice, ma il risultato valutativo finale resta responsabilita del finalize trusted.
+
 ### Runtime standalone con propria UI
 
 Esempio concettuale: Efesto.

--- a/doc/architecture/runtime-plugin-contract.md
+++ b/doc/architecture/runtime-plugin-contract.md
@@ -229,6 +229,53 @@ Apre una sessione interattiva quando supportata. L'endpoint/comando operativo pr
 
 Esegue la parte headless quando supportata e restituisce il normale `ExecutionResult` TheBitLab.
 
+Per compatibilita, `run()` resta il percorso locale formativo della API v1. Non e un confine
+di sicurezza: TheBitLab marca questi risultati `authoritative=false` e
+`execution_isolation=process-only`.
+
+### Estensione sandbox autorevole
+
+Un plugin che dichiara la capability `sandbox-plan.v1` deve implementare anche:
+
+```text
+prepare_sandbox(RuntimeRequest) -> runtime_sandbox_plan.v1
+finalize_sandbox(RuntimeRequest, runtime_sandbox_result.v1) -> runtime_execution.v1
+```
+
+Il flusso e:
+
+```text
+plugin trusted prepara il piano
+  -> broker Docker comune TheBitLab esegue gli input untrusted
+  -> plugin trusted ricostruisce test e grading dal solo risultato untrusted
+```
+
+Il piano puo scegliere esclusivamente un'immagine OCI con digest `sha256`, piattaforma,
+schema worker, input espliciti e un payload dati per il worker. Non puo scegliere comando,
+environment, mount, rete, capability Linux o altri controlli host. L'entrypoint appartiene
+all'immagine installata e bloccata dal plugin trusted.
+
+Gli input ammessi sono:
+
+- artifact submission gia dichiarati dall'Activity;
+- file teacher-side espliciti sotto la directory dell'Activity, per esempio
+  `hidden_tests.py`.
+
+TheBitLab copia soltanto questi file regolari in un workspace temporaneo read-only e rifiuta
+symlink, path escape e target duplicati. Scenario, rubrica, grader host, altre submission e
+directory degli artifact di risultato non entrano nel container salvo siano stati
+erroneamente elencati dal plugin trusted. La policy degli adapter deve quindi includere nel
+piano solo il minimo necessario al worker.
+
+Un file Activity copiato nel container non e segreto rispetto al codice in esecuzione nello
+stesso container. Gli hidden test possono restare non distribuiti prima del tentativo, ma non
+devono contenere credenziali, risposte o expected outcome che richiedano segretezza durante
+l'esecuzione. Il confronto autorevole resta sull'host.
+
+Il payload del container resta interamente untrusted. Non puo assegnare voto, stato del
+simulatore o risultato geometrico: `finalize_sandbox()` deve validarlo e ricostruire questi
+valori sul processo host trusted. Timeout o errore infrastrutturale non chiamano il finalize.
+
 ### `close`
 
 Chiude una sessione aperta dal plugin.
@@ -243,6 +290,8 @@ Chiude una sessione aperta dal plugin.
 6. La configurazione runtime-specifica proviene dal course bundle trusted e viene validata dal plugin.
 7. Gli artifact studente restano untrusted.
 8. Il grading deterministico, quando dichiarato, deve poter essere ricostruito lato trusted.
+9. Il backend Docker per runtime fallisce chiuso se manca `sandbox-plan.v1`; non ripiega su
+   `run()` locale.
 
 ## Runtime proprietari o con licenza
 

--- a/doc/architecture/technical-services.md
+++ b/doc/architecture/technical-services.md
@@ -115,6 +115,13 @@ I report prodotti da `scripts/grade_activity.py` vengono convertiti nel contratt
 
 `DockerGradeActivityExecutionService` implementa la stessa porta sopra il runner Docker autorevole. Normalizza runner assente, timeout e errori di protocollo, mentre `student_lab_runner.py` si limita a costruire la richiesta tecnica e serializzare il risultato nel contratto pubblico `student_lab_run.v1`. Durante la transizione, `ExecutionResult.metadata.runner_report` conserva una copia difensiva del report del runner per non perdere campi di toolchain o dettagli gia consumati dalle dashboard.
 
+Le Activity runtime usano il port specializzato `RuntimeSandboxExecutionService`, definito in
+`scripts/thebitlab_runtime_sandbox.py`. Il plugin trusted prepara un piano dichiarativo, il
+servizio applica lo stesso boundary Docker di `grade_activity.py`, quindi il plugin trusted
+ricostruisce `ExecutionResult`. Questa specializzazione e necessaria per lasciare semantica,
+simulatore e grader nel package runtime senza permettere al plugin di modificare i controlli
+host del container. Non introduce un secondo profilo sandbox.
+
 `DeterministicAiFeedbackService` fornisce una prima implementazione mockabile di `AiFeedbackService`: genera bozze di feedback a partire dal `GradingResult` senza chiamare provider esterni. Serve per stabilizzare flussi, test e dashboard prima di collegare un adapter AI reale.
 
 ## Provider AI e workflow ChatGPT

--- a/docker/assignment-runner/Dockerfile
+++ b/docker/assignment-runner/Dockerfile
@@ -36,6 +36,7 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources \
 RUN useradd --create-home --shell /usr/sbin/nologin runner
 
 COPY scripts/grade_activity.py /opt/thebitlab/grade_activity.py
+COPY scripts/thebitlab_sandbox_boundary.py /opt/thebitlab/thebitlab_sandbox_boundary.py
 
 WORKDIR /submission
 

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -18,7 +18,10 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from scripts.thebitlab_runtime_sandbox import docker_boundary_command
+try:
+    from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+except ModuleNotFoundError:  # direct ``python scripts/grade_activity.py`` execution
+    from thebitlab_sandbox_boundary import docker_boundary_command
 
 DEFAULT_TIMEOUT_SECONDS = 5
 DEFAULT_NODE_STARTUP_GRACE_SECONDS = 10

--- a/scripts/grade_activity.py
+++ b/scripts/grade_activity.py
@@ -6,18 +6,19 @@ import argparse
 import json
 import os
 import re
-import signal
 import shutil
+import signal
 import sqlite3
 import subprocess
+import sys
 import tempfile
 import threading
-import sys
 import time
 import uuid
 from pathlib import Path
 from typing import Any
 
+from scripts.thebitlab_runtime_sandbox import docker_boundary_command
 
 DEFAULT_TIMEOUT_SECONDS = 5
 DEFAULT_NODE_STARTUP_GRACE_SECONDS = 10
@@ -744,9 +745,9 @@ def confined_regular_input(path: Path, root: Path, label: str) -> Path:
     """Resolve one input without following links outside its authorized root."""
 
     resolved_root = root.resolve(strict=True)
-    resolved = path.resolve(strict=True)
+    lexical = Path(os.path.abspath(path))
     try:
-        relative = resolved.relative_to(resolved_root)
+        relative = lexical.relative_to(resolved_root)
     except ValueError as error:
         raise ValueError(f"{label} deve trovarsi dentro {resolved_root}.") from error
     candidate = resolved_root
@@ -754,6 +755,11 @@ def confined_regular_input(path: Path, root: Path, label: str) -> Path:
         candidate = candidate / part
         if candidate.is_symlink():
             raise ValueError(f"{label} non puo essere un collegamento simbolico.")
+    resolved = lexical.resolve(strict=True)
+    try:
+        resolved.relative_to(resolved_root)
+    except ValueError as error:
+        raise ValueError(f"{label} deve trovarsi dentro {resolved_root}.") from error
     if not resolved.is_file():
         raise ValueError(f"{label} deve essere un file regolare.")
     return resolved
@@ -793,42 +799,14 @@ def docker_command(
     """Build the docker command used to run grading in a container."""
     workspace = (workspace or Path.cwd()).resolve()
     source_path = source.resolve()
-    command = [
-        "docker",
-        "run",
-        "-i",
-        "--rm",
-        "--network",
-        "none",
-        "--user",
-        "runner",
-        "--read-only",
-        "--cap-drop",
-        "ALL",
-        "--security-opt",
-        "no-new-privileges",
-        "--pids-limit",
-        "128",
-        "--memory",
-        "256m",
-        "--cpus",
-        "1",
-        "-v",
-        f"{workspace}:/submission:ro",
-        "--tmpfs",
-        "/thebitlab-work:rw,exec,nosuid,nodev,mode=1777,size=64m",
-        "-e",
-        "TMPDIR=/thebitlab-work",
-        "-w",
-        "/submission",
-    ]
-    if cidfile is not None:
-        command.extend(["--cidfile", str(cidfile.resolve())])
-    if container_name is not None:
-        command.extend(["--name", container_name])
+    command = docker_boundary_command(
+        image=image,
+        workspace=workspace,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
     command.extend(
         [
-        image,
         "--worker",
         "--source",
         path_inside_workspace(source_path, workspace, "source"),

--- a/scripts/student_lab_runner.py
+++ b/scripts/student_lab_runner.py
@@ -23,7 +23,6 @@ from scripts.thebitlab_technical_services import (
     ExecutionService,
 )
 
-
 DEFAULT_TIMEOUT_SECONDS = 5
 DEFAULT_DOCKER_IMAGE = grade_activity.DEFAULT_DOCKER_IMAGE
 RUNNER_BACKENDS = {"local", "docker"}
@@ -516,6 +515,7 @@ def run_assignment(
             assignment,
             root=root,
             timeout_seconds=timeout_seconds,
+            backend=backend,
         )
     if backend == "local":
         return run_local_assignment(assignment, root=root, timeout_seconds=timeout_seconds)

--- a/scripts/student_runtime.py
+++ b/scripts/student_runtime.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from scripts import student_lab_service, thebitlab_runtime_contracts, thebitlab_runtime_plugins
-
+from scripts import (
+    student_lab_service,
+    thebitlab_runtime_contracts,
+    thebitlab_runtime_plugins,
+    thebitlab_runtime_sandbox,
+)
 
 DEFAULT_REGISTRY = thebitlab_runtime_plugins.RuntimePluginRegistry()
 
@@ -136,7 +141,9 @@ def run_runtime_assignment(
     *,
     root: Path,
     timeout_seconds: int,
+    backend: str = "local",
     registry: thebitlab_runtime_plugins.RuntimePluginRegistry = DEFAULT_REGISTRY,
+    sandbox_service: thebitlab_runtime_sandbox.RuntimeSandboxExecutionService | None = None,
 ) -> dict[str, Any]:
     runtime_id = "unknown"
     source = root
@@ -154,7 +161,51 @@ def run_runtime_assignment(
             registry=registry,
         )
         source = _source_from_request(request)
-        execution = thebitlab_runtime_plugins.run_runtime(loaded, request)
+        if backend == "local":
+            execution = thebitlab_runtime_plugins.run_runtime(loaded, request)
+        elif backend == "docker":
+            plan = thebitlab_runtime_plugins.prepare_sandbox_runtime(loaded, request)
+            service = (
+                sandbox_service
+                or thebitlab_runtime_sandbox.DockerRuntimeSandboxExecutionService()
+            )
+            try:
+                sandbox_result = service.run(plan, request)
+            except subprocess.TimeoutExpired as error:
+                return runtime_error_report(
+                    assignment,
+                    runtime_id=runtime_id,
+                    source=source,
+                    error=f"Sandbox runtime interrotta dopo {error.timeout} secondi.",
+                    status="timeout",
+                )
+            except FileNotFoundError:
+                return runtime_error_report(
+                    assignment,
+                    runtime_id=runtime_id,
+                    source=source,
+                    error=(
+                        "Docker non trovato; il grading runtime autorevole "
+                        "non e disponibile."
+                    ),
+                )
+            if sandbox_result.get("worker_schema") != plan.profile.worker_schema:
+                raise thebitlab_runtime_plugins.RuntimePluginIncompatibleError(
+                    "Il worker schema restituito dalla sandbox non coincide con il piano"
+                )
+            execution = thebitlab_runtime_plugins.finalize_sandbox_runtime(
+                loaded, request, sandbox_result
+            )
+        else:
+            raise ValueError(f"Backend runtime non supportato: {backend}")
+    except FileNotFoundError as error:
+        missing = error.filename or str(error)
+        return runtime_error_report(
+            assignment,
+            runtime_id=runtime_id,
+            source=source,
+            error=f"File runtime non trovato: {missing}",
+        )
     except (ValueError, thebitlab_runtime_plugins.RuntimePluginError) as error:
         return runtime_error_report(
             assignment,
@@ -190,6 +241,7 @@ def run_runtime_assignment(
         "detail": execution.detail,
         "runtime": {
             "plugin_version": loaded.descriptor.plugin_version,
+            "backend": backend,
             "metadata": execution.metadata,
         },
     }

--- a/scripts/thebitlab_runtime_plugins.py
+++ b/scripts/thebitlab_runtime_plugins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from importlib import metadata
@@ -12,7 +13,6 @@ from scripts.thebitlab_runtime_contracts import (
 )
 from scripts.thebitlab_technical_services import ExecutionResult, RunnerTestResult
 
-
 RUNTIME_PLUGIN_API_VERSION = "runtime_plugin.v1"
 RUNTIME_ENTRY_POINT_GROUP = "thebitlab.runtimes"
 RUNTIME_DESCRIPTOR_SCHEMA_VERSION = "runtime_descriptor.v1"
@@ -20,7 +20,16 @@ RUNTIME_REQUEST_SCHEMA_VERSION = "runtime_request.v1"
 RUNTIME_PROBE_SCHEMA_VERSION = "runtime_probe.v1"
 RUNTIME_LAUNCH_SCHEMA_VERSION = "runtime_launch.v1"
 RUNTIME_EXECUTION_SCHEMA_VERSION = "runtime_execution.v1"
+RUNTIME_SANDBOX_PLAN_SCHEMA_VERSION = "runtime_sandbox_plan.v1"
+RUNTIME_SANDBOX_RESULT_SCHEMA_VERSION = "runtime_sandbox_result.v1"
+RUNTIME_SANDBOX_CAPABILITY = "sandbox-plan.v1"
 _RUNTIME_TOKEN_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+_OCI_DIGEST_RE = re.compile(
+    r"^[a-z0-9][a-z0-9._/-]*(?::[a-z0-9._-]+)?@sha256:[0-9a-f]{64}$"
+)
+_SAFE_RELATIVE_RE = re.compile(r"^[^\\:]+$")
+MAX_RUNTIME_SANDBOX_INPUTS = 32
+MAX_RUNTIME_WORKER_REQUEST_BYTES = 64 * 1024
 
 RuntimeLaunchStatus = Literal[
     "started",
@@ -77,6 +86,30 @@ class RuntimeArtifactSpec:
             "media_type": self.media_type,
             "required": self.required,
         }
+
+
+@dataclass(frozen=True)
+class RuntimeSandboxProfile:
+    image: str
+    platform: str
+    worker_schema: str
+
+
+@dataclass(frozen=True)
+class RuntimeSandboxInput:
+    source: Literal["submission", "activity"]
+    target: str
+    artifact_id: str = ""
+    path: str = ""
+
+
+@dataclass(frozen=True)
+class RuntimeSandboxPlan:
+    """Validated plan produced by a trusted plugin for the common broker."""
+
+    profile: RuntimeSandboxProfile
+    inputs: tuple[RuntimeSandboxInput, ...]
+    worker_request: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -161,6 +194,14 @@ class RuntimePlugin(Protocol):
     def launch(self, request: Mapping[str, Any]) -> Mapping[str, Any]: ...
 
     def run(self, request: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+    def prepare_sandbox(self, request: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+    def finalize_sandbox(
+        self,
+        request: Mapping[str, Any],
+        sandbox_result: Mapping[str, Any],
+    ) -> Mapping[str, Any]: ...
 
     def close(self, session_id: str) -> None: ...
 
@@ -380,6 +421,127 @@ def execution_result_from_payload(payload: Any) -> ExecutionResult:
     )
 
 
+def sandbox_plan_from_payload(payload: Any) -> RuntimeSandboxPlan:
+    """Validate the declarative plan; commands and host controls are forbidden."""
+
+    raw = _mapping(payload, field_name="runtime sandbox plan")
+    schema = _text(raw.get("schema_version"), field_name="sandbox.schema_version", required=True)
+    if schema != RUNTIME_SANDBOX_PLAN_SCHEMA_VERSION:
+        raise RuntimePluginIncompatibleError(
+            f"Piano sandbox con schema {schema}; richiesto {RUNTIME_SANDBOX_PLAN_SCHEMA_VERSION}"
+        )
+    allowed_keys = {"schema_version", "profile", "inputs", "worker_request"}
+    unexpected = sorted(set(raw) - allowed_keys)
+    if unexpected:
+        raise RuntimePluginIncompatibleError(
+            f"Piano sandbox contiene campi non autorizzati: {', '.join(unexpected)}"
+        )
+    profile_raw = _mapping(raw.get("profile"), field_name="sandbox.profile")
+    if set(profile_raw) - {"image", "platform", "worker_schema"}:
+        raise RuntimePluginIncompatibleError(
+            "sandbox.profile puo dichiarare solo image, platform e worker_schema"
+        )
+    image = _text(profile_raw.get("image"), field_name="sandbox.profile.image", required=True)
+    if not _OCI_DIGEST_RE.fullmatch(image):
+        raise RuntimePluginIncompatibleError(
+            "sandbox.profile.image deve essere un riferimento OCI con digest sha256 immutabile"
+        )
+    platform = _text(
+        profile_raw.get("platform"), field_name="sandbox.profile.platform", required=True
+    )
+    if platform != "linux/amd64":
+        raise RuntimePluginIncompatibleError("sandbox.profile.platform deve essere linux/amd64")
+    worker_schema = _text(
+        profile_raw.get("worker_schema"),
+        field_name="sandbox.profile.worker_schema",
+        required=True,
+    )
+    if not _RUNTIME_TOKEN_RE.fullmatch(worker_schema):
+        raise RuntimePluginIncompatibleError("sandbox.profile.worker_schema non valido")
+
+    inputs_raw = raw.get("inputs")
+    if not isinstance(inputs_raw, list) or not inputs_raw:
+        raise RuntimePluginIncompatibleError("sandbox.inputs deve essere una lista non vuota")
+    if len(inputs_raw) > MAX_RUNTIME_SANDBOX_INPUTS:
+        raise RuntimePluginIncompatibleError(
+            f"sandbox.inputs supera il limite di {MAX_RUNTIME_SANDBOX_INPUTS} elementi"
+        )
+    inputs: list[RuntimeSandboxInput] = []
+    targets: set[str] = set()
+    for index, item in enumerate(inputs_raw):
+        entry = _mapping(item, field_name=f"sandbox.inputs[{index}]")
+        source = _text(
+            entry.get("source"), field_name=f"sandbox.inputs[{index}].source", required=True
+        )
+        target = _portable_relative(
+            entry.get("target"), field_name=f"sandbox.inputs[{index}].target"
+        )
+        target_key = target.casefold()
+        if target_key in targets:
+            raise RuntimePluginIncompatibleError(f"sandbox.inputs target duplicato: {target}")
+        targets.add(target_key)
+        if source == "submission":
+            if set(entry) - {"source", "artifact_id", "target"}:
+                raise RuntimePluginIncompatibleError(
+                    f"sandbox.inputs[{index}] submission contiene campi non autorizzati"
+                )
+            artifact_id = _text(
+                entry.get("artifact_id"),
+                field_name=f"sandbox.inputs[{index}].artifact_id",
+                required=True,
+            )
+            if not _RUNTIME_TOKEN_RE.fullmatch(artifact_id):
+                raise RuntimePluginIncompatibleError(
+                    f"sandbox.inputs[{index}].artifact_id non valido"
+                )
+            inputs.append(RuntimeSandboxInput("submission", target, artifact_id=artifact_id))
+        elif source == "activity":
+            if set(entry) - {"source", "path", "target"}:
+                raise RuntimePluginIncompatibleError(
+                    f"sandbox.inputs[{index}] activity contiene campi non autorizzati"
+                )
+            path = _portable_relative(
+                entry.get("path"), field_name=f"sandbox.inputs[{index}].path"
+            )
+            inputs.append(RuntimeSandboxInput("activity", target, path=path))
+        else:
+            raise RuntimePluginIncompatibleError(
+                f"sandbox.inputs[{index}].source deve essere submission o activity"
+            )
+
+    worker_request = _metadata_dict(
+        raw.get("worker_request"), field_name="sandbox.worker_request"
+    )
+    try:
+        encoded_request = json.dumps(worker_request, allow_nan=False).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise RuntimePluginIncompatibleError(
+            "sandbox.worker_request deve essere JSON serializzabile senza NaN o Infinity"
+        ) from error
+    if len(encoded_request) > MAX_RUNTIME_WORKER_REQUEST_BYTES:
+        raise RuntimePluginIncompatibleError(
+            "sandbox.worker_request supera il limite di 64 KiB"
+        )
+    return RuntimeSandboxPlan(
+        profile=RuntimeSandboxProfile(image, platform, worker_schema),
+        inputs=tuple(inputs),
+        worker_request=worker_request,
+    )
+
+
+def _portable_relative(value: Any, *, field_name: str) -> str:
+    text = _text(value, field_name=field_name, required=True)
+    path = Path(text)
+    parts = text.split("/")
+    if (
+        not _SAFE_RELATIVE_RE.fullmatch(text)
+        or path.is_absolute()
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise RuntimePluginIncompatibleError(f"{field_name} deve essere un path relativo POSIX sicuro")
+    return text
+
+
 class RuntimePluginRegistry:
     """Resolve administrator-installed runtime plugins through Python entry points."""
 
@@ -594,6 +756,92 @@ def run_runtime(
             **result.metadata,
             "runtime_id": loaded.descriptor.runtime_id,
             "runtime_plugin_version": loaded.descriptor.plugin_version,
+            "authoritative": False,
+            "execution_isolation": "process-only",
+        },
+    )
+
+
+def prepare_sandbox_runtime(
+    loaded: LoadedRuntimePlugin,
+    request: RuntimeRequest,
+) -> RuntimeSandboxPlan:
+    """Ask a trusted plugin for a declarative, host-enforced sandbox plan."""
+
+    if RUNTIME_SANDBOX_CAPABILITY not in loaded.descriptor.capabilities:
+        raise RuntimePluginIncompatibleError(
+            f"Runtime {loaded.descriptor.runtime_id} non dichiara {RUNTIME_SANDBOX_CAPABILITY}"
+        )
+    prepare = getattr(loaded.plugin, "prepare_sandbox", None)
+    finalize = getattr(loaded.plugin, "finalize_sandbox", None)
+    if not callable(prepare) or not callable(finalize):
+        raise RuntimePluginIncompatibleError(
+            f"Runtime {loaded.descriptor.runtime_id} dichiara {RUNTIME_SANDBOX_CAPABILITY} "
+            "ma non implementa prepare_sandbox() e finalize_sandbox()"
+        )
+    try:
+        payload = prepare(request.to_payload())
+    except Exception as error:
+        raise RuntimePluginIncompatibleError(
+            f"Runtime {loaded.descriptor.runtime_id} ha fallito prepare_sandbox(): {error}"
+        ) from error
+    return sandbox_plan_from_payload(payload)
+
+
+def finalize_sandbox_runtime(
+    loaded: LoadedRuntimePlugin,
+    request: RuntimeRequest,
+    sandbox_result: Mapping[str, Any],
+) -> ExecutionResult:
+    """Let the trusted host plugin reconstruct grading from untrusted output."""
+
+    finalize = getattr(loaded.plugin, "finalize_sandbox", None)
+    if not callable(finalize):
+        raise RuntimePluginIncompatibleError(
+            f"Runtime {loaded.descriptor.runtime_id} non implementa finalize_sandbox()"
+        )
+    if sandbox_result.get("schema_version") != RUNTIME_SANDBOX_RESULT_SCHEMA_VERSION:
+        raise RuntimePluginIncompatibleError("Risultato sandbox runtime con schema non valido")
+    if sandbox_result.get("status") != "completed":
+        raise RuntimePluginIncompatibleError("Risultato sandbox runtime non completato")
+    unexpected = set(sandbox_result) - {
+        "schema_version",
+        "worker_schema",
+        "status",
+        "payload",
+    }
+    if unexpected:
+        raise RuntimePluginIncompatibleError(
+            "Risultato sandbox runtime contiene campi non autorizzati"
+        )
+    worker_schema = _text(
+        sandbox_result.get("worker_schema"),
+        field_name="sandbox_result.worker_schema",
+        required=True,
+    )
+    if not _RUNTIME_TOKEN_RE.fullmatch(worker_schema):
+        raise RuntimePluginIncompatibleError("sandbox_result.worker_schema non valido")
+    _mapping(sandbox_result.get("payload"), field_name="sandbox_result.payload")
+    try:
+        payload = finalize(request.to_payload(), dict(sandbox_result))
+    except Exception as error:
+        raise RuntimePluginIncompatibleError(
+            f"Runtime {loaded.descriptor.runtime_id} ha fallito finalize_sandbox(): {error}"
+        ) from error
+    result = execution_result_from_payload(payload)
+    return ExecutionResult(
+        status=result.status,
+        tests=result.tests,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        duration_ms=result.duration_ms,
+        detail=result.detail,
+        metadata={
+            **result.metadata,
+            "runtime_id": loaded.descriptor.runtime_id,
+            "runtime_plugin_version": loaded.descriptor.plugin_version,
+            "authoritative": True,
+            "execution_isolation": "docker",
         },
     )
 

--- a/scripts/thebitlab_runtime_sandbox.py
+++ b/scripts/thebitlab_runtime_sandbox.py
@@ -8,6 +8,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Protocol
 
 from scripts import thebitlab_runtime_plugins
+from scripts.thebitlab_sandbox_boundary import docker_boundary_command
 
 RUNTIME_SANDBOX_RESULT_SCHEMA_VERSION = "runtime_sandbox_result.v1"
 DEFAULT_RUNTIME_SANDBOX_TIMEOUT_GRACE_SECONDS = 10
@@ -21,55 +22,6 @@ class RuntimeSandboxExecutionService(Protocol):
         plan: thebitlab_runtime_plugins.RuntimeSandboxPlan,
         request: thebitlab_runtime_plugins.RuntimeRequest,
     ) -> dict[str, Any]: ...
-
-
-def docker_boundary_command(
-    *,
-    image: str,
-    workspace: Path,
-    cidfile: Path | None = None,
-    container_name: str | None = None,
-    platform: str | None = None,
-) -> list[str]:
-    """Return the single hardened Docker boundary shared by all runners."""
-
-    command = [
-        "docker",
-        "run",
-        "-i",
-        "--rm",
-        "--network",
-        "none",
-        "--user",
-        "runner",
-        "--read-only",
-        "--cap-drop",
-        "ALL",
-        "--security-opt",
-        "no-new-privileges",
-        "--pids-limit",
-        "128",
-        "--memory",
-        "256m",
-        "--cpus",
-        "1",
-        "-v",
-        f"{workspace.resolve()}:/submission:ro",
-        "--tmpfs",
-        "/thebitlab-work:rw,exec,nosuid,nodev,mode=1777,size=64m",
-        "-e",
-        "TMPDIR=/thebitlab-work",
-        "-w",
-        "/submission",
-    ]
-    if platform is not None:
-        command.extend(["--platform", platform])
-    if cidfile is not None:
-        command.extend(["--cidfile", str(cidfile.resolve())])
-    if container_name is not None:
-        command.extend(["--name", container_name])
-    command.append(image)
-    return command
 
 
 class DockerRuntimeSandboxExecutionService:

--- a/scripts/thebitlab_runtime_sandbox.py
+++ b/scripts/thebitlab_runtime_sandbox.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
+
+from scripts import thebitlab_runtime_plugins
+
+RUNTIME_SANDBOX_RESULT_SCHEMA_VERSION = "runtime_sandbox_result.v1"
+DEFAULT_RUNTIME_SANDBOX_TIMEOUT_GRACE_SECONDS = 10
+
+
+class RuntimeSandboxExecutionService(Protocol):
+    """Port owned by TheBitLab for isolated execution of runtime inputs."""
+
+    def run(
+        self,
+        plan: thebitlab_runtime_plugins.RuntimeSandboxPlan,
+        request: thebitlab_runtime_plugins.RuntimeRequest,
+    ) -> dict[str, Any]: ...
+
+
+def docker_boundary_command(
+    *,
+    image: str,
+    workspace: Path,
+    cidfile: Path | None = None,
+    container_name: str | None = None,
+    platform: str | None = None,
+) -> list[str]:
+    """Return the single hardened Docker boundary shared by all runners."""
+
+    command = [
+        "docker",
+        "run",
+        "-i",
+        "--rm",
+        "--network",
+        "none",
+        "--user",
+        "runner",
+        "--read-only",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--pids-limit",
+        "128",
+        "--memory",
+        "256m",
+        "--cpus",
+        "1",
+        "-v",
+        f"{workspace.resolve()}:/submission:ro",
+        "--tmpfs",
+        "/thebitlab-work:rw,exec,nosuid,nodev,mode=1777,size=64m",
+        "-e",
+        "TMPDIR=/thebitlab-work",
+        "-w",
+        "/submission",
+    ]
+    if platform is not None:
+        command.extend(["--platform", platform])
+    if cidfile is not None:
+        command.extend(["--cidfile", str(cidfile.resolve())])
+    if container_name is not None:
+        command.extend(["--name", container_name])
+    command.append(image)
+    return command
+
+
+class DockerRuntimeSandboxExecutionService:
+    """Execute one plugin-prepared plan through the official Docker boundary."""
+
+    def run(
+        self,
+        plan: thebitlab_runtime_plugins.RuntimeSandboxPlan,
+        request: thebitlab_runtime_plugins.RuntimeRequest,
+    ) -> dict[str, Any]:
+        # Imported lazily to keep the shared boundary helper independent while
+        # reusing the existing bounded process and verified cleanup verbatim.
+        from scripts import grade_activity
+
+        with tempfile.TemporaryDirectory(prefix="thebitlab-runtime-") as temp_dir:
+            temp_root = Path(temp_dir)
+            workspace = temp_root / "workspace"
+            workspace.mkdir()
+            copied_inputs = self._copy_inputs(plan, request, workspace)
+            cidfile = temp_root / "container.cid"
+            container_name = f"thebitlab-runtime-{uuid.uuid4().hex}"
+            command = docker_boundary_command(
+                image=plan.profile.image,
+                platform=plan.profile.platform,
+                workspace=workspace,
+                cidfile=cidfile,
+                container_name=container_name,
+            )
+            worker_request = {
+                "schema_version": "runtime_sandbox_worker_request.v1",
+                "worker_schema": plan.profile.worker_schema,
+                "inputs": copied_inputs,
+                "request": plan.worker_request,
+            }
+            try:
+                completed = grade_activity.run_bounded_process(
+                    command,
+                    input_text=json.dumps(worker_request, ensure_ascii=False),
+                    timeout=(
+                        request.timeout_seconds
+                        + DEFAULT_RUNTIME_SANDBOX_TIMEOUT_GRACE_SECONDS
+                    ),
+                )
+            except FileNotFoundError:
+                cidfile.unlink(missing_ok=True)
+                raise
+            except BaseException as execution_error:
+                try:
+                    grade_activity.remove_docker_container(cidfile, container_name)
+                except grade_activity.DockerCleanupError as cleanup_error:
+                    raise cleanup_error from execution_error
+                raise
+            else:
+                grade_activity.remove_docker_container(cidfile, container_name)
+
+            if completed.returncode != 0:
+                raise ValueError(
+                    f"Sandbox runtime terminata con codice {completed.returncode}."
+                )
+            try:
+                payload = json.loads(completed.stdout)
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    "Sandbox runtime non ha prodotto un payload JSON valido."
+                ) from error
+            if not isinstance(payload, dict):
+                raise ValueError("Il payload della sandbox runtime deve essere un oggetto.")
+            return {
+                "schema_version": RUNTIME_SANDBOX_RESULT_SCHEMA_VERSION,
+                "worker_schema": plan.profile.worker_schema,
+                "status": "completed",
+                "payload": payload,
+            }
+
+    @staticmethod
+    def _copy_inputs(
+        plan: thebitlab_runtime_plugins.RuntimeSandboxPlan,
+        request: thebitlab_runtime_plugins.RuntimeRequest,
+        workspace: Path,
+    ) -> list[dict[str, str]]:
+        from scripts import grade_activity
+
+        artifacts = {item.id: item for item in request.submission_artifacts}
+        copied: list[dict[str, str]] = []
+        for item in plan.inputs:
+            target = _safe_target(item.target)
+            if item.source == "submission":
+                artifact = artifacts.get(item.artifact_id)
+                if artifact is None:
+                    raise ValueError(
+                        f"Il piano richiede artifact non dichiarato: {item.artifact_id}"
+                    )
+                source = grade_activity.confined_regular_input(
+                    request.workspace_path / artifact.path,
+                    request.workspace_path,
+                    f"runtime input {item.artifact_id}",
+                )
+            else:
+                source = grade_activity.confined_regular_input(
+                    request.activity_path.parent.joinpath(*PurePosixPath(item.path).parts),
+                    request.activity_path.parent,
+                    f"runtime activity input {item.path}",
+                )
+            destination = workspace.joinpath(*target.parts)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+            copied.append(
+                {
+                    "source": item.source,
+                    "id": item.artifact_id if item.source == "submission" else item.path,
+                    "path": target.as_posix(),
+                }
+            )
+        return copied
+
+
+def _safe_target(value: str) -> PurePosixPath:
+    if "\\" in value or ":" in value:
+        raise ValueError(f"Target sandbox non sicuro: {value}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"Target sandbox non sicuro: {value}")
+    return path

--- a/scripts/thebitlab_sandbox_boundary.py
+++ b/scripts/thebitlab_sandbox_boundary.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def docker_boundary_command(
+    *,
+    image: str,
+    workspace: Path,
+    cidfile: Path | None = None,
+    container_name: str | None = None,
+    platform: str | None = None,
+) -> list[str]:
+    """Return the single hardened Docker boundary shared by all runners."""
+
+    command = [
+        "docker",
+        "run",
+        "-i",
+        "--rm",
+        "--network",
+        "none",
+        "--user",
+        "runner",
+        "--read-only",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--pids-limit",
+        "128",
+        "--memory",
+        "256m",
+        "--cpus",
+        "1",
+        "-v",
+        f"{workspace.resolve()}:/submission:ro",
+        "--tmpfs",
+        "/thebitlab-work:rw,exec,nosuid,nodev,mode=1777,size=64m",
+        "-e",
+        "TMPDIR=/thebitlab-work",
+        "-w",
+        "/submission",
+    ]
+    if platform is not None:
+        command.extend(["--platform", platform])
+    if cidfile is not None:
+        command.extend(["--cidfile", str(cidfile.resolve())])
+    if container_name is not None:
+        command.extend(["--name", container_name])
+    command.append(image)
+    return command

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -678,7 +678,7 @@ def test_prepare_docker_workspace_rejects_input_outside_authorized_root(tmp_path
     activity_path.write_text("{}", encoding="utf-8")
     source_path.write_text("print(1)\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="source deve trovarsi dentro"):
+    with pytest.raises(ValueError, match="source"):
         grade_activity.prepare_docker_workspace(
             activity_path,
             source_path,

--- a/tests/test_grade_activity.py
+++ b/tests/test_grade_activity.py
@@ -678,7 +678,7 @@ def test_prepare_docker_workspace_rejects_input_outside_authorized_root(tmp_path
     activity_path.write_text("{}", encoding="utf-8")
     source_path.write_text("print(1)\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="source"):
+    with pytest.raises(ValueError, match="source deve trovarsi dentro"):
         grade_activity.prepare_docker_workspace(
             activity_path,
             source_path,
@@ -703,7 +703,7 @@ def test_prepare_docker_workspace_rejects_symlink_escaping_source_root(tmp_path)
     except OSError:
         pytest.skip("Creazione symlink non consentita su questa piattaforma.")
 
-    with pytest.raises(ValueError, match="source deve trovarsi dentro"):
+    with pytest.raises(ValueError, match="source non puo essere un collegamento simbolico"):
         grade_activity.prepare_docker_workspace(
             activity_path,
             linked_source,

--- a/tests/test_student_runtime.py
+++ b/tests/test_student_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from scripts import student_runtime, thebitlab_runtime_plugins
@@ -63,6 +64,60 @@ class FakeRuntime:
         return None
 
 
+class FakeSandboxRuntime(FakeRuntime):
+    def describe(self):
+        descriptor = super().describe()
+        descriptor["capabilities"].append("sandbox-plan.v1")
+        return descriptor
+
+    def prepare_sandbox(self, request):
+        return {
+            "schema_version": "runtime_sandbox_plan.v1",
+            "profile": {
+                "image": "ghcr.io/thebitpoets/example@sha256:" + "a" * 64,
+                "platform": "linux/amd64",
+                "worker_schema": "example.trace.v1",
+            },
+            "inputs": [
+                {"source": "submission", "artifact_id": "answer", "target": "main.py"}
+            ],
+            "worker_request": {"schema_version": "example.worker.v1"},
+        }
+
+    def finalize_sandbox(self, request, sandbox_result):
+        assert sandbox_result["payload"] == {"trace": ["forward"]}
+        return {
+            "schema_version": "runtime_execution.v1",
+            "status": "passed",
+            "tests": [{"name": "trusted replay", "passed": True, "detail": "ok"}],
+            "metadata": {"score": 10.0},
+        }
+
+
+class FakeSandboxService:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, plan, request):
+        self.calls.append((plan, request))
+        return {
+            "schema_version": "runtime_sandbox_result.v1",
+            "worker_schema": "example.trace.v1",
+            "status": "completed",
+            "payload": {"trace": ["forward"]},
+        }
+
+
+class TimeoutSandboxService:
+    def run(self, plan, request):
+        raise subprocess.TimeoutExpired("docker run", 20)
+
+
+class MissingDockerSandboxService:
+    def run(self, plan, request):
+        raise FileNotFoundError("docker")
+
+
 def fixture(tmp_path: Path) -> tuple[dict, thebitlab_runtime_plugins.RuntimePluginRegistry]:
     activity_dir = tmp_path / "activity"
     workspace = tmp_path / "workspace"
@@ -120,6 +175,102 @@ def test_runtime_assignment_generates_normal_student_report(tmp_path: Path) -> N
     assert report["summary"] == {"passed": 1, "total": 2}
     assert report["score"] == 5.0
     assert report["tests"][1]["message"] == "fix me"
+    assert report["runtime"]["backend"] == "local"
+    assert report["runtime"]["metadata"]["authoritative"] is False
+
+
+def test_runtime_docker_uses_prepare_broker_and_trusted_finalize(tmp_path: Path) -> None:
+    assignment, _ = fixture(tmp_path)
+    registry = thebitlab_runtime_plugins.RuntimePluginRegistry(
+        lambda: (FakeEntryPoint("example-runtime", FakeSandboxRuntime),)
+    )
+    service = FakeSandboxService()
+
+    report = student_runtime.run_runtime_assignment(
+        assignment,
+        root=tmp_path,
+        timeout_seconds=10,
+        backend="docker",
+        registry=registry,
+        sandbox_service=service,
+    )
+
+    assert report["passed"] is True
+    assert report["runtime"]["backend"] == "docker"
+    assert report["runtime"]["metadata"]["authoritative"] is True
+    assert report["runtime"]["metadata"]["execution_isolation"] == "docker"
+    assert len(service.calls) == 1
+
+
+def test_runtime_docker_fails_closed_for_v1_only_plugin(tmp_path: Path) -> None:
+    assignment, registry = fixture(tmp_path)
+
+    report = student_runtime.run_runtime_assignment(
+        assignment,
+        root=tmp_path,
+        timeout_seconds=10,
+        backend="docker",
+        registry=registry,
+        sandbox_service=FakeSandboxService(),
+    )
+
+    assert report["passed"] is False
+    assert report["status"] == "runtime-unavailable"
+    assert "sandbox-plan.v1" in report["error"]
+
+
+def test_runtime_timeout_does_not_call_trusted_finalize(tmp_path: Path) -> None:
+    assignment, _ = fixture(tmp_path)
+    plugin = FakeSandboxRuntime()
+    plugin.finalize_sandbox = lambda *args: (_ for _ in ()).throw(  # type: ignore[method-assign]
+        AssertionError("finalize must not run after infrastructure timeout")
+    )
+    registry = thebitlab_runtime_plugins.RuntimePluginRegistry(
+        lambda: (FakeEntryPoint("example-runtime", lambda: plugin),)
+    )
+
+    report = student_runtime.run_runtime_assignment(
+        assignment,
+        root=tmp_path,
+        timeout_seconds=10,
+        backend="docker",
+        registry=registry,
+        sandbox_service=TimeoutSandboxService(),
+    )
+
+    assert report["status"] == "timeout"
+    assert report["passed"] is False
+
+
+def test_runtime_distinguishes_missing_docker_from_missing_activity_file(
+    tmp_path: Path,
+) -> None:
+    assignment, _ = fixture(tmp_path)
+    registry = thebitlab_runtime_plugins.RuntimePluginRegistry(
+        lambda: (FakeEntryPoint("example-runtime", FakeSandboxRuntime),)
+    )
+
+    missing_docker = student_runtime.run_runtime_assignment(
+        assignment,
+        root=tmp_path,
+        timeout_seconds=10,
+        backend="docker",
+        registry=registry,
+        sandbox_service=MissingDockerSandboxService(),
+    )
+    (tmp_path / assignment["activity"]["path"]).unlink()
+    missing_activity = student_runtime.run_runtime_assignment(
+        assignment,
+        root=tmp_path,
+        timeout_seconds=10,
+        backend="docker",
+        registry=registry,
+        sandbox_service=MissingDockerSandboxService(),
+    )
+
+    assert "Docker non trovato" in missing_docker["error"]
+    assert "Activity non trovata" in missing_activity["error"]
+    assert "Docker non trovato" not in missing_activity["error"]
 
 
 def test_runtime_launch_is_generic(tmp_path: Path) -> None:

--- a/tests/test_student_runtime_dispatch.py
+++ b/tests/test_student_runtime_dispatch.py
@@ -19,8 +19,8 @@ def test_run_assignment_dispatches_runtime_before_code_backend(monkeypatch, tmp_
     monkeypatch.setattr(student_lab_runner, "load_activity", lambda root, item: runtime_activity)
     calls = []
 
-    def fake_runtime(item, *, root, timeout_seconds):
-        calls.append((item, root, timeout_seconds))
+    def fake_runtime(item, *, root, timeout_seconds, backend):
+        calls.append((item, root, timeout_seconds, backend))
         return {"status": "passed", "passed": True, "backend": "runtime"}
 
     monkeypatch.setattr(student_lab_runner.student_runtime, "run_runtime_assignment", fake_runtime)
@@ -39,7 +39,7 @@ def test_run_assignment_dispatches_runtime_before_code_backend(monkeypatch, tmp_
     )
 
     assert report["backend"] == "runtime"
-    assert calls == [(assignment, tmp_path, 17)]
+    assert calls == [(assignment, tmp_path, 17, "docker")]
 
 
 def test_run_assignment_keeps_legacy_backend_for_non_runtime_activity(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_thebitlab_runtime_plugins.py
+++ b/tests/test_thebitlab_runtime_plugins.py
@@ -68,6 +68,26 @@ class FakePlugin:
             "detail": "completed",
         }
 
+    def prepare_sandbox(self, request):
+        self.last_request = request
+        return {
+            "schema_version": plugins.RUNTIME_SANDBOX_PLAN_SCHEMA_VERSION,
+            "profile": {
+                "image": "ghcr.io/thebitpoets/example@sha256:" + "a" * 64,
+                "platform": "linux/amd64",
+                "worker_schema": "example.trace.v1",
+            },
+            "inputs": [
+                {"source": "submission", "artifact_id": "primary", "target": "main.py"},
+                {"source": "activity", "path": "hidden_tests.py", "target": "hidden_tests.py"},
+            ],
+            "worker_request": {"schema_version": "example.worker.v1"},
+        }
+
+    def finalize_sandbox(self, request, sandbox_result):
+        self.last_request = (request, sandbox_result)
+        return self.run(request)
+
     def close(self, session_id: str) -> None:
         self.closed.append(session_id)
 
@@ -181,6 +201,86 @@ def test_registry_rejects_invalid_plugin_capability() -> None:
 
     with pytest.raises(plugins.RuntimePluginIncompatibleError, match="capabilities"):
         runtime_registry.get("bad-runtime")
+
+
+def test_sandbox_plan_accepts_explicit_submission_and_activity_inputs() -> None:
+    plan = plugins.sandbox_plan_from_payload(
+        FakePlugin(capabilities=("headless-run", "sandbox-plan.v1")).prepare_sandbox({})
+    )
+
+    assert plan.profile.image.endswith("a" * 64)
+    assert plan.inputs[0].source == "submission"
+    assert plan.inputs[0].artifact_id == "primary"
+    assert plan.inputs[1].source == "activity"
+    assert plan.inputs[1].path == "hidden_tests.py"
+
+
+@pytest.mark.parametrize(
+    "update, message",
+    [
+        ({"profile": {"image": "ghcr.io/example:latest"}}, "digest sha256"),
+        ({"command": ["sh", "-c", "evil"]}, "campi non autorizzati"),
+        ({"environment": {"SECRET": "value"}}, "campi non autorizzati"),
+        ({"mounts": ["/"]}, "campi non autorizzati"),
+        ({"network": "host"}, "campi non autorizzati"),
+    ],
+)
+def test_sandbox_plan_rejects_mutable_image_and_host_controls(update, message) -> None:
+    payload = FakePlugin(capabilities=("sandbox-plan.v1",)).prepare_sandbox({})
+    if "profile" in update:
+        payload["profile"].update(update["profile"])
+    else:
+        payload.update(update)
+
+    with pytest.raises(plugins.RuntimePluginIncompatibleError, match=message):
+        plugins.sandbox_plan_from_payload(payload)
+
+
+def test_sandbox_plan_rejects_non_json_worker_request() -> None:
+    payload = FakePlugin(capabilities=("sandbox-plan.v1",)).prepare_sandbox({})
+    payload["worker_request"] = {"limit": float("nan")}
+
+    with pytest.raises(plugins.RuntimePluginIncompatibleError, match="JSON serializzabile"):
+        plugins.sandbox_plan_from_payload(payload)
+
+
+def test_sandbox_plan_rejects_case_insensitive_target_collision() -> None:
+    payload = FakePlugin(capabilities=("sandbox-plan.v1",)).prepare_sandbox({})
+    payload["inputs"][1]["target"] = "MAIN.py"
+
+    with pytest.raises(plugins.RuntimePluginIncompatibleError, match="target duplicato"):
+        plugins.sandbox_plan_from_payload(payload)
+
+
+def test_sandbox_plan_bounds_worker_request() -> None:
+    payload = FakePlugin(capabilities=("sandbox-plan.v1",)).prepare_sandbox({})
+    payload["worker_request"] = {"padding": "x" * (64 * 1024)}
+
+    with pytest.raises(plugins.RuntimePluginIncompatibleError, match="64 KiB"):
+        plugins.sandbox_plan_from_payload(payload)
+
+
+def test_prepare_sandbox_fails_closed_when_capability_is_missing(tmp_path: Path) -> None:
+    fake_plugin = FakePlugin()
+    loaded = plugins.LoadedRuntimePlugin(
+        descriptor=plugins.descriptor_from_payload("example-runtime", fake_plugin.describe()),
+        plugin=fake_plugin,
+    )
+
+    with pytest.raises(plugins.RuntimePluginIncompatibleError, match="sandbox-plan.v1"):
+        plugins.prepare_sandbox_runtime(loaded, request(tmp_path))
+
+
+def test_sandbox_capability_requires_both_extension_methods(tmp_path: Path) -> None:
+    fake_plugin = FakePlugin(capabilities=("headless-run", "sandbox-plan.v1"))
+    fake_plugin.finalize_sandbox = None  # type: ignore[method-assign]
+    loaded = plugins.LoadedRuntimePlugin(
+        descriptor=plugins.descriptor_from_payload("example-runtime", fake_plugin.describe()),
+        plugin=fake_plugin,
+    )
+
+    with pytest.raises(plugins.RuntimePluginIncompatibleError, match="non implementa"):
+        plugins.prepare_sandbox_runtime(loaded, request(tmp_path))
 
 
 def test_capability_matching_is_activity_driven() -> None:

--- a/tests/test_thebitlab_runtime_sandbox.py
+++ b/tests/test_thebitlab_runtime_sandbox.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import grade_activity
+from scripts import thebitlab_runtime_plugins as plugins
+from scripts import thebitlab_runtime_sandbox as sandbox
+
+IMAGE = "ghcr.io/thebitpoets/romeo-runtime@sha256:" + "a" * 64
+
+
+def runtime_request(tmp_path: Path) -> plugins.RuntimeRequest:
+    activity_root = tmp_path / "activity"
+    workspace = tmp_path / "student"
+    activity_root.mkdir()
+    workspace.mkdir()
+    activity_path = activity_root / "activity.json"
+    activity_path.write_text("{}", encoding="utf-8")
+    (activity_root / "hidden_tests.py").write_text("# teacher test", encoding="utf-8")
+    (activity_root / "scenario.json").write_text("{\"secret\": true}", encoding="utf-8")
+    (workspace / "main.py").write_text("print('student')", encoding="utf-8")
+    (workspace / "other.py").write_text("SECRET = True", encoding="utf-8")
+    return plugins.RuntimeRequest(
+        runtime_id="romeo-sim",
+        activity_id="a1",
+        assignment_id="assignment-1",
+        student_id="student-1",
+        activity_path=activity_path,
+        workspace_path=workspace,
+        config_path=None,
+        submission_artifacts=(
+            plugins.RuntimeArtifactSpec("main", "main.py", "text/x-python"),
+        ),
+        timeout_seconds=7,
+    )
+
+
+def runtime_plan() -> plugins.RuntimeSandboxPlan:
+    return plugins.RuntimeSandboxPlan(
+        profile=plugins.RuntimeSandboxProfile(IMAGE, "linux/amd64", "romeo.trace.v1"),
+        inputs=(
+            plugins.RuntimeSandboxInput("submission", "main.py", artifact_id="main"),
+            plugins.RuntimeSandboxInput("activity", "hidden_tests.py", path="hidden_tests.py"),
+        ),
+        worker_request={"schema_version": "romeo.worker.v1"},
+    )
+
+
+def test_runtime_broker_uses_official_boundary_and_copies_only_explicit_inputs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    request = runtime_request(tmp_path)
+    observed: dict[str, object] = {}
+
+    def fake_run(
+        command,
+        *,
+        input_text,
+        timeout,
+        max_output_bytes=grade_activity.MAX_DOCKER_OUTPUT_BYTES,
+    ):
+        observed["command"] = command
+        observed["request"] = json.loads(input_text)
+        observed["timeout"] = timeout
+        mount = command[command.index("-v") + 1]
+        host_workspace = Path(mount.rsplit(":/submission:ro", 1)[0])
+        observed["files"] = sorted(
+            path.relative_to(host_workspace).as_posix()
+            for path in host_workspace.rglob("*")
+            if path.is_file()
+        )
+        return subprocess.CompletedProcess(command, 0, json.dumps({"commands": []}), "")
+
+    removed = []
+    monkeypatch.setattr(grade_activity, "run_bounded_process", fake_run)
+    monkeypatch.setattr(
+        grade_activity,
+        "remove_docker_container",
+        lambda cidfile, name: removed.append((cidfile, name)),
+    )
+
+    result = sandbox.DockerRuntimeSandboxExecutionService().run(runtime_plan(), request)
+
+    command = observed["command"]
+    assert isinstance(command, list)
+    for value in (
+        "--network", "none", "--read-only", "--cap-drop", "ALL",
+        "no-new-privileges", "--pids-limit", "128", "--memory", "256m",
+        "--cpus", "1", "TMPDIR=/thebitlab-work",
+    ):
+        assert value in command
+    assert command[command.index("--platform") + 1] == "linux/amd64"
+    assert IMAGE in command
+    assert observed["files"] == ["hidden_tests.py", "main.py"]
+    assert "scenario.json" not in observed["files"]
+    assert "other.py" not in observed["files"]
+    assert observed["timeout"] == 17
+    assert removed
+    assert result["payload"] == {"commands": []}
+
+
+def test_runtime_broker_rejects_undeclared_submission_artifact(tmp_path: Path) -> None:
+    request = runtime_request(tmp_path)
+    plan = plugins.RuntimeSandboxPlan(
+        profile=runtime_plan().profile,
+        inputs=(plugins.RuntimeSandboxInput("submission", "x.py", artifact_id="missing"),),
+        worker_request={},
+    )
+
+    with pytest.raises(ValueError, match="non dichiarato"):
+        sandbox.DockerRuntimeSandboxExecutionService._copy_inputs(
+            plan, request, tmp_path / "copy"
+        )
+
+
+def test_runtime_broker_rejects_activity_path_escape(tmp_path: Path) -> None:
+    request = runtime_request(tmp_path)
+    (tmp_path / "outside.py").write_text("", encoding="utf-8")
+    plan = plugins.RuntimeSandboxPlan(
+        profile=runtime_plan().profile,
+        inputs=(plugins.RuntimeSandboxInput("activity", "x.py", path="../outside.py"),),
+        worker_request={},
+    )
+    target = tmp_path / "copy"
+    target.mkdir()
+
+    with pytest.raises(ValueError, match="deve trovarsi dentro"):
+        sandbox.DockerRuntimeSandboxExecutionService._copy_inputs(plan, request, target)
+
+
+def test_runtime_broker_rejects_activity_symlink(tmp_path: Path) -> None:
+    request = runtime_request(tmp_path)
+    linked = request.activity_path.parent / "linked_tests.py"
+    try:
+        linked.symlink_to(request.activity_path.parent / "hidden_tests.py")
+    except OSError:
+        pytest.skip("symlink non disponibile su questo host")
+    plan = plugins.RuntimeSandboxPlan(
+        profile=runtime_plan().profile,
+        inputs=(plugins.RuntimeSandboxInput("activity", "hidden.py", path="linked_tests.py"),),
+        worker_request={},
+    )
+    target = tmp_path / "copy"
+    target.mkdir()
+
+    with pytest.raises(ValueError, match="collegamento simbolico"):
+        sandbox.DockerRuntimeSandboxExecutionService._copy_inputs(plan, request, target)
+
+
+def test_assignment_runner_and_runtime_share_identical_docker_boundary(tmp_path: Path) -> None:
+    common = sandbox.docker_boundary_command(
+        image=IMAGE,
+        workspace=tmp_path,
+        cidfile=tmp_path / "container.cid",
+        container_name="thebitlab-test",
+    )
+    source = tmp_path / "main.py"
+    source.write_text("", encoding="utf-8")
+    grading = grade_activity.docker_command(
+        source=source,
+        timeout_seconds=5,
+        image=IMAGE,
+        workspace=tmp_path,
+        cidfile=tmp_path / "container.cid",
+        container_name="thebitlab-test",
+    )
+
+    assert grading[: len(common)] == common


### PR DESCRIPTION
Estende il boundary Docker ufficiale alle activity runtime tramite la capability sandbox-plan.v1, mantenendo ABI v1 e grading trusted sul lato host. Include validazione fail-closed di immagini OCI per digest, input confinati, limiti di risorse, test e documentazione. Coordinata con TheBitPoets/romeo#2. Non include nuove feature didattiche.