### PR TITLE
Define reusable Course Delivery Standard v1

### DIFF
--- a/docs/standards/.noissue
+++ b/docs/standards/.noissue
@@ -1,0 +1,1 @@
+temporary sentinel? no

--- a/docs/standards/.noissue
+++ b/docs/standards/.noissue
@@ -1,1 +1,0 @@
-temporary sentinel? no

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -1,0 +1,10 @@
+# Standards
+
+This directory contains shared standards used across course repositories and runtime/lab projects.
+
+## Course delivery
+
+- [Course Delivery Standard v1](course_delivery_standard.md)
+- [Course Delivery Standard v1 — rollout plan](course_delivery_rollout.md)
+
+The delivery standard is intentionally separate from Content Pack curriculum contracts. It defines how courses are taught, navigated, presented, patched during the year and packaged for teachers/students.

--- a/docs/standards/course_delivery_checklist.md
+++ b/docs/standards/course_delivery_checklist.md
@@ -1,0 +1,57 @@
+# Course Delivery Checklist
+
+Use this checklist when creating or reviewing a course delivery layer.
+
+## Repository navigation
+
+- [ ] Root README explains the course to a new teacher/student.
+- [ ] README has clickable module/UDA index.
+- [ ] Every module links to lesson material.
+- [ ] Every module links to slides or explicitly says slides are pending.
+- [ ] Every module links to Activity/lab entry points where applicable.
+- [ ] Longitudinal project milestones are visible from the README.
+
+## Slides
+
+- [ ] Slides source lives under `slides/<course-id>/`.
+- [ ] Slide anchors or filenames are stable.
+- [ ] The slide index explains how to present/build the deck.
+- [ ] Generated slide artifacts are reproducible or intentionally not committed.
+- [ ] Slides include lab handoff points, not only theory.
+
+## Teacher documentation
+
+- [ ] `doc/teacher/README.md` exists.
+- [ ] Lesson notes identify demos, timing, expected difficulties and recovery paths.
+- [ ] Assessment/rubric guidance is available.
+- [ ] Licensed teacher-only references are linked, not redistributed.
+
+## Student documentation
+
+- [ ] `doc/student/README.md` exists.
+- [ ] Setup guide exists.
+- [ ] Run/test/debug/submit workflow exists.
+- [ ] Troubleshooting guide exists.
+- [ ] TheBitLab and local fallback are both documented where applicable.
+
+## Operational workflow
+
+- [ ] Local setup is reproducible.
+- [ ] Lab execution commands are documented.
+- [ ] Test commands are documented.
+- [ ] Evidence/submission expectations are documented.
+- [ ] Safety notes exist for hardware/robotics courses.
+
+## During-year changes
+
+- [ ] PR is labeled or described as `delivery-only` or `curriculum-change`.
+- [ ] Delivery-only PR does not modify curriculum contracts.
+- [ ] Curriculum-change PR updates Course Design, coverage, manifest and tests as needed.
+- [ ] Delivery changelog is updated when the change affects class use.
+
+## Quality
+
+- [ ] Existing curriculum CI remains green.
+- [ ] Link checks/build checks are run when available.
+- [ ] Slide build succeeds when enabled.
+- [ ] Generated artifacts are reproducible from source.

