### PR TITLE
fix(runtime): default student grading to authoritative sandbox

### DIFF
--- a/doc/RUNTIME_STUDENT_EXECUTION.md
+++ b/doc/RUNTIME_STUDENT_EXECUTION.md
@@ -1,0 +1,47 @@
+# Runtime plugin: policy di esecuzione studente
+
+Le Activity che usano `extensions.thebitlab.runtime` possono offrire due percorsi tecnici:
+
+- `run()` locale/process-only, utile per sviluppo del plugin e test controllati;
+- `sandbox-plan.v1`, eseguito dal broker Docker TheBitLab e finalizzato sul processo trusted.
+
+## Regola del flusso studente
+
+`student_runtime.run_runtime_assignment()` applica una policy fail-closed:
+
+1. carica e valida il runtime installato;
+2. se il runtime dichiara `sandbox-plan.v1`, una richiesta storica con backend `local` viene
+   promossa automaticamente a `docker`;
+3. il broker esegue `prepare_sandbox -> container untrusted -> finalize_sandbox`;
+4. se Docker, l'immagine pin-nata o il broker non sono disponibili, l'esecuzione fallisce;
+5. non esiste fallback silenzioso a `plugin.run()` dopo un errore della sandbox.
+
+Questo comportamento rende sicuri anche i chiamanti storici (`student_lab_runner`, TUI e
+`student_runtime_cli`) che usavano `local` come valore predefinito prima dell'introduzione del
+broker.
+
+## Compatibilita con runtime legacy
+
+Un plugin `runtime_plugin.v1` che non dichiara `sandbox-plan.v1` conserva il comportamento locale
+esistente. In questo caso il report rimane `authoritative=false` e `execution_isolation=process-only`.
+
+I nuovi runtime destinati a eseguire codice studente non fidato devono implementare
+`sandbox-plan.v1`; il percorso locale non deve essere presentato come grading autorevole.
+
+## Diagnostica nel report
+
+Per i runtime sandbox-capable il report studente registra:
+
+- `runtime.requested_backend`: valore ricevuto dal chiamante storico;
+- `runtime.backend`: backend effettivamente usato;
+- `runtime.metadata.authoritative`: `true` solo dopo finalizzazione trusted;
+- `runtime.metadata.execution_isolation`: confine effettivo dichiarato da TheBitLab.
+
+Questa distinzione rende visibile l'eventuale promozione `local -> docker` senza cambiare le API
+delle Activity o il contratto `runtime_plugin.v1`.
+
+## Sviluppo locale del plugin
+
+Il percorso process-only resta disponibile agli sviluppatori tramite le API di basso livello
+`thebitlab_runtime_plugins.run_runtime()` / `plugin.run()`. Non viene usato automaticamente dal
+flusso studente per un runtime che offre il broker sandbox.

--- a/scripts/student_runtime.py
+++ b/scripts/student_runtime.py
@@ -62,7 +62,11 @@ def _runtime_context(
     root: Path,
     timeout_seconds: int,
     registry: thebitlab_runtime_plugins.RuntimePluginRegistry,
-) -> tuple[dict[str, Any], thebitlab_runtime_plugins.LoadedRuntimePlugin, thebitlab_runtime_plugins.RuntimeRequest]:
+) -> tuple[
+    dict[str, Any],
+    thebitlab_runtime_plugins.LoadedRuntimePlugin,
+    thebitlab_runtime_plugins.RuntimeRequest,
+]:
     activity_path = _activity_path(root, assignment)
     workspace_path = _workspace_path(root, assignment)
     activity = _load_activity(activity_path)
@@ -136,6 +140,28 @@ def runtime_error_report(
     }
 
 
