### PR TITLE
Draft Git Lab G1 validator + Student Lab routing adapters

### DIFF
--- a/doc/architecture/git-lab-g1.md
+++ b/doc/architecture/git-lab-g1.md
@@ -1,0 +1,150 @@
+# TheBitLab Git Lab G1 — assignment, repository and feedback boundary
+
+Issue: #761  
+PR: #762  
+Status: implementation draft; public platform canary exists, normal Student Lab routing still being completed.
+
+## Purpose
+
+Git Activities are different from code-runner Activities: the student's answer is the **state and history of a Git repository**, not one source file and not the stdout of one command.
+
+The platform therefore treats Git Lab as a deterministic evidence profile over an assignment-owned repository.
+
+## Canonical assignment layout
+
+The normal TheBitLab scaffold remains the outer assignment container:
+
+```text
+assignments/<activity-id>/
+├── README.md
+├── activity.json
+├── GUIDA.md / other student assets
+└── repository/
+    ├── .git/
+    └── exercise files
+```
+
+`repository/` is fixed by the platform. The Activity does not supply an arbitrary student repository path.
+
+Why this split:
+
+- normal Activity metadata/guides remain outside the repository exercise;
+- the repository has a precise Git toplevel;
+- grading files never need to enter the repository;
+- assignment/report infrastructure can remain unchanged;
+- repository reset/reprepare can be governed explicitly without overwriting scaffold metadata.
+
+## Preparation boundary
+
+`git_lab_activity.prepare_repository()` consumes teacher/grading-side fixture assets:
+
+```text
+fixture/base/
+fixture/working/
+grading/expectations.json
+```
+
+Preparation:
+
+1. requires an empty real destination directory;
+2. copies only baseline fixture files;
+3. creates the initial Git repository and fixture commit with controlled identity/hooks/config;
+4. applies the working-tree overlay;
+5. returns normalized repository evidence.
+
+The following are never copied into the student repository:
+
+- `grading/`;
+- `expectations.json`;
+- teacher notes;
+- expected SHA-256 values.
+
+Fixture trees may not smuggle `.git` or symlinks.
+
+## Reassignment / reset rule
+
+A generic course-level overwrite flag **must not silently erase an existing Git Lab repository**.
+
+If `repository/` already contains student work, preparation fails closed.
+
+A future Reset/Reprepare Git Lab operation, if added, must be an explicit user/teacher action with separate semantics and auditability.
+
+## Grading boundary
+
+The canonical validator assesses repository evidence, not command history.
+
+Examples:
+
+- branch/HEAD;
+- staged/unstaged/untracked paths;
+- clean/dirty state;
+- commit graph/parent chain;
+- changed paths;
+- selected working-tree/index/commit blob hashes;
+- later G2+ refs/remotes/merge shape.
+
+A student may reach the target through any safe/correct command sequence unless the learning outcome explicitly constrains a property of the resulting history.
+
+## Student-safe report
+
+Raw Git Lab evidence is teacher/grader-side. It can contain exact expected values and blob hashes.
+
+`git_lab_student.student_safe_evidence()` projects that evidence into actionable but non-revealing feedback.
+
+Allowed examples:
+
+```text
+Controlla con status e diff --staged quali path sono nell'index.
+Controlla quali modifiche devono restare nel working tree senza essere staged.
+La storia non ha ancora la decomposizione in commit richiesta.
+```
+
+Forbidden in student report:
+
+- expected SHA-256;
+- exact hidden expected contents;
+- teacher expectation JSON;
+- hidden grading paths;
+- commands that directly solve the exercise.
+
+The Student Lab report uses the existing `student_lab_run.v1` envelope with:
+
+```text
+backend = git-lab
+language = git
+summary/tests = student-safe checks
+```
+
+## Routing target
+
+Normal runner dispatch should be:
+
+```text
+Activity
+  ├─ external runtime extension? → runtime broker
+  ├─ Git Lab extension?         → Git Lab student adapter
+  └─ code Activity?             → local/docker code runner
+```
+
+Git Lab is not treated as a fake programming language compiler and does not require a synthetic `main.*` source.
+
+## Security summary
+
+- exact assignment repository root;
+- no parent/nested repo ambiguity;
+- no bare repo in G1;
+- hooks/config/fsmonitor hardening;
+- no network/remotes required in G1;
+- bounded history/path/file/output/time;
+- no grading assets in student repo;
+- no symlink/path escape;
+- report redaction before persistence/display.
+
+## Acceptance remaining for G1 routing
+
+- normal assignment flow creates `repository/` after scaffold creation;
+- normal Student Lab runner dispatches Git Lab before code backends;
+- stored report remains student-safe;
+- non-Git Activity behavior unchanged;
+- public CI green on integrated routing;
+- real managed Classroom Environment rehearsal remains a later GO gate.

--- a/doc/architecture/git-lab-v1.md
+++ b/doc/architecture/git-lab-v1.md
@@ -1,0 +1,230 @@
+# TheBitLab Git Lab v1 — G1 repository-state validator
+
+Issue: #761
+
+## Status
+
+Implementation candidate for the first Git G1 consumer. This document does not declare G2/G3/G4 support.
+
+Schema identities:
+
+```text
+thebitlab.git-lab.v1
+thebitlab.git-report.v1
+```
+
+## Learning boundary
+
+Git Lab validates **repository state and history**, not a memorized command transcript.
+
+Equivalent correct command sequences should receive the same result.
+
+The platform may therefore assess outcomes such as:
+
+```text
+working tree
+→ index
+→ commit history
+→ content at a commit
+```
+
+without requiring the student to have typed one particular sequence.
+
+## G1 evidence
+
+Current normalized report exposes:
+
+- current branch;
+- HEAD SHA;
+- detached-HEAD state;
+- staged paths;
+- unstaged paths;
+- untracked paths;
+- working-tree clean/dirty;
+- bounded first-parent-visible commit list from normal `git log` order;
+- parent SHA list for each commit;
+- subject;
+- changed paths for each commit;
+- SHA-256 of selected file blobs at selected commits.
+
+Commit SHAs are evidence, **not expected values**: student commit timestamps/metadata naturally make them different.
+
+## Expectation example
+
+```json
+{
+  "schema_version": "thebitlab.git-lab.v1",
+  "expectations": {
+    "clean": true,
+    "branch": "main",
+    "commit_count": 3,
+    "staged_paths": [],
+    "unstaged_paths": [],
+    "untracked_paths": [],
+    "commits": [
+      {
+        "position": 0,
+        "subject_contains": "note",
+        "changed_paths": ["note.txt"],
+        "files": {
+          "note.txt": "<sha256>"
+        }
+      },
+      {
+        "position": 1,
+        "subject_contains": "programma",
+        "changed_paths": ["programma.py"],
+        "files": {
+          "programma.py": "<sha256>"
+        }
+      }
+    ]
+  }
+}
+```
+
+Position `0` means `HEAD`, position `1` means its predecessor in log order.
+
+## First canary
+
+Fixture history:
+
+```text
+C0 fixture iniziale
+```
+
+Student changes two files and must create:
+
+```text
+C0 ← C1 programma.py ← C2 note.txt (HEAD)
+```
+
+Final checks:
+
+- branch `main`;
+- clean working tree;
+- exactly three commits including the fixture;
+- C2 changes only `note.txt` and contains the expected blob;
+- C1 changes only `programma.py` and contains the expected blob.
+
+A single commit containing both changes fails even if the final working-tree files are identical.
+
+This measures the idea of **intentional history**, not command memorization.
+
+## Read-only implementation
+
+`scripts/git_lab_validator.py` invokes Git without `shell=True` and performs only inspection commands:
+
+- `rev-parse`;
+- `status --porcelain`;
+- `symbolic-ref`;
+- `log`;
+- `diff-tree --name-only`;
+- `cat-file`.
+
+The validator never runs `add`, `commit`, `checkout`, `reset`, `clean`, `merge`, `fetch`, `push` or other mutating/network commands.
+
+## Repository boundary
+
+G1 accepts only an explicit assignment repository root.
+
+It rejects:
+
+- a nested path whose top-level Git root is elsewhere;
+- a parent directory that is not the repository;
+- a symlink supplied as the repository root;
+- bare repositories.
+
+The assignment launcher remains responsible for creating the temporary/student workspace. The validator must never be pointed at the teacher/course source repository.
+
+## Git configuration hardening
+
+Inspection runs with:
+
+```text
+GIT_TERMINAL_PROMPT=0
+GIT_CONFIG_NOSYSTEM=1
+GIT_CONFIG_GLOBAL=<null device>
+GIT_OPTIONAL_LOCKS=0
+core.fsmonitor=false
+core.untrackedCache=false
+```
+
+The `core.fsmonitor` override is important: repository-local configuration must not cause a student-controlled fsmonitor program to execute merely because TheBitLab inspects `git status`.
+
+No network Git command is part of G1 validation.
+
+## Resource bounds
+
+Initial G1 bounds:
+
+- maximum 64 commits inspected;
+- maximum 512 relevant paths;
+- maximum Git command output 2 MiB;
+- maximum selected blob evidence 512 KiB;
+- per-command timeout 4 seconds;
+- commit subject bounded to 240 characters.
+
+These are validation bounds, not general Git limitations.
+
+## Path model
+
+Expectation paths must be portable POSIX-style relative repository paths.
+
+Rejected examples:
+
+```text
+../teacher/solution.txt
+/absolute/path
+C:\host\path
+```
+
+This deliberately narrows G1 Activity fixtures to predictable classroom repositories.
+
+## Deterministic vs manual assessment
+
+### Deterministic
+
+Git Lab may score:
+
+- expected stage/working-tree state;
+- clean/dirty final state;
+- commit count when pedagogically required;
+- changed path sets;
+- content at commits;
+- branch/HEAD state;
+- later tags/refs/remotes once added.
+
+### Manual/rubric
+
+Remain manual when they assess:
+
+- quality of commit-message wording beyond a simple required concept;
+- whether the chosen commit granularity is professionally ideal in an open-ended project;
+- explanation of why a history structure was chosen;
+- trade-offs between alternative workflows.
+
+Do not turn qualitative history aesthetics into a fake deterministic score.
+
+## G1 non-goals
+
+Not implemented in v1 G1:
+
+- merge graph assertions;
+- conflict resolution grading;
+- remotes/fetch/push/pull;
+- tags/releases;
+- rebase/cherry-pick/bisect;
+- reflog;
+- plumbing/object-store assignments;
+- hosted GitHub pull-request state.
+
+Those belong to G2–G4 extensions.
+
+## Course relationship
+
+Canonical course: `TheBitPoets/git`.
+
+First consumer: G1, also consumed by Python second year around M14–M16 / Checkpoint A.
+
+The consuming Python course must not fork this validator or duplicate the Git curriculum.