--- a/docs/standards/course_delivery_rollout.md
+++ b/docs/standards/course_delivery_rollout.md
@@ -1,0 +1,182 @@
+# Course Delivery Standard v1 — rollout plan
+
+Status: proposed
+Tracker: #737
+Reference implementation: `TheBitPoets/tpsi-quinto-docente`
+
+## Goal
+
+Apply one reusable delivery model to multiple courses without forcing every course to be rebuilt at the same time.
+
+The common target is:
+
+```text
+curriculum contract
+  +
+course dashboard
+  +
+slides
+  +
+teacher guide
+  +
+student guide
+  +
+run/test/debug workflow
+  +
+release/evidence artifacts
+```
+
+## Adoption matrix
+
+| Course | Current target | First delivery increment | Special notes |
+|---|---:|---|---|
+| TPSI quinto 2026/27 | Level 3 -> 4 | split slide decks 00-18, teacher guide, student guide | Content Pack 1.0.0 already frozen; delivery patches can move during the year |
+| TPSI quarto | Level 2 -> 3 | README/dashboard and slide/lab map aligned to TPSI5 pattern | keep existing Content Pack decisions; do not retrofit unnecessary tech |
+| Hardware/Proxmox | Level 2 -> 3 | virtual lab guide, topology diagrams, compatibility checklist | must support no-hardware and limited-hardware scenarios |
+| Romeo robotics | Level 3 | install/simulator/physical commissioning workflow | must separate simulation, package/plugin setup and physical robot self-test |
+| C course | Level 1 -> 2 | dashboard, first deck, compiler/debugger workflow | preserve large legacy corpus; add navigation instead of rewriting everything |
+| Future Python | Level 3 native | start from standard skeleton before content expansion | avoid later migration cost |
+
+## Work packages
+
+### WP1 — Standard approval
+
+- [ ] Review `docs/standards/course_delivery_standard.md`.
+- [ ] Decide where Course Delivery Standard v1 is referenced from Content Pack v1 docs.
+- [ ] Add a simple checklist template for future course repositories.
+- [ ] Decide whether delivery artifacts are committed, released, or published via Pages.
+
+### WP2 — TPSI quinto as reference course
+
+- [ ] Split `slides/tpsi5/COURSE_SLIDES.md` into module decks `00` through `18`.
+- [ ] Keep stable README links from module table to slide anchors or deck files.
+- [ ] Add `doc/teacher/README.md`.
+- [ ] Add `doc/teacher/lesson_notes/` incrementally.
+- [ ] Add `doc/student/README.md`.
+- [ ] Add `doc/student/setup.md` and `workflow.md`.
+- [ ] Add slide build workflow: HTML first, then PDF/PPTX if stable.
+- [ ] Add delivery changelog for school-year patching.
+
+### WP3 — Hardware/Proxmox
+
+- [ ] Define course dashboard.
+- [ ] Add topology slides.
+- [ ] Add virtual lab pathway for students without hardware.
+- [ ] Add hardware checklist and compatibility glossary.
+- [ ] Add install/run/rollback notes for Proxmox experiments.
+- [ ] Add evidence capture workflow: screenshots, configs, VM topology.
+
+### WP4 — Romeo robotics
+
+- [ ] Define README dashboard.
+- [ ] Add install guide for package/plugin.
+- [ ] Add simulator workflow.
+- [ ] Add physical commissioning checklist.
+- [ ] Add robot self-test script workflow: motors, direction, sensors, emergency stop assumptions.
+- [ ] Add student-safe testing protocol.
+- [ ] Add teacher guide for lab supervision.
+
+### WP5 — TPSI quarto
+
+- [ ] Audit existing course shape against standard levels.
+- [ ] Add or update README dashboard.
+- [ ] Add slide index.
+- [ ] Link modules to Activity and reference solutions.
+- [ ] Add student workflow.
+
+### WP6 — C course
+
+- [ ] Preserve existing corpus.
+- [ ] Add roadmap dashboard before rewriting lessons.
+- [ ] Add compiler/debugger setup guide.
+- [ ] Add first narrative slide deck.
+- [ ] Add lab workflow and common errors.
+
+### WP7 — Future Python
+
+- [ ] Create course skeleton from standard before content expansion.
+- [ ] Define README, slide, teacher, student and Activity directories from day one.
+- [ ] Reuse Python runner and pytest conventions from TPSI5 UDA26 when appropriate.
+
+## During-year modification policy
+
+A teacher can request changes during the year. Each request is classified before implementation.
+
+### Delivery patch
+
+Examples:
+
+- clearer slide;
+- better diagram;
+- missing link;
+- wrong command in setup;
+- troubleshooting addition;
+- alternative explanation;
+- teacher timing note;
+- student FAQ;
+- typo or translation fix.
+
+Required checks:
+
+- Content Pack unchanged;
+- Course Design unchanged;
+- existing CI still green;
+- PR body says `delivery-only: yes`.
+
+### Curriculum patch
+
+Examples:
+
+- add/remove module;
+- change UDA duration;
+- change grading;
+- change Activity expected output;
+- add required framework/tool;
+- change milestone behavior.
+
+Required checks:
+
+- update Content Pack or Course Design;
+- update coverage;
+- update Activity contracts;
+- update regression tests;
+- version decision explicitly.
+
+## Branch naming
+
+Recommended:
+
+```text
+delivery/<course>/<short-topic>
+slides/<course>/<module-range>
+docs/<course>/<teacher-or-student-topic>
+curriculum/<course>/<decision-or-version>
+```
+
+Examples:
+
+```text
+slides/tpsi5/00-04-foundations
+docs/romeo/physical-commissioning
+delivery/hardware-proxmox/virtual-lab-guide
+curriculum/tpsi4/course-design-adjustment
+```
+
+## Definition of done for a delivery PR
+
+- [ ] Scope says delivery-only or curriculum-change.
+- [ ] README links work for modified areas.
+- [ ] Teacher/student audience is clear.
+- [ ] No dead references to missing slide decks or labs.
+- [ ] Existing curriculum CI remains green.
+- [ ] Generated artifacts are either reproducible or intentionally absent.
+- [ ] PR description states what the teacher should review.
+
+## First next PRs suggested
+
+1. TPSI5 split slide decks 00-18.
+2. TPSI5 teacher guide skeleton.
+3. TPSI5 student workflow guide.
+4. Delivery build workflow for Markdown/Marp HTML output.
+5. Romeo install/simulator/physical self-test delivery skeleton.
+6. Hardware/Proxmox virtual lab and topology delivery skeleton.

