### PR TITLE
Draft P2 Python function-behavior grading profile + Student Lab integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@ docker/assignment-runner/*
 scripts/*
 !scripts/grade_activity.py
 !scripts/thebitlab_sandbox_boundary.py
+!scripts/python_function_profile.py
+!scripts/python_function_worker.py

--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -122,6 +122,7 @@ jobs:
       - name: Exercise P2 through normal Student Lab Docker dispatch
         env:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-assignment-runner"
         run: python -m pytest -q tests/test_python_function_student_lab_docker.py
 
   publish:

--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -9,11 +9,25 @@ on:
     branches:
       - main
     paths:
+      - ".dockerignore"
       - ".github/workflows/publish-assignment-runner.yml"
       - "docker/assignment-runner/**"
       - "scripts/build_assignment_runner.py"
       - "scripts/publish_assignment_runner.py"
       - "scripts/grade_activity.py"
+      - "scripts/python_function_profile.py"
+      - "scripts/python_function_worker.py"
+      - "scripts/grade_python_function_activity.py"
+      - "scripts/thebitlab_technical_services.py"
+      - "scripts/validate_activity.py"
+      - "scripts/create_submission_scaffold.py"
+      - "scripts/student_lab_runner.py"
+      - "tests/test_python_function_profile.py"
+      - "tests/test_python_function_worker.py"
+      - "tests/test_python_function_profile_dispatch.py"
+      - "tests/test_python_function_student_lab_docker.py"
+      - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_p2_release_candidate.py"
 
 concurrency:
   group: assignment-runner-toolchain
@@ -30,6 +44,19 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+
+      - name: Install validation dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Validate P2 contracts, dispatch and release identity
+        run: >-
+          python -m pytest -q
+          tests/test_build_assignment_runner.py
+          tests/test_p2_release_candidate.py
+          tests/test_python_function_profile.py
+          tests/test_python_function_worker.py
+          tests/test_python_function_profile_dispatch.py
+          tests/test_validate_activity_function_profile.py
 
       - name: Build pinned runner
         run: >-
@@ -66,13 +93,15 @@ jobs:
           path: ${{ runner.temp }}/runner-toolchain
           if-no-files-found: error
 
-      - name: Install smoke test dependencies
-        run: python -m pip install -r requirements-dev.txt
-
-      - name: Exercise isolated runner
+      - name: Exercise legacy Docker runner regressions
         env:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
         run: python -m pytest -q tests/test_student_lab_runner_docker.py
+
+      - name: Exercise P2 through normal Student Lab Docker dispatch
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+        run: python -m pytest -q tests/test_python_function_student_lab_docker.py
 
   publish:
     needs: validate

--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -5,6 +5,27 @@ permissions:
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/publish-assignment-runner.yml"
+      - "docker/assignment-runner/**"
+      - "scripts/build_assignment_runner.py"
+      - "scripts/publish_assignment_runner.py"
+      - "scripts/grade_activity.py"
+      - "scripts/python_function_profile.py"
+      - "scripts/python_function_worker.py"
+      - "scripts/grade_python_function_activity.py"
+      - "scripts/thebitlab_technical_services.py"
+      - "scripts/validate_activity.py"
+      - "scripts/create_submission_scaffold.py"
+      - "scripts/student_lab_runner.py"
+      - "tests/test_python_function_profile.py"
+      - "tests/test_python_function_worker.py"
+      - "tests/test_python_function_profile_dispatch.py"
+      - "tests/test_python_function_student_lab_docker.py"
+      - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_p2_release_candidate.py"
   push:
     branches:
       - main

--- a/.github/workflows/python-function-profile.yml
+++ b/.github/workflows/python-function-profile.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - ".dockerignore"
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"

--- a/.github/workflows/python-function-profile.yml
+++ b/.github/workflows/python-function-profile.yml
@@ -1,0 +1,182 @@
+name: Python function profile P2 candidate
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/python_function_profile.py"
+      - "scripts/python_function_worker.py"
+      - "scripts/grade_python_function_activity.py"
+      - "scripts/validate_activity.py"
+      - "docker/assignment-runner/**"
+      - "tests/test_python_function_profile.py"
+      - "tests/test_python_function_worker.py"
+      - "tests/test_validate_activity_function_profile.py"
+      - ".github/workflows/python-function-profile.yml"
+
+jobs:
+  p2-candidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run P2 contract and worker tests
+        run: >-
+          python -m pytest -q
+          tests/test_python_function_profile.py
+          tests/test_python_function_worker.py
+          tests/test_validate_activity_function_profile.py
+
+      - name: Build assignment-runner candidate
+        run: >-
+          python scripts/build_assignment_runner.py
+          --source-revision "$GITHUB_SHA"
+          --tag thebitlab-p2-candidate
+          --metadata "$RUNNER_TEMP/p2-toolchain-build.json"
+
+      - name: Exercise P2 authoritative Docker behavior
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p2"
+          cat > "$RUNNER_TEMP/p2/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p2-smoke-001",
+            "titolo": "Funzioni P2 smoke",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["funzioni", "return"],
+            "consegna": "Implementa le funzioni richieste.",
+            "linguaggio": "python",
+            "correzione": {
+              "compila": true,
+              "test": true,
+              "sandbox": true,
+              "ai_feedback": false
+            },
+            "metriche": {
+              "tempo_stimato_minuti": 15,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "function_tests": [
+              {
+                "profile": "python-function-v1",
+                "name": "area 3x4",
+                "function": "area",
+                "args": [3, 4],
+                "expected_return": 12
+              },
+              {
+                "profile": "python-function-v1",
+                "name": "pari",
+                "function": "pari",
+                "args": [8],
+                "expected_return": true
+              },
+              {
+                "profile": "python-function-v1",
+                "name": "zero division",
+                "function": "reciproco",
+                "args": [0],
+                "expected_exception": "ZeroDivisionError"
+              }
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p2/main.py" <<'PY'
+          def area(base, altezza):
+              return base * altezza
+
+          def pari(n):
+              return n % 2 == 0
+
+          def reciproco(x):
+              return 1 / x
+          PY
+          python scripts/grade_python_function_activity.py \
+            --activity "$RUNNER_TEMP/p2/activity.json" \
+            --source "$RUNNER_TEMP/p2/main.py" \
+            --activity-root "$RUNNER_TEMP/p2" \
+            --source-root "$RUNNER_TEMP/p2" \
+            --docker-image thebitlab-p2-candidate \
+            --report "$RUNNER_TEMP/p2/report.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "p2" / "report.json").read_text(encoding="utf-8"))
+          assert report["passed"] is True
+          assert report["profile"] == "python-function-v1"
+          assert report["summary"] == {"passed": 3, "total": 3}
+          assert all("expected_return" not in json.dumps(test) for test in report["tests"])
+          PY
+
+      - name: Exercise P2 timeout fail-closed
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p2-timeout"
+          cat > "$RUNNER_TEMP/p2-timeout/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p2-timeout-001",
+            "titolo": "Timeout P2",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["funzioni"],
+            "consegna": "Implementa f.",
+            "linguaggio": "python",
+            "correzione": {"compila": true, "test": true, "sandbox": true, "ai_feedback": false},
+            "metriche": {
+              "tempo_stimato_minuti": 5,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "function_tests": [
+              {"profile": "python-function-v1", "function": "f", "expected_return": 1}
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p2-timeout/main.py" <<'PY'
+          def f():
+              while True:
+                  pass
+          PY
+          set +e
+          python scripts/grade_python_function_activity.py \
+            --activity "$RUNNER_TEMP/p2-timeout/activity.json" \
+            --source "$RUNNER_TEMP/p2-timeout/main.py" \
+            --activity-root "$RUNNER_TEMP/p2-timeout" \
+            --source-root "$RUNNER_TEMP/p2-timeout" \
+            --docker-image thebitlab-p2-candidate \
+            --timeout 1 \
+            --report "$RUNNER_TEMP/p2-timeout/report.json"
+          status=$?
+          set -e
+          test "$status" = "1"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "p2-timeout" / "report.json").read_text(encoding="utf-8"))
+          assert report["passed"] is False
+          assert report["tests"][0]["worker_status"] == "timeout"
+          PY

--- a/.github/workflows/python-function-profile.yml
+++ b/.github/workflows/python-function-profile.yml
@@ -17,6 +17,7 @@ on:
       - "tests/test_python_function_profile.py"
       - "tests/test_python_function_worker.py"
       - "tests/test_python_function_profile_dispatch.py"
+      - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
       - ".github/workflows/python-function-profile.yml"
 
@@ -184,3 +185,8 @@ jobs:
           assert report["passed"] is False
           assert report["tests"][0]["worker_status"] == "timeout"
           PY
+
+      - name: Exercise P2 through normal Student Lab Docker dispatch
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+        run: python -m pytest -q tests/test_python_function_student_lab_docker.py

--- a/.github/workflows/python-function-profile.yml
+++ b/.github/workflows/python-function-profile.yml
@@ -11,10 +11,12 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/thebitlab_technical_services.py"
       - "scripts/validate_activity.py"
       - "docker/assignment-runner/**"
       - "tests/test_python_function_profile.py"
       - "tests/test_python_function_worker.py"
+      - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_validate_activity_function_profile.py"
       - ".github/workflows/python-function-profile.yml"
 
@@ -35,11 +37,12 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Run P2 contract and worker tests
+      - name: Run P2 contract, worker and dispatch tests
         run: >-
           python -m pytest -q
           tests/test_python_function_profile.py
           tests/test_python_function_worker.py
+          tests/test_python_function_profile_dispatch.py
           tests/test_validate_activity_function_profile.py
 
       - name: Build assignment-runner candidate

--- a/doc/architecture/python-function-grading-v1.md
+++ b/doc/architecture/python-function-grading-v1.md
@@ -1,0 +1,166 @@
+# Python function-behavior grading v1 — DRAFT
+
+Issue: #756
+
+## Goal
+
+Assess beginner Python functions directly without wrapping every exercise in stdin/stdout.
+
+Profile identity:
+
+```text
+python-function-v1
+```
+
+Worker protocol:
+
+```text
+thebitlab.python-function-worker.v1
+```
+
+This remains part of the core Python grader and reuses the assignment-runner Docker sandbox. It is not a runtime plugin.
+
+## Trust boundary
+
+Teacher-side test:
+
+```json
+{
+  "profile": "python-function-v1",
+  "function": "area",
+  "args": [3, 4],
+  "kwargs": {},
+  "expected_return": 12
+}
+```
+
+Worker request:
+
+```json
+{
+  "schema_version": "thebitlab.python-function-worker.v1",
+  "function": "area",
+  "args": [3, 4],
+  "kwargs": {}
+}
+```
+
+`expected_return`, `expected_exception`, rubrics and grading decisions never enter the untrusted worker request. The worker reports only observed behavior; the trusted host compares it with the teacher expectation.
+
+## V1 value codec
+
+Supported deterministic values:
+
+- `None`;
+- `bool`;
+- bounded `int`;
+- finite bounded `float`;
+- bounded `str`;
+- bounded JSON-like `list`;
+- bounded string-keyed `dict`.
+
+Not supported in v1:
+
+- tuples/sets;
+- arbitrary/custom objects;
+- bytes;
+- NaN/Infinity;
+- recursive or deeply nested structures.
+
+The initial profile rejects unsupported values rather than serializing arbitrary Python objects.
+
+## Return comparison
+
+Default return comparison is value + exact Python type. This prevents `True` from silently satisfying an expected integer `1` or vice versa.
+
+Float tolerance is opt-in and explicit:
+
+```json
+{
+  "float_tolerance": 0.001
+}
+```
+
+It uses absolute tolerance only in v1. No hidden approximate comparison occurs when tolerance is omitted.
+
+## Expected exceptions
+
+A teacher test may declare exactly one expected exception type:
+
+```json
+{
+  "expected_exception": "ZeroDivisionError"
+}
+```
+
+The worker returns a bounded descriptor with exception type and sanitized message. V1 grading compares the exception type; message text is diagnostic, not a grading oracle.
+
+## Worker result states
+
+```text
+returned
+raised
+missing-function
+not-callable
+import-error
+timeout
+```
+
+Missing/non-callable/import/timeout are normal failed student behaviors, not platform crashes.
+
+## Limits
+
+Current contract limits include:
+
+- max 64 function tests per Activity;
+- max 16 positional args;
+- max 16 keyword args;
+- function/parameter names must be simple Python identifiers;
+- max 4096 characters per string/stdout/stderr;
+- max 64 items per supported container;
+- max value nesting depth 4;
+- bounded finite numeric range.
+
+Docker process/output limits remain governed by the existing assignment-runner boundary and must be reused rather than reimplemented.
+
+## Student-facing progression
+
+P2 is a delivery/evidence profile, not a curriculum requirement to teach test frameworks.
+
+```text
+paper test cases
+→ P1 stdin/stdout
+→ assert
+→ P2 direct function behavior
+→ structured test suites later
+```
+
+## Implementation state
+
+Implemented on the candidate branch:
+
+```text
+scripts/python_function_profile.py
+tests/test_python_function_profile.py
+```
+
+Current module covers:
+
+- strict teacher test validation;
+- bounded value codec;
+- expectation redaction from worker requests;
+- worker request/result validation;
+- trusted-host comparison;
+- explicit float tolerance;
+- expected exception type comparison.
+
+Still required before #756 can close:
+
+1. Activity schema integration;
+2. Docker worker function loader/invoker;
+3. import timeout/side-effect containment through existing sandbox;
+4. bounded stdout/stderr capture in the real worker;
+5. grader report integration + student redaction;
+6. Docker integration tests;
+7. one real `python-docente` PY2-05 Activity consumer;
+8. consumer evidence before declaring the profile stable.

--- a/docker/assignment-runner/Dockerfile
+++ b/docker/assignment-runner/Dockerfile
@@ -37,6 +37,8 @@ RUN useradd --create-home --shell /usr/sbin/nologin runner
 
 COPY scripts/grade_activity.py /opt/thebitlab/grade_activity.py
 COPY scripts/thebitlab_sandbox_boundary.py /opt/thebitlab/thebitlab_sandbox_boundary.py
+COPY scripts/python_function_profile.py /opt/thebitlab/python_function_profile.py
+COPY scripts/python_function_worker.py /opt/thebitlab/python_function_worker.py
 
 WORKDIR /submission
 

--- a/docker/assignment-runner/toolchain.json
+++ b/docker/assignment-runner/toolchain.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "thebitlab.grading-toolchain-build.v1",
-  "version": "2026.07.1",
+  "version": "2026.08.1",
   "platform": "linux/amd64",
   "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
   "worker_schema_version": "thebitlab.grading-worker.v1",

--- a/scripts/grade_python_function_activity.py
+++ b/scripts/grade_python_function_activity.py
@@ -4,20 +4,20 @@ import argparse
 import json
 from pathlib import Path
 import subprocess
+import sys
 import tempfile
 import uuid
 from typing import Any
 
-try:
-    from scripts import grade_activity
-    from scripts import python_function_profile as p2
-    from scripts import validate_activity
-    from scripts.thebitlab_sandbox_boundary import docker_boundary_command
-except ModuleNotFoundError:  # direct ``python scripts/...`` execution
-    import grade_activity
-    import python_function_profile as p2
-    import validate_activity
-    from thebitlab_sandbox_boundary import docker_boundary_command
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import grade_activity
+from scripts import python_function_profile as p2
+from scripts import validate_activity
+from scripts.thebitlab_sandbox_boundary import docker_boundary_command
 
 
 DEFAULT_TIMEOUT_SECONDS = 5

--- a/scripts/grade_python_function_activity.py
+++ b/scripts/grade_python_function_activity.py
@@ -8,10 +8,16 @@ import tempfile
 import uuid
 from typing import Any
 
-from scripts import grade_activity
-from scripts import python_function_profile as p2
-from scripts import validate_activity
-from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+try:
+    from scripts import grade_activity
+    from scripts import python_function_profile as p2
+    from scripts import validate_activity
+    from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+except ModuleNotFoundError:  # direct ``python scripts/...`` execution
+    import grade_activity
+    import python_function_profile as p2
+    import validate_activity
+    from thebitlab_sandbox_boundary import docker_boundary_command
 
 
 DEFAULT_TIMEOUT_SECONDS = 5
@@ -97,10 +103,7 @@ def run_function_test_in_docker(
             raise ValueError("P2 worker non ha prodotto JSON valido") from error
         return p2.validate_worker_result(result)
     finally:
-        try:
-            grade_activity.remove_docker_container(cidfile, container_name)
-        except grade_activity.DockerCleanupError:
-            raise
+        grade_activity.remove_docker_container(cidfile, container_name)
 
 
 def grade_in_docker(
@@ -169,7 +172,10 @@ def grade_in_docker(
 
 
 def positive_int(value: str) -> int:
-    number = int(value)
+    try:
+        number = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("deve essere un intero") from error
     if number <= 0:
         raise argparse.ArgumentTypeError("deve essere positivo")
     return number

--- a/scripts/grade_python_function_activity.py
+++ b/scripts/grade_python_function_activity.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import uuid
+from typing import Any
+
+from scripts import grade_activity
+from scripts import python_function_profile as p2
+from scripts import validate_activity
+from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+
+
+DEFAULT_TIMEOUT_SECONDS = 5
+DEFAULT_DOCKER_IMAGE = grade_activity.DEFAULT_DOCKER_IMAGE
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: JSON root deve essere un oggetto")
+    return value
+
+
+def p2_docker_command(
+    *,
+    image: str,
+    workspace: Path,
+    source: Path,
+    timeout_seconds: int,
+    cidfile: Path,
+    container_name: str,
+) -> list[str]:
+    command = docker_boundary_command(
+        image=image,
+        workspace=workspace,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    image_ref = command.pop()
+    command.extend(["--entrypoint", "python3", image_ref])
+    command.extend(
+        [
+            "/opt/thebitlab/python_function_worker.py",
+            "--source",
+            grade_activity.path_inside_workspace(source, workspace, "source"),
+        ]
+    )
+    return command
+
+
+def run_function_test_in_docker(
+    *,
+    image: str,
+    workspace: Path,
+    source: Path,
+    teacher_test: dict[str, Any],
+    timeout_seconds: int,
+    temp_root: Path,
+    test_index: int,
+) -> dict[str, Any]:
+    cidfile = temp_root / f"p2-container-{test_index}.cid"
+    container_name = f"thebitlab-p2-{uuid.uuid4().hex}"
+    command = p2_docker_command(
+        image=image,
+        workspace=workspace,
+        source=source,
+        timeout_seconds=timeout_seconds,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    request = p2.worker_request(teacher_test)
+    try:
+        try:
+            completed = grade_activity.run_bounded_process(
+                command,
+                input_text=json.dumps(request, ensure_ascii=False, allow_nan=False),
+                timeout=timeout_seconds + grade_activity.DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "schema_version": p2.WORKER_SCHEMA,
+                "status": "timeout",
+                "stdout": "",
+                "stderr": "",
+            }
+        if completed.returncode != 0:
+            raise ValueError(
+                f"P2 worker terminato con errore infrastrutturale: exit={completed.returncode}"
+            )
+        try:
+            result = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise ValueError("P2 worker non ha prodotto JSON valido") from error
+        return p2.validate_worker_result(result)
+    finally:
+        try:
+            grade_activity.remove_docker_container(cidfile, container_name)
+        except grade_activity.DockerCleanupError:
+            raise
+
+
+def grade_in_docker(
+    *,
+    activity_path: Path,
+    source_path: Path,
+    image: str,
+    timeout_seconds: int,
+    activity_root: Path | None = None,
+    source_root: Path | None = None,
+) -> dict[str, Any]:
+    safe_activity = grade_activity.confined_regular_input(
+        activity_path,
+        activity_root or activity_path.parent,
+        "activity",
+    )
+    safe_source = grade_activity.confined_regular_input(
+        source_path,
+        source_root or source_path.parent,
+        "source",
+    )
+    activity = load_object(safe_activity)
+    errors = validate_activity.validate_activity(activity, str(safe_activity))
+    if errors:
+        raise ValueError("Activity non valida: " + "; ".join(errors))
+    if (activity.get("language") or activity.get("linguaggio")) not in {"python", "py", None}:
+        raise ValueError("P2 supporta solo Activity Python")
+    teacher_tests = p2.validate_function_tests(activity.get("function_tests"))
+
+    with tempfile.TemporaryDirectory(prefix="thebitlab-p2-") as raw_temp:
+        temp_root = Path(raw_temp)
+        workspace, source = grade_activity.prepare_docker_workspace(
+            safe_activity,
+            safe_source,
+            temp_root,
+            activity_root=activity_root or safe_activity.parent,
+            source_root=source_root or safe_source.parent,
+        )
+        tests: list[dict[str, Any]] = []
+        for index, teacher_test in enumerate(teacher_tests):
+            worker_result = run_function_test_in_docker(
+                image=image,
+                workspace=workspace,
+                source=source,
+                teacher_test=teacher_test,
+                timeout_seconds=timeout_seconds,
+                temp_root=temp_root,
+                test_index=index,
+            )
+            tests.append(p2.compare_worker_result(teacher_test, worker_result))
+
+    passed = all(test["passed"] for test in tests)
+    return {
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "activity_id": activity.get("id"),
+        "language": "python",
+        "profile": p2.PROFILE_ID,
+        "source": str(source_path),
+        "tests": tests,
+        "summary": {
+            "passed": sum(1 for test in tests if test["passed"]),
+            "total": len(tests),
+        },
+    }
+
+
+def positive_int(value: str) -> int:
+    number = int(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("deve essere positivo")
+    return number
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Grade Python function-behavior Activity in Docker")
+    parser.add_argument("--activity", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--activity-root", type=Path)
+    parser.add_argument("--source-root", type=Path)
+    parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE)
+    parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--report", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = grade_in_docker(
+            activity_path=args.activity,
+            source_path=args.source,
+            image=args.docker_image,
+            timeout_seconds=args.timeout,
+            activity_root=args.activity_root,
+            source_root=args.source_root,
+        )
+    except (OSError, ValueError, grade_activity.DockerCleanupError) as error:
+        print(f"P2 Docker grading non avviato: {error}")
+        return 2
+    if args.report:
+        grade_activity.write_report(report, args.report)
+    else:
+        print(json.dumps(report, ensure_ascii=False, indent=2, allow_nan=False))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python_function_profile.py
+++ b/scripts/python_function_profile.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+
+PROFILE_ID = "python-function-v1"
+WORKER_SCHEMA = "thebitlab.python-function-worker.v1"
+FUNCTION_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+MAX_TESTS = 64
+MAX_ARGS = 16
+MAX_KWARGS = 16
+MAX_STRING_CHARS = 4096
+MAX_CONTAINER_ITEMS = 64
+
+
+class FunctionProfileError(ValueError):
+    """Invalid teacher-side or worker-side function grading payload."""
+
+
+def _bounded_scalar(value: Any) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if abs(value) > 10**18:
+            raise FunctionProfileError("intero fuori dal limite supportato")
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value) or abs(value) > 1e18:
+            raise FunctionProfileError("float non finito o fuori limite")
+        return value
+    if isinstance(value, str):
+        if len(value) > MAX_STRING_CHARS:
+            raise FunctionProfileError("stringa troppo lunga")
+        return value
+    raise FunctionProfileError(f"tipo valore non supportato: {type(value).__name__}")
+
+
+def validate_value(value: Any, *, depth: int = 0) -> Any:
+    """Validate and normalize the small deterministic value codec used by P2."""
+    if depth > 4:
+        raise FunctionProfileError("valore troppo annidato")
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return _bounded_scalar(value)
+    if isinstance(value, list):
+        if len(value) > MAX_CONTAINER_ITEMS:
+            raise FunctionProfileError("lista troppo grande")
+        return [validate_value(item, depth=depth + 1) for item in value]
+    if isinstance(value, dict):
+        if len(value) > MAX_CONTAINER_ITEMS:
+            raise FunctionProfileError("dict troppo grande")
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key or len(key) > 128:
+                raise FunctionProfileError("chiave dict non supportata")
+            if key in normalized:
+                raise FunctionProfileError("chiave dict duplicata")
+            normalized[key] = validate_value(item, depth=depth + 1)
+        return normalized
+    raise FunctionProfileError(f"tipo valore non supportato: {type(value).__name__}")
+
+
+def _function_name(value: Any) -> str:
+    if not isinstance(value, str) or not FUNCTION_RE.fullmatch(value):
+        raise FunctionProfileError("function deve essere un identificatore Python semplice")
+    return value
+
+
+def validate_function_test(test: Any, *, source: str = "test") -> dict[str, Any]:
+    if not isinstance(test, dict):
+        raise FunctionProfileError(f"{source} deve essere un oggetto")
+    allowed = {
+        "profile",
+        "name",
+        "function",
+        "args",
+        "kwargs",
+        "expected_return",
+        "expected_exception",
+        "float_tolerance",
+        "visibility",
+    }
+    unknown = sorted(set(test) - allowed)
+    if unknown:
+        raise FunctionProfileError(f"{source} contiene campi non supportati: {', '.join(unknown)}")
+    if test.get("profile") != PROFILE_ID:
+        raise FunctionProfileError(f"{source}.profile deve essere {PROFILE_ID}")
+
+    function = _function_name(test.get("function"))
+    args = test.get("args", [])
+    kwargs = test.get("kwargs", {})
+    if not isinstance(args, list) or len(args) > MAX_ARGS:
+        raise FunctionProfileError(f"{source}.args deve essere una lista con massimo {MAX_ARGS} elementi")
+    if not isinstance(kwargs, dict) or len(kwargs) > MAX_KWARGS:
+        raise FunctionProfileError(f"{source}.kwargs deve essere un oggetto con massimo {MAX_KWARGS} elementi")
+    normalized_args = [validate_value(value) for value in args]
+    normalized_kwargs: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if not isinstance(key, str) or not FUNCTION_RE.fullmatch(key):
+            raise FunctionProfileError(f"{source}.kwargs contiene nome parametro non valido")
+        normalized_kwargs[key] = validate_value(value)
+
+    has_return = "expected_return" in test
+    has_exception = "expected_exception" in test
+    if has_return == has_exception:
+        raise FunctionProfileError(
+            f"{source} deve dichiarare esattamente uno tra expected_return ed expected_exception"
+        )
+
+    normalized: dict[str, Any] = {
+        "profile": PROFILE_ID,
+        "function": function,
+        "args": normalized_args,
+        "kwargs": normalized_kwargs,
+    }
+    if isinstance(test.get("name"), str) and test["name"]:
+        normalized["name"] = test["name"][:128]
+    if isinstance(test.get("visibility"), str):
+        normalized["visibility"] = test["visibility"]
+
+    if has_return:
+        normalized["expected_return"] = validate_value(test["expected_return"])
+        tolerance = test.get("float_tolerance")
+        if tolerance is not None:
+            if isinstance(tolerance, bool) or not isinstance(tolerance, (int, float)):
+                raise FunctionProfileError(f"{source}.float_tolerance deve essere numerico")
+            tolerance = float(tolerance)
+            if not math.isfinite(tolerance) or tolerance < 0 or tolerance > 1e6:
+                raise FunctionProfileError(f"{source}.float_tolerance fuori limite")
+            normalized["float_tolerance"] = tolerance
+    else:
+        exception_name = test["expected_exception"]
+        if not isinstance(exception_name, str) or not FUNCTION_RE.fullmatch(exception_name):
+            raise FunctionProfileError(f"{source}.expected_exception non valido")
+        normalized["expected_exception"] = exception_name
+        if "float_tolerance" in test:
+            raise FunctionProfileError(f"{source}.float_tolerance non ammesso con expected_exception")
+    return normalized
+
+
+def validate_function_tests(value: Any, *, source: str = "function_tests") -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise FunctionProfileError(f"{source} deve essere una lista non vuota")
+    if len(value) > MAX_TESTS:
+        raise FunctionProfileError(f"{source} supera il limite di {MAX_TESTS} test")
+    return [validate_function_test(test, source=f"{source}[{index}]") for index, test in enumerate(value)]
+
+
+def worker_request(test: dict[str, Any]) -> dict[str, Any]:
+    """Build the untrusted-worker request. Teacher expectations never cross this boundary."""
+    normalized = validate_function_test(test)
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "function": normalized["function"],
+        "args": normalized["args"],
+        "kwargs": normalized["kwargs"],
+    }
+
+
+def validate_worker_request(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FunctionProfileError("worker request deve essere un oggetto")
+    if set(value) != {"schema_version", "function", "args", "kwargs"}:
+        raise FunctionProfileError("worker request contiene campi mancanti o inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise FunctionProfileError("worker schema non supportato")
+    function = _function_name(value.get("function"))
+    args = value.get("args")
+    kwargs = value.get("kwargs")
+    if not isinstance(args, list) or len(args) > MAX_ARGS:
+        raise FunctionProfileError("worker args non validi")
+    if not isinstance(kwargs, dict) or len(kwargs) > MAX_KWARGS:
+        raise FunctionProfileError("worker kwargs non validi")
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "function": function,
+        "args": [validate_value(item) for item in args],
+        "kwargs": {key: validate_value(item) for key, item in kwargs.items()},
+    }
+
+
+def validate_worker_result(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FunctionProfileError("worker result deve essere un oggetto")
+    allowed = {"schema_version", "status", "return_value", "exception", "stdout", "stderr"}
+    if set(value) - allowed:
+        raise FunctionProfileError("worker result contiene campi inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise FunctionProfileError("worker result schema non supportato")
+    status = value.get("status")
+    if status not in {"returned", "raised", "missing-function", "not-callable", "import-error", "timeout"}:
+        raise FunctionProfileError("worker result status non supportato")
+    stdout = value.get("stdout", "")
+    stderr = value.get("stderr", "")
+    if not isinstance(stdout, str) or not isinstance(stderr, str):
+        raise FunctionProfileError("worker stdout/stderr devono essere stringhe")
+    if len(stdout) > MAX_STRING_CHARS or len(stderr) > MAX_STRING_CHARS:
+        raise FunctionProfileError("worker stdout/stderr troppo grandi")
+    normalized: dict[str, Any] = {
+        "schema_version": WORKER_SCHEMA,
+        "status": status,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    if status == "returned":
+        if "return_value" not in value:
+            raise FunctionProfileError("worker returned senza return_value")
+        normalized["return_value"] = validate_value(value["return_value"])
+    elif status == "raised":
+        exception = value.get("exception")
+        if not isinstance(exception, dict) or set(exception) - {"type", "message"}:
+            raise FunctionProfileError("worker exception non valida")
+        exception_type = exception.get("type")
+        message = exception.get("message", "")
+        if not isinstance(exception_type, str) or not FUNCTION_RE.fullmatch(exception_type):
+            raise FunctionProfileError("worker exception type non valido")
+        if not isinstance(message, str) or len(message) > 512:
+            raise FunctionProfileError("worker exception message non valido")
+        normalized["exception"] = {"type": exception_type, "message": message}
+    return normalized
+
+
+def compare_worker_result(test: dict[str, Any], worker_result: dict[str, Any]) -> dict[str, Any]:
+    """Perform the authoritative teacher-side comparison."""
+    expected = validate_function_test(test)
+    actual = validate_worker_result(worker_result)
+    passed = False
+    if "expected_exception" in expected:
+        passed = (
+            actual["status"] == "raised"
+            and actual.get("exception", {}).get("type") == expected["expected_exception"]
+        )
+    elif actual["status"] == "returned":
+        expected_value = expected["expected_return"]
+        actual_value = actual.get("return_value")
+        tolerance = expected.get("float_tolerance")
+        if tolerance is not None and isinstance(expected_value, (int, float)) and not isinstance(expected_value, bool):
+            passed = isinstance(actual_value, (int, float)) and not isinstance(actual_value, bool) and math.isclose(
+                float(actual_value), float(expected_value), rel_tol=0.0, abs_tol=tolerance
+            )
+        else:
+            passed = type(actual_value) is type(expected_value) and actual_value == expected_value
+    return {
+        "name": expected.get("name", expected["function"]),
+        "profile": PROFILE_ID,
+        "function": expected["function"],
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "worker_status": actual["status"],
+        "stdout": actual["stdout"],
+        "stderr": actual["stderr"],
+        "actual_return": actual.get("return_value"),
+        "actual_exception": actual.get("exception"),
+    }

--- a/scripts/python_function_profile.py
+++ b/scripts/python_function_profile.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from contextlib import redirect_stderr, redirect_stdout
+import importlib.util
 import math
+from pathlib import Path
 import re
+import sys
 from typing import Any
 
 
@@ -17,6 +21,36 @@ MAX_CONTAINER_ITEMS = 64
 
 class FunctionProfileError(ValueError):
     """Invalid teacher-side or worker-side function grading payload."""
+
+
+class FunctionOutputLimitError(RuntimeError):
+    """Student stdout/stderr exceeded the bounded diagnostic surface."""
+
+
+class _BoundedTextCapture:
+    def __init__(self, limit: int = MAX_STRING_CHARS) -> None:
+        self.limit = limit
+        self._parts: list[str] = []
+        self._size = 0
+
+    def write(self, value: str) -> int:
+        text = str(value)
+        next_size = self._size + len(text)
+        if next_size > self.limit:
+            remaining = max(0, self.limit - self._size)
+            if remaining:
+                self._parts.append(text[:remaining])
+                self._size += remaining
+            raise FunctionOutputLimitError("stdout/stderr supera il limite P2")
+        self._parts.append(text)
+        self._size = next_size
+        return len(text)
+
+    def flush(self) -> None:
+        return
+
+    def getvalue(self) -> str:
+        return "".join(self._parts)
 
 
 def _bounded_scalar(value: Any) -> Any:
@@ -172,12 +206,114 @@ def validate_worker_request(value: Any) -> dict[str, Any]:
         raise FunctionProfileError("worker args non validi")
     if not isinstance(kwargs, dict) or len(kwargs) > MAX_KWARGS:
         raise FunctionProfileError("worker kwargs non validi")
+    normalized_kwargs: dict[str, Any] = {}
+    for key, item in kwargs.items():
+        if not isinstance(key, str) or not FUNCTION_RE.fullmatch(key):
+            raise FunctionProfileError("worker kwargs contiene nome parametro non valido")
+        normalized_kwargs[key] = validate_value(item)
     return {
         "schema_version": WORKER_SCHEMA,
         "function": function,
         "args": [validate_value(item) for item in args],
-        "kwargs": {key: validate_value(item) for key, item in kwargs.items()},
+        "kwargs": normalized_kwargs,
     }
+
+
+def _exception_message(error: BaseException) -> str:
+    message = str(error)
+    return message[:512]
+
+
+def execute_worker_request(value: Any, source: Path) -> dict[str, Any]:
+    """Load one student module and invoke one declared function inside the untrusted worker."""
+    request = validate_worker_request(value)
+    stdout = _BoundedTextCapture()
+    stderr = _BoundedTextCapture()
+    module_name = "_thebitlab_student_function_submission"
+    sys.modules.pop(module_name, None)
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            try:
+                spec = importlib.util.spec_from_file_location(module_name, source)
+                if spec is None or spec.loader is None:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "import-error",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = module
+                try:
+                    spec.loader.exec_module(module)
+                except FunctionOutputLimitError:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "output-limit",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                except BaseException as error:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "import-error",
+                        "stdout": stdout.getvalue(),
+                        "stderr": (stderr.getvalue() + f"{type(error).__name__}: {_exception_message(error)}")[:MAX_STRING_CHARS],
+                    }
+
+                if not hasattr(module, request["function"]):
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "missing-function",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                function = getattr(module, request["function"])
+                if not callable(function):
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "not-callable",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                try:
+                    returned = function(*request["args"], **request["kwargs"])
+                except FunctionOutputLimitError:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "output-limit",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                except BaseException as error:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "raised",
+                        "exception": {
+                            "type": type(error).__name__,
+                            "message": _exception_message(error),
+                        },
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                try:
+                    normalized_return = validate_value(returned)
+                except FunctionProfileError:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "unsupported-return",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                return {
+                    "schema_version": WORKER_SCHEMA,
+                    "status": "returned",
+                    "return_value": normalized_return,
+                    "stdout": stdout.getvalue(),
+                    "stderr": stderr.getvalue(),
+                }
+    finally:
+        sys.modules.pop(module_name, None)
 
 
 def validate_worker_result(value: Any) -> dict[str, Any]:
@@ -189,7 +325,16 @@ def validate_worker_result(value: Any) -> dict[str, Any]:
     if value.get("schema_version") != WORKER_SCHEMA:
         raise FunctionProfileError("worker result schema non supportato")
     status = value.get("status")
-    if status not in {"returned", "raised", "missing-function", "not-callable", "import-error", "timeout"}:
+    if status not in {
+        "returned",
+        "raised",
+        "missing-function",
+        "not-callable",
+        "import-error",
+        "timeout",
+        "output-limit",
+        "unsupported-return",
+    }:
         raise FunctionProfileError("worker result status non supportato")
     stdout = value.get("stdout", "")
     stderr = value.get("stderr", "")
@@ -245,6 +390,7 @@ def compare_worker_result(test: dict[str, Any], worker_result: dict[str, Any]) -
         "name": expected.get("name", expected["function"]),
         "profile": PROFILE_ID,
         "function": expected["function"],
+        "visibility": expected.get("visibility", "teacher"),
         "passed": passed,
         "status": "passed" if passed else "failed",
         "worker_status": actual["status"],

--- a/scripts/python_function_profile.py
+++ b/scripts/python_function_profile.py
@@ -88,8 +88,6 @@ def validate_value(value: Any, *, depth: int = 0) -> Any:
         for key, item in value.items():
             if not isinstance(key, str) or not key or len(key) > 128:
                 raise FunctionProfileError("chiave dict non supportata")
-            if key in normalized:
-                raise FunctionProfileError("chiave dict duplicata")
             normalized[key] = validate_value(item, depth=depth + 1)
         return normalized
     raise FunctionProfileError(f"tipo valore non supportato: {type(value).__name__}")
@@ -220,8 +218,17 @@ def validate_worker_request(value: Any) -> dict[str, Any]:
 
 
 def _exception_message(error: BaseException) -> str:
-    message = str(error)
-    return message[:512]
+    return str(error)[:512]
+
+
+def _worker_result(status: str, stdout: _BoundedTextCapture, stderr: _BoundedTextCapture, **extra: Any) -> dict[str, Any]:
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "status": status,
+        "stdout": stdout.getvalue(),
+        "stderr": stderr.getvalue(),
+        **extra,
+    }
 
 
 def execute_worker_request(value: Any, source: Path) -> dict[str, Any]:
@@ -233,85 +240,52 @@ def execute_worker_request(value: Any, source: Path) -> dict[str, Any]:
     sys.modules.pop(module_name, None)
     try:
         with redirect_stdout(stdout), redirect_stderr(stderr):
+            spec = importlib.util.spec_from_file_location(module_name, source)
+            if spec is None or spec.loader is None:
+                return _worker_result("import-error", stdout, stderr)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
             try:
-                spec = importlib.util.spec_from_file_location(module_name, source)
-                if spec is None or spec.loader is None:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "import-error",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                module = importlib.util.module_from_spec(spec)
-                sys.modules[module_name] = module
-                try:
-                    spec.loader.exec_module(module)
-                except FunctionOutputLimitError:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "output-limit",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                except BaseException as error:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "import-error",
-                        "stdout": stdout.getvalue(),
-                        "stderr": (stderr.getvalue() + f"{type(error).__name__}: {_exception_message(error)}")[:MAX_STRING_CHARS],
-                    }
+                spec.loader.exec_module(module)
+            except FunctionOutputLimitError:
+                return _worker_result("output-limit", stdout, stderr)
+            except BaseException as error:
+                stderr.write(
+                    f"{type(error).__name__}: {_exception_message(error)}"[
+                        : max(0, MAX_STRING_CHARS - len(stderr.getvalue()))
+                    ]
+                )
+                return _worker_result("import-error", stdout, stderr)
 
-                if not hasattr(module, request["function"]):
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "missing-function",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                function = getattr(module, request["function"])
-                if not callable(function):
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "not-callable",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                try:
-                    returned = function(*request["args"], **request["kwargs"])
-                except FunctionOutputLimitError:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "output-limit",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                except BaseException as error:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "raised",
-                        "exception": {
-                            "type": type(error).__name__,
-                            "message": _exception_message(error),
-                        },
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                try:
-                    normalized_return = validate_value(returned)
-                except FunctionProfileError:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "unsupported-return",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                return {
-                    "schema_version": WORKER_SCHEMA,
-                    "status": "returned",
-                    "return_value": normalized_return,
-                    "stdout": stdout.getvalue(),
-                    "stderr": stderr.getvalue(),
-                }
+            if not hasattr(module, request["function"]):
+                return _worker_result("missing-function", stdout, stderr)
+            function = getattr(module, request["function"])
+            if not callable(function):
+                return _worker_result("not-callable", stdout, stderr)
+            try:
+                returned = function(*request["args"], **request["kwargs"])
+            except FunctionOutputLimitError:
+                return _worker_result("output-limit", stdout, stderr)
+            except BaseException as error:
+                return _worker_result(
+                    "raised",
+                    stdout,
+                    stderr,
+                    exception={
+                        "type": type(error).__name__,
+                        "message": _exception_message(error),
+                    },
+                )
+            try:
+                normalized_return = validate_value(returned)
+            except FunctionProfileError:
+                return _worker_result("unsupported-return", stdout, stderr)
+            return _worker_result(
+                "returned",
+                stdout,
+                stderr,
+                return_value=normalized_return,
+            )
     finally:
         sys.modules.pop(module_name, None)
 

--- a/scripts/python_function_worker.py
+++ b/scripts/python_function_worker.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+try:
+    from scripts import python_function_profile as p2
+except ModuleNotFoundError:  # assignment-runner image copies modules into /opt/thebitlab
+    import python_function_profile as p2
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="TheBitLab Python function worker")
+    parser.add_argument("--source", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = json.load(sys.stdin)
+        result = p2.execute_worker_request(request, args.source)
+        result = p2.validate_worker_result(result)
+    except (OSError, json.JSONDecodeError, p2.FunctionProfileError) as error:
+        print(
+            json.dumps(
+                {
+                    "schema_version": p2.WORKER_SCHEMA,
+                    "status": "worker-error",
+                    "stdout": "",
+                    "stderr": str(error)[: p2.MAX_STRING_CHARS],
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 2
+    print(json.dumps(result, ensure_ascii=False, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import copy
 import json
@@ -237,7 +237,7 @@ class DockerGradeActivityExecutionService:
     """ExecutionService adapter backed by the authoritative Docker runner."""
 
     def run(self, request: ExecutionRequest) -> ExecutionResult:
-        """Run grade_activity in Docker and normalize infrastructure failures."""
+        """Run the appropriate authoritative Docker grader and normalize failures."""
 
         from scripts import grade_activity
 
@@ -250,14 +250,43 @@ class DockerGradeActivityExecutionService:
                 detail="ExecutionRequest.metadata deve includere activity_path e source_path.",
             )
 
+        activity_file = Path(str(activity_path))
+        source_file = Path(str(source_path))
         try:
-            report, worker_stderr = grade_activity.grade_activity_in_docker(
-                Path(str(activity_path)),
-                Path(str(source_path)),
-                timeout_seconds=request.timeout_seconds,
-                language=request.language,
-                image=docker_image,
+            activity = grade_activity.load_activity(activity_file)
+        except (OSError, json.JSONDecodeError):
+            # Preserve the historical adapter contract: the legacy Docker grader
+            # remains authoritative for its own loading/setup errors.
+            activity = None
+        uses_function_profile = isinstance(activity, dict) and "function_tests" in activity
+        requested_language = str(request.language or "").strip().lower()
+        if uses_function_profile and requested_language != "python":
+            return ExecutionResult(
+                status="invalid_payload",
+                detail="function_tests richiede una ExecutionRequest Python.",
             )
+
+        try:
+            if uses_function_profile:
+                from scripts import grade_python_function_activity
+
+                report = grade_python_function_activity.grade_in_docker(
+                    activity_path=activity_file,
+                    source_path=source_file,
+                    image=docker_image,
+                    timeout_seconds=request.timeout_seconds,
+                )
+                worker_stderr = ""
+                grading_profile = str(report.get("profile") or "python-function-v1")
+            else:
+                report, worker_stderr = grade_activity.grade_activity_in_docker(
+                    activity_file,
+                    source_file,
+                    timeout_seconds=request.timeout_seconds,
+                    language=request.language,
+                    image=docker_image,
+                )
+                grading_profile = "legacy"
         except subprocess.TimeoutExpired as error:
             return ExecutionResult(
                 status="timeout",
@@ -285,6 +314,7 @@ class DockerGradeActivityExecutionService:
             metadata={
                 "backend": "docker",
                 "docker_image": docker_image,
+                "grading_profile": grading_profile,
                 "runner_report": copy.deepcopy(report),
                 "worker_stderr": str(worker_stderr or ""),
             },

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from scripts import python_function_profile
 from scripts.thebitlab_contracts import ALLOWED_ACTIVITY_KINDS
 from scripts.thebitlab_runtime_contracts import validate_runtime_extension
 
@@ -72,6 +73,18 @@ def load_json(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
     return data, []
 
 
+def validate_function_tests(value: Any, source: str) -> list[str]:
+    """Validate optional teacher-only Python function-behavior tests."""
+    try:
+        python_function_profile.validate_function_tests(
+            value,
+            source=f"{source}: function_tests",
+        )
+    except python_function_profile.FunctionProfileError as error:
+        return [str(error)]
+    return []
+
+
 def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[str]:
     """Validate the minimal TheBitLab activity schema."""
     errors: list[str] = []
@@ -116,6 +129,9 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
     assets = data.get("assets")
     if assets is not None:
         errors.extend(validate_assets(assets, source))
+
+    if "function_tests" in data:
+        errors.extend(validate_function_tests(data.get("function_tests"), source))
 
     errors.extend(validate_runtime_extension(data, source))
     return errors

--- a/tests/test_build_assignment_runner.py
+++ b/tests/test_build_assignment_runner.py
@@ -19,7 +19,7 @@ def manifest() -> dict:
 def test_checked_in_toolchain_manifest_is_strict_and_immutable() -> None:
     payload = manifest()
 
-    assert payload["version"] == "2026.07.1"
+    assert payload["version"] == "2026.08.1"
     assert payload["platform"] == "linux/amd64"
     assert payload["image_repository"] == builder.IMAGE_REPOSITORY
     assert payload["base_image"].startswith("debian:bookworm-slim@sha256:")

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -64,22 +64,27 @@ def test_publish_workflow_only_publishes_reviewed_main_toolchains() -> None:
         ".github/workflows/publish-assignment-runner.yml"
     ).read_text(encoding="utf-8")
 
-    assert "packages: write" in source
-    assert "pull_request:" not in source
+    validate_block, publish_block = source.split("  publish:\n", maxsplit=1)
+    assert "pull_request:" in source
     assert "branches:\n      - main" in source
-    assert "if: github.ref == 'refs/heads/main'" in source
+    assert "if: github.ref == 'refs/heads/main'" in publish_block
+    assert "packages: write" not in validate_block
+    assert "packages: write" in publish_block
+    assert "docker login ghcr.io" not in validate_block
+    assert "docker login ghcr.io" in publish_block
     assert "scripts/build_assignment_runner.py" in source
     assert "scripts/publish_assignment_runner.py" in source
-    assert "THEBITLAB_RUN_DOCKER_TESTS" in source
-    assert "tests/test_student_lab_runner_docker.py" in source
-    assert "docker login ghcr.io" in source
-    assert "image_id: ${{ steps.image-digest.outputs.image_id }}" in source
-    assert "VALIDATED_IMAGE_ID: ${{ needs.validate.outputs.image_id }}" in source
-    assert "actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16" in source
+    assert "THEBITLAB_RUN_DOCKER_TESTS" in validate_block
+    assert "tests/test_student_lab_runner_docker.py" in validate_block
+    assert "tests/test_python_function_student_lab_docker.py" in validate_block
+    assert "tests/test_p2_release_candidate.py" in validate_block
+    assert "image_id: ${{ steps.image-digest.outputs.image_id }}" in validate_block
+    assert "VALIDATED_IMAGE_ID: ${{ needs.validate.outputs.image_id }}" in publish_block
+    assert "actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16" in publish_block
     assert "runner-toolchain" in source
-    assert "docker save" in source
-    assert "docker load" in source
-    assert "gunzip" in source
+    assert "docker save" in validate_block
+    assert "docker load" in publish_block
+    assert "gunzip" in publish_block
     assert ":latest" not in source
     assert source.count("tests/test_student_lab_runner_docker.py") == 1
     assert '".github/workflows/publish-assignment-runner.yml"' in source

--- a/tests/test_p2_release_candidate.py
+++ b/tests/test_p2_release_candidate.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "docker" / "assignment-runner" / "toolchain.json"
+LOCK = ROOT / "docker" / "assignment-runner" / "toolchain.lock.json"
+
+
+def load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_p2_build_candidate_has_new_version_without_faking_published_lock() -> None:
+    manifest = load(MANIFEST)
+    lock = load(LOCK)
+
+    assert manifest["version"] == "2026.08.1"
+    assert manifest["platform"] == "linux/amd64"
+    assert manifest["image_repository"] == lock["image_repository"]
+
+    # Until the release is actually published and its remote digest is known,
+    # the checked-in immutable lock must remain the previously published release.
+    assert lock["version"] == "2026.07.1"
+    assert lock["source_revision"] == "bd102146a684a9b06835204ec1b7f668f7655a03"
+    assert lock["immutable_reference"].endswith(
+        "@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+    )
+
+
+def test_candidate_and_stable_lock_are_deliberately_different_release_identities() -> None:
+    manifest = load(MANIFEST)
+    lock = load(LOCK)
+
+    assert manifest["version"] != lock["version"]

--- a/tests/test_python_function_profile.py
+++ b/tests/test_python_function_profile.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts import python_function_profile as p2
+
+
+def test_scalar_return_and_worker_redaction() -> None:
+    test = {
+        "profile": "python-function-v1",
+        "name": "area 3x4",
+        "function": "area",
+        "args": [3, 4],
+        "kwargs": {},
+        "expected_return": 12,
+    }
+    request = p2.worker_request(test)
+    assert request == {
+        "schema_version": p2.WORKER_SCHEMA,
+        "function": "area",
+        "args": [3, 4],
+        "kwargs": {},
+    }
+    assert "expected_return" not in request
+    assert "expected_exception" not in request
+
+    result = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "returned",
+            "return_value": 12,
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is True
+
+
+def test_exact_type_is_part_of_default_return_contract() -> None:
+    test = {
+        "profile": p2.PROFILE_ID,
+        "function": "is_even",
+        "args": [2],
+        "expected_return": True,
+    }
+    result = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "returned",
+            "return_value": 1,
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is False
+
+
+@pytest.mark.parametrize("value", [None, True, False, 0, -4, 2.5, "ciao", [1, "x"], {"a": 1}])
+def test_supported_value_codec(value) -> None:
+    assert p2.validate_value(value) == value
+
+
+@pytest.mark.parametrize("value", [{1, 2}, (1, 2), object(), float("nan"), float("inf")])
+def test_unsupported_or_non_deterministic_values_are_rejected(value) -> None:
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_value(value)
+
+
+def test_float_tolerance_is_explicit_and_absolute() -> None:
+    test = {
+        "profile": p2.PROFILE_ID,
+        "function": "media",
+        "args": [1.0, 2.0],
+        "expected_return": 1.5,
+        "float_tolerance": 0.01,
+    }
+    passed = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "returned",
+            "return_value": 1.505,
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    failed = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "returned",
+            "return_value": 1.52,
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert passed["passed"] is True
+    assert failed["passed"] is False
+
+
+def test_exception_expectation_compares_only_type() -> None:
+    test = {
+        "profile": p2.PROFILE_ID,
+        "function": "reciproco",
+        "args": [0],
+        "expected_exception": "ZeroDivisionError",
+    }
+    result = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "raised",
+            "exception": {"type": "ZeroDivisionError", "message": "division by zero"},
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is True
+
+
+def test_unknown_teacher_fields_fail_closed() -> None:
+    with pytest.raises(p2.FunctionProfileError, match="campi non supportati"):
+        p2.validate_function_test(
+            {
+                "profile": p2.PROFILE_ID,
+                "function": "area",
+                "args": [],
+                "expected_return": 1,
+                "magic": "no",
+            }
+        )
+
+
+def test_exactly_one_expectation_is_required() -> None:
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_function_test({"profile": p2.PROFILE_ID, "function": "f"})
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_function_test(
+            {
+                "profile": p2.PROFILE_ID,
+                "function": "f",
+                "expected_return": 1,
+                "expected_exception": "ValueError",
+            }
+        )
+
+
+def test_worker_request_rejects_expectation_leakage() -> None:
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_worker_request(
+            {
+                "schema_version": p2.WORKER_SCHEMA,
+                "function": "f",
+                "args": [],
+                "kwargs": {},
+                "expected_return": 42,
+            }
+        )
+
+
+def test_worker_result_is_bounded_and_fail_closed() -> None:
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_worker_result(
+            {
+                "schema_version": p2.WORKER_SCHEMA,
+                "status": "returned",
+                "return_value": 1,
+                "stdout": "x" * (p2.MAX_STRING_CHARS + 1),
+                "stderr": "",
+            }
+        )
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_worker_result(
+            {
+                "schema_version": p2.WORKER_SCHEMA,
+                "status": "returned",
+                "return_value": 1,
+                "stdout": "",
+                "stderr": "",
+                "teacher_expected": 1,
+            }
+        )
+
+
+def test_missing_and_non_callable_are_normal_failed_behaviors() -> None:
+    test = {
+        "profile": p2.PROFILE_ID,
+        "function": "area",
+        "args": [2, 3],
+        "expected_return": 6,
+    }
+    for status in ("missing-function", "not-callable", "import-error", "timeout"):
+        result = p2.compare_worker_result(
+            test,
+            {
+                "schema_version": p2.WORKER_SCHEMA,
+                "status": status,
+                "stdout": "",
+                "stderr": "",
+            },
+        )
+        assert result["passed"] is False
+        assert result["worker_status"] == status

--- a/tests/test_python_function_profile_dispatch.py
+++ b/tests/test_python_function_profile_dispatch.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.thebitlab_technical_services import (
+    DockerGradeActivityExecutionService,
+    ExecutionRequest,
+    RunnerTestResult,
+)
+
+
+def _request(activity_path: Path, source_path: Path, *, language: str = "python") -> ExecutionRequest:
+    return ExecutionRequest(
+        activity_id="python-p2-dispatch",
+        student_id="rossi-mario",
+        files={source_path.name: str(source_path)},
+        language=language,
+        timeout_seconds=7,
+        metadata={
+            "activity_path": activity_path,
+            "source_path": source_path,
+            "docker_image": "p2-candidate:test",
+        },
+    )
+
+
+def test_docker_service_dispatches_function_tests_to_p2_only(monkeypatch, tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "id": "python-p2-dispatch",
+                "language": "python",
+                "function_tests": [
+                    {
+                        "profile": "python-function-v1",
+                        "function": "doppio",
+                        "args": [3],
+                        "expected_return": 6,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    source_path.write_text("def doppio(x):\n    return x * 2\n", encoding="utf-8")
+
+    from scripts import grade_activity, grade_python_function_activity
+
+    def legacy_must_not_run(*args, **kwargs):
+        raise AssertionError("legacy Docker grader must not run for P2")
+
+    def fake_p2(*, activity_path, source_path, image, timeout_seconds, activity_root=None, source_root=None):
+        assert activity_path == tmp_path / "activity.json"
+        assert source_path == tmp_path / "main.py"
+        assert image == "p2-candidate:test"
+        assert timeout_seconds == 7
+        assert activity_root is None
+        assert source_root is None
+        return {
+            "passed": True,
+            "status": "passed",
+            "activity_id": "python-p2-dispatch",
+            "language": "python",
+            "profile": "python-function-v1",
+            "source": str(source_path),
+            "tests": [
+                {
+                    "name": "doppio",
+                    "passed": True,
+                    "status": "passed",
+                    "worker_status": "returned",
+                }
+            ],
+            "summary": {"passed": 1, "total": 1},
+        }
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", legacy_must_not_run)
+    monkeypatch.setattr(grade_python_function_activity, "grade_in_docker", fake_p2)
+
+    result = DockerGradeActivityExecutionService().run(_request(activity_path, source_path))
+
+    assert result.status == "passed"
+    assert result.tests == [RunnerTestResult("doppio", True)]
+    assert result.metadata["backend"] == "docker"
+    assert result.metadata["docker_image"] == "p2-candidate:test"
+    assert result.metadata["grading_profile"] == "python-function-v1"
+    assert result.metadata["runner_report"]["profile"] == "python-function-v1"
+
+
+def test_docker_service_keeps_legacy_path_without_function_tests(monkeypatch, tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "id": "python-p1-dispatch",
+                "language": "python",
+                "test_cases": [{"stdin": "2\n", "expected_stdout": "4\n"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    source_path.write_text("print(int(input()) * 2)\n", encoding="utf-8")
+
+    from scripts import grade_activity, grade_python_function_activity
+
+    def p2_must_not_run(*args, **kwargs):
+        raise AssertionError("P2 grader must not run for legacy Activity")
+
+    def fake_legacy(activity, source, *, timeout_seconds, language, image):
+        assert activity == activity_path
+        assert source == source_path
+        assert timeout_seconds == 7
+        assert language == "python"
+        assert image == "p2-candidate:test"
+        return (
+            {
+                "passed": True,
+                "status": "passed",
+                "activity_id": "python-p1-dispatch",
+                "language": "python",
+                "source": str(source_path),
+                "tests": [{"name": "base", "passed": True, "status": "passed"}],
+                "summary": {"passed": 1, "total": 1},
+            },
+            "",
+        )
+
+    monkeypatch.setattr(grade_python_function_activity, "grade_in_docker", p2_must_not_run)
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", fake_legacy)
+
+    result = DockerGradeActivityExecutionService().run(_request(activity_path, source_path))
+
+    assert result.status == "passed"
+    assert result.tests == [RunnerTestResult("base", True)]
+    assert result.metadata["grading_profile"] == "legacy"
+
+
+def test_docker_service_rejects_function_profile_for_non_python_request(monkeypatch, tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.c"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "id": "invalid-p2-language",
+                "language": "c",
+                "function_tests": [
+                    {
+                        "profile": "python-function-v1",
+                        "function": "f",
+                        "expected_return": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    source_path.write_text("int main(void){return 0;}\n", encoding="utf-8")
+
+    from scripts import grade_activity, grade_python_function_activity
+
+    monkeypatch.setattr(
+        grade_activity,
+        "grade_activity_in_docker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("legacy must not run")),
+    )
+    monkeypatch.setattr(
+        grade_python_function_activity,
+        "grade_in_docker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("P2 must not run")),
+    )
+
+    result = DockerGradeActivityExecutionService().run(
+        _request(activity_path, source_path, language="c")
+    )
+
+    assert result.status == "invalid_payload"
+    assert "function_tests" in result.detail
+    assert "Python" in result.detail

--- a/tests/test_python_function_report_redaction.py
+++ b/tests/test_python_function_report_redaction.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+
+from scripts import student_lab_runner
+
+
+def test_teacher_p2_results_are_redacted_for_student_report() -> None:
+    teacher_report = {
+        "passed": False,
+        "status": "failed",
+        "profile": "python-function-v1",
+        "summary": {"passed": 1, "total": 2},
+        "tests": [
+            {
+                "name": "area hidden oracle",
+                "profile": "python-function-v1",
+                "function": "area",
+                "visibility": "teacher",
+                "passed": True,
+                "status": "passed",
+                "worker_status": "returned",
+                "stdout": "debug segreto",
+                "stderr": "",
+                "actual_return": 12,
+                "actual_exception": None,
+            },
+            {
+                "name": "exception hidden oracle",
+                "profile": "python-function-v1",
+                "function": "reciproco",
+                "visibility": "teacher",
+                "passed": False,
+                "status": "failed",
+                "worker_status": "raised",
+                "stdout": "",
+                "stderr": "",
+                "actual_return": None,
+                "actual_exception": {
+                    "type": "ValueError",
+                    "message": "teacher-only diagnostic",
+                },
+            },
+        ],
+    }
+
+    student = student_lab_runner.redact_student_grading_report(teacher_report)
+
+    assert student["tests"] == [
+        {"name": "Test 1", "passed": True, "status": "passed"},
+        {"name": "Test 2", "passed": False, "status": "failed"},
+    ]
+    serialized = json.dumps(student, ensure_ascii=False)
+    for forbidden in (
+        "area hidden oracle",
+        "exception hidden oracle",
+        "actual_return",
+        "actual_exception",
+        "teacher-only diagnostic",
+        "debug segreto",
+        "reciproco",
+    ):
+        assert forbidden not in serialized
+
+
+def test_explicit_public_p2_result_can_preserve_public_observation() -> None:
+    report = {
+        "tests": [
+            {
+                "name": "esempio pubblico",
+                "visibility": "public",
+                "passed": True,
+                "status": "passed",
+                "worker_status": "returned",
+                "actual_return": 6,
+            }
+        ]
+    }
+    student = student_lab_runner.redact_student_grading_report(report)
+    assert student["tests"][0]["name"] == "esempio pubblico"
+    assert student["tests"][0]["actual_return"] == 6

--- a/tests/test_python_function_student_lab_docker.py
+++ b/tests/test_python_function_student_lab_docker.py
@@ -110,11 +110,12 @@ def test_p2_runs_through_normal_student_lab_and_redacts_teacher_oracles(tmp_path
         encoding="utf-8",
     )
 
+    docker_image = os.environ.get("THEBITLAB_P2_DOCKER_IMAGE", "thebitlab-p2-candidate")
     report = student_lab_runner.run_docker_assignment(
         _assignment(),
         root=tmp_path,
         timeout_seconds=3,
-        docker_image="thebitlab-p2-candidate",
+        docker_image=docker_image,
     )
 
     assert report["backend"] == "docker"

--- a/tests/test_python_function_student_lab_docker.py
+++ b/tests/test_python_function_student_lab_docker.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts import student_lab_runner
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1",
+    reason="set THEBITLAB_RUN_DOCKER_TESTS=1 to exercise the Docker sandbox",
+)
+
+
+def _activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p2-student-lab-001",
+        "title": "Return nel percorso Student Lab",
+        "titolo": "Return nel percorso Student Lab",
+        "kind": "laboratorio",
+        "tipo": "laboratorio",
+        "language": "python",
+        "linguaggio": "python",
+        "source_name": "main.py",
+        "difficulty": "B",
+        "difficolta": "B",
+        "topics": ["funzioni", "return"],
+        "argomenti": ["funzioni", "return"],
+        "instructions": "Implementa le funzioni richieste.",
+        "consegna": "Implementa le funzioni richieste.",
+        "grading_policy": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 10,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "function_tests": [
+            {
+                "profile": "python-function-v1",
+                "name": "doppio positivo",
+                "function": "doppio",
+                "args": [3],
+                "expected_return": 6,
+            },
+            {
+                "profile": "python-function-v1",
+                "name": "doppio zero",
+                "function": "doppio",
+                "args": [0],
+                "expected_return": 0,
+            },
+            {
+                "profile": "python-function-v1",
+                "name": "predicate pari",
+                "function": "pari",
+                "args": [8],
+                "expected_return": True,
+            },
+        ],
+    }
+
+
+def _assignment() -> dict:
+    return {
+        "assignment_id": "assignment-python-p2-student-lab",
+        "activity_id": "python-p2-student-lab-001",
+        "student_id": "rossi-mario",
+        "activity": {"path": "activities/python-p2-student-lab-001.json"},
+        "workspace": {
+            "path": "students/rossi-mario/assignments/python-p2-student-lab-001"
+        },
+    }
+
+
+def test_p2_runs_through_normal_student_lab_and_redacts_teacher_oracles(tmp_path: Path) -> None:
+    activity_path = tmp_path / "activities" / "python-p2-student-lab-001.json"
+    activity_path.parent.mkdir(parents=True)
+    activity_path.write_text(json.dumps(_activity()), encoding="utf-8")
+
+    workspace = (
+        tmp_path
+        / "students"
+        / "rossi-mario"
+        / "assignments"
+        / "python-p2-student-lab-001"
+    )
+    workspace.mkdir(parents=True)
+    (workspace / "main.py").write_text(
+        "def doppio(x):\n"
+        "    return x * 2\n\n"
+        "def pari(n):\n"
+        "    return n % 2 == 0\n",
+        encoding="utf-8",
+    )
+
+    report = student_lab_runner.run_docker_assignment(
+        _assignment(),
+        root=tmp_path,
+        timeout_seconds=3,
+        docker_image="thebitlab-p2-candidate",
+    )
+
+    assert report["backend"] == "docker"
+    assert report["passed"] is True
+    assert report["status"] == "passed"
+    assert report["profile"] == "python-function-v1"
+    assert report["summary"] == {"passed": 3, "total": 3}
+    assert report["tests"] == [
+        {"name": "Test 1", "passed": True, "status": "passed"},
+        {"name": "Test 2", "passed": True, "status": "passed"},
+        {"name": "Test 3", "passed": True, "status": "passed"},
+    ]
+
+    serialized = json.dumps(report, ensure_ascii=False).casefold()
+    for forbidden in (
+        "expected_return",
+        "actual_return",
+        "worker_status",
+        "doppio positivo",
+        "doppio zero",
+        "predicate pari",
+    ):
+        assert forbidden not in serialized

--- a/tests/test_python_function_worker.py
+++ b/tests/test_python_function_worker.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import python_function_profile as p2
+
+
+def write_source(tmp_path: Path, text: str) -> Path:
+    source = tmp_path / "main.py"
+    source.write_text(text, encoding="utf-8")
+    return source
+
+
+def request(function: str, *args, **kwargs) -> dict:
+    return {
+        "schema_version": p2.WORKER_SCHEMA,
+        "function": function,
+        "args": list(args),
+        "kwargs": kwargs,
+    }
+
+
+def test_worker_invokes_top_level_function(tmp_path: Path) -> None:
+    source = write_source(tmp_path, "def area(base, altezza):\n    return base * altezza\n")
+    result = p2.execute_worker_request(request("area", 3, 4), source)
+    assert result == {
+        "schema_version": p2.WORKER_SCHEMA,
+        "status": "returned",
+        "return_value": 12,
+        "stdout": "",
+        "stderr": "",
+    }
+
+
+def test_worker_captures_stdout_without_using_it_as_oracle(tmp_path: Path) -> None:
+    source = write_source(
+        tmp_path,
+        "def saluta(nome):\n    print('debug', nome)\n    return 'ciao ' + nome\n",
+    )
+    result = p2.execute_worker_request(request("saluta", "Ada"), source)
+    assert result["status"] == "returned"
+    assert result["return_value"] == "ciao Ada"
+    assert result["stdout"] == "debug Ada\n"
+
+
+def test_worker_reports_missing_and_non_callable(tmp_path: Path) -> None:
+    missing = write_source(tmp_path, "x = 1\n")
+    assert p2.execute_worker_request(request("area"), missing)["status"] == "missing-function"
+
+    non_callable = write_source(tmp_path, "area = 12\n")
+    assert p2.execute_worker_request(request("area"), non_callable)["status"] == "not-callable"
+
+
+def test_worker_reports_student_exception(tmp_path: Path) -> None:
+    source = write_source(tmp_path, "def reciproco(x):\n    return 1 / x\n")
+    result = p2.execute_worker_request(request("reciproco", 0), source)
+    assert result["status"] == "raised"
+    assert result["exception"]["type"] == "ZeroDivisionError"
+    assert len(result["exception"]["message"]) <= 512
+
+
+def test_import_side_effect_failure_is_not_a_platform_crash(tmp_path: Path) -> None:
+    source = write_source(tmp_path, "raise RuntimeError('boom import')\n")
+    result = p2.execute_worker_request(request("f"), source)
+    assert result["status"] == "import-error"
+    assert "RuntimeError" in result["stderr"]
+
+
+def test_unsupported_return_fails_closed(tmp_path: Path) -> None:
+    source = write_source(tmp_path, "def f():\n    return {1, 2}\n")
+    result = p2.execute_worker_request(request("f"), source)
+    assert result["status"] == "unsupported-return"
+    assert "return_value" not in result
+
+
+def test_stdout_limit_is_enforced_during_import(tmp_path: Path) -> None:
+    source = write_source(tmp_path, f"print('x' * {p2.MAX_STRING_CHARS + 1})\ndef f():\n    return 1\n")
+    result = p2.execute_worker_request(request("f"), source)
+    assert result["status"] == "output-limit"
+    assert len(result["stdout"]) <= p2.MAX_STRING_CHARS
+
+
+def test_stdout_limit_is_enforced_during_function_call(tmp_path: Path) -> None:
+    source = write_source(
+        tmp_path,
+        f"def f():\n    print('x' * {p2.MAX_STRING_CHARS + 1})\n    return 1\n",
+    )
+    result = p2.execute_worker_request(request("f"), source)
+    assert result["status"] == "output-limit"
+    assert len(result["stdout"]) <= p2.MAX_STRING_CHARS
+
+
+def test_worker_request_never_contains_teacher_expectations(tmp_path: Path) -> None:
+    teacher_test = {
+        "profile": p2.PROFILE_ID,
+        "function": "area",
+        "args": [5, 6],
+        "expected_return": 30,
+    }
+    worker = p2.worker_request(teacher_test)
+    assert set(worker) == {"schema_version", "function", "args", "kwargs"}
+    assert "expected_return" not in worker
+    assert "expected_exception" not in worker

--- a/tests/test_validate_activity_function_profile.py
+++ b/tests/test_validate_activity_function_profile.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from scripts import create_submission_scaffold, validate_activity
+
+
+def base_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-function-test-001",
+        "titolo": "Area rettangolo",
+        "tipo": "laboratorio",
+        "difficolta": "B",
+        "argomenti": ["funzioni", "return"],
+        "consegna": "Completa la funzione area(base, altezza).",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 15,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "function_tests": [
+            {
+                "profile": "python-function-v1",
+                "name": "rettangolo 3x4",
+                "function": "area",
+                "args": [3, 4],
+                "expected_return": 12,
+            }
+        ],
+    }
+
+
+def test_activity_accepts_valid_function_profile_tests() -> None:
+    assert validate_activity.validate_activity(base_activity(), "activity.json") == []
+
+
+def test_activity_rejects_unknown_function_profile_version() -> None:
+    activity = base_activity()
+    activity["function_tests"][0]["profile"] = "python-function-v2"
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("profile deve essere python-function-v1" in error for error in errors)
+
+
+def test_activity_rejects_unknown_function_test_fields() -> None:
+    activity = base_activity()
+    activity["function_tests"][0]["expected_magic"] = 12
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("campi non supportati" in error for error in errors)
+
+
+def test_student_activity_payload_redacts_teacher_function_tests() -> None:
+    public = create_submission_scaffold.student_activity_payload(base_activity())
+    assert "function_tests" not in public
+    serialized = str(public)
+    assert "expected_return" not in serialized
+    assert "rettangolo 3x4" not in serialized


### PR DESCRIPTION
Implements the candidate `python-function-v1` grading profile for #756 and proves it through the normal Student Lab Docker path plus a real `python-docente` M13 consumer.

**Keep this PR DRAFT until stable assignment-runner/toolchain promotion is explicitly decided. Do not silently treat the candidate source as the existing stable `2026.07.1` release.**

## Integrated candidate

```text
head family: c718c40045c69f0863a4a68c7a3f802241685230
profile: python-function-v1
worker schema: thebitlab.python-function-worker.v1
```

## Implemented

- versioned teacher-side `python-function-v1` contract;
- strict Activity `function_tests` validation;
- bounded deterministic value codec (`None/bool/int/finite float/str/list/string-key dict`);
- exact-type return comparison by default;
- explicit absolute float tolerance;
- expected-exception type comparison;
- worker request contains only function + args + kwargs;
- expected return/exception and grading decision stay on the trusted host;
- real worker module load + top-level function invocation;
- missing-function / not-callable / import-error / raised / timeout / output-limit / unsupported-return behavior;
- bounded stdout/stderr;
- one fresh hardened assignment-runner container per test;
- existing no-network/read-only/cap-drop/PID/memory/CPU sandbox reused;
- student scaffold removes all `function_tests` teacher metadata;
- student report redaction hides teacher test names, expected/actual return, worker status and diagnostics for hidden tests;
- normal `DockerGradeActivityExecutionService` dispatches readable Python Activities with `function_tests` to P2;
- Activities without `function_tests` retain the existing P1/C/Node/SQL path;
- non-Python `function_tests` requests fail closed;
- normal `student_lab_runner.run_docker_assignment()` path is exercised with real Docker;
- assignment-runner image includes P2 worker while preserving the legacy entrypoint.

## Trust boundary

```text
teacher Activity.function_tests
        |
        | worker_request(function,args,kwargs) only
        v
hardened Docker worker
        |
        | observed return / exception / bounded stdout/stderr
        v
trusted host comparison
        |
        v
teacher report -> student redaction
```

Teacher expected outcomes never enter the untrusted worker request.

## Platform evidence

Dedicated P2 candidate workflow:

```text
run 33182445790 / #12
job 98886802968
SUCCESS
```

It proves:

```text
contract + worker + dispatch tests       PASS
assignment-runner candidate build       PASS
direct P2 Docker behavior               PASS
infinite loop -> bounded timeout         PASS
normal Student Lab Docker dispatch      PASS
student-facing redaction                 PASS
```

General runner regression on the same candidate family:

```text
Build assignment runner Docker image
run 33182445721 / #1008
SUCCESS

C / Python P1 / Node.js / SQLite         PASS
Student Lab Docker regression            PASS
```

`Quality` Python + minimum-Python jobs are PASS; template smoke and uTUI consumer are PASS. The long Windows filesystem job is unrelated to P2 and may complete independently.

## Real course consumer

`TheBitPoets/python-docente` now contains exactly one P2 canary:

```text
py2-activity-b-return-area-001
M13 / PY2-05
controlled change: print(area) -> return area
```

Current consumer evidence:

```text
workflow: Python M13 P2 canary
run: 33182614844 / #3
job: 98887384355
SUCCESS
platform pin: c718c40045c69f0863a4a68c7a3f802241685230
```

The course consumer now calls the normal `DockerGradeActivityExecutionService`, not the side harness, and requires `metadata.grading_profile == python-function-v1`.

Behavioral oracle:

```text
solution = 3/3 PASS
starter  = 0/3 FAIL
```

The starter prints the correct numeric areas but returns `None`, proving the integrated service grades function return behavior rather than stdout.

## Still required before #756 / this PR can be promoted stable

The grading capability and its first consumer are functionally proven. Remaining work is release governance:

1. choose a new stable assignment-runner/toolchain identity for the P2-capable source;
2. update/publish the corresponding immutable release lock rather than reusing the old stable identity;
3. complete final PR/release review and merge decision;
4. repin `python-docente` from candidate SHA to the promoted stable source/toolchain;
5. only then allow broader P2 Activity materialization.

## Non-goals

- teaching pytest as a prerequisite;
- arbitrary Python object serialization;
- multi-file function projects in v1;
- P3 object-state grading;
- P4 filesystem grading;
- replacing P1 stdin/stdout;
- classroom-ready or Content Pack approval claims.