### PR TITLE
docs(runtime): link Romeo implementation portal

### DIFF
--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -9,6 +9,18 @@ The authoritative Italian guides remain Markdown documents in the repository:
 * `Architettura MVP <https://github.com/TheBitPoets/2cornot2c/blob/main/doc/ARCHITETTURA_MVP.md>`_
 * `Architettura frontend <https://github.com/TheBitPoets/2cornot2c/blob/main/doc/FRONTEND_ARCHITECTURE.md>`_
 * `Catalogo delle fonti <https://github.com/TheBitPoets/2cornot2c/blob/main/doc/COURSE_SOURCE_CATALOG.md>`_
+* `Contratto dei runtime plugin <https://github.com/TheBitPoets/2cornot2c/blob/main/doc/architecture/runtime-plugin-contract.md>`_
+
+Runtime implementations
+-----------------------
+
+TheBitLab keeps runtime implementations outside the platform core. Their own
+repositories are the authoritative source for domain-specific installation,
+teaching and API documentation.
+
+* `Romeo · Python e robotica <https://github.com/TheBitPoets/romeo/blob/main/docs/index.md>`_
+  — reference implementation of a ``runtime_plugin.v1`` adapter with
+  ``sandbox-plan.v1``, deterministic simulation and an external Course Bundle.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Summary

- keep TheBitLab runtime documentation generic and platform-owned
- surface the generic runtime plugin contract from the Sphinx entry point
- link Romeo as an external reference implementation of `runtime_plugin.v1` + `sandbox-plan.v1`
- keep Romeo-specific installation, teaching and API documentation in the Romeo repository

## Scope

Documentation only. No runtime ABI, discovery, sandbox broker or student execution behavior changes.