--- a/docs/standards/course_delivery_standard.md
+++ b/docs/standards/course_delivery_standard.md
@@ -1,0 +1,310 @@
+# Course Delivery Standard v1
+
+Status: proposed
+Owner: TheBitPoets / course content packs
+Applies to: TPSI quinto, TPSI quarto, hardware/Proxmox, Romeo robotics, C, future Python and any new Content Pack course.
+
+## 1. Purpose
+
+A Content Pack defines curriculum contracts: objectives, content items, activities, coverage, reference solutions and quality gates.
+
+A Course Delivery Pack makes that curriculum teachable in a real classroom: README dashboard, slides, teacher guide, student guide, operational workflow, generated artifacts, troubleshooting, evidence and change policy during the school year.
+
+The two layers must stay separate:
+
+- curriculum freeze: what the course is;
+- delivery layer: how the course is taught, explained, run, fixed and improved.
+
+This separation lets a teacher improve slides, setup instructions and explanations during the year without pretending that every small correction is a curriculum redesign.
+
+## 2. Minimum repository shape
+
+Every course repository SHOULD expose the same navigation shape.
+
+```text
+README.md
+content-pack.json
+doc/
+  course_designs/
+  COVERAGE.md
+  teacher/
+    README.md
+    lesson_notes/
+    assessment.md
+    troubleshooting.md
+  student/
+    README.md
+    setup.md
+    workflow.md
+    troubleshooting.md
+slides/
+  <course-id>/
+    README.md
+    COURSE_SLIDES.md
+    00_<module>.md        # optional split deck
+    01_<module>.md
+activities/
+reference_solutions/
+scripts/
+  build_slides.*          # when generated artifacts are supported
+  check_links.*           # when link checks are supported
+```
+
+A mature course may split slide decks by module. A young course may start with one `COURSE_SLIDES.md` file with stable anchors and later split it without changing the Content Pack.
+
+## 3. README as course home
+
+The root README SHOULD be readable by a teacher or student who has never seen the design conversation.
+
+It SHOULD include:
+
+1. course title, year and status;
+2. short course promise in plain language;
+3. prerequisites;
+4. learning arc;
+5. longitudinal project, when present;
+6. clickable UDA/module index;
+7. links to canonical lesson Markdown;
+8. links to slides;
+9. links to Activity/lab entry points;
+10. teacher guide link;
+11. student guide link;
+12. local setup and TheBitLab setup summary;
+13. contribution/change policy.
+
+The README is not the Course Design. It is the entry page used in class.
+
+## 4. Slide standard
+
+Slides are source material, not screenshots of the course.
+
+Preferred source format: Markdown/Marp.
+
+Each module deck SHOULD follow this teaching rhythm:
+
+1. title and position in the course;
+2. what students already know;
+3. learning objectives;
+4. motivating problem;
+5. visual explanation;
+6. minimal code example;
+7. realistic code example;
+8. common mistakes;
+9. connection to the longitudinal project;
+10. live checkpoint questions;
+11. lab handoff: Activity to open;
+12. recap;
+13. next lesson preview.
+
+Slide anchors MUST be stable if they are linked by README tables.
+
+Generated outputs such as HTML, PDF or PPTX SHOULD be treated as artifacts. The Markdown source remains the source of truth.
+
+## 5. Teacher guide
+
+`doc/teacher/` SHOULD answer operational classroom questions:
+
+- how to prepare the lesson;
+- what to demo live;
+- what can fail;
+- timing suggestions;
+- expected student difficulties;
+- reference solution notes;
+- assessment and rubric;
+- recovery and strengthening paths;
+- safe shortcuts when time is short;
+- links to external teacher-only references.
+
+Licensed sources such as Manning or Pluralsight can be referenced for the teacher, but must not be redistributed unless the license explicitly allows it.
+
+## 6. Student guide
+
+`doc/student/` SHOULD answer student workflow questions:
+
+- how to set up the environment;
+- how to open/run/test a lab;
+- how to use TheBitLab;
+- how to submit work;
+- how to debug common errors;
+- how to read failing tests;
+- how to recover from broken dependencies;
+- where to find the next Activity.
+
+Student docs should not depend on private teacher context.
+
+## 7. Activity and lab mapping
+
+Every teaching module SHOULD be traceable:
+
+```text
+module -> lesson -> slides -> Activity -> reference solution -> milestone/evidence
+```
+
+A README or module index SHOULD make this mapping explicit.
+
+For longitudinal projects, each milestone SHOULD say:
+
+- what changed;
+- what did not change;
+- how to run it;
+- how to test it;
+- which Activity produced it;
+- how it connects to the next milestone.
+
+## 8. Generated artifacts
+
+Courses MAY generate:
+
+- slide HTML;
+- slide PDF;
+- PPTX for classroom delivery;
+- evidence bundles;
+- printable handouts;
+- GitHub Pages site.
+
+Generated artifacts SHOULD be reproducible from source and SHOULD NOT become the source of truth.
+
+If artifacts are committed, the repository MUST document why. Otherwise they should be built in CI or release workflows.
+
+## 9. Change policy during the school year
+
+Delivery changes are expected during the school year.
+
+Patch-safe delivery changes include:
+
+- typo fixes;
+- clearer explanations;
+- additional slide examples;
+- troubleshooting notes;
+- README navigation improvements;
+- teacher timing notes;
+- student setup clarifications;
+- generated artifact fixes;
+- link fixes;
+- lab wording improvements that do not change expected outcomes.
+
+Curriculum changes require explicit curriculum review when they alter:
+
+- learning objectives;
+- UDA duration;
+- Activity contract;
+- grading policy;
+- reference solution behavior;
+- scope of the longitudinal project;
+- required toolchain;
+- assessment criteria;
+- Content Pack status/version.
+
+A patch-safe PR MUST state: `delivery-only: yes`.
+
+A curriculum-changing PR MUST update Course Design, coverage, manifest, tests and release notes where applicable.
+
+## 10. Versioning
+
+Recommended version tracks:
+
+- `Content Pack version`: curriculum contract version, for example `1.0.0 approved`;
+- `Delivery version`: classroom material version, for example `delivery-2026.09`, `delivery-2026.10`;
+- `Artifact version`: generated PDFs/PPTX/HTML, derived from source commit.
+
+Delivery versions can move during the year while the Content Pack remains frozen.
+
+## 11. Quality gates
+
+At minimum, a delivery PR SHOULD preserve existing curriculum CI.
+
+Additional delivery gates MAY include:
+
+- Markdown lint;
+- link check;
+- slide build;
+- generated PDF smoke;
+- generated PPTX smoke;
+- screenshot or artifact upload;
+- README index consistency check.
+
+No delivery gate should mask a curriculum regression.
+
+## 12. Profiles
+
+### Software/web courses
+
+Examples: TPSI quinto, TPSI quarto, future Python.
+
+Extra delivery requirements:
+
+- environment setup;
+- local and TheBitLab workflows;
+- run/test/debug commands;
+- API and frontend milestone maps;
+- screenshots or screen flow when useful.
+
+### Systems and infrastructure courses
+
+Examples: hardware/Proxmox.
+
+Extra delivery requirements:
+
+- topology diagrams;
+- hardware compatibility notes;
+- safety and rollback procedures;
+- virtual lab alternatives;
+- checklists for diagnostics;
+- evidence capture for configurations.
+
+### Robotics courses
+
+Example: Romeo.
+
+Extra delivery requirements:
+
+- simulator workflow;
+- package/plugin installation workflow;
+- robot physical commissioning checklist;
+- motor/direction/sensor self-test scripts;
+- safe test area checklist;
+- recovery procedure;
+- clear separation between simulation pass and physical robot pass.
+
+### Low-level / C courses
+
+Extra delivery requirements:
+
+- compiler setup;
+- debugger workflow;
+- memory model visuals;
+- sanitizers when available;
+- deterministic CLI exercises;
+- architecture/ABI notes only when needed.
+
+## 13. Adoption levels
+
+Level 0 — Content only.
+The course has lessons and activities but no structured delivery layer.
+
+Level 1 — Navigable.
+README dashboard and clickable index exist.
+
+Level 2 — Teachable.
+Slides and basic teacher/student guides exist.
+
+Level 3 — Classroom-ready.
+Slides, guides, lab workflows, troubleshooting, generated artifacts and CI gates exist.
+
+Level 4 — Maintained during the year.
+Delivery changelog, patch policy, issue triage and periodic release artifacts exist.
+
+## 14. Reference implementation
+
+TPSI quinto 2026/27 is the first reference implementation of this delivery standard after Content Pack 1.0.0 freeze.
+
+It already demonstrates:
+
+- README as course home;
+- clickable UDA/module index;
+- stable slide anchors;
+- Markdown/Marp slide source;
+- delivery-only PRs that preserve Content Pack 1.0.0;
+- green curriculum CI after delivery changes.
+
+The next reference milestone for TPSI quinto is split module decks plus teacher/student guides.


### PR DESCRIPTION
## Goal

Turn the TPSI5 delivery pattern into a reusable standard for all current and future courses.

## Changes

- Add `docs/standards/course_delivery_standard.md`.
- Add `docs/standards/course_delivery_rollout.md`.
- Add `docs/standards/course_delivery_checklist.md`.
- Add `docs/standards/README.md` index.

## Scope

This is documentation/governance only. It does not modify existing Content Pack contracts, runtime code or course implementations.

## Rollout

Tracks #737 and review checklist #739.

Target adoption:

- TPSI quinto: split slide decks, teacher guide, student guide, delivery changelog.
- Hardware/Proxmox: virtual lab, topology diagrams, compatibility/safety checklists.
- Romeo: simulator workflow, package/plugin install, physical robot commissioning/self-test.
- TPSI quarto: dashboard and slide/lab mapping.
- C: dashboard, compiler/debugger workflow, first deck.
- Future Python: start native from the standard skeleton.

## During-year policy

Course fixes during the year are classified as either `delivery-only` or `curriculum-change`, so small corrections can be reviewed safely without breaking approved curriculum freezes.