### PR TITLE
Draft P4 Python filesystem-behavior grading + Student Lab integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@ docker/assignment-runner/*
 scripts/*
 !scripts/grade_activity.py
 !scripts/thebitlab_sandbox_boundary.py
+!scripts/python_filesystem_profile.py
+!scripts/python_filesystem_worker.py

--- a/.github/workflows/python-filesystem-profile.yml
+++ b/.github/workflows/python-filesystem-profile.yml
@@ -1,0 +1,243 @@
+name: Python filesystem profile P4 candidate
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".dockerignore"
+      - "docker/assignment-runner/**"
+      - "scripts/python_filesystem_profile.py"
+      - "scripts/python_filesystem_worker.py"
+      - "scripts/grade_python_filesystem_activity.py"
+      - "scripts/validate_activity.py"
+      - "tests/test_python_filesystem_profile.py"
+      - "tests/test_python_filesystem_worker.py"
+      - "tests/test_validate_activity_filesystem_profile.py"
+      - ".github/workflows/python-filesystem-profile.yml"
+
+jobs:
+  p4-candidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run P4 contract worker and Activity tests
+        run: >-
+          python -m pytest -q
+          tests/test_python_filesystem_profile.py
+          tests/test_python_filesystem_worker.py
+          tests/test_validate_activity_filesystem_profile.py
+
+      - name: Build assignment-runner candidate
+        run: >-
+          python scripts/build_assignment_runner.py
+          --source-revision "$GITHUB_SHA"
+          --tag thebitlab-p4-candidate
+          --metadata "$RUNNER_TEMP/p4-toolchain-build.json"
+
+      - name: Exercise P4 read-only fixture and output artifact
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p4/fixtures"
+          printf '12\n15\n9\n' > "$RUNNER_TEMP/p4/fixtures/misure.txt"
+          cat > "$RUNNER_TEMP/p4/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p4-smoke-001",
+            "titolo": "Somma misure",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["file", "pathlib"],
+            "consegna": "Leggi misure.txt e crea risultato.txt.",
+            "linguaggio": "python",
+            "correzione": {"compila": true, "test": true, "sandbox": true, "ai_feedback": false},
+            "metriche": {
+              "tempo_stimato_minuti": 15,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "filesystem_tests": [
+              {
+                "profile": "python-filesystem-v1",
+                "name": "somma base",
+                "fixtures": [
+                  {"id": "input", "source": "fixtures/misure.txt", "target": "misure.txt", "mode": "read-only"}
+                ],
+                "expected_artifacts": [
+                  {"path": "risultato.txt", "text": "36\n", "encoding": "utf-8"}
+                ]
+              }
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p4/main.py" <<'PY'
+          from pathlib import Path
+
+          values = [int(line) for line in Path("misure.txt").read_text(encoding="utf-8").splitlines()]
+          Path("risultato.txt").write_text(f"{sum(values)}\n", encoding="utf-8")
+          PY
+          python scripts/grade_python_filesystem_activity.py \
+            --activity "$RUNNER_TEMP/p4/activity.json" \
+            --activity-root "$RUNNER_TEMP/p4" \
+            --source "$RUNNER_TEMP/p4/main.py" \
+            --source-root "$RUNNER_TEMP/p4" \
+            --docker-image thebitlab-p4-candidate \
+            --report "$RUNNER_TEMP/p4/report.json"
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "p4" / "report.json").read_text(encoding="utf-8"))
+          assert report["passed"] is True
+          assert report["profile"] == "python-filesystem-v1"
+          assert report["summary"] == {"passed": 1, "total": 1}
+          assert report["tests"][0]["worker_status"] == "completed"
+          assert all("36" not in key for key in report["tests"][0] if key.startswith("expected"))
+          PY
+
+      - name: Exercise P4 fixture mutation protection
+        shell: bash
+        run: |
+          cp "$RUNNER_TEMP/p4/activity.json" "$RUNNER_TEMP/p4/activity-mutation.json"
+          cat > "$RUNNER_TEMP/p4/mutate.py" <<'PY'
+          from pathlib import Path
+          Path("misure.txt").write_text("99\n", encoding="utf-8")
+          Path("risultato.txt").write_text("99\n", encoding="utf-8")
+          PY
+          set +e
+          python scripts/grade_python_filesystem_activity.py \
+            --activity "$RUNNER_TEMP/p4/activity-mutation.json" \
+            --activity-root "$RUNNER_TEMP/p4" \
+            --source "$RUNNER_TEMP/p4/mutate.py" \
+            --source-root "$RUNNER_TEMP/p4" \
+            --docker-image thebitlab-p4-candidate \
+            --report "$RUNNER_TEMP/p4/mutation-report.json"
+          status=$?
+          set -e
+          test "$status" = "1"
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "p4" / "mutation-report.json").read_text(encoding="utf-8"))
+          test = report["tests"][0]
+          assert report["passed"] is False
+          assert test["worker_status"] == "runtime-error"
+          assert test["exception"]["type"] in {"PermissionError", "OSError"}
+          PY
+
+      - name: Exercise P4 missing fixture and external path policy
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p4-errors"
+          cat > "$RUNNER_TEMP/p4-errors/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p4-errors-001",
+            "titolo": "Errori filesystem",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["file"],
+            "consegna": "Prova filesystem.",
+            "linguaggio": "python",
+            "correzione": {"compila": true, "test": true, "sandbox": true, "ai_feedback": false},
+            "metriche": {
+              "tempo_stimato_minuti": 5,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "filesystem_tests": [
+              {
+                "profile": "python-filesystem-v1",
+                "expected_artifacts": [{"path": "out.txt", "text": "ok\n", "encoding": "utf-8"}]
+              }
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p4-errors/missing.py" <<'PY'
+          from pathlib import Path
+          Path("missing.txt").read_text(encoding="utf-8")
+          PY
+          cat > "$RUNNER_TEMP/p4-errors/escape.py" <<'PY'
+          from pathlib import Path
+          Path("/etc/passwd").read_text(encoding="utf-8")
+          PY
+          for source in missing escape; do
+            set +e
+            python scripts/grade_python_filesystem_activity.py \
+              --activity "$RUNNER_TEMP/p4-errors/activity.json" \
+              --activity-root "$RUNNER_TEMP/p4-errors" \
+              --source "$RUNNER_TEMP/p4-errors/$source.py" \
+              --source-root "$RUNNER_TEMP/p4-errors" \
+              --docker-image thebitlab-p4-candidate \
+              --report "$RUNNER_TEMP/p4-errors/$source-report.json"
+            status=$?
+            set -e
+            test "$status" = "1"
+          done
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          root = Path(os.environ["RUNNER_TEMP"]) / "p4-errors"
+          missing = json.loads((root / "missing-report.json").read_text(encoding="utf-8"))["tests"][0]
+          escape = json.loads((root / "escape-report.json").read_text(encoding="utf-8"))["tests"][0]
+          assert missing["worker_status"] == "runtime-error"
+          assert missing["exception"]["type"] == "FileNotFoundError"
+          assert escape["worker_status"] == "runtime-error"
+          assert escape["exception"]["type"] == "PermissionError"
+          PY
+
+      - name: Exercise P4 output limit and timeout cleanup
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p4-limits"
+          cp "$RUNNER_TEMP/p4-errors/activity.json" "$RUNNER_TEMP/p4-limits/activity.json"
+          cat > "$RUNNER_TEMP/p4-limits/big.py" <<'PY'
+          from pathlib import Path
+          Path("big.txt").write_text("x" * 70000, encoding="utf-8")
+          PY
+          cat > "$RUNNER_TEMP/p4-limits/loop.py" <<'PY'
+          while True:
+              pass
+          PY
+          for source in big loop; do
+            extra=""
+            if [ "$source" = loop ]; then extra="--timeout 1"; fi
+            set +e
+            python scripts/grade_python_filesystem_activity.py \
+              --activity "$RUNNER_TEMP/p4-limits/activity.json" \
+              --activity-root "$RUNNER_TEMP/p4-limits" \
+              --source "$RUNNER_TEMP/p4-limits/$source.py" \
+              --source-root "$RUNNER_TEMP/p4-limits" \
+              --docker-image thebitlab-p4-candidate \
+              $extra \
+              --report "$RUNNER_TEMP/p4-limits/$source-report.json"
+            status=$?
+            set -e
+            test "$status" = "1"
+          done
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          root = Path(os.environ["RUNNER_TEMP"]) / "p4-limits"
+          big = json.loads((root / "big-report.json").read_text(encoding="utf-8"))["tests"][0]
+          loop = json.loads((root / "loop-report.json").read_text(encoding="utf-8"))["tests"][0]
+          assert big["worker_status"] == "output-limit"
+          assert loop["worker_status"] == "timeout"
+          PY

--- a/.github/workflows/python-filesystem-student-lab.yml
+++ b/.github/workflows/python-filesystem-student-lab.yml
@@ -1,0 +1,52 @@
+name: Python filesystem P4 Student Lab integration
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".dockerignore"
+      - "docker/assignment-runner/**"
+      - "scripts/python_filesystem_profile.py"
+      - "scripts/python_filesystem_worker.py"
+      - "scripts/grade_python_filesystem_activity.py"
+      - "scripts/thebitlab_technical_services.py"
+      - "scripts/student_lab_runner.py"
+      - "tests/test_python_filesystem_profile_dispatch.py"
+      - "tests/test_python_filesystem_student_lab_docker.py"
+      - ".github/workflows/python-filesystem-student-lab.yml"
+
+jobs:
+  p4-student-lab:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Verify P4 canonical Docker dispatch
+        run: python -m pytest -q tests/test_python_filesystem_profile_dispatch.py
+
+      - name: Build P4 assignment runner
+        run: >-
+          python scripts/build_assignment_runner.py
+          --source-revision "$GITHUB_SHA"
+          --tag thebitlab-p4-candidate
+          --metadata "$RUNNER_TEMP/p4-student-lab-toolchain.json"
+
+      - name: Exercise P4 through normal Student Lab Docker path
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P4_DOCKER_IMAGE: "thebitlab-p4-candidate"
+        run: python -m pytest -q tests/test_python_filesystem_student_lab_docker.py

--- a/doc/PYTHON_FILESYSTEM_PROFILE.md
+++ b/doc/PYTHON_FILESYSTEM_PROFILE.md
@@ -1,0 +1,155 @@
+# Python filesystem-behavior grading profile — design checkpoint
+
+> Status: design / implementation candidate for `2cornot2c#757`.
+>
+> This document does not certify P4 and does not authorize course-side mass materialization.
+
+## Purpose
+
+`python-filesystem-v1` grades deterministic beginner file-I/O behavior without replacing real files with stdin/stdout.
+
+The trusted host owns:
+
+- fixture definitions and source bytes;
+- expected output paths/content;
+- grading decisions.
+
+The untrusted container receives only:
+
+- the student source;
+- declared input fixture bytes/targets;
+- bounded filesystem policy.
+
+It returns observed execution state and a bounded manifest of student-created regular files. Expected artifact contents stay host-side.
+
+## V1 workspace
+
+One fresh sandbox per test:
+
+```text
+/submission/
+  main.py                 read-only mount input
+
+/thebitlab-work/p4/
+  workspace/
+    <declared fixtures>   copied before execution
+    main.py               copied student source
+```
+
+Student code executes with `cwd` set to the writable P4 workspace. The outer Docker boundary remains network-off, read-only root filesystem, no-new-privileges, cap-drop ALL, PID/memory/CPU bounded.
+
+Fixtures are copied from trusted host staging into the per-test workspace immediately before execution. Only regular files declared by the teacher contract are accepted.
+
+## Teacher-side test contract
+
+Conceptual v1:
+
+```json
+{
+  "profile": "python-filesystem-v1",
+  "name": "normalizza righe",
+  "fixtures": [
+    {
+      "id": "input",
+      "source": "fixtures/dati.txt",
+      "target": "dati.txt",
+      "mode": "read-only"
+    }
+  ],
+  "expected_artifacts": [
+    {
+      "path": "risultato.txt",
+      "text": "uno\ndue\n",
+      "encoding": "utf-8"
+    }
+  ],
+  "forbid_unexpected_artifacts": true
+}
+```
+
+`source` and expected text are trusted-host fields. They must not be serialized into a student-facing scaffold or worker request.
+
+## Worker request
+
+The worker request may contain only the execution policy and fixture **target metadata**, never teacher source paths or expected artifact contents. Fixture bytes are staged separately by the trusted host.
+
+```json
+{
+  "schema_version": "thebitlab.python-filesystem-worker.v1",
+  "fixture_targets": ["dati.txt"],
+  "max_output_files": 16,
+  "max_output_file_bytes": 65536,
+  "max_output_total_bytes": 262144
+}
+```
+
+## V1 limits
+
+Initial hard limits:
+
+```text
+fixtures                    <= 16
+single fixture              <= 64 KiB
+all fixture bytes           <= 256 KiB
+output regular files        <= 16
+single output file          <= 64 KiB
+all output bytes            <= 256 KiB
+relative path depth         <= 4
+path length                 <= 240 chars
+text codec                  UTF-8 only
+```
+
+No symlinks, hard-link tricks, device files, sockets, FIFOs or absolute/traversal paths are valid artifacts.
+
+## Artifact observation
+
+After execution the worker returns only bounded observed data:
+
+```json
+{
+  "path": "risultato.txt",
+  "size": 8,
+  "sha256": "...",
+  "text": "uno\ndue\n"
+}
+```
+
+V1 may return bounded UTF-8 text because the total output surface is tightly capped. The trusted host compares it with teacher expectations. A later binary profile should prefer digest/typed artifact handling rather than extending this contract implicitly.
+
+Newlines are normalized only for an explicitly declared text comparison policy. V1 default is exact UTF-8 text after normalizing CRLF to LF; no whitespace stripping.
+
+## Fixture immutability
+
+Fixture targets are snapshotted before student execution. After execution the worker verifies their bytes and file type are unchanged. Mutation produces a structured `fixture-mutated` result even if the program otherwise exits zero.
+
+This is a grading/policy guarantee, not a claim that normal Unix permissions alone prevent every write: the per-test worker must actively verify fixture integrity.
+
+## Expected failure statuses
+
+At minimum:
+
+```text
+completed
+runtime-error
+timeout
+fixture-mutated
+filesystem-policy-violation
+output-limit
+invalid-utf8-output
+```
+
+The trusted host then distinguishes grading outcomes such as missing required artifact, unexpected artifact, or content mismatch.
+
+A normal student `FileNotFoundError` remains a runtime error with bounded diagnostics; it is not converted to infrastructure failure.
+
+## Promotion policy
+
+P4 can become stable only after:
+
+1. strict contract + Activity validation;
+2. real worker execution in the hardened assignment-runner;
+3. fixture/path/symlink/output-limit/timeout tests;
+4. normal Student Lab dispatch;
+5. student-report redaction;
+6. one real `python-docente` M26 consumer;
+7. release identity/immutable lock governance analogous to P2.

--- a/docker/assignment-runner/Dockerfile
+++ b/docker/assignment-runner/Dockerfile
@@ -37,6 +37,8 @@ RUN useradd --create-home --shell /usr/sbin/nologin runner
 
 COPY scripts/grade_activity.py /opt/thebitlab/grade_activity.py
 COPY scripts/thebitlab_sandbox_boundary.py /opt/thebitlab/thebitlab_sandbox_boundary.py
+COPY scripts/python_filesystem_profile.py /opt/thebitlab/python_filesystem_profile.py
+COPY scripts/python_filesystem_worker.py /opt/thebitlab/python_filesystem_worker.py
 
 WORKDIR /submission
 

--- a/scripts/grade_python_filesystem_activity.py
+++ b/scripts/grade_python_filesystem_activity.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import grade_activity
+from scripts import python_filesystem_profile as p4
+from scripts import validate_activity
+from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+
+
+DEFAULT_TIMEOUT_SECONDS = 5
+DEFAULT_DOCKER_IMAGE = grade_activity.DEFAULT_DOCKER_IMAGE
+P4_TMPFS_SPEC = "/thebitlab-work:rw,exec,nosuid,nodev,mode=1777,size=1m"
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: JSON root deve essere un oggetto")
+    return value
+
+
+def prepare_fixture_mounts(
+    *,
+    activity_root: Path,
+    teacher_test: dict[str, Any],
+    temp_root: Path,
+) -> list[tuple[Path, str]]:
+    """Copy declared teacher fixtures into bounded temporary read-only mount sources."""
+
+    normalized = p4.validate_filesystem_test(teacher_test)
+    fixture_root = temp_root / "fixture-mounts"
+    fixture_root.mkdir(parents=True, exist_ok=True)
+    mounts: list[tuple[Path, str]] = []
+    total = 0
+    for index, fixture in enumerate(normalized["fixtures"]):
+        source = activity_root / fixture["source"]
+        safe_source = grade_activity.confined_regular_input(
+            source,
+            activity_root,
+            f"filesystem fixture {fixture['id']}",
+        )
+        size = safe_source.stat().st_size
+        if size > p4.MAX_FIXTURE_FILE_BYTES:
+            raise ValueError(
+                f"Fixture {fixture['id']} supera {p4.MAX_FIXTURE_FILE_BYTES} byte"
+            )
+        total += size
+        if total > p4.MAX_FIXTURE_TOTAL_BYTES:
+            raise ValueError("Fixture P4 superano il limite totale")
+        raw = safe_source.read_bytes()
+        try:
+            raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as error:
+            raise ValueError(f"Fixture {fixture['id']} non e UTF-8 valida") from error
+        copied = fixture_root / f"{index:02d}-{fixture['target']}"
+        copied.write_bytes(raw)
+        try:
+            copied.chmod(0o444)
+        except OSError:
+            pass
+        mounts.append((copied, fixture["target"]))
+    return mounts
+
+
+def p4_docker_command(
+    *,
+    image: str,
+    workspace: Path,
+    source: Path,
+    fixture_mounts: list[tuple[Path, str]],
+    cidfile: Path,
+    container_name: str,
+) -> list[str]:
+    """Return the hardened P4 Docker command with read-only fixture mounts."""
+
+    command = docker_boundary_command(
+        image=image,
+        workspace=workspace,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    for index, item in enumerate(command):
+        if isinstance(item, str) and item.startswith("/thebitlab-work:"):
+            command[index] = P4_TMPFS_SPEC
+    image_ref = command.pop()
+    for host_path, target in fixture_mounts:
+        host = str(host_path.resolve())
+        if "," in host:
+            raise ValueError("Fixture host path contiene una virgola non supportata da Docker --mount")
+        command.extend(
+            [
+                "--mount",
+                f"type=bind,src={host},dst=/thebitlab-work/{target},readonly",
+            ]
+        )
+    command.extend(["--entrypoint", "python3", image_ref])
+    command.extend(
+        [
+            "/opt/thebitlab/python_filesystem_worker.py",
+            "--source",
+            grade_activity.path_inside_workspace(source, workspace, "source"),
+            "--workdir",
+            "/thebitlab-work",
+        ]
+    )
+    return command
+
+
+def timeout_test_result(teacher_test: dict[str, Any]) -> dict[str, Any]:
+    normalized = p4.validate_filesystem_test(teacher_test)
+    return {
+        "name": normalized.get("name", "filesystem"),
+        "profile": p4.PROFILE_ID,
+        "visibility": normalized.get("visibility", "teacher"),
+        "passed": False,
+        "status": "failed",
+        "worker_status": "timeout",
+        "checks": [],
+        "stdout": "",
+        "stderr": "",
+        "exception": None,
+    }
+
+
+def run_filesystem_test_in_docker(
+    *,
+    image: str,
+    activity_root: Path,
+    activity_path: Path,
+    source_path: Path,
+    teacher_test: dict[str, Any],
+    timeout_seconds: int,
+    temp_root: Path,
+    test_index: int,
+) -> dict[str, Any]:
+    """Run one P4 test in a fresh container and compare only on the trusted host."""
+
+    test_root = temp_root / f"test-{test_index:02d}"
+    test_root.mkdir(parents=True)
+    workspace, source = grade_activity.prepare_docker_workspace(
+        activity_path,
+        source_path,
+        test_root,
+        activity_root=activity_root,
+        source_root=source_path.parent,
+    )
+    fixture_mounts = prepare_fixture_mounts(
+        activity_root=activity_root,
+        teacher_test=teacher_test,
+        temp_root=test_root,
+    )
+    cidfile = test_root / "container.cid"
+    container_name = f"thebitlab-p4-{uuid.uuid4().hex}"
+    command = p4_docker_command(
+        image=image,
+        workspace=workspace,
+        source=source,
+        fixture_mounts=fixture_mounts,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    request = p4.worker_request(teacher_test)
+    try:
+        try:
+            completed = grade_activity.run_bounded_process(
+                command,
+                input_text=json.dumps(request, ensure_ascii=False, allow_nan=False),
+                timeout=timeout_seconds + grade_activity.DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return timeout_test_result(teacher_test)
+        if completed.returncode != 0:
+            raise ValueError(
+                f"P4 worker terminato con errore infrastrutturale: exit={completed.returncode}"
+            )
+        try:
+            worker_result = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise ValueError("P4 worker non ha prodotto JSON valido") from error
+        validated = p4.validate_worker_result(worker_result)
+        return p4.compare_worker_result(teacher_test, validated)
+    finally:
+        grade_activity.remove_docker_container(cidfile, container_name)
+
+
+def grade_in_docker(
+    *,
+    activity_path: Path,
+    source_path: Path,
+    image: str = DEFAULT_DOCKER_IMAGE,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    activity_root: Path | None = None,
+    source_root: Path | None = None,
+) -> dict[str, Any]:
+    """Grade a Python P4 Activity with clean filesystem state per test."""
+
+    resolved_activity_root = (activity_root or activity_path.parent).resolve(strict=True)
+    resolved_source_root = (source_root or source_path.parent).resolve(strict=True)
+    safe_activity = grade_activity.confined_regular_input(
+        activity_path,
+        resolved_activity_root,
+        "activity",
+    )
+    safe_source = grade_activity.confined_regular_input(
+        source_path,
+        resolved_source_root,
+        "source",
+    )
+    activity = load_object(safe_activity)
+    errors = validate_activity.validate_activity(activity, str(safe_activity))
+    if errors:
+        raise ValueError("Activity P4 non valida: " + "; ".join(errors))
+    language = str(activity.get("language") or activity.get("linguaggio") or "python").lower()
+    if language not in {"python", "py"}:
+        raise ValueError("P4 supporta solo Activity Python")
+    teacher_tests = p4.validate_filesystem_tests(activity.get("filesystem_tests"))
+
+    with tempfile.TemporaryDirectory(prefix="thebitlab-p4-") as raw_temp:
+        temp_root = Path(raw_temp)
+        tests: list[dict[str, Any]] = []
+        for index, teacher_test in enumerate(teacher_tests):
+            tests.append(
+                run_filesystem_test_in_docker(
+                    image=image,
+                    activity_root=resolved_activity_root,
+                    activity_path=safe_activity,
+                    source_path=safe_source,
+                    teacher_test=teacher_test,
+                    timeout_seconds=timeout_seconds,
+                    temp_root=temp_root,
+                    test_index=index,
+                )
+            )
+
+    passed = all(test["passed"] for test in tests)
+    return {
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "activity_id": activity.get("id"),
+        "language": "python",
+        "profile": p4.PROFILE_ID,
+        "source": str(source_path),
+        "tests": tests,
+        "summary": {
+            "passed": sum(1 for test in tests if test["passed"]),
+            "total": len(tests),
+        },
+    }
+
+
+def positive_int(value: str) -> int:
+    try:
+        number = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("deve essere intero") from error
+    if number <= 0:
+        raise argparse.ArgumentTypeError("deve essere positivo")
+    return number
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Grade Python filesystem-behavior Activity in Docker")
+    parser.add_argument("--activity", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--activity-root", type=Path)
+    parser.add_argument("--source-root", type=Path)
+    parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE)
+    parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--report", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = grade_in_docker(
+            activity_path=args.activity,
+            source_path=args.source,
+            image=args.docker_image,
+            timeout_seconds=args.timeout,
+            activity_root=args.activity_root,
+            source_root=args.source_root,
+        )
+    except subprocess.TimeoutExpired as error:
+        print(f"P4 Docker grading interrotto dopo {error.timeout} secondi")
+        return 2
+    except FileNotFoundError:
+        print("Docker non trovato. Installa Docker per il grading P4 autorevole.")
+        return 2
+    except (OSError, ValueError, grade_activity.DockerCleanupError) as error:
+        print(f"P4 Docker grading non avviato: {error}")
+        return 2
+    if args.report:
+        grade_activity.write_report(report, args.report)
+    else:
+        print(json.dumps(report, ensure_ascii=False, indent=2, allow_nan=False))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python_filesystem_profile.py
+++ b/scripts/python_filesystem_profile.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import PurePosixPath
+from typing import Any
+
+
+PROFILE_ID = "python-filesystem-v1"
+WORKER_SCHEMA = "thebitlab.python-filesystem-worker.v1"
+
+MAX_TESTS = 32
+MAX_FIXTURES = 8
+MAX_FIXTURE_FILE_BYTES = 64 * 1024
+MAX_FIXTURE_TOTAL_BYTES = 256 * 1024
+MAX_OUTPUT_FILES = 16
+MAX_OUTPUT_FILE_BYTES = 64 * 1024
+MAX_OUTPUT_TOTAL_BYTES = 256 * 1024
+MAX_STDIO_CHARS = 4096
+
+_PORTABLE_FILE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+
+class FilesystemProfileError(ValueError):
+    """Invalid P4 teacher contract, worker request or worker result."""
+
+
+def safe_bundle_path(value: Any) -> str:
+    """Return a safe portable Activity-bundle relative path."""
+
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise FilesystemProfileError("fixture source deve essere un path relativo POSIX")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise FilesystemProfileError("fixture source contiene traversal o path non portabile")
+    if len(value) > 240:
+        raise FilesystemProfileError("fixture source troppo lungo")
+    return value
+
+
+def portable_root_file(value: Any, *, label: str) -> str:
+    """Return one root-level portable file name used inside the P4 workdir."""
+
+    if not isinstance(value, str) or not _PORTABLE_FILE_RE.fullmatch(value):
+        raise FilesystemProfileError(
+            f"{label} deve essere un nome file root-level ASCII portabile"
+        )
+    if value in {".", ".."}:
+        raise FilesystemProfileError(f"{label} non valido")
+    return value
+
+
+def normalize_text(value: str) -> str:
+    """Normalize only newline representation; whitespace/trailing newline stay semantic."""
+
+    return value.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def text_sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _validate_fixture(value: Any, *, source: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise FilesystemProfileError(f"{source} deve essere un oggetto")
+    allowed = {"id", "source", "target", "mode"}
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise FilesystemProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    fixture_id = value.get("id")
+    if not isinstance(fixture_id, str) or not _ID_RE.fullmatch(fixture_id):
+        raise FilesystemProfileError(f"{source}.id non valido")
+    if value.get("mode") != "read-only":
+        raise FilesystemProfileError(f"{source}.mode deve essere read-only")
+    return {
+        "id": fixture_id,
+        "source": safe_bundle_path(value.get("source")),
+        "target": portable_root_file(value.get("target"), label=f"{source}.target"),
+        "mode": "read-only",
+    }
+
+
+def _validate_expected_artifact(value: Any, *, source: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise FilesystemProfileError(f"{source} deve essere un oggetto")
+    allowed = {"path", "text", "encoding"}
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise FilesystemProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    path = portable_root_file(value.get("path"), label=f"{source}.path")
+    if value.get("encoding", "utf-8") != "utf-8":
+        raise FilesystemProfileError(f"{source}.encoding supporta solo utf-8")
+    text = value.get("text")
+    if not isinstance(text, str):
+        raise FilesystemProfileError(f"{source}.text deve essere una stringa")
+    if len(text.encode("utf-8")) > MAX_OUTPUT_FILE_BYTES:
+        raise FilesystemProfileError(f"{source}.text supera il limite P4")
+    return {"path": path, "text": normalize_text(text), "encoding": "utf-8"}
+
+
+def validate_filesystem_test(value: Any, *, source: str = "test") -> dict[str, Any]:
+    """Validate one teacher-side filesystem behavior test."""
+
+    if not isinstance(value, dict):
+        raise FilesystemProfileError(f"{source} deve essere un oggetto")
+    allowed = {
+        "profile",
+        "name",
+        "fixtures",
+        "expected_artifacts",
+        "expected_absent",
+        "allow_unexpected_artifacts",
+        "visibility",
+    }
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise FilesystemProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    if value.get("profile") != PROFILE_ID:
+        raise FilesystemProfileError(f"{source}.profile deve essere {PROFILE_ID}")
+
+    fixtures_raw = value.get("fixtures", [])
+    if not isinstance(fixtures_raw, list) or len(fixtures_raw) > MAX_FIXTURES:
+        raise FilesystemProfileError(
+            f"{source}.fixtures deve essere una lista con massimo {MAX_FIXTURES} elementi"
+        )
+    fixtures = [
+        _validate_fixture(item, source=f"{source}.fixtures[{index}]")
+        for index, item in enumerate(fixtures_raw)
+    ]
+    fixture_ids = [item["id"] for item in fixtures]
+    fixture_targets = [item["target"] for item in fixtures]
+    if len(fixture_ids) != len(set(fixture_ids)):
+        raise FilesystemProfileError(f"{source}.fixtures contiene id duplicati")
+    if len(fixture_targets) != len(set(fixture_targets)):
+        raise FilesystemProfileError(f"{source}.fixtures contiene target duplicati")
+
+    expected_raw = value.get("expected_artifacts", [])
+    if not isinstance(expected_raw, list) or len(expected_raw) > MAX_OUTPUT_FILES:
+        raise FilesystemProfileError(
+            f"{source}.expected_artifacts deve essere una lista con massimo "
+            f"{MAX_OUTPUT_FILES} elementi"
+        )
+    expected = [
+        _validate_expected_artifact(item, source=f"{source}.expected_artifacts[{index}]")
+        for index, item in enumerate(expected_raw)
+    ]
+    expected_paths = [item["path"] for item in expected]
+    if len(expected_paths) != len(set(expected_paths)):
+        raise FilesystemProfileError(f"{source}.expected_artifacts contiene path duplicati")
+
+    absent_raw = value.get("expected_absent", [])
+    if not isinstance(absent_raw, list) or len(absent_raw) > MAX_OUTPUT_FILES:
+        raise FilesystemProfileError(
+            f"{source}.expected_absent deve essere una lista con massimo {MAX_OUTPUT_FILES} elementi"
+        )
+    absent = [
+        portable_root_file(item, label=f"{source}.expected_absent[{index}]")
+        for index, item in enumerate(absent_raw)
+    ]
+    if len(absent) != len(set(absent)):
+        raise FilesystemProfileError(f"{source}.expected_absent contiene duplicati")
+
+    collisions = (
+        set(fixture_targets) & set(expected_paths)
+        | set(fixture_targets) & set(absent)
+        | set(expected_paths) & set(absent)
+    )
+    if collisions:
+        raise FilesystemProfileError(
+            f"{source} contiene path con ruoli incompatibili: {', '.join(sorted(collisions))}"
+        )
+    if not expected and not absent:
+        raise FilesystemProfileError(
+            f"{source} deve dichiarare expected_artifacts e/o expected_absent"
+        )
+
+    allow_unexpected = value.get("allow_unexpected_artifacts", False)
+    if not isinstance(allow_unexpected, bool):
+        raise FilesystemProfileError(
+            f"{source}.allow_unexpected_artifacts deve essere boolean"
+        )
+
+    normalized: dict[str, Any] = {
+        "profile": PROFILE_ID,
+        "fixtures": fixtures,
+        "expected_artifacts": expected,
+        "expected_absent": absent,
+        "allow_unexpected_artifacts": allow_unexpected,
+    }
+    name = value.get("name")
+    if isinstance(name, str) and name:
+        normalized["name"] = name[:128]
+    visibility = value.get("visibility")
+    if visibility is not None:
+        if visibility not in {"teacher", "student", "public"}:
+            raise FilesystemProfileError(f"{source}.visibility non valida")
+        normalized["visibility"] = visibility
+    return normalized
+
+
+def validate_filesystem_tests(value: Any, *, source: str = "filesystem_tests") -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise FilesystemProfileError(f"{source} deve essere una lista non vuota")
+    if len(value) > MAX_TESTS:
+        raise FilesystemProfileError(f"{source} supera il limite di {MAX_TESTS} test")
+    return [
+        validate_filesystem_test(item, source=f"{source}[{index}]")
+        for index, item in enumerate(value)
+    ]
+
+
+def worker_request(test: dict[str, Any]) -> dict[str, Any]:
+    """Build the untrusted-worker request without teacher expected artifact content."""
+
+    normalized = validate_filesystem_test(test)
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "fixture_targets": [item["target"] for item in normalized["fixtures"]],
+    }
+
+
+def validate_worker_request(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != {"schema_version", "fixture_targets"}:
+        raise FilesystemProfileError("worker request contiene campi mancanti o inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise FilesystemProfileError("worker schema non supportato")
+    targets = value.get("fixture_targets")
+    if not isinstance(targets, list) or len(targets) > MAX_FIXTURES:
+        raise FilesystemProfileError("worker fixture_targets non valido")
+    normalized = [
+        portable_root_file(item, label=f"worker.fixture_targets[{index}]")
+        for index, item in enumerate(targets)
+    ]
+    if len(normalized) != len(set(normalized)):
+        raise FilesystemProfileError("worker fixture_targets contiene duplicati")
+    return {"schema_version": WORKER_SCHEMA, "fixture_targets": normalized}
+
+
+def validate_worker_result(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FilesystemProfileError("worker result deve essere un oggetto")
+    allowed = {"schema_version", "status", "artifacts", "stdout", "stderr", "exception"}
+    if set(value) - allowed:
+        raise FilesystemProfileError("worker result contiene campi inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise FilesystemProfileError("worker result schema non supportato")
+    status = value.get("status")
+    if status not in {"completed", "runtime-error", "output-limit", "policy-violation"}:
+        raise FilesystemProfileError("worker result status non supportato")
+    stdout = value.get("stdout", "")
+    stderr = value.get("stderr", "")
+    if not isinstance(stdout, str) or not isinstance(stderr, str):
+        raise FilesystemProfileError("worker stdout/stderr devono essere stringhe")
+    if len(stdout) > MAX_STDIO_CHARS or len(stderr) > MAX_STDIO_CHARS:
+        raise FilesystemProfileError("worker stdout/stderr superano il limite")
+
+    artifacts_raw = value.get("artifacts", [])
+    if not isinstance(artifacts_raw, list) or len(artifacts_raw) > MAX_OUTPUT_FILES:
+        raise FilesystemProfileError("worker artifacts non valido")
+    artifacts: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    total_bytes = 0
+    for index, item in enumerate(artifacts_raw):
+        if not isinstance(item, dict) or set(item) != {"path", "text", "bytes", "sha256"}:
+            raise FilesystemProfileError(f"worker artifacts[{index}] non valido")
+        path = portable_root_file(item.get("path"), label=f"worker artifacts[{index}].path")
+        if path in seen:
+            raise FilesystemProfileError("worker artifacts contiene path duplicati")
+        seen.add(path)
+        text = item.get("text")
+        size = item.get("bytes")
+        digest = item.get("sha256")
+        if not isinstance(text, str):
+            raise FilesystemProfileError("worker artifact text non valido")
+        encoded = text.encode("utf-8")
+        if (
+            isinstance(size, bool)
+            or not isinstance(size, int)
+            or size != len(encoded)
+            or size > MAX_OUTPUT_FILE_BYTES
+        ):
+            raise FilesystemProfileError("worker artifact size non valido")
+        if not isinstance(digest, str) or digest != hashlib.sha256(encoded).hexdigest():
+            raise FilesystemProfileError("worker artifact sha256 non valido")
+        total_bytes += size
+        artifacts.append(
+            {
+                "path": path,
+                "text": normalize_text(text),
+                "bytes": size,
+                "sha256": digest,
+            }
+        )
+    if total_bytes > MAX_OUTPUT_TOTAL_BYTES:
+        raise FilesystemProfileError("worker artifact bytes totali oltre limite")
+
+    normalized: dict[str, Any] = {
+        "schema_version": WORKER_SCHEMA,
+        "status": status,
+        "artifacts": artifacts,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    if status == "runtime-error":
+        exception = value.get("exception")
+        if not isinstance(exception, dict) or set(exception) != {"type", "message"}:
+            raise FilesystemProfileError("worker runtime exception non valida")
+        exc_type = exception.get("type")
+        message = exception.get("message")
+        if not isinstance(exc_type, str) or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,63}", exc_type):
+            raise FilesystemProfileError("worker exception type non valido")
+        if not isinstance(message, str) or len(message) > 512:
+            raise FilesystemProfileError("worker exception message non valido")
+        normalized["exception"] = {"type": exc_type, "message": message}
+    return normalized
+
+
+def compare_worker_result(test: dict[str, Any], worker_result: dict[str, Any]) -> dict[str, Any]:
+    """Compare observed filesystem state with teacher expectations on the trusted host."""
+
+    expected = validate_filesystem_test(test)
+    actual = validate_worker_result(worker_result)
+    artifacts = {item["path"]: item for item in actual["artifacts"]}
+    checks: list[dict[str, Any]] = []
+
+    if actual["status"] != "completed":
+        return {
+            "name": expected.get("name", "filesystem"),
+            "profile": PROFILE_ID,
+            "visibility": expected.get("visibility", "teacher"),
+            "passed": False,
+            "status": "failed",
+            "worker_status": actual["status"],
+            "checks": [],
+            "stdout": actual["stdout"],
+            "stderr": actual["stderr"],
+            "exception": actual.get("exception"),
+        }
+
+    for item in expected["expected_artifacts"]:
+        observed = artifacts.get(item["path"])
+        if observed is None:
+            checks.append(
+                {"path": item["path"], "kind": "required-artifact", "passed": False, "status": "missing"}
+            )
+            continue
+        passed = observed["text"] == item["text"]
+        checks.append(
+            {
+                "path": item["path"],
+                "kind": "text-content",
+                "passed": passed,
+                "status": "matched" if passed else "content-mismatch",
+            }
+        )
+
+    for path in expected["expected_absent"]:
+        absent = path not in artifacts
+        checks.append(
+            {
+                "path": path,
+                "kind": "expected-absent",
+                "passed": absent,
+                "status": "absent" if absent else "unexpected-present",
+            }
+        )
+
+    declared = {item["path"] for item in expected["expected_artifacts"]}
+    unexpected = sorted(set(artifacts) - declared)
+    if unexpected and not expected["allow_unexpected_artifacts"]:
+        for path in unexpected:
+            checks.append(
+                {"path": path, "kind": "unexpected-artifact", "passed": False, "status": "unexpected"}
+            )
+
+    passed = bool(checks) and all(check["passed"] for check in checks)
+    return {
+        "name": expected.get("name", "filesystem"),
+        "profile": PROFILE_ID,
+        "visibility": expected.get("visibility", "teacher"),
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "worker_status": actual["status"],
+        "checks": checks,
+        "stdout": actual["stdout"],
+        "stderr": actual["stderr"],
+        "exception": actual.get("exception"),
+        "observed_artifacts": sorted(artifacts),
+    }

--- a/scripts/python_filesystem_worker.py
+++ b/scripts/python_filesystem_worker.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import argparse
+from contextlib import redirect_stderr, redirect_stdout
+import hashlib
+import json
+import os
+from pathlib import Path
+import runpy
+import sys
+from typing import Any
+
+try:
+    import python_filesystem_profile as p4
+except ModuleNotFoundError:
+    from scripts import python_filesystem_profile as p4
+
+
+class FilesystemOutputLimitError(RuntimeError):
+    """Student stdout/stderr exceeded the P4 diagnostic limit."""
+
+
+class _BoundedTextCapture:
+    def __init__(self, limit: int = p4.MAX_STDIO_CHARS) -> None:
+        self.limit = limit
+        self._parts: list[str] = []
+        self._size = 0
+
+    def write(self, value: str) -> int:
+        text = str(value)
+        remaining = self.limit - self._size
+        if len(text) > remaining:
+            if remaining > 0:
+                self._parts.append(text[:remaining])
+                self._size += remaining
+            raise FilesystemOutputLimitError("stdout/stderr supera il limite P4")
+        self._parts.append(text)
+        self._size += len(text)
+        return len(text)
+
+    def flush(self) -> None:
+        return
+
+    def getvalue(self) -> str:
+        return "".join(self._parts)
+
+
+def _resolved(value: str | os.PathLike[str], *, cwd: Path) -> Path:
+    path = Path(value)
+    if not path.is_absolute():
+        path = cwd / path
+    return path.resolve(strict=False)
+
+
+def install_filesystem_audit_policy(*, workdir: Path, source: Path) -> None:
+    """Deny Python-level filesystem access outside the P4 workdir/source surface.
+
+    This complements, but does not replace, the outer Docker sandbox. P4 stable
+    promotion still requires the Docker boundary because Python audit hooks are
+    an application policy layer rather than a host security boundary.
+    """
+
+    workdir = workdir.resolve(strict=True)
+    source = source.resolve(strict=True)
+
+    def allowed_path(value: Any) -> bool:
+        if isinstance(value, int) or value is None:
+            return True
+        if isinstance(value, bytes):
+            try:
+                value = os.fsdecode(value)
+            except UnicodeDecodeError:
+                return False
+        if not isinstance(value, (str, os.PathLike)):
+            return False
+        try:
+            candidate = _resolved(value, cwd=Path.cwd())
+        except (OSError, RuntimeError, ValueError):
+            return False
+        return candidate == source or candidate == workdir or workdir in candidate.parents
+
+    def deny_external(value: Any, event: str) -> None:
+        if not allowed_path(value):
+            raise PermissionError(f"P4 filesystem policy: {event} fuori dal workdir")
+
+    def hook(event: str, args: tuple[Any, ...]) -> None:
+        if event == "open" and args:
+            deny_external(args[0], event)
+            return
+        if event in {"os.listdir", "os.scandir", "os.chdir", "os.remove", "os.rmdir", "os.mkdir"}:
+            if args:
+                deny_external(args[0], event)
+            return
+        if event in {"os.rename", "os.replace"}:
+            if len(args) >= 2:
+                deny_external(args[0], event)
+                deny_external(args[1], event)
+            return
+        if event in {"os.symlink", "os.link"}:
+            raise PermissionError("P4 filesystem policy: link non consentiti")
+        if event in {"os.system", "subprocess.Popen"}:
+            raise PermissionError("P4 filesystem policy: processi secondari non consentiti")
+        if event == "import" and args and args[0] in {"ctypes", "subprocess"}:
+            raise PermissionError(f"P4 filesystem policy: import non consentito: {args[0]}")
+
+    sys.addaudithook(hook)
+
+
+def scan_artifacts(workdir: Path, fixture_targets: set[str]) -> tuple[str | None, list[dict[str, Any]]]:
+    """Return bounded regular UTF-8 artifacts or a policy/limit status."""
+
+    artifacts: list[dict[str, Any]] = []
+    total_bytes = 0
+    try:
+        entries = sorted(workdir.iterdir(), key=lambda path: path.name)
+    except OSError:
+        return "policy-violation", []
+
+    for path in entries:
+        if path.name in fixture_targets:
+            continue
+        if path.is_symlink() or not path.is_file():
+            return "policy-violation", []
+        if len(artifacts) >= p4.MAX_OUTPUT_FILES:
+            return "output-limit", []
+        try:
+            size = path.stat().st_size
+        except OSError:
+            return "policy-violation", []
+        if size > p4.MAX_OUTPUT_FILE_BYTES:
+            return "output-limit", []
+        total_bytes += size
+        if total_bytes > p4.MAX_OUTPUT_TOTAL_BYTES:
+            return "output-limit", []
+        try:
+            raw = path.read_bytes()
+            text = raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return "policy-violation", []
+        except OSError:
+            return "policy-violation", []
+        if len(raw) != size:
+            return "policy-violation", []
+        artifacts.append(
+            {
+                "path": path.name,
+                "text": text,
+                "bytes": len(raw),
+                "sha256": hashlib.sha256(raw).hexdigest(),
+            }
+        )
+    return None, artifacts
+
+
+def execute(request_value: Any, *, source: Path, workdir: Path) -> dict[str, Any]:
+    request = p4.validate_worker_request(request_value)
+    source = source.resolve(strict=True)
+    workdir = workdir.resolve(strict=True)
+    if not source.is_file() or not workdir.is_dir():
+        raise p4.FilesystemProfileError("source/workdir P4 non validi")
+
+    fixture_targets = set(request["fixture_targets"])
+    for target in fixture_targets:
+        fixture = workdir / target
+        if fixture.is_symlink() or not fixture.is_file():
+            return {
+                "schema_version": p4.WORKER_SCHEMA,
+                "status": "policy-violation",
+                "artifacts": [],
+                "stdout": "",
+                "stderr": "fixture dichiarata assente o non regolare",
+            }
+
+    # pathlib/os/json are already loaded before the audit hook. This is enough
+    # for the deliberately small M26/P4 v1 surface without allowing arbitrary
+    # dynamic filesystem-oriented imports after confinement begins.
+    previous_cwd = Path.cwd()
+    os.chdir(workdir)
+    stdout = _BoundedTextCapture()
+    stderr = _BoundedTextCapture()
+    execution_status = "completed"
+    exception: dict[str, str] | None = None
+    try:
+        install_filesystem_audit_policy(workdir=workdir, source=source)
+        try:
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                runpy.run_path(str(source), run_name="__main__")
+        except FilesystemOutputLimitError:
+            execution_status = "output-limit"
+        except BaseException as error:
+            execution_status = "runtime-error"
+            message = str(error).replace(str(workdir), "<workdir>").replace(str(source), "<source>")
+            exception = {"type": type(error).__name__, "message": message[:512]}
+
+        scan_status, artifacts = scan_artifacts(workdir, fixture_targets)
+        if scan_status is not None:
+            execution_status = scan_status
+            artifacts = []
+        result: dict[str, Any] = {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": execution_status,
+            "artifacts": artifacts,
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+        }
+        if execution_status == "runtime-error" and exception is not None:
+            result["exception"] = exception
+        return result
+    finally:
+        # The worker process exits immediately after this call. chdir is kept
+        # best-effort because the installed audit hook intentionally rejects
+        # leaving the workdir; restoring cwd is not required for isolation.
+        _ = previous_cwd
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="TheBitLab P4 filesystem worker")
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--workdir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = json.load(sys.stdin)
+        result = execute(request, source=args.source, workdir=args.workdir)
+        result = p4.validate_worker_result(result)
+    except (OSError, json.JSONDecodeError, p4.FilesystemProfileError) as error:
+        print(
+            json.dumps(
+                {
+                    "schema_version": p4.WORKER_SCHEMA,
+                    "status": "policy-violation",
+                    "artifacts": [],
+                    "stdout": "",
+                    "stderr": str(error)[: p4.MAX_STDIO_CHARS],
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 2
+    print(json.dumps(result, ensure_ascii=False, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python_filesystem_worker.py
+++ b/scripts/python_filesystem_worker.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import os
 from pathlib import Path
-import runpy
 import sys
 from typing import Any
 
@@ -55,9 +54,12 @@ def _resolved(value: str | os.PathLike[str], *, cwd: Path) -> Path:
 def install_filesystem_audit_policy(*, workdir: Path, source: Path) -> None:
     """Deny Python-level filesystem access outside the P4 workdir/source surface.
 
-    This complements, but does not replace, the outer Docker sandbox. P4 stable
-    promotion still requires the Docker boundary because Python audit hooks are
-    an application policy layer rather than a host security boundary.
+    The student source is compiled before this hook is installed. This is
+    deliberate: importlib/runpy may read Python runtime files outside the
+    submission surface even when student code itself does not. The audit hook
+    therefore governs student execution rather than Python's own source loader.
+
+    This complements, but does not replace, the outer Docker sandbox.
     """
 
     workdir = workdir.resolve(strict=True)
@@ -171,10 +173,32 @@ def execute(request_value: Any, *, source: Path, workdir: Path) -> dict[str, Any
                 "stderr": "fixture dichiarata assente o non regolare",
             }
 
-    # pathlib/os/json are already loaded before the audit hook. This is enough
-    # for the deliberately small M26/P4 v1 surface without allowing arbitrary
-    # dynamic filesystem-oriented imports after confinement begins.
-    previous_cwd = Path.cwd()
+    # Read and compile before installing the audit hook. The source itself is
+    # trusted only as bytes to compile; execution remains fully untrusted and
+    # happens after confinement. This avoids classifying Python's own loader
+    # reads as student filesystem access.
+    try:
+        source_text = source.read_text(encoding="utf-8", errors="strict")
+        code = compile(source_text, str(source), "exec")
+    except UnicodeDecodeError as error:
+        return {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "runtime-error",
+            "artifacts": [],
+            "stdout": "",
+            "stderr": "",
+            "exception": {"type": type(error).__name__, "message": "source Python non UTF-8"},
+        }
+    except SyntaxError as error:
+        return {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "runtime-error",
+            "artifacts": [],
+            "stdout": "",
+            "stderr": "",
+            "exception": {"type": "SyntaxError", "message": str(error)[:512]},
+        }
+
     os.chdir(workdir)
     stdout = _BoundedTextCapture()
     stderr = _BoundedTextCapture()
@@ -182,9 +206,14 @@ def execute(request_value: Any, *, source: Path, workdir: Path) -> dict[str, Any
     exception: dict[str, str] | None = None
     try:
         install_filesystem_audit_policy(workdir=workdir, source=source)
+        namespace = {
+            "__name__": "__main__",
+            "__file__": str(source),
+            "__builtins__": __builtins__,
+        }
         try:
             with redirect_stdout(stdout), redirect_stderr(stderr):
-                runpy.run_path(str(source), run_name="__main__")
+                exec(code, namespace, namespace)
         except FilesystemOutputLimitError:
             execution_status = "output-limit"
         except BaseException as error:
@@ -207,10 +236,9 @@ def execute(request_value: Any, *, source: Path, workdir: Path) -> dict[str, Any
             result["exception"] = exception
         return result
     finally:
-        # The worker process exits immediately after this call. chdir is kept
-        # best-effort because the installed audit hook intentionally rejects
-        # leaving the workdir; restoring cwd is not required for isolation.
-        _ = previous_cwd
+        # Process exits after one test; audit confinement deliberately prevents
+        # restoring a cwd outside the workdir.
+        pass
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import copy
 import json
@@ -237,7 +237,7 @@ class DockerGradeActivityExecutionService:
     """ExecutionService adapter backed by the authoritative Docker runner."""
 
     def run(self, request: ExecutionRequest) -> ExecutionResult:
-        """Run grade_activity in Docker and normalize infrastructure failures."""
+        """Dispatch authoritative Docker grading to P4 or the legacy runner."""
 
         from scripts import grade_activity
 
@@ -250,14 +250,46 @@ class DockerGradeActivityExecutionService:
                 detail="ExecutionRequest.metadata deve includere activity_path e source_path.",
             )
 
+        activity_file = Path(str(activity_path))
+        source_file = Path(str(source_path))
         try:
-            report, worker_stderr = grade_activity.grade_activity_in_docker(
-                Path(str(activity_path)),
-                Path(str(source_path)),
-                timeout_seconds=request.timeout_seconds,
-                language=request.language,
-                image=docker_image,
+            activity = grade_activity.load_activity(activity_file)
+        except (OSError, json.JSONDecodeError):
+            # Preserve the historical adapter contract: the legacy Docker grader
+            # remains authoritative for its own loading/setup errors.
+            activity = None
+
+        uses_filesystem_profile = isinstance(activity, dict) and "filesystem_tests" in activity
+        requested_language = str(request.language or "").strip().lower()
+        if uses_filesystem_profile and requested_language not in {"python", "py"}:
+            return ExecutionResult(
+                status="invalid_payload",
+                detail="filesystem_tests richiede una ExecutionRequest Python.",
             )
+
+        try:
+            if uses_filesystem_profile:
+                from scripts import grade_python_filesystem_activity
+
+                report = grade_python_filesystem_activity.grade_in_docker(
+                    activity_path=activity_file,
+                    source_path=source_file,
+                    image=docker_image,
+                    timeout_seconds=request.timeout_seconds,
+                    activity_root=activity_file.parent,
+                    source_root=source_file.parent,
+                )
+                worker_stderr = ""
+                grading_profile = str(report.get("profile") or "python-filesystem-v1")
+            else:
+                report, worker_stderr = grade_activity.grade_activity_in_docker(
+                    activity_file,
+                    source_file,
+                    timeout_seconds=request.timeout_seconds,
+                    language=request.language,
+                    image=docker_image,
+                )
+                grading_profile = "legacy"
         except subprocess.TimeoutExpired as error:
             return ExecutionResult(
                 status="timeout",
@@ -285,6 +317,7 @@ class DockerGradeActivityExecutionService:
             metadata={
                 "backend": "docker",
                 "docker_image": docker_image,
+                "grading_profile": grading_profile,
                 "runner_report": copy.deepcopy(report),
                 "worker_stderr": str(worker_stderr or ""),
             },

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from scripts import python_filesystem_profile
 from scripts.thebitlab_contracts import ALLOWED_ACTIVITY_KINDS
 from scripts.thebitlab_runtime_contracts import validate_runtime_extension
 
@@ -116,6 +117,19 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
     assets = data.get("assets")
     if assets is not None:
         errors.extend(validate_assets(assets, source))
+
+    filesystem_tests = data.get("filesystem_tests")
+    if filesystem_tests is not None:
+        language = str(data.get("language") or data.get("linguaggio") or "").strip().lower()
+        if language and language not in {"python", "py"}:
+            errors.append(f"{source}: filesystem_tests e supportato solo per Activity Python")
+        try:
+            python_filesystem_profile.validate_filesystem_tests(
+                filesystem_tests,
+                source="filesystem_tests",
+            )
+        except python_filesystem_profile.FilesystemProfileError as error:
+            errors.append(f"{source}: {error}")
 
     errors.extend(validate_runtime_extension(data, source))
     return errors

--- a/tests/test_python_filesystem_profile.py
+++ b/tests/test_python_filesystem_profile.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts import python_filesystem_profile as p4
+
+
+def valid_test() -> dict:
+    return {
+        "profile": p4.PROFILE_ID,
+        "name": "somma misure",
+        "fixtures": [
+            {
+                "id": "input",
+                "source": "fixtures/misure.txt",
+                "target": "misure.txt",
+                "mode": "read-only",
+            }
+        ],
+        "expected_artifacts": [
+            {"path": "risultato.txt", "text": "36\n", "encoding": "utf-8"}
+        ],
+    }
+
+
+def test_teacher_contract_and_worker_request_hide_expected_content() -> None:
+    test = p4.validate_filesystem_test(valid_test())
+    assert test["fixtures"][0]["source"] == "fixtures/misure.txt"
+    assert test["expected_artifacts"][0]["text"] == "36\n"
+
+    request = p4.worker_request(valid_test())
+    assert request == {
+        "schema_version": p4.WORKER_SCHEMA,
+        "fixture_targets": ["misure.txt"],
+    }
+    serialized = repr(request)
+    assert "36" not in serialized
+    assert "expected" not in serialized
+    assert "fixtures/misure.txt" not in serialized
+
+
+def test_newline_normalization_is_explicit_but_trailing_newline_is_semantic() -> None:
+    expected = valid_test()
+    expected["expected_artifacts"][0]["text"] = "a\r\nb\r\n"
+    result = p4.compare_worker_result(
+        expected,
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [
+                {
+                    "path": "risultato.txt",
+                    "text": "a\nb\n",
+                    "bytes": 4,
+                    "sha256": p4.text_sha256("a\nb\n"),
+                }
+            ],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is True
+
+    no_trailing = p4.compare_worker_result(
+        expected,
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [
+                {
+                    "path": "risultato.txt",
+                    "text": "a\nb",
+                    "bytes": 3,
+                    "sha256": p4.text_sha256("a\nb"),
+                }
+            ],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert no_trailing["passed"] is False
+    assert no_trailing["checks"][0]["status"] == "content-mismatch"
+
+
+def test_missing_and_unexpected_artifacts_fail_closed() -> None:
+    missing = p4.compare_worker_result(
+        valid_test(),
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert missing["passed"] is False
+    assert missing["checks"][0]["status"] == "missing"
+
+    unexpected_text = "extra\n"
+    unexpected = p4.compare_worker_result(
+        valid_test(),
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [
+                {
+                    "path": "risultato.txt",
+                    "text": "36\n",
+                    "bytes": 3,
+                    "sha256": p4.text_sha256("36\n"),
+                },
+                {
+                    "path": "debug.txt",
+                    "text": unexpected_text,
+                    "bytes": len(unexpected_text.encode("utf-8")),
+                    "sha256": p4.text_sha256(unexpected_text),
+                },
+            ],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert unexpected["passed"] is False
+    assert any(check["kind"] == "unexpected-artifact" for check in unexpected["checks"])
+
+
+def test_expected_absence_is_part_of_the_contract() -> None:
+    test = valid_test()
+    test["expected_absent"] = ["errore.txt"]
+    result = p4.compare_worker_result(
+        test,
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [
+                {
+                    "path": "risultato.txt",
+                    "text": "36\n",
+                    "bytes": 3,
+                    "sha256": p4.text_sha256("36\n"),
+                }
+            ],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is True
+
+
+def test_runtime_error_is_reported_as_student_behavior_not_platform_pass() -> None:
+    result = p4.compare_worker_result(
+        valid_test(),
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "runtime-error",
+            "artifacts": [],
+            "stdout": "",
+            "stderr": "",
+            "exception": {"type": "FileNotFoundError", "message": "misure.txt"},
+        },
+    )
+    assert result["passed"] is False
+    assert result["worker_status"] == "runtime-error"
+    assert result["exception"]["type"] == "FileNotFoundError"
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    ["../secret.txt", "/etc/passwd", "subdir/out.txt", "subdir\\out.txt", ".."],
+)
+def test_output_and_fixture_targets_reject_traversal_and_directory_trees(bad_path: str) -> None:
+    test = valid_test()
+    test["expected_artifacts"][0]["path"] = bad_path
+    with pytest.raises(p4.FilesystemProfileError):
+        p4.validate_filesystem_test(test)
+
+    test = valid_test()
+    test["fixtures"][0]["target"] = bad_path
+    with pytest.raises(p4.FilesystemProfileError):
+        p4.validate_filesystem_test(test)
+
+
+def test_fixture_source_may_be_nested_but_must_stay_inside_activity_bundle() -> None:
+    assert p4.safe_bundle_path("fixtures/dati/misure.txt") == "fixtures/dati/misure.txt"
+    for bad in ("../misure.txt", "/tmp/misure.txt", "fixtures\\misure.txt"):
+        with pytest.raises(p4.FilesystemProfileError):
+            p4.safe_bundle_path(bad)
+
+
+def test_fixture_expected_output_and_absence_roles_cannot_collide() -> None:
+    test = valid_test()
+    test["expected_artifacts"][0]["path"] = "misure.txt"
+    with pytest.raises(p4.FilesystemProfileError, match="ruoli incompatibili"):
+        p4.validate_filesystem_test(test)
+
+
+def test_unknown_fields_and_mutable_fixture_modes_fail_closed() -> None:
+    test = valid_test()
+    test["magic"] = True
+    with pytest.raises(p4.FilesystemProfileError, match="campi non supportati"):
+        p4.validate_filesystem_test(test)
+
+    test = valid_test()
+    test["fixtures"][0]["mode"] = "writable"
+    with pytest.raises(p4.FilesystemProfileError, match="read-only"):
+        p4.validate_filesystem_test(test)
+
+
+def test_worker_result_digest_size_and_limits_are_validated() -> None:
+    with pytest.raises(p4.FilesystemProfileError):
+        p4.validate_worker_result(
+            {
+                "schema_version": p4.WORKER_SCHEMA,
+                "status": "completed",
+                "artifacts": [
+                    {
+                        "path": "x.txt",
+                        "text": "abc",
+                        "bytes": 2,
+                        "sha256": p4.text_sha256("abc"),
+                    }
+                ],
+                "stdout": "",
+                "stderr": "",
+            }
+        )
+
+    with pytest.raises(p4.FilesystemProfileError):
+        p4.validate_worker_result(
+            {
+                "schema_version": p4.WORKER_SCHEMA,
+                "status": "completed",
+                "artifacts": [
+                    {
+                        "path": "x.txt",
+                        "text": "abc",
+                        "bytes": 3,
+                        "sha256": "0" * 64,
+                    }
+                ],
+                "stdout": "",
+                "stderr": "",
+            }
+        )

--- a/tests/test_python_filesystem_profile_dispatch.py
+++ b/tests/test_python_filesystem_profile_dispatch.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.thebitlab_technical_services import (
+    DockerGradeActivityExecutionService,
+    ExecutionRequest,
+)
+
+
+def p4_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p4-dispatch-001",
+        "titolo": "P4 dispatch",
+        "tipo": "laboratorio",
+        "difficolta": "B",
+        "argomenti": ["file"],
+        "consegna": "Crea risultato.txt.",
+        "language": "python",
+        "linguaggio": "python",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 10,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "filesystem_tests": [
+            {
+                "profile": "python-filesystem-v1",
+                "name": "output",
+                "expected_artifacts": [
+                    {"path": "risultato.txt", "text": "ok\n", "encoding": "utf-8"}
+                ],
+            }
+        ],
+    }
+
+
+def request(activity_path: Path, source_path: Path, *, language: str = "python") -> ExecutionRequest:
+    return ExecutionRequest(
+        activity_id="python-p4-dispatch-001",
+        student_id="student",
+        files={"main.py": str(source_path)},
+        language=language,
+        timeout_seconds=4,
+        metadata={
+            "activity_path": activity_path,
+            "source_path": source_path,
+            "docker_image": "runner:test",
+        },
+    )
+
+
+def test_docker_service_dispatches_filesystem_tests_to_p4(monkeypatch, tmp_path: Path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(json.dumps(p4_activity()), encoding="utf-8")
+    source_path.write_text("pass\n", encoding="utf-8")
+
+    from scripts import grade_activity, grade_python_filesystem_activity
+
+    legacy_called = False
+
+    def fake_legacy(*args, **kwargs):
+        nonlocal legacy_called
+        legacy_called = True
+        raise AssertionError("legacy grader must not run for filesystem_tests")
+
+    def fake_p4(**kwargs):
+        assert kwargs["activity_path"] == activity_path
+        assert kwargs["source_path"] == source_path
+        assert kwargs["image"] == "runner:test"
+        assert kwargs["timeout_seconds"] == 4
+        assert kwargs["activity_root"] == tmp_path
+        assert kwargs["source_root"] == tmp_path
+        return {
+            "activity_id": "python-p4-dispatch-001",
+            "language": "python",
+            "profile": "python-filesystem-v1",
+            "passed": True,
+            "status": "passed",
+            "tests": [
+                {
+                    "name": "output",
+                    "profile": "python-filesystem-v1",
+                    "visibility": "teacher",
+                    "passed": True,
+                    "status": "passed",
+                    "worker_status": "completed",
+                    "checks": [],
+                }
+            ],
+            "summary": {"passed": 1, "total": 1},
+        }
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", fake_legacy)
+    monkeypatch.setattr(grade_python_filesystem_activity, "grade_in_docker", fake_p4)
+
+    result = DockerGradeActivityExecutionService().run(request(activity_path, source_path))
+
+    assert legacy_called is False
+    assert result.status == "passed"
+    assert result.metadata["grading_profile"] == "python-filesystem-v1"
+    assert result.metadata["docker_image"] == "runner:test"
+    assert result.metadata["runner_report"]["profile"] == "python-filesystem-v1"
+
+
+def test_docker_service_rejects_filesystem_profile_for_non_python_request(tmp_path: Path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(json.dumps(p4_activity()), encoding="utf-8")
+    source_path.write_text("pass\n", encoding="utf-8")
+
+    result = DockerGradeActivityExecutionService().run(
+        request(activity_path, source_path, language="c")
+    )
+
+    assert result.status == "invalid_payload"
+    assert "filesystem_tests" in result.detail
+    assert "Python" in result.detail
+
+
+def test_docker_service_keeps_legacy_path_without_filesystem_tests(monkeypatch, tmp_path: Path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    legacy_activity = p4_activity()
+    legacy_activity.pop("filesystem_tests")
+    activity_path.write_text(json.dumps(legacy_activity), encoding="utf-8")
+    source_path.write_text("print('ok')\n", encoding="utf-8")
+
+    from scripts import grade_activity
+
+    def fake_legacy(activity, source, *, timeout_seconds, language, image):
+        assert activity == activity_path
+        assert source == source_path
+        assert timeout_seconds == 4
+        assert language == "python"
+        assert image == "runner:test"
+        return (
+            {
+                "activity_id": "python-p4-dispatch-001",
+                "language": "python",
+                "passed": True,
+                "status": "passed",
+                "tests": [{"name": "legacy", "passed": True, "status": "passed"}],
+                "summary": {"passed": 1, "total": 1},
+            },
+            "",
+        )
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", fake_legacy)
+    result = DockerGradeActivityExecutionService().run(request(activity_path, source_path))
+
+    assert result.status == "passed"
+    assert result.metadata["grading_profile"] == "legacy"

--- a/tests/test_python_filesystem_student_lab_docker.py
+++ b/tests/test_python_filesystem_student_lab_docker.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts import student_lab_runner
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1",
+    reason="set THEBITLAB_RUN_DOCKER_TESTS=1 to exercise the Docker sandbox",
+)
+
+
+def activity_payload() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p4-student-lab-001",
+        "title": "Persistenza nel percorso Student Lab",
+        "titolo": "Persistenza nel percorso Student Lab",
+        "kind": "laboratorio",
+        "tipo": "laboratorio",
+        "language": "python",
+        "linguaggio": "python",
+        "source_name": "main.py",
+        "difficulty": "B",
+        "difficolta": "B",
+        "topics": ["file", "pathlib"],
+        "argomenti": ["file", "pathlib"],
+        "instructions": "Leggi misure.txt e crea risultato.txt.",
+        "consegna": "Leggi misure.txt e crea risultato.txt.",
+        "grading_policy": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 10,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "filesystem_tests": [
+            {
+                "profile": "python-filesystem-v1",
+                "name": "oracle docente totale 36",
+                "fixtures": [
+                    {
+                        "id": "misure",
+                        "source": "fixtures/misure.txt",
+                        "target": "misure.txt",
+                        "mode": "read-only",
+                    }
+                ],
+                "expected_artifacts": [
+                    {
+                        "path": "risultato.txt",
+                        "text": "36\n",
+                        "encoding": "utf-8",
+                    }
+                ],
+                "visibility": "teacher",
+            }
+        ],
+    }
+
+
+def assignment_payload() -> dict:
+    return {
+        "assignment_id": "assignment-python-p4-student-lab",
+        "activity_id": "python-p4-student-lab-001",
+        "student_id": "rossi-mario",
+        "activity": {"path": "activities/python-p4-student-lab-001/activity.json"},
+        "workspace": {
+            "path": "students/rossi-mario/assignments/python-p4-student-lab-001"
+        },
+    }
+
+
+def test_p4_runs_through_normal_student_lab_and_redacts_teacher_oracles(tmp_path: Path) -> None:
+    activity_root = tmp_path / "activities" / "python-p4-student-lab-001"
+    fixtures = activity_root / "fixtures"
+    fixtures.mkdir(parents=True)
+    (fixtures / "misure.txt").write_text("12\n15\n9\n", encoding="utf-8")
+    (activity_root / "activity.json").write_text(
+        json.dumps(activity_payload()),
+        encoding="utf-8",
+    )
+
+    workspace = (
+        tmp_path
+        / "students"
+        / "rossi-mario"
+        / "assignments"
+        / "python-p4-student-lab-001"
+    )
+    workspace.mkdir(parents=True)
+    (workspace / "main.py").write_text(
+        "from pathlib import Path\n"
+        "values = [int(x) for x in Path('misure.txt').read_text(encoding='utf-8').splitlines()]\n"
+        "Path('risultato.txt').write_text(f'{sum(values)}\\n', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+
+    image = os.environ.get("THEBITLAB_P4_DOCKER_IMAGE", "thebitlab-p4-candidate")
+    report = student_lab_runner.run_docker_assignment(
+        assignment_payload(),
+        root=tmp_path,
+        timeout_seconds=3,
+        docker_image=image,
+    )
+
+    assert report["backend"] == "docker"
+    assert report["passed"] is True
+    assert report["status"] == "passed"
+    assert report["profile"] == "python-filesystem-v1"
+    assert report["summary"] == {"passed": 1, "total": 1}
+    assert report["tests"] == [
+        {"name": "Test 1", "passed": True, "status": "passed"}
+    ]
+
+    serialized = json.dumps(report, ensure_ascii=False).casefold()
+    for forbidden in (
+        "oracle docente totale 36",
+        "worker_status",
+        "observed_artifacts",
+        "checks",
+        "fixtures/misure.txt",
+        "expected_artifacts",
+        '"36\\n"',
+    ):
+        assert forbidden not in serialized

--- a/tests/test_python_filesystem_worker.py
+++ b/tests/test_python_filesystem_worker.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from scripts import python_filesystem_profile as p4
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKER = ROOT / "scripts" / "python_filesystem_worker.py"
+
+
+def run_worker(tmp_path: Path, source_text: str, *, fixtures: dict[str, str] | None = None) -> tuple[int, dict]:
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    fixture_targets = []
+    for name, text in (fixtures or {}).items():
+        (workdir / name).write_text(text, encoding="utf-8")
+        fixture_targets.append(name)
+    source = tmp_path / "main.py"
+    source.write_text(source_text, encoding="utf-8")
+    request = {
+        "schema_version": p4.WORKER_SCHEMA,
+        "fixture_targets": fixture_targets,
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WORKER),
+            "--source",
+            str(source),
+            "--workdir",
+            str(workdir),
+        ],
+        input=json.dumps(request),
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    return result.returncode, json.loads(result.stdout)
+
+
+def test_worker_executes_in_workdir_and_returns_text_artifact(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\n"
+        "values = [int(x) for x in Path('misure.txt').read_text(encoding='utf-8').splitlines()]\n"
+        "Path('risultato.txt').write_text(str(sum(values)) + '\\n', encoding='utf-8')\n",
+        fixtures={"misure.txt": "12\n15\n9\n"},
+    )
+    assert code == 0
+    assert report["status"] == "completed"
+    assert report["artifacts"] == [
+        {
+            "path": "risultato.txt",
+            "text": "36\n",
+            "bytes": 3,
+            "sha256": p4.text_sha256("36\n"),
+        }
+    ]
+    assert "misure.txt" not in {item["path"] for item in report["artifacts"]}
+
+
+def test_worker_reports_student_filenotfounderror(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('manca.txt').read_text(encoding='utf-8')\n",
+    )
+    assert code == 0
+    assert report["status"] == "runtime-error"
+    assert report["exception"]["type"] == "FileNotFoundError"
+    assert report["artifacts"] == []
+
+
+def test_worker_blocks_absolute_read_outside_workdir(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('/etc/passwd').read_text(encoding='utf-8')\n",
+    )
+    assert code == 0
+    assert report["status"] == "runtime-error"
+    assert report["exception"]["type"] == "PermissionError"
+    assert "fuori dal workdir" in report["exception"]["message"]
+
+
+def test_worker_blocks_parent_traversal(tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("teacher secret", encoding="utf-8")
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('../secret.txt').read_text(encoding='utf-8')\n",
+    )
+    assert code == 0
+    assert report["status"] == "runtime-error"
+    assert report["exception"]["type"] == "PermissionError"
+    assert "teacher secret" not in json.dumps(report)
+
+
+def test_worker_rejects_symlink_creation(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('escape').symlink_to('/etc/passwd')\n",
+    )
+    assert code == 0
+    assert report["status"] == "runtime-error"
+    assert report["exception"]["type"] == "PermissionError"
+
+
+def test_worker_rejects_subdirectories_in_v1(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('nested').mkdir()\n",
+    )
+    assert code == 0
+    assert report["status"] == "policy-violation"
+    assert report["artifacts"] == []
+
+
+def test_worker_enforces_output_file_byte_limit(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('big.txt').write_text('x' * 70000, encoding='utf-8')\n",
+    )
+    assert code == 0
+    assert report["status"] == "output-limit"
+    assert report["artifacts"] == []
+
+
+def test_worker_requires_declared_fixture_target_to_exist(tmp_path: Path) -> None:
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    source = tmp_path / "main.py"
+    source.write_text("pass\n", encoding="utf-8")
+    request = {
+        "schema_version": p4.WORKER_SCHEMA,
+        "fixture_targets": ["misure.txt"],
+    }
+    result = subprocess.run(
+        [sys.executable, str(WORKER), "--source", str(source), "--workdir", str(workdir)],
+        input=json.dumps(request),
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    report = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert report["status"] == "policy-violation"

--- a/tests/test_validate_activity_filesystem_profile.py
+++ b/tests/test_validate_activity_filesystem_profile.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from scripts import create_submission_scaffold, validate_activity
+
+
+def p4_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p4-files-001",
+        "titolo": "Somma misure da file",
+        "tipo": "laboratorio",
+        "difficolta": "B",
+        "argomenti": ["file", "pathlib"],
+        "consegna": "Leggi misure.txt e crea risultato.txt.",
+        "language": "python",
+        "linguaggio": "python",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "filesystem_tests": [
+            {
+                "profile": "python-filesystem-v1",
+                "name": "somma base",
+                "fixtures": [
+                    {
+                        "id": "input",
+                        "source": "fixtures/misure.txt",
+                        "target": "misure.txt",
+                        "mode": "read-only",
+                    }
+                ],
+                "expected_artifacts": [
+                    {
+                        "path": "risultato.txt",
+                        "text": "36\n",
+                        "encoding": "utf-8",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_activity_validator_accepts_p4_contract() -> None:
+    assert validate_activity.validate_activity(p4_activity(), "activity.json") == []
+
+
+def test_activity_validator_rejects_p4_on_non_python_activity() -> None:
+    activity = p4_activity()
+    activity["language"] = "c"
+    activity["linguaggio"] = "c"
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("filesystem_tests" in error and "Python" in error for error in errors)
+
+
+def test_activity_validator_rejects_teacher_contract_errors() -> None:
+    activity = p4_activity()
+    activity["filesystem_tests"][0]["expected_artifacts"][0]["path"] = "../out.txt"
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("expected_artifacts" in error for error in errors)
+
+
+def test_student_activity_payload_redacts_filesystem_tests_and_fixture_source() -> None:
+    public = create_submission_scaffold.student_activity_payload(p4_activity())
+    assert "filesystem_tests" not in public
+    serialized = repr(public).casefold()
+    assert "fixtures/misure.txt" not in serialized
+    assert "risultato.txt" not in serialized
+    assert "36" not in serialized

--- a/tests/test_validate_activity_filesystem_profile.py
+++ b/tests/test_validate_activity_filesystem_profile.py
@@ -70,10 +70,13 @@ def test_activity_validator_rejects_teacher_contract_errors() -> None:
     assert any("expected_artifacts" in error for error in errors)
 
 
-def test_student_activity_payload_redacts_filesystem_tests_and_fixture_source() -> None:
+def test_student_activity_payload_redacts_filesystem_teacher_contract() -> None:
     public = create_submission_scaffold.student_activity_payload(p4_activity())
     assert "filesystem_tests" not in public
     serialized = repr(public).casefold()
     assert "fixtures/misure.txt" not in serialized
-    assert "risultato.txt" not in serialized
-    assert "36" not in serialized
+    assert "expected_artifacts" not in serialized
+    assert "36\\n" not in serialized
+    # The requested output filename is intentionally public because it is part
+    # of the student-facing assignment text, not a grading oracle.
+    assert "risultato.txt" in serialized


### PR DESCRIPTION
Implements the candidate `python-filesystem-v1` profile for #757 and proves it through the normal Student Lab Docker path plus a real `python-docente` M26 consumer.

**Keep this PR DRAFT. P4 is functionally proven but is not a stable toolchain release yet. Do not mass-materialize filesystem Activities until the unified immutable runner release is decided.**

## Integrated candidate

```text
head family: fb3cf4b923f776dd2c57cca73126d906541531bd
profile: python-filesystem-v1
worker schema: thebitlab.python-filesystem-worker.v1
```

## Implemented

- versioned teacher-side `filesystem_tests` contract;
- strict Activity validation;
- declared read-only teacher fixtures;
- teacher expected UTF-8 artifacts / expected absence remain host-side;
- worker request contains fixture target names only, not expected contents;
- explicit LF newline normalization without stripping semantic whitespace/newline;
- root-level portable workdir filenames for v1;
- traversal, absolute paths, symlinks and directory trees rejected;
- duplicate/colliding fixture/output/absence roles rejected;
- strict fixture/output count and byte limits;
- clean bounded tmpfs workdir per test;
- read-only fixture bind mounts and mutation protection;
- regular-file-only output manifest with UTF-8 text, bytes and SHA-256;
- student FileNotFoundError retained as student runtime behavior;
- external reads such as `/etc/passwd` denied;
- output-limit and timeout fail closed;
- hardened assignment-runner Docker boundary reused;
- canonical `DockerGradeActivityExecutionService` dispatches Activities with `filesystem_tests` to P4;
- non-Python filesystem requests fail closed;
- Activities without `filesystem_tests` retain the legacy Docker path;
- normal `student_lab_runner.run_docker_assignment()` path is exercised with real Docker;
- student scaffold omits `filesystem_tests` and teacher fixture sources;
- hidden P4 test results are redacted to generic student-visible test outcome before persistence.

## Limits v1

```text
max tests              32
max fixtures/test       8
max fixture file       64 KiB
max fixture total     256 KiB
max output files       16
max output file        64 KiB
max output total      256 KiB
UTF-8 text only
```

## Platform evidence

```text
Python filesystem profile P4 candidate
run 33258370195 / #8
SUCCESS

Python filesystem P4 Student Lab integration
run 33258370237 / #1
SUCCESS

Build assignment runner Docker image
run 33258370210 / #1031
SUCCESS

Quality
run 33258370217 / #1868
SUCCESS
```

Quality includes Python, minimum supported Python, Windows filesystem and Mermaid jobs. Existing runner/template/uTUI regressions remain green.

## Real course consumer

`TheBitPoets/python-docente` contains exactly one P4 canary:

```text
py2-activity-b-file-risultato-001
M26 / PY2-09
controlled change: print(total) -> write risultato.txt
```

Current end-to-end evidence:

```text
workflow: Python M26 P4 canary
run: 33258589185 / #4
SUCCESS
platform pin: fb3cf4b923f776dd2c57cca73126d906541531bd
```

The consumer uses the normal `student_lab_runner.run_docker_assignment()` path.

Behavioral oracle:

```text
solution -> risultato.txt created -> 1/1 PASS
starter  -> correct total printed but result file absent -> 0/1 FAIL
```

The scaffold has a separate public sample fixture (`2\n3\n`) while grading uses the teacher fixture (`12\n15\n9\n`), so the exercise cannot pass by reproducing the sample output.

## Trust boundary

```text
teacher filesystem_tests + fixture source + expected artifact
        |
        | fixture target names only
        v
hardened P4 Docker worker
        |
        | bounded observed file manifest
        v
trusted host comparison
        |
        v
teacher report -> student redaction
```

## Still required before #757 / stable promotion

P4 has no known functional blocker on its current branch, but release governance is deliberately unresolved:

1. P4 currently inherits the old `2026.07.1` runner identity, while P2 has a separate `2026.08.1` release candidate;
2. unify the P2 and P4 changes into one reviewed assignment-runner source/toolchain rather than publishing competing identities;
3. run the combined P1/P2/P4 + C/Node/SQLite + Student Lab regression suite;
4. assign/publish one new immutable toolchain release and digest;
5. repin `python-docente` from the P4 candidate SHA to that stable source/toolchain;
6. only then allow broader P4 Activity materialization and decide #757 closure.

## Non-goals v1

- arbitrary directory trees;
- binary/media files;
- databases;
- network storage;
- multi-process services;
- replacing manual/rubric evidence where filesystem semantics are not deterministic;
- classroom-ready or Content Pack approval claims.