--- a/scripts/git_lab_activity.py
+++ b/scripts/git_lab_activity.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Prepare and grade Activity 1.0 bundles using the TheBitLab Git Lab extension."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import subprocess
+import tempfile
+from typing import Any
+
+from scripts import git_lab_validator
+
+
+EXTENSION_KEY = "thebitlab.git-lab"
+ACTIVITY_SCHEMA = "git_activity.v1"
+MAX_FIXTURE_FILES = 128
+MAX_FIXTURE_BYTES = 2 * 1024 * 1024
+COMMAND_TIMEOUT_SECONDS = 5
+
+
+class GitLabActivityError(ValueError):
+    """The Activity Git Lab extension or fixture is invalid."""
+
+
+def _safe_relative_path(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or value != value.strip() or not value:
+        raise GitLabActivityError(f"{field} deve essere un path relativo non vuoto")
+    if "\\" in value or value.startswith("/") or ":" in value:
+        raise GitLabActivityError(f"{field} non è un path portabile")
+    path = PurePosixPath(value)
+    if path.is_absolute() or path.as_posix() != value or any(
+        part in {"", ".", ".."} for part in path.parts
+    ):
+        raise GitLabActivityError(f"{field} non è un path relativo sicuro")
+    return value
+
+
+def load_activity(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise GitLabActivityError("activity.json non leggibile/valido") from error
+    if not isinstance(value, dict):
+        raise GitLabActivityError("activity.json deve contenere un oggetto")
+    return value
+
+
+def validate_extension(activity: dict[str, Any]) -> dict[str, Any]:
+    extensions = activity.get("extensions")
+    if not isinstance(extensions, dict):
+        raise GitLabActivityError("Activity senza extensions")
+    extension = extensions.get(EXTENSION_KEY)
+    if not isinstance(extension, dict):
+        raise GitLabActivityError(f"Activity senza extensions.{EXTENSION_KEY}")
+    if extension.get("schema_version") != ACTIVITY_SCHEMA:
+        raise GitLabActivityError(f"Git Lab extension schema deve essere {ACTIVITY_SCHEMA}")
+
+    fixture = extension.get("fixture")
+    if not isinstance(fixture, dict):
+        raise GitLabActivityError("Git Lab fixture deve essere un oggetto")
+    _safe_relative_path(fixture.get("base_dir"), field="fixture.base_dir")
+    _safe_relative_path(fixture.get("working_overlay_dir"), field="fixture.working_overlay_dir")
+    branch = fixture.get("initial_branch")
+    if not isinstance(branch, str) or not branch or len(branch) > 120 or any(
+        char.isspace() for char in branch
+    ):
+        raise GitLabActivityError("fixture.initial_branch non valido")
+    message = fixture.get("initial_commit_message")
+    if not isinstance(message, str) or not message.strip() or len(message) > 240:
+        raise GitLabActivityError("fixture.initial_commit_message non valido")
+
+    expectations = extension.get("expectations")
+    if not isinstance(expectations, dict):
+        raise GitLabActivityError("Git Lab expectations deve essere un oggetto")
+    _safe_relative_path(expectations.get("path"), field="expectations.path")
+    if expectations.get("media_type") not in {None, "application/json"}:
+        raise GitLabActivityError("expectations.media_type non supportato")
+
+    submission = extension.get("submission")
+    if not isinstance(submission, dict) or submission.get("kind") != "git-repository":
+        raise GitLabActivityError("submission.kind deve essere git-repository")
+    return extension
+
+
+def _resolve_activity_path(activity_dir: Path, relative: str, *, expect_dir: bool) -> Path:
+    root = activity_dir.resolve(strict=True)
+    candidate = root.joinpath(*PurePosixPath(relative).parts)
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError) as error:
+        raise GitLabActivityError(f"asset fuori activity root o mancante: {relative}") from error
+    if candidate.is_symlink() or resolved.is_symlink():
+        raise GitLabActivityError(f"asset Git Lab non può essere symlink: {relative}")
+    if expect_dir and not resolved.is_dir():
+        raise GitLabActivityError(f"asset deve essere directory: {relative}")
+    if not expect_dir and not resolved.is_file():
+        raise GitLabActivityError(f"asset deve essere file: {relative}")
+    return resolved
+
+
+def _copy_fixture_tree(source: Path, destination: Path) -> None:
+    file_count = 0
+    total_bytes = 0
+    for item in sorted(source.rglob("*")):
+        relative = item.relative_to(source)
+        if ".git" in relative.parts:
+            raise GitLabActivityError("fixture non può contenere .git")
+        if item.is_symlink():
+            raise GitLabActivityError(f"fixture symlink non ammesso: {relative.as_posix()}")
+        target = destination / relative
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if not item.is_file():
+            raise GitLabActivityError(f"fixture contiene tipo file non supportato: {relative.as_posix()}")
+        file_count += 1
+        total_bytes += item.stat().st_size
+        if file_count > MAX_FIXTURE_FILES or total_bytes > MAX_FIXTURE_BYTES:
+            raise GitLabActivityError("fixture oltre i limiti G1")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(item, target)
+
+
+def _git_env(hooks_dir: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_AUTHOR_NAME": "TheBitLab Fixture",
+            "GIT_AUTHOR_EMAIL": "fixture@thebitlab.invalid",
+            "GIT_COMMITTER_NAME": "TheBitLab Fixture",
+            "GIT_COMMITTER_EMAIL": "fixture@thebitlab.invalid",
+            "GIT_CONFIG_COUNT": "3",
+            "GIT_CONFIG_KEY_0": "core.hooksPath",
+            "GIT_CONFIG_VALUE_0": str(hooks_dir),
+            "GIT_CONFIG_KEY_1": "core.fsmonitor",
+            "GIT_CONFIG_VALUE_1": "false",
+            "GIT_CONFIG_KEY_2": "core.untrackedCache",
+            "GIT_CONFIG_VALUE_2": "false",
+            "LC_ALL": "C",
+            "LANG": "C",
+        }
+    )
+    return env
+
+
+def _run_git(repo: Path, hooks_dir: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "--no-pager", *args],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=_git_env(hooks_dir),
+            timeout=COMMAND_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise GitLabActivityError(f"Git fixture command non eseguibile: {' '.join(args)}") from error
+    if result.returncode != 0:
+        raise GitLabActivityError(
+            f"git {' '.join(args)} fallito ({result.returncode}): {result.stderr.strip()[:500]}"
+        )
+    return result.stdout.strip()
+
+
+def prepare_repository(activity_json: Path, destination: Path) -> dict[str, Any]:
+    """Create a deterministic student Git repository from one Activity fixture."""
+    activity_json = activity_json.resolve(strict=True)
+    activity_dir = activity_json.parent
+    activity = load_activity(activity_json)
+    extension = validate_extension(activity)
+    fixture = extension["fixture"]
+
+    if destination.exists():
+        if destination.is_symlink() or not destination.is_dir():
+            raise GitLabActivityError("destination deve essere una directory reale")
+        if any(destination.iterdir()):
+            raise GitLabActivityError("destination Git Lab deve essere vuota")
+    else:
+        destination.mkdir(parents=True)
+    destination = destination.resolve(strict=True)
+
+    base_dir = _resolve_activity_path(activity_dir, fixture["base_dir"], expect_dir=True)
+    overlay_dir = _resolve_activity_path(
+        activity_dir, fixture["working_overlay_dir"], expect_dir=True
+    )
+
+    _copy_fixture_tree(base_dir, destination)
+
+    with tempfile.TemporaryDirectory(prefix="thebitlab-git-hooks-") as hooks:
+        hooks_dir = Path(hooks)
+        _run_git(destination, hooks_dir, "init")
+        _run_git(
+            destination,
+            hooks_dir,
+            "symbolic-ref",
+            "HEAD",
+            f"refs/heads/{fixture['initial_branch']}",
+        )
+        _run_git(destination, hooks_dir, "add", "--all")
+        _run_git(
+            destination,
+            hooks_dir,
+            "commit",
+            "-m",
+            fixture["initial_commit_message"],
+        )
+
+    _copy_fixture_tree(overlay_dir, destination)
+    report = git_lab_validator.inspect_repository(destination)
+    return {
+        "schema_version": "thebitlab.git-fixture-report.v1",
+        "activity_id": activity.get("id"),
+        "repository": report,
+    }
+
+
+def load_expectations(activity_json: Path) -> dict[str, Any]:
+    activity_json = activity_json.resolve(strict=True)
+    activity_dir = activity_json.parent
+    activity = load_activity(activity_json)
+    extension = validate_extension(activity)
+    path = _resolve_activity_path(
+        activity_dir, extension["expectations"]["path"], expect_dir=False
+    )
+    try:
+        spec = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise GitLabActivityError("expectations JSON non valido") from error
+    git_lab_validator.validate_spec(spec)
+    return spec
+
+
+def grade_repository(activity_json: Path, repository: Path) -> dict[str, Any]:
+    spec = load_expectations(activity_json)
+    return git_lab_validator.evaluate_repository(repository, spec)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Prepare/grade a TheBitLab Git Lab Activity")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    prepare = sub.add_parser("prepare")
+    prepare.add_argument("activity_json", type=Path)
+    prepare.add_argument("destination", type=Path)
+
+    grade = sub.add_parser("grade")
+    grade.add_argument("activity_json", type=Path)
+    grade.add_argument("repository", type=Path)
+
+    args = parser.parse_args()
+    if args.command == "prepare":
+        result = prepare_repository(args.activity_json, args.destination)
+    else:
+        result = grade_repository(args.activity_json, args.repository)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    if args.command == "grade" and not result["passed"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/git_lab_assignment.py
+++ b/scripts/git_lab_assignment.py
@@ -1,11 +1,115 @@
-"""Prepare Git Lab repository workspaces after normal Activity scaffolding."""
+"""Prepare safe assignment scaffolds and nested repositories for Git Lab."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
-from scripts import git_lab_activity, git_lab_student
+from scripts import create_submission_scaffold, git_lab_activity, git_lab_student
+
+
+def repository_path(assignment_dir: Path) -> Path:
+    """Return the fixed Git Lab repository location inside an assignment scaffold."""
+    return assignment_dir / git_lab_student.REPOSITORY_DIRNAME
+
+
+def git_assignment_readme(activity: dict[str, Any], identifier: str) -> str:
+    """Return a repository-submission README without code-runner instructions."""
+    normalized = create_submission_scaffold.normalize_activity(activity)
+    title = str(normalized.get("title") or identifier)
+    prompt = str(normalized.get("instructions") or "Segui le indicazioni del docente.")
+    assets = create_submission_scaffold.student_assets(activity)
+    asset_lines = [
+        f"- `{str(asset.get('target_path', asset.get('path', ''))).strip()}`"
+        for asset in assets
+        if str(asset.get("target_path", asset.get("path", ""))).strip()
+    ]
+    files = "\n".join(asset_lines) if asset_lines else "- nessun file guida aggiuntivo"
+    return (
+        f"# {title}\n\n"
+        f"Activity ID: `{identifier}`\n\n"
+        "## Consegna\n\n"
+        f"{prompt}\n\n"
+        "## Workspace Git\n\n"
+        "Lavora esclusivamente nella sottocartella `repository/`.\n\n"
+        "Prima di agire, osserva sempre lo stato del repository. Il grading valuta "
+        "lo stato e la storia Git risultanti, non una sequenza obbligatoria di comandi.\n\n"
+        "## Materiale studente\n\n"
+        f"{files}\n\n"
+        "Le aspettative di grading, gli hash attesi e gli asset docente non sono presenti "
+        "nel repository dello studente.\n"
+    )
+
+
+def create_assignment_scaffold(
+    *,
+    activity_path: Path,
+    target_dir: Path,
+    state_dir: Path | None = None,
+) -> Path:
+    """Create the outer Git Lab scaffold using shared safe scaffold primitives.
+
+    Git is a repository submission kind, not a fake code language. Therefore this
+    path deliberately skips code-language/source-name selection while reusing the
+    shared Activity validation, asset redaction, confinement and atomic writes.
+    """
+    activity_path = activity_path.resolve(strict=True)
+    activity = git_lab_activity.load_activity(activity_path)
+    if not git_lab_student.activity_uses_git_lab(activity):
+        raise git_lab_activity.GitLabActivityError("L'Activity non dichiara Git Lab.")
+    identifier = create_submission_scaffold.activity_id(activity)
+    create_submission_scaffold.validate_activity_contract_or_raise(activity, identifier)
+    git_lab_activity.validate_extension(activity)
+    asset_plan = create_submission_scaffold.student_asset_copy_plan(activity_path, activity)
+    destination = create_submission_scaffold.scaffold_dir(target_dir, identifier)
+    create_submission_scaffold.prepare_scaffold_destination(target_dir, destination)
+    if any(destination.iterdir()):
+        raise git_lab_activity.GitLabActivityError(
+            "Consegna Git Lab già esistente; reset/reprepare deve essere esplicito."
+        )
+
+    current_targets = {target_rel for _, target_rel in asset_plan}
+    for target_rel in current_targets:
+        if create_submission_scaffold.is_reserved_scaffold_target(target_rel):
+            raise git_lab_activity.GitLabActivityError(
+                f"Target asset sovrapposto a file riservato: {target_rel}"
+            )
+        if create_submission_scaffold.portable_paths_overlap(
+            target_rel, Path(git_lab_student.REPOSITORY_DIRNAME)
+        ):
+            raise git_lab_activity.GitLabActivityError(
+                f"Target asset non può occupare il repository Git Lab: {target_rel}"
+            )
+
+    manifest_path = create_submission_scaffold.managed_assets_path(
+        target_dir, identifier, state_dir
+    )
+    distributed = create_submission_scaffold.student_activity_payload(activity)
+    create_submission_scaffold.atomic_write_text(
+        destination,
+        Path("activity.json"),
+        json.dumps(distributed, ensure_ascii=False, indent=2) + "\n",
+    )
+
+    copied = create_submission_scaffold.copy_student_assets(
+        destination=destination,
+        asset_plan=asset_plan,
+        managed_assets={},
+        source_name=git_lab_student.REPOSITORY_DIRNAME,
+        overwrite_source=False,
+    )
+    managed = {
+        path.relative_to(destination): create_submission_scaffold.file_sha256(path)
+        for path in copied
+    }
+    create_submission_scaffold.write_managed_assets(manifest_path, managed)
+    create_submission_scaffold.atomic_write_text(
+        destination,
+        Path("README.md"),
+        git_assignment_readme(activity, identifier),
+    )
+    return destination
 
 
 def prepare_assignment_repository(activity_path: Path, assignment_dir: Path) -> dict[str, Any] | None:
@@ -14,11 +118,33 @@ def prepare_assignment_repository(activity_path: Path, assignment_dir: Path) -> 
     if not git_lab_student.activity_uses_git_lab(activity):
         return None
     if assignment_dir.is_symlink() or not assignment_dir.is_dir():
-        raise git_lab_activity.GitLabActivityError("assignment_dir deve essere una directory reale già creata dallo scaffold")
-    repository = assignment_dir / git_lab_student.REPOSITORY_DIRNAME
+        raise git_lab_activity.GitLabActivityError(
+            "assignment_dir deve essere una directory reale già creata dallo scaffold"
+        )
+    repository = repository_path(assignment_dir)
     return git_lab_activity.prepare_repository(activity_path, repository)
 
 
-def repository_path(assignment_dir: Path) -> Path:
-    """Return the fixed Git Lab repository location inside an assignment scaffold."""
-    return assignment_dir / git_lab_student.REPOSITORY_DIRNAME
+def create_git_lab_assignment(
+    *,
+    activity_path: Path,
+    target_dir: Path,
+    state_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Create outer scaffold plus the nested deterministic Git exercise repo."""
+    assignment_dir = create_assignment_scaffold(
+        activity_path=activity_path,
+        target_dir=target_dir,
+        state_dir=state_dir,
+    )
+    fixture = prepare_assignment_repository(activity_path, assignment_dir)
+    assert fixture is not None
+    activity = git_lab_activity.load_activity(activity_path)
+    return {
+        "schema_version": "thebitlab.git-assignment-result.v1",
+        "activity_id": create_submission_scaffold.activity_id(activity),
+        "target": str(target_dir.resolve(strict=False)),
+        "assignment_dir": str(assignment_dir),
+        "repository": str(repository_path(assignment_dir)),
+        "fixture": fixture,
+    }

--- a/scripts/git_lab_assignment.py
+++ b/scripts/git_lab_assignment.py
@@ -1,0 +1,24 @@
+"""Prepare Git Lab repository workspaces after normal Activity scaffolding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from scripts import git_lab_activity, git_lab_student
+
+
+def prepare_assignment_repository(activity_path: Path, assignment_dir: Path) -> dict[str, Any] | None:
+    """Prepare repository/ for a Git Lab Activity; return None for other Activities."""
+    activity = git_lab_activity.load_activity(activity_path)
+    if not git_lab_student.activity_uses_git_lab(activity):
+        return None
+    if assignment_dir.is_symlink() or not assignment_dir.is_dir():
+        raise git_lab_activity.GitLabActivityError("assignment_dir deve essere una directory reale già creata dallo scaffold")
+    repository = assignment_dir / git_lab_student.REPOSITORY_DIRNAME
+    return git_lab_activity.prepare_repository(activity_path, repository)
+
+
+def repository_path(assignment_dir: Path) -> Path:
+    """Return the fixed Git Lab repository location inside an assignment scaffold."""
+    return assignment_dir / git_lab_student.REPOSITORY_DIRNAME

--- a/scripts/git_lab_lifecycle.py
+++ b/scripts/git_lab_lifecycle.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Composable assignment/run lifecycle for TheBitLab Git Lab G1.
 
-This wrapper uses the existing normal Activity scaffold plus the Git Lab adapters.
-It is intentionally thin so final Course Board / Student Lab routing can call the
-same functions without duplicating Git-specific semantics.
+Git Lab uses a repository-submission scaffold rather than pretending Git is a
+code language. Final Course Board / Student Lab routing can call these same
+functions without duplicating Git-specific semantics.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from scripts import assign_activity, git_lab_assignment, git_lab_student
+from scripts import git_lab_assignment, git_lab_student
 
 
 def assign_git_lab(
@@ -22,36 +22,12 @@ def assign_git_lab(
     target: Path,
     thebitlab_ref: str = "main",
 ) -> dict[str, Any]:
-    """Create the normal assignment scaffold and its nested Git repository."""
-    plan = assign_activity.build_assignment_plan(
+    """Create the safe Git Lab scaffold and its nested repository."""
+    del thebitlab_ref  # repository submissions do not expose code-runner workflow refs.
+    return git_lab_assignment.create_git_lab_assignment(
         activity_path=activity_path,
-        targets=[target],
-        thebitlab_ref=thebitlab_ref,
-        overwrite=False,
+        target_dir=target,
     )
-    if not plan.can_assign:
-        raise ValueError("Consegna Git Lab già esistente; reset/reprepare deve essere esplicito.")
-    results = assign_activity.assign_activity_to_targets(
-        activity_path=activity_path,
-        targets=[target],
-        thebitlab_ref=thebitlab_ref,
-        overwrite=False,
-        overwrite_source=False,
-    )
-    if len(results) != 1:
-        raise ValueError("Assegnazione Git Lab non deterministica.")
-    result = results[0]
-    fixture = git_lab_assignment.prepare_assignment_repository(activity_path, result.assignment_dir)
-    if fixture is None:
-        raise ValueError("L'Activity non dichiara Git Lab.")
-    return {
-        "schema_version": "thebitlab.git-assignment-result.v1",
-        "activity_id": plan.activity_id,
-        "target": str(result.target),
-        "assignment_dir": str(result.assignment_dir),
-        "repository": str(git_lab_assignment.repository_path(result.assignment_dir)),
-        "fixture": fixture,
-    }
 
 
 def run_git_lab(

--- a/scripts/git_lab_lifecycle.py
+++ b/scripts/git_lab_lifecycle.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Composable assignment/run lifecycle for TheBitLab Git Lab G1.
+
+This wrapper uses the existing normal Activity scaffold plus the Git Lab adapters.
+It is intentionally thin so final Course Board / Student Lab routing can call the
+same functions without duplicating Git-specific semantics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts import assign_activity, git_lab_assignment, git_lab_student
+
+
+def assign_git_lab(
+    *,
+    activity_path: Path,
+    target: Path,
+    thebitlab_ref: str = "main",
+) -> dict[str, Any]:
+    """Create the normal assignment scaffold and its nested Git repository."""
+    plan = assign_activity.build_assignment_plan(
+        activity_path=activity_path,
+        targets=[target],
+        thebitlab_ref=thebitlab_ref,
+        overwrite=False,
+    )
+    if not plan.can_assign:
+        raise ValueError("Consegna Git Lab già esistente; reset/reprepare deve essere esplicito.")
+    results = assign_activity.assign_activity_to_targets(
+        activity_path=activity_path,
+        targets=[target],
+        thebitlab_ref=thebitlab_ref,
+        overwrite=False,
+        overwrite_source=False,
+    )
+    if len(results) != 1:
+        raise ValueError("Assegnazione Git Lab non deterministica.")
+    result = results[0]
+    fixture = git_lab_assignment.prepare_assignment_repository(activity_path, result.assignment_dir)
+    if fixture is None:
+        raise ValueError("L'Activity non dichiara Git Lab.")
+    return {
+        "schema_version": "thebitlab.git-assignment-result.v1",
+        "activity_id": plan.activity_id,
+        "target": str(result.target),
+        "assignment_dir": str(result.assignment_dir),
+        "repository": str(git_lab_assignment.repository_path(result.assignment_dir)),
+        "fixture": fixture,
+    }
+
+
+def run_git_lab(
+    *,
+    root: Path,
+    assignment: dict[str, Any],
+) -> dict[str, Any]:
+    """Grade one already-prepared Git Lab assignment using student-safe output."""
+    return git_lab_student.run_git_lab_assignment(assignment, root=root)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Assign or grade one TheBitLab Git Lab Activity")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    assign_cmd = sub.add_parser("assign")
+    assign_cmd.add_argument("--activity", type=Path, required=True)
+    assign_cmd.add_argument("--target", type=Path, required=True)
+    assign_cmd.add_argument("--thebitlab-ref", default="main")
+
+    grade_cmd = sub.add_parser("grade")
+    grade_cmd.add_argument("--root", type=Path, required=True)
+    grade_cmd.add_argument("--assignment-json", type=Path, required=True)
+
+    args = parser.parse_args()
+    if args.command == "assign":
+        payload = assign_git_lab(
+            activity_path=args.activity,
+            target=args.target,
+            thebitlab_ref=args.thebitlab_ref,
+        )
+    else:
+        assignment = json.loads(args.assignment_json.read_text(encoding="utf-8"))
+        if not isinstance(assignment, dict):
+            raise SystemExit("assignment JSON deve essere un oggetto")
+        payload = run_git_lab(root=args.root, assignment=assignment)
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0 if payload.get("passed", True) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/git_lab_student.py
+++ b/scripts/git_lab_student.py
@@ -1,0 +1,138 @@
+"""Student-lab adapter and safe feedback for TheBitLab Git Lab Activities."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from scripts import git_lab_activity, student_lab_service
+
+
+REPOSITORY_DIRNAME = "repository"
+
+
+def clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def activity_uses_git_lab(activity: dict[str, Any]) -> bool:
+    extensions = activity.get("extensions")
+    if not isinstance(extensions, dict):
+        return False
+    extension = extensions.get(git_lab_activity.EXTENSION_KEY)
+    return isinstance(extension, dict) and extension.get("schema_version") == git_lab_activity.ACTIVITY_SCHEMA
+
+
+def assignment_activity_path(root: Path, assignment: dict[str, Any]) -> Path:
+    summary = assignment.get("activity") if isinstance(assignment.get("activity"), dict) else {}
+    value = clean_text(summary.get("path"))
+    if not value:
+        raise ValueError("activity.path mancante nella consegna Git Lab.")
+    path = student_lab_service.resolve_local_path(root, value)
+    if not path.is_file():
+        raise ValueError(f"Activity Git Lab non trovata: {value}")
+    return path
+
+
+def assignment_repository_path(root: Path, assignment: dict[str, Any]) -> Path:
+    workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}
+    value = clean_text(workspace.get("path"))
+    if not value:
+        raise ValueError("workspace.path mancante nella consegna Git Lab.")
+    workspace_path = student_lab_service.resolve_local_path(root, value)
+    repository = workspace_path / REPOSITORY_DIRNAME
+    if repository.is_symlink() or not repository.is_dir():
+        raise ValueError("Repository Git Lab non preparato nella workspace della consegna.")
+    return repository
+
+
+def _check_feedback(name: str, passed: bool) -> str:
+    if name == "clean":
+        return "Il working tree ha lo stato finale richiesto." if passed else "Controlla se il working tree deve essere pulito o avere modifiche residue."
+    if name == "branch":
+        return "Sei sul branch richiesto." if passed else "Controlla il branch corrente prima di consegnare."
+    if name == "commit_count":
+        return "La storia contiene il numero di commit richiesto." if passed else "La storia non ha ancora la decomposizione in commit richiesta."
+    if name == "staged_paths":
+        return "Nell'index ci sono i path richiesti." if passed else "Controlla con status e diff --staged quali path sono nell'index."
+    if name == "unstaged_paths":
+        return "Le modifiche non staged corrispondono alla consegna." if passed else "Controlla quali modifiche devono restare nel working tree senza essere staged."
+    if name == "untracked_paths":
+        return "I file untracked corrispondono alla consegna." if passed else "Controlla i file untracked prima di consegnare."
+    if name.startswith("working_files."):
+        path = name.split(".", 1)[1]
+        return f"Il contenuto corrente di {path} è quello richiesto." if passed else f"Il contenuto corrente di {path} non corrisponde allo stato richiesto."
+    if name.startswith("index_files."):
+        path = name.split(".", 1)[1]
+        return f"Lo snapshot staged di {path} è corretto." if passed else f"Controlla con diff --staged quale versione di {path} hai preparato nell'index."
+    if name.startswith("commits["):
+        return "Il commit controllato rispetta il requisito." if passed else "Controlla la storia e il contenuto del commit indicato dalla consegna."
+    return "Requisito Git verificato." if passed else "Un requisito Git della consegna non è ancora soddisfatto."
+
+
+def student_safe_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
+    """Remove hashes, exact expected state and teacher-only details."""
+    checks = evidence.get("checks") if isinstance(evidence.get("checks"), list) else []
+    public_checks: list[dict[str, Any]] = []
+    for index, item in enumerate(checks, start=1):
+        if not isinstance(item, dict):
+            continue
+        name = clean_text(item.get("name")) or f"check-{index}"
+        passed = item.get("passed") is True
+        public_checks.append({
+            "name": name,
+            "passed": passed,
+            "status": "passed" if passed else "failed",
+            "message": _check_feedback(name, passed),
+            "visibility": "student",
+        })
+    state = evidence.get("state") if isinstance(evidence.get("state"), dict) else {}
+    return {
+        "passed": evidence.get("passed") is True,
+        "checks": public_checks,
+        "state_summary": {
+            "branch": state.get("repository", {}).get("branch") if isinstance(state.get("repository"), dict) else state.get("branch"),
+            "clean": state.get("working_tree", {}).get("clean") if isinstance(state.get("working_tree"), dict) else state.get("clean"),
+            "commit_count": len(state.get("commits", [])) if isinstance(state.get("commits"), list) else state.get("commit_count"),
+        },
+    }
+
+
+def run_git_lab_assignment(
+    assignment: dict[str, Any],
+    *,
+    root: Path,
+    timeout_seconds: int = 5,
+    backend: str = "local",
+) -> dict[str, Any]:
+    """Grade the prepared Git Lab repository and return student_lab_run.v1."""
+    del timeout_seconds  # Git Lab commands have their own bounded platform timeout.
+    del backend
+    activity_path = assignment_activity_path(root, assignment)
+    activity = json.loads(activity_path.read_text(encoding="utf-8"))
+    if not activity_uses_git_lab(activity):
+        raise ValueError("Activity non dichiara extensions.thebitlab.git-lab.")
+    repository = assignment_repository_path(root, assignment)
+    evidence = git_lab_activity.grade_repository(activity_path, repository)
+    public = student_safe_evidence(evidence)
+    checks = public["checks"]
+    passed_count = sum(1 for item in checks if item.get("passed") is True)
+    return {
+        "schema_version": "student_lab_run.v1",
+        "backend": "git-lab",
+        "assignment_id": clean_text(assignment.get("assignment_id")),
+        "activity_id": clean_text(assignment.get("activity_id")),
+        "student_id": clean_text(assignment.get("student_id")),
+        "language": "git",
+        "source": str(repository),
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "passed": public["passed"],
+        "status": "passed" if public["passed"] else "failed",
+        "summary": {"passed": passed_count, "total": len(checks)},
+        "tests": checks,
+        "stdout": "",
+        "stderr": "",
+        "git": public["state_summary"],
+    }

