### PR TITLE
Add Course Delivery layer for legacy C course

### DIFF
--- a/COURSE_DELIVERY.md
+++ b/COURSE_DELIVERY.md
@@ -1,0 +1,73 @@
+# C 101 — Course Delivery Dashboard
+
+Questo file è il layer di **delivery** del corso C legacy contenuto in `README.md`. La grande dispensa storica resta la fonte canonica: non viene spezzata o riscritta per adottare il Course Delivery Standard.
+
+## Stato del corso
+
+- Percorso principale: **Terzo anno**, 33 settimane, 3 ore settimanali.
+- Course Design: [`doc/course_designs/course_design_code.json`](doc/course_designs/course_design_code.json).
+- Fonti canoniche: [`README.md`](README.md) e [`LINUX_PROGRAMMING.md`](LINUX_PROGRAMMING.md).
+- Cornici didattiche: già inserite nelle sezioni della dispensa e mantenute dal Course Design.
+- Laboratori: contenuti in `lab/` e collegati alla pipeline snippet/output del repository.
+- TheBitLab: piattaforma del repository per Activity, grading, feedback e dashboard.
+
+Il Course Design è ancora un artefatto vivo con frame in stato `draft`: questo dashboard migliora la conduzione in classe ma non dichiara il curriculum automaticamente congelato.
+
+## Entrate rapide
+
+- [Dispensa C completa](README.md)
+- [Percorso didattico generato](doc/PERCORSO_DIDATTICO.md)
+- [Course Design JSON](doc/course_designs/course_design_code.json)
+- [Guida docente](doc/course-delivery/c/TEACHER_GUIDE.md)
+- [Guida studente](doc/course-delivery/c/STUDENT_GUIDE.md)
+- [Delivery Change Log](doc/course-delivery/c/DELIVERY_CHANGELOG.md)
+- [Indice slide](slides/c/README.md)
+- [Guida laboratori/output](doc/LAB_OUTPUTS.md)
+- [Activity e assignment](doc/ACTIVITIES_SCHEMA.md)
+
+## Mappa del percorso
+
+```text
+ambiente / toolchain
+        ↓
+rappresentazione / tipi / operatori
+        ↓
+controllo del flusso
+        ↓
+funzioni / scope / moduli / preprocessore
+        ↓
+puntatori / array / stringhe
+        ↓
+memoria dinamica / strutture / layout memoria
+        ↓
+assembly e modello macchina
+        ↓
+programmazione Linux come ponte ai sistemi
+```
+
+## Indice cliccabile — macro-aree
+
+| Blocco | Dispensa canonica | Slide | Laboratorio/evidenza |
+|---:|---|---|---|
+| 00 | [Introduzione](README.md#introduzione), [ambiente](README.md#installare-lambiente-di-sviluppo), [compilazione](README.md#il-processo-di-compilazione), [primo programma](README.md#il-primo-programma-in-c) | [00 — Ambiente, toolchain e primo C](slides/c/modules/00_AMBIENTE_TOOLCHAIN_PRIMO_C.md) | `lab/`, compilazione, output riproducibile |
+| 01 | [Rappresentazione delle informazioni](README.md#rappresentazione-delle-informazioni), [tipi](README.md#tipi-di-dato), [operatori](README.md#operatori) | [01 — Bit, tipi e operatori](slides/c/modules/01_RAPPRESENTAZIONE_TIPI_OPERATORI.md) | conversioni, overflow, esperimenti su memoria/byte |
+| 02 | [Controllo del flusso](README.md#controllo-del-flusso) | [02 — Selezione e iterazione](slides/c/modules/02_CONTROLLO_FLUSSO.md) | trace manuale, casi limite, cicli |
+| 03 | [Funzioni](README.md#funzioni-1), [scope/linkage/storage](README.md#classi-di-memorizzazione), [preprocessore](README.md#il-preprocessore) | [03 — Funzioni, scope, moduli e preprocessore](slides/c/modules/03_FUNZIONI_SCOPE_MODULI.md) | compilazione multi-file, header, linkage |
+| 04 | [Puntatori](README.md#i-puntatori), [vettori](README.md#vettori), [stringhe](README.md#le-stringhe) | [04 — Puntatori, array e stringhe](slides/c/modules/04_PUNTATORI_ARRAY_STRINGHE.md) | indirizzi, aritmetica puntatori, buffer |
+| 05 | [Allocazione dinamica](README.md#allocazione-dinamica-della-memoria), [array 2D](README.md#array-bidimensionali), [strutture](README.md#le-strutture), [sezioni memoria](README.md#sezioni-di-memoria-di-un-programma-c) | [05 — Memoria dinamica e strutture](slides/c/modules/05_MEMORIA_DINAMICA_STRUTTURE.md) | malloc/free, matrici, layout e sanitizer |
+| 06 | [Programmazione Assembly](ASM_PROGRAMMING.md) | [06 — Dal C alla macchina](slides/c/modules/06_ASSEMBLY_BRIDGE.md) | compilatore/assembler, registri e calling convention come osservazione |
+| 07 | [Linux Programming](LINUX_PROGRAMMING.md) | [07 — Ponte alla programmazione di sistema](slides/c/modules/07_LINUX_SYSTEMS_BRIDGE.md) | processi/file/API POSIX secondo il percorso assegnato |
+
+## Come usare il materiale in classe
+
+1. Apri il blocco dalla tabella.
+2. Usa la slide come **sequenza narrativa**, non come sostituto della dispensa.
+3. Torna alla sezione canonica del README per dettaglio, esempi e frame didattico.
+4. Passa al laboratorio e conserva output/evidenze generati dagli script del repository.
+5. Se un chiarimento o una slide cambia durante l'anno, registra la revisione nel Delivery Change Log.
+
+## Regola legacy
+
+Una modifica al delivery layer non autorizza a riscrivere il grande README senza audit. Le correzioni della fonte canonica devono preservare marker dei laboratori, frame e pipeline già esistenti.
+
+Per gli artifact generati dai lab valgono le procedure in `doc/LAB_SNIPPETS.md` e `doc/LAB_OUTPUTS.md`.

--- a/doc/course-delivery/c/DELIVERY_CHANGELOG.md
+++ b/doc/course-delivery/c/DELIVERY_CHANGELOG.md
@@ -1,0 +1,31 @@
+# C 101 — Delivery Change Log
+
+Questo file traccia correzioni e miglioramenti del **delivery layer** del corso C senza riscrivere automaticamente la dispensa legacy o il Course Design.
+
+## Tipi
+
+- `errata` — correzione di errore senza cambio di obiettivo;
+- `clarification` — spiegazione/esempio equivalente;
+- `slides` — modifica ai deck docente;
+- `lab-fix` — correzione di laboratorio che preserva l'obiettivo;
+- `setup` — installazione, compilazione, esecuzione o troubleshooting;
+- `curriculum-change` — modifica a obiettivi, prerequisiti, UDA o contenuti obbligatori.
+
+## Registro
+
+| Data | Area | Tipo | Modifica | Motivo | Materiale precedente superato? |
+|---|---|---|---|---|---|
+| 2026-08-21 | Course Delivery iniziale | clarification | Aggiunti dashboard legacy, guide docente/studente e macro-slide | Rendere navigabile la grande dispensa senza spezzarla | No |
+
+## Regole legacy
+
+`README.md` contiene marker generati per laboratori e cornici didattiche. Una correzione della fonte canonica deve preservare questi contratti e usare gli script dedicati quando la sezione è generata.
+
+Workflow consigliato per una segnalazione in classe:
+
+1. capire se il difetto è nella fonte, nella slide, nel setup o nel lab;
+2. correggere la fonte appropriata;
+3. rigenerare snippet/output quando necessario;
+4. aggiornare slide/guida derivate;
+5. registrare qui la revisione;
+6. classificare `curriculum-change` se cambiano obiettivi, prerequisiti, UDA o argomenti obbligatori.

--- a/doc/course-delivery/c/STUDENT_GUIDE.md
+++ b/doc/course-delivery/c/STUDENT_GUIDE.md
@@ -1,0 +1,127 @@
+# Guida studente — C 101
+
+Questa guida descrive il modo di lavorare nel corso C. La dispensa completa resta `README.md`; qui trovi il workflow operativo da ripetere in laboratorio.
+
+## Workflow
+
+```text
+leggi → prevedi → compila → esegui → osserva → modifica → ricompila → debug → conserva evidenza
+```
+
+In C è importante non saltare la previsione: molti errori diventano comprensibili solo se distingui ciò che **pensavi** sarebbe successo da ciò che il compilatore o il programma hanno realmente mostrato.
+
+## Ambiente
+
+Usa l'ambiente predisposto dal corso. La procedura canonica è descritta nella sezione `Installare l'ambiente di sviluppo` del README e negli script bootstrap del repository.
+
+Prima di iniziare verifica almeno:
+
+```bash
+git --version
+gcc --version
+gdb --version
+```
+
+Se il docente assegna `student-dev`, VM o altra modalità, non mischiare toolchain diverse senza motivo: l'ambiente dichiarato fa parte della riproducibilità dell'esercizio.
+
+## Compilare con attenzione
+
+Usa i flag indicati dal docente e **leggi i warning**. Un warning non è rumore da nascondere.
+
+Esempio tipico:
+
+```bash
+gcc -Wall -Wextra -pedantic -std=c17 programma.c -o programma
+```
+
+Quando una build fallisce chiediti in quale fase:
+
+```text
+preprocessore → compilatore → assembler → linker → esecuzione
+```
+
+## Prima di eseguire
+
+Per un frammento breve annota:
+
+- valori iniziali;
+- tipo delle variabili;
+- operazioni previste;
+- output atteso;
+- eventuale comportamento non definito o dubbio.
+
+Poi confronta con l'esecuzione.
+
+## Debugging
+
+Non correggere a tentativi casuali. Usa:
+
+```text
+riproduci → riduci → ipotizza → raccogli evidenza → modifica una cosa → verifica
+```
+
+Strumenti possibili, quando introdotti:
+
+- warning del compilatore;
+- `gdb`;
+- sanitizer;
+- output controllato;
+- test/casi limite.
+
+## Puntatori e memoria
+
+Prima di dereferenziare un puntatore devi saper rispondere:
+
+```text
+a quale oggetto punta?
+è inizializzato?
+l'oggetto è ancora vivo?
+l'indirizzo è nel range valido?
+il tipo puntato è coerente?
+```
+
+Per memoria dinamica aggiungi:
+
+```text
+chi alloca?
+quanto?
+chi possiede il blocco?
+chi lo libera?
+può essere liberato due volte?
+```
+
+## Laboratori
+
+I laboratori nel README possono includere codice e output generati automaticamente. Non modificare i blocchi generati nella documentazione: modifica i sorgenti del lab e usa gli script del repository quando richiesto dal docente.
+
+Per ogni consegna conserva l'evidenza minima richiesta, per esempio:
+
+- sorgente;
+- comando di compilazione;
+- warning/errori significativi;
+- output;
+- test/caso limite;
+- breve spiegazione tecnica.
+
+## TheBitLab
+
+Quando l'esercizio è una Activity formalizzata, usa il runner/grader indicato. Se un esercizio è manuale, la valutazione può dipendere da codice, output, spiegazione e rubric docente: non assumere che ogni attività abbia autograding.
+
+## Git
+
+Fai commit piccoli e comprensibili. Prima di consegnare controlla:
+
+```bash
+git status
+git diff
+```
+
+Un messaggio come `Fix bounds check in string loop` è più utile di `fix`.
+
+## Uso di fonti e AI
+
+Puoi usare documentazione e strumenti autorizzati, ma devi saper spiegare il codice che consegni. Non inserire segreti o dati personali nei prompt. Distingui sempre tra materiale del corso, documentazione ufficiale, esempi esterni e suggerimenti AI.
+
+## Se il materiale cambia durante l'anno
+
+Slide, chiarimenti e comandi possono essere corretti. Questo non significa automaticamente che il programma del corso sia cambiato. Il docente registra le revisioni nel Delivery Change Log e indica quando un materiale precedente è superato.

--- a/doc/course-delivery/c/TEACHER_GUIDE.md
+++ b/doc/course-delivery/c/TEACHER_GUIDE.md
@@ -1,0 +1,110 @@
+# Guida docente — C 101
+
+Questa guida descrive **come condurre** il corso C senza duplicare la dispensa storica `README.md`.
+
+## Principio
+
+La fonte canonica contiene già teoria, esempi, frame didattici e laboratori. Il delivery layer deve aiutare a scegliere **che cosa mostrare, in quale ordine e con quale evidenza**, non produrre una seconda dispensa divergente.
+
+## Sequenza di una lezione
+
+1. **Richiamo**: domanda breve sul concetto precedente.
+2. **Modello mentale**: memoria, bit, stack, controllo o puntatore prima della sintassi.
+3. **Esempio minimo**: pochi statement, output prevedibile.
+4. **Previsione**: gli studenti indicano risultato/stato prima dell'esecuzione.
+5. **Esecuzione**: compilatore con warning, output e strumenti.
+6. **Errore tipico**: introdurre un difetto riproducibile.
+7. **Checkpoint**: una domanda o trace manuale.
+8. **Laboratorio**: modifica/esercizio/debug.
+9. **Evidenza**: sorgente + comando + output/test.
+10. **Recap e ponte** al blocco successivo.
+
+## Ambiente
+
+Usare il bootstrap classroom già mantenuto dal repository:
+
+- VM Ubuntu 24.04 per l'ambiente completo;
+- `student-dev` Docker leggero quando appropriato;
+- stessa toolchain dichiarata dal corso.
+
+Non creare una seconda procedura di installazione dentro questa guida: aggiornare la fonte canonica e i documenti MVP se l'ambiente cambia.
+
+## Compilatore come strumento didattico
+
+Trattare warning ed errori come evidenza. Gli studenti devono imparare a distinguere:
+
+```text
+preprocessore → compilazione → assembly → linking → esecuzione
+```
+
+Quando un esercizio fallisce, chiedere **in quale fase** fallisce prima di correggere il codice.
+
+## Rappresentazione e tipi
+
+Usare esempi concreti su byte e memoria. Collegare sempre:
+
+```text
+pattern di bit ↔ tipo ↔ interpretazione ↔ operazione C
+```
+
+Evitare di presentare overflow, cast e signed/unsigned come sole regole sintattiche.
+
+## Puntatori
+
+Prima dell'aritmetica dei puntatori, far disegnare:
+
+- oggetto;
+- indirizzo;
+- tipo puntato;
+- dimensione dell'elemento;
+- range valido.
+
+Un puntatore è un valore con un contratto di interpretazione e validità, non “una freccia magica”.
+
+## Memoria dinamica
+
+Ogni esercizio `malloc` dovrebbe avere una tabella minima:
+
+```text
+chi alloca | dimensione | ownership | durata | chi libera | errore possibile
+```
+
+Usare sanitizer/debugger quando previsti dal laboratorio e far conservare il report utile.
+
+## Laboratori e marker
+
+Le sezioni lab della dispensa sono sincronizzate dagli script del repository. Non modificare a mano i contenuti dentro i marker generati. Per aggiornare codice/output seguire:
+
+- `doc/LAB_SNIPPETS.md`;
+- `doc/LAB_OUTPUTS.md`.
+
+## TheBitLab
+
+Quando un'attività è formalizzata come Activity, indicare runner/grader realmente disponibile. Se un esercizio resta manuale, dichiararlo chiaramente invece di simulare autograding inesistente.
+
+## Valutazione formativa
+
+Buone evidenze brevi:
+
+- predire l'output;
+- spiegare un warning;
+- disegnare stack/heap/indirizzi;
+- trovare un undefined behavior;
+- trasformare un programma monolitico in moduli;
+- scrivere un caso limite;
+- spiegare una differenza tra array e puntatore senza slogan.
+
+## Recupero
+
+Ridurre dimensione e numero di concetti contemporanei. Esempio: prima un solo puntatore a `int`, poi array, poi stringhe, poi funzioni con puntatori.
+
+## Potenziamento
+
+Usare Assembly e Linux Programming come ponte al modello macchina/sistemi, senza trasformare automaticamente gli approfondimenti in prerequisiti per chi sta ancora consolidando il C di base.
+
+## Modifiche durante l'anno
+
+- chiarimento, slide, comando corretto, esempio equivalente → delivery patch;
+- cambiamento di obiettivo/UDA/prerequisito/argomento obbligatorio → curriculum change;
+- modifica a lab generato → aggiornare fonte + rigenerare snippet/output;
+- ogni revisione distribuita alla classe va registrata in `DELIVERY_CHANGELOG.md`.

--- a/slides/c/README.md
+++ b/slides/c/README.md
@@ -1,0 +1,22 @@
+# Slide docente — C 101
+
+Macro-deck Markdown/Marp per condurre il corso C legacy senza duplicare la grande dispensa `README.md`.
+
+| Deck | Macro-area | Fonte canonica principale |
+|---:|---|---|
+| 00 | [Ambiente, toolchain e primo C](modules/00_AMBIENTE_TOOLCHAIN_PRIMO_C.md) | `README.md`: introduzione, ambiente, compilazione, primo programma |
+| 01 | [Rappresentazione, tipi e operatori](modules/01_RAPPRESENTAZIONE_TIPI_OPERATORI.md) | `README.md`: rappresentazione, tipi, cast, operatori |
+| 02 | [Controllo del flusso](modules/02_CONTROLLO_FLUSSO.md) | `README.md`: if/switch/cicli/break/continue |
+| 03 | [Funzioni, scope, moduli e preprocessore](modules/03_FUNZIONI_SCOPE_MODULI.md) | `README.md`: funzioni, storage/linkage, moduli, preprocessore |
+| 04 | [Puntatori, array e stringhe](modules/04_PUNTATORI_ARRAY_STRINGHE.md) | `README.md`: puntatori, vettori, stringhe, passaggio parametri |
+| 05 | [Memoria dinamica e strutture](modules/05_MEMORIA_DINAMICA_STRUTTURE.md) | `README.md`: malloc/free, matrici, memoria, struct |
+| 06 | [Dal C alla macchina](modules/06_ASSEMBLY_BRIDGE.md) | `ASM_PROGRAMMING.md` |
+| 07 | [Ponte alla programmazione Linux](modules/07_LINUX_SYSTEMS_BRIDGE.md) | `LINUX_PROGRAMMING.md` |
+
+## Uso
+
+Le slide servono per la sequenza di spiegazione:
+
+`richiamo → obiettivi → modello mentale → esempio → errore tipico → checkpoint → lab → recap`.
+
+Il dettaglio tecnico, i frame didattici e i laboratori restano nelle fonti canoniche. In questa prima adozione Level 2 non generiamo ancora automaticamente PDF/PPTX: prima consolidiamo la navigazione e la qualità dei macro-deck sul corso legacy.

--- a/slides/c/modules/00_AMBIENTE_TOOLCHAIN_PRIMO_C.md
+++ b/slides/c/modules/00_AMBIENTE_TOOLCHAIN_PRIMO_C.md
@@ -1,0 +1,201 @@
+---
+marp: true
+paginate: true
+size: 16:9
+title: 00 — Ambiente, toolchain e primo C
+---
+
+# 00 — Ambiente, toolchain e primo C
+
+Terzo anno — avvio del percorso
+
+---
+
+# Domanda iniziale
+
+Quando scrivi:
+
+```c
+printf("ciao\n");
+```
+
+quali passaggi avvengono **prima** che il terminale mostri `ciao`?
+
+Il corso parte da questa catena, non dalla sola sintassi.
+
+---
+
+# Obiettivi
+
+- usare l'ambiente classroom dichiarato;
+- distinguere sorgente, oggetto ed eseguibile;
+- riconoscere preprocessore, compilatore, assembler e linker;
+- leggere warning/errori;
+- compilare ed eseguire un programma minimo;
+- modificare un esempio in modo controllato;
+- conservare comando e output come evidenza.
+
+---
+
+# Toolchain
+
+```text
+file.c
+  ↓ preprocessore
+sorgente espanso
+  ↓ compilatore
+assembly
+  ↓ assembler
+file.o
+  ↓ linker
+eseguibile
+```
+
+Un errore in una fase non è la stessa cosa di un errore in un'altra.
+
+---
+
+# Primo programma
+
+```c
+#include <stdio.h>
+
+int main(void) {
+    printf("Hello, C!\n");
+    return 0;
+}
+```
+
+Riconosci:
+
+- direttiva `#include`;
+- funzione `main`;
+- chiamata `printf`;
+- valore restituito al sistema operativo.
+
+---
+
+# Compilare con warning
+
+```bash
+gcc -Wall -Wextra -pedantic -std=c17 hello.c -o hello
+```
+
+Il compilatore è un partner di debugging.
+
+Non “far sparire” i warning: capisci perché esistono.
+
+---
+
+# Errore di compilazione
+
+```c
+printf("ciao\n")
+```
+
+Manca `;`.
+
+Il programma non arriva al linker né all'esecuzione.
+
+Prima domanda: **in quale fase siamo?**
+
+---
+
+# Errore di linking
+
+Dichiari/chiedi una funzione ma non fornisci una definizione compatibile.
+
+```text
+compilazione dei file → OK
+link → simbolo non risolto
+```
+
+Un errore linker racconta una storia diversa da un errore sintattico.
+
+---
+
+# Prevedi prima di eseguire
+
+```c
+#include <stdio.h>
+
+int main(void) {
+    printf("A");
+    printf("B\n");
+    return 0;
+}
+```
+
+Scrivi l'output atteso, poi compila ed esegui.
+
+Questa abitudine tornerà in ogni modulo.
+
+---
+
+# Exit status
+
+```c
+return 0;
+```
+
+comunica successo secondo la convenzione comune.
+
+Dal terminale puoi osservare lo stato di uscita e usarlo nei test/script.
+
+Output visibile ed exit status sono **evidenze diverse**.
+
+---
+
+# Errore tipico
+
+> Modificare più righe insieme e poi non sapere quale modifica ha causato l'errore.
+
+Usa variazioni piccole:
+
+```text
+cambia una cosa → ricompila → osserva
+```
+
+---
+
+# Checkpoint
+
+Classifica:
+
+1. `stdio.h` non trovato;
+2. `;` mancante;
+3. simbolo `foo` non definito al link;
+4. eseguibile termina con segmentation fault.
+
+Fasi: preprocessore/compilazione/link/esecuzione.
+
+---
+
+# Lab
+
+Esegui il primo programma e conserva:
+
+- file sorgente;
+- comando `gcc`;
+- output;
+- un errore introdotto volontariamente;
+- messaggio del compilatore;
+- correzione.
+
+---
+
+# Recap
+
+- C passa attraverso una toolchain;
+- warning/errori hanno una fase;
+- `main` è l'ingresso del programma;
+- previsione ed evidenza rendono l'esercizio ripetibile;
+- l'ambiente dichiarato fa parte del contratto del lab.
+
+---
+
+# Prossimo blocco
+
+Ora chiediamo che cosa rappresentano davvero i valori:
+
+**bit, byte, tipi, signed/unsigned, cast e operatori**.

--- a/slides/c/modules/01_RAPPRESENTAZIONE_TIPI_OPERATORI.md
+++ b/slides/c/modules/01_RAPPRESENTAZIONE_TIPI_OPERATORI.md
@@ -1,0 +1,224 @@
+---
+marp: true
+paginate: true
+size: 16:9
+title: 01 — Rappresentazione, tipi e operatori
+---
+
+# 01 — Rappresentazione, tipi e operatori
+
+Bit → interpretazione → operazione C
+
+---
+
+# Richiamo
+
+Un eseguibile manipola memoria.
+
+La memoria contiene **bit**, ma il programma attribuisce loro un significato attraverso i tipi.
+
+```text
+pattern di bit + tipo = interpretazione
+```
+
+---
+
+# Obiettivi
+
+- ragionare su bit, byte e basi numeriche;
+- distinguere valore e rappresentazione;
+- spiegare unsigned e complemento a due;
+- riconoscere endianess a livello byte;
+- distinguere tipi interi e `char`;
+- prevedere conversioni/cast semplici;
+- usare operatori senza perdere di vista tipo e range.
+
+---
+
+# Un byte, molti significati
+
+```text
+01000001
+```
+
+Può essere interpretato come:
+
+- intero 65;
+- carattere `'A'` in una codifica compatibile;
+- parte di un valore multibyte;
+- campo di bit in un protocollo.
+
+I bit non portano da soli l'etichetta del significato.
+
+---
+
+# Unsigned
+
+Con `n` bit, un unsigned rappresenta tipicamente:
+
+```text
+0 ... 2^n - 1
+```
+
+Esempio 8 bit:
+
+```text
+00000000 = 0
+11111111 = 255
+```
+
+Le operazioni aritmetiche unsigned seguono regole modulari definite dal linguaggio.
+
+---
+
+# Signed e complemento a due
+
+Per gli interi signed moderni il modello utile è il complemento a due.
+
+Con 8 bit:
+
+```text
+01111111 =  127
+10000000 = -128
+11111111 =   -1
+```
+
+Il bit pattern va interpretato secondo il tipo.
+
+---
+
+# Overflow: non tutto è uguale
+
+```text
+unsigned overflow → comportamento modulare definito
+signed overflow   → non trattarlo come wrap garantito
+```
+
+Questa differenza è importante per correttezza, ottimizzazioni e debugging.
+
+---
+
+# Endianness
+
+Valore multibyte:
+
+```text
+0x12345678
+```
+
+In memoria l'ordine dei byte dipende dall'architettura:
+
+```text
+little endian: 78 56 34 12
+big endian:    12 34 56 78
+```
+
+Endianness riguarda **ordine dei byte**, non l'ordine dei bit scritto su carta.
+
+---
+
+# `sizeof`
+
+```c
+sizeof(int)
+sizeof x
+```
+
+Restituisce dimensione in byte dell'oggetto/tipo.
+
+Non assumere valori specifici quando il linguaggio non li garantisce: osserva l'ambiente e usa i limiti definiti dagli header standard quando serve.
+
+---
+
+# Cast
+
+```c
+unsigned int u = (unsigned int)x;
+```
+
+Un cast non “cambia i bit a caso”: applica regole di conversione del linguaggio.
+
+Prima domanda:
+
+> qual è il valore sorgente, qual è il tipo destinazione e quale range può rappresentare?
+
+---
+
+# Operatori e tipi
+
+```c
+5 / 2     // divisione intera
+5.0 / 2   // divisione floating
+```
+
+La stessa forma `/` produce risultati diversi perché i tipi degli operandi cambiano il contratto dell'operazione.
+
+---
+
+# Precedenza ≠ intenzione
+
+```c
+x + y * z
+```
+
+La precedenza definisce parsing, ma parentesi esplicite possono rendere l'intenzione più leggibile:
+
+```c
+x + (y * z)
+```
+
+Non usare la tabella di precedenza come test di memoria fine a sé stesso.
+
+---
+
+# Errore tipico
+
+> Mischiare signed e unsigned senza capire la conversione implicita.
+
+Un confronto apparentemente banale può sorprendere se un operando viene convertito in un tipo unsigned più ampio.
+
+Prima di correggere “a caso”, identifica i tipi reali dell'espressione.
+
+---
+
+# Checkpoint
+
+Per ciascun caso indica **valore, tipo e rischio**:
+
+1. `255u + 1u` su un tipo unsigned di 8 bit ipotetico;
+2. `5 / 2`;
+3. `(unsigned int)-1`;
+4. lettura byte di `0x1234` su little endian;
+5. confronto tra `int` negativo e `unsigned int`.
+
+---
+
+# Lab
+
+Costruisci piccoli programmi che stampano:
+
+- `sizeof` dei tipi usati;
+- rappresentazioni esadecimali;
+- cast signed/unsigned;
+- divisioni intere;
+- byte di un valore multibyte tramite accesso controllato.
+
+Annota **previsione → output → spiegazione**.
+
+---
+
+# Recap
+
+- memoria = bit/byte, tipo = interpretazione;
+- signed/unsigned hanno regole diverse;
+- endianess ordina i byte;
+- cast e promozioni seguono regole precise;
+- operatori vanno letti insieme ai tipi.
+
+---
+
+# Prossimo blocco
+
+Dai valori passiamo alla scelta dell'ordine di esecuzione:
+
+**if, switch, for, while, do-while, break e continue**.

--- a/slides/c/modules/02_CONTROLLO_FLUSSO.md
+++ b/slides/c/modules/02_CONTROLLO_FLUSSO.md
@@ -1,0 +1,247 @@
+---
+marp: true
+paginate: true
+size: 16:9
+title: 02 — Controllo del flusso
+---
+
+# 02 — Controllo del flusso
+
+Dal calcolo lineare alla scelta e alla ripetizione
+
+---
+
+# Richiamo
+
+Finora abbiamo valutato espressioni.
+
+Ora il programma deve decidere **quali istruzioni eseguire e quante volte**.
+
+```text
+sequenza → selezione → iterazione
+```
+
+---
+
+# Obiettivi
+
+- costruire condizioni leggibili;
+- usare `if`/`else` e `switch` in modo appropriato;
+- scegliere tra `for`, `while` e `do-while`;
+- fare trace manuale di una iterazione;
+- riconoscere off-by-one e cicli infiniti;
+- usare `break`/`continue` senza nascondere la logica;
+- progettare casi limite prima del lab.
+
+---
+
+# `if`
+
+```c
+if (x > 0) {
+    puts("positivo");
+} else {
+    puts("non positivo");
+}
+```
+
+La domanda importante è:
+
+> quali insiemi di input percorrono ciascun ramo?
+
+---
+
+# Condizioni complesse
+
+```c
+if (age >= 18 && enabled) {
+    ...
+}
+```
+
+Prima di scrivere una condizione lunga, traducila in una frase e identifica:
+
+- operatori relazionali;
+- operatori logici;
+- short-circuit;
+- casi limite.
+
+---
+
+# `switch`
+
+Utile quando un singolo valore discreto seleziona tra casi chiari:
+
+```c
+switch (command) {
+case 'a': ...; break;
+case 'b': ...; break;
+default: ...;
+}
+```
+
+Non è un sostituto universale di `if`.
+
+---
+
+# `for`
+
+Quando inizializzazione, condizione e aggiornamento formano una iterazione regolare:
+
+```c
+for (size_t i = 0; i < n; ++i) {
+    ...
+}
+```
+
+Trace:
+
+```text
+i iniziale → test → body → update → test → ...
+```
+
+---
+
+# Off-by-one
+
+Con array di `n` elementi gli indici validi sono:
+
+```text
+0 ... n-1
+```
+
+Confronta:
+
+```c
+i < n      // tipicamente corretto
+
+i <= n     // accede anche a n: fuori range
+```
+
+Il confine va derivato dal dominio, non memorizzato meccanicamente.
+
+---
+
+# `while`
+
+```c
+while (condition) {
+    ...
+}
+```
+
+Prima domanda:
+
+> quale modifica rende eventualmente falsa `condition`?
+
+Se non sai rispondere, il rischio di ciclo infinito è concreto.
+
+---
+
+# `do-while`
+
+Garantisce almeno una esecuzione del body:
+
+```c
+do {
+    leggi_input();
+} while (!valido);
+```
+
+È utile quando il primo tentativo deve avvenire prima di poter valutare la continuazione.
+
+---
+
+# `break` e `continue`
+
+Possono rendere una soluzione più chiara, ma possono anche frammentare la lettura.
+
+Usali quando esprimono bene l'intenzione:
+
+```text
+break    → termina il ciclo
+continue → salta al prossimo giro
+```
+
+Non usarli per evitare di progettare una condizione comprensibile.
+
+---
+
+# Trace manuale
+
+```c
+int sum = 0;
+for (int i = 1; i <= 3; ++i) {
+    sum += i;
+}
+```
+
+Tabella:
+
+| i | sum prima | sum dopo |
+|---:|---:|---:|
+| 1 | 0 | 1 |
+| 2 | 1 | 3 |
+| 3 | 3 | 6 |
+
+Il trace rende visibile lo stato.
+
+---
+
+# Errore tipico
+
+> Cambiare una condizione finché “sembra funzionare” su un input.
+
+Una condizione va testata almeno su:
+
+- valore interno al dominio;
+- bordo inferiore;
+- bordo superiore;
+- appena fuori dai bordi;
+- input speciale/errato quando applicabile.
+
+---
+
+# Checkpoint
+
+Scegli la struttura e motiva:
+
+1. stampare 0..9;
+2. leggere finché l'utente inserisce un valore valido;
+3. menu con comandi `'a'`, `'b'`, `'q'`;
+4. cercare un elemento e fermarsi quando trovato;
+5. elaborare tutti gli elementi tranne quelli marcati invalidi.
+
+---
+
+# Lab
+
+Per ogni esercizio consegna anche almeno un **caso limite**.
+
+Esempi:
+
+- massimo tra numeri;
+- somma/conta con ciclo;
+- validazione input;
+- ricerca in sequenza;
+- menu semplice.
+
+Prima dell'esecuzione scrivi il trace previsto per un input piccolo.
+
+---
+
+# Recap
+
+- selezione e iterazione modellano il flusso;
+- condizioni descrivono insiemi di casi;
+- trace = stato reso visibile;
+- off-by-one nasce dai confini;
+- ogni ciclo deve avere una logica di terminazione.
+
+---
+
+# Prossimo blocco
+
+Ora separiamo responsabilità e visibilità del codice:
+
+**funzioni, scope, linkage, moduli e preprocessore**.

--- a/slides/c/modules/03_FUNZIONI_SCOPE_MODULI.md
+++ b/slides/c/modules/03_FUNZIONI_SCOPE_MODULI.md
@@ -1,0 +1,243 @@
+---
+marp: true
+paginate: true
+size: 16:9
+title: 03 — Funzioni, scope, moduli e preprocessore
+---
+
+# 03 — Funzioni, scope, moduli e preprocessore
+
+Dare nomi alle responsabilità e governare la visibilità
+
+---
+
+# Richiamo
+
+Il controllo del flusso organizza **quando** eseguiamo istruzioni.
+
+Le funzioni e i moduli organizzano **dove vive una responsabilità** e quali nomi sono visibili.
+
+---
+
+# Obiettivi
+
+- dichiarare, definire e chiamare funzioni;
+- distinguere parametri e argomenti;
+- capire passaggio per valore e indirizzo;
+- ragionare su block/file scope, linkage e storage duration;
+- separare `.c` e `.h`;
+- usare include guard;
+- capire il ruolo del preprocessore;
+- diagnosticare errori di compilazione e linking multi-file.
+
+---
+
+# Dichiarazione e definizione
+
+Dichiarazione:
+
+```c
+int square(int x);
+```
+
+Definizione:
+
+```c
+int square(int x) {
+    return x * x;
+}
+```
+
+La dichiarazione rende noto un contratto; la definizione fornisce il corpo.
+
+---
+
+# Passaggio per valore
+
+```c
+void increment(int x) {
+    ++x;
+}
+```
+
+Il parametro riceve una copia del valore.
+
+Se vuoi modificare un oggetto del chiamante devi passare informazioni sufficienti a raggiungerlo, tipicamente un puntatore.
+
+---
+
+# Scope
+
+```c
+{
+    int x = 10;
+}
+```
+
+Lo scope risponde:
+
+> in quale parte del sorgente questo **nome** è visibile?
+
+Non confonderlo con la durata dell'oggetto in memoria.
+
+---
+
+# Storage duration
+
+Domanda diversa:
+
+> per quanto tempo esiste l'oggetto?
+
+Esempi concettuali:
+
+- automatic storage duration;
+- static storage duration;
+- allocated storage duration.
+
+Scope e lifetime possono essere diversi.
+
+---
+
+# Linkage
+
+Il linkage riguarda l'identità di un nome tra scope/unità di traduzione.
+
+```text
+nessun linkage
+internal linkage
+external linkage
+```
+
+Serve per capire come più file `.c` collaborano e quali simboli esportano.
+
+---
+
+# Moduli C
+
+Struttura tipica:
+
+```text
+math_utils.h   → interfaccia pubblica
+math_utils.c   → implementazione
+main.c         → client
+```
+
+Il file header non dovrebbe diventare un contenitore casuale di definizioni duplicate.
+
+---
+
+# Header guard
+
+```c
+#ifndef MATH_UTILS_H
+#define MATH_UTILS_H
+
+int square(int x);
+
+#endif
+```
+
+Evita inclusioni multiple problematiche nello stesso preprocessing della translation unit.
+
+---
+
+# Preprocessore
+
+```c
+#include <stdio.h>
+#define SIZE 10
+#ifdef DEBUG
+...
+#endif
+```
+
+Il preprocessore trasforma testo prima della compilazione C vera e propria.
+
+Una macro non è una funzione tipizzata.
+
+---
+
+# Macro: attenzione alla sostituzione testuale
+
+```c
+#define SQUARE(x) x * x
+```
+
+Con:
+
+```c
+SQUARE(1 + 2)
+```
+
+la sostituzione può non esprimere l'intenzione attesa.
+
+Le parentesi aiutano, ma le macro restano un meccanismo testuale con rischi specifici.
+
+---
+
+# Errore tipico
+
+> Definire la stessa funzione globale in due file `.c` e scoprire l'errore soltanto al linking.
+
+Diagnosi:
+
+```text
+file singoli compilano
+→ linker vede simboli incompatibili/duplicati
+```
+
+Identifica fase e ownership del simbolo.
+
+---
+
+# Checkpoint
+
+Per ciascuna domanda indica il concetto corretto:
+
+1. “Dove posso usare il nome `x`?”
+2. “Quanto vive l'oggetto?”
+3. “Questo simbolo è condiviso tra due translation unit?”
+4. “Dove dichiaro la funzione pubblica?”
+5. “In quale fase viene espanso `#include`?”
+
+Scelte: scope, storage duration, linkage, header, preprocessore.
+
+---
+
+# Lab
+
+Dividi un programma in:
+
+```text
+main.c
+utils.c
+utils.h
+```
+
+Poi prova volontariamente:
+
+- header senza guard;
+- funzione dichiarata ma non definita;
+- firma incoerente;
+- simbolo duplicato.
+
+Conserva il messaggio di compilatore/linker e la diagnosi.
+
+---
+
+# Recap
+
+- funzione = contratto + implementazione;
+- C passa parametri per valore;
+- scope, lifetime e linkage sono concetti distinti;
+- header = interfaccia;
+- preprocessore precede la compilazione;
+- moduli rendono esplicite responsabilità e dipendenze.
+
+---
+
+# Prossimo blocco
+
+Ora affrontiamo il concetto che collega direttamente il linguaggio alla memoria:
+
+**puntatori, array e stringhe**.

--- a/slides/c/modules/04_PUNTATORI_ARRAY_STRINGHE.md
+++ b/slides/c/modules/04_PUNTATORI_ARRAY_STRINGHE.md
@@ -1,0 +1,267 @@
+---
+marp: true
+paginate: true
+size: 16:9
+title: 04 — Puntatori, array e stringhe
+---
+
+# 04 — Puntatori, array e stringhe
+
+Valori che descrivono indirizzi e contratti di accesso
+
+---
+
+# Richiamo
+
+Una variabile occupa memoria.
+
+Un puntatore contiene un valore che può identificare l'indirizzo di un oggetto compatibile.
+
+```text
+oggetto x          puntatore p
+[ valore ]   ←──── [ indirizzo ]
+```
+
+---
+
+# Obiettivi
+
+- dichiarare e inizializzare puntatori;
+- distinguere puntatore valido, nullo, dangling e non inizializzato;
+- usare `&` e `*` con un modello mentale corretto;
+- spiegare aritmetica dei puntatori;
+- capire relazione e differenze tra array e puntatori;
+- trattare stringhe C come sequenze terminate da `\0`;
+- passare array/puntatori a funzioni;
+- riconoscere accessi fuori limite e rischi di buffer.
+
+---
+
+# Indirizzo e dereferenziazione
+
+```c
+int x = 42;
+int *p = &x;
+```
+
+- `&x` produce l'indirizzo di `x`;
+- `p` conserva quell'indirizzo;
+- `*p` accede all'oggetto puntato, se il puntatore è valido.
+
+Dereferenziare non è “leggere il puntatore”: è accedere all'oggetto referenziato.
+
+---
+
+# Puntatore non inizializzato
+
+```c
+int *p;
+*p = 3;   // errore concettuale grave
+```
+
+`p` non è stato associato a un oggetto valido.
+
+Prima di dereferenziare devi poter spiegare **da dove arriva l'indirizzo e perché è ancora valido**.
+
+---
+
+# Puntatore nullo
+
+```c
+int *p = NULL;
+```
+
+Il puntatore nullo rappresenta esplicitamente “nessun oggetto”.
+
+Puoi confrontarlo, ma non dereferenziarlo.
+
+```c
+if (p != NULL) {
+    printf("%d\n", *p);
+}
+```
+
+---
+
+# Aritmetica dei puntatori
+
+Per `int *p`:
+
+```c
+p + 1
+```
+
+avanza all'elemento `int` successivo, non semplicemente di un byte.
+
+Il tipo puntato determina la scala dell'aritmetica.
+
+La validità resta vincolata all'array/oggetto ammesso dal linguaggio.
+
+---
+
+# Array
+
+```c
+int a[4] = {10, 20, 30, 40};
+```
+
+Modello:
+
+```text
+indice:   0    1    2    3
+        [10] [20] [30] [40]
+```
+
+Gli elementi sono contigui. L'indice valido dipende dalla dimensione.
+
+---
+
+# Array ≠ puntatore
+
+In molte espressioni il nome di un array viene convertito in puntatore al primo elemento.
+
+Ma array e puntatore **non sono lo stesso oggetto**.
+
+Esempio:
+
+```c
+sizeof a        // dimensione dell'intero array, nello scope dove a è array
+sizeof p        // dimensione del puntatore
+```
+
+Evita lo slogan “gli array sono puntatori”.
+
+---
+
+# Indicizzazione e aritmetica
+
+```c
+a[i]
+```
+
+è strettamente collegato al modello:
+
+```c
+*(a + i)
+```
+
+Questo rende evidente perché `i == n` è fuori range per un array di `n` elementi.
+
+---
+
+# Stringhe C
+
+```c
+char s[] = "ciao";
+```
+
+In memoria:
+
+```text
+'c' 'i' 'a' 'o' '\0'
+```
+
+La terminazione nul è parte del contratto della stringa C.
+
+La capacità del buffer e la lunghezza logica non sono la stessa cosa.
+
+---
+
+# Buffer e limiti
+
+```c
+char name[8];
+```
+
+Per una stringa valida serve spazio anche per `\0`.
+
+Prima di copiare/chiedere input devi conoscere:
+
+- capacità;
+- numero massimo di caratteri;
+- politica di terminazione;
+- funzione usata e suo contratto.
+
+---
+
+# Parametri array
+
+```c
+void print_values(const int *a, size_t n);
+```
+
+Il puntatore da solo non trasporta automaticamente la dimensione.
+
+Per questo spesso il contratto include:
+
+```text
+puntatore + numero elementi
+```
+
+---
+
+# `const` sul puntato
+
+```c
+void print_values(const int *a, size_t n);
+```
+
+comunica che la funzione non deve modificare gli elementi attraverso quel puntatore.
+
+Il tipo diventa anche documentazione verificabile dal compilatore.
+
+---
+
+# Errore tipico
+
+> “Il programma ha stampato correttamente anche accedendo a `a[4]`, quindi quell'indice va bene.”
+
+No: un accesso fuori limite può produrre comportamento non definito e **sembrare** funzionare.
+
+L'assenza di crash non dimostra validità.
+
+---
+
+# Checkpoint
+
+Per ogni caso indica se il problema principale è inizializzazione, lifetime, range o terminazione:
+
+1. `int *p; printf("%d", *p);`
+2. restituisci il puntatore a una variabile locale già terminata;
+3. accedi a `a[n]` in un array di `n` elementi;
+4. buffer di 4 char usato per la stringa `"ciao"`;
+5. funzione riceve `int *p` ma nessuna informazione sulla lunghezza.
+
+---
+
+# Lab
+
+Costruisci esperimenti piccoli su:
+
+- `&` e `*`;
+- array + `sizeof`;
+- `a[i]` vs `*(a+i)`;
+- stringa con terminatore;
+- funzione con `const int *` + `size_t n`;
+- errore fuori limite osservato con strumenti sicuri quando previsti.
+
+Disegna memoria/indirizzi prima di eseguire.
+
+---
+
+# Recap
+
+- puntatore = valore di indirizzo con contratto di validità;
+- dereferenziazione richiede oggetto vivo e compatibile;
+- array e puntatori sono collegati ma non identici;
+- stringa C = sequenza di char terminata da zero;
+- puntatore + dimensione è un contratto frequente;
+- fuori limite può non crashare e restare sbagliato.
+
+---
+
+# Prossimo blocco
+
+Ora gli indirizzi possono riferire memoria richiesta a runtime:
+
+**allocazione dinamica, matrici e strutture**.

--- a/slides/c/modules/05_MEMORIA_DINAMICA_STRUTTURE.md
+++ b/slides/c/modules/05_MEMORIA_DINAMICA_STRUTTURE.md
@@ -1,0 +1,274 @@
+---
+marp: true
+paginate: true
+size: 16:9
+title: 05 — Memoria dinamica e strutture
+---
+
+# 05 — Memoria dinamica e strutture
+
+Ownership, lifetime e dati composti
+
+---
+
+# Richiamo
+
+Un puntatore può riferire un oggetto esistente.
+
+Con l'allocazione dinamica chiediamo memoria **durante l'esecuzione** e diventiamo responsabili del suo ciclo di vita.
+
+```text
+allocate → use → release
+```
+
+---
+
+# Obiettivi
+
+- usare `malloc`/`calloc`/`realloc`/`free` con un contratto chiaro;
+- controllare errori di allocazione;
+- ragionare su ownership e lifetime;
+- riconoscere leak, use-after-free e double-free;
+- allocare vettori/matrici dinamiche;
+- distinguere array 2D e array di puntatori;
+- definire e usare `struct`;
+- collegare layout dei dati e sezioni di memoria del processo.
+
+---
+
+# `malloc`
+
+```c
+int *values = malloc(n * sizeof *values);
+if (values == NULL) {
+    /* errore */
+}
+```
+
+Il pattern rende espliciti:
+
+- numero elementi;
+- dimensione dell'elemento;
+- possibile fallimento;
+- tipo del puntatore che userà il blocco.
+
+---
+
+# Ownership
+
+Per ogni blocco dinamico chiedi:
+
+```text
+chi alloca?
+chi può usare?
+chi è responsabile di free()?
+quando termina la validità?
+```
+
+Se la risposta non è chiara, il bug può emergere molto lontano dal punto di allocazione.
+
+---
+
+# `free`
+
+```c
+free(values);
+values = NULL;
+```
+
+`free` termina la validità del blocco allocato.
+
+Il valore del puntatore non rende l'oggetto ancora vivo.
+
+Azzerare il puntatore locale può aiutare alcuni flussi, ma non risolve alias dangling conservati altrove.
+
+---
+
+# Leak
+
+```text
+malloc → perdi l'ultimo riferimento → nessun free possibile
+```
+
+Un leak non significa necessariamente crash immediato.
+
+È una perdita di risorsa e può diventare grave in processi lunghi o iterazioni ripetute.
+
+---
+
+# Use-after-free
+
+```c
+int *p = malloc(sizeof *p);
+free(p);
+printf("%d\n", *p);   // non valido
+```
+
+Il fatto che “la memoria sembri ancora contenere il valore” non rende l'accesso corretto.
+
+---
+
+# Double free
+
+```c
+free(p);
+free(p);   // errore
+```
+
+Il secondo `free` non “ripulisce meglio”.
+
+L'ownership deve garantire una sola liberazione per il blocco valido.
+
+---
+
+# `realloc`
+
+`realloc` può spostare il blocco.
+
+Pattern prudente:
+
+```c
+int *tmp = realloc(values, new_n * sizeof *values);
+if (tmp != NULL) {
+    values = tmp;
+}
+```
+
+Non perdere il puntatore originale in caso di fallimento.
+
+---
+
+# Matrice dinamica contigua
+
+Una scelta:
+
+```text
+rows * cols elementi in un unico blocco
+```
+
+Accesso concettuale:
+
+```text
+index = r * cols + c
+```
+
+Pro: un blocco, buona località, ownership semplice.
+
+---
+
+# Array di puntatori
+
+Altra scelta:
+
+```text
+row pointers → blocchi separati
+```
+
+Può supportare righe di dimensioni diverse, ma aumenta numero di allocazioni e responsabilità di cleanup.
+
+Non è la stessa rappresentazione di un array 2D contiguo.
+
+---
+
+# `struct`
+
+```c
+struct Student {
+    int id;
+    double score;
+};
+```
+
+Una struct raggruppa campi correlati in un nuovo tipo composto.
+
+Il layout reale può includere padding: non dedurlo sommando semplicemente le dimensioni dei campi.
+
+---
+
+# Puntatore a struct
+
+```c
+struct Student *s = ...;
+printf("%d\n", s->id);
+```
+
+`->` combina dereferenziazione e accesso a membro.
+
+Restano validi tutti i vincoli su lifetime e puntatore.
+
+---
+
+# Sezioni di memoria
+
+Modello didattico utile:
+
+```text
+text/code
+static/global data
+heap       ← allocazione dinamica
+...
+stack      ← chiamate/automatic storage
+```
+
+È una mappa concettuale: dettagli esatti dipendono da piattaforma, loader e toolchain.
+
+---
+
+# Errore tipico
+
+> “Se il programma termina subito, non importa liberare memoria.”
+
+Anche quando l'OS recupera risorse alla fine, imparare ownership e cleanup serve per:
+
+- funzioni riutilizzabili;
+- processi lunghi;
+- librerie;
+- error paths;
+- codice verificabile.
+
+---
+
+# Checkpoint
+
+Trova il rischio principale:
+
+1. `malloc` senza controllo `NULL`;
+2. puntatore sovrascritto prima di `free`;
+3. accesso dopo `free`;
+4. due owner chiamano entrambi `free`;
+5. `realloc` assegnato direttamente al puntatore originale;
+6. matrice a righe allocate ma cleanup libera solo il vettore dei puntatori.
+
+---
+
+# Lab
+
+Realizza una piccola struttura dati con:
+
+- allocazione dinamica;
+- inizializzazione;
+- funzione di stampa con `const`;
+- cleanup completo;
+- caso di fallimento gestito;
+- test con sanitizer/debugger quando previsto.
+
+Consegna anche una tabella ownership/lifetime.
+
+---
+
+# Recap
+
+- allocazione dinamica crea responsabilità;
+- ownership governa chi libera;
+- lifetime non coincide col valore memorizzato nel puntatore;
+- matrici possono avere rappresentazioni diverse;
+- struct modella dati composti;
+- strumenti aiutano a rendere visibili bug di memoria.
+
+---
+
+# Prossimo blocco
+
+Ora osserviamo cosa succede sotto il C:
+
+**compilatore, assembly, registri e modello macchina**.

--- a/slides/c/modules/06_ASSEMBLY_BRIDGE.md
+++ b/slides/c/modules/06_ASSEMBLY_BRIDGE.md
@@ -1,0 +1,274 @@
+---
+marp: true
+paginate: true
+size: 16:9
+title: 06 — Dal C alla macchina
+---
+
+# 06 — Dal C alla macchina
+## Assembly come lente sul modello di esecuzione
+
+---
+
+# Perché guardare l'Assembly?
+
+Non per sostituire il C.
+
+Serve a rendere visibili domande come:
+
+- dove finiscono valori e parametri?
+- che cosa fa davvero una chiamata di funzione?
+- perché `sizeof` e tipi contano?
+- che cosa può ottimizzare il compilatore?
+
+---
+
+# Obiettivi
+
+- collegare sorgente C e assembly generato;
+- riconoscere registri, memoria e istruzioni elementari;
+- distinguere valore immediato, registro e indirizzo;
+- osservare chiamata/ritorno di funzione;
+- leggere semplici branch e loop;
+- capire che l'assembly dipende da ISA, ABI, compilatore e ottimizzazione;
+- usare l'output assembly come evidenza, non come “verità universale del C”.
+
+---
+
+# Dal sorgente all'assembly
+
+Con GCC puoi fermarti alla fase assembly:
+
+```bash
+gcc -S -O0 -std=c17 example.c -o example.s
+```
+
+Il file `.s` è **un possibile risultato** del compilatore per quella configurazione.
+
+Cambiando ottimizzazione o target può cambiare molto.
+
+---
+
+# Modello minimo CPU
+
+```text
+istruzione
+  ↓
+registri ↔ ALU
+  ↕
+memoria
+```
+
+Il C nasconde molti dettagli; l'assembly li rende più espliciti.
+
+---
+
+# Variabile locale
+
+C:
+
+```c
+int x = 5;
+int y = x + 2;
+```
+
+A `-O0` potresti osservare movimenti tra memoria/registri.
+
+A ottimizzazione maggiore il compilatore può eliminare completamente alcune variabili materiali.
+
+La semantica C resta il contratto, non la forma del `.s`.
+
+---
+
+# Registri
+
+I registri sono risorse CPU molto veloci usate per:
+
+- valori temporanei;
+- indirizzi;
+- parametri/return secondo ABI;
+- stack/frame pointer quando usati;
+- stato specifico dell'architettura.
+
+I nomi e ruoli precisi dipendono dall'ISA/ABI.
+
+---
+
+# Indirizzo vs valore
+
+Questo confronto aiuta a capire i puntatori:
+
+```text
+registro contiene 42        → valore
+registro contiene 0x7fff... → può essere usato come indirizzo
+```
+
+È il **contesto/istruzione/tipo del programma** che determina come quel pattern viene interpretato.
+
+---
+
+# Branch
+
+C:
+
+```c
+if (x > 0) {
+    y = 1;
+} else {
+    y = 0;
+}
+```
+
+Assembly concettuale:
+
+```text
+compare
+conditional jump
+ramo A
+jump fine
+ramo B
+```
+
+Il controllo del flusso del C diventa confronto + cambiamento del program counter.
+
+---
+
+# Loop
+
+Un `for` non esiste necessariamente come istruzione speciale.
+
+Modello:
+
+```text
+inizializza
+label:
+  confronta
+  salta a fine se falso
+  body
+  aggiorna
+  salta a label
+fine:
+```
+
+Riconoscere questo schema rafforza il trace manuale.
+
+---
+
+# Chiamata di funzione
+
+Una ABI definisce convenzioni come:
+
+- dove passano i primi parametri;
+- dove arriva il return value;
+- quali registri deve preservare il chiamante/callee;
+- allineamento dello stack.
+
+La chiamata C è quindi anche un **contratto binario** tra parti compilate.
+
+---
+
+# Stack frame
+
+Un modello didattico:
+
+```text
+stack
+┌───────────────┐
+│ dati caller   │
+├───────────────┤
+│ return info   │
+├───────────────┤
+│ locali/calcoli│
+└───────────────┘
+```
+
+Non assumere che ogni funzione debba avere sempre lo stesso frame: l'ottimizzatore può trasformarlo.
+
+---
+
+# Ottimizzazione
+
+Confronta:
+
+```bash
+gcc -S -O0 example.c
+gcc -S -O2 example.c
+```
+
+Possibili effetti:
+
+- constant folding;
+- eliminazione di codice morto;
+- inlining;
+- uso diverso dei registri;
+- riorganizzazione compatibile con la semantica permessa.
+
+---
+
+# Undefined behavior e ottimizzatore
+
+Se il programma C entra in comportamento non definito, non puoi usare l'assembly osservato come prova che “il compilatore deve fare sempre così”.
+
+Il compilatore ottimizza assumendo che il programma rispetti il contratto del linguaggio.
+
+---
+
+# Errore tipico
+
+> “Ho visto che GCC mette `x` nello stack, quindi una variabile locale C vive sempre nello stack.”
+
+No.
+
+Hai osservato **una compilazione concreta**. Il modello C definisce storage duration e semantica; il mapping fisico può cambiare.
+
+---
+
+# Checkpoint
+
+Associa il concetto C al modello macchina:
+
+1. `if`;
+2. puntatore;
+3. parametro di funzione;
+4. `return`;
+5. ciclo;
+6. variabile eliminata da `-O2`.
+
+Parole utili: branch, indirizzo, ABI, return register, jump/label, ottimizzazione.
+
+---
+
+# Lab
+
+Prendi tre programmi piccoli:
+
+- somma di due interi;
+- `if/else`;
+- funzione `square`.
+
+Per ciascuno:
+
+1. prevedi la struttura assembly;
+2. genera `.s` a `-O0`;
+3. individua confronto/chiamata/return;
+4. confronta con `-O2`;
+5. descrivi che cosa è cambiato e che cosa no.
+
+---
+
+# Recap
+
+- assembly rende visibile un'implementazione del C;
+- registri/memoria sono risorse del modello macchina;
+- branch e loop traducono controllo del flusso;
+- ABI governa contratti binari delle chiamate;
+- ottimizzazione può cambiare radicalmente la forma;
+- semantica C resta il riferimento.
+
+---
+
+# Prossimo blocco
+
+Dal modello macchina passiamo alle API del sistema operativo:
+
+**file, processi e programmazione Linux/POSIX**.

--- a/slides/c/modules/07_LINUX_SYSTEMS_BRIDGE.md
+++ b/slides/c/modules/07_LINUX_SYSTEMS_BRIDGE.md
@@ -1,0 +1,253 @@
+---
+marp: true
+paginate: true
+size: 16:9
+title: 07 — Ponte alla programmazione Linux
+---
+
+# 07 — Ponte alla programmazione Linux
+
+Dal linguaggio C alle API del sistema operativo
+
+---
+
+# Richiamo
+
+Abbiamo visto il C come linguaggio vicino alla memoria e l'assembly come lente sulla macchina.
+
+Ora aggiungiamo un altro livello:
+
+```text
+programma C
+   ↓ system/library API
+kernel / sistema operativo
+   ↓
+hardware e risorse
+```
+
+---
+
+# Obiettivi
+
+- distinguere libreria C e servizi del sistema operativo;
+- usare file descriptor come handle di risorse;
+- capire il modello read/write;
+- riconoscere errori e return value;
+- introdurre processi e `fork/exec/wait` come ponte al quarto anno;
+- leggere documentazione/man page;
+- mantenere ownership/cleanup delle risorse;
+- collegare C, memoria e sistemi senza anticipare inutilmente tutto il corso successivo.
+
+---
+
+# Libreria vs syscall
+
+Una funzione usata dal programma può essere:
+
+- pura funzione di libreria;
+- wrapper che alla fine chiede un servizio al kernel;
+- combinazione di logica user-space e syscall.
+
+Non assumere che ogni funzione C sia direttamente una syscall.
+
+---
+
+# File descriptor
+
+In Unix-like systems molte risorse vengono rappresentate da piccoli interi associati al processo:
+
+```text
+0 stdin
+1 stdout
+2 stderr
+...
+```
+
+Un file descriptor è un **handle**, non il contenuto del file.
+
+---
+
+# `open` / `read` / `write` / `close`
+
+Modello:
+
+```text
+open → fd
+read/write usando fd
+close → rilascio della risorsa
+```
+
+Torna lo stesso schema già visto con memoria dinamica:
+
+```text
+acquire → use → release
+```
+
+---
+
+# Return value ed errori
+
+Le API di sistema espongono fallimenti normali:
+
+- file inesistente;
+- permesso negato;
+- descriptor non valido;
+- lettura interrotta/parziale;
+- processo non creabile.
+
+Il codice robusto controlla i return value e gestisce gli error path.
+
+---
+
+# Letture/scritture parziali
+
+Nel system programming non assumere automaticamente:
+
+```text
+write(n byte) → sempre n byte trasferiti
+read(n byte)  → sempre n byte ricevuti
+```
+
+Il contratto della specifica API stabilisce che cosa è possibile e come reagire.
+
+---
+
+# Processi
+
+Un processo è una istanza in esecuzione con:
+
+- spazio di indirizzamento;
+- stato CPU;
+- file descriptor;
+- PID;
+- credenziali e altre risorse.
+
+Questo modello sarà approfondito nel quarto anno.
+
+---
+
+# `fork`
+
+```c
+pid_t pid = fork();
+```
+
+Crea una nuova relazione padre/figlio secondo le regole POSIX.
+
+Il punto didattico qui è collegare concetti già noti:
+
+```text
+memoria / valori / return value / branch di controllo
+```
+
+al ciclo di vita dei processi.
+
+---
+
+# `exec`
+
+`exec` sostituisce il programma eseguito dal processo corrente.
+
+```text
+processo PID X + programma A
+          ↓ exec
+processo PID X + programma B
+```
+
+Questo distingue **processo** da **programma/eseguibile**.
+
+---
+
+# `wait`
+
+Il padre può attendere e raccogliere lo stato di un figlio.
+
+Il return value di `main`/`exit` diventa quindi parte di un protocollo osservabile tra processo e ambiente.
+
+---
+
+# Man page
+
+Abitudine da costruire:
+
+```bash
+man 2 open
+man 2 read
+man 2 fork
+```
+
+Leggi almeno:
+
+- synopsis;
+- return value;
+- errors;
+- note rilevanti.
+
+La documentazione tecnica ufficiale fa parte del lavoro, non è un aiuto “extra”.
+
+---
+
+# Errore tipico
+
+> Copiare una chiamata POSIX da un esempio senza controllare il return value.
+
+Nel system programming l'errore non è un'eccezione rara da ignorare: è un ramo previsto del contratto.
+
+---
+
+# Checkpoint
+
+Collega le idee già studiate:
+
+1. `malloc/free` e `open/close`;
+2. `main` return e child exit status;
+3. puntatore a buffer e `read`;
+4. process file descriptor table e integer `fd`;
+5. `fork` return value e `if`.
+
+Spiega il ponte concettuale.
+
+---
+
+# Lab
+
+Scegli un'attività semplice da `LINUX_PROGRAMMING.md`, ad esempio file I/O o processo base.
+
+Conserva:
+
+- sorgente;
+- man page consultata;
+- comando di compilazione;
+- output/exit status;
+- almeno un errore gestito volontariamente;
+- spiegazione di quali risorse vengono acquisite e rilasciate.
+
+---
+
+# Recap
+
+- C è un ottimo linguaggio per vedere i contratti del sistema;
+- file descriptor = handle di risorsa del processo;
+- API di sistema richiedono error handling esplicito;
+- acquire/use/release ricorre in memoria e I/O;
+- processo ≠ programma;
+- questa è la base naturale per processi, IPC e concorrenza del quarto anno.
+
+---
+
+# Chiusura del percorso
+
+Il filo del C 101 diventa:
+
+```text
+bit
+→ tipi
+→ controllo
+→ funzioni/moduli
+→ indirizzi
+→ ownership memoria
+→ macchina
+→ sistema operativo
+```
+
+Il linguaggio serve a costruire un modello preciso di **come il software vive davvero nella macchina**.

--- a/tests/test_c_course_delivery.py
+++ b/tests/test_c_course_delivery.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_c_course_delivery_surfaces_exist_and_preserve_course_design():
+    dashboard = ROOT / "COURSE_DELIVERY.md"
+    teacher = ROOT / "doc" / "course-delivery" / "c" / "TEACHER_GUIDE.md"
+    student = ROOT / "doc" / "course-delivery" / "c" / "STUDENT_GUIDE.md"
+    changelog = ROOT / "doc" / "course-delivery" / "c" / "DELIVERY_CHANGELOG.md"
+    slide_index = ROOT / "slides" / "c" / "README.md"
+    module_dir = ROOT / "slides" / "c" / "modules"
+
+    for path in (dashboard, teacher, student, changelog, slide_index):
+        assert path.exists(), path
+
+    decks = sorted(module_dir.glob("[0-9][0-9]_*.md"))
+    assert [path.name[:2] for path in decks] == [f"{index:02d}" for index in range(8)]
+    for deck in decks:
+        text = deck.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        assert "marp: true" in text
+        assert "Obiettivi" in text
+        assert "Checkpoint" in text
+
+    course_design = json.loads(
+        (ROOT / "doc" / "course_designs" / "course_design_code.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    third_year = next(year for year in course_design["years"] if year["id"] == "terzo-anno")
+    assert third_year["weeks"] == 33
+    assert third_year["weekly_hours"] == 3
+
+    dashboard_text = dashboard.read_text(encoding="utf-8")
+    for deck in decks:
+        assert f"slides/c/modules/{deck.name}" in dashboard_text


### PR DESCRIPTION
## Goal

Adopt Course Delivery Standard v1 incrementally for the legacy C course without rewriting or splitting the large canonical `README.md`.

## Legacy strategy

The root `README.md` and `LINUX_PROGRAMMING.md` remain canonical. Existing COURSE-FRAME blocks, lab snippet/output markers, bootstrap procedures and TheBitLab surfaces are preserved.

A separate root-level `COURSE_DELIVERY.md` acts as the safe legacy dashboard instead of replacing the historical README wholesale.

## Adds

- `COURSE_DELIVERY.md` with a clickable macro-area map over the canonical sources;
- teacher delivery guide;
- student delivery guide;
- in-year Delivery Change Log;
- slide index;
- 8 modular Marp macro-decks:
  - environment/toolchain/first C;
  - representation/types/operators;
  - control flow;
  - functions/scope/modules/preprocessor;
  - pointers/arrays/strings;
  - dynamic memory/structs;
  - Assembly bridge;
  - Linux systems bridge;
- a lightweight regression test confirming delivery surfaces, 8 decks and the existing 33-week / 3-hour Third Year Course Design.

## Adoption level

This PR intentionally targets **Level 2 — Teacher ready** first. It does not add another artifact-rendering workflow to the already large 2cornot2c CI surface. Generated HTML/PDF/PPTX can be added later after the legacy navigation/deck structure is reviewed in class.

## Boundary

No existing lab markers are rewritten. No Content Pack/Activity/TheBitLab contract is changed. No UDA/week allocation is changed. The existing Course Design frames remain draft/live.

Cross-course rollout: #737. Draft standard: #738.