+def _student_runtime_backend(
+    requested_backend: str,
+    loaded: thebitlab_runtime_plugins.LoadedRuntimePlugin,
+) -> str:
+    """Prefer the authoritative sandbox for student-facing sandbox-capable runtimes.
+
+    Historical student callers default to ``local``. Once an administrator-installed
+    runtime advertises ``sandbox-plan.v1``, treating that implicit local value as
+    process-only grading would silently downgrade the security boundary. Promote it
+    to Docker instead. Legacy v1 runtimes that do not offer the sandbox capability
+    keep their existing local behavior.
+    """
+
+    if (
+        requested_backend == "local"
+        and thebitlab_runtime_plugins.RUNTIME_SANDBOX_CAPABILITY
+        in loaded.descriptor.capabilities
+    ):
+        return "docker"
+    return requested_backend
+
+
 def run_runtime_assignment(
     assignment: dict[str, Any],
     *,
@@ -147,6 +173,7 @@ def run_runtime_assignment(
 ) -> dict[str, Any]:
     runtime_id = "unknown"
     source = root
+    effective_backend = backend
     try:
         activity_path = _activity_path(root, assignment)
         activity = _load_activity(activity_path)
@@ -161,9 +188,10 @@ def run_runtime_assignment(
             registry=registry,
         )
         source = _source_from_request(request)
-        if backend == "local":
+        effective_backend = _student_runtime_backend(backend, loaded)
+        if effective_backend == "local":
             execution = thebitlab_runtime_plugins.run_runtime(loaded, request)
-        elif backend == "docker":
+        elif effective_backend == "docker":
             plan = thebitlab_runtime_plugins.prepare_sandbox_runtime(loaded, request)
             service = (
                 sandbox_service
@@ -197,7 +225,7 @@ def run_runtime_assignment(
                 loaded, request, sandbox_result
             )
         else:
-            raise ValueError(f"Backend runtime non supportato: {backend}")
+            raise ValueError(f"Backend runtime non supportato: {effective_backend}")
     except FileNotFoundError as error:
         missing = error.filename or str(error)
         return runtime_error_report(
@@ -241,7 +269,8 @@ def run_runtime_assignment(
         "detail": execution.detail,
         "runtime": {
             "plugin_version": loaded.descriptor.plugin_version,
-            "backend": backend,
+            "backend": effective_backend,
+            "requested_backend": backend,
             "metadata": execution.metadata,
         },
     }

--- a/tests/test_student_runtime.py
+++ b/tests/test_student_runtime.py
@@ -138,7 +138,12 @@ def fixture(tmp_path: Path) -> tuple[dict, thebitlab_runtime_plugins.RuntimePlug
                 "required_capabilities": ["headless-run", "deterministic-grade"],
                 "submission": {
                     "artifacts": [
-                        {"id": "answer", "path": "answer.bin", "media_type": "application/octet-stream", "required": True}
+                        {
+                            "id": "answer",
+                            "path": "answer.bin",
+                            "media_type": "application/octet-stream",
+                            "required": True,
+                        }
                     ]
                 },
             }
@@ -176,7 +181,51 @@ def test_runtime_assignment_generates_normal_student_report(tmp_path: Path) -> N
     assert report["score"] == 5.0
     assert report["tests"][1]["message"] == "fix me"
     assert report["runtime"]["backend"] == "local"
+    assert report["runtime"]["requested_backend"] == "local"
     assert report["runtime"]["metadata"]["authoritative"] is False
+
+
+def test_sandbox_capable_runtime_promotes_default_local_to_docker(tmp_path: Path) -> None:
+    assignment, _ = fixture(tmp_path)
+    registry = thebitlab_runtime_plugins.RuntimePluginRegistry(
+        lambda: (FakeEntryPoint("example-runtime", FakeSandboxRuntime),)
+    )
+    service = FakeSandboxService()
+
+    report = student_runtime.run_runtime_assignment(
+        assignment,
+        root=tmp_path,
+        timeout_seconds=10,
+        registry=registry,
+        sandbox_service=service,
+    )
+
+    assert report["passed"] is True
+    assert report["runtime"]["requested_backend"] == "local"
+    assert report["runtime"]["backend"] == "docker"
+    assert report["runtime"]["metadata"]["authoritative"] is True
+    assert report["runtime"]["metadata"]["execution_isolation"] == "docker"
+    assert len(service.calls) == 1
+
+
+def test_sandbox_capable_runtime_default_fails_closed_without_docker(tmp_path: Path) -> None:
+    assignment, _ = fixture(tmp_path)
+    registry = thebitlab_runtime_plugins.RuntimePluginRegistry(
+        lambda: (FakeEntryPoint("example-runtime", FakeSandboxRuntime),)
+    )
+
+    report = student_runtime.run_runtime_assignment(
+        assignment,
+        root=tmp_path,
+        timeout_seconds=10,
+        registry=registry,
+        sandbox_service=MissingDockerSandboxService(),
+    )
+
+    assert report["passed"] is False
+    assert report["status"] == "runtime-unavailable"
+    assert "Docker non trovato" in report["error"]
+    assert "fix me" not in json.dumps(report)
 
 
 def test_runtime_docker_uses_prepare_broker_and_trusted_finalize(tmp_path: Path) -> None:
@@ -197,6 +246,7 @@ def test_runtime_docker_uses_prepare_broker_and_trusted_finalize(tmp_path: Path)
 
     assert report["passed"] is True
     assert report["runtime"]["backend"] == "docker"
+    assert report["runtime"]["requested_backend"] == "docker"
     assert report["runtime"]["metadata"]["authoritative"] is True
     assert report["runtime"]["metadata"]["execution_isolation"] == "docker"
     assert len(service.calls) == 1


### PR DESCRIPTION
## Summary

- prevent sandbox-capable runtime Activities from silently using process-only grading through historical `local` defaults
- promote student-facing `local` requests to Docker when the installed runtime advertises `sandbox-plan.v1`
- keep legacy runtime_plugin.v1 runtimes without sandbox support on their existing local path
- fail closed when Docker or the sandbox boundary is unavailable; never fall back to `plugin.run()` after sandbox failure
- expose requested vs effective backend in runtime report metadata
- add regression tests and document the student execution policy

## Compatibility

No runtime ABI change and no CLI flag change. Existing student callers can continue passing/omitting `local`; sandbox-capable runtimes become authoritative automatically. Low-level `run_runtime()` / `plugin.run()` remain available for controlled developer use.

Coordinated follow-up for the Romeo runtime deployment; after merge Romeo will update its pinned TheBitLab broker SHA and republish/re-smoke the runtime digest.