--- a/scripts/git_lab_student.py
+++ b/scripts/git_lab_student.py
@@ -49,27 +49,67 @@ def assignment_repository_path(root: Path, assignment: dict[str, Any]) -> Path:
 
 
 def _check_feedback(name: str, passed: bool) -> str:
-    if name == "clean":
-        return "Il working tree ha lo stato finale richiesto." if passed else "Controlla se il working tree deve essere pulito o avere modifiche residue."
-    if name == "branch":
-        return "Sei sul branch richiesto." if passed else "Controlla il branch corrente prima di consegnare."
-    if name == "commit_count":
-        return "La storia contiene il numero di commit richiesto." if passed else "La storia non ha ancora la decomposizione in commit richiesta."
-    if name == "staged_paths":
-        return "Nell'index ci sono i path richiesti." if passed else "Controlla con status e diff --staged quali path sono nell'index."
-    if name == "unstaged_paths":
-        return "Le modifiche non staged corrispondono alla consegna." if passed else "Controlla quali modifiche devono restare nel working tree senza essere staged."
-    if name == "untracked_paths":
-        return "I file untracked corrispondono alla consegna." if passed else "Controlla i file untracked prima di consegnare."
-    if name.startswith("working_files."):
-        path = name.split(".", 1)[1]
-        return f"Il contenuto corrente di {path} è quello richiesto." if passed else f"Il contenuto corrente di {path} non corrisponde allo stato richiesto."
-    if name.startswith("index_files."):
-        path = name.split(".", 1)[1]
-        return f"Lo snapshot staged di {path} è corretto." if passed else f"Controlla con diff --staged quale versione di {path} hai preparato nell'index."
-    if name.startswith("commits["):
-        return "Il commit controllato rispetta il requisito." if passed else "Controlla la storia e il contenuto del commit indicato dalla consegna."
-    return "Requisito Git verificato." if passed else "Un requisito Git della consegna non è ancora soddisfatto."
+    if name == "working_tree.clean":
+        return (
+            "Il working tree ha lo stato finale richiesto."
+            if passed
+            else "Controlla con git status se il working tree deve essere pulito o avere modifiche residue."
+        )
+    if name == "repository.branch":
+        return (
+            "Sei sul branch richiesto."
+            if passed
+            else "Controlla il branch corrente prima di consegnare."
+        )
+    if name == "history.commit_count":
+        return (
+            "La storia contiene il numero di commit richiesto."
+            if passed
+            else "La storia non ha ancora la decomposizione in commit richiesta: controlla git log."
+        )
+    if name == "working_tree.staged":
+        return (
+            "Nell'index ci sono i path richiesti."
+            if passed
+            else "Controlla con git status e git diff --staged quali path sono nell'index."
+        )
+    if name == "working_tree.unstaged":
+        return (
+            "Le modifiche non staged corrispondono alla consegna."
+            if passed
+            else "Controlla con git status e git diff quali modifiche devono restare nel working tree senza essere staged."
+        )
+    if name == "working_tree.untracked":
+        return (
+            "I file untracked corrispondono alla consegna."
+            if passed
+            else "Controlla i file untracked mostrati da git status prima di consegnare."
+        )
+    if name.startswith("working_tree.file:"):
+        path = name.split(":", 1)[1]
+        return (
+            f"Il contenuto corrente di {path} è quello richiesto."
+            if passed
+            else f"Il contenuto corrente di {path} non corrisponde allo stato richiesto."
+        )
+    if name.startswith("index.file:"):
+        path = name.split(":", 1)[1]
+        return (
+            f"Lo snapshot staged di {path} è corretto."
+            if passed
+            else f"Controlla con git diff --staged quale versione di {path} hai preparato nell'index."
+        )
+    if name.startswith("commit["):
+        return (
+            "Il commit controllato rispetta il requisito."
+            if passed
+            else "Controlla git log/git show e la struttura dei commit richiesta dalla consegna."
+        )
+    return (
+        "Requisito Git verificato."
+        if passed
+        else "Un requisito Git della consegna non è ancora soddisfatto."
+    )
 
 
 def student_safe_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
@@ -81,21 +121,27 @@ def student_safe_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
             continue
         name = clean_text(item.get("name")) or f"check-{index}"
         passed = item.get("passed") is True
-        public_checks.append({
-            "name": name,
-            "passed": passed,
-            "status": "passed" if passed else "failed",
-            "message": _check_feedback(name, passed),
-            "visibility": "student",
-        })
-    state = evidence.get("state") if isinstance(evidence.get("state"), dict) else {}
+        public_checks.append(
+            {
+                "name": name,
+                "passed": passed,
+                "status": "passed" if passed else "failed",
+                "message": _check_feedback(name, passed),
+                "visibility": "student",
+            }
+        )
+
+    state = evidence.get("evidence") if isinstance(evidence.get("evidence"), dict) else {}
+    repository = state.get("repository") if isinstance(state.get("repository"), dict) else {}
+    working_tree = state.get("working_tree") if isinstance(state.get("working_tree"), dict) else {}
+    commits = state.get("commits") if isinstance(state.get("commits"), list) else []
     return {
         "passed": evidence.get("passed") is True,
         "checks": public_checks,
         "state_summary": {
-            "branch": state.get("repository", {}).get("branch") if isinstance(state.get("repository"), dict) else state.get("branch"),
-            "clean": state.get("working_tree", {}).get("clean") if isinstance(state.get("working_tree"), dict) else state.get("clean"),
-            "commit_count": len(state.get("commits", [])) if isinstance(state.get("commits"), list) else state.get("commit_count"),
+            "branch": repository.get("branch"),
+            "clean": working_tree.get("clean"),
+            "commit_count": len(commits),
         },
     }
 

--- a/scripts/git_lab_validator.py
+++ b/scripts/git_lab_validator.py
@@ -56,9 +56,6 @@ def _git_environment() -> dict[str, str]:
             "GIT_CONFIG_NOSYSTEM": "1",
             "GIT_CONFIG_GLOBAL": os.devnull,
             "GIT_OPTIONAL_LOCKS": "0",
-            # Override repository-local fsmonitor configuration. A validator
-            # must not execute a student-controlled fsmonitor hook/program
-            # merely to inspect status.
             "GIT_CONFIG_COUNT": "2",
             "GIT_CONFIG_KEY_0": "core.fsmonitor",
             "GIT_CONFIG_VALUE_0": "false",
@@ -146,7 +143,6 @@ def _parse_status(repo: Path, *, max_paths: int) -> dict[str, list[str]]:
         xy = record[:2]
         path = record[3:]
         if xy[0] in {"R", "C"}:
-            # porcelain v1 -z emits the source path as the next NUL field.
             index += 1
             if index >= len(parts):
                 raise GitLabInspectionError("rename/copy status incompleto")
@@ -234,9 +230,7 @@ def _history(repo: Path, *, max_commits: int, max_paths: int) -> list[dict[str, 
     return commits
 
 
-def _blob_sha256(repo: Path, commit_sha: str, path: str) -> str | None:
-    safe_path = _safe_relative_path(path)
-    object_name = f"{commit_sha}:{safe_path}"
+def _hash_blob_object(repo: Path, object_name: str, label: str) -> str | None:
     blob_sha = _run_git(repo, "rev-parse", "--verify", object_name, check=False)
     assert isinstance(blob_sha, str)
     blob_sha = blob_sha.strip()
@@ -253,12 +247,42 @@ def _blob_sha256(repo: Path, commit_sha: str, path: str) -> str | None:
     except ValueError as error:
         raise GitLabInspectionError("dimensione blob non valida") from error
     if size > MAX_FILE_BYTES:
-        raise GitLabInspectionError(f"file troppo grande per evidence G1: {safe_path}")
+        raise GitLabInspectionError(f"file troppo grande per evidence G1: {label}")
     content = _run_git(repo, "cat-file", "-p", blob_sha, binary=True)
     assert isinstance(content, bytes)
     if len(content) != size:
         raise GitLabInspectionError("dimensione blob incoerente")
     return hashlib.sha256(content).hexdigest()
+
+
+def _blob_sha256(repo: Path, commit_sha: str, path: str) -> str | None:
+    safe_path = _safe_relative_path(path)
+    return _hash_blob_object(repo, f"{commit_sha}:{safe_path}", safe_path)
+
+
+def _index_sha256(repo: Path, path: str) -> str | None:
+    safe_path = _safe_relative_path(path)
+    return _hash_blob_object(repo, f":{safe_path}", safe_path)
+
+
+def _working_tree_sha256(repo: Path, path: str) -> str | None:
+    safe_path = _safe_relative_path(path)
+    target = repo.joinpath(*PurePosixPath(safe_path).parts)
+    if not target.exists():
+        return None
+    if target.is_symlink():
+        raise GitLabInspectionError(f"working-tree evidence non segue symlink: {safe_path}")
+    try:
+        resolved = target.resolve(strict=True)
+        resolved.relative_to(repo)
+    except (OSError, ValueError) as error:
+        raise GitLabInspectionError(f"working-tree path esce dal repository: {safe_path}") from error
+    if not resolved.is_file():
+        return None
+    size = resolved.stat().st_size
+    if size > MAX_FILE_BYTES:
+        raise GitLabInspectionError(f"file troppo grande per evidence G1: {safe_path}")
+    return hashlib.sha256(resolved.read_bytes()).hexdigest()
 
 
 def inspect_repository(
@@ -278,10 +302,7 @@ def inspect_repository(
     return {
         "schema_version": REPORT_SCHEMA,
         "repository": {"branch": branch, "head": head, "detached": detached},
-        "working_tree": {
-            **status,
-            "clean": not any(status.values()),
-        },
+        "working_tree": {**status, "clean": not any(status.values())},
         "commits": commits,
     }
 
@@ -293,6 +314,20 @@ def _validate_string_list(value: Any, field: str) -> list[str]:
     if len(result) != len(set(result)):
         raise GitLabValidationError(f"{field} contiene duplicati")
     return sorted(result)
+
+
+def _validate_hash_map(value: Any, field: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise GitLabValidationError(f"{field} deve essere un oggetto")
+    result: dict[str, str] = {}
+    for path, expected_hash in value.items():
+        safe_path = _safe_relative_path(path)
+        if not isinstance(expected_hash, str) or len(expected_hash) != 64 or any(
+            char not in "0123456789abcdef" for char in expected_hash
+        ):
+            raise GitLabValidationError(f"{field}[{path!r}] deve essere sha256 lowercase")
+        result[safe_path] = expected_hash
+    return result
 
 
 def validate_spec(spec: Any) -> None:
@@ -307,6 +342,9 @@ def validate_spec(spec: Any) -> None:
     for field in ("staged_paths", "unstaged_paths", "untracked_paths"):
         if field in expectations:
             _validate_string_list(expectations[field], field)
+    for field in ("working_files", "index_files"):
+        if field in expectations:
+            _validate_hash_map(expectations[field], field)
     if "clean" in expectations and not isinstance(expectations["clean"], bool):
         raise GitLabValidationError("clean deve essere boolean")
     if "branch" in expectations:
@@ -339,17 +377,8 @@ def validate_spec(spec: Any) -> None:
                 )
         if "changed_paths" in item:
             _validate_string_list(item["changed_paths"], f"commits[{index}].changed_paths")
-        files = item.get("files", {})
-        if not isinstance(files, dict):
-            raise GitLabValidationError(f"commits[{index}].files deve essere un oggetto")
-        for path, expected_hash in files.items():
-            _safe_relative_path(path)
-            if not isinstance(expected_hash, str) or len(expected_hash) != 64 or any(
-                char not in "0123456789abcdef" for char in expected_hash
-            ):
-                raise GitLabValidationError(
-                    f"commits[{index}].files[{path!r}] deve essere sha256 lowercase"
-                )
+        if "files" in item:
+            _validate_hash_map(item["files"], f"commits[{index}].files")
 
 
 def evaluate_repository(repo_root: Path, spec: dict[str, Any]) -> dict[str, Any]:
@@ -377,6 +406,13 @@ def evaluate_repository(repo_root: Path, spec: dict[str, Any]) -> dict[str, Any]
             expected = sorted(expectations[spec_field])
             actual = working[report_field]
             check(f"working_tree.{report_field}", actual == expected, expected, actual)
+
+    for path, expected_hash in expectations.get("working_files", {}).items():
+        actual_hash = _working_tree_sha256(repo, path)
+        check(f"working_tree.file:{path}", actual_hash == expected_hash, expected_hash, actual_hash)
+    for path, expected_hash in expectations.get("index_files", {}).items():
+        actual_hash = _index_sha256(repo, path)
+        check(f"index.file:{path}", actual_hash == expected_hash, expected_hash, actual_hash)
 
     commits = report["commits"]
     if "commit_count" in expectations:

--- a/scripts/git_lab_validator.py
+++ b/scripts/git_lab_validator.py
@@ -24,6 +24,7 @@ DEFAULT_MAX_PATHS = 512
 DEFAULT_TIMEOUT_SECONDS = 4
 MAX_GIT_OUTPUT_BYTES = 2 * 1024 * 1024
 MAX_FILE_BYTES = 512 * 1024
+MAX_SUBJECT_CHARS = 240
 
 
 class GitLabValidationError(ValueError):
@@ -55,6 +56,14 @@ def _git_environment() -> dict[str, str]:
             "GIT_CONFIG_NOSYSTEM": "1",
             "GIT_CONFIG_GLOBAL": os.devnull,
             "GIT_OPTIONAL_LOCKS": "0",
+            # Override repository-local fsmonitor configuration. A validator
+            # must not execute a student-controlled fsmonitor hook/program
+            # merely to inspect status.
+            "GIT_CONFIG_COUNT": "2",
+            "GIT_CONFIG_KEY_0": "core.fsmonitor",
+            "GIT_CONFIG_VALUE_0": "false",
+            "GIT_CONFIG_KEY_1": "core.untrackedCache",
+            "GIT_CONFIG_VALUE_1": "false",
             "LC_ALL": "C",
             "LANG": "C",
         }
@@ -210,6 +219,8 @@ def _history(repo: Path, *, max_commits: int, max_paths: int) -> list[dict[str, 
         if len(fields) != 3:
             raise GitLabInspectionError("git log ha prodotto un record inatteso")
         sha, parents_text, subject = fields
+        if len(subject) > MAX_SUBJECT_CHARS:
+            raise GitLabInspectionError("commit subject oltre il limite G1")
         parents = [value for value in parents_text.split() if value]
         commits.append(
             {
@@ -298,8 +309,14 @@ def validate_spec(spec: Any) -> None:
             _validate_string_list(expectations[field], field)
     if "clean" in expectations and not isinstance(expectations["clean"], bool):
         raise GitLabValidationError("clean deve essere boolean")
-    if "branch" in expectations and not isinstance(expectations["branch"], str):
-        raise GitLabValidationError("branch deve essere stringa")
+    if "branch" in expectations:
+        branch = expectations["branch"]
+        if not isinstance(branch, str) or not branch.strip() or len(branch) > 200:
+            raise GitLabValidationError("branch deve essere stringa non vuota")
+    if "commit_count" in expectations:
+        count = expectations["commit_count"]
+        if not isinstance(count, int) or not 0 <= count <= DEFAULT_MAX_COMMITS:
+            raise GitLabValidationError("commit_count deve essere intero nel range G1")
 
     commits = expectations.get("commits", [])
     if not isinstance(commits, list):
@@ -314,8 +331,12 @@ def validate_spec(spec: Any) -> None:
         if position in seen_positions:
             raise GitLabValidationError("commit position duplicata")
         seen_positions.add(position)
-        if "subject_contains" in item and not isinstance(item["subject_contains"], str):
-            raise GitLabValidationError(f"commits[{index}].subject_contains deve essere stringa")
+        if "subject_contains" in item:
+            subject = item["subject_contains"]
+            if not isinstance(subject, str) or not subject or len(subject) > MAX_SUBJECT_CHARS:
+                raise GitLabValidationError(
+                    f"commits[{index}].subject_contains deve essere stringa breve non vuota"
+                )
         if "changed_paths" in item:
             _validate_string_list(item["changed_paths"], f"commits[{index}].changed_paths")
         files = item.get("files", {})
@@ -333,7 +354,8 @@ def validate_spec(spec: Any) -> None:
 
 def evaluate_repository(repo_root: Path, spec: dict[str, Any]) -> dict[str, Any]:
     validate_spec(spec)
-    report = inspect_repository(repo_root)
+    repo = validate_repository_root(repo_root)
+    report = inspect_repository(repo)
     expectations = spec["expectations"]
     checks: list[dict[str, Any]] = []
 
@@ -359,8 +381,6 @@ def evaluate_repository(repo_root: Path, spec: dict[str, Any]) -> dict[str, Any]
     commits = report["commits"]
     if "commit_count" in expectations:
         expected_count = expectations["commit_count"]
-        if not isinstance(expected_count, int) or expected_count < 0:
-            raise GitLabValidationError("commit_count deve essere intero >= 0")
         check("history.commit_count", len(commits) == expected_count, expected_count, len(commits))
 
     for item in expectations.get("commits", []):
@@ -386,7 +406,7 @@ def evaluate_repository(repo_root: Path, spec: dict[str, Any]) -> dict[str, Any]
                 commit["changed_paths"],
             )
         for path, expected_hash in item.get("files", {}).items():
-            actual_hash = _blob_sha256(validate_repository_root(repo_root), commit["sha"], path)
+            actual_hash = _blob_sha256(repo, commit["sha"], path)
             check(f"commit[{position}].file:{path}", actual_hash == expected_hash, expected_hash, actual_hash)
 
     return {

--- a/scripts/git_lab_validator.py
+++ b/scripts/git_lab_validator.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Read-only repository-state validator for TheBitLab Git Lab G1.
+
+The validator assesses the resulting Git repository state/history rather than
+requiring one exact student command sequence. It never runs a shell and only
+uses read-only Git commands against an explicit assignment repository root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import subprocess
+from typing import Any
+
+
+SPEC_SCHEMA = "thebitlab.git-lab.v1"
+REPORT_SCHEMA = "thebitlab.git-report.v1"
+DEFAULT_MAX_COMMITS = 64
+DEFAULT_MAX_PATHS = 512
+DEFAULT_TIMEOUT_SECONDS = 4
+MAX_GIT_OUTPUT_BYTES = 2 * 1024 * 1024
+MAX_FILE_BYTES = 512 * 1024
+
+
+class GitLabValidationError(ValueError):
+    """Expectation/specification or assignment-repository contract is invalid."""
+
+
+class GitLabInspectionError(RuntimeError):
+    """Git repository inspection failed or exceeded the bounded contract."""
+
+
+def _safe_relative_path(value: Any) -> str:
+    if not isinstance(value, str) or value != value.strip() or not value:
+        raise GitLabValidationError("path deve essere una stringa relativa non vuota")
+    if "\\" in value or value.startswith("/") or ":" in value:
+        raise GitLabValidationError(f"path non portabile/sicuro: {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or path.as_posix() != value or any(
+        part in {"", ".", ".."} for part in path.parts
+    ):
+        raise GitLabValidationError(f"path non portabile/sicuro: {value!r}")
+    return value
+
+
+def _git_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_OPTIONAL_LOCKS": "0",
+            "LC_ALL": "C",
+            "LANG": "C",
+        }
+    )
+    return env
+
+
+def _run_git(
+    repo: Path,
+    *args: str,
+    check: bool = True,
+    binary: bool = False,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> bytes | str:
+    command = ["git", "-C", str(repo), "--no-pager", *args]
+    try:
+        result = subprocess.run(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=_git_environment(),
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise GitLabInspectionError(f"comando Git non eseguibile/timeout: {' '.join(args)}") from error
+
+    if len(result.stdout) > MAX_GIT_OUTPUT_BYTES or len(result.stderr) > MAX_GIT_OUTPUT_BYTES:
+        raise GitLabInspectionError("output Git oltre il limite")
+    if check and result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise GitLabInspectionError(
+            f"git {' '.join(args)} fallito ({result.returncode}): {detail[:500]}"
+        )
+    if binary:
+        return result.stdout
+    return result.stdout.decode("utf-8", errors="strict")
+
+
+def validate_repository_root(repo_root: Path) -> Path:
+    root = repo_root.expanduser()
+    if root.is_symlink():
+        raise GitLabValidationError("assignment repository root non può essere un symlink")
+    try:
+        root = root.resolve(strict=True)
+    except OSError as error:
+        raise GitLabValidationError("assignment repository root inesistente") from error
+    if not root.is_dir():
+        raise GitLabValidationError("assignment repository root deve essere una directory")
+
+    try:
+        top = str(_run_git(root, "rev-parse", "--show-toplevel")).strip()
+        bare = str(_run_git(root, "rev-parse", "--is-bare-repository")).strip()
+    except GitLabInspectionError as error:
+        raise GitLabValidationError("directory non è un repository Git valido") from error
+
+    if Path(top).resolve() != root:
+        raise GitLabValidationError(
+            "il path fornito deve essere esattamente la root del repository assegnato"
+        )
+    if bare != "false":
+        raise GitLabValidationError("Git Lab G1 non accetta repository bare")
+    return root
+
+
+def _parse_status(repo: Path, *, max_paths: int) -> dict[str, list[str]]:
+    raw = _run_git(repo, "status", "--porcelain=v1", "-z", "--untracked-files=all", binary=True)
+    assert isinstance(raw, bytes)
+    parts = [part for part in raw.split(b"\0") if part]
+    staged: set[str] = set()
+    unstaged: set[str] = set()
+    untracked: set[str] = set()
+
+    index = 0
+    while index < len(parts):
+        record = parts[index].decode("utf-8", errors="strict")
+        if len(record) < 4:
+            raise GitLabInspectionError("status porcelain non valido")
+        xy = record[:2]
+        path = record[3:]
+        if xy[0] in {"R", "C"}:
+            # porcelain v1 -z emits the source path as the next NUL field.
+            index += 1
+            if index >= len(parts):
+                raise GitLabInspectionError("rename/copy status incompleto")
+            _ = parts[index].decode("utf-8", errors="strict")
+        path = _safe_relative_path(path)
+        if xy == "??":
+            untracked.add(path)
+        else:
+            if xy[0] != " ":
+                staged.add(path)
+            if xy[1] != " ":
+                unstaged.add(path)
+        index += 1
+
+    all_paths = staged | unstaged | untracked
+    if len(all_paths) > max_paths:
+        raise GitLabInspectionError("troppi path nel working tree per il profilo G1")
+    return {
+        "staged": sorted(staged),
+        "unstaged": sorted(unstaged),
+        "untracked": sorted(untracked),
+    }
+
+
+def _head_state(repo: Path) -> tuple[str | None, str | None, bool]:
+    result = _run_git(repo, "rev-parse", "--verify", "HEAD", check=False)
+    assert isinstance(result, str)
+    if not result.strip():
+        return None, None, False
+    head = result.strip()
+    branch_result = _run_git(repo, "symbolic-ref", "--quiet", "--short", "HEAD", check=False)
+    assert isinstance(branch_result, str)
+    branch = branch_result.strip() or None
+    return head, branch, branch is None
+
+
+def _commit_changed_paths(repo: Path, sha: str, *, max_paths: int) -> list[str]:
+    output = _run_git(
+        repo,
+        "diff-tree",
+        "--root",
+        "--no-commit-id",
+        "--name-only",
+        "-r",
+        "--no-renames",
+        sha,
+    )
+    assert isinstance(output, str)
+    paths = [_safe_relative_path(line) for line in output.splitlines() if line]
+    if len(paths) > max_paths:
+        raise GitLabInspectionError("commit con troppi path per il profilo G1")
+    return sorted(paths)
+
+
+def _history(repo: Path, *, max_commits: int, max_paths: int) -> list[dict[str, Any]]:
+    output = _run_git(
+        repo,
+        "log",
+        f"--max-count={max_commits + 1}",
+        "--format=%H%x00%P%x00%s%x1e",
+    )
+    assert isinstance(output, str)
+    records = [record for record in output.split("\x1e") if record.strip()]
+    if len(records) > max_commits:
+        raise GitLabInspectionError("cronologia oltre il limite G1")
+
+    commits: list[dict[str, Any]] = []
+    for position, record in enumerate(records):
+        fields = record.strip("\n").split("\x00")
+        if len(fields) != 3:
+            raise GitLabInspectionError("git log ha prodotto un record inatteso")
+        sha, parents_text, subject = fields
+        parents = [value for value in parents_text.split() if value]
+        commits.append(
+            {
+                "position": position,
+                "sha": sha,
+                "parents": parents,
+                "subject": subject,
+                "changed_paths": _commit_changed_paths(repo, sha, max_paths=max_paths),
+            }
+        )
+    return commits
+
+
+def _blob_sha256(repo: Path, commit_sha: str, path: str) -> str | None:
+    safe_path = _safe_relative_path(path)
+    object_name = f"{commit_sha}:{safe_path}"
+    blob_sha = _run_git(repo, "rev-parse", "--verify", object_name, check=False)
+    assert isinstance(blob_sha, str)
+    blob_sha = blob_sha.strip()
+    if not blob_sha:
+        return None
+    blob_type = _run_git(repo, "cat-file", "-t", blob_sha)
+    assert isinstance(blob_type, str)
+    if blob_type.strip() != "blob":
+        return None
+    size_text = _run_git(repo, "cat-file", "-s", blob_sha)
+    assert isinstance(size_text, str)
+    try:
+        size = int(size_text.strip())
+    except ValueError as error:
+        raise GitLabInspectionError("dimensione blob non valida") from error
+    if size > MAX_FILE_BYTES:
+        raise GitLabInspectionError(f"file troppo grande per evidence G1: {safe_path}")
+    content = _run_git(repo, "cat-file", "-p", blob_sha, binary=True)
+    assert isinstance(content, bytes)
+    if len(content) != size:
+        raise GitLabInspectionError("dimensione blob incoerente")
+    return hashlib.sha256(content).hexdigest()
+
+
+def inspect_repository(
+    repo_root: Path,
+    *,
+    max_commits: int = DEFAULT_MAX_COMMITS,
+    max_paths: int = DEFAULT_MAX_PATHS,
+) -> dict[str, Any]:
+    if not 1 <= max_commits <= DEFAULT_MAX_COMMITS:
+        raise GitLabValidationError("max_commits fuori dal profilo G1")
+    if not 1 <= max_paths <= DEFAULT_MAX_PATHS:
+        raise GitLabValidationError("max_paths fuori dal profilo G1")
+    repo = validate_repository_root(repo_root)
+    status = _parse_status(repo, max_paths=max_paths)
+    head, branch, detached = _head_state(repo)
+    commits = _history(repo, max_commits=max_commits, max_paths=max_paths) if head else []
+    return {
+        "schema_version": REPORT_SCHEMA,
+        "repository": {"branch": branch, "head": head, "detached": detached},
+        "working_tree": {
+            **status,
+            "clean": not any(status.values()),
+        },
+        "commits": commits,
+    }
+
+
+def _validate_string_list(value: Any, field: str) -> list[str]:
+    if not isinstance(value, list):
+        raise GitLabValidationError(f"{field} deve essere una lista")
+    result = [_safe_relative_path(item) for item in value]
+    if len(result) != len(set(result)):
+        raise GitLabValidationError(f"{field} contiene duplicati")
+    return sorted(result)
+
+
+def validate_spec(spec: Any) -> None:
+    if not isinstance(spec, dict):
+        raise GitLabValidationError("spec deve essere un oggetto JSON")
+    if spec.get("schema_version") != SPEC_SCHEMA:
+        raise GitLabValidationError(f"schema_version deve essere {SPEC_SCHEMA}")
+    expectations = spec.get("expectations")
+    if not isinstance(expectations, dict) or not expectations:
+        raise GitLabValidationError("expectations deve essere un oggetto non vuoto")
+
+    for field in ("staged_paths", "unstaged_paths", "untracked_paths"):
+        if field in expectations:
+            _validate_string_list(expectations[field], field)
+    if "clean" in expectations and not isinstance(expectations["clean"], bool):
+        raise GitLabValidationError("clean deve essere boolean")
+    if "branch" in expectations and not isinstance(expectations["branch"], str):
+        raise GitLabValidationError("branch deve essere stringa")
+
+    commits = expectations.get("commits", [])
+    if not isinstance(commits, list):
+        raise GitLabValidationError("commits deve essere una lista")
+    seen_positions: set[int] = set()
+    for index, item in enumerate(commits):
+        if not isinstance(item, dict):
+            raise GitLabValidationError(f"commits[{index}] deve essere un oggetto")
+        position = item.get("position")
+        if not isinstance(position, int) or position < 0 or position >= DEFAULT_MAX_COMMITS:
+            raise GitLabValidationError(f"commits[{index}].position non valida")
+        if position in seen_positions:
+            raise GitLabValidationError("commit position duplicata")
+        seen_positions.add(position)
+        if "subject_contains" in item and not isinstance(item["subject_contains"], str):
+            raise GitLabValidationError(f"commits[{index}].subject_contains deve essere stringa")
+        if "changed_paths" in item:
+            _validate_string_list(item["changed_paths"], f"commits[{index}].changed_paths")
+        files = item.get("files", {})
+        if not isinstance(files, dict):
+            raise GitLabValidationError(f"commits[{index}].files deve essere un oggetto")
+        for path, expected_hash in files.items():
+            _safe_relative_path(path)
+            if not isinstance(expected_hash, str) or len(expected_hash) != 64 or any(
+                char not in "0123456789abcdef" for char in expected_hash
+            ):
+                raise GitLabValidationError(
+                    f"commits[{index}].files[{path!r}] deve essere sha256 lowercase"
+                )
+
+
+def evaluate_repository(repo_root: Path, spec: dict[str, Any]) -> dict[str, Any]:
+    validate_spec(spec)
+    report = inspect_repository(repo_root)
+    expectations = spec["expectations"]
+    checks: list[dict[str, Any]] = []
+
+    def check(name: str, passed: bool, expected: Any, actual: Any) -> None:
+        checks.append({"name": name, "passed": bool(passed), "expected": expected, "actual": actual})
+
+    working = report["working_tree"]
+    if "clean" in expectations:
+        check("working_tree.clean", working["clean"] == expectations["clean"], expectations["clean"], working["clean"])
+    if "branch" in expectations:
+        actual_branch = report["repository"]["branch"]
+        check("repository.branch", actual_branch == expectations["branch"], expectations["branch"], actual_branch)
+    for spec_field, report_field in (
+        ("staged_paths", "staged"),
+        ("unstaged_paths", "unstaged"),
+        ("untracked_paths", "untracked"),
+    ):
+        if spec_field in expectations:
+            expected = sorted(expectations[spec_field])
+            actual = working[report_field]
+            check(f"working_tree.{report_field}", actual == expected, expected, actual)
+
+    commits = report["commits"]
+    if "commit_count" in expectations:
+        expected_count = expectations["commit_count"]
+        if not isinstance(expected_count, int) or expected_count < 0:
+            raise GitLabValidationError("commit_count deve essere intero >= 0")
+        check("history.commit_count", len(commits) == expected_count, expected_count, len(commits))
+
+    for item in expectations.get("commits", []):
+        position = item["position"]
+        if position >= len(commits):
+            check(f"commit[{position}].exists", False, True, False)
+            continue
+        commit = commits[position]
+        if "subject_contains" in item:
+            needle = item["subject_contains"]
+            check(
+                f"commit[{position}].subject_contains",
+                needle.casefold() in commit["subject"].casefold(),
+                needle,
+                commit["subject"],
+            )
+        if "changed_paths" in item:
+            expected_paths = sorted(item["changed_paths"])
+            check(
+                f"commit[{position}].changed_paths",
+                commit["changed_paths"] == expected_paths,
+                expected_paths,
+                commit["changed_paths"],
+            )
+        for path, expected_hash in item.get("files", {}).items():
+            actual_hash = _blob_sha256(validate_repository_root(repo_root), commit["sha"], path)
+            check(f"commit[{position}].file:{path}", actual_hash == expected_hash, expected_hash, actual_hash)
+
+    return {
+        "schema_version": REPORT_SCHEMA,
+        "passed": all(item["passed"] for item in checks),
+        "checks": checks,
+        "evidence": report,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a TheBitLab Git Lab G1 assignment repository")
+    parser.add_argument("repo", type=Path)
+    parser.add_argument("spec", type=Path)
+    args = parser.parse_args()
+    spec = json.loads(args.spec.read_text(encoding="utf-8"))
+    result = evaluate_repository(args.repo, spec)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if result["passed"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_git_lab_activity.py
+++ b/tests/test_git_lab_activity.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from scripts import git_lab_activity
+
+
+def sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def run(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        timeout=5,
+    )
+    return result.stdout.strip()
+
+
+def build_activity(tmp_path: Path) -> Path:
+    activity_dir = tmp_path / "activity"
+    base = activity_dir / "fixture" / "base"
+    working = activity_dir / "fixture" / "working"
+    grading = activity_dir / "grading"
+    base.mkdir(parents=True)
+    working.mkdir(parents=True)
+    grading.mkdir(parents=True)
+
+    (base / "README.md").write_text("# fixture\n", encoding="utf-8")
+    (base / "programma.py").write_text('print("versione iniziale")\n', encoding="utf-8")
+    (base / "note.txt").write_text("appunti iniziali\n", encoding="utf-8")
+    (working / "programma.py").write_text('print("versione laboratorio")\n', encoding="utf-8")
+    (working / "note.txt").write_text("appunti aggiornati\n", encoding="utf-8")
+
+    expectations = {
+        "schema_version": "thebitlab.git-lab.v1",
+        "expectations": {
+            "clean": False,
+            "branch": "main",
+            "commit_count": 1,
+            "staged_paths": ["programma.py"],
+            "unstaged_paths": ["note.txt"],
+            "untracked_paths": [],
+            "working_files": {
+                "programma.py": sha256('print("versione laboratorio")\n'),
+                "note.txt": sha256("appunti aggiornati\n"),
+            },
+            "index_files": {
+                "programma.py": sha256('print("versione laboratorio")\n'),
+                "note.txt": sha256("appunti iniziali\n"),
+            },
+        },
+    }
+    (grading / "expectations.json").write_text(
+        json.dumps(expectations), encoding="utf-8"
+    )
+
+    activity = {
+        "schema_version": "1.0",
+        "id": "git-canary",
+        "extensions": {
+            "thebitlab.git-lab": {
+                "schema_version": "git_activity.v1",
+                "fixture": {
+                    "base_dir": "fixture/base",
+                    "working_overlay_dir": "fixture/working",
+                    "initial_branch": "main",
+                    "initial_commit_message": "Fixture iniziale",
+                },
+                "expectations": {
+                    "path": "grading/expectations.json",
+                    "media_type": "application/json",
+                },
+                "submission": {"kind": "git-repository"},
+            }
+        },
+    }
+    activity_json = activity_dir / "activity.json"
+    activity_json.write_text(json.dumps(activity), encoding="utf-8")
+    return activity_json
+
+
+def test_prepare_then_student_stage_then_grade_passes(tmp_path: Path) -> None:
+    activity_json = build_activity(tmp_path)
+    repo = tmp_path / "student-repo"
+
+    fixture_report = git_lab_activity.prepare_repository(activity_json, repo)
+
+    evidence = fixture_report["repository"]
+    assert evidence["repository"]["branch"] == "main"
+    assert len(evidence["commits"]) == 1
+    assert evidence["working_tree"]["staged"] == []
+    assert evidence["working_tree"]["unstaged"] == ["note.txt", "programma.py"]
+    assert (repo / "grading").exists() is False
+    assert (repo / "expectations.json").exists() is False
+
+    run(repo, "add", "programma.py")
+    grade = git_lab_activity.grade_repository(activity_json, repo)
+
+    assert grade["passed"] is True
+
+
+def test_prepare_is_deterministic_at_semantic_level(tmp_path: Path) -> None:
+    activity_json = build_activity(tmp_path)
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+
+    one = git_lab_activity.prepare_repository(activity_json, first)["repository"]
+    two = git_lab_activity.prepare_repository(activity_json, second)["repository"]
+
+    assert one["repository"]["branch"] == two["repository"]["branch"] == "main"
+    assert one["working_tree"] == two["working_tree"]
+    assert one["commits"][0]["subject"] == two["commits"][0]["subject"] == "Fixture iniziale"
+    assert one["commits"][0]["changed_paths"] == two["commits"][0]["changed_paths"]
+
+
+def test_nonempty_destination_fails_closed(tmp_path: Path) -> None:
+    activity_json = build_activity(tmp_path)
+    repo = tmp_path / "student-repo"
+    repo.mkdir()
+    (repo / "existing.txt").write_text("do not overwrite\n", encoding="utf-8")
+
+    with pytest.raises(git_lab_activity.GitLabActivityError, match="vuota"):
+        git_lab_activity.prepare_repository(activity_json, repo)
+
+    assert (repo / "existing.txt").read_text(encoding="utf-8") == "do not overwrite\n"
+
+
+def test_fixture_cannot_smuggle_dot_git(tmp_path: Path) -> None:
+    activity_json = build_activity(tmp_path)
+    dot_git = activity_json.parent / "fixture" / "base" / ".git"
+    dot_git.mkdir()
+    (dot_git / "config").write_text("malicious\n", encoding="utf-8")
+
+    with pytest.raises(git_lab_activity.GitLabActivityError, match=".git"):
+        git_lab_activity.prepare_repository(activity_json, tmp_path / "repo")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation may require privileges")
+def test_fixture_symlink_is_rejected(tmp_path: Path) -> None:
+    activity_json = build_activity(tmp_path)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    link = activity_json.parent / "fixture" / "base" / "link.txt"
+    link.symlink_to(outside)
+
+    with pytest.raises(git_lab_activity.GitLabActivityError, match="symlink"):
+        git_lab_activity.prepare_repository(activity_json, tmp_path / "repo")
+
+
+def test_invalid_extension_or_expectation_path_fails(tmp_path: Path) -> None:
+    activity_json = build_activity(tmp_path)
+    activity = json.loads(activity_json.read_text(encoding="utf-8"))
+    activity["extensions"]["thebitlab.git-lab"]["schema_version"] = "wrong"
+    activity_json.write_text(json.dumps(activity), encoding="utf-8")
+
+    with pytest.raises(git_lab_activity.GitLabActivityError, match="schema"):
+        git_lab_activity.prepare_repository(activity_json, tmp_path / "repo")
+
+    activity_json = build_activity(tmp_path / "second")
+    activity = json.loads(activity_json.read_text(encoding="utf-8"))
+    activity["extensions"]["thebitlab.git-lab"]["expectations"]["path"] = "../teacher/answer.json"
+    activity_json.write_text(json.dumps(activity), encoding="utf-8")
+
+    with pytest.raises(git_lab_activity.GitLabActivityError, match="sicuro"):
+        git_lab_activity.load_expectations(activity_json)

--- a/tests/test_git_lab_assignment.py
+++ b/tests/test_git_lab_assignment.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import git_lab_activity, git_lab_assignment
+
+
+def build_git_activity(tmp_path: Path) -> Path:
+    activity_dir = tmp_path / "activity"
+    base = activity_dir / "fixture" / "base"
+    overlay = activity_dir / "fixture" / "working"
+    grading = activity_dir / "grading"
+    base.mkdir(parents=True)
+    overlay.mkdir(parents=True)
+    grading.mkdir(parents=True)
+    (base / "programma.py").write_text("print('base')\n", encoding="utf-8")
+    (overlay / "programma.py").write_text("print('changed')\n", encoding="utf-8")
+    (grading / "expectations.json").write_text(
+        json.dumps({
+            "schema_version": "thebitlab.git-lab.v1",
+            "expectations": {"clean": False, "branch": "main", "commit_count": 1},
+        }),
+        encoding="utf-8",
+    )
+    activity = {
+        "schema_version": "1.0",
+        "id": "git-canary",
+        "extensions": {
+            "thebitlab.git-lab": {
+                "schema_version": "git_activity.v1",
+                "fixture": {
+                    "base_dir": "fixture/base",
+                    "working_overlay_dir": "fixture/working",
+                    "initial_branch": "main",
+                    "initial_commit_message": "Fixture iniziale",
+                },
+                "expectations": {"path": "grading/expectations.json", "media_type": "application/json"},
+                "submission": {"kind": "git-repository"},
+            }
+        },
+    }
+    path = activity_dir / "activity.json"
+    path.write_text(json.dumps(activity), encoding="utf-8")
+    return path
+
+
+def test_prepare_assignment_creates_fixed_nested_git_repository(tmp_path: Path) -> None:
+    activity = build_git_activity(tmp_path)
+    assignment_dir = tmp_path / "student" / "assignments" / "git-canary"
+    assignment_dir.mkdir(parents=True)
+    (assignment_dir / "GUIDA.md").write_text("student guide\n", encoding="utf-8")
+
+    report = git_lab_assignment.prepare_assignment_repository(activity, assignment_dir)
+    repo = git_lab_assignment.repository_path(assignment_dir)
+
+    assert report is not None
+    assert repo.is_dir()
+    assert (repo / ".git").is_dir()
+    assert (repo / "programma.py").read_text(encoding="utf-8") == "print('changed')\n"
+    assert (assignment_dir / "GUIDA.md").read_text(encoding="utf-8") == "student guide\n"
+    assert not (repo / "grading").exists()
+    assert not (repo / "expectations.json").exists()
+
+
+def test_non_git_activity_is_noop(tmp_path: Path) -> None:
+    activity = tmp_path / "activity.json"
+    activity.write_text(json.dumps({"schema_version": "1.0", "id": "plain"}), encoding="utf-8")
+    assignment_dir = tmp_path / "assignment"
+    assignment_dir.mkdir()
+
+    result = git_lab_assignment.prepare_assignment_repository(activity, assignment_dir)
+
+    assert result is None
+    assert not git_lab_assignment.repository_path(assignment_dir).exists()
+
+
+def test_existing_student_repository_fails_closed_without_reset(tmp_path: Path) -> None:
+    activity = build_git_activity(tmp_path)
+    assignment_dir = tmp_path / "assignment"
+    assignment_dir.mkdir()
+    repo = git_lab_assignment.repository_path(assignment_dir)
+    repo.mkdir()
+    (repo / "student-work.txt").write_text("do not delete\n", encoding="utf-8")
+
+    with pytest.raises(git_lab_activity.GitLabActivityError, match="vuota"):
+        git_lab_assignment.prepare_assignment_repository(activity, assignment_dir)
+
+    assert (repo / "student-work.txt").read_text(encoding="utf-8") == "do not delete\n"
+
+
+def test_assignment_dir_symlink_is_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "real"
+    target.mkdir()
+    link = tmp_path / "assignment"
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation unavailable")
+    activity = build_git_activity(tmp_path / "source")
+
+    with pytest.raises(git_lab_activity.GitLabActivityError, match="directory reale"):
+        git_lab_assignment.prepare_assignment_repository(activity, link)

--- a/tests/test_git_lab_content_evidence.py
+++ b/tests/test_git_lab_content_evidence.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+
+from scripts import git_lab_validator as validator
+
+
+def run(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "TheBitLab Student",
+            "GIT_AUTHOR_EMAIL": "student@example.invalid",
+            "GIT_COMMITTER_NAME": "TheBitLab Student",
+            "GIT_COMMITTER_EMAIL": "student@example.invalid",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+        }
+    )
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        timeout=5,
+    )
+    return result.stdout.strip()
+
+
+def sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def fixture(tmp_path: Path) -> Path:
+    repo = tmp_path / "assignment"
+    repo.mkdir()
+    run(repo, "init")
+    run(repo, "symbolic-ref", "HEAD", "refs/heads/main")
+    (repo / "programma.py").write_text('print("versione iniziale")\n', encoding="utf-8")
+    (repo / "note.txt").write_text("appunti iniziali\n", encoding="utf-8")
+    run(repo, "add", "programma.py", "note.txt")
+    run(repo, "commit", "-m", "fixture iniziale")
+
+    (repo / "programma.py").write_text('print("versione laboratorio")\n', encoding="utf-8")
+    (repo / "note.txt").write_text("appunti aggiornati\n", encoding="utf-8")
+    return repo
+
+
+def stage_spec() -> dict:
+    return {
+        "schema_version": validator.SPEC_SCHEMA,
+        "expectations": {
+            "clean": False,
+            "branch": "main",
+            "commit_count": 1,
+            "staged_paths": ["programma.py"],
+            "unstaged_paths": ["note.txt"],
+            "untracked_paths": [],
+            "working_files": {
+                "programma.py": sha256('print("versione laboratorio")\n'),
+                "note.txt": sha256("appunti aggiornati\n"),
+            },
+            "index_files": {
+                "programma.py": sha256('print("versione laboratorio")\n'),
+                "note.txt": sha256("appunti iniziali\n"),
+            },
+        },
+    }
+
+
+def test_selective_stage_checks_both_state_and_content(tmp_path: Path) -> None:
+    repo = fixture(tmp_path)
+    run(repo, "add", "programma.py")
+
+    result = validator.evaluate_repository(repo, stage_spec())
+
+    assert result["passed"] is True
+    names = {check["name"] for check in result["checks"]}
+    assert "working_tree.file:programma.py" in names
+    assert "working_tree.file:note.txt" in names
+    assert "index.file:programma.py" in names
+    assert "index.file:note.txt" in names
+
+
+def test_wrong_staged_content_fails_even_with_correct_path_state(tmp_path: Path) -> None:
+    repo = fixture(tmp_path)
+    run(repo, "add", "programma.py")
+    # Modify programma.py again after staging. The status still contains the
+    # requested staged path, but the working-tree content is now wrong.
+    (repo / "programma.py").write_text('print("alterato dopo lo stage")\n', encoding="utf-8")
+
+    result = validator.evaluate_repository(repo, stage_spec())
+
+    assert result["passed"] is False
+    failure_names = {check["name"] for check in result["checks"] if not check["passed"]}
+    assert "working_tree.file:programma.py" in failure_names
+
+
+def test_staging_wrong_snapshot_fails_index_hash(tmp_path: Path) -> None:
+    repo = fixture(tmp_path)
+    # Stage a different snapshot, then restore the desired working-tree content.
+    (repo / "programma.py").write_text('print("snapshot sbagliato")\n', encoding="utf-8")
+    run(repo, "add", "programma.py")
+    (repo / "programma.py").write_text('print("versione laboratorio")\n', encoding="utf-8")
+
+    spec = stage_spec()
+    # State now has both staged and unstaged changes on programma.py; ignore
+    # the exact unstaged set here so the content-specific failure is visible.
+    spec["expectations"].pop("unstaged_paths")
+    result = validator.evaluate_repository(repo, spec)
+
+    assert result["passed"] is False
+    failure_names = {check["name"] for check in result["checks"] if not check["passed"]}
+    assert "index.file:programma.py" in failure_names
+
+
+def test_unrequested_index_file_can_be_checked_against_baseline(tmp_path: Path) -> None:
+    repo = fixture(tmp_path)
+    run(repo, "add", "programma.py")
+
+    result = validator.evaluate_repository(repo, stage_spec())
+    note_check = next(check for check in result["checks"] if check["name"] == "index.file:note.txt")
+
+    assert note_check["passed"] is True
+    assert note_check["actual"] == sha256("appunti iniziali\n")

--- a/tests/test_git_lab_lifecycle.py
+++ b/tests/test_git_lab_lifecycle.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import git_lab_lifecycle
+
+
+def sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def run_git(repo: Path, *args: str) -> None:
+    env = os.environ.copy()
+    env.update({"GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.devnull})
+    subprocess.run(["git", *args], cwd=repo, env=env, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def build_activity(root: Path) -> Path:
+    activity_dir = root / "activities" / "git-canary"
+    base = activity_dir / "fixture" / "base"
+    working = activity_dir / "fixture" / "working"
+    grading = activity_dir / "grading"
+    student = activity_dir / "student"
+    for path in (base, working, grading, student):
+        path.mkdir(parents=True, exist_ok=True)
+    (base / "programma.py").write_text('print("base")\n', encoding="utf-8")
+    (base / "note.txt").write_text("base notes\n", encoding="utf-8")
+    (working / "programma.py").write_text('print("changed")\n', encoding="utf-8")
+    (working / "note.txt").write_text("changed notes\n", encoding="utf-8")
+    (student / "GUIDA.md").write_text("Stage only programma.py\n", encoding="utf-8")
+    spec = {
+        "schema_version": "thebitlab.git-lab.v1",
+        "expectations": {
+            "clean": False,
+            "branch": "main",
+            "commit_count": 1,
+            "staged_paths": ["programma.py"],
+            "unstaged_paths": ["note.txt"],
+            "untracked_paths": [],
+            "working_files": {
+                "programma.py": sha256('print("changed")\n'),
+                "note.txt": sha256("changed notes\n"),
+            },
+            "index_files": {
+                "programma.py": sha256('print("changed")\n'),
+                "note.txt": sha256("base notes\n"),
+            },
+        },
+    }
+    (grading / "expectations.json").write_text(json.dumps(spec), encoding="utf-8")
+    activity = {
+        "schema_version": "1.0",
+        "id": "git-canary",
+        "title": "Selective stage",
+        "titolo": "Selective stage",
+        "kind": "laboratorio",
+        "tipo": "laboratorio",
+        "difficulty": "B",
+        "difficolta": "B",
+        "language": "git",
+        "linguaggio": "git",
+        "source_name": "repository",
+        "instructions": "Stage only programma.py",
+        "consegna": "Stage only programma.py",
+        "topics": ["git-status", "staging"],
+        "argomenti": ["git-status", "staging"],
+        "student_support_mode": "feedback-tecnico",
+        "grading_policy": {"compila": False, "test": True, "sandbox": True, "ai_feedback": False},
+        "correzione": {"compila": False, "test": True, "sandbox": True, "ai_feedback": False},
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": False,
+        },
+        "assets": [
+            {
+                "type": "fixture",
+                "path": "student/GUIDA.md",
+                "target_path": "GUIDA.md",
+                "visibility": "student",
+                "description": "Student guide",
+            }
+        ],
+        "extensions": {
+            "thebitlab.git-lab": {
+                "schema_version": "git_activity.v1",
+                "fixture": {
+                    "base_dir": "fixture/base",
+                    "working_overlay_dir": "fixture/working",
+                    "initial_branch": "main",
+                    "initial_commit_message": "Fixture iniziale",
+                },
+                "expectations": {"path": "grading/expectations.json", "media_type": "application/json"},
+                "submission": {"kind": "git-repository"},
+            }
+        },
+    }
+    path = activity_dir / "activity.json"
+    path.write_text(json.dumps(activity), encoding="utf-8")
+    return path
+
+
+def assignment_from_result(root: Path, result: dict, activity_path: Path) -> dict:
+    assignment_dir = Path(result["assignment_dir"])
+    return {
+        "assignment_id": "a1",
+        "activity_id": "git-canary",
+        "student_id": "s1",
+        "activity": {"path": activity_path.relative_to(root).as_posix()},
+        "workspace": {"path": assignment_dir.relative_to(root).as_posix()},
+    }
+
+
+def test_composed_assign_then_grade_passes_without_grading_leak(tmp_path: Path) -> None:
+    activity = build_activity(tmp_path)
+    student_repo_root = tmp_path / "students" / "s1"
+    student_repo_root.mkdir(parents=True)
+
+    result = git_lab_lifecycle.assign_git_lab(activity_path=activity, target=student_repo_root)
+    repository = Path(result["repository"])
+
+    assert (repository / ".git").is_dir()
+    assert (Path(result["assignment_dir"]) / "GUIDA.md").is_file()
+    assert not (repository / "grading").exists()
+    assert not (repository / "expectations.json").exists()
+
+    run_git(repository, "add", "programma.py")
+    report = git_lab_lifecycle.run_git_lab(
+        root=tmp_path,
+        assignment=assignment_from_result(tmp_path, result, activity),
+    )
+
+    assert report["backend"] == "git-lab"
+    assert report["passed"] is True
+    serialized = json.dumps(report)
+    assert "working_files" not in serialized
+    assert "index_files" not in serialized
+    assert sha256('print("changed")\n') not in serialized
+
+
+def test_second_assignment_does_not_destroy_existing_repository(tmp_path: Path) -> None:
+    activity = build_activity(tmp_path)
+    target = tmp_path / "students" / "s1"
+    target.mkdir(parents=True)
+    first = git_lab_lifecycle.assign_git_lab(activity_path=activity, target=target)
+    repository = Path(first["repository"])
+    (repository / "student-note.txt").write_text("keep me\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="già esistente"):
+        git_lab_lifecycle.assign_git_lab(activity_path=activity, target=target)
+
+    assert (repository / "student-note.txt").read_text(encoding="utf-8") == "keep me\n"

--- a/tests/test_git_lab_student.py
+++ b/tests/test_git_lab_student.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from scripts import git_lab_activity, git_lab_student
+
+
+def sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def run(repo: Path, *args: str) -> None:
+    env = os.environ.copy()
+    env.update({"GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.devnull})
+    subprocess.run(["git", *args], cwd=repo, env=env, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def build_activity(root: Path) -> Path:
+    activity_dir = root / "activities" / "git-canary"
+    base = activity_dir / "fixture" / "base"
+    working = activity_dir / "fixture" / "working"
+    grading = activity_dir / "grading"
+    base.mkdir(parents=True)
+    working.mkdir(parents=True)
+    grading.mkdir(parents=True)
+    (base / "programma.py").write_text('print("base")\n', encoding="utf-8")
+    (base / "note.txt").write_text("base\n", encoding="utf-8")
+    (working / "programma.py").write_text('print("changed")\n', encoding="utf-8")
+    (working / "note.txt").write_text("changed\n", encoding="utf-8")
+    spec = {
+        "schema_version": "thebitlab.git-lab.v1",
+        "expectations": {
+            "clean": False,
+            "branch": "main",
+            "commit_count": 1,
+            "staged_paths": ["programma.py"],
+            "unstaged_paths": ["note.txt"],
+            "untracked_paths": [],
+            "working_files": {
+                "programma.py": sha256('print("changed")\n'),
+                "note.txt": sha256("changed\n"),
+            },
+            "index_files": {
+                "programma.py": sha256('print("changed")\n'),
+                "note.txt": sha256("base\n"),
+            },
+        },
+    }
+    (grading / "expectations.json").write_text(json.dumps(spec), encoding="utf-8")
+    activity = {
+        "schema_version": "1.0",
+        "id": "git-canary",
+        "extensions": {
+            "thebitlab.git-lab": {
+                "schema_version": "git_activity.v1",
+                "fixture": {
+                    "base_dir": "fixture/base",
+                    "working_overlay_dir": "fixture/working",
+                    "initial_branch": "main",
+                    "initial_commit_message": "Fixture iniziale",
+                },
+                "expectations": {"path": "grading/expectations.json", "media_type": "application/json"},
+                "submission": {"kind": "git-repository"},
+            }
+        },
+    }
+    path = activity_dir / "activity.json"
+    path.write_text(json.dumps(activity), encoding="utf-8")
+    return path
+
+
+def assignment(root: Path, activity_path: Path) -> tuple[dict, Path]:
+    workspace = root / "students" / "s1" / "assignments" / "git-canary"
+    workspace.mkdir(parents=True)
+    relative_activity = activity_path.relative_to(root).as_posix()
+    relative_workspace = workspace.relative_to(root).as_posix()
+    item = {
+        "assignment_id": "a1",
+        "activity_id": "git-canary",
+        "student_id": "s1",
+        "activity": {"path": relative_activity},
+        "workspace": {"path": relative_workspace},
+    }
+    return item, workspace
+
+
+def test_student_adapter_grades_prepared_repository_without_leaking_hashes(tmp_path: Path) -> None:
+    activity_path = build_activity(tmp_path)
+    item, workspace = assignment(tmp_path, activity_path)
+    repo = workspace / git_lab_student.REPOSITORY_DIRNAME
+    git_lab_activity.prepare_repository(activity_path, repo)
+    run(repo, "add", "programma.py")
+
+    report = git_lab_student.run_git_lab_assignment(item, root=tmp_path)
+
+    assert report["backend"] == "git-lab"
+    assert report["passed"] is True
+    assert report["summary"]["passed"] == report["summary"]["total"]
+    serialized = json.dumps(report)
+    assert sha256('print("changed")\n') not in serialized
+    assert "expected" not in serialized
+    assert "index_files" not in serialized
+    assert any("diff --staged" in test["message"] or test["passed"] for test in report["tests"])
+
+
+def test_student_adapter_failure_is_actionable_not_teacher_revealing(tmp_path: Path) -> None:
+    activity_path = build_activity(tmp_path)
+    item, workspace = assignment(tmp_path, activity_path)
+    repo = workspace / git_lab_student.REPOSITORY_DIRNAME
+    git_lab_activity.prepare_repository(activity_path, repo)
+    run(repo, "add", "note.txt")
+
+    report = git_lab_student.run_git_lab_assignment(item, root=tmp_path)
+
+    assert report["passed"] is False
+    messages = " ".join(test["message"] for test in report["tests"] if not test["passed"])
+    assert "index" in messages.lower() or "staged" in messages.lower()
+    assert "sha" not in messages.lower()
+
+
+def test_activity_detection_is_strict() -> None:
+    assert git_lab_student.activity_uses_git_lab({}) is False
+    assert git_lab_student.activity_uses_git_lab({"extensions": {"thebitlab.git-lab": {"schema_version": "wrong"}}}) is False
+    assert git_lab_student.activity_uses_git_lab({"extensions": {"thebitlab.git-lab": {"schema_version": "git_activity.v1"}}}) is True

--- a/tests/test_git_lab_validator.py
+++ b/tests/test_git_lab_validator.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from scripts import git_lab_validator as validator
+
+
+def run(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "TheBitLab Student",
+            "GIT_AUTHOR_EMAIL": "student@example.invalid",
+            "GIT_COMMITTER_NAME": "TheBitLab Student",
+            "GIT_COMMITTER_EMAIL": "student@example.invalid",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+        }
+    )
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        timeout=5,
+    )
+    return result.stdout.strip()
+
+
+def write(repo: Path, path: str, content: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+
+def sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def init_fixture(tmp_path: Path) -> Path:
+    repo = tmp_path / "assignment"
+    repo.mkdir()
+    run(repo, "init")
+    run(repo, "branch", "-M", "main")
+    write(repo, "README.md", "# Git Lab\n")
+    write(repo, "programma.py", 'print("v1")\n')
+    write(repo, "note.txt", "iniziale\n")
+    run(repo, "add", "README.md", "programma.py", "note.txt")
+    run(repo, "commit", "-m", "fixture iniziale")
+    return repo
+
+
+def target_spec() -> dict:
+    return {
+        "schema_version": validator.SPEC_SCHEMA,
+        "expectations": {
+            "clean": True,
+            "branch": "main",
+            "commit_count": 3,
+            "staged_paths": [],
+            "unstaged_paths": [],
+            "untracked_paths": [],
+            "commits": [
+                {
+                    "position": 0,
+                    "subject_contains": "note",
+                    "changed_paths": ["note.txt"],
+                    "files": {"note.txt": sha256("seconda versione\n")},
+                },
+                {
+                    "position": 1,
+                    "subject_contains": "programma",
+                    "changed_paths": ["programma.py"],
+                    "files": {"programma.py": sha256('print("v2")\n')},
+                },
+            ],
+        },
+    }
+
+
+def create_correct_student_history(repo: Path) -> None:
+    # The student may edit both files before staging. What matters is that the
+    # two commits contain the requested independent changes.
+    write(repo, "programma.py", 'print("v2")\n')
+    write(repo, "note.txt", "seconda versione\n")
+
+    run(repo, "add", "programma.py")
+    run(repo, "commit", "-m", "Aggiorna programma")
+
+    run(repo, "add", "note.txt")
+    run(repo, "commit", "-m", "Aggiorna note")
+
+
+def test_correct_two_commit_history_passes(tmp_path: Path) -> None:
+    repo = init_fixture(tmp_path)
+    create_correct_student_history(repo)
+
+    result = validator.evaluate_repository(repo, target_spec())
+
+    assert result["passed"] is True
+    assert result["evidence"]["working_tree"]["clean"] is True
+    assert result["evidence"]["repository"]["branch"] == "main"
+    assert [commit["changed_paths"] for commit in result["evidence"]["commits"][:2]] == [
+        ["note.txt"],
+        ["programma.py"],
+    ]
+
+
+def test_one_big_commit_fails_even_if_final_files_are_correct(tmp_path: Path) -> None:
+    repo = init_fixture(tmp_path)
+    write(repo, "programma.py", 'print("v2")\n')
+    write(repo, "note.txt", "seconda versione\n")
+    run(repo, "add", "programma.py", "note.txt")
+    run(repo, "commit", "-m", "Aggiorna tutto")
+
+    result = validator.evaluate_repository(repo, target_spec())
+
+    assert result["passed"] is False
+    failures = {item["name"] for item in result["checks"] if not item["passed"]}
+    assert "history.commit_count" in failures
+    assert "commit[0].changed_paths" in failures
+
+
+def test_dirty_or_staged_repository_is_reported(tmp_path: Path) -> None:
+    repo = init_fixture(tmp_path)
+    write(repo, "programma.py", 'print("working")\n')
+    write(repo, "note.txt", "staged\n")
+    write(repo, "nuovo.txt", "untracked\n")
+    run(repo, "add", "note.txt")
+
+    report = validator.inspect_repository(repo)
+
+    assert report["working_tree"] == {
+        "staged": ["note.txt"],
+        "unstaged": ["programma.py"],
+        "untracked": ["nuovo.txt"],
+        "clean": False,
+    }
+
+
+def test_file_evidence_is_read_from_commit_not_current_worktree(tmp_path: Path) -> None:
+    repo = init_fixture(tmp_path)
+    create_correct_student_history(repo)
+    # Change the working copy after commits; commit evidence must stay stable.
+    write(repo, "note.txt", "working copy diversa\n")
+
+    spec = target_spec()
+    spec["expectations"]["clean"] = False
+    spec["expectations"]["unstaged_paths"] = ["note.txt"]
+    result = validator.evaluate_repository(repo, spec)
+
+    note_check = next(item for item in result["checks"] if item["name"] == "commit[0].file:note.txt")
+    assert note_check["passed"] is True
+
+
+def test_exact_repo_root_is_required(tmp_path: Path) -> None:
+    repo = init_fixture(tmp_path)
+    nested = repo / "nested"
+    nested.mkdir()
+
+    with pytest.raises(validator.GitLabValidationError, match="esattamente la root"):
+        validator.inspect_repository(nested)
+
+
+def test_symlink_repository_root_is_rejected(tmp_path: Path) -> None:
+    if os.name == "nt":
+        pytest.skip("symlink creation may require elevated privileges on Windows")
+    repo = init_fixture(tmp_path)
+    link = tmp_path / "repo-link"
+    link.symlink_to(repo, target_is_directory=True)
+
+    with pytest.raises(validator.GitLabValidationError, match="symlink"):
+        validator.inspect_repository(link)
+
+
+def test_invalid_specs_fail_closed(tmp_path: Path) -> None:
+    repo = init_fixture(tmp_path)
+
+    with pytest.raises(validator.GitLabValidationError, match="schema_version"):
+        validator.evaluate_repository(repo, {"schema_version": "wrong", "expectations": {"clean": True}})
+
+    with pytest.raises(validator.GitLabValidationError, match="path"):
+        validator.evaluate_repository(
+            repo,
+            {
+                "schema_version": validator.SPEC_SCHEMA,
+                "expectations": {"staged_paths": ["../teacher/solution.txt"]},
+            },
+        )
+
+
+def test_detached_head_is_visible_in_normalized_report(tmp_path: Path) -> None:
+    repo = init_fixture(tmp_path)
+    head = run(repo, "rev-parse", "HEAD")
+    run(repo, "checkout", "--detach", head)
+
+    report = validator.inspect_repository(repo)
+
+    assert report["repository"]["detached"] is True
+    assert report["repository"]["branch"] is None
+
+
+def test_empty_repository_is_supported_as_evidence(tmp_path: Path) -> None:
+    repo = tmp_path / "empty"
+    repo.mkdir()
+    run(repo, "init")
+    run(repo, "branch", "-M", "main")
+
+    report = validator.inspect_repository(repo)
+
+    assert report["repository"]["head"] is None
+    assert report["commits"] == []
+    assert report["working_tree"]["clean"] is True

--- a/tests/test_git_lab_validator_security.py
+++ b/tests/test_git_lab_validator_security.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+import pytest
+
+from scripts import git_lab_validator as validator
+
+
+def run(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "TheBitLab Student",
+            "GIT_AUTHOR_EMAIL": "student@example.invalid",
+            "GIT_COMMITTER_NAME": "TheBitLab Student",
+            "GIT_COMMITTER_EMAIL": "student@example.invalid",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+        }
+    )
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        timeout=5,
+    )
+    return result.stdout.strip()
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "assignment"
+    repo.mkdir()
+    run(repo, "init")
+    run(repo, "symbolic-ref", "HEAD", "refs/heads/main")
+    (repo / "file.txt").write_text("baseline\n", encoding="utf-8")
+    run(repo, "add", "file.txt")
+    run(repo, "commit", "-m", "fixture")
+    return repo
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable fixture")
+def test_student_controlled_fsmonitor_is_not_executed(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    marker = tmp_path / "fsmonitor-ran"
+    hook = tmp_path / "malicious-fsmonitor.sh"
+    hook.write_text(
+        "#!/bin/sh\n"
+        f"printf ran > '{marker}'\n"
+        "printf '0\\n'\n",
+        encoding="utf-8",
+    )
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+    run(repo, "config", "core.fsmonitor", str(hook))
+
+    report = validator.inspect_repository(repo)
+
+    assert report["working_tree"]["clean"] is True
+    assert marker.exists() is False
+
+
+def test_validator_process_environment_disables_interactive_git() -> None:
+    env = validator._git_environment()
+
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert env["GIT_OPTIONAL_LOCKS"] == "0"
+    assert env["GIT_CONFIG_KEY_0"] == "core.fsmonitor"
+    assert env["GIT_CONFIG_VALUE_0"] == "false"
+
+
+def test_repository_parent_is_not_accepted_as_assignment_repo(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+
+    with pytest.raises(validator.GitLabValidationError):
+        validator.inspect_repository(tmp_path)


### PR DESCRIPTION
Implements the first TheBitLab Git Lab vertical slice for `TheBitPoets/git` G1 and consuming courses.

**Keep this PR draft.** G2–G4 and final normal-lifecycle wiring/rehearsal remain out of scope for now.

## Existing green platform canary

Previously certified public candidate:

`24570f7a3af67634ec0cfbf54f486660359baaf2`

- Quality #1761 — PASS;
- Build assignment runner Docker image #924 — PASS;
- uTUI consumer evidence #823 — PASS.

The private Git course currently pins that SHA. Do not move the pin to newer commits until their public CI is green.

## Repository-state validator

`scripts/git_lab_validator.py`

Schemas:

```text
thebitlab.git-lab.v1
thebitlab.git-report.v1
```

Evidence includes exact assignment repository root, branch/HEAD, staged/unstaged/untracked state, bounded history/parents/subjects/changed paths and selected working/index/commit blob SHA-256 values.

It grades **resulting repository state/history**, not one required command sequence.

## Activity prepare/grade adapter

`scripts/git_lab_activity.py`

Activity extension:

```text
extensions.thebitlab.git-lab
schema = git_activity.v1
submission.kind = git-repository
```

Preparation creates a controlled fixture commit and applies a working-tree overlay. Teacher/grading expectations never enter the student repository.

## New Student Lab integration surfaces

### Student-safe report adapter

`scripts/git_lab_student.py`

- detects Git Lab Activities;
- grades the fixed assignment repository;
- emits the existing `student_lab_run.v1` envelope;
- uses `backend = git-lab` / `language = git`;
- redacts exact expected hashes/content and grading JSON;
- returns actionable feedback such as checking `status` / `diff --staged` instead of revealing the answer.

Tests verify that expected SHA-256 values and teacher-side expectation fields do not leak into the student report.

### Assignment repository boundary

`scripts/git_lab_assignment.py`

Canonical workspace layout:

```text
assignments/<activity-id>/
├── README.md / activity.json / student assets
└── repository/
    ├── .git/
    └── exercise files
```

The fixed `repository/` child keeps Activity metadata outside the exercise Git toplevel and avoids Activity-controlled repository paths.

Reassignment is fail-closed: an existing non-empty student repository is not silently erased by generic overwrite behavior. Any future reset/reprepare action must be explicit.

Tests cover repository creation, grading-asset isolation, non-Git no-op behavior, symlink rejection and preservation of existing student work.

### Architecture document

`doc/architecture/git-lab-g1.md` records assignment, grading, redaction and routing rules.

## Target normal routing

The final dispatcher should remain small:

```text
Activity
  ├─ external runtime? → runtime broker
  ├─ Git Lab?          → git_lab_student
  └─ code Activity?    → local/docker runner
```

The normal assignment path should create the standard scaffold first and then prepare `assignment/repository/` only for Git Lab Activities.

The helper/adapters are implemented and tested; the final calls from `assign_activity.py` and `student_lab_runner.py` remain the last wiring step so that existing non-Git behavior stays unchanged.

## Safety

- read-only Git commands in validator;
- no shell command supplied by Activity/student;
- no network Git required in G1;
- exact repo root only;
- symlink/path escape rejection;
- embedded `.git` fixture rejection;
- bounded files/history/output/time;
- global/system config neutralized;
- fsmonitor/hook hardening;
- grading expectations remain outside student repo/report.

## Course consumer

`TheBitPoets/git` G1 is already editorially complete M01–M08 and has the canary:

`activities/git/g1-stage-selettivo-001`

The course-side consumer smoke validates Content Pack + Activity + fixture prepare + correct selective-stage PASS + stage-all FAIL. Its private GitHub Actions remain independently blocked before runner startup.

## Still open

- final normal assignment/runner dispatch calls;
- public CI green on that integrated routing;
- update course pin only after green evidence;
- managed Classroom Environment rehearsal;
- G2 branch/merge/remotes evidence profiles;
- G3/G4 extensions.

Issue: #761. Course-side issue: TheBitPoets/git#4.