### PR TITLE
[Landed via #770] Combined P2 + P3 + P4 toolchain 2026.08.3 candidate

### DIFF
--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -16,6 +16,9 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/python_object_profile.py"
+      - "scripts/python_object_worker.py"
+      - "scripts/grade_python_object_activity.py"
       - "scripts/python_filesystem_profile.py"
       - "scripts/python_filesystem_worker.py"
       - "scripts/grade_python_filesystem_activity.py"
@@ -29,6 +32,11 @@ on:
       - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_python_object_profile.py"
+      - "tests/test_python_object_worker.py"
+      - "tests/test_python_object_profile_dispatch.py"
+      - "tests/test_python_object_student_lab_docker.py"
+      - "tests/test_validate_activity_object_profile.py"
       - "tests/test_python_filesystem_profile.py"
       - "tests/test_python_filesystem_worker.py"
       - "tests/test_python_filesystem_profile_dispatch.py"
@@ -48,6 +56,9 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/python_object_profile.py"
+      - "scripts/python_object_worker.py"
+      - "scripts/grade_python_object_activity.py"
       - "scripts/python_filesystem_profile.py"
       - "scripts/python_filesystem_worker.py"
       - "scripts/grade_python_filesystem_activity.py"
@@ -61,6 +72,11 @@ on:
       - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_python_object_profile.py"
+      - "tests/test_python_object_worker.py"
+      - "tests/test_python_object_profile_dispatch.py"
+      - "tests/test_python_object_student_lab_docker.py"
+      - "tests/test_validate_activity_object_profile.py"
       - "tests/test_python_filesystem_profile.py"
       - "tests/test_python_filesystem_worker.py"
       - "tests/test_python_filesystem_profile_dispatch.py"
@@ -75,7 +91,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     outputs:
       image_id: ${{ steps.image-digest.outputs.image_id }}
     steps:
@@ -87,7 +103,7 @@ jobs:
       - name: Install validation dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Validate combined P2 P4 contracts dispatch and release identity
+      - name: Validate combined P2 P3 P4 contracts dispatch and release identity
         run: >-
           python -m pytest -q
           tests/test_build_assignment_runner.py
@@ -97,6 +113,10 @@ jobs:
           tests/test_python_function_worker.py
           tests/test_python_function_profile_dispatch.py
           tests/test_validate_activity_function_profile.py
+          tests/test_python_object_profile.py
+          tests/test_python_object_worker.py
+          tests/test_python_object_profile_dispatch.py
+          tests/test_validate_activity_object_profile.py
           tests/test_python_filesystem_profile.py
           tests/test_python_filesystem_worker.py
           tests/test_python_filesystem_profile_dispatch.py
@@ -119,7 +139,7 @@ jobs:
           metadata = json.loads(
               Path(os.environ["RUNNER_TEMP"], "toolchain-build.json").read_text(encoding="utf-8")
           )
-          assert metadata["version"] == "2026.08.2"
+          assert metadata["version"] == "2026.08.3"
           assert metadata["source_revision"] == os.environ["GITHUB_SHA"]
           print(f"image_id={metadata['local_image_id']}")
           PY
@@ -149,6 +169,12 @@ jobs:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
           THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-assignment-runner"
         run: python -m pytest -q tests/test_python_function_student_lab_docker.py
+
+      - name: Exercise P3 through normal Student Lab Docker dispatch
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P3_DOCKER_IMAGE: "thebitlab-assignment-runner"
+        run: python -m pytest -q tests/test_python_object_student_lab_docker.py
 
       - name: Exercise P4 through normal Student Lab Docker dispatch
         env:

--- a/.github/workflows/python-grading-profiles.yml
+++ b/.github/workflows/python-grading-profiles.yml
@@ -12,6 +12,9 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/python_object_profile.py"
+      - "scripts/python_object_worker.py"
+      - "scripts/grade_python_object_activity.py"
       - "scripts/python_filesystem_profile.py"
       - "scripts/python_filesystem_worker.py"
       - "scripts/grade_python_filesystem_activity.py"
@@ -25,6 +28,11 @@ on:
       - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_python_object_profile.py"
+      - "tests/test_python_object_worker.py"
+      - "tests/test_python_object_profile_dispatch.py"
+      - "tests/test_python_object_student_lab_docker.py"
+      - "tests/test_validate_activity_object_profile.py"
       - "tests/test_python_filesystem_profile.py"
       - "tests/test_python_filesystem_worker.py"
       - "tests/test_python_filesystem_profile_dispatch.py"
@@ -36,7 +44,7 @@ on:
 jobs:
   combined-python-grading:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     steps:
       - name: Checkout combined candidate
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -51,7 +59,7 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Validate combined contracts and release identity
+      - name: Validate combined P2 P3 P4 contracts and release identity
         run: >-
           python -m pytest -q
           tests/test_build_assignment_runner.py
@@ -61,6 +69,10 @@ jobs:
           tests/test_python_function_worker.py
           tests/test_python_function_profile_dispatch.py
           tests/test_validate_activity_function_profile.py
+          tests/test_python_object_profile.py
+          tests/test_python_object_worker.py
+          tests/test_python_object_profile_dispatch.py
+          tests/test_validate_activity_object_profile.py
           tests/test_python_filesystem_profile.py
           tests/test_python_filesystem_worker.py
           tests/test_python_filesystem_profile_dispatch.py
@@ -84,7 +96,7 @@ jobs:
           metadata = json.loads(
               (Path(os.environ["RUNNER_TEMP"]) / "python-grading-toolchain.json").read_text(encoding="utf-8")
           )
-          assert metadata["version"] == "2026.08.2"
+          assert metadata["version"] == "2026.08.3"
           assert metadata["source_revision"] == os.environ["GITHUB_SHA"]
           assert metadata["platform"] == "linux/amd64"
           assert metadata["local_tag"] == "thebitlab-assignment-runner"
@@ -93,10 +105,12 @@ jobs:
           import sys
           sys.path.insert(0, "/opt/thebitlab")
           import python_function_profile as p2
+          import python_object_profile as p3
           import python_filesystem_profile as p4
           assert p2.PROFILE_ID == "python-function-v1"
+          assert p3.PROFILE_ID == "python-object-v1"
           assert p4.PROFILE_ID == "python-filesystem-v1"
-          print("PASS: combined runner contains P2 and P4 profiles")
+          print("PASS: combined runner contains P2, P3 and P4 profiles")
           PY
 
       - name: Exercise legacy P1 C Node SQLite Student Lab regressions
@@ -109,6 +123,12 @@ jobs:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
           THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-assignment-runner"
         run: python -m pytest -q tests/test_python_function_student_lab_docker.py
+
+      - name: Exercise P3 through the same combined runner
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P3_DOCKER_IMAGE: "thebitlab-assignment-runner"
+        run: python -m pytest -q tests/test_python_object_student_lab_docker.py
 
       - name: Exercise P4 through the same combined runner
         env:

--- a/docker/assignment-runner/toolchain.json
+++ b/docker/assignment-runner/toolchain.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "thebitlab.grading-toolchain-build.v1",
-  "version": "2026.08.2",
+  "version": "2026.08.3",
   "platform": "linux/amd64",
   "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
   "worker_schema_version": "thebitlab.grading-worker.v1",

--- a/tests/test_build_assignment_runner.py
+++ b/tests/test_build_assignment_runner.py
@@ -19,7 +19,7 @@ def manifest() -> dict:
 def test_checked_in_toolchain_manifest_is_strict_and_immutable() -> None:
     payload = manifest()
 
-    assert payload["version"] == "2026.08.2"
+    assert payload["version"] == "2026.08.3"
     assert payload["platform"] == "linux/amd64"
     assert payload["image_repository"] == builder.IMAGE_REPOSITORY
     assert payload["base_image"].startswith("debian:bookworm-slim@sha256:")

--- a/tests/test_p2_release_candidate.py
+++ b/tests/test_p2_release_candidate.py
@@ -17,16 +17,16 @@ def load(path: Path) -> dict:
     return value
 
 
-def test_combined_build_candidate_has_new_version_without_faking_published_lock() -> None:
+def test_combined_p2_p3_p4_candidate_has_distinct_version_without_faking_published_lock() -> None:
     manifest = load(MANIFEST)
     lock = load(LOCK)
 
-    assert manifest["version"] == "2026.08.2"
+    assert manifest["version"] == "2026.08.3"
     assert manifest["platform"] == "linux/amd64"
     assert manifest["image_repository"] == lock["image_repository"]
 
-    # Until the combined release is actually published and its remote digest is known,
-    # the checked-in immutable lock must remain the previously published release.
+    # Until the combined P2/P3/P4 release is actually reviewed, merged and
+    # published, the checked-in immutable lock remains the previous stable release.
     assert lock["version"] == "2026.07.1"
     assert lock["source_revision"] == "bd102146a684a9b06835204ec1b7f668f7655a03"
     assert lock["immutable_reference"].endswith(
@@ -41,13 +41,15 @@ def test_candidate_and_stable_lock_are_deliberately_different_release_identities
     assert manifest["version"] != lock["version"]
 
 
-def test_combined_runner_packages_both_python_profile_workers() -> None:
+def test_combined_runner_packages_all_three_python_profile_workers() -> None:
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     dockerignore = DOCKERIGNORE.read_text(encoding="utf-8")
 
     for path in (
         "scripts/python_function_profile.py",
         "scripts/python_function_worker.py",
+        "scripts/python_object_profile.py",
+        "scripts/python_object_worker.py",
         "scripts/python_filesystem_profile.py",
         "scripts/python_filesystem_worker.py",
     ):


### PR DESCRIPTION
Historical release-candidate PR that introduced the truthful combined `2026.08.3` identity for P2 + P3 + P4.

The exact cumulative lineage was released through #770 to avoid intermediate publication states. Real GHCR publication succeeded, and #771 promoted the real digest into the stable lock with an anti-republish guard.

Do not merge this stacked candidate separately.

Final release source: `23bc1d36c7eb8c1b10a11cbde5f226ce7554f85e`  
Stable version: `2026.08.3`  
Immutable digest: `sha256:c0594df833925044831463a9ee631aba2688929951a7dbcb53612b86d221ed51`  
Stable lock: #771.