### PR TITLE
Release unified Python grading toolchain 2026.08.3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ scripts/*
 !scripts/thebitlab_sandbox_boundary.py
 !scripts/python_function_profile.py
 !scripts/python_function_worker.py
+!scripts/python_filesystem_profile.py
+!scripts/python_filesystem_worker.py

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ scripts/*
 !scripts/python_function_worker.py
 !scripts/python_filesystem_profile.py
 !scripts/python_filesystem_worker.py
+!scripts/python_object_profile.py
+!scripts/python_object_worker.py

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@ docker/assignment-runner/*
 scripts/*
 !scripts/grade_activity.py
 !scripts/thebitlab_sandbox_boundary.py
+!scripts/python_function_profile.py
+!scripts/python_function_worker.py

--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -16,6 +16,9 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/python_object_profile.py"
+      - "scripts/python_object_worker.py"
+      - "scripts/grade_python_object_activity.py"
       - "scripts/python_filesystem_profile.py"
       - "scripts/python_filesystem_worker.py"
       - "scripts/grade_python_filesystem_activity.py"
@@ -29,6 +32,11 @@ on:
       - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_python_object_profile.py"
+      - "tests/test_python_object_worker.py"
+      - "tests/test_python_object_profile_dispatch.py"
+      - "tests/test_python_object_student_lab_docker.py"
+      - "tests/test_validate_activity_object_profile.py"
       - "tests/test_python_filesystem_profile.py"
       - "tests/test_python_filesystem_worker.py"
       - "tests/test_python_filesystem_profile_dispatch.py"
@@ -48,6 +56,9 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/python_object_profile.py"
+      - "scripts/python_object_worker.py"
+      - "scripts/grade_python_object_activity.py"
       - "scripts/python_filesystem_profile.py"
       - "scripts/python_filesystem_worker.py"
       - "scripts/grade_python_filesystem_activity.py"
@@ -61,6 +72,11 @@ on:
       - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_python_object_profile.py"
+      - "tests/test_python_object_worker.py"
+      - "tests/test_python_object_profile_dispatch.py"
+      - "tests/test_python_object_student_lab_docker.py"
+      - "tests/test_validate_activity_object_profile.py"
       - "tests/test_python_filesystem_profile.py"
       - "tests/test_python_filesystem_worker.py"
       - "tests/test_python_filesystem_profile_dispatch.py"
@@ -75,7 +91,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     outputs:
       image_id: ${{ steps.image-digest.outputs.image_id }}
     steps:
@@ -87,7 +103,7 @@ jobs:
       - name: Install validation dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Validate combined P2 P4 contracts dispatch and release identity
+      - name: Validate combined P2 P3 P4 contracts dispatch and release identity
         run: >-
           python -m pytest -q
           tests/test_build_assignment_runner.py
@@ -97,6 +113,10 @@ jobs:
           tests/test_python_function_worker.py
           tests/test_python_function_profile_dispatch.py
           tests/test_validate_activity_function_profile.py
+          tests/test_python_object_profile.py
+          tests/test_python_object_worker.py
+          tests/test_python_object_profile_dispatch.py
+          tests/test_validate_activity_object_profile.py
           tests/test_python_filesystem_profile.py
           tests/test_python_filesystem_worker.py
           tests/test_python_filesystem_profile_dispatch.py
@@ -119,7 +139,7 @@ jobs:
           metadata = json.loads(
               Path(os.environ["RUNNER_TEMP"], "toolchain-build.json").read_text(encoding="utf-8")
           )
-          assert metadata["version"] == "2026.08.2"
+          assert metadata["version"] == "2026.08.3"
           assert metadata["source_revision"] == os.environ["GITHUB_SHA"]
           print(f"image_id={metadata['local_image_id']}")
           PY
@@ -149,6 +169,12 @@ jobs:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
           THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-assignment-runner"
         run: python -m pytest -q tests/test_python_function_student_lab_docker.py
+
+      - name: Exercise P3 through normal Student Lab Docker dispatch
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P3_DOCKER_IMAGE: "thebitlab-assignment-runner"
+        run: python -m pytest -q tests/test_python_object_student_lab_docker.py
 
       - name: Exercise P4 through normal Student Lab Docker dispatch
         env:

--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -122,6 +122,7 @@ jobs:
       - name: Exercise P2 through normal Student Lab Docker dispatch
         env:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-assignment-runner"
         run: python -m pytest -q tests/test_python_function_student_lab_docker.py
 
   publish:

--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -16,15 +16,24 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/python_filesystem_profile.py"
+      - "scripts/python_filesystem_worker.py"
+      - "scripts/grade_python_filesystem_activity.py"
       - "scripts/thebitlab_technical_services.py"
       - "scripts/validate_activity.py"
       - "scripts/create_submission_scaffold.py"
       - "scripts/student_lab_runner.py"
+      - "tests/test_python_grading_profiles_integration.py"
       - "tests/test_python_function_profile.py"
       - "tests/test_python_function_worker.py"
       - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_python_filesystem_profile.py"
+      - "tests/test_python_filesystem_worker.py"
+      - "tests/test_python_filesystem_profile_dispatch.py"
+      - "tests/test_python_filesystem_student_lab_docker.py"
+      - "tests/test_validate_activity_filesystem_profile.py"
       - "tests/test_p2_release_candidate.py"
   push:
     branches:
@@ -39,15 +48,24 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/python_filesystem_profile.py"
+      - "scripts/python_filesystem_worker.py"
+      - "scripts/grade_python_filesystem_activity.py"
       - "scripts/thebitlab_technical_services.py"
       - "scripts/validate_activity.py"
       - "scripts/create_submission_scaffold.py"
       - "scripts/student_lab_runner.py"
+      - "tests/test_python_grading_profiles_integration.py"
       - "tests/test_python_function_profile.py"
       - "tests/test_python_function_worker.py"
       - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_python_filesystem_profile.py"
+      - "tests/test_python_filesystem_worker.py"
+      - "tests/test_python_filesystem_profile_dispatch.py"
+      - "tests/test_python_filesystem_student_lab_docker.py"
+      - "tests/test_validate_activity_filesystem_profile.py"
       - "tests/test_p2_release_candidate.py"
 
 concurrency:
@@ -57,7 +75,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     outputs:
       image_id: ${{ steps.image-digest.outputs.image_id }}
     steps:
@@ -69,17 +87,22 @@ jobs:
       - name: Install validation dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Validate P2 contracts, dispatch and release identity
+      - name: Validate combined P2 P4 contracts dispatch and release identity
         run: >-
           python -m pytest -q
           tests/test_build_assignment_runner.py
           tests/test_p2_release_candidate.py
+          tests/test_python_grading_profiles_integration.py
           tests/test_python_function_profile.py
           tests/test_python_function_worker.py
           tests/test_python_function_profile_dispatch.py
           tests/test_validate_activity_function_profile.py
+          tests/test_python_filesystem_profile.py
+          tests/test_python_filesystem_worker.py
+          tests/test_python_filesystem_profile_dispatch.py
+          tests/test_validate_activity_filesystem_profile.py
 
-      - name: Build pinned runner
+      - name: Build pinned combined runner
         run: >-
           python scripts/build_assignment_runner.py
           --source-revision "$GITHUB_SHA"
@@ -96,10 +119,12 @@ jobs:
           metadata = json.loads(
               Path(os.environ["RUNNER_TEMP"], "toolchain-build.json").read_text(encoding="utf-8")
           )
+          assert metadata["version"] == "2026.08.2"
+          assert metadata["source_revision"] == os.environ["GITHUB_SHA"]
           print(f"image_id={metadata['local_image_id']}")
           PY
 
-      - name: Stage validated runner toolchain
+      - name: Stage validated combined runner toolchain
         run: |
           mkdir -p "$RUNNER_TEMP/runner-toolchain"
           docker save thebitlab-assignment-runner \
@@ -124,6 +149,12 @@ jobs:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
           THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-assignment-runner"
         run: python -m pytest -q tests/test_python_function_student_lab_docker.py
+
+      - name: Exercise P4 through normal Student Lab Docker dispatch
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P4_DOCKER_IMAGE: "thebitlab-assignment-runner"
+        run: python -m pytest -q tests/test_python_filesystem_student_lab_docker.py
 
   publish:
     needs: validate

--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -9,11 +9,25 @@ on:
     branches:
       - main
     paths:
+      - ".dockerignore"
       - ".github/workflows/publish-assignment-runner.yml"
       - "docker/assignment-runner/**"
       - "scripts/build_assignment_runner.py"
       - "scripts/publish_assignment_runner.py"
       - "scripts/grade_activity.py"
+      - "scripts/python_function_profile.py"
+      - "scripts/python_function_worker.py"
+      - "scripts/grade_python_function_activity.py"
+      - "scripts/thebitlab_technical_services.py"
+      - "scripts/validate_activity.py"
+      - "scripts/create_submission_scaffold.py"
+      - "scripts/student_lab_runner.py"
+      - "tests/test_python_function_profile.py"
+      - "tests/test_python_function_worker.py"
+      - "tests/test_python_function_profile_dispatch.py"
+      - "tests/test_python_function_student_lab_docker.py"
+      - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_p2_release_candidate.py"
 
 concurrency:
   group: assignment-runner-toolchain
@@ -30,6 +44,19 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+
+      - name: Install validation dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Validate P2 contracts, dispatch and release identity
+        run: >-
+          python -m pytest -q
+          tests/test_build_assignment_runner.py
+          tests/test_p2_release_candidate.py
+          tests/test_python_function_profile.py
+          tests/test_python_function_worker.py
+          tests/test_python_function_profile_dispatch.py
+          tests/test_validate_activity_function_profile.py
 
       - name: Build pinned runner
         run: >-
@@ -66,13 +93,15 @@ jobs:
           path: ${{ runner.temp }}/runner-toolchain
           if-no-files-found: error
 
-      - name: Install smoke test dependencies
-        run: python -m pip install -r requirements-dev.txt
-
-      - name: Exercise isolated runner
+      - name: Exercise legacy Docker runner regressions
         env:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
         run: python -m pytest -q tests/test_student_lab_runner_docker.py
+
+      - name: Exercise P2 through normal Student Lab Docker dispatch
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+        run: python -m pytest -q tests/test_python_function_student_lab_docker.py
 
   publish:
     needs: validate

--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -5,6 +5,27 @@ permissions:
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/publish-assignment-runner.yml"
+      - "docker/assignment-runner/**"
+      - "scripts/build_assignment_runner.py"
+      - "scripts/publish_assignment_runner.py"
+      - "scripts/grade_activity.py"
+      - "scripts/python_function_profile.py"
+      - "scripts/python_function_worker.py"
+      - "scripts/grade_python_function_activity.py"
+      - "scripts/thebitlab_technical_services.py"
+      - "scripts/validate_activity.py"
+      - "scripts/create_submission_scaffold.py"
+      - "scripts/student_lab_runner.py"
+      - "tests/test_python_function_profile.py"
+      - "tests/test_python_function_worker.py"
+      - "tests/test_python_function_profile_dispatch.py"
+      - "tests/test_python_function_student_lab_docker.py"
+      - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_p2_release_candidate.py"
   push:
     branches:
       - main

--- a/.github/workflows/python-filesystem-profile.yml
+++ b/.github/workflows/python-filesystem-profile.yml
@@ -1,0 +1,243 @@
+name: Python filesystem profile P4 candidate
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".dockerignore"
+      - "docker/assignment-runner/**"
+      - "scripts/python_filesystem_profile.py"
+      - "scripts/python_filesystem_worker.py"
+      - "scripts/grade_python_filesystem_activity.py"
+      - "scripts/validate_activity.py"
+      - "tests/test_python_filesystem_profile.py"
+      - "tests/test_python_filesystem_worker.py"
+      - "tests/test_validate_activity_filesystem_profile.py"
+      - ".github/workflows/python-filesystem-profile.yml"
+
+jobs:
+  p4-candidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run P4 contract worker and Activity tests
+        run: >-
+          python -m pytest -q
+          tests/test_python_filesystem_profile.py
+          tests/test_python_filesystem_worker.py
+          tests/test_validate_activity_filesystem_profile.py
+
+      - name: Build assignment-runner candidate
+        run: >-
+          python scripts/build_assignment_runner.py
+          --source-revision "$GITHUB_SHA"
+          --tag thebitlab-p4-candidate
+          --metadata "$RUNNER_TEMP/p4-toolchain-build.json"
+
+      - name: Exercise P4 read-only fixture and output artifact
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p4/fixtures"
+          printf '12\n15\n9\n' > "$RUNNER_TEMP/p4/fixtures/misure.txt"
+          cat > "$RUNNER_TEMP/p4/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p4-smoke-001",
+            "titolo": "Somma misure",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["file", "pathlib"],
+            "consegna": "Leggi misure.txt e crea risultato.txt.",
+            "linguaggio": "python",
+            "correzione": {"compila": true, "test": true, "sandbox": true, "ai_feedback": false},
+            "metriche": {
+              "tempo_stimato_minuti": 15,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "filesystem_tests": [
+              {
+                "profile": "python-filesystem-v1",
+                "name": "somma base",
+                "fixtures": [
+                  {"id": "input", "source": "fixtures/misure.txt", "target": "misure.txt", "mode": "read-only"}
+                ],
+                "expected_artifacts": [
+                  {"path": "risultato.txt", "text": "36\n", "encoding": "utf-8"}
+                ]
+              }
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p4/main.py" <<'PY'
+          from pathlib import Path
+
+          values = [int(line) for line in Path("misure.txt").read_text(encoding="utf-8").splitlines()]
+          Path("risultato.txt").write_text(f"{sum(values)}\n", encoding="utf-8")
+          PY
+          python scripts/grade_python_filesystem_activity.py \
+            --activity "$RUNNER_TEMP/p4/activity.json" \
+            --activity-root "$RUNNER_TEMP/p4" \
+            --source "$RUNNER_TEMP/p4/main.py" \
+            --source-root "$RUNNER_TEMP/p4" \
+            --docker-image thebitlab-p4-candidate \
+            --report "$RUNNER_TEMP/p4/report.json"
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "p4" / "report.json").read_text(encoding="utf-8"))
+          assert report["passed"] is True
+          assert report["profile"] == "python-filesystem-v1"
+          assert report["summary"] == {"passed": 1, "total": 1}
+          assert report["tests"][0]["worker_status"] == "completed"
+          assert all("36" not in key for key in report["tests"][0] if key.startswith("expected"))
+          PY
+
+      - name: Exercise P4 fixture mutation protection
+        shell: bash
+        run: |
+          cp "$RUNNER_TEMP/p4/activity.json" "$RUNNER_TEMP/p4/activity-mutation.json"
+          cat > "$RUNNER_TEMP/p4/mutate.py" <<'PY'
+          from pathlib import Path
+          Path("misure.txt").write_text("99\n", encoding="utf-8")
+          Path("risultato.txt").write_text("99\n", encoding="utf-8")
+          PY
+          set +e
+          python scripts/grade_python_filesystem_activity.py \
+            --activity "$RUNNER_TEMP/p4/activity-mutation.json" \
+            --activity-root "$RUNNER_TEMP/p4" \
+            --source "$RUNNER_TEMP/p4/mutate.py" \
+            --source-root "$RUNNER_TEMP/p4" \
+            --docker-image thebitlab-p4-candidate \
+            --report "$RUNNER_TEMP/p4/mutation-report.json"
+          status=$?
+          set -e
+          test "$status" = "1"
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "p4" / "mutation-report.json").read_text(encoding="utf-8"))
+          test = report["tests"][0]
+          assert report["passed"] is False
+          assert test["worker_status"] == "runtime-error"
+          assert test["exception"]["type"] in {"PermissionError", "OSError"}
+          PY
+
+      - name: Exercise P4 missing fixture and external path policy
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p4-errors"
+          cat > "$RUNNER_TEMP/p4-errors/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p4-errors-001",
+            "titolo": "Errori filesystem",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["file"],
+            "consegna": "Prova filesystem.",
+            "linguaggio": "python",
+            "correzione": {"compila": true, "test": true, "sandbox": true, "ai_feedback": false},
+            "metriche": {
+              "tempo_stimato_minuti": 5,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "filesystem_tests": [
+              {
+                "profile": "python-filesystem-v1",
+                "expected_artifacts": [{"path": "out.txt", "text": "ok\n", "encoding": "utf-8"}]
+              }
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p4-errors/missing.py" <<'PY'
+          from pathlib import Path
+          Path("missing.txt").read_text(encoding="utf-8")
+          PY
+          cat > "$RUNNER_TEMP/p4-errors/escape.py" <<'PY'
+          from pathlib import Path
+          Path("/etc/passwd").read_text(encoding="utf-8")
+          PY
+          for source in missing escape; do
+            set +e
+            python scripts/grade_python_filesystem_activity.py \
+              --activity "$RUNNER_TEMP/p4-errors/activity.json" \
+              --activity-root "$RUNNER_TEMP/p4-errors" \
+              --source "$RUNNER_TEMP/p4-errors/$source.py" \
+              --source-root "$RUNNER_TEMP/p4-errors" \
+              --docker-image thebitlab-p4-candidate \
+              --report "$RUNNER_TEMP/p4-errors/$source-report.json"
+            status=$?
+            set -e
+            test "$status" = "1"
+          done
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          root = Path(os.environ["RUNNER_TEMP"]) / "p4-errors"
+          missing = json.loads((root / "missing-report.json").read_text(encoding="utf-8"))["tests"][0]
+          escape = json.loads((root / "escape-report.json").read_text(encoding="utf-8"))["tests"][0]
+          assert missing["worker_status"] == "runtime-error"
+          assert missing["exception"]["type"] == "FileNotFoundError"
+          assert escape["worker_status"] == "runtime-error"
+          assert escape["exception"]["type"] == "PermissionError"
+          PY
+
+      - name: Exercise P4 output limit and timeout cleanup
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p4-limits"
+          cp "$RUNNER_TEMP/p4-errors/activity.json" "$RUNNER_TEMP/p4-limits/activity.json"
+          cat > "$RUNNER_TEMP/p4-limits/big.py" <<'PY'
+          from pathlib import Path
+          Path("big.txt").write_text("x" * 70000, encoding="utf-8")
+          PY
+          cat > "$RUNNER_TEMP/p4-limits/loop.py" <<'PY'
+          while True:
+              pass
+          PY
+          for source in big loop; do
+            extra=""
+            if [ "$source" = loop ]; then extra="--timeout 1"; fi
+            set +e
+            python scripts/grade_python_filesystem_activity.py \
+              --activity "$RUNNER_TEMP/p4-limits/activity.json" \
+              --activity-root "$RUNNER_TEMP/p4-limits" \
+              --source "$RUNNER_TEMP/p4-limits/$source.py" \
+              --source-root "$RUNNER_TEMP/p4-limits" \
+              --docker-image thebitlab-p4-candidate \
+              $extra \
+              --report "$RUNNER_TEMP/p4-limits/$source-report.json"
+            status=$?
+            set -e
+            test "$status" = "1"
+          done
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          root = Path(os.environ["RUNNER_TEMP"]) / "p4-limits"
+          big = json.loads((root / "big-report.json").read_text(encoding="utf-8"))["tests"][0]
+          loop = json.loads((root / "loop-report.json").read_text(encoding="utf-8"))["tests"][0]
+          assert big["worker_status"] == "output-limit"
+          assert loop["worker_status"] == "timeout"
+          PY

--- a/.github/workflows/python-filesystem-student-lab.yml
+++ b/.github/workflows/python-filesystem-student-lab.yml
@@ -1,0 +1,52 @@
+name: Python filesystem P4 Student Lab integration
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".dockerignore"
+      - "docker/assignment-runner/**"
+      - "scripts/python_filesystem_profile.py"
+      - "scripts/python_filesystem_worker.py"
+      - "scripts/grade_python_filesystem_activity.py"
+      - "scripts/thebitlab_technical_services.py"
+      - "scripts/student_lab_runner.py"
+      - "tests/test_python_filesystem_profile_dispatch.py"
+      - "tests/test_python_filesystem_student_lab_docker.py"
+      - ".github/workflows/python-filesystem-student-lab.yml"
+
+jobs:
+  p4-student-lab:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Verify P4 canonical Docker dispatch
+        run: python -m pytest -q tests/test_python_filesystem_profile_dispatch.py
+
+      - name: Build P4 assignment runner
+        run: >-
+          python scripts/build_assignment_runner.py
+          --source-revision "$GITHUB_SHA"
+          --tag thebitlab-p4-candidate
+          --metadata "$RUNNER_TEMP/p4-student-lab-toolchain.json"
+
+      - name: Exercise P4 through normal Student Lab Docker path
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P4_DOCKER_IMAGE: "thebitlab-p4-candidate"
+        run: python -m pytest -q tests/test_python_filesystem_student_lab_docker.py

--- a/.github/workflows/python-function-profile.yml
+++ b/.github/workflows/python-function-profile.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - ".dockerignore"
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"

--- a/.github/workflows/python-function-profile.yml
+++ b/.github/workflows/python-function-profile.yml
@@ -1,0 +1,182 @@
+name: Python function profile P2 candidate
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/python_function_profile.py"
+      - "scripts/python_function_worker.py"
+      - "scripts/grade_python_function_activity.py"
+      - "scripts/validate_activity.py"
+      - "docker/assignment-runner/**"
+      - "tests/test_python_function_profile.py"
+      - "tests/test_python_function_worker.py"
+      - "tests/test_validate_activity_function_profile.py"
+      - ".github/workflows/python-function-profile.yml"
+
+jobs:
+  p2-candidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run P2 contract and worker tests
+        run: >-
+          python -m pytest -q
+          tests/test_python_function_profile.py
+          tests/test_python_function_worker.py
+          tests/test_validate_activity_function_profile.py
+
+      - name: Build assignment-runner candidate
+        run: >-
+          python scripts/build_assignment_runner.py
+          --source-revision "$GITHUB_SHA"
+          --tag thebitlab-p2-candidate
+          --metadata "$RUNNER_TEMP/p2-toolchain-build.json"
+
+      - name: Exercise P2 authoritative Docker behavior
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p2"
+          cat > "$RUNNER_TEMP/p2/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p2-smoke-001",
+            "titolo": "Funzioni P2 smoke",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["funzioni", "return"],
+            "consegna": "Implementa le funzioni richieste.",
+            "linguaggio": "python",
+            "correzione": {
+              "compila": true,
+              "test": true,
+              "sandbox": true,
+              "ai_feedback": false
+            },
+            "metriche": {
+              "tempo_stimato_minuti": 15,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "function_tests": [
+              {
+                "profile": "python-function-v1",
+                "name": "area 3x4",
+                "function": "area",
+                "args": [3, 4],
+                "expected_return": 12
+              },
+              {
+                "profile": "python-function-v1",
+                "name": "pari",
+                "function": "pari",
+                "args": [8],
+                "expected_return": true
+              },
+              {
+                "profile": "python-function-v1",
+                "name": "zero division",
+                "function": "reciproco",
+                "args": [0],
+                "expected_exception": "ZeroDivisionError"
+              }
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p2/main.py" <<'PY'
+          def area(base, altezza):
+              return base * altezza
+
+          def pari(n):
+              return n % 2 == 0
+
+          def reciproco(x):
+              return 1 / x
+          PY
+          python scripts/grade_python_function_activity.py \
+            --activity "$RUNNER_TEMP/p2/activity.json" \
+            --source "$RUNNER_TEMP/p2/main.py" \
+            --activity-root "$RUNNER_TEMP/p2" \
+            --source-root "$RUNNER_TEMP/p2" \
+            --docker-image thebitlab-p2-candidate \
+            --report "$RUNNER_TEMP/p2/report.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "p2" / "report.json").read_text(encoding="utf-8"))
+          assert report["passed"] is True
+          assert report["profile"] == "python-function-v1"
+          assert report["summary"] == {"passed": 3, "total": 3}
+          assert all("expected_return" not in json.dumps(test) for test in report["tests"])
+          PY
+
+      - name: Exercise P2 timeout fail-closed
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p2-timeout"
+          cat > "$RUNNER_TEMP/p2-timeout/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p2-timeout-001",
+            "titolo": "Timeout P2",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["funzioni"],
+            "consegna": "Implementa f.",
+            "linguaggio": "python",
+            "correzione": {"compila": true, "test": true, "sandbox": true, "ai_feedback": false},
+            "metriche": {
+              "tempo_stimato_minuti": 5,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "function_tests": [
+              {"profile": "python-function-v1", "function": "f", "expected_return": 1}
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p2-timeout/main.py" <<'PY'
+          def f():
+              while True:
+                  pass
+          PY
+          set +e
+          python scripts/grade_python_function_activity.py \
+            --activity "$RUNNER_TEMP/p2-timeout/activity.json" \
+            --source "$RUNNER_TEMP/p2-timeout/main.py" \
+            --activity-root "$RUNNER_TEMP/p2-timeout" \
+            --source-root "$RUNNER_TEMP/p2-timeout" \
+            --docker-image thebitlab-p2-candidate \
+            --timeout 1 \
+            --report "$RUNNER_TEMP/p2-timeout/report.json"
+          status=$?
+          set -e
+          test "$status" = "1"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "p2-timeout" / "report.json").read_text(encoding="utf-8"))
+          assert report["passed"] is False
+          assert report["tests"][0]["worker_status"] == "timeout"
+          PY

--- a/.github/workflows/python-function-profile.yml
+++ b/.github/workflows/python-function-profile.yml
@@ -17,6 +17,7 @@ on:
       - "tests/test_python_function_profile.py"
       - "tests/test_python_function_worker.py"
       - "tests/test_python_function_profile_dispatch.py"
+      - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
       - ".github/workflows/python-function-profile.yml"
 
@@ -184,3 +185,8 @@ jobs:
           assert report["passed"] is False
           assert report["tests"][0]["worker_status"] == "timeout"
           PY
+
+      - name: Exercise P2 through normal Student Lab Docker dispatch
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+        run: python -m pytest -q tests/test_python_function_student_lab_docker.py

--- a/.github/workflows/python-function-profile.yml
+++ b/.github/workflows/python-function-profile.yml
@@ -11,10 +11,12 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/thebitlab_technical_services.py"
       - "scripts/validate_activity.py"
       - "docker/assignment-runner/**"
       - "tests/test_python_function_profile.py"
       - "tests/test_python_function_worker.py"
+      - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_validate_activity_function_profile.py"
       - ".github/workflows/python-function-profile.yml"
 
@@ -35,11 +37,12 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Run P2 contract and worker tests
+      - name: Run P2 contract, worker and dispatch tests
         run: >-
           python -m pytest -q
           tests/test_python_function_profile.py
           tests/test_python_function_worker.py
+          tests/test_python_function_profile_dispatch.py
           tests/test_validate_activity_function_profile.py
 
       - name: Build assignment-runner candidate

--- a/.github/workflows/python-grading-profiles.yml
+++ b/.github/workflows/python-grading-profiles.yml
@@ -70,7 +70,7 @@ jobs:
         run: >-
           python scripts/build_assignment_runner.py
           --source-revision "$GITHUB_SHA"
-          --tag thebitlab-python-grading-candidate
+          --tag thebitlab-assignment-runner
           --metadata "$RUNNER_TEMP/python-grading-toolchain.json"
 
       - name: Verify combined runner identity and packaged profiles
@@ -87,8 +87,9 @@ jobs:
           assert metadata["version"] == "2026.08.2"
           assert metadata["source_revision"] == os.environ["GITHUB_SHA"]
           assert metadata["platform"] == "linux/amd64"
+          assert metadata["local_tag"] == "thebitlab-assignment-runner"
           PY
-          docker run --rm --entrypoint python3 thebitlab-python-grading-candidate - <<'PY'
+          docker run --rm --entrypoint python3 thebitlab-assignment-runner - <<'PY'
           import sys
           sys.path.insert(0, "/opt/thebitlab")
           import python_function_profile as p2
@@ -101,17 +102,16 @@ jobs:
       - name: Exercise legacy P1 C Node SQLite Student Lab regressions
         env:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
-          THEBITLAB_DOCKER_IMAGE: "thebitlab-python-grading-candidate"
         run: python -m pytest -q tests/test_student_lab_runner_docker.py
 
       - name: Exercise P2 through the same combined runner
         env:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
-          THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-python-grading-candidate"
+          THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-assignment-runner"
         run: python -m pytest -q tests/test_python_function_student_lab_docker.py
 
       - name: Exercise P4 through the same combined runner
         env:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
-          THEBITLAB_P4_DOCKER_IMAGE: "thebitlab-python-grading-candidate"
+          THEBITLAB_P4_DOCKER_IMAGE: "thebitlab-assignment-runner"
         run: python -m pytest -q tests/test_python_filesystem_student_lab_docker.py

--- a/.github/workflows/python-grading-profiles.yml
+++ b/.github/workflows/python-grading-profiles.yml
@@ -12,6 +12,9 @@ on:
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
       - "scripts/grade_python_function_activity.py"
+      - "scripts/python_object_profile.py"
+      - "scripts/python_object_worker.py"
+      - "scripts/grade_python_object_activity.py"
       - "scripts/python_filesystem_profile.py"
       - "scripts/python_filesystem_worker.py"
       - "scripts/grade_python_filesystem_activity.py"
@@ -25,6 +28,11 @@ on:
       - "tests/test_python_function_profile_dispatch.py"
       - "tests/test_python_function_student_lab_docker.py"
       - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_python_object_profile.py"
+      - "tests/test_python_object_worker.py"
+      - "tests/test_python_object_profile_dispatch.py"
+      - "tests/test_python_object_student_lab_docker.py"
+      - "tests/test_validate_activity_object_profile.py"
       - "tests/test_python_filesystem_profile.py"
       - "tests/test_python_filesystem_worker.py"
       - "tests/test_python_filesystem_profile_dispatch.py"
@@ -36,7 +44,7 @@ on:
 jobs:
   combined-python-grading:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     steps:
       - name: Checkout combined candidate
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -51,7 +59,7 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Validate combined contracts and release identity
+      - name: Validate combined P2 P3 P4 contracts and release identity
         run: >-
           python -m pytest -q
           tests/test_build_assignment_runner.py
@@ -61,6 +69,10 @@ jobs:
           tests/test_python_function_worker.py
           tests/test_python_function_profile_dispatch.py
           tests/test_validate_activity_function_profile.py
+          tests/test_python_object_profile.py
+          tests/test_python_object_worker.py
+          tests/test_python_object_profile_dispatch.py
+          tests/test_validate_activity_object_profile.py
           tests/test_python_filesystem_profile.py
           tests/test_python_filesystem_worker.py
           tests/test_python_filesystem_profile_dispatch.py
@@ -84,7 +96,7 @@ jobs:
           metadata = json.loads(
               (Path(os.environ["RUNNER_TEMP"]) / "python-grading-toolchain.json").read_text(encoding="utf-8")
           )
-          assert metadata["version"] == "2026.08.2"
+          assert metadata["version"] == "2026.08.3"
           assert metadata["source_revision"] == os.environ["GITHUB_SHA"]
           assert metadata["platform"] == "linux/amd64"
           assert metadata["local_tag"] == "thebitlab-assignment-runner"
@@ -93,10 +105,12 @@ jobs:
           import sys
           sys.path.insert(0, "/opt/thebitlab")
           import python_function_profile as p2
+          import python_object_profile as p3
           import python_filesystem_profile as p4
           assert p2.PROFILE_ID == "python-function-v1"
+          assert p3.PROFILE_ID == "python-object-v1"
           assert p4.PROFILE_ID == "python-filesystem-v1"
-          print("PASS: combined runner contains P2 and P4 profiles")
+          print("PASS: combined runner contains P2, P3 and P4 profiles")
           PY
 
       - name: Exercise legacy P1 C Node SQLite Student Lab regressions
@@ -109,6 +123,12 @@ jobs:
           THEBITLAB_RUN_DOCKER_TESTS: "1"
           THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-assignment-runner"
         run: python -m pytest -q tests/test_python_function_student_lab_docker.py
+
+      - name: Exercise P3 through the same combined runner
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P3_DOCKER_IMAGE: "thebitlab-assignment-runner"
+        run: python -m pytest -q tests/test_python_object_student_lab_docker.py
 
       - name: Exercise P4 through the same combined runner
         env:

--- a/.github/workflows/python-grading-profiles.yml
+++ b/.github/workflows/python-grading-profiles.yml
@@ -1,0 +1,117 @@
+name: Combined Python grading profiles
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".dockerignore"
+      - "docker/assignment-runner/**"
+      - "scripts/python_function_profile.py"
+      - "scripts/python_function_worker.py"
+      - "scripts/grade_python_function_activity.py"
+      - "scripts/python_filesystem_profile.py"
+      - "scripts/python_filesystem_worker.py"
+      - "scripts/grade_python_filesystem_activity.py"
+      - "scripts/thebitlab_technical_services.py"
+      - "scripts/validate_activity.py"
+      - "scripts/student_lab_runner.py"
+      - "tests/test_build_assignment_runner.py"
+      - "tests/test_p2_release_candidate.py"
+      - "tests/test_python_function_profile.py"
+      - "tests/test_python_function_worker.py"
+      - "tests/test_python_function_profile_dispatch.py"
+      - "tests/test_python_function_student_lab_docker.py"
+      - "tests/test_validate_activity_function_profile.py"
+      - "tests/test_python_filesystem_profile.py"
+      - "tests/test_python_filesystem_worker.py"
+      - "tests/test_python_filesystem_profile_dispatch.py"
+      - "tests/test_python_filesystem_student_lab_docker.py"
+      - "tests/test_validate_activity_filesystem_profile.py"
+      - "tests/test_python_grading_profiles_integration.py"
+      - ".github/workflows/python-grading-profiles.yml"
+
+jobs:
+  combined-python-grading:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout combined candidate
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Validate combined contracts and release identity
+        run: >-
+          python -m pytest -q
+          tests/test_build_assignment_runner.py
+          tests/test_p2_release_candidate.py
+          tests/test_python_grading_profiles_integration.py
+          tests/test_python_function_profile.py
+          tests/test_python_function_worker.py
+          tests/test_python_function_profile_dispatch.py
+          tests/test_validate_activity_function_profile.py
+          tests/test_python_filesystem_profile.py
+          tests/test_python_filesystem_worker.py
+          tests/test_python_filesystem_profile_dispatch.py
+          tests/test_validate_activity_filesystem_profile.py
+
+      - name: Build one combined assignment runner
+        run: >-
+          python scripts/build_assignment_runner.py
+          --source-revision "$GITHUB_SHA"
+          --tag thebitlab-python-grading-candidate
+          --metadata "$RUNNER_TEMP/python-grading-toolchain.json"
+
+      - name: Verify combined runner identity and packaged profiles
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          metadata = json.loads(
+              (Path(os.environ["RUNNER_TEMP"]) / "python-grading-toolchain.json").read_text(encoding="utf-8")
+          )
+          assert metadata["version"] == "2026.08.2"
+          assert metadata["source_revision"] == os.environ["GITHUB_SHA"]
+          assert metadata["platform"] == "linux/amd64"
+          PY
+          docker run --rm --entrypoint python3 thebitlab-python-grading-candidate - <<'PY'
+          import sys
+          sys.path.insert(0, "/opt/thebitlab")
+          import python_function_profile as p2
+          import python_filesystem_profile as p4
+          assert p2.PROFILE_ID == "python-function-v1"
+          assert p4.PROFILE_ID == "python-filesystem-v1"
+          print("PASS: combined runner contains P2 and P4 profiles")
+          PY
+
+      - name: Exercise legacy P1 C Node SQLite Student Lab regressions
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_DOCKER_IMAGE: "thebitlab-python-grading-candidate"
+        run: python -m pytest -q tests/test_student_lab_runner_docker.py
+
+      - name: Exercise P2 through the same combined runner
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P2_DOCKER_IMAGE: "thebitlab-python-grading-candidate"
+        run: python -m pytest -q tests/test_python_function_student_lab_docker.py
+
+      - name: Exercise P4 through the same combined runner
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P4_DOCKER_IMAGE: "thebitlab-python-grading-candidate"
+        run: python -m pytest -q tests/test_python_filesystem_student_lab_docker.py

--- a/.github/workflows/python-object-profile.yml
+++ b/.github/workflows/python-object-profile.yml
@@ -1,0 +1,266 @@
+name: Python object profile P3 candidate
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".dockerignore"
+      - "scripts/python_object_profile.py"
+      - "scripts/python_object_worker.py"
+      - "scripts/grade_python_object_activity.py"
+      - "scripts/thebitlab_technical_services.py"
+      - "scripts/validate_activity.py"
+      - "scripts/student_lab_runner.py"
+      - "docker/assignment-runner/**"
+      - "tests/test_python_object_profile.py"
+      - "tests/test_python_object_worker.py"
+      - "tests/test_python_object_profile_dispatch.py"
+      - "tests/test_python_object_student_lab_docker.py"
+      - "tests/test_validate_activity_object_profile.py"
+      - ".github/workflows/python-object-profile.yml"
+
+jobs:
+  p3-candidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run P3 contract worker validation and dispatch tests
+        run: >-
+          python -m pytest -q
+          tests/test_python_object_profile.py
+          tests/test_python_object_worker.py
+          tests/test_python_object_profile_dispatch.py
+          tests/test_validate_activity_object_profile.py
+
+      - name: Build assignment-runner candidate
+        run: >-
+          python scripts/build_assignment_runner.py
+          --source-revision "$GITHUB_SHA"
+          --tag thebitlab-p3-candidate
+          --metadata "$RUNNER_TEMP/p3-toolchain-build.json"
+
+      - name: Exercise P3 authoritative Docker behavior and discrimination
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p3"
+          cat > "$RUNNER_TEMP/p3/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p3-smoke-001",
+            "titolo": "Oggetti P3 smoke",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["classi", "stato", "invarianti"],
+            "consegna": "Implementa Conto con stato e invarianti.",
+            "linguaggio": "python",
+            "correzione": {
+              "compila": true,
+              "test": true,
+              "sandbox": true,
+              "ai_feedback": false
+            },
+            "metriche": {
+              "tempo_stimato_minuti": 20,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "object_tests": [
+              {
+                "profile": "python-object-v1",
+                "name": "deposito modifica stato e query",
+                "class": "Conto",
+                "construct": {"args": ["Anna", 100]},
+                "steps": [
+                  {"call": "deposita", "args": [20], "expected_return": null},
+                  {"observe": "saldo", "expected": 120},
+                  {"call": "saldo_corrente", "expected_return": 120}
+                ]
+              },
+              {
+                "profile": "python-object-v1",
+                "name": "deposito invalido",
+                "class": "Conto",
+                "construct": {"args": ["Anna", 100]},
+                "steps": [
+                  {"call": "deposita", "args": [-5], "expected_exception": "ValueError"},
+                  {"observe": "saldo", "expected": 100}
+                ]
+              },
+              {
+                "profile": "python-object-v1",
+                "name": "istanze indipendenti",
+                "class": "Conto",
+                "construct": {"args": ["Anna", 100]},
+                "additional_instances": [
+                  {"id": "other", "construct": {"args": ["Luca", 50]}}
+                ],
+                "steps": [
+                  {"call": "deposita", "args": [20], "expected_return": null},
+                  {"observe": "saldo", "expected": 120},
+                  {"instance": "other", "observe": "saldo", "expected": 50}
+                ]
+              },
+              {
+                "profile": "python-object-v1",
+                "name": "costruttore protegge invariante",
+                "class": "Conto",
+                "construct": {"args": ["Anna", -1]},
+                "expected_constructor_exception": "ValueError"
+              }
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p3/solution.py" <<'PY'
+          class Conto:
+              def __init__(self, titolare, saldo):
+                  if saldo < 0:
+                      raise ValueError("saldo iniziale negativo")
+                  self.titolare = titolare
+                  self.saldo = saldo
+
+              def deposita(self, importo):
+                  if importo <= 0:
+                      raise ValueError("importo non valido")
+                  self.saldo += importo
+
+              def saldo_corrente(self):
+                  return self.saldo
+          PY
+          cat > "$RUNNER_TEMP/p3/starter.py" <<'PY'
+          class Conto:
+              def __init__(self, titolare, saldo):
+                  self.titolare = titolare
+                  self.saldo = saldo
+
+              def deposita(self, importo):
+                  self.saldo += importo
+
+              def saldo_corrente(self):
+                  print(self.saldo)
+          PY
+
+          python scripts/grade_python_object_activity.py \
+            --activity "$RUNNER_TEMP/p3/activity.json" \
+            --source "$RUNNER_TEMP/p3/solution.py" \
+            --activity-root "$RUNNER_TEMP/p3" \
+            --source-root "$RUNNER_TEMP/p3" \
+            --docker-image thebitlab-p3-candidate \
+            --report "$RUNNER_TEMP/p3/solution-report.json"
+
+          set +e
+          python scripts/grade_python_object_activity.py \
+            --activity "$RUNNER_TEMP/p3/activity.json" \
+            --source "$RUNNER_TEMP/p3/starter.py" \
+            --activity-root "$RUNNER_TEMP/p3" \
+            --source-root "$RUNNER_TEMP/p3" \
+            --docker-image thebitlab-p3-candidate \
+            --report "$RUNNER_TEMP/p3/starter-report.json"
+          starter_status=$?
+          set -e
+          test "$starter_status" = "1"
+
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"]) / "p3"
+          solution = json.loads((root / "solution-report.json").read_text(encoding="utf-8"))
+          starter = json.loads((root / "starter-report.json").read_text(encoding="utf-8"))
+
+          assert solution["passed"] is True
+          assert solution["profile"] == "python-object-v1"
+          assert solution["summary"] == {"passed": 4, "total": 4}
+          assert all(test["passed"] is True for test in solution["tests"])
+
+          assert starter["passed"] is False
+          assert starter["profile"] == "python-object-v1"
+          assert starter["summary"]["total"] == 4
+          assert starter["summary"]["passed"] < 4
+          assert any(test["passed"] is False for test in starter["tests"])
+          PY
+
+      - name: Exercise P3 timeout fail-closed
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/p3-timeout"
+          cat > "$RUNNER_TEMP/p3-timeout/activity.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "id": "python-p3-timeout-001",
+            "titolo": "Timeout P3",
+            "tipo": "laboratorio",
+            "difficolta": "B",
+            "argomenti": ["classi"],
+            "consegna": "Implementa Blocco.",
+            "linguaggio": "python",
+            "correzione": {"compila": true, "test": true, "sandbox": true, "ai_feedback": false},
+            "metriche": {
+              "tempo_stimato_minuti": 5,
+              "traccia_tempo_dichiarato": true,
+              "traccia_sessioni_thebitlab": true,
+              "traccia_eventi_didattici": true,
+              "traccia_errori_compilazione": true
+            },
+            "object_tests": [
+              {
+                "profile": "python-object-v1",
+                "class": "Blocco",
+                "construct": {},
+                "steps": [
+                  {"call": "esegui", "expected_return": 1}
+                ]
+              }
+            ]
+          }
+          JSON
+          cat > "$RUNNER_TEMP/p3-timeout/main.py" <<'PY'
+          class Blocco:
+              def esegui(self):
+                  while True:
+                      pass
+          PY
+          set +e
+          python scripts/grade_python_object_activity.py \
+            --activity "$RUNNER_TEMP/p3-timeout/activity.json" \
+            --source "$RUNNER_TEMP/p3-timeout/main.py" \
+            --activity-root "$RUNNER_TEMP/p3-timeout" \
+            --source-root "$RUNNER_TEMP/p3-timeout" \
+            --docker-image thebitlab-p3-candidate \
+            --timeout 1 \
+            --report "$RUNNER_TEMP/p3-timeout/report.json"
+          status=$?
+          set -e
+          test "$status" = "1"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          report = json.loads((Path(os.environ["RUNNER_TEMP"]) / "p3-timeout" / "report.json").read_text(encoding="utf-8"))
+          assert report["passed"] is False
+          assert report["summary"] == {"passed": 0, "total": 1}
+          assert report["tests"][0]["worker_status"] == "timeout"
+          PY
+
+      - name: Exercise P3 through normal Student Lab Docker dispatch
+        env:
+          THEBITLAB_RUN_DOCKER_TESTS: "1"
+          THEBITLAB_P3_DOCKER_IMAGE: "thebitlab-p3-candidate"
+        run: python -m pytest -q tests/test_python_object_student_lab_docker.py

--- a/doc/PYTHON_FILESYSTEM_PROFILE.md
+++ b/doc/PYTHON_FILESYSTEM_PROFILE.md
@@ -1,0 +1,155 @@
+# Python filesystem-behavior grading profile — design checkpoint
+
+> Status: design / implementation candidate for `2cornot2c#757`.
+>
+> This document does not certify P4 and does not authorize course-side mass materialization.
+
+## Purpose
+
+`python-filesystem-v1` grades deterministic beginner file-I/O behavior without replacing real files with stdin/stdout.
+
+The trusted host owns:
+
+- fixture definitions and source bytes;
+- expected output paths/content;
+- grading decisions.
+
+The untrusted container receives only:
+
+- the student source;
+- declared input fixture bytes/targets;
+- bounded filesystem policy.
+
+It returns observed execution state and a bounded manifest of student-created regular files. Expected artifact contents stay host-side.
+
+## V1 workspace
+
+One fresh sandbox per test:
+
+```text
+/submission/
+  main.py                 read-only mount input
+
+/thebitlab-work/p4/
+  workspace/
+    <declared fixtures>   copied before execution
+    main.py               copied student source
+```
+
+Student code executes with `cwd` set to the writable P4 workspace. The outer Docker boundary remains network-off, read-only root filesystem, no-new-privileges, cap-drop ALL, PID/memory/CPU bounded.
+
+Fixtures are copied from trusted host staging into the per-test workspace immediately before execution. Only regular files declared by the teacher contract are accepted.
+
+## Teacher-side test contract
+
+Conceptual v1:
+
+```json
+{
+  "profile": "python-filesystem-v1",
+  "name": "normalizza righe",
+  "fixtures": [
+    {
+      "id": "input",
+      "source": "fixtures/dati.txt",
+      "target": "dati.txt",
+      "mode": "read-only"
+    }
+  ],
+  "expected_artifacts": [
+    {
+      "path": "risultato.txt",
+      "text": "uno\ndue\n",
+      "encoding": "utf-8"
+    }
+  ],
+  "forbid_unexpected_artifacts": true
+}
+```
+
+`source` and expected text are trusted-host fields. They must not be serialized into a student-facing scaffold or worker request.
+
+## Worker request
+
+The worker request may contain only the execution policy and fixture **target metadata**, never teacher source paths or expected artifact contents. Fixture bytes are staged separately by the trusted host.
+
+```json
+{
+  "schema_version": "thebitlab.python-filesystem-worker.v1",
+  "fixture_targets": ["dati.txt"],
+  "max_output_files": 16,
+  "max_output_file_bytes": 65536,
+  "max_output_total_bytes": 262144
+}
+```
+
+## V1 limits
+
+Initial hard limits:
+
+```text
+fixtures                    <= 16
+single fixture              <= 64 KiB
+all fixture bytes           <= 256 KiB
+output regular files        <= 16
+single output file          <= 64 KiB
+all output bytes            <= 256 KiB
+relative path depth         <= 4
+path length                 <= 240 chars
+text codec                  UTF-8 only
+```
+
+No symlinks, hard-link tricks, device files, sockets, FIFOs or absolute/traversal paths are valid artifacts.
+
+## Artifact observation
+
+After execution the worker returns only bounded observed data:
+
+```json
+{
+  "path": "risultato.txt",
+  "size": 8,
+  "sha256": "...",
+  "text": "uno\ndue\n"
+}
+```
+
+V1 may return bounded UTF-8 text because the total output surface is tightly capped. The trusted host compares it with teacher expectations. A later binary profile should prefer digest/typed artifact handling rather than extending this contract implicitly.
+
+Newlines are normalized only for an explicitly declared text comparison policy. V1 default is exact UTF-8 text after normalizing CRLF to LF; no whitespace stripping.
+
+## Fixture immutability
+
+Fixture targets are snapshotted before student execution. After execution the worker verifies their bytes and file type are unchanged. Mutation produces a structured `fixture-mutated` result even if the program otherwise exits zero.
+
+This is a grading/policy guarantee, not a claim that normal Unix permissions alone prevent every write: the per-test worker must actively verify fixture integrity.
+
+## Expected failure statuses
+
+At minimum:
+
+```text
+completed
+runtime-error
+timeout
+fixture-mutated
+filesystem-policy-violation
+output-limit
+invalid-utf8-output
+```
+
+The trusted host then distinguishes grading outcomes such as missing required artifact, unexpected artifact, or content mismatch.
+
+A normal student `FileNotFoundError` remains a runtime error with bounded diagnostics; it is not converted to infrastructure failure.
+
+## Promotion policy
+
+P4 can become stable only after:
+
+1. strict contract + Activity validation;
+2. real worker execution in the hardened assignment-runner;
+3. fixture/path/symlink/output-limit/timeout tests;
+4. normal Student Lab dispatch;
+5. student-report redaction;
+6. one real `python-docente` M26 consumer;
+7. release identity/immutable lock governance analogous to P2.

--- a/doc/architecture/python-function-grading-v1.md
+++ b/doc/architecture/python-function-grading-v1.md
@@ -1,0 +1,166 @@
+# Python function-behavior grading v1 — DRAFT
+
+Issue: #756
+
+## Goal
+
+Assess beginner Python functions directly without wrapping every exercise in stdin/stdout.
+
+Profile identity:
+
+```text
+python-function-v1
+```
+
+Worker protocol:
+
+```text
+thebitlab.python-function-worker.v1
+```
+
+This remains part of the core Python grader and reuses the assignment-runner Docker sandbox. It is not a runtime plugin.
+
+## Trust boundary
+
+Teacher-side test:
+
+```json
+{
+  "profile": "python-function-v1",
+  "function": "area",
+  "args": [3, 4],
+  "kwargs": {},
+  "expected_return": 12
+}
+```
+
+Worker request:
+
+```json
+{
+  "schema_version": "thebitlab.python-function-worker.v1",
+  "function": "area",
+  "args": [3, 4],
+  "kwargs": {}
+}
+```
+
+`expected_return`, `expected_exception`, rubrics and grading decisions never enter the untrusted worker request. The worker reports only observed behavior; the trusted host compares it with the teacher expectation.
+
+## V1 value codec
+
+Supported deterministic values:
+
+- `None`;
+- `bool`;
+- bounded `int`;
+- finite bounded `float`;
+- bounded `str`;
+- bounded JSON-like `list`;
+- bounded string-keyed `dict`.
+
+Not supported in v1:
+
+- tuples/sets;
+- arbitrary/custom objects;
+- bytes;
+- NaN/Infinity;
+- recursive or deeply nested structures.
+
+The initial profile rejects unsupported values rather than serializing arbitrary Python objects.
+
+## Return comparison
+
+Default return comparison is value + exact Python type. This prevents `True` from silently satisfying an expected integer `1` or vice versa.
+
+Float tolerance is opt-in and explicit:
+
+```json
+{
+  "float_tolerance": 0.001
+}
+```
+
+It uses absolute tolerance only in v1. No hidden approximate comparison occurs when tolerance is omitted.
+
+## Expected exceptions
+
+A teacher test may declare exactly one expected exception type:
+
+```json
+{
+  "expected_exception": "ZeroDivisionError"
+}
+```
+
+The worker returns a bounded descriptor with exception type and sanitized message. V1 grading compares the exception type; message text is diagnostic, not a grading oracle.
+
+## Worker result states
+
+```text
+returned
+raised
+missing-function
+not-callable
+import-error
+timeout
+```
+
+Missing/non-callable/import/timeout are normal failed student behaviors, not platform crashes.
+
+## Limits
+
+Current contract limits include:
+
+- max 64 function tests per Activity;
+- max 16 positional args;
+- max 16 keyword args;
+- function/parameter names must be simple Python identifiers;
+- max 4096 characters per string/stdout/stderr;
+- max 64 items per supported container;
+- max value nesting depth 4;
+- bounded finite numeric range.
+
+Docker process/output limits remain governed by the existing assignment-runner boundary and must be reused rather than reimplemented.
+
+## Student-facing progression
+
+P2 is a delivery/evidence profile, not a curriculum requirement to teach test frameworks.
+
+```text
+paper test cases
+→ P1 stdin/stdout
+→ assert
+→ P2 direct function behavior
+→ structured test suites later
+```
+
+## Implementation state
+
+Implemented on the candidate branch:
+
+```text
+scripts/python_function_profile.py
+tests/test_python_function_profile.py
+```
+
+Current module covers:
+
+- strict teacher test validation;
+- bounded value codec;
+- expectation redaction from worker requests;
+- worker request/result validation;
+- trusted-host comparison;
+- explicit float tolerance;
+- expected exception type comparison.
+
+Still required before #756 can close:
+
+1. Activity schema integration;
+2. Docker worker function loader/invoker;
+3. import timeout/side-effect containment through existing sandbox;
+4. bounded stdout/stderr capture in the real worker;
+5. grader report integration + student redaction;
+6. Docker integration tests;
+7. one real `python-docente` PY2-05 Activity consumer;
+8. consumer evidence before declaring the profile stable.

--- a/docker/assignment-runner/Dockerfile
+++ b/docker/assignment-runner/Dockerfile
@@ -37,6 +37,8 @@ RUN useradd --create-home --shell /usr/sbin/nologin runner
 
 COPY scripts/grade_activity.py /opt/thebitlab/grade_activity.py
 COPY scripts/thebitlab_sandbox_boundary.py /opt/thebitlab/thebitlab_sandbox_boundary.py
+COPY scripts/python_function_profile.py /opt/thebitlab/python_function_profile.py
+COPY scripts/python_function_worker.py /opt/thebitlab/python_function_worker.py
 
 WORKDIR /submission
 

--- a/docker/assignment-runner/Dockerfile
+++ b/docker/assignment-runner/Dockerfile
@@ -39,6 +39,8 @@ COPY scripts/grade_activity.py /opt/thebitlab/grade_activity.py
 COPY scripts/thebitlab_sandbox_boundary.py /opt/thebitlab/thebitlab_sandbox_boundary.py
 COPY scripts/python_function_profile.py /opt/thebitlab/python_function_profile.py
 COPY scripts/python_function_worker.py /opt/thebitlab/python_function_worker.py
+COPY scripts/python_filesystem_profile.py /opt/thebitlab/python_filesystem_profile.py
+COPY scripts/python_filesystem_worker.py /opt/thebitlab/python_filesystem_worker.py
 
 WORKDIR /submission
 

--- a/docker/assignment-runner/Dockerfile
+++ b/docker/assignment-runner/Dockerfile
@@ -41,6 +41,8 @@ COPY scripts/python_function_profile.py /opt/thebitlab/python_function_profile.p
 COPY scripts/python_function_worker.py /opt/thebitlab/python_function_worker.py
 COPY scripts/python_filesystem_profile.py /opt/thebitlab/python_filesystem_profile.py
 COPY scripts/python_filesystem_worker.py /opt/thebitlab/python_filesystem_worker.py
+COPY scripts/python_object_profile.py /opt/thebitlab/python_object_profile.py
+COPY scripts/python_object_worker.py /opt/thebitlab/python_object_worker.py
 
 WORKDIR /submission
 

--- a/docker/assignment-runner/toolchain.json
+++ b/docker/assignment-runner/toolchain.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "thebitlab.grading-toolchain-build.v1",
-  "version": "2026.08.2",
+  "version": "2026.08.3",
   "platform": "linux/amd64",
   "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
   "worker_schema_version": "thebitlab.grading-worker.v1",

--- a/docker/assignment-runner/toolchain.json
+++ b/docker/assignment-runner/toolchain.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "thebitlab.grading-toolchain-build.v1",
-  "version": "2026.08.1",
+  "version": "2026.08.2",
   "platform": "linux/amd64",
   "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
   "worker_schema_version": "thebitlab.grading-worker.v1",

--- a/docker/assignment-runner/toolchain.json
+++ b/docker/assignment-runner/toolchain.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "thebitlab.grading-toolchain-build.v1",
-  "version": "2026.07.1",
+  "version": "2026.08.1",
   "platform": "linux/amd64",
   "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
   "worker_schema_version": "thebitlab.grading-worker.v1",

--- a/scripts/grade_python_filesystem_activity.py
+++ b/scripts/grade_python_filesystem_activity.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import grade_activity
+from scripts import python_filesystem_profile as p4
+from scripts import validate_activity
+from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+
+
+DEFAULT_TIMEOUT_SECONDS = 5
+DEFAULT_DOCKER_IMAGE = grade_activity.DEFAULT_DOCKER_IMAGE
+P4_TMPFS_SPEC = "/thebitlab-work:rw,exec,nosuid,nodev,mode=1777,size=1m"
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: JSON root deve essere un oggetto")
+    return value
+
+
+def prepare_fixture_mounts(
+    *,
+    activity_root: Path,
+    teacher_test: dict[str, Any],
+    temp_root: Path,
+) -> list[tuple[Path, str]]:
+    """Copy declared teacher fixtures into bounded temporary read-only mount sources."""
+
+    normalized = p4.validate_filesystem_test(teacher_test)
+    fixture_root = temp_root / "fixture-mounts"
+    fixture_root.mkdir(parents=True, exist_ok=True)
+    mounts: list[tuple[Path, str]] = []
+    total = 0
+    for index, fixture in enumerate(normalized["fixtures"]):
+        source = activity_root / fixture["source"]
+        safe_source = grade_activity.confined_regular_input(
+            source,
+            activity_root,
+            f"filesystem fixture {fixture['id']}",
+        )
+        size = safe_source.stat().st_size
+        if size > p4.MAX_FIXTURE_FILE_BYTES:
+            raise ValueError(
+                f"Fixture {fixture['id']} supera {p4.MAX_FIXTURE_FILE_BYTES} byte"
+            )
+        total += size
+        if total > p4.MAX_FIXTURE_TOTAL_BYTES:
+            raise ValueError("Fixture P4 superano il limite totale")
+        raw = safe_source.read_bytes()
+        try:
+            raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as error:
+            raise ValueError(f"Fixture {fixture['id']} non e UTF-8 valida") from error
+        copied = fixture_root / f"{index:02d}-{fixture['target']}"
+        copied.write_bytes(raw)
+        try:
+            copied.chmod(0o444)
+        except OSError:
+            pass
+        mounts.append((copied, fixture["target"]))
+    return mounts
+
+
+def p4_docker_command(
+    *,
+    image: str,
+    workspace: Path,
+    source: Path,
+    fixture_mounts: list[tuple[Path, str]],
+    cidfile: Path,
+    container_name: str,
+) -> list[str]:
+    """Return the hardened P4 Docker command with read-only fixture mounts."""
+
+    command = docker_boundary_command(
+        image=image,
+        workspace=workspace,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    for index, item in enumerate(command):
+        if isinstance(item, str) and item.startswith("/thebitlab-work:"):
+            command[index] = P4_TMPFS_SPEC
+    image_ref = command.pop()
+    for host_path, target in fixture_mounts:
+        host = str(host_path.resolve())
+        if "," in host:
+            raise ValueError("Fixture host path contiene una virgola non supportata da Docker --mount")
+        command.extend(
+            [
+                "--mount",
+                f"type=bind,src={host},dst=/thebitlab-work/{target},readonly",
+            ]
+        )
+    command.extend(["--entrypoint", "python3", image_ref])
+    command.extend(
+        [
+            "/opt/thebitlab/python_filesystem_worker.py",
+            "--source",
+            grade_activity.path_inside_workspace(source, workspace, "source"),
+            "--workdir",
+            "/thebitlab-work",
+        ]
+    )
+    return command
+
+
+def timeout_test_result(teacher_test: dict[str, Any]) -> dict[str, Any]:
+    normalized = p4.validate_filesystem_test(teacher_test)
+    return {
+        "name": normalized.get("name", "filesystem"),
+        "profile": p4.PROFILE_ID,
+        "visibility": normalized.get("visibility", "teacher"),
+        "passed": False,
+        "status": "failed",
+        "worker_status": "timeout",
+        "checks": [],
+        "stdout": "",
+        "stderr": "",
+        "exception": None,
+    }
+
+
+def run_filesystem_test_in_docker(
+    *,
+    image: str,
+    activity_root: Path,
+    activity_path: Path,
+    source_path: Path,
+    teacher_test: dict[str, Any],
+    timeout_seconds: int,
+    temp_root: Path,
+    test_index: int,
+) -> dict[str, Any]:
+    """Run one P4 test in a fresh container and compare only on the trusted host."""
+
+    test_root = temp_root / f"test-{test_index:02d}"
+    test_root.mkdir(parents=True)
+    workspace, source = grade_activity.prepare_docker_workspace(
+        activity_path,
+        source_path,
+        test_root,
+        activity_root=activity_root,
+        source_root=source_path.parent,
+    )
+    fixture_mounts = prepare_fixture_mounts(
+        activity_root=activity_root,
+        teacher_test=teacher_test,
+        temp_root=test_root,
+    )
+    cidfile = test_root / "container.cid"
+    container_name = f"thebitlab-p4-{uuid.uuid4().hex}"
+    command = p4_docker_command(
+        image=image,
+        workspace=workspace,
+        source=source,
+        fixture_mounts=fixture_mounts,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    request = p4.worker_request(teacher_test)
+    try:
+        try:
+            completed = grade_activity.run_bounded_process(
+                command,
+                input_text=json.dumps(request, ensure_ascii=False, allow_nan=False),
+                timeout=timeout_seconds + grade_activity.DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return timeout_test_result(teacher_test)
+        if completed.returncode != 0:
+            raise ValueError(
+                f"P4 worker terminato con errore infrastrutturale: exit={completed.returncode}"
+            )
+        try:
+            worker_result = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise ValueError("P4 worker non ha prodotto JSON valido") from error
+        validated = p4.validate_worker_result(worker_result)
+        return p4.compare_worker_result(teacher_test, validated)
+    finally:
+        grade_activity.remove_docker_container(cidfile, container_name)
+
+
+def grade_in_docker(
+    *,
+    activity_path: Path,
+    source_path: Path,
+    image: str = DEFAULT_DOCKER_IMAGE,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    activity_root: Path | None = None,
+    source_root: Path | None = None,
+) -> dict[str, Any]:
+    """Grade a Python P4 Activity with clean filesystem state per test."""
+
+    resolved_activity_root = (activity_root or activity_path.parent).resolve(strict=True)
+    resolved_source_root = (source_root or source_path.parent).resolve(strict=True)
+    safe_activity = grade_activity.confined_regular_input(
+        activity_path,
+        resolved_activity_root,
+        "activity",
+    )
+    safe_source = grade_activity.confined_regular_input(
+        source_path,
+        resolved_source_root,
+        "source",
+    )
+    activity = load_object(safe_activity)
+    errors = validate_activity.validate_activity(activity, str(safe_activity))
+    if errors:
+        raise ValueError("Activity P4 non valida: " + "; ".join(errors))
+    language = str(activity.get("language") or activity.get("linguaggio") or "python").lower()
+    if language not in {"python", "py"}:
+        raise ValueError("P4 supporta solo Activity Python")
+    teacher_tests = p4.validate_filesystem_tests(activity.get("filesystem_tests"))
+
+    with tempfile.TemporaryDirectory(prefix="thebitlab-p4-") as raw_temp:
+        temp_root = Path(raw_temp)
+        tests: list[dict[str, Any]] = []
+        for index, teacher_test in enumerate(teacher_tests):
+            tests.append(
+                run_filesystem_test_in_docker(
+                    image=image,
+                    activity_root=resolved_activity_root,
+                    activity_path=safe_activity,
+                    source_path=safe_source,
+                    teacher_test=teacher_test,
+                    timeout_seconds=timeout_seconds,
+                    temp_root=temp_root,
+                    test_index=index,
+                )
+            )
+
+    passed = all(test["passed"] for test in tests)
+    return {
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "activity_id": activity.get("id"),
+        "language": "python",
+        "profile": p4.PROFILE_ID,
+        "source": str(source_path),
+        "tests": tests,
+        "summary": {
+            "passed": sum(1 for test in tests if test["passed"]),
+            "total": len(tests),
+        },
+    }
+
+
+def positive_int(value: str) -> int:
+    try:
+        number = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("deve essere intero") from error
+    if number <= 0:
+        raise argparse.ArgumentTypeError("deve essere positivo")
+    return number
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Grade Python filesystem-behavior Activity in Docker")
+    parser.add_argument("--activity", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--activity-root", type=Path)
+    parser.add_argument("--source-root", type=Path)
+    parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE)
+    parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--report", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = grade_in_docker(
+            activity_path=args.activity,
+            source_path=args.source,
+            image=args.docker_image,
+            timeout_seconds=args.timeout,
+            activity_root=args.activity_root,
+            source_root=args.source_root,
+        )
+    except subprocess.TimeoutExpired as error:
+        print(f"P4 Docker grading interrotto dopo {error.timeout} secondi")
+        return 2
+    except FileNotFoundError:
+        print("Docker non trovato. Installa Docker per il grading P4 autorevole.")
+        return 2
+    except (OSError, ValueError, grade_activity.DockerCleanupError) as error:
+        print(f"P4 Docker grading non avviato: {error}")
+        return 2
+    if args.report:
+        grade_activity.write_report(report, args.report)
+    else:
+        print(json.dumps(report, ensure_ascii=False, indent=2, allow_nan=False))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/grade_python_function_activity.py
+++ b/scripts/grade_python_function_activity.py
@@ -4,20 +4,20 @@ import argparse
 import json
 from pathlib import Path
 import subprocess
+import sys
 import tempfile
 import uuid
 from typing import Any
 
-try:
-    from scripts import grade_activity
-    from scripts import python_function_profile as p2
-    from scripts import validate_activity
-    from scripts.thebitlab_sandbox_boundary import docker_boundary_command
-except ModuleNotFoundError:  # direct ``python scripts/...`` execution
-    import grade_activity
-    import python_function_profile as p2
-    import validate_activity
-    from thebitlab_sandbox_boundary import docker_boundary_command
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import grade_activity
+from scripts import python_function_profile as p2
+from scripts import validate_activity
+from scripts.thebitlab_sandbox_boundary import docker_boundary_command
 
 
 DEFAULT_TIMEOUT_SECONDS = 5

--- a/scripts/grade_python_function_activity.py
+++ b/scripts/grade_python_function_activity.py
@@ -8,10 +8,16 @@ import tempfile
 import uuid
 from typing import Any
 
-from scripts import grade_activity
-from scripts import python_function_profile as p2
-from scripts import validate_activity
-from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+try:
+    from scripts import grade_activity
+    from scripts import python_function_profile as p2
+    from scripts import validate_activity
+    from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+except ModuleNotFoundError:  # direct ``python scripts/...`` execution
+    import grade_activity
+    import python_function_profile as p2
+    import validate_activity
+    from thebitlab_sandbox_boundary import docker_boundary_command
 
 
 DEFAULT_TIMEOUT_SECONDS = 5
@@ -97,10 +103,7 @@ def run_function_test_in_docker(
             raise ValueError("P2 worker non ha prodotto JSON valido") from error
         return p2.validate_worker_result(result)
     finally:
-        try:
-            grade_activity.remove_docker_container(cidfile, container_name)
-        except grade_activity.DockerCleanupError:
-            raise
+        grade_activity.remove_docker_container(cidfile, container_name)
 
 
 def grade_in_docker(
@@ -169,7 +172,10 @@ def grade_in_docker(
 
 
 def positive_int(value: str) -> int:
-    number = int(value)
+    try:
+        number = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("deve essere un intero") from error
     if number <= 0:
         raise argparse.ArgumentTypeError("deve essere positivo")
     return number

--- a/scripts/grade_python_function_activity.py
+++ b/scripts/grade_python_function_activity.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import uuid
+from typing import Any
+
+from scripts import grade_activity
+from scripts import python_function_profile as p2
+from scripts import validate_activity
+from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+
+
+DEFAULT_TIMEOUT_SECONDS = 5
+DEFAULT_DOCKER_IMAGE = grade_activity.DEFAULT_DOCKER_IMAGE
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: JSON root deve essere un oggetto")
+    return value
+
+
+def p2_docker_command(
+    *,
+    image: str,
+    workspace: Path,
+    source: Path,
+    timeout_seconds: int,
+    cidfile: Path,
+    container_name: str,
+) -> list[str]:
+    command = docker_boundary_command(
+        image=image,
+        workspace=workspace,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    image_ref = command.pop()
+    command.extend(["--entrypoint", "python3", image_ref])
+    command.extend(
+        [
+            "/opt/thebitlab/python_function_worker.py",
+            "--source",
+            grade_activity.path_inside_workspace(source, workspace, "source"),
+        ]
+    )
+    return command
+
+
+def run_function_test_in_docker(
+    *,
+    image: str,
+    workspace: Path,
+    source: Path,
+    teacher_test: dict[str, Any],
+    timeout_seconds: int,
+    temp_root: Path,
+    test_index: int,
+) -> dict[str, Any]:
+    cidfile = temp_root / f"p2-container-{test_index}.cid"
+    container_name = f"thebitlab-p2-{uuid.uuid4().hex}"
+    command = p2_docker_command(
+        image=image,
+        workspace=workspace,
+        source=source,
+        timeout_seconds=timeout_seconds,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    request = p2.worker_request(teacher_test)
+    try:
+        try:
+            completed = grade_activity.run_bounded_process(
+                command,
+                input_text=json.dumps(request, ensure_ascii=False, allow_nan=False),
+                timeout=timeout_seconds + grade_activity.DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "schema_version": p2.WORKER_SCHEMA,
+                "status": "timeout",
+                "stdout": "",
+                "stderr": "",
+            }
+        if completed.returncode != 0:
+            raise ValueError(
+                f"P2 worker terminato con errore infrastrutturale: exit={completed.returncode}"
+            )
+        try:
+            result = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise ValueError("P2 worker non ha prodotto JSON valido") from error
+        return p2.validate_worker_result(result)
+    finally:
+        try:
+            grade_activity.remove_docker_container(cidfile, container_name)
+        except grade_activity.DockerCleanupError:
+            raise
+
+
+def grade_in_docker(
+    *,
+    activity_path: Path,
+    source_path: Path,
+    image: str,
+    timeout_seconds: int,
+    activity_root: Path | None = None,
+    source_root: Path | None = None,
+) -> dict[str, Any]:
+    safe_activity = grade_activity.confined_regular_input(
+        activity_path,
+        activity_root or activity_path.parent,
+        "activity",
+    )
+    safe_source = grade_activity.confined_regular_input(
+        source_path,
+        source_root or source_path.parent,
+        "source",
+    )
+    activity = load_object(safe_activity)
+    errors = validate_activity.validate_activity(activity, str(safe_activity))
+    if errors:
+        raise ValueError("Activity non valida: " + "; ".join(errors))
+    if (activity.get("language") or activity.get("linguaggio")) not in {"python", "py", None}:
+        raise ValueError("P2 supporta solo Activity Python")
+    teacher_tests = p2.validate_function_tests(activity.get("function_tests"))
+
+    with tempfile.TemporaryDirectory(prefix="thebitlab-p2-") as raw_temp:
+        temp_root = Path(raw_temp)
+        workspace, source = grade_activity.prepare_docker_workspace(
+            safe_activity,
+            safe_source,
+            temp_root,
+            activity_root=activity_root or safe_activity.parent,
+            source_root=source_root or safe_source.parent,
+        )
+        tests: list[dict[str, Any]] = []
+        for index, teacher_test in enumerate(teacher_tests):
+            worker_result = run_function_test_in_docker(
+                image=image,
+                workspace=workspace,
+                source=source,
+                teacher_test=teacher_test,
+                timeout_seconds=timeout_seconds,
+                temp_root=temp_root,
+                test_index=index,
+            )
+            tests.append(p2.compare_worker_result(teacher_test, worker_result))
+
+    passed = all(test["passed"] for test in tests)
+    return {
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "activity_id": activity.get("id"),
+        "language": "python",
+        "profile": p2.PROFILE_ID,
+        "source": str(source_path),
+        "tests": tests,
+        "summary": {
+            "passed": sum(1 for test in tests if test["passed"]),
+            "total": len(tests),
+        },
+    }
+
+
+def positive_int(value: str) -> int:
+    number = int(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("deve essere positivo")
+    return number
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Grade Python function-behavior Activity in Docker")
+    parser.add_argument("--activity", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--activity-root", type=Path)
+    parser.add_argument("--source-root", type=Path)
+    parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE)
+    parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--report", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = grade_in_docker(
+            activity_path=args.activity,
+            source_path=args.source,
+            image=args.docker_image,
+            timeout_seconds=args.timeout,
+            activity_root=args.activity_root,
+            source_root=args.source_root,
+        )
+    except (OSError, ValueError, grade_activity.DockerCleanupError) as error:
+        print(f"P2 Docker grading non avviato: {error}")
+        return 2
+    if args.report:
+        grade_activity.write_report(report, args.report)
+    else:
+        print(json.dumps(report, ensure_ascii=False, indent=2, allow_nan=False))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/grade_python_object_activity.py
+++ b/scripts/grade_python_object_activity.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import uuid
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import grade_activity
+from scripts import python_object_profile as p3
+from scripts import validate_activity
+from scripts.thebitlab_sandbox_boundary import docker_boundary_command
+
+
+DEFAULT_TIMEOUT_SECONDS = 5
+DEFAULT_DOCKER_IMAGE = grade_activity.DEFAULT_DOCKER_IMAGE
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: JSON root deve essere un oggetto")
+    return value
+
+
+def p3_docker_command(
+    *,
+    image: str,
+    workspace: Path,
+    source: Path,
+    cidfile: Path,
+    container_name: str,
+) -> list[str]:
+    command = docker_boundary_command(
+        image=image,
+        workspace=workspace,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    image_ref = command.pop()
+    command.extend(["--entrypoint", "python3", image_ref])
+    command.extend(
+        [
+            "/opt/thebitlab/python_object_worker.py",
+            "--source",
+            grade_activity.path_inside_workspace(source, workspace, "source"),
+        ]
+    )
+    return command
+
+
+def timeout_worker_result() -> dict[str, Any]:
+    return {
+        "schema_version": p3.WORKER_SCHEMA,
+        "status": "timeout",
+        "stdout": "",
+        "stderr": "",
+        "steps": [],
+    }
+
+
+def run_object_test_in_docker(
+    *,
+    image: str,
+    workspace: Path,
+    source: Path,
+    teacher_test: dict[str, Any],
+    timeout_seconds: int,
+    temp_root: Path,
+    test_index: int,
+) -> dict[str, Any]:
+    """Run one P3 scenario in a fresh hardened container."""
+    cidfile = temp_root / f"p3-container-{test_index}.cid"
+    container_name = f"thebitlab-p3-{uuid.uuid4().hex}"
+    command = p3_docker_command(
+        image=image,
+        workspace=workspace,
+        source=source,
+        cidfile=cidfile,
+        container_name=container_name,
+    )
+    request = p3.worker_request(teacher_test)
+    try:
+        try:
+            completed = grade_activity.run_bounded_process(
+                command,
+                input_text=json.dumps(request, ensure_ascii=False, allow_nan=False),
+                timeout=timeout_seconds
+                + grade_activity.DEFAULT_DOCKER_TIMEOUT_GRACE_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return timeout_worker_result()
+        if completed.returncode != 0:
+            raise ValueError(
+                f"P3 worker terminato con errore infrastrutturale: exit={completed.returncode}"
+            )
+        try:
+            result = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise ValueError("P3 worker non ha prodotto JSON valido") from error
+        return p3.validate_worker_result(result)
+    finally:
+        grade_activity.remove_docker_container(cidfile, container_name)
+
+
+def grade_in_docker(
+    *,
+    activity_path: Path,
+    source_path: Path,
+    image: str = DEFAULT_DOCKER_IMAGE,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    activity_root: Path | None = None,
+    source_root: Path | None = None,
+) -> dict[str, Any]:
+    """Grade Python object behavior with one isolated container per scenario."""
+    resolved_activity_root = (activity_root or activity_path.parent).resolve(strict=True)
+    resolved_source_root = (source_root or source_path.parent).resolve(strict=True)
+    safe_activity = grade_activity.confined_regular_input(
+        activity_path,
+        resolved_activity_root,
+        "activity",
+    )
+    safe_source = grade_activity.confined_regular_input(
+        source_path,
+        resolved_source_root,
+        "source",
+    )
+    activity = load_object(safe_activity)
+    errors = validate_activity.validate_activity(activity, str(safe_activity))
+    if errors:
+        raise ValueError("Activity P3 non valida: " + "; ".join(errors))
+    language = str(activity.get("language") or activity.get("linguaggio") or "python").lower()
+    if language not in {"python", "py"}:
+        raise ValueError("P3 supporta solo Activity Python")
+    teacher_tests = p3.validate_object_tests(activity.get("object_tests"))
+
+    with tempfile.TemporaryDirectory(prefix="thebitlab-p3-") as raw_temp:
+        temp_root = Path(raw_temp)
+        workspace, source = grade_activity.prepare_docker_workspace(
+            safe_activity,
+            safe_source,
+            temp_root,
+            activity_root=resolved_activity_root,
+            source_root=resolved_source_root,
+        )
+        tests: list[dict[str, Any]] = []
+        for index, teacher_test in enumerate(teacher_tests):
+            worker_result = run_object_test_in_docker(
+                image=image,
+                workspace=workspace,
+                source=source,
+                teacher_test=teacher_test,
+                timeout_seconds=timeout_seconds,
+                temp_root=temp_root,
+                test_index=index,
+            )
+            tests.append(p3.compare_worker_result(teacher_test, worker_result))
+
+    passed = all(test["passed"] for test in tests)
+    return {
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "activity_id": activity.get("id"),
+        "language": "python",
+        "profile": p3.PROFILE_ID,
+        "source": str(source_path),
+        "tests": tests,
+        "summary": {
+            "passed": sum(1 for test in tests if test["passed"]),
+            "total": len(tests),
+        },
+    }
+
+
+def positive_int(value: str) -> int:
+    try:
+        number = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("deve essere un intero") from error
+    if number <= 0:
+        raise argparse.ArgumentTypeError("deve essere positivo")
+    return number
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Grade Python object-behavior Activity in Docker"
+    )
+    parser.add_argument("--activity", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--activity-root", type=Path)
+    parser.add_argument("--source-root", type=Path)
+    parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE)
+    parser.add_argument("--timeout", type=positive_int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--report", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = grade_in_docker(
+            activity_path=args.activity,
+            source_path=args.source,
+            image=args.docker_image,
+            timeout_seconds=args.timeout,
+            activity_root=args.activity_root,
+            source_root=args.source_root,
+        )
+    except subprocess.TimeoutExpired as error:
+        print(f"P3 Docker grading interrotto dopo {error.timeout} secondi")
+        return 2
+    except FileNotFoundError:
+        print("Docker non trovato. Installa Docker per il grading P3 autorevole.")
+        return 2
+    except (OSError, ValueError, grade_activity.DockerCleanupError) as error:
+        print(f"P3 Docker grading non avviato: {error}")
+        return 2
+    if args.report:
+        grade_activity.write_report(report, args.report)
+    else:
+        print(json.dumps(report, ensure_ascii=False, indent=2, allow_nan=False))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/grade_python_object_activity.py
+++ b/scripts/grade_python_object_activity.py
@@ -140,7 +140,15 @@ def grade_in_docker(
     language = str(activity.get("language") or activity.get("linguaggio") or "python").lower()
     if language not in {"python", "py"}:
         raise ValueError("P3 supporta solo Activity Python")
-    teacher_tests = p3.validate_object_tests(activity.get("object_tests"))
+
+    # Keep the teacher contract in its canonical raw Activity form. The worker
+    # request builder and host-side comparator each validate/normalize that raw
+    # scenario at their own trust boundary. Replacing it here with the normalized
+    # representation would make those boundaries parse an internal shape twice.
+    teacher_tests = activity.get("object_tests")
+    p3.validate_object_tests(teacher_tests)
+    if not isinstance(teacher_tests, list):
+        raise ValueError("Activity P3 senza object_tests validi")
 
     with tempfile.TemporaryDirectory(prefix="thebitlab-p3-") as raw_temp:
         temp_root = Path(raw_temp)

--- a/scripts/python_filesystem_profile.py
+++ b/scripts/python_filesystem_profile.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import PurePosixPath
+from typing import Any
+
+
+PROFILE_ID = "python-filesystem-v1"
+WORKER_SCHEMA = "thebitlab.python-filesystem-worker.v1"
+
+MAX_TESTS = 32
+MAX_FIXTURES = 8
+MAX_FIXTURE_FILE_BYTES = 64 * 1024
+MAX_FIXTURE_TOTAL_BYTES = 256 * 1024
+MAX_OUTPUT_FILES = 16
+MAX_OUTPUT_FILE_BYTES = 64 * 1024
+MAX_OUTPUT_TOTAL_BYTES = 256 * 1024
+MAX_STDIO_CHARS = 4096
+
+_PORTABLE_FILE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+
+class FilesystemProfileError(ValueError):
+    """Invalid P4 teacher contract, worker request or worker result."""
+
+
+def safe_bundle_path(value: Any) -> str:
+    """Return a safe portable Activity-bundle relative path."""
+
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise FilesystemProfileError("fixture source deve essere un path relativo POSIX")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise FilesystemProfileError("fixture source contiene traversal o path non portabile")
+    if len(value) > 240:
+        raise FilesystemProfileError("fixture source troppo lungo")
+    return value
+
+
+def portable_root_file(value: Any, *, label: str) -> str:
+    """Return one root-level portable file name used inside the P4 workdir."""
+
+    if not isinstance(value, str) or not _PORTABLE_FILE_RE.fullmatch(value):
+        raise FilesystemProfileError(
+            f"{label} deve essere un nome file root-level ASCII portabile"
+        )
+    if value in {".", ".."}:
+        raise FilesystemProfileError(f"{label} non valido")
+    return value
+
+
+def normalize_text(value: str) -> str:
+    """Normalize only newline representation; whitespace/trailing newline stay semantic."""
+
+    return value.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def text_sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _validate_fixture(value: Any, *, source: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise FilesystemProfileError(f"{source} deve essere un oggetto")
+    allowed = {"id", "source", "target", "mode"}
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise FilesystemProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    fixture_id = value.get("id")
+    if not isinstance(fixture_id, str) or not _ID_RE.fullmatch(fixture_id):
+        raise FilesystemProfileError(f"{source}.id non valido")
+    if value.get("mode") != "read-only":
+        raise FilesystemProfileError(f"{source}.mode deve essere read-only")
+    return {
+        "id": fixture_id,
+        "source": safe_bundle_path(value.get("source")),
+        "target": portable_root_file(value.get("target"), label=f"{source}.target"),
+        "mode": "read-only",
+    }
+
+
+def _validate_expected_artifact(value: Any, *, source: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise FilesystemProfileError(f"{source} deve essere un oggetto")
+    allowed = {"path", "text", "encoding"}
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise FilesystemProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    path = portable_root_file(value.get("path"), label=f"{source}.path")
+    if value.get("encoding", "utf-8") != "utf-8":
+        raise FilesystemProfileError(f"{source}.encoding supporta solo utf-8")
+    text = value.get("text")
+    if not isinstance(text, str):
+        raise FilesystemProfileError(f"{source}.text deve essere una stringa")
+    if len(text.encode("utf-8")) > MAX_OUTPUT_FILE_BYTES:
+        raise FilesystemProfileError(f"{source}.text supera il limite P4")
+    return {"path": path, "text": normalize_text(text), "encoding": "utf-8"}
+
+
+def validate_filesystem_test(value: Any, *, source: str = "test") -> dict[str, Any]:
+    """Validate one teacher-side filesystem behavior test."""
+
+    if not isinstance(value, dict):
+        raise FilesystemProfileError(f"{source} deve essere un oggetto")
+    allowed = {
+        "profile",
+        "name",
+        "fixtures",
+        "expected_artifacts",
+        "expected_absent",
+        "allow_unexpected_artifacts",
+        "visibility",
+    }
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise FilesystemProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    if value.get("profile") != PROFILE_ID:
+        raise FilesystemProfileError(f"{source}.profile deve essere {PROFILE_ID}")
+
+    fixtures_raw = value.get("fixtures", [])
+    if not isinstance(fixtures_raw, list) or len(fixtures_raw) > MAX_FIXTURES:
+        raise FilesystemProfileError(
+            f"{source}.fixtures deve essere una lista con massimo {MAX_FIXTURES} elementi"
+        )
+    fixtures = [
+        _validate_fixture(item, source=f"{source}.fixtures[{index}]")
+        for index, item in enumerate(fixtures_raw)
+    ]
+    fixture_ids = [item["id"] for item in fixtures]
+    fixture_targets = [item["target"] for item in fixtures]
+    if len(fixture_ids) != len(set(fixture_ids)):
+        raise FilesystemProfileError(f"{source}.fixtures contiene id duplicati")
+    if len(fixture_targets) != len(set(fixture_targets)):
+        raise FilesystemProfileError(f"{source}.fixtures contiene target duplicati")
+
+    expected_raw = value.get("expected_artifacts", [])
+    if not isinstance(expected_raw, list) or len(expected_raw) > MAX_OUTPUT_FILES:
+        raise FilesystemProfileError(
+            f"{source}.expected_artifacts deve essere una lista con massimo "
+            f"{MAX_OUTPUT_FILES} elementi"
+        )
+    expected = [
+        _validate_expected_artifact(item, source=f"{source}.expected_artifacts[{index}]")
+        for index, item in enumerate(expected_raw)
+    ]
+    expected_paths = [item["path"] for item in expected]
+    if len(expected_paths) != len(set(expected_paths)):
+        raise FilesystemProfileError(f"{source}.expected_artifacts contiene path duplicati")
+
+    absent_raw = value.get("expected_absent", [])
+    if not isinstance(absent_raw, list) or len(absent_raw) > MAX_OUTPUT_FILES:
+        raise FilesystemProfileError(
+            f"{source}.expected_absent deve essere una lista con massimo {MAX_OUTPUT_FILES} elementi"
+        )
+    absent = [
+        portable_root_file(item, label=f"{source}.expected_absent[{index}]")
+        for index, item in enumerate(absent_raw)
+    ]
+    if len(absent) != len(set(absent)):
+        raise FilesystemProfileError(f"{source}.expected_absent contiene duplicati")
+
+    collisions = (
+        set(fixture_targets) & set(expected_paths)
+        | set(fixture_targets) & set(absent)
+        | set(expected_paths) & set(absent)
+    )
+    if collisions:
+        raise FilesystemProfileError(
+            f"{source} contiene path con ruoli incompatibili: {', '.join(sorted(collisions))}"
+        )
+    if not expected and not absent:
+        raise FilesystemProfileError(
+            f"{source} deve dichiarare expected_artifacts e/o expected_absent"
+        )
+
+    allow_unexpected = value.get("allow_unexpected_artifacts", False)
+    if not isinstance(allow_unexpected, bool):
+        raise FilesystemProfileError(
+            f"{source}.allow_unexpected_artifacts deve essere boolean"
+        )
+
+    normalized: dict[str, Any] = {
+        "profile": PROFILE_ID,
+        "fixtures": fixtures,
+        "expected_artifacts": expected,
+        "expected_absent": absent,
+        "allow_unexpected_artifacts": allow_unexpected,
+    }
+    name = value.get("name")
+    if isinstance(name, str) and name:
+        normalized["name"] = name[:128]
+    visibility = value.get("visibility")
+    if visibility is not None:
+        if visibility not in {"teacher", "student", "public"}:
+            raise FilesystemProfileError(f"{source}.visibility non valida")
+        normalized["visibility"] = visibility
+    return normalized
+
+
+def validate_filesystem_tests(value: Any, *, source: str = "filesystem_tests") -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise FilesystemProfileError(f"{source} deve essere una lista non vuota")
+    if len(value) > MAX_TESTS:
+        raise FilesystemProfileError(f"{source} supera il limite di {MAX_TESTS} test")
+    return [
+        validate_filesystem_test(item, source=f"{source}[{index}]")
+        for index, item in enumerate(value)
+    ]
+
+
+def worker_request(test: dict[str, Any]) -> dict[str, Any]:
+    """Build the untrusted-worker request without teacher expected artifact content."""
+
+    normalized = validate_filesystem_test(test)
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "fixture_targets": [item["target"] for item in normalized["fixtures"]],
+    }
+
+
+def validate_worker_request(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != {"schema_version", "fixture_targets"}:
+        raise FilesystemProfileError("worker request contiene campi mancanti o inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise FilesystemProfileError("worker schema non supportato")
+    targets = value.get("fixture_targets")
+    if not isinstance(targets, list) or len(targets) > MAX_FIXTURES:
+        raise FilesystemProfileError("worker fixture_targets non valido")
+    normalized = [
+        portable_root_file(item, label=f"worker.fixture_targets[{index}]")
+        for index, item in enumerate(targets)
+    ]
+    if len(normalized) != len(set(normalized)):
+        raise FilesystemProfileError("worker fixture_targets contiene duplicati")
+    return {"schema_version": WORKER_SCHEMA, "fixture_targets": normalized}
+
+
+def validate_worker_result(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FilesystemProfileError("worker result deve essere un oggetto")
+    allowed = {"schema_version", "status", "artifacts", "stdout", "stderr", "exception"}
+    if set(value) - allowed:
+        raise FilesystemProfileError("worker result contiene campi inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise FilesystemProfileError("worker result schema non supportato")
+    status = value.get("status")
+    if status not in {"completed", "runtime-error", "output-limit", "policy-violation"}:
+        raise FilesystemProfileError("worker result status non supportato")
+    stdout = value.get("stdout", "")
+    stderr = value.get("stderr", "")
+    if not isinstance(stdout, str) or not isinstance(stderr, str):
+        raise FilesystemProfileError("worker stdout/stderr devono essere stringhe")
+    if len(stdout) > MAX_STDIO_CHARS or len(stderr) > MAX_STDIO_CHARS:
+        raise FilesystemProfileError("worker stdout/stderr superano il limite")
+
+    artifacts_raw = value.get("artifacts", [])
+    if not isinstance(artifacts_raw, list) or len(artifacts_raw) > MAX_OUTPUT_FILES:
+        raise FilesystemProfileError("worker artifacts non valido")
+    artifacts: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    total_bytes = 0
+    for index, item in enumerate(artifacts_raw):
+        if not isinstance(item, dict) or set(item) != {"path", "text", "bytes", "sha256"}:
+            raise FilesystemProfileError(f"worker artifacts[{index}] non valido")
+        path = portable_root_file(item.get("path"), label=f"worker artifacts[{index}].path")
+        if path in seen:
+            raise FilesystemProfileError("worker artifacts contiene path duplicati")
+        seen.add(path)
+        text = item.get("text")
+        size = item.get("bytes")
+        digest = item.get("sha256")
+        if not isinstance(text, str):
+            raise FilesystemProfileError("worker artifact text non valido")
+        encoded = text.encode("utf-8")
+        if (
+            isinstance(size, bool)
+            or not isinstance(size, int)
+            or size != len(encoded)
+            or size > MAX_OUTPUT_FILE_BYTES
+        ):
+            raise FilesystemProfileError("worker artifact size non valido")
+        if not isinstance(digest, str) or digest != hashlib.sha256(encoded).hexdigest():
+            raise FilesystemProfileError("worker artifact sha256 non valido")
+        total_bytes += size
+        artifacts.append(
+            {
+                "path": path,
+                "text": normalize_text(text),
+                "bytes": size,
+                "sha256": digest,
+            }
+        )
+    if total_bytes > MAX_OUTPUT_TOTAL_BYTES:
+        raise FilesystemProfileError("worker artifact bytes totali oltre limite")
+
+    normalized: dict[str, Any] = {
+        "schema_version": WORKER_SCHEMA,
+        "status": status,
+        "artifacts": artifacts,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    if status == "runtime-error":
+        exception = value.get("exception")
+        if not isinstance(exception, dict) or set(exception) != {"type", "message"}:
+            raise FilesystemProfileError("worker runtime exception non valida")
+        exc_type = exception.get("type")
+        message = exception.get("message")
+        if not isinstance(exc_type, str) or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,63}", exc_type):
+            raise FilesystemProfileError("worker exception type non valido")
+        if not isinstance(message, str) or len(message) > 512:
+            raise FilesystemProfileError("worker exception message non valido")
+        normalized["exception"] = {"type": exc_type, "message": message}
+    return normalized
+
+
+def compare_worker_result(test: dict[str, Any], worker_result: dict[str, Any]) -> dict[str, Any]:
+    """Compare observed filesystem state with teacher expectations on the trusted host."""
+
+    expected = validate_filesystem_test(test)
+    actual = validate_worker_result(worker_result)
+    artifacts = {item["path"]: item for item in actual["artifacts"]}
+    checks: list[dict[str, Any]] = []
+
+    if actual["status"] != "completed":
+        return {
+            "name": expected.get("name", "filesystem"),
+            "profile": PROFILE_ID,
+            "visibility": expected.get("visibility", "teacher"),
+            "passed": False,
+            "status": "failed",
+            "worker_status": actual["status"],
+            "checks": [],
+            "stdout": actual["stdout"],
+            "stderr": actual["stderr"],
+            "exception": actual.get("exception"),
+        }
+
+    for item in expected["expected_artifacts"]:
+        observed = artifacts.get(item["path"])
+        if observed is None:
+            checks.append(
+                {"path": item["path"], "kind": "required-artifact", "passed": False, "status": "missing"}
+            )
+            continue
+        passed = observed["text"] == item["text"]
+        checks.append(
+            {
+                "path": item["path"],
+                "kind": "text-content",
+                "passed": passed,
+                "status": "matched" if passed else "content-mismatch",
+            }
+        )
+
+    for path in expected["expected_absent"]:
+        absent = path not in artifacts
+        checks.append(
+            {
+                "path": path,
+                "kind": "expected-absent",
+                "passed": absent,
+                "status": "absent" if absent else "unexpected-present",
+            }
+        )
+
+    declared = {item["path"] for item in expected["expected_artifacts"]}
+    unexpected = sorted(set(artifacts) - declared)
+    if unexpected and not expected["allow_unexpected_artifacts"]:
+        for path in unexpected:
+            checks.append(
+                {"path": path, "kind": "unexpected-artifact", "passed": False, "status": "unexpected"}
+            )
+
+    passed = bool(checks) and all(check["passed"] for check in checks)
+    return {
+        "name": expected.get("name", "filesystem"),
+        "profile": PROFILE_ID,
+        "visibility": expected.get("visibility", "teacher"),
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "worker_status": actual["status"],
+        "checks": checks,
+        "stdout": actual["stdout"],
+        "stderr": actual["stderr"],
+        "exception": actual.get("exception"),
+        "observed_artifacts": sorted(artifacts),
+    }

--- a/scripts/python_filesystem_worker.py
+++ b/scripts/python_filesystem_worker.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import argparse
+from contextlib import redirect_stderr, redirect_stdout
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+try:
+    import python_filesystem_profile as p4
+except ModuleNotFoundError:
+    from scripts import python_filesystem_profile as p4
+
+
+class FilesystemOutputLimitError(RuntimeError):
+    """Student stdout/stderr exceeded the P4 diagnostic limit."""
+
+
+class _BoundedTextCapture:
+    def __init__(self, limit: int = p4.MAX_STDIO_CHARS) -> None:
+        self.limit = limit
+        self._parts: list[str] = []
+        self._size = 0
+
+    def write(self, value: str) -> int:
+        text = str(value)
+        remaining = self.limit - self._size
+        if len(text) > remaining:
+            if remaining > 0:
+                self._parts.append(text[:remaining])
+                self._size += remaining
+            raise FilesystemOutputLimitError("stdout/stderr supera il limite P4")
+        self._parts.append(text)
+        self._size += len(text)
+        return len(text)
+
+    def flush(self) -> None:
+        return
+
+    def getvalue(self) -> str:
+        return "".join(self._parts)
+
+
+def _resolved(value: str | os.PathLike[str], *, cwd: Path) -> Path:
+    path = Path(value)
+    if not path.is_absolute():
+        path = cwd / path
+    return path.resolve(strict=False)
+
+
+def install_filesystem_audit_policy(*, workdir: Path, source: Path) -> None:
+    """Deny Python-level filesystem access outside the P4 workdir/source surface.
+
+    The student source is compiled before this hook is installed. This is
+    deliberate: importlib/runpy may read Python runtime files outside the
+    submission surface even when student code itself does not. The audit hook
+    therefore governs student execution rather than Python's own source loader.
+
+    This complements, but does not replace, the outer Docker sandbox.
+    """
+
+    workdir = workdir.resolve(strict=True)
+    source = source.resolve(strict=True)
+
+    def allowed_path(value: Any) -> bool:
+        if isinstance(value, int) or value is None:
+            return True
+        if isinstance(value, bytes):
+            try:
+                value = os.fsdecode(value)
+            except UnicodeDecodeError:
+                return False
+        if not isinstance(value, (str, os.PathLike)):
+            return False
+        try:
+            candidate = _resolved(value, cwd=Path.cwd())
+        except (OSError, RuntimeError, ValueError):
+            return False
+        return candidate == source or candidate == workdir or workdir in candidate.parents
+
+    def deny_external(value: Any, event: str) -> None:
+        if not allowed_path(value):
+            raise PermissionError(f"P4 filesystem policy: {event} fuori dal workdir")
+
+    def hook(event: str, args: tuple[Any, ...]) -> None:
+        if event == "open" and args:
+            deny_external(args[0], event)
+            return
+        if event in {"os.listdir", "os.scandir", "os.chdir", "os.remove", "os.rmdir", "os.mkdir"}:
+            if args:
+                deny_external(args[0], event)
+            return
+        if event in {"os.rename", "os.replace"}:
+            if len(args) >= 2:
+                deny_external(args[0], event)
+                deny_external(args[1], event)
+            return
+        if event in {"os.symlink", "os.link"}:
+            raise PermissionError("P4 filesystem policy: link non consentiti")
+        if event in {"os.system", "subprocess.Popen"}:
+            raise PermissionError("P4 filesystem policy: processi secondari non consentiti")
+        if event == "import" and args and args[0] in {"ctypes", "subprocess"}:
+            raise PermissionError(f"P4 filesystem policy: import non consentito: {args[0]}")
+
+    sys.addaudithook(hook)
+
+
+def scan_artifacts(workdir: Path, fixture_targets: set[str]) -> tuple[str | None, list[dict[str, Any]]]:
+    """Return bounded regular UTF-8 artifacts or a policy/limit status."""
+
+    artifacts: list[dict[str, Any]] = []
+    total_bytes = 0
+    try:
+        entries = sorted(workdir.iterdir(), key=lambda path: path.name)
+    except OSError:
+        return "policy-violation", []
+
+    for path in entries:
+        if path.name in fixture_targets:
+            continue
+        if path.is_symlink() or not path.is_file():
+            return "policy-violation", []
+        if len(artifacts) >= p4.MAX_OUTPUT_FILES:
+            return "output-limit", []
+        try:
+            size = path.stat().st_size
+        except OSError:
+            return "policy-violation", []
+        if size > p4.MAX_OUTPUT_FILE_BYTES:
+            return "output-limit", []
+        total_bytes += size
+        if total_bytes > p4.MAX_OUTPUT_TOTAL_BYTES:
+            return "output-limit", []
+        try:
+            raw = path.read_bytes()
+            text = raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return "policy-violation", []
+        except OSError:
+            return "policy-violation", []
+        if len(raw) != size:
+            return "policy-violation", []
+        artifacts.append(
+            {
+                "path": path.name,
+                "text": text,
+                "bytes": len(raw),
+                "sha256": hashlib.sha256(raw).hexdigest(),
+            }
+        )
+    return None, artifacts
+
+
+def execute(request_value: Any, *, source: Path, workdir: Path) -> dict[str, Any]:
+    request = p4.validate_worker_request(request_value)
+    source = source.resolve(strict=True)
+    workdir = workdir.resolve(strict=True)
+    if not source.is_file() or not workdir.is_dir():
+        raise p4.FilesystemProfileError("source/workdir P4 non validi")
+
+    fixture_targets = set(request["fixture_targets"])
+    for target in fixture_targets:
+        fixture = workdir / target
+        if fixture.is_symlink() or not fixture.is_file():
+            return {
+                "schema_version": p4.WORKER_SCHEMA,
+                "status": "policy-violation",
+                "artifacts": [],
+                "stdout": "",
+                "stderr": "fixture dichiarata assente o non regolare",
+            }
+
+    # Read and compile before installing the audit hook. The source itself is
+    # trusted only as bytes to compile; execution remains fully untrusted and
+    # happens after confinement. This avoids classifying Python's own loader
+    # reads as student filesystem access.
+    try:
+        source_text = source.read_text(encoding="utf-8", errors="strict")
+        code = compile(source_text, str(source), "exec")
+    except UnicodeDecodeError as error:
+        return {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "runtime-error",
+            "artifacts": [],
+            "stdout": "",
+            "stderr": "",
+            "exception": {"type": type(error).__name__, "message": "source Python non UTF-8"},
+        }
+    except SyntaxError as error:
+        return {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "runtime-error",
+            "artifacts": [],
+            "stdout": "",
+            "stderr": "",
+            "exception": {"type": "SyntaxError", "message": str(error)[:512]},
+        }
+
+    os.chdir(workdir)
+    stdout = _BoundedTextCapture()
+    stderr = _BoundedTextCapture()
+    execution_status = "completed"
+    exception: dict[str, str] | None = None
+    try:
+        install_filesystem_audit_policy(workdir=workdir, source=source)
+        namespace = {
+            "__name__": "__main__",
+            "__file__": str(source),
+            "__builtins__": __builtins__,
+        }
+        try:
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                exec(code, namespace, namespace)
+        except FilesystemOutputLimitError:
+            execution_status = "output-limit"
+        except BaseException as error:
+            execution_status = "runtime-error"
+            message = str(error).replace(str(workdir), "<workdir>").replace(str(source), "<source>")
+            exception = {"type": type(error).__name__, "message": message[:512]}
+
+        scan_status, artifacts = scan_artifacts(workdir, fixture_targets)
+        if scan_status is not None:
+            execution_status = scan_status
+            artifacts = []
+        result: dict[str, Any] = {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": execution_status,
+            "artifacts": artifacts,
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+        }
+        if execution_status == "runtime-error" and exception is not None:
+            result["exception"] = exception
+        return result
+    finally:
+        # Process exits after one test; audit confinement deliberately prevents
+        # restoring a cwd outside the workdir.
+        pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="TheBitLab P4 filesystem worker")
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--workdir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = json.load(sys.stdin)
+        result = execute(request, source=args.source, workdir=args.workdir)
+        result = p4.validate_worker_result(result)
+    except (OSError, json.JSONDecodeError, p4.FilesystemProfileError) as error:
+        print(
+            json.dumps(
+                {
+                    "schema_version": p4.WORKER_SCHEMA,
+                    "status": "policy-violation",
+                    "artifacts": [],
+                    "stdout": "",
+                    "stderr": str(error)[: p4.MAX_STDIO_CHARS],
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 2
+    print(json.dumps(result, ensure_ascii=False, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python_function_profile.py
+++ b/scripts/python_function_profile.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+
+PROFILE_ID = "python-function-v1"
+WORKER_SCHEMA = "thebitlab.python-function-worker.v1"
+FUNCTION_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+MAX_TESTS = 64
+MAX_ARGS = 16
+MAX_KWARGS = 16
+MAX_STRING_CHARS = 4096
+MAX_CONTAINER_ITEMS = 64
+
+
+class FunctionProfileError(ValueError):
+    """Invalid teacher-side or worker-side function grading payload."""
+
+
+def _bounded_scalar(value: Any) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if abs(value) > 10**18:
+            raise FunctionProfileError("intero fuori dal limite supportato")
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value) or abs(value) > 1e18:
+            raise FunctionProfileError("float non finito o fuori limite")
+        return value
+    if isinstance(value, str):
+        if len(value) > MAX_STRING_CHARS:
+            raise FunctionProfileError("stringa troppo lunga")
+        return value
+    raise FunctionProfileError(f"tipo valore non supportato: {type(value).__name__}")
+
+
+def validate_value(value: Any, *, depth: int = 0) -> Any:
+    """Validate and normalize the small deterministic value codec used by P2."""
+    if depth > 4:
+        raise FunctionProfileError("valore troppo annidato")
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return _bounded_scalar(value)
+    if isinstance(value, list):
+        if len(value) > MAX_CONTAINER_ITEMS:
+            raise FunctionProfileError("lista troppo grande")
+        return [validate_value(item, depth=depth + 1) for item in value]
+    if isinstance(value, dict):
+        if len(value) > MAX_CONTAINER_ITEMS:
+            raise FunctionProfileError("dict troppo grande")
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key or len(key) > 128:
+                raise FunctionProfileError("chiave dict non supportata")
+            if key in normalized:
+                raise FunctionProfileError("chiave dict duplicata")
+            normalized[key] = validate_value(item, depth=depth + 1)
+        return normalized
+    raise FunctionProfileError(f"tipo valore non supportato: {type(value).__name__}")
+
+
+def _function_name(value: Any) -> str:
+    if not isinstance(value, str) or not FUNCTION_RE.fullmatch(value):
+        raise FunctionProfileError("function deve essere un identificatore Python semplice")
+    return value
+
+
+def validate_function_test(test: Any, *, source: str = "test") -> dict[str, Any]:
+    if not isinstance(test, dict):
+        raise FunctionProfileError(f"{source} deve essere un oggetto")
+    allowed = {
+        "profile",
+        "name",
+        "function",
+        "args",
+        "kwargs",
+        "expected_return",
+        "expected_exception",
+        "float_tolerance",
+        "visibility",
+    }
+    unknown = sorted(set(test) - allowed)
+    if unknown:
+        raise FunctionProfileError(f"{source} contiene campi non supportati: {', '.join(unknown)}")
+    if test.get("profile") != PROFILE_ID:
+        raise FunctionProfileError(f"{source}.profile deve essere {PROFILE_ID}")
+
+    function = _function_name(test.get("function"))
+    args = test.get("args", [])
+    kwargs = test.get("kwargs", {})
+    if not isinstance(args, list) or len(args) > MAX_ARGS:
+        raise FunctionProfileError(f"{source}.args deve essere una lista con massimo {MAX_ARGS} elementi")
+    if not isinstance(kwargs, dict) or len(kwargs) > MAX_KWARGS:
+        raise FunctionProfileError(f"{source}.kwargs deve essere un oggetto con massimo {MAX_KWARGS} elementi")
+    normalized_args = [validate_value(value) for value in args]
+    normalized_kwargs: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if not isinstance(key, str) or not FUNCTION_RE.fullmatch(key):
+            raise FunctionProfileError(f"{source}.kwargs contiene nome parametro non valido")
+        normalized_kwargs[key] = validate_value(value)
+
+    has_return = "expected_return" in test
+    has_exception = "expected_exception" in test
+    if has_return == has_exception:
+        raise FunctionProfileError(
+            f"{source} deve dichiarare esattamente uno tra expected_return ed expected_exception"
+        )
+
+    normalized: dict[str, Any] = {
+        "profile": PROFILE_ID,
+        "function": function,
+        "args": normalized_args,
+        "kwargs": normalized_kwargs,
+    }
+    if isinstance(test.get("name"), str) and test["name"]:
+        normalized["name"] = test["name"][:128]
+    if isinstance(test.get("visibility"), str):
+        normalized["visibility"] = test["visibility"]
+
+    if has_return:
+        normalized["expected_return"] = validate_value(test["expected_return"])
+        tolerance = test.get("float_tolerance")
+        if tolerance is not None:
+            if isinstance(tolerance, bool) or not isinstance(tolerance, (int, float)):
+                raise FunctionProfileError(f"{source}.float_tolerance deve essere numerico")
+            tolerance = float(tolerance)
+            if not math.isfinite(tolerance) or tolerance < 0 or tolerance > 1e6:
+                raise FunctionProfileError(f"{source}.float_tolerance fuori limite")
+            normalized["float_tolerance"] = tolerance
+    else:
+        exception_name = test["expected_exception"]
+        if not isinstance(exception_name, str) or not FUNCTION_RE.fullmatch(exception_name):
+            raise FunctionProfileError(f"{source}.expected_exception non valido")
+        normalized["expected_exception"] = exception_name
+        if "float_tolerance" in test:
+            raise FunctionProfileError(f"{source}.float_tolerance non ammesso con expected_exception")
+    return normalized
+
+
+def validate_function_tests(value: Any, *, source: str = "function_tests") -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise FunctionProfileError(f"{source} deve essere una lista non vuota")
+    if len(value) > MAX_TESTS:
+        raise FunctionProfileError(f"{source} supera il limite di {MAX_TESTS} test")
+    return [validate_function_test(test, source=f"{source}[{index}]") for index, test in enumerate(value)]
+
+
+def worker_request(test: dict[str, Any]) -> dict[str, Any]:
+    """Build the untrusted-worker request. Teacher expectations never cross this boundary."""
+    normalized = validate_function_test(test)
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "function": normalized["function"],
+        "args": normalized["args"],
+        "kwargs": normalized["kwargs"],
+    }
+
+
+def validate_worker_request(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FunctionProfileError("worker request deve essere un oggetto")
+    if set(value) != {"schema_version", "function", "args", "kwargs"}:
+        raise FunctionProfileError("worker request contiene campi mancanti o inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise FunctionProfileError("worker schema non supportato")
+    function = _function_name(value.get("function"))
+    args = value.get("args")
+    kwargs = value.get("kwargs")
+    if not isinstance(args, list) or len(args) > MAX_ARGS:
+        raise FunctionProfileError("worker args non validi")
+    if not isinstance(kwargs, dict) or len(kwargs) > MAX_KWARGS:
+        raise FunctionProfileError("worker kwargs non validi")
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "function": function,
+        "args": [validate_value(item) for item in args],
+        "kwargs": {key: validate_value(item) for key, item in kwargs.items()},
+    }
+
+
+def validate_worker_result(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FunctionProfileError("worker result deve essere un oggetto")
+    allowed = {"schema_version", "status", "return_value", "exception", "stdout", "stderr"}
+    if set(value) - allowed:
+        raise FunctionProfileError("worker result contiene campi inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise FunctionProfileError("worker result schema non supportato")
+    status = value.get("status")
+    if status not in {"returned", "raised", "missing-function", "not-callable", "import-error", "timeout"}:
+        raise FunctionProfileError("worker result status non supportato")
+    stdout = value.get("stdout", "")
+    stderr = value.get("stderr", "")
+    if not isinstance(stdout, str) or not isinstance(stderr, str):
+        raise FunctionProfileError("worker stdout/stderr devono essere stringhe")
+    if len(stdout) > MAX_STRING_CHARS or len(stderr) > MAX_STRING_CHARS:
+        raise FunctionProfileError("worker stdout/stderr troppo grandi")
+    normalized: dict[str, Any] = {
+        "schema_version": WORKER_SCHEMA,
+        "status": status,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    if status == "returned":
+        if "return_value" not in value:
+            raise FunctionProfileError("worker returned senza return_value")
+        normalized["return_value"] = validate_value(value["return_value"])
+    elif status == "raised":
+        exception = value.get("exception")
+        if not isinstance(exception, dict) or set(exception) - {"type", "message"}:
+            raise FunctionProfileError("worker exception non valida")
+        exception_type = exception.get("type")
+        message = exception.get("message", "")
+        if not isinstance(exception_type, str) or not FUNCTION_RE.fullmatch(exception_type):
+            raise FunctionProfileError("worker exception type non valido")
+        if not isinstance(message, str) or len(message) > 512:
+            raise FunctionProfileError("worker exception message non valido")
+        normalized["exception"] = {"type": exception_type, "message": message}
+    return normalized
+
+
+def compare_worker_result(test: dict[str, Any], worker_result: dict[str, Any]) -> dict[str, Any]:
+    """Perform the authoritative teacher-side comparison."""
+    expected = validate_function_test(test)
+    actual = validate_worker_result(worker_result)
+    passed = False
+    if "expected_exception" in expected:
+        passed = (
+            actual["status"] == "raised"
+            and actual.get("exception", {}).get("type") == expected["expected_exception"]
+        )
+    elif actual["status"] == "returned":
+        expected_value = expected["expected_return"]
+        actual_value = actual.get("return_value")
+        tolerance = expected.get("float_tolerance")
+        if tolerance is not None and isinstance(expected_value, (int, float)) and not isinstance(expected_value, bool):
+            passed = isinstance(actual_value, (int, float)) and not isinstance(actual_value, bool) and math.isclose(
+                float(actual_value), float(expected_value), rel_tol=0.0, abs_tol=tolerance
+            )
+        else:
+            passed = type(actual_value) is type(expected_value) and actual_value == expected_value
+    return {
+        "name": expected.get("name", expected["function"]),
+        "profile": PROFILE_ID,
+        "function": expected["function"],
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "worker_status": actual["status"],
+        "stdout": actual["stdout"],
+        "stderr": actual["stderr"],
+        "actual_return": actual.get("return_value"),
+        "actual_exception": actual.get("exception"),
+    }

--- a/scripts/python_function_profile.py
+++ b/scripts/python_function_profile.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from contextlib import redirect_stderr, redirect_stdout
+import importlib.util
 import math
+from pathlib import Path
 import re
+import sys
 from typing import Any
 
 
@@ -17,6 +21,36 @@ MAX_CONTAINER_ITEMS = 64
 
 class FunctionProfileError(ValueError):
     """Invalid teacher-side or worker-side function grading payload."""
+
+
+class FunctionOutputLimitError(RuntimeError):
+    """Student stdout/stderr exceeded the bounded diagnostic surface."""
+
+
+class _BoundedTextCapture:
+    def __init__(self, limit: int = MAX_STRING_CHARS) -> None:
+        self.limit = limit
+        self._parts: list[str] = []
+        self._size = 0
+
+    def write(self, value: str) -> int:
+        text = str(value)
+        next_size = self._size + len(text)
+        if next_size > self.limit:
+            remaining = max(0, self.limit - self._size)
+            if remaining:
+                self._parts.append(text[:remaining])
+                self._size += remaining
+            raise FunctionOutputLimitError("stdout/stderr supera il limite P2")
+        self._parts.append(text)
+        self._size = next_size
+        return len(text)
+
+    def flush(self) -> None:
+        return
+
+    def getvalue(self) -> str:
+        return "".join(self._parts)
 
 
 def _bounded_scalar(value: Any) -> Any:
@@ -172,12 +206,114 @@ def validate_worker_request(value: Any) -> dict[str, Any]:
         raise FunctionProfileError("worker args non validi")
     if not isinstance(kwargs, dict) or len(kwargs) > MAX_KWARGS:
         raise FunctionProfileError("worker kwargs non validi")
+    normalized_kwargs: dict[str, Any] = {}
+    for key, item in kwargs.items():
+        if not isinstance(key, str) or not FUNCTION_RE.fullmatch(key):
+            raise FunctionProfileError("worker kwargs contiene nome parametro non valido")
+        normalized_kwargs[key] = validate_value(item)
     return {
         "schema_version": WORKER_SCHEMA,
         "function": function,
         "args": [validate_value(item) for item in args],
-        "kwargs": {key: validate_value(item) for key, item in kwargs.items()},
+        "kwargs": normalized_kwargs,
     }
+
+
+def _exception_message(error: BaseException) -> str:
+    message = str(error)
+    return message[:512]
+
+
+def execute_worker_request(value: Any, source: Path) -> dict[str, Any]:
+    """Load one student module and invoke one declared function inside the untrusted worker."""
+    request = validate_worker_request(value)
+    stdout = _BoundedTextCapture()
+    stderr = _BoundedTextCapture()
+    module_name = "_thebitlab_student_function_submission"
+    sys.modules.pop(module_name, None)
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            try:
+                spec = importlib.util.spec_from_file_location(module_name, source)
+                if spec is None or spec.loader is None:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "import-error",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = module
+                try:
+                    spec.loader.exec_module(module)
+                except FunctionOutputLimitError:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "output-limit",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                except BaseException as error:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "import-error",
+                        "stdout": stdout.getvalue(),
+                        "stderr": (stderr.getvalue() + f"{type(error).__name__}: {_exception_message(error)}")[:MAX_STRING_CHARS],
+                    }
+
+                if not hasattr(module, request["function"]):
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "missing-function",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                function = getattr(module, request["function"])
+                if not callable(function):
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "not-callable",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                try:
+                    returned = function(*request["args"], **request["kwargs"])
+                except FunctionOutputLimitError:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "output-limit",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                except BaseException as error:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "raised",
+                        "exception": {
+                            "type": type(error).__name__,
+                            "message": _exception_message(error),
+                        },
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                try:
+                    normalized_return = validate_value(returned)
+                except FunctionProfileError:
+                    return {
+                        "schema_version": WORKER_SCHEMA,
+                        "status": "unsupported-return",
+                        "stdout": stdout.getvalue(),
+                        "stderr": stderr.getvalue(),
+                    }
+                return {
+                    "schema_version": WORKER_SCHEMA,
+                    "status": "returned",
+                    "return_value": normalized_return,
+                    "stdout": stdout.getvalue(),
+                    "stderr": stderr.getvalue(),
+                }
+    finally:
+        sys.modules.pop(module_name, None)
 
 
 def validate_worker_result(value: Any) -> dict[str, Any]:
@@ -189,7 +325,16 @@ def validate_worker_result(value: Any) -> dict[str, Any]:
     if value.get("schema_version") != WORKER_SCHEMA:
         raise FunctionProfileError("worker result schema non supportato")
     status = value.get("status")
-    if status not in {"returned", "raised", "missing-function", "not-callable", "import-error", "timeout"}:
+    if status not in {
+        "returned",
+        "raised",
+        "missing-function",
+        "not-callable",
+        "import-error",
+        "timeout",
+        "output-limit",
+        "unsupported-return",
+    }:
         raise FunctionProfileError("worker result status non supportato")
     stdout = value.get("stdout", "")
     stderr = value.get("stderr", "")
@@ -245,6 +390,7 @@ def compare_worker_result(test: dict[str, Any], worker_result: dict[str, Any]) -
         "name": expected.get("name", expected["function"]),
         "profile": PROFILE_ID,
         "function": expected["function"],
+        "visibility": expected.get("visibility", "teacher"),
         "passed": passed,
         "status": "passed" if passed else "failed",
         "worker_status": actual["status"],

--- a/scripts/python_function_profile.py
+++ b/scripts/python_function_profile.py
@@ -88,8 +88,6 @@ def validate_value(value: Any, *, depth: int = 0) -> Any:
         for key, item in value.items():
             if not isinstance(key, str) or not key or len(key) > 128:
                 raise FunctionProfileError("chiave dict non supportata")
-            if key in normalized:
-                raise FunctionProfileError("chiave dict duplicata")
             normalized[key] = validate_value(item, depth=depth + 1)
         return normalized
     raise FunctionProfileError(f"tipo valore non supportato: {type(value).__name__}")
@@ -220,8 +218,17 @@ def validate_worker_request(value: Any) -> dict[str, Any]:
 
 
 def _exception_message(error: BaseException) -> str:
-    message = str(error)
-    return message[:512]
+    return str(error)[:512]
+
+
+def _worker_result(status: str, stdout: _BoundedTextCapture, stderr: _BoundedTextCapture, **extra: Any) -> dict[str, Any]:
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "status": status,
+        "stdout": stdout.getvalue(),
+        "stderr": stderr.getvalue(),
+        **extra,
+    }
 
 
 def execute_worker_request(value: Any, source: Path) -> dict[str, Any]:
@@ -233,85 +240,52 @@ def execute_worker_request(value: Any, source: Path) -> dict[str, Any]:
     sys.modules.pop(module_name, None)
     try:
         with redirect_stdout(stdout), redirect_stderr(stderr):
+            spec = importlib.util.spec_from_file_location(module_name, source)
+            if spec is None or spec.loader is None:
+                return _worker_result("import-error", stdout, stderr)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
             try:
-                spec = importlib.util.spec_from_file_location(module_name, source)
-                if spec is None or spec.loader is None:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "import-error",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                module = importlib.util.module_from_spec(spec)
-                sys.modules[module_name] = module
-                try:
-                    spec.loader.exec_module(module)
-                except FunctionOutputLimitError:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "output-limit",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                except BaseException as error:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "import-error",
-                        "stdout": stdout.getvalue(),
-                        "stderr": (stderr.getvalue() + f"{type(error).__name__}: {_exception_message(error)}")[:MAX_STRING_CHARS],
-                    }
+                spec.loader.exec_module(module)
+            except FunctionOutputLimitError:
+                return _worker_result("output-limit", stdout, stderr)
+            except BaseException as error:
+                stderr.write(
+                    f"{type(error).__name__}: {_exception_message(error)}"[
+                        : max(0, MAX_STRING_CHARS - len(stderr.getvalue()))
+                    ]
+                )
+                return _worker_result("import-error", stdout, stderr)
 
-                if not hasattr(module, request["function"]):
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "missing-function",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                function = getattr(module, request["function"])
-                if not callable(function):
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "not-callable",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                try:
-                    returned = function(*request["args"], **request["kwargs"])
-                except FunctionOutputLimitError:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "output-limit",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                except BaseException as error:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "raised",
-                        "exception": {
-                            "type": type(error).__name__,
-                            "message": _exception_message(error),
-                        },
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                try:
-                    normalized_return = validate_value(returned)
-                except FunctionProfileError:
-                    return {
-                        "schema_version": WORKER_SCHEMA,
-                        "status": "unsupported-return",
-                        "stdout": stdout.getvalue(),
-                        "stderr": stderr.getvalue(),
-                    }
-                return {
-                    "schema_version": WORKER_SCHEMA,
-                    "status": "returned",
-                    "return_value": normalized_return,
-                    "stdout": stdout.getvalue(),
-                    "stderr": stderr.getvalue(),
-                }
+            if not hasattr(module, request["function"]):
+                return _worker_result("missing-function", stdout, stderr)
+            function = getattr(module, request["function"])
+            if not callable(function):
+                return _worker_result("not-callable", stdout, stderr)
+            try:
+                returned = function(*request["args"], **request["kwargs"])
+            except FunctionOutputLimitError:
+                return _worker_result("output-limit", stdout, stderr)
+            except BaseException as error:
+                return _worker_result(
+                    "raised",
+                    stdout,
+                    stderr,
+                    exception={
+                        "type": type(error).__name__,
+                        "message": _exception_message(error),
+                    },
+                )
+            try:
+                normalized_return = validate_value(returned)
+            except FunctionProfileError:
+                return _worker_result("unsupported-return", stdout, stderr)
+            return _worker_result(
+                "returned",
+                stdout,
+                stderr,
+                return_value=normalized_return,
+            )
     finally:
         sys.modules.pop(module_name, None)
 

--- a/scripts/python_function_worker.py
+++ b/scripts/python_function_worker.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+try:
+    from scripts import python_function_profile as p2
+except ModuleNotFoundError:  # assignment-runner image copies modules into /opt/thebitlab
+    import python_function_profile as p2
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="TheBitLab Python function worker")
+    parser.add_argument("--source", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = json.load(sys.stdin)
+        result = p2.execute_worker_request(request, args.source)
+        result = p2.validate_worker_result(result)
+    except (OSError, json.JSONDecodeError, p2.FunctionProfileError) as error:
+        print(
+            json.dumps(
+                {
+                    "schema_version": p2.WORKER_SCHEMA,
+                    "status": "worker-error",
+                    "stdout": "",
+                    "stderr": str(error)[: p2.MAX_STRING_CHARS],
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 2
+    print(json.dumps(result, ensure_ascii=False, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python_object_profile.py
+++ b/scripts/python_object_profile.py
@@ -4,7 +4,10 @@ import math
 import re
 from typing import Any
 
-from scripts import python_function_profile as p2
+try:
+    import python_function_profile as p2
+except ModuleNotFoundError:
+    from scripts import python_function_profile as p2
 
 
 PROFILE_ID = "python-object-v1"

--- a/scripts/python_object_profile.py
+++ b/scripts/python_object_profile.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+from scripts import python_function_profile as p2
+
+
+PROFILE_ID = "python-object-v1"
+WORKER_SCHEMA = "thebitlab.python-object-worker.v1"
+MAX_TESTS = 32
+MAX_STEPS = 32
+MAX_INSTANCES = 4
+MAX_ARGS = p2.MAX_ARGS
+MAX_KWARGS = p2.MAX_KWARGS
+PUBLIC_MEMBER_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+INSTANCE_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+
+
+class ObjectProfileError(ValueError):
+    """Invalid P3 teacher contract, worker request or worker result."""
+
+
+def validate_value(value: Any) -> Any:
+    """Reuse the bounded deterministic P2 value codec."""
+    try:
+        return p2.validate_value(value)
+    except p2.FunctionProfileError as error:
+        raise ObjectProfileError(str(error)) from error
+
+
+def public_member_name(value: Any, *, label: str) -> str:
+    """Validate one explicitly observable public class/member name."""
+    if not isinstance(value, str) or not PUBLIC_MEMBER_RE.fullmatch(value):
+        raise ObjectProfileError(
+            f"{label} deve essere un identificatore Python pubblico semplice"
+        )
+    if value.startswith("_"):
+        raise ObjectProfileError(f"{label} privato/dunder non consentito")
+    return value
+
+
+def instance_id(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not INSTANCE_ID_RE.fullmatch(value):
+        raise ObjectProfileError(f"{label} non valido")
+    if value == "main":
+        raise ObjectProfileError(f"{label} non puo usare l'id riservato main")
+    return value
+
+
+def _validate_args_kwargs(value: Any, *, source: str) -> dict[str, Any]:
+    if value is None:
+        value = {}
+    if not isinstance(value, dict):
+        raise ObjectProfileError(f"{source} deve essere un oggetto")
+    allowed = {"args", "kwargs"}
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ObjectProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    args = value.get("args", [])
+    kwargs = value.get("kwargs", {})
+    if not isinstance(args, list) or len(args) > MAX_ARGS:
+        raise ObjectProfileError(
+            f"{source}.args deve essere una lista con massimo {MAX_ARGS} elementi"
+        )
+    if not isinstance(kwargs, dict) or len(kwargs) > MAX_KWARGS:
+        raise ObjectProfileError(
+            f"{source}.kwargs deve essere un oggetto con massimo {MAX_KWARGS} elementi"
+        )
+    normalized_kwargs: dict[str, Any] = {}
+    for key, item in kwargs.items():
+        if not isinstance(key, str) or not p2.FUNCTION_RE.fullmatch(key):
+            raise ObjectProfileError(f"{source}.kwargs contiene nome parametro non valido")
+        normalized_kwargs[key] = validate_value(item)
+    return {
+        "args": [validate_value(item) for item in args],
+        "kwargs": normalized_kwargs,
+    }
+
+
+def _validate_tolerance(value: Any, *, source: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ObjectProfileError(f"{source} deve essere numerico")
+    result = float(value)
+    if not math.isfinite(result) or result < 0 or result > 1e6:
+        raise ObjectProfileError(f"{source} fuori limite")
+    return result
+
+
+def _validate_call_step(value: dict[str, Any], *, source: str) -> dict[str, Any]:
+    allowed = {
+        "instance",
+        "call",
+        "args",
+        "kwargs",
+        "expected_return",
+        "expected_exception",
+        "float_tolerance",
+    }
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ObjectProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    member = public_member_name(value.get("call"), label=f"{source}.call")
+    target = value.get("instance", "main")
+    if target != "main":
+        target = instance_id(target, label=f"{source}.instance")
+    invocation = _validate_args_kwargs(
+        {"args": value.get("args", []), "kwargs": value.get("kwargs", {})},
+        source=source,
+    )
+    has_return = "expected_return" in value
+    has_exception = "expected_exception" in value
+    if has_return == has_exception:
+        raise ObjectProfileError(
+            f"{source} deve dichiarare esattamente uno tra expected_return ed expected_exception"
+        )
+    normalized: dict[str, Any] = {
+        "kind": "call",
+        "instance": target,
+        "member": member,
+        **invocation,
+    }
+    if has_return:
+        normalized["expected_return"] = validate_value(value["expected_return"])
+        if "float_tolerance" in value:
+            normalized["float_tolerance"] = _validate_tolerance(
+                value["float_tolerance"], source=f"{source}.float_tolerance"
+            )
+    else:
+        exception_name = value.get("expected_exception")
+        if not isinstance(exception_name, str) or not p2.FUNCTION_RE.fullmatch(exception_name):
+            raise ObjectProfileError(f"{source}.expected_exception non valido")
+        normalized["expected_exception"] = exception_name
+        if "float_tolerance" in value:
+            raise ObjectProfileError(
+                f"{source}.float_tolerance non ammesso con expected_exception"
+            )
+    return normalized
+
+
+def _validate_observe_step(value: dict[str, Any], *, source: str) -> dict[str, Any]:
+    allowed = {"instance", "observe", "expected", "float_tolerance"}
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ObjectProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    member = public_member_name(value.get("observe"), label=f"{source}.observe")
+    target = value.get("instance", "main")
+    if target != "main":
+        target = instance_id(target, label=f"{source}.instance")
+    if "expected" not in value:
+        raise ObjectProfileError(f"{source}.expected mancante")
+    normalized: dict[str, Any] = {
+        "kind": "observe",
+        "instance": target,
+        "member": member,
+        "expected": validate_value(value["expected"]),
+    }
+    if "float_tolerance" in value:
+        normalized["float_tolerance"] = _validate_tolerance(
+            value["float_tolerance"], source=f"{source}.float_tolerance"
+        )
+    return normalized
+
+
+def validate_object_step(value: Any, *, source: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ObjectProfileError(f"{source} deve essere un oggetto")
+    has_call = "call" in value
+    has_observe = "observe" in value
+    if has_call == has_observe:
+        raise ObjectProfileError(
+            f"{source} deve dichiarare esattamente uno tra call e observe"
+        )
+    if has_call:
+        return _validate_call_step(value, source=source)
+    return _validate_observe_step(value, source=source)
+
+
+def validate_object_test(value: Any, *, source: str = "test") -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ObjectProfileError(f"{source} deve essere un oggetto")
+    allowed = {
+        "profile",
+        "name",
+        "class",
+        "construct",
+        "additional_instances",
+        "steps",
+        "expected_constructor_exception",
+        "visibility",
+    }
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ObjectProfileError(
+            f"{source} contiene campi non supportati: {', '.join(unknown)}"
+        )
+    if value.get("profile") != PROFILE_ID:
+        raise ObjectProfileError(f"{source}.profile deve essere {PROFILE_ID}")
+
+    class_name = public_member_name(value.get("class"), label=f"{source}.class")
+    construct = _validate_args_kwargs(value.get("construct", {}), source=f"{source}.construct")
+
+    additions_raw = value.get("additional_instances", [])
+    if not isinstance(additions_raw, list) or len(additions_raw) > MAX_INSTANCES - 1:
+        raise ObjectProfileError(
+            f"{source}.additional_instances deve avere massimo {MAX_INSTANCES - 1} elementi"
+        )
+    additions: list[dict[str, Any]] = []
+    ids: set[str] = {"main"}
+    for index, item in enumerate(additions_raw):
+        item_source = f"{source}.additional_instances[{index}]"
+        if not isinstance(item, dict) or set(item) != {"id", "construct"}:
+            raise ObjectProfileError(
+                f"{item_source} deve contenere esattamente id e construct"
+            )
+        identifier = instance_id(item.get("id"), label=f"{item_source}.id")
+        if identifier in ids:
+            raise ObjectProfileError(f"{item_source}.id duplicato")
+        ids.add(identifier)
+        additions.append(
+            {
+                "id": identifier,
+                "construct": _validate_args_kwargs(
+                    item.get("construct"), source=f"{item_source}.construct"
+                ),
+            }
+        )
+
+    has_constructor_exception = "expected_constructor_exception" in value
+    steps_raw = value.get("steps", [])
+    if not isinstance(steps_raw, list) or len(steps_raw) > MAX_STEPS:
+        raise ObjectProfileError(
+            f"{source}.steps deve essere una lista con massimo {MAX_STEPS} elementi"
+        )
+    if has_constructor_exception:
+        exception_name = value.get("expected_constructor_exception")
+        if not isinstance(exception_name, str) or not p2.FUNCTION_RE.fullmatch(exception_name):
+            raise ObjectProfileError(f"{source}.expected_constructor_exception non valido")
+        if additions_raw or steps_raw:
+            raise ObjectProfileError(
+                f"{source} con expected_constructor_exception non puo dichiarare additional_instances o steps"
+            )
+        steps: list[dict[str, Any]] = []
+    else:
+        if not steps_raw:
+            raise ObjectProfileError(f"{source}.steps deve essere non vuoto")
+        steps = [
+            validate_object_step(item, source=f"{source}.steps[{index}]")
+            for index, item in enumerate(steps_raw)
+        ]
+        for index, step in enumerate(steps):
+            if step["instance"] not in ids:
+                raise ObjectProfileError(
+                    f"{source}.steps[{index}].instance non dichiarata: {step['instance']}"
+                )
+
+    normalized: dict[str, Any] = {
+        "profile": PROFILE_ID,
+        "class": class_name,
+        "construct": construct,
+        "additional_instances": additions,
+        "steps": steps,
+    }
+    if has_constructor_exception:
+        normalized["expected_constructor_exception"] = value["expected_constructor_exception"]
+    name = value.get("name")
+    if isinstance(name, str) and name:
+        normalized["name"] = name[:128]
+    visibility = value.get("visibility")
+    if visibility is not None:
+        if visibility not in {"teacher", "student", "public"}:
+            raise ObjectProfileError(f"{source}.visibility non valida")
+        normalized["visibility"] = visibility
+    return normalized
+
+
+def validate_object_tests(value: Any, *, source: str = "object_tests") -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise ObjectProfileError(f"{source} deve essere una lista non vuota")
+    if len(value) > MAX_TESTS:
+        raise ObjectProfileError(f"{source} supera il limite di {MAX_TESTS} test")
+    return [
+        validate_object_test(item, source=f"{source}[{index}]")
+        for index, item in enumerate(value)
+    ]
+
+
+def worker_request(test: dict[str, Any]) -> dict[str, Any]:
+    """Build the untrusted request without any teacher expected values."""
+    normalized = validate_object_test(test)
+    steps: list[dict[str, Any]] = []
+    for step in normalized["steps"]:
+        if step["kind"] == "call":
+            steps.append(
+                {
+                    "kind": "call",
+                    "instance": step["instance"],
+                    "member": step["member"],
+                    "args": step["args"],
+                    "kwargs": step["kwargs"],
+                }
+            )
+        else:
+            steps.append(
+                {
+                    "kind": "observe",
+                    "instance": step["instance"],
+                    "member": step["member"],
+                }
+            )
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "class": normalized["class"],
+        "construct": normalized["construct"],
+        "additional_instances": normalized["additional_instances"],
+        "steps": steps,
+    }
+
+
+def validate_worker_request(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != {
+        "schema_version",
+        "class",
+        "construct",
+        "additional_instances",
+        "steps",
+    }:
+        raise ObjectProfileError("worker request contiene campi mancanti o inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise ObjectProfileError("worker schema non supportato")
+    class_name = public_member_name(value.get("class"), label="worker.class")
+    construct = _validate_args_kwargs(value.get("construct"), source="worker.construct")
+
+    additions_raw = value.get("additional_instances")
+    if not isinstance(additions_raw, list) or len(additions_raw) > MAX_INSTANCES - 1:
+        raise ObjectProfileError("worker additional_instances non valido")
+    additions: list[dict[str, Any]] = []
+    ids = {"main"}
+    for index, item in enumerate(additions_raw):
+        source = f"worker.additional_instances[{index}]"
+        if not isinstance(item, dict) or set(item) != {"id", "construct"}:
+            raise ObjectProfileError(f"{source} non valido")
+        identifier = instance_id(item.get("id"), label=f"{source}.id")
+        if identifier in ids:
+            raise ObjectProfileError(f"{source}.id duplicato")
+        ids.add(identifier)
+        additions.append(
+            {
+                "id": identifier,
+                "construct": _validate_args_kwargs(
+                    item.get("construct"), source=f"{source}.construct"
+                ),
+            }
+        )
+
+    steps_raw = value.get("steps")
+    if not isinstance(steps_raw, list) or len(steps_raw) > MAX_STEPS:
+        raise ObjectProfileError("worker steps non valido")
+    steps: list[dict[str, Any]] = []
+    for index, item in enumerate(steps_raw):
+        source = f"worker.steps[{index}]"
+        if not isinstance(item, dict):
+            raise ObjectProfileError(f"{source} non valido")
+        kind = item.get("kind")
+        target = item.get("instance")
+        if target not in ids:
+            raise ObjectProfileError(f"{source}.instance non dichiarata")
+        member = public_member_name(item.get("member"), label=f"{source}.member")
+        if kind == "call":
+            if set(item) != {"kind", "instance", "member", "args", "kwargs"}:
+                raise ObjectProfileError(f"{source} call contiene campi inattesi")
+            invocation = _validate_args_kwargs(
+                {"args": item.get("args"), "kwargs": item.get("kwargs")},
+                source=source,
+            )
+            steps.append(
+                {
+                    "kind": "call",
+                    "instance": target,
+                    "member": member,
+                    **invocation,
+                }
+            )
+        elif kind == "observe":
+            if set(item) != {"kind", "instance", "member"}:
+                raise ObjectProfileError(f"{source} observe contiene campi inattesi")
+            steps.append(
+                {"kind": "observe", "instance": target, "member": member}
+            )
+        else:
+            raise ObjectProfileError(f"{source}.kind non supportato")
+    return {
+        "schema_version": WORKER_SCHEMA,
+        "class": class_name,
+        "construct": construct,
+        "additional_instances": additions,
+        "steps": steps,
+    }
+
+
+def _normalize_exception(value: Any, *, source: str) -> dict[str, str]:
+    if not isinstance(value, dict) or set(value) != {"type", "message"}:
+        raise ObjectProfileError(f"{source} exception non valida")
+    exc_type = value.get("type")
+    message = value.get("message")
+    if not isinstance(exc_type, str) or not p2.FUNCTION_RE.fullmatch(exc_type):
+        raise ObjectProfileError(f"{source} exception type non valido")
+    if not isinstance(message, str) or len(message) > 512:
+        raise ObjectProfileError(f"{source} exception message non valido")
+    return {"type": exc_type, "message": message}
+
+
+def validate_worker_result(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ObjectProfileError("worker result deve essere un oggetto")
+    allowed = {
+        "schema_version",
+        "status",
+        "stdout",
+        "stderr",
+        "steps",
+        "exception",
+        "instance",
+    }
+    if set(value) - allowed:
+        raise ObjectProfileError("worker result contiene campi inattesi")
+    if value.get("schema_version") != WORKER_SCHEMA:
+        raise ObjectProfileError("worker result schema non supportato")
+    status = value.get("status")
+    if status not in {
+        "completed",
+        "import-error",
+        "missing-class",
+        "not-class",
+        "constructor-raised",
+        "additional-constructor-raised",
+        "timeout",
+        "output-limit",
+    }:
+        raise ObjectProfileError("worker result status non supportato")
+    stdout = value.get("stdout", "")
+    stderr = value.get("stderr", "")
+    if not isinstance(stdout, str) or not isinstance(stderr, str):
+        raise ObjectProfileError("worker stdout/stderr devono essere stringhe")
+    if len(stdout) > p2.MAX_STRING_CHARS or len(stderr) > p2.MAX_STRING_CHARS:
+        raise ObjectProfileError("worker stdout/stderr troppo grandi")
+
+    steps_raw = value.get("steps", [])
+    if not isinstance(steps_raw, list) or len(steps_raw) > MAX_STEPS:
+        raise ObjectProfileError("worker result steps non valido")
+    steps: list[dict[str, Any]] = []
+    for index, item in enumerate(steps_raw):
+        source = f"worker result steps[{index}]"
+        if not isinstance(item, dict):
+            raise ObjectProfileError(f"{source} non valido")
+        kind = item.get("kind")
+        target = item.get("instance")
+        member = item.get("member")
+        step_status = item.get("status")
+        if target != "main":
+            instance_id(target, label=f"{source}.instance")
+        public_member_name(member, label=f"{source}.member")
+        base = {"kind": kind, "instance": target, "member": member, "status": step_status}
+        if kind == "call":
+            allowed_call = {"kind", "instance", "member", "status", "return_value", "exception"}
+            if set(item) - allowed_call or step_status not in {
+                "returned",
+                "raised",
+                "missing-member",
+                "not-callable",
+                "unsupported-return",
+            }:
+                raise ObjectProfileError(f"{source} call non valido")
+            if step_status == "returned":
+                if "return_value" not in item:
+                    raise ObjectProfileError(f"{source} returned senza valore")
+                base["return_value"] = validate_value(item["return_value"])
+            elif step_status == "raised":
+                base["exception"] = _normalize_exception(item.get("exception"), source=source)
+        elif kind == "observe":
+            allowed_observe = {"kind", "instance", "member", "status", "value", "exception"}
+            if set(item) - allowed_observe or step_status not in {
+                "observed",
+                "missing-member",
+                "access-raised",
+                "unsupported-value",
+            }:
+                raise ObjectProfileError(f"{source} observe non valido")
+            if step_status == "observed":
+                if "value" not in item:
+                    raise ObjectProfileError(f"{source} observed senza valore")
+                base["value"] = validate_value(item["value"])
+            elif step_status == "access-raised":
+                base["exception"] = _normalize_exception(item.get("exception"), source=source)
+        else:
+            raise ObjectProfileError(f"{source}.kind non supportato")
+        steps.append(base)
+
+    normalized: dict[str, Any] = {
+        "schema_version": WORKER_SCHEMA,
+        "status": status,
+        "stdout": stdout,
+        "stderr": stderr,
+        "steps": steps,
+    }
+    if status in {"constructor-raised", "additional-constructor-raised", "import-error"}:
+        normalized["exception"] = _normalize_exception(value.get("exception"), source="worker result")
+    if status in {"constructor-raised", "additional-constructor-raised"}:
+        target = value.get("instance", "main")
+        if target != "main":
+            instance_id(target, label="worker result instance")
+        normalized["instance"] = target
+    return normalized
+
+
+def _values_equal(actual: Any, expected: Any, tolerance: float | None) -> bool:
+    if tolerance is not None and isinstance(expected, (int, float)) and not isinstance(expected, bool):
+        return (
+            isinstance(actual, (int, float))
+            and not isinstance(actual, bool)
+            and math.isclose(float(actual), float(expected), rel_tol=0.0, abs_tol=tolerance)
+        )
+    return type(actual) is type(expected) and actual == expected
+
+
+def compare_worker_result(test: dict[str, Any], worker_result: dict[str, Any]) -> dict[str, Any]:
+    expected = validate_object_test(test)
+    actual = validate_worker_result(worker_result)
+
+    if "expected_constructor_exception" in expected:
+        passed = (
+            actual["status"] == "constructor-raised"
+            and actual.get("instance") == "main"
+            and actual.get("exception", {}).get("type") == expected["expected_constructor_exception"]
+        )
+        return {
+            "name": expected.get("name", expected["class"]),
+            "profile": PROFILE_ID,
+            "visibility": expected.get("visibility", "teacher"),
+            "passed": passed,
+            "status": "passed" if passed else "failed",
+            "worker_status": actual["status"],
+            "observations": [],
+            "stdout": actual["stdout"],
+            "stderr": actual["stderr"],
+            "actual_exception": actual.get("exception"),
+        }
+
+    observations: list[dict[str, Any]] = []
+    if actual["status"] == "completed" and len(actual["steps"]) == len(expected["steps"]):
+        for expected_step, actual_step in zip(expected["steps"], actual["steps"], strict=True):
+            step_passed = False
+            if (
+                actual_step["kind"] == expected_step["kind"]
+                and actual_step["instance"] == expected_step["instance"]
+                and actual_step["member"] == expected_step["member"]
+            ):
+                if expected_step["kind"] == "call":
+                    if "expected_exception" in expected_step:
+                        step_passed = (
+                            actual_step["status"] == "raised"
+                            and actual_step.get("exception", {}).get("type")
+                            == expected_step["expected_exception"]
+                        )
+                    elif actual_step["status"] == "returned":
+                        step_passed = _values_equal(
+                            actual_step.get("return_value"),
+                            expected_step["expected_return"],
+                            expected_step.get("float_tolerance"),
+                        )
+                elif actual_step["status"] == "observed":
+                    step_passed = _values_equal(
+                        actual_step.get("value"),
+                        expected_step["expected"],
+                        expected_step.get("float_tolerance"),
+                    )
+            observations.append(
+                {
+                    "kind": expected_step["kind"],
+                    "instance": expected_step["instance"],
+                    "member": expected_step["member"],
+                    "passed": step_passed,
+                    "status": actual_step["status"],
+                    "actual_return": actual_step.get("return_value"),
+                    "actual_value": actual_step.get("value"),
+                    "actual_exception": actual_step.get("exception"),
+                }
+            )
+
+    passed = (
+        actual["status"] == "completed"
+        and len(observations) == len(expected["steps"])
+        and bool(observations)
+        and all(item["passed"] for item in observations)
+    )
+    return {
+        "name": expected.get("name", expected["class"]),
+        "profile": PROFILE_ID,
+        "visibility": expected.get("visibility", "teacher"),
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "worker_status": actual["status"],
+        "observations": observations,
+        "stdout": actual["stdout"],
+        "stderr": actual["stderr"],
+        "actual_exception": actual.get("exception"),
+    }

--- a/scripts/python_object_worker.py
+++ b/scripts/python_object_worker.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import argparse
+from contextlib import redirect_stderr, redirect_stdout
+import importlib.util
+from pathlib import Path
+import sys
+from typing import Any
+
+try:
+    import python_object_profile as p3
+except ModuleNotFoundError:
+    from scripts import python_object_profile as p3
+
+
+class ObjectOutputLimitError(RuntimeError):
+    """Student stdout/stderr exceeded the P3 diagnostic limit."""
+
+
+class _BoundedTextCapture:
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        self._parts: list[str] = []
+        self._size = 0
+
+    def write(self, value: str) -> int:
+        text = str(value)
+        remaining = self.limit - self._size
+        if len(text) > remaining:
+            if remaining > 0:
+                self._parts.append(text[:remaining])
+                self._size += remaining
+            raise ObjectOutputLimitError("stdout/stderr supera il limite P3")
+        self._parts.append(text)
+        self._size += len(text)
+        return len(text)
+
+    def flush(self) -> None:
+        return
+
+    def getvalue(self) -> str:
+        return "".join(self._parts)
+
+
+def _exception(error: BaseException) -> dict[str, str]:
+    return {"type": type(error).__name__, "message": str(error)[:512]}
+
+
+def _result(
+    status: str,
+    stdout: _BoundedTextCapture,
+    stderr: _BoundedTextCapture,
+    steps: list[dict[str, Any]],
+    **extra: Any,
+) -> dict[str, Any]:
+    return {
+        "schema_version": p3.WORKER_SCHEMA,
+        "status": status,
+        "stdout": stdout.getvalue(),
+        "stderr": stderr.getvalue(),
+        "steps": steps,
+        **extra,
+    }
+
+
+def _construct(
+    target_class: type,
+    specification: dict[str, Any],
+) -> Any:
+    return target_class(*specification["args"], **specification["kwargs"])
+
+
+def execute_worker_request(value: Any, source: Path) -> dict[str, Any]:
+    """Execute one declarative object scenario in the untrusted worker."""
+    request = p3.validate_worker_request(value)
+    source = source.resolve(strict=True)
+    stdout = _BoundedTextCapture(p3.p2.MAX_STRING_CHARS)
+    stderr = _BoundedTextCapture(p3.p2.MAX_STRING_CHARS)
+    observations: list[dict[str, Any]] = []
+    module_name = "_thebitlab_student_object_submission"
+    sys.modules.pop(module_name, None)
+
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            try:
+                spec = importlib.util.spec_from_file_location(module_name, source)
+                if spec is None or spec.loader is None:
+                    return _result(
+                        "import-error",
+                        stdout,
+                        stderr,
+                        observations,
+                        exception={"type": "ImportError", "message": "module spec unavailable"},
+                    )
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = module
+                spec.loader.exec_module(module)
+            except ObjectOutputLimitError:
+                return _result("output-limit", stdout, stderr, observations)
+            except BaseException as error:
+                return _result(
+                    "import-error",
+                    stdout,
+                    stderr,
+                    observations,
+                    exception=_exception(error),
+                )
+
+            if not hasattr(module, request["class"]):
+                return _result("missing-class", stdout, stderr, observations)
+            target_class = getattr(module, request["class"])
+            if not isinstance(target_class, type):
+                return _result("not-class", stdout, stderr, observations)
+
+            instances: dict[str, Any] = {}
+            try:
+                instances["main"] = _construct(target_class, request["construct"])
+            except ObjectOutputLimitError:
+                return _result("output-limit", stdout, stderr, observations)
+            except BaseException as error:
+                return _result(
+                    "constructor-raised",
+                    stdout,
+                    stderr,
+                    observations,
+                    instance="main",
+                    exception=_exception(error),
+                )
+
+            for item in request["additional_instances"]:
+                try:
+                    instances[item["id"]] = _construct(target_class, item["construct"])
+                except ObjectOutputLimitError:
+                    return _result("output-limit", stdout, stderr, observations)
+                except BaseException as error:
+                    return _result(
+                        "additional-constructor-raised",
+                        stdout,
+                        stderr,
+                        observations,
+                        instance=item["id"],
+                        exception=_exception(error),
+                    )
+
+            for step in request["steps"]:
+                target = instances[step["instance"]]
+                if step["kind"] == "call":
+                    try:
+                        member = getattr(target, step["member"])
+                    except AttributeError:
+                        observations.append(
+                            {
+                                "kind": "call",
+                                "instance": step["instance"],
+                                "member": step["member"],
+                                "status": "missing-member",
+                            }
+                        )
+                        continue
+                    except ObjectOutputLimitError:
+                        return _result("output-limit", stdout, stderr, observations)
+                    except BaseException as error:
+                        observations.append(
+                            {
+                                "kind": "call",
+                                "instance": step["instance"],
+                                "member": step["member"],
+                                "status": "raised",
+                                "exception": _exception(error),
+                            }
+                        )
+                        continue
+                    if not callable(member):
+                        observations.append(
+                            {
+                                "kind": "call",
+                                "instance": step["instance"],
+                                "member": step["member"],
+                                "status": "not-callable",
+                            }
+                        )
+                        continue
+                    try:
+                        returned = member(*step["args"], **step["kwargs"])
+                    except ObjectOutputLimitError:
+                        return _result("output-limit", stdout, stderr, observations)
+                    except BaseException as error:
+                        observations.append(
+                            {
+                                "kind": "call",
+                                "instance": step["instance"],
+                                "member": step["member"],
+                                "status": "raised",
+                                "exception": _exception(error),
+                            }
+                        )
+                        continue
+                    try:
+                        normalized_return = p3.validate_value(returned)
+                    except p3.ObjectProfileError:
+                        observations.append(
+                            {
+                                "kind": "call",
+                                "instance": step["instance"],
+                                "member": step["member"],
+                                "status": "unsupported-return",
+                            }
+                        )
+                        continue
+                    observations.append(
+                        {
+                            "kind": "call",
+                            "instance": step["instance"],
+                            "member": step["member"],
+                            "status": "returned",
+                            "return_value": normalized_return,
+                        }
+                    )
+                    continue
+
+                try:
+                    observed = getattr(target, step["member"])
+                except AttributeError:
+                    observations.append(
+                        {
+                            "kind": "observe",
+                            "instance": step["instance"],
+                            "member": step["member"],
+                            "status": "missing-member",
+                        }
+                    )
+                    continue
+                except ObjectOutputLimitError:
+                    return _result("output-limit", stdout, stderr, observations)
+                except BaseException as error:
+                    observations.append(
+                        {
+                            "kind": "observe",
+                            "instance": step["instance"],
+                            "member": step["member"],
+                            "status": "access-raised",
+                            "exception": _exception(error),
+                        }
+                    )
+                    continue
+                try:
+                    normalized_value = p3.validate_value(observed)
+                except p3.ObjectProfileError:
+                    observations.append(
+                        {
+                            "kind": "observe",
+                            "instance": step["instance"],
+                            "member": step["member"],
+                            "status": "unsupported-value",
+                        }
+                    )
+                    continue
+                observations.append(
+                    {
+                        "kind": "observe",
+                        "instance": step["instance"],
+                        "member": step["member"],
+                        "status": "observed",
+                        "value": normalized_value,
+                    }
+                )
+
+            return _result("completed", stdout, stderr, observations)
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="TheBitLab P3 Python object worker")
+    parser.add_argument("--source", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = __import__("json").load(sys.stdin)
+        result = execute_worker_request(request, args.source)
+        result = p3.validate_worker_result(result)
+    except (OSError, ValueError, p3.ObjectProfileError) as error:
+        print(
+            __import__("json").dumps(
+                {
+                    "schema_version": p3.WORKER_SCHEMA,
+                    "status": "import-error",
+                    "stdout": "",
+                    "stderr": "",
+                    "steps": [],
+                    "exception": {
+                        "type": type(error).__name__,
+                        "message": str(error)[:512],
+                    },
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 2
+    print(__import__("json").dumps(result, ensure_ascii=False, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import copy
 import json
@@ -237,7 +237,7 @@ class DockerGradeActivityExecutionService:
     """ExecutionService adapter backed by the authoritative Docker runner."""
 
     def run(self, request: ExecutionRequest) -> ExecutionResult:
-        """Run grade_activity in Docker and normalize infrastructure failures."""
+        """Run the appropriate authoritative Docker grader and normalize failures."""
 
         from scripts import grade_activity
 
@@ -250,14 +250,43 @@ class DockerGradeActivityExecutionService:
                 detail="ExecutionRequest.metadata deve includere activity_path e source_path.",
             )
 
+        activity_file = Path(str(activity_path))
+        source_file = Path(str(source_path))
         try:
-            report, worker_stderr = grade_activity.grade_activity_in_docker(
-                Path(str(activity_path)),
-                Path(str(source_path)),
-                timeout_seconds=request.timeout_seconds,
-                language=request.language,
-                image=docker_image,
+            activity = grade_activity.load_activity(activity_file)
+        except (OSError, json.JSONDecodeError):
+            # Preserve the historical adapter contract: the legacy Docker grader
+            # remains authoritative for its own loading/setup errors.
+            activity = None
+        uses_function_profile = isinstance(activity, dict) and "function_tests" in activity
+        requested_language = str(request.language or "").strip().lower()
+        if uses_function_profile and requested_language != "python":
+            return ExecutionResult(
+                status="invalid_payload",
+                detail="function_tests richiede una ExecutionRequest Python.",
             )
+
+        try:
+            if uses_function_profile:
+                from scripts import grade_python_function_activity
+
+                report = grade_python_function_activity.grade_in_docker(
+                    activity_path=activity_file,
+                    source_path=source_file,
+                    image=docker_image,
+                    timeout_seconds=request.timeout_seconds,
+                )
+                worker_stderr = ""
+                grading_profile = str(report.get("profile") or "python-function-v1")
+            else:
+                report, worker_stderr = grade_activity.grade_activity_in_docker(
+                    activity_file,
+                    source_file,
+                    timeout_seconds=request.timeout_seconds,
+                    language=request.language,
+                    image=docker_image,
+                )
+                grading_profile = "legacy"
         except subprocess.TimeoutExpired as error:
             return ExecutionResult(
                 status="timeout",
@@ -285,6 +314,7 @@ class DockerGradeActivityExecutionService:
             metadata={
                 "backend": "docker",
                 "docker_image": docker_image,
+                "grading_profile": grading_profile,
                 "runner_report": copy.deepcopy(report),
                 "worker_stderr": str(worker_stderr or ""),
             },

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -237,7 +237,7 @@ class DockerGradeActivityExecutionService:
     """ExecutionService adapter backed by the authoritative Docker runner."""
 
     def run(self, request: ExecutionRequest) -> ExecutionResult:
-        """Run the appropriate authoritative Docker grader and normalize failures."""
+        """Dispatch P2/P4 explicitly, otherwise preserve the legacy Docker path."""
 
         from scripts import grade_activity
 
@@ -258,16 +258,38 @@ class DockerGradeActivityExecutionService:
             # Preserve the historical adapter contract: the legacy Docker grader
             # remains authoritative for its own loading/setup errors.
             activity = None
+
         uses_function_profile = isinstance(activity, dict) and "function_tests" in activity
-        requested_language = str(request.language or "").strip().lower()
-        if uses_function_profile and requested_language != "python":
+        uses_filesystem_profile = isinstance(activity, dict) and "filesystem_tests" in activity
+        if uses_function_profile and uses_filesystem_profile:
             return ExecutionResult(
                 status="invalid_payload",
-                detail="function_tests richiede una ExecutionRequest Python.",
+                detail="Activity ambigua: function_tests e filesystem_tests non possono coesistere.",
+            )
+
+        requested_language = str(request.language or "").strip().lower()
+        if (uses_function_profile or uses_filesystem_profile) and requested_language not in {"python", "py"}:
+            field = "function_tests" if uses_function_profile else "filesystem_tests"
+            return ExecutionResult(
+                status="invalid_payload",
+                detail=f"{field} richiede una ExecutionRequest Python.",
             )
 
         try:
-            if uses_function_profile:
+            if uses_filesystem_profile:
+                from scripts import grade_python_filesystem_activity
+
+                report = grade_python_filesystem_activity.grade_in_docker(
+                    activity_path=activity_file,
+                    source_path=source_file,
+                    image=docker_image,
+                    timeout_seconds=request.timeout_seconds,
+                    activity_root=activity_file.parent,
+                    source_root=source_file.parent,
+                )
+                worker_stderr = ""
+                grading_profile = str(report.get("profile") or "python-filesystem-v1")
+            elif uses_function_profile:
                 from scripts import grade_python_function_activity
 
                 report = grade_python_function_activity.grade_in_docker(

--- a/scripts/thebitlab_technical_services.py
+++ b/scripts/thebitlab_technical_services.py
@@ -237,7 +237,7 @@ class DockerGradeActivityExecutionService:
     """ExecutionService adapter backed by the authoritative Docker runner."""
 
     def run(self, request: ExecutionRequest) -> ExecutionResult:
-        """Dispatch P2/P4 explicitly, otherwise preserve the legacy Docker path."""
+        """Dispatch P2/P3/P4 explicitly, otherwise preserve the legacy Docker path."""
 
         from scripts import grade_activity
 
@@ -261,18 +261,32 @@ class DockerGradeActivityExecutionService:
 
         uses_function_profile = isinstance(activity, dict) and "function_tests" in activity
         uses_filesystem_profile = isinstance(activity, dict) and "filesystem_tests" in activity
-        if uses_function_profile and uses_filesystem_profile:
-            return ExecutionResult(
-                status="invalid_payload",
-                detail="Activity ambigua: function_tests e filesystem_tests non possono coesistere.",
+        uses_object_profile = isinstance(activity, dict) and "object_tests" in activity
+        profile_fields = [
+            field
+            for field, enabled in (
+                ("function_tests", uses_function_profile),
+                ("filesystem_tests", uses_filesystem_profile),
+                ("object_tests", uses_object_profile),
             )
+            if enabled
+        ]
+        if len(profile_fields) > 1:
+            if set(profile_fields) == {"function_tests", "filesystem_tests"}:
+                detail = "Activity ambigua: function_tests e filesystem_tests non possono coesistere."
+            else:
+                detail = (
+                    "Activity ambigua: profili Python incompatibili: "
+                    + ", ".join(profile_fields)
+                    + "."
+                )
+            return ExecutionResult(status="invalid_payload", detail=detail)
 
         requested_language = str(request.language or "").strip().lower()
-        if (uses_function_profile or uses_filesystem_profile) and requested_language not in {"python", "py"}:
-            field = "function_tests" if uses_function_profile else "filesystem_tests"
+        if profile_fields and requested_language not in {"python", "py"}:
             return ExecutionResult(
                 status="invalid_payload",
-                detail=f"{field} richiede una ExecutionRequest Python.",
+                detail=f"{profile_fields[0]} richiede una ExecutionRequest Python.",
             )
 
         try:
@@ -289,6 +303,19 @@ class DockerGradeActivityExecutionService:
                 )
                 worker_stderr = ""
                 grading_profile = str(report.get("profile") or "python-filesystem-v1")
+            elif uses_object_profile:
+                from scripts import grade_python_object_activity
+
+                report = grade_python_object_activity.grade_in_docker(
+                    activity_path=activity_file,
+                    source_path=source_file,
+                    image=docker_image,
+                    timeout_seconds=request.timeout_seconds,
+                    activity_root=activity_file.parent,
+                    source_root=source_file.parent,
+                )
+                worker_stderr = ""
+                grading_profile = str(report.get("profile") or "python-object-v1")
             elif uses_function_profile:
                 from scripts import grade_python_function_activity
 

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from scripts import python_function_profile
 from scripts.thebitlab_contracts import ALLOWED_ACTIVITY_KINDS
 from scripts.thebitlab_runtime_contracts import validate_runtime_extension
 
@@ -72,6 +73,18 @@ def load_json(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
     return data, []
 
 
+def validate_function_tests(value: Any, source: str) -> list[str]:
+    """Validate optional teacher-only Python function-behavior tests."""
+    try:
+        python_function_profile.validate_function_tests(
+            value,
+            source=f"{source}: function_tests",
+        )
+    except python_function_profile.FunctionProfileError as error:
+        return [str(error)]
+    return []
+
+
 def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[str]:
     """Validate the minimal TheBitLab activity schema."""
     errors: list[str] = []
@@ -116,6 +129,9 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
     assets = data.get("assets")
     if assets is not None:
         errors.extend(validate_assets(assets, source))
+
+    if "function_tests" in data:
+        errors.extend(validate_function_tests(data.get("function_tests"), source))
 
     errors.extend(validate_runtime_extension(data, source))
     return errors

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -5,7 +5,11 @@ import json
 from pathlib import Path
 from typing import Any
 
-from scripts import python_filesystem_profile, python_function_profile
+from scripts import (
+    python_filesystem_profile,
+    python_function_profile,
+    python_object_profile,
+)
 from scripts.thebitlab_contracts import ALLOWED_ACTIVITY_KINDS
 from scripts.thebitlab_runtime_contracts import validate_runtime_extension
 
@@ -97,7 +101,21 @@ def validate_filesystem_tests(value: Any, source: str) -> list[str]:
     return []
 
 
-def _python_profile_language_errors(data: dict[str, Any], source: str, field: str) -> list[str]:
+def validate_object_tests(value: Any, source: str) -> list[str]:
+    """Validate optional teacher-only Python object-behavior scenarios."""
+    try:
+        python_object_profile.validate_object_tests(
+            value,
+            source=f"{source}: object_tests",
+        )
+    except python_object_profile.ObjectProfileError as error:
+        return [str(error)]
+    return []
+
+
+def _python_profile_language_errors(
+    data: dict[str, Any], source: str, field: str
+) -> list[str]:
     language = str(data.get("language") or data.get("linguaggio") or "").strip().lower()
     if language and language not in {"python", "py"}:
         return [f"{source}: {field} e supportato solo per Activity Python"]
@@ -130,8 +148,12 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
 
     topics = data.get("argomenti")
     if topics is not None:
-        if not isinstance(topics, list) or not topics or not all(isinstance(topic, str) and topic for topic in topics):
-            errors.append(f"{source}: argomenti deve essere una lista non vuota di stringhe")
+        if not isinstance(topics, list) or not topics or not all(
+            isinstance(topic, str) and topic for topic in topics
+        ):
+            errors.append(
+                f"{source}: argomenti deve essere una lista non vuota di stringhe"
+            )
 
     correction = data.get("correzione")
     if correction is not None:
@@ -149,20 +171,28 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
     if assets is not None:
         errors.extend(validate_assets(assets, source))
 
-    has_function_tests = "function_tests" in data
-    has_filesystem_tests = "filesystem_tests" in data
-    if has_function_tests and has_filesystem_tests:
+    profile_fields = [
+        field
+        for field in ("function_tests", "filesystem_tests", "object_tests")
+        if field in data
+    ]
+    if len(profile_fields) > 1:
         errors.append(
-            f"{source}: function_tests e filesystem_tests non possono coesistere nella stessa Activity"
+            f"{source}: profili Python incompatibili nella stessa Activity: "
+            + ", ".join(profile_fields)
         )
 
-    if has_function_tests:
+    if "function_tests" in data:
         errors.extend(_python_profile_language_errors(data, source, "function_tests"))
         errors.extend(validate_function_tests(data.get("function_tests"), source))
 
-    if has_filesystem_tests:
+    if "filesystem_tests" in data:
         errors.extend(_python_profile_language_errors(data, source, "filesystem_tests"))
         errors.extend(validate_filesystem_tests(data.get("filesystem_tests"), source))
+
+    if "object_tests" in data:
+        errors.extend(_python_profile_language_errors(data, source, "object_tests"))
+        errors.extend(validate_object_tests(data.get("object_tests"), source))
 
     errors.extend(validate_runtime_extension(data, source))
     return errors
@@ -201,7 +231,9 @@ def validate_assets(assets: Any, source: str) -> list[str]:
         if not is_safe_relative_path(asset.get("path")):
             errors.append(f"{prefix}.path deve essere un path relativo sicuro")
 
-        if "target_path" in asset and not is_safe_relative_path(asset.get("target_path")):
+        if "target_path" in asset and not is_safe_relative_path(
+            asset.get("target_path")
+        ):
             errors.append(f"{prefix}.target_path deve essere un path relativo sicuro")
 
         visibility = asset.get("visibility")
@@ -246,7 +278,11 @@ def validate_rubric(rubric: Any, source: str) -> list[str]:
         if not isinstance(item.get("criterio"), str) or not item.get("criterio"):
             errors.append(f"{prefix}.criterio deve essere una stringa non vuota")
         points = item.get("punti")
-        if isinstance(points, bool) or not isinstance(points, (int, float)) or points < 0:
+        if (
+            isinstance(points, bool)
+            or not isinstance(points, (int, float))
+            or points < 0
+        ):
             errors.append(f"{prefix}.punti deve essere un numero non negativo")
     return errors
 
@@ -263,8 +299,14 @@ def validate_metrics(metrics: Any, source: str) -> list[str]:
 
     estimated_time = metrics.get("tempo_stimato_minuti")
     if estimated_time is not None:
-        if isinstance(estimated_time, bool) or not isinstance(estimated_time, (int, float)) or estimated_time < 0:
-            errors.append(f"{source}: metriche.tempo_stimato_minuti deve essere un numero non negativo")
+        if (
+            isinstance(estimated_time, bool)
+            or not isinstance(estimated_time, (int, float))
+            or estimated_time < 0
+        ):
+            errors.append(
+                f"{source}: metriche.tempo_stimato_minuti deve essere un numero non negativo"
+            )
 
     for field in BOOLEAN_METRIC_FIELDS & metrics.keys():
         if not isinstance(metrics[field], bool):

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -177,10 +177,15 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
         if field in data
     ]
     if len(profile_fields) > 1:
-        errors.append(
-            f"{source}: profili Python incompatibili nella stessa Activity: "
-            + ", ".join(profile_fields)
-        )
+        if set(profile_fields) == {"function_tests", "filesystem_tests"}:
+            errors.append(
+                f"{source}: function_tests e filesystem_tests non possono coesistere nella stessa Activity"
+            )
+        else:
+            errors.append(
+                f"{source}: profili Python incompatibili nella stessa Activity: "
+                + ", ".join(profile_fields)
+            )
 
     if "function_tests" in data:
         errors.extend(_python_profile_language_errors(data, source, "function_tests"))

--- a/scripts/validate_activity.py
+++ b/scripts/validate_activity.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from scripts import python_function_profile
+from scripts import python_filesystem_profile, python_function_profile
 from scripts.thebitlab_contracts import ALLOWED_ACTIVITY_KINDS
 from scripts.thebitlab_runtime_contracts import validate_runtime_extension
 
@@ -85,6 +85,25 @@ def validate_function_tests(value: Any, source: str) -> list[str]:
     return []
 
 
+def validate_filesystem_tests(value: Any, source: str) -> list[str]:
+    """Validate optional teacher-only Python filesystem-behavior tests."""
+    try:
+        python_filesystem_profile.validate_filesystem_tests(
+            value,
+            source=f"{source}: filesystem_tests",
+        )
+    except python_filesystem_profile.FilesystemProfileError as error:
+        return [str(error)]
+    return []
+
+
+def _python_profile_language_errors(data: dict[str, Any], source: str, field: str) -> list[str]:
+    language = str(data.get("language") or data.get("linguaggio") or "").strip().lower()
+    if language and language not in {"python", "py"}:
+        return [f"{source}: {field} e supportato solo per Activity Python"]
+    return []
+
+
 def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[str]:
     """Validate the minimal TheBitLab activity schema."""
     errors: list[str] = []
@@ -130,8 +149,20 @@ def validate_activity(data: dict[str, Any], source: str = "<activity>") -> list[
     if assets is not None:
         errors.extend(validate_assets(assets, source))
 
-    if "function_tests" in data:
+    has_function_tests = "function_tests" in data
+    has_filesystem_tests = "filesystem_tests" in data
+    if has_function_tests and has_filesystem_tests:
+        errors.append(
+            f"{source}: function_tests e filesystem_tests non possono coesistere nella stessa Activity"
+        )
+
+    if has_function_tests:
+        errors.extend(_python_profile_language_errors(data, source, "function_tests"))
         errors.extend(validate_function_tests(data.get("function_tests"), source))
+
+    if has_filesystem_tests:
+        errors.extend(_python_profile_language_errors(data, source, "filesystem_tests"))
+        errors.extend(validate_filesystem_tests(data.get("filesystem_tests"), source))
 
     errors.extend(validate_runtime_extension(data, source))
     return errors

--- a/tests/test_build_assignment_runner.py
+++ b/tests/test_build_assignment_runner.py
@@ -19,7 +19,7 @@ def manifest() -> dict:
 def test_checked_in_toolchain_manifest_is_strict_and_immutable() -> None:
     payload = manifest()
 
-    assert payload["version"] == "2026.08.1"
+    assert payload["version"] == "2026.08.2"
     assert payload["platform"] == "linux/amd64"
     assert payload["image_repository"] == builder.IMAGE_REPOSITORY
     assert payload["base_image"].startswith("debian:bookworm-slim@sha256:")

--- a/tests/test_build_assignment_runner.py
+++ b/tests/test_build_assignment_runner.py
@@ -19,7 +19,7 @@ def manifest() -> dict:
 def test_checked_in_toolchain_manifest_is_strict_and_immutable() -> None:
     payload = manifest()
 
-    assert payload["version"] == "2026.07.1"
+    assert payload["version"] == "2026.08.1"
     assert payload["platform"] == "linux/amd64"
     assert payload["image_repository"] == builder.IMAGE_REPOSITORY
     assert payload["base_image"].startswith("debian:bookworm-slim@sha256:")

--- a/tests/test_build_assignment_runner.py
+++ b/tests/test_build_assignment_runner.py
@@ -19,7 +19,7 @@ def manifest() -> dict:
 def test_checked_in_toolchain_manifest_is_strict_and_immutable() -> None:
     payload = manifest()
 
-    assert payload["version"] == "2026.08.2"
+    assert payload["version"] == "2026.08.3"
     assert payload["platform"] == "linux/amd64"
     assert payload["image_repository"] == builder.IMAGE_REPOSITORY
     assert payload["base_image"].startswith("debian:bookworm-slim@sha256:")

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -64,22 +64,27 @@ def test_publish_workflow_only_publishes_reviewed_main_toolchains() -> None:
         ".github/workflows/publish-assignment-runner.yml"
     ).read_text(encoding="utf-8")
 
-    assert "packages: write" in source
-    assert "pull_request:" not in source
+    validate_block, publish_block = source.split("  publish:\n", maxsplit=1)
+    assert "pull_request:" in source
     assert "branches:\n      - main" in source
-    assert "if: github.ref == 'refs/heads/main'" in source
+    assert "if: github.ref == 'refs/heads/main'" in publish_block
+    assert "packages: write" not in validate_block
+    assert "packages: write" in publish_block
+    assert "docker login ghcr.io" not in validate_block
+    assert "docker login ghcr.io" in publish_block
     assert "scripts/build_assignment_runner.py" in source
     assert "scripts/publish_assignment_runner.py" in source
-    assert "THEBITLAB_RUN_DOCKER_TESTS" in source
-    assert "tests/test_student_lab_runner_docker.py" in source
-    assert "docker login ghcr.io" in source
-    assert "image_id: ${{ steps.image-digest.outputs.image_id }}" in source
-    assert "VALIDATED_IMAGE_ID: ${{ needs.validate.outputs.image_id }}" in source
-    assert "actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16" in source
+    assert "THEBITLAB_RUN_DOCKER_TESTS" in validate_block
+    assert "tests/test_student_lab_runner_docker.py" in validate_block
+    assert "tests/test_python_function_student_lab_docker.py" in validate_block
+    assert "tests/test_p2_release_candidate.py" in validate_block
+    assert "image_id: ${{ steps.image-digest.outputs.image_id }}" in validate_block
+    assert "VALIDATED_IMAGE_ID: ${{ needs.validate.outputs.image_id }}" in publish_block
+    assert "actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16" in publish_block
     assert "runner-toolchain" in source
-    assert "docker save" in source
-    assert "docker load" in source
-    assert "gunzip" in source
+    assert "docker save" in validate_block
+    assert "docker load" in publish_block
+    assert "gunzip" in publish_block
     assert ":latest" not in source
     assert source.count("tests/test_student_lab_runner_docker.py") == 1
     assert '".github/workflows/publish-assignment-runner.yml"' in source

--- a/tests/test_p2_release_candidate.py
+++ b/tests/test_p2_release_candidate.py
@@ -7,6 +7,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / "docker" / "assignment-runner" / "toolchain.json"
 LOCK = ROOT / "docker" / "assignment-runner" / "toolchain.lock.json"
+DOCKERFILE = ROOT / "docker" / "assignment-runner" / "Dockerfile"
+DOCKERIGNORE = ROOT / ".dockerignore"
 
 
 def load(path: Path) -> dict:
@@ -15,15 +17,15 @@ def load(path: Path) -> dict:
     return value
 
 
-def test_p2_build_candidate_has_new_version_without_faking_published_lock() -> None:
+def test_combined_build_candidate_has_new_version_without_faking_published_lock() -> None:
     manifest = load(MANIFEST)
     lock = load(LOCK)
 
-    assert manifest["version"] == "2026.08.1"
+    assert manifest["version"] == "2026.08.2"
     assert manifest["platform"] == "linux/amd64"
     assert manifest["image_repository"] == lock["image_repository"]
 
-    # Until the release is actually published and its remote digest is known,
+    # Until the combined release is actually published and its remote digest is known,
     # the checked-in immutable lock must remain the previously published release.
     assert lock["version"] == "2026.07.1"
     assert lock["source_revision"] == "bd102146a684a9b06835204ec1b7f668f7655a03"
@@ -37,3 +39,19 @@ def test_candidate_and_stable_lock_are_deliberately_different_release_identities
     lock = load(LOCK)
 
     assert manifest["version"] != lock["version"]
+
+
+def test_combined_runner_packages_both_python_profile_workers() -> None:
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    dockerignore = DOCKERIGNORE.read_text(encoding="utf-8")
+
+    for path in (
+        "scripts/python_function_profile.py",
+        "scripts/python_function_worker.py",
+        "scripts/python_filesystem_profile.py",
+        "scripts/python_filesystem_worker.py",
+    ):
+        assert f"COPY {path} /opt/thebitlab/{Path(path).name}" in dockerfile
+        assert f"!{path}" in dockerignore
+
+    assert 'ENTRYPOINT ["python3", "/opt/thebitlab/grade_activity.py"]' in dockerfile

--- a/tests/test_p2_release_candidate.py
+++ b/tests/test_p2_release_candidate.py
@@ -17,16 +17,16 @@ def load(path: Path) -> dict:
     return value
 
 
-def test_combined_build_candidate_has_new_version_without_faking_published_lock() -> None:
+def test_combined_p2_p3_p4_candidate_has_distinct_version_without_faking_published_lock() -> None:
     manifest = load(MANIFEST)
     lock = load(LOCK)
 
-    assert manifest["version"] == "2026.08.2"
+    assert manifest["version"] == "2026.08.3"
     assert manifest["platform"] == "linux/amd64"
     assert manifest["image_repository"] == lock["image_repository"]
 
-    # Until the combined release is actually published and its remote digest is known,
-    # the checked-in immutable lock must remain the previously published release.
+    # Until the combined P2/P3/P4 release is actually reviewed, merged and
+    # published, the checked-in immutable lock remains the previous stable release.
     assert lock["version"] == "2026.07.1"
     assert lock["source_revision"] == "bd102146a684a9b06835204ec1b7f668f7655a03"
     assert lock["immutable_reference"].endswith(
@@ -41,13 +41,15 @@ def test_candidate_and_stable_lock_are_deliberately_different_release_identities
     assert manifest["version"] != lock["version"]
 
 
-def test_combined_runner_packages_both_python_profile_workers() -> None:
+def test_combined_runner_packages_all_three_python_profile_workers() -> None:
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     dockerignore = DOCKERIGNORE.read_text(encoding="utf-8")
 
     for path in (
         "scripts/python_function_profile.py",
         "scripts/python_function_worker.py",
+        "scripts/python_object_profile.py",
+        "scripts/python_object_worker.py",
         "scripts/python_filesystem_profile.py",
         "scripts/python_filesystem_worker.py",
     ):

--- a/tests/test_p2_release_candidate.py
+++ b/tests/test_p2_release_candidate.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "docker" / "assignment-runner" / "toolchain.json"
+LOCK = ROOT / "docker" / "assignment-runner" / "toolchain.lock.json"
+
+
+def load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_p2_build_candidate_has_new_version_without_faking_published_lock() -> None:
+    manifest = load(MANIFEST)
+    lock = load(LOCK)
+
+    assert manifest["version"] == "2026.08.1"
+    assert manifest["platform"] == "linux/amd64"
+    assert manifest["image_repository"] == lock["image_repository"]
+
+    # Until the release is actually published and its remote digest is known,
+    # the checked-in immutable lock must remain the previously published release.
+    assert lock["version"] == "2026.07.1"
+    assert lock["source_revision"] == "bd102146a684a9b06835204ec1b7f668f7655a03"
+    assert lock["immutable_reference"].endswith(
+        "@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+    )
+
+
+def test_candidate_and_stable_lock_are_deliberately_different_release_identities() -> None:
+    manifest = load(MANIFEST)
+    lock = load(LOCK)
+
+    assert manifest["version"] != lock["version"]

--- a/tests/test_python_filesystem_profile.py
+++ b/tests/test_python_filesystem_profile.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts import python_filesystem_profile as p4
+
+
+def valid_test() -> dict:
+    return {
+        "profile": p4.PROFILE_ID,
+        "name": "somma misure",
+        "fixtures": [
+            {
+                "id": "input",
+                "source": "fixtures/misure.txt",
+                "target": "misure.txt",
+                "mode": "read-only",
+            }
+        ],
+        "expected_artifacts": [
+            {"path": "risultato.txt", "text": "36\n", "encoding": "utf-8"}
+        ],
+    }
+
+
+def test_teacher_contract_and_worker_request_hide_expected_content() -> None:
+    test = p4.validate_filesystem_test(valid_test())
+    assert test["fixtures"][0]["source"] == "fixtures/misure.txt"
+    assert test["expected_artifacts"][0]["text"] == "36\n"
+
+    request = p4.worker_request(valid_test())
+    assert request == {
+        "schema_version": p4.WORKER_SCHEMA,
+        "fixture_targets": ["misure.txt"],
+    }
+    serialized = repr(request)
+    assert "36" not in serialized
+    assert "expected" not in serialized
+    assert "fixtures/misure.txt" not in serialized
+
+
+def test_newline_normalization_is_explicit_but_trailing_newline_is_semantic() -> None:
+    expected = valid_test()
+    expected["expected_artifacts"][0]["text"] = "a\r\nb\r\n"
+    result = p4.compare_worker_result(
+        expected,
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [
+                {
+                    "path": "risultato.txt",
+                    "text": "a\nb\n",
+                    "bytes": 4,
+                    "sha256": p4.text_sha256("a\nb\n"),
+                }
+            ],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is True
+
+    no_trailing = p4.compare_worker_result(
+        expected,
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [
+                {
+                    "path": "risultato.txt",
+                    "text": "a\nb",
+                    "bytes": 3,
+                    "sha256": p4.text_sha256("a\nb"),
+                }
+            ],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert no_trailing["passed"] is False
+    assert no_trailing["checks"][0]["status"] == "content-mismatch"
+
+
+def test_missing_and_unexpected_artifacts_fail_closed() -> None:
+    missing = p4.compare_worker_result(
+        valid_test(),
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert missing["passed"] is False
+    assert missing["checks"][0]["status"] == "missing"
+
+    unexpected_text = "extra\n"
+    unexpected = p4.compare_worker_result(
+        valid_test(),
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [
+                {
+                    "path": "risultato.txt",
+                    "text": "36\n",
+                    "bytes": 3,
+                    "sha256": p4.text_sha256("36\n"),
+                },
+                {
+                    "path": "debug.txt",
+                    "text": unexpected_text,
+                    "bytes": len(unexpected_text.encode("utf-8")),
+                    "sha256": p4.text_sha256(unexpected_text),
+                },
+            ],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert unexpected["passed"] is False
+    assert any(check["kind"] == "unexpected-artifact" for check in unexpected["checks"])
+
+
+def test_expected_absence_is_part_of_the_contract() -> None:
+    test = valid_test()
+    test["expected_absent"] = ["errore.txt"]
+    result = p4.compare_worker_result(
+        test,
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "completed",
+            "artifacts": [
+                {
+                    "path": "risultato.txt",
+                    "text": "36\n",
+                    "bytes": 3,
+                    "sha256": p4.text_sha256("36\n"),
+                }
+            ],
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is True
+
+
+def test_runtime_error_is_reported_as_student_behavior_not_platform_pass() -> None:
+    result = p4.compare_worker_result(
+        valid_test(),
+        {
+            "schema_version": p4.WORKER_SCHEMA,
+            "status": "runtime-error",
+            "artifacts": [],
+            "stdout": "",
+            "stderr": "",
+            "exception": {"type": "FileNotFoundError", "message": "misure.txt"},
+        },
+    )
+    assert result["passed"] is False
+    assert result["worker_status"] == "runtime-error"
+    assert result["exception"]["type"] == "FileNotFoundError"
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    ["../secret.txt", "/etc/passwd", "subdir/out.txt", "subdir\\out.txt", ".."],
+)
+def test_output_and_fixture_targets_reject_traversal_and_directory_trees(bad_path: str) -> None:
+    test = valid_test()
+    test["expected_artifacts"][0]["path"] = bad_path
+    with pytest.raises(p4.FilesystemProfileError):
+        p4.validate_filesystem_test(test)
+
+    test = valid_test()
+    test["fixtures"][0]["target"] = bad_path
+    with pytest.raises(p4.FilesystemProfileError):
+        p4.validate_filesystem_test(test)
+
+
+def test_fixture_source_may_be_nested_but_must_stay_inside_activity_bundle() -> None:
+    assert p4.safe_bundle_path("fixtures/dati/misure.txt") == "fixtures/dati/misure.txt"
+    for bad in ("../misure.txt", "/tmp/misure.txt", "fixtures\\misure.txt"):
+        with pytest.raises(p4.FilesystemProfileError):
+            p4.safe_bundle_path(bad)
+
+
+def test_fixture_expected_output_and_absence_roles_cannot_collide() -> None:
+    test = valid_test()
+    test["expected_artifacts"][0]["path"] = "misure.txt"
+    with pytest.raises(p4.FilesystemProfileError, match="ruoli incompatibili"):
+        p4.validate_filesystem_test(test)
+
+
+def test_unknown_fields_and_mutable_fixture_modes_fail_closed() -> None:
+    test = valid_test()
+    test["magic"] = True
+    with pytest.raises(p4.FilesystemProfileError, match="campi non supportati"):
+        p4.validate_filesystem_test(test)
+
+    test = valid_test()
+    test["fixtures"][0]["mode"] = "writable"
+    with pytest.raises(p4.FilesystemProfileError, match="read-only"):
+        p4.validate_filesystem_test(test)
+
+
+def test_worker_result_digest_size_and_limits_are_validated() -> None:
+    with pytest.raises(p4.FilesystemProfileError):
+        p4.validate_worker_result(
+            {
+                "schema_version": p4.WORKER_SCHEMA,
+                "status": "completed",
+                "artifacts": [
+                    {
+                        "path": "x.txt",
+                        "text": "abc",
+                        "bytes": 2,
+                        "sha256": p4.text_sha256("abc"),
+                    }
+                ],
+                "stdout": "",
+                "stderr": "",
+            }
+        )
+
+    with pytest.raises(p4.FilesystemProfileError):
+        p4.validate_worker_result(
+            {
+                "schema_version": p4.WORKER_SCHEMA,
+                "status": "completed",
+                "artifacts": [
+                    {
+                        "path": "x.txt",
+                        "text": "abc",
+                        "bytes": 3,
+                        "sha256": "0" * 64,
+                    }
+                ],
+                "stdout": "",
+                "stderr": "",
+            }
+        )

--- a/tests/test_python_filesystem_profile_dispatch.py
+++ b/tests/test_python_filesystem_profile_dispatch.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.thebitlab_technical_services import (
+    DockerGradeActivityExecutionService,
+    ExecutionRequest,
+)
+
+
+def p4_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p4-dispatch-001",
+        "titolo": "P4 dispatch",
+        "tipo": "laboratorio",
+        "difficolta": "B",
+        "argomenti": ["file"],
+        "consegna": "Crea risultato.txt.",
+        "language": "python",
+        "linguaggio": "python",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 10,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "filesystem_tests": [
+            {
+                "profile": "python-filesystem-v1",
+                "name": "output",
+                "expected_artifacts": [
+                    {"path": "risultato.txt", "text": "ok\n", "encoding": "utf-8"}
+                ],
+            }
+        ],
+    }
+
+
+def request(activity_path: Path, source_path: Path, *, language: str = "python") -> ExecutionRequest:
+    return ExecutionRequest(
+        activity_id="python-p4-dispatch-001",
+        student_id="student",
+        files={"main.py": str(source_path)},
+        language=language,
+        timeout_seconds=4,
+        metadata={
+            "activity_path": activity_path,
+            "source_path": source_path,
+            "docker_image": "runner:test",
+        },
+    )
+
+
+def test_docker_service_dispatches_filesystem_tests_to_p4(monkeypatch, tmp_path: Path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(json.dumps(p4_activity()), encoding="utf-8")
+    source_path.write_text("pass\n", encoding="utf-8")
+
+    from scripts import grade_activity, grade_python_filesystem_activity
+
+    legacy_called = False
+
+    def fake_legacy(*args, **kwargs):
+        nonlocal legacy_called
+        legacy_called = True
+        raise AssertionError("legacy grader must not run for filesystem_tests")
+
+    def fake_p4(**kwargs):
+        assert kwargs["activity_path"] == activity_path
+        assert kwargs["source_path"] == source_path
+        assert kwargs["image"] == "runner:test"
+        assert kwargs["timeout_seconds"] == 4
+        assert kwargs["activity_root"] == tmp_path
+        assert kwargs["source_root"] == tmp_path
+        return {
+            "activity_id": "python-p4-dispatch-001",
+            "language": "python",
+            "profile": "python-filesystem-v1",
+            "passed": True,
+            "status": "passed",
+            "tests": [
+                {
+                    "name": "output",
+                    "profile": "python-filesystem-v1",
+                    "visibility": "teacher",
+                    "passed": True,
+                    "status": "passed",
+                    "worker_status": "completed",
+                    "checks": [],
+                }
+            ],
+            "summary": {"passed": 1, "total": 1},
+        }
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", fake_legacy)
+    monkeypatch.setattr(grade_python_filesystem_activity, "grade_in_docker", fake_p4)
+
+    result = DockerGradeActivityExecutionService().run(request(activity_path, source_path))
+
+    assert legacy_called is False
+    assert result.status == "passed"
+    assert result.metadata["grading_profile"] == "python-filesystem-v1"
+    assert result.metadata["docker_image"] == "runner:test"
+    assert result.metadata["runner_report"]["profile"] == "python-filesystem-v1"
+
+
+def test_docker_service_rejects_filesystem_profile_for_non_python_request(tmp_path: Path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(json.dumps(p4_activity()), encoding="utf-8")
+    source_path.write_text("pass\n", encoding="utf-8")
+
+    result = DockerGradeActivityExecutionService().run(
+        request(activity_path, source_path, language="c")
+    )
+
+    assert result.status == "invalid_payload"
+    assert "filesystem_tests" in result.detail
+    assert "Python" in result.detail
+
+
+def test_docker_service_keeps_legacy_path_without_filesystem_tests(monkeypatch, tmp_path: Path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    legacy_activity = p4_activity()
+    legacy_activity.pop("filesystem_tests")
+    activity_path.write_text(json.dumps(legacy_activity), encoding="utf-8")
+    source_path.write_text("print('ok')\n", encoding="utf-8")
+
+    from scripts import grade_activity
+
+    def fake_legacy(activity, source, *, timeout_seconds, language, image):
+        assert activity == activity_path
+        assert source == source_path
+        assert timeout_seconds == 4
+        assert language == "python"
+        assert image == "runner:test"
+        return (
+            {
+                "activity_id": "python-p4-dispatch-001",
+                "language": "python",
+                "passed": True,
+                "status": "passed",
+                "tests": [{"name": "legacy", "passed": True, "status": "passed"}],
+                "summary": {"passed": 1, "total": 1},
+            },
+            "",
+        )
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", fake_legacy)
+    result = DockerGradeActivityExecutionService().run(request(activity_path, source_path))
+
+    assert result.status == "passed"
+    assert result.metadata["grading_profile"] == "legacy"

--- a/tests/test_python_filesystem_student_lab_docker.py
+++ b/tests/test_python_filesystem_student_lab_docker.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts import student_lab_runner
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1",
+    reason="set THEBITLAB_RUN_DOCKER_TESTS=1 to exercise the Docker sandbox",
+)
+
+
+def activity_payload() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p4-student-lab-001",
+        "title": "Persistenza nel percorso Student Lab",
+        "titolo": "Persistenza nel percorso Student Lab",
+        "kind": "laboratorio",
+        "tipo": "laboratorio",
+        "language": "python",
+        "linguaggio": "python",
+        "source_name": "main.py",
+        "difficulty": "B",
+        "difficolta": "B",
+        "topics": ["file", "pathlib"],
+        "argomenti": ["file", "pathlib"],
+        "instructions": "Leggi misure.txt e crea risultato.txt.",
+        "consegna": "Leggi misure.txt e crea risultato.txt.",
+        "grading_policy": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 10,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "filesystem_tests": [
+            {
+                "profile": "python-filesystem-v1",
+                "name": "oracle docente totale 36",
+                "fixtures": [
+                    {
+                        "id": "misure",
+                        "source": "fixtures/misure.txt",
+                        "target": "misure.txt",
+                        "mode": "read-only",
+                    }
+                ],
+                "expected_artifacts": [
+                    {
+                        "path": "risultato.txt",
+                        "text": "36\n",
+                        "encoding": "utf-8",
+                    }
+                ],
+                "visibility": "teacher",
+            }
+        ],
+    }
+
+
+def assignment_payload() -> dict:
+    return {
+        "assignment_id": "assignment-python-p4-student-lab",
+        "activity_id": "python-p4-student-lab-001",
+        "student_id": "rossi-mario",
+        "activity": {"path": "activities/python-p4-student-lab-001/activity.json"},
+        "workspace": {
+            "path": "students/rossi-mario/assignments/python-p4-student-lab-001"
+        },
+    }
+
+
+def test_p4_runs_through_normal_student_lab_and_redacts_teacher_oracles(tmp_path: Path) -> None:
+    activity_root = tmp_path / "activities" / "python-p4-student-lab-001"
+    fixtures = activity_root / "fixtures"
+    fixtures.mkdir(parents=True)
+    (fixtures / "misure.txt").write_text("12\n15\n9\n", encoding="utf-8")
+    (activity_root / "activity.json").write_text(
+        json.dumps(activity_payload()),
+        encoding="utf-8",
+    )
+
+    workspace = (
+        tmp_path
+        / "students"
+        / "rossi-mario"
+        / "assignments"
+        / "python-p4-student-lab-001"
+    )
+    workspace.mkdir(parents=True)
+    (workspace / "main.py").write_text(
+        "from pathlib import Path\n"
+        "values = [int(x) for x in Path('misure.txt').read_text(encoding='utf-8').splitlines()]\n"
+        "Path('risultato.txt').write_text(f'{sum(values)}\\n', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+
+    image = os.environ.get("THEBITLAB_P4_DOCKER_IMAGE", "thebitlab-p4-candidate")
+    report = student_lab_runner.run_docker_assignment(
+        assignment_payload(),
+        root=tmp_path,
+        timeout_seconds=3,
+        docker_image=image,
+    )
+
+    assert report["backend"] == "docker"
+    assert report["passed"] is True
+    assert report["status"] == "passed"
+    assert report["profile"] == "python-filesystem-v1"
+    assert report["summary"] == {"passed": 1, "total": 1}
+    assert report["tests"] == [
+        {"name": "Test 1", "passed": True, "status": "passed"}
+    ]
+
+    serialized = json.dumps(report, ensure_ascii=False).casefold()
+    for forbidden in (
+        "oracle docente totale 36",
+        "worker_status",
+        "observed_artifacts",
+        "checks",
+        "fixtures/misure.txt",
+        "expected_artifacts",
+        '"36\\n"',
+    ):
+        assert forbidden not in serialized

--- a/tests/test_python_filesystem_worker.py
+++ b/tests/test_python_filesystem_worker.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from scripts import python_filesystem_profile as p4
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKER = ROOT / "scripts" / "python_filesystem_worker.py"
+
+
+def run_worker(tmp_path: Path, source_text: str, *, fixtures: dict[str, str] | None = None) -> tuple[int, dict]:
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    fixture_targets = []
+    for name, text in (fixtures or {}).items():
+        (workdir / name).write_text(text, encoding="utf-8")
+        fixture_targets.append(name)
+    source = tmp_path / "main.py"
+    source.write_text(source_text, encoding="utf-8")
+    request = {
+        "schema_version": p4.WORKER_SCHEMA,
+        "fixture_targets": fixture_targets,
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WORKER),
+            "--source",
+            str(source),
+            "--workdir",
+            str(workdir),
+        ],
+        input=json.dumps(request),
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    return result.returncode, json.loads(result.stdout)
+
+
+def test_worker_executes_in_workdir_and_returns_text_artifact(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\n"
+        "values = [int(x) for x in Path('misure.txt').read_text(encoding='utf-8').splitlines()]\n"
+        "Path('risultato.txt').write_text(str(sum(values)) + '\\n', encoding='utf-8')\n",
+        fixtures={"misure.txt": "12\n15\n9\n"},
+    )
+    assert code == 0
+    assert report["status"] == "completed"
+    assert report["artifacts"] == [
+        {
+            "path": "risultato.txt",
+            "text": "36\n",
+            "bytes": 3,
+            "sha256": p4.text_sha256("36\n"),
+        }
+    ]
+    assert "misure.txt" not in {item["path"] for item in report["artifacts"]}
+
+
+def test_worker_reports_student_filenotfounderror(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('manca.txt').read_text(encoding='utf-8')\n",
+    )
+    assert code == 0
+    assert report["status"] == "runtime-error"
+    assert report["exception"]["type"] == "FileNotFoundError"
+    assert report["artifacts"] == []
+
+
+def test_worker_blocks_absolute_read_outside_workdir(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('/etc/passwd').read_text(encoding='utf-8')\n",
+    )
+    assert code == 0
+    assert report["status"] == "runtime-error"
+    assert report["exception"]["type"] == "PermissionError"
+    assert "fuori dal workdir" in report["exception"]["message"]
+
+
+def test_worker_blocks_parent_traversal(tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("teacher secret", encoding="utf-8")
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('../secret.txt').read_text(encoding='utf-8')\n",
+    )
+    assert code == 0
+    assert report["status"] == "runtime-error"
+    assert report["exception"]["type"] == "PermissionError"
+    assert "teacher secret" not in json.dumps(report)
+
+
+def test_worker_rejects_symlink_creation(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('escape').symlink_to('/etc/passwd')\n",
+    )
+    assert code == 0
+    assert report["status"] == "runtime-error"
+    assert report["exception"]["type"] == "PermissionError"
+
+
+def test_worker_rejects_subdirectories_in_v1(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('nested').mkdir()\n",
+    )
+    assert code == 0
+    assert report["status"] == "policy-violation"
+    assert report["artifacts"] == []
+
+
+def test_worker_enforces_output_file_byte_limit(tmp_path: Path) -> None:
+    code, report = run_worker(
+        tmp_path,
+        "from pathlib import Path\nPath('big.txt').write_text('x' * 70000, encoding='utf-8')\n",
+    )
+    assert code == 0
+    assert report["status"] == "output-limit"
+    assert report["artifacts"] == []
+
+
+def test_worker_requires_declared_fixture_target_to_exist(tmp_path: Path) -> None:
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    source = tmp_path / "main.py"
+    source.write_text("pass\n", encoding="utf-8")
+    request = {
+        "schema_version": p4.WORKER_SCHEMA,
+        "fixture_targets": ["misure.txt"],
+    }
+    result = subprocess.run(
+        [sys.executable, str(WORKER), "--source", str(source), "--workdir", str(workdir)],
+        input=json.dumps(request),
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    report = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert report["status"] == "policy-violation"

--- a/tests/test_python_function_profile.py
+++ b/tests/test_python_function_profile.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts import python_function_profile as p2
+
+
+def test_scalar_return_and_worker_redaction() -> None:
+    test = {
+        "profile": "python-function-v1",
+        "name": "area 3x4",
+        "function": "area",
+        "args": [3, 4],
+        "kwargs": {},
+        "expected_return": 12,
+    }
+    request = p2.worker_request(test)
+    assert request == {
+        "schema_version": p2.WORKER_SCHEMA,
+        "function": "area",
+        "args": [3, 4],
+        "kwargs": {},
+    }
+    assert "expected_return" not in request
+    assert "expected_exception" not in request
+
+    result = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "returned",
+            "return_value": 12,
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is True
+
+
+def test_exact_type_is_part_of_default_return_contract() -> None:
+    test = {
+        "profile": p2.PROFILE_ID,
+        "function": "is_even",
+        "args": [2],
+        "expected_return": True,
+    }
+    result = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "returned",
+            "return_value": 1,
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is False
+
+
+@pytest.mark.parametrize("value", [None, True, False, 0, -4, 2.5, "ciao", [1, "x"], {"a": 1}])
+def test_supported_value_codec(value) -> None:
+    assert p2.validate_value(value) == value
+
+
+@pytest.mark.parametrize("value", [{1, 2}, (1, 2), object(), float("nan"), float("inf")])
+def test_unsupported_or_non_deterministic_values_are_rejected(value) -> None:
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_value(value)
+
+
+def test_float_tolerance_is_explicit_and_absolute() -> None:
+    test = {
+        "profile": p2.PROFILE_ID,
+        "function": "media",
+        "args": [1.0, 2.0],
+        "expected_return": 1.5,
+        "float_tolerance": 0.01,
+    }
+    passed = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "returned",
+            "return_value": 1.505,
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    failed = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "returned",
+            "return_value": 1.52,
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert passed["passed"] is True
+    assert failed["passed"] is False
+
+
+def test_exception_expectation_compares_only_type() -> None:
+    test = {
+        "profile": p2.PROFILE_ID,
+        "function": "reciproco",
+        "args": [0],
+        "expected_exception": "ZeroDivisionError",
+    }
+    result = p2.compare_worker_result(
+        test,
+        {
+            "schema_version": p2.WORKER_SCHEMA,
+            "status": "raised",
+            "exception": {"type": "ZeroDivisionError", "message": "division by zero"},
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    assert result["passed"] is True
+
+
+def test_unknown_teacher_fields_fail_closed() -> None:
+    with pytest.raises(p2.FunctionProfileError, match="campi non supportati"):
+        p2.validate_function_test(
+            {
+                "profile": p2.PROFILE_ID,
+                "function": "area",
+                "args": [],
+                "expected_return": 1,
+                "magic": "no",
+            }
+        )
+
+
+def test_exactly_one_expectation_is_required() -> None:
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_function_test({"profile": p2.PROFILE_ID, "function": "f"})
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_function_test(
+            {
+                "profile": p2.PROFILE_ID,
+                "function": "f",
+                "expected_return": 1,
+                "expected_exception": "ValueError",
+            }
+        )
+
+
+def test_worker_request_rejects_expectation_leakage() -> None:
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_worker_request(
+            {
+                "schema_version": p2.WORKER_SCHEMA,
+                "function": "f",
+                "args": [],
+                "kwargs": {},
+                "expected_return": 42,
+            }
+        )
+
+
+def test_worker_result_is_bounded_and_fail_closed() -> None:
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_worker_result(
+            {
+                "schema_version": p2.WORKER_SCHEMA,
+                "status": "returned",
+                "return_value": 1,
+                "stdout": "x" * (p2.MAX_STRING_CHARS + 1),
+                "stderr": "",
+            }
+        )
+    with pytest.raises(p2.FunctionProfileError):
+        p2.validate_worker_result(
+            {
+                "schema_version": p2.WORKER_SCHEMA,
+                "status": "returned",
+                "return_value": 1,
+                "stdout": "",
+                "stderr": "",
+                "teacher_expected": 1,
+            }
+        )
+
+
+def test_missing_and_non_callable_are_normal_failed_behaviors() -> None:
+    test = {
+        "profile": p2.PROFILE_ID,
+        "function": "area",
+        "args": [2, 3],
+        "expected_return": 6,
+    }
+    for status in ("missing-function", "not-callable", "import-error", "timeout"):
+        result = p2.compare_worker_result(
+            test,
+            {
+                "schema_version": p2.WORKER_SCHEMA,
+                "status": status,
+                "stdout": "",
+                "stderr": "",
+            },
+        )
+        assert result["passed"] is False
+        assert result["worker_status"] == status

--- a/tests/test_python_function_profile_dispatch.py
+++ b/tests/test_python_function_profile_dispatch.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.thebitlab_technical_services import (
+    DockerGradeActivityExecutionService,
+    ExecutionRequest,
+    RunnerTestResult,
+)
+
+
+def _request(activity_path: Path, source_path: Path, *, language: str = "python") -> ExecutionRequest:
+    return ExecutionRequest(
+        activity_id="python-p2-dispatch",
+        student_id="rossi-mario",
+        files={source_path.name: str(source_path)},
+        language=language,
+        timeout_seconds=7,
+        metadata={
+            "activity_path": activity_path,
+            "source_path": source_path,
+            "docker_image": "p2-candidate:test",
+        },
+    )
+
+
+def test_docker_service_dispatches_function_tests_to_p2_only(monkeypatch, tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "id": "python-p2-dispatch",
+                "language": "python",
+                "function_tests": [
+                    {
+                        "profile": "python-function-v1",
+                        "function": "doppio",
+                        "args": [3],
+                        "expected_return": 6,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    source_path.write_text("def doppio(x):\n    return x * 2\n", encoding="utf-8")
+
+    from scripts import grade_activity, grade_python_function_activity
+
+    def legacy_must_not_run(*args, **kwargs):
+        raise AssertionError("legacy Docker grader must not run for P2")
+
+    def fake_p2(*, activity_path, source_path, image, timeout_seconds, activity_root=None, source_root=None):
+        assert activity_path == tmp_path / "activity.json"
+        assert source_path == tmp_path / "main.py"
+        assert image == "p2-candidate:test"
+        assert timeout_seconds == 7
+        assert activity_root is None
+        assert source_root is None
+        return {
+            "passed": True,
+            "status": "passed",
+            "activity_id": "python-p2-dispatch",
+            "language": "python",
+            "profile": "python-function-v1",
+            "source": str(source_path),
+            "tests": [
+                {
+                    "name": "doppio",
+                    "passed": True,
+                    "status": "passed",
+                    "worker_status": "returned",
+                }
+            ],
+            "summary": {"passed": 1, "total": 1},
+        }
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", legacy_must_not_run)
+    monkeypatch.setattr(grade_python_function_activity, "grade_in_docker", fake_p2)
+
+    result = DockerGradeActivityExecutionService().run(_request(activity_path, source_path))
+
+    assert result.status == "passed"
+    assert result.tests == [RunnerTestResult("doppio", True)]
+    assert result.metadata["backend"] == "docker"
+    assert result.metadata["docker_image"] == "p2-candidate:test"
+    assert result.metadata["grading_profile"] == "python-function-v1"
+    assert result.metadata["runner_report"]["profile"] == "python-function-v1"
+
+
+def test_docker_service_keeps_legacy_path_without_function_tests(monkeypatch, tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "id": "python-p1-dispatch",
+                "language": "python",
+                "test_cases": [{"stdin": "2\n", "expected_stdout": "4\n"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    source_path.write_text("print(int(input()) * 2)\n", encoding="utf-8")
+
+    from scripts import grade_activity, grade_python_function_activity
+
+    def p2_must_not_run(*args, **kwargs):
+        raise AssertionError("P2 grader must not run for legacy Activity")
+
+    def fake_legacy(activity, source, *, timeout_seconds, language, image):
+        assert activity == activity_path
+        assert source == source_path
+        assert timeout_seconds == 7
+        assert language == "python"
+        assert image == "p2-candidate:test"
+        return (
+            {
+                "passed": True,
+                "status": "passed",
+                "activity_id": "python-p1-dispatch",
+                "language": "python",
+                "source": str(source_path),
+                "tests": [{"name": "base", "passed": True, "status": "passed"}],
+                "summary": {"passed": 1, "total": 1},
+            },
+            "",
+        )
+
+    monkeypatch.setattr(grade_python_function_activity, "grade_in_docker", p2_must_not_run)
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", fake_legacy)
+
+    result = DockerGradeActivityExecutionService().run(_request(activity_path, source_path))
+
+    assert result.status == "passed"
+    assert result.tests == [RunnerTestResult("base", True)]
+    assert result.metadata["grading_profile"] == "legacy"
+
+
+def test_docker_service_rejects_function_profile_for_non_python_request(monkeypatch, tmp_path) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.c"
+    activity_path.write_text(
+        json.dumps(
+            {
+                "id": "invalid-p2-language",
+                "language": "c",
+                "function_tests": [
+                    {
+                        "profile": "python-function-v1",
+                        "function": "f",
+                        "expected_return": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    source_path.write_text("int main(void){return 0;}\n", encoding="utf-8")
+
+    from scripts import grade_activity, grade_python_function_activity
+
+    monkeypatch.setattr(
+        grade_activity,
+        "grade_activity_in_docker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("legacy must not run")),
+    )
+    monkeypatch.setattr(
+        grade_python_function_activity,
+        "grade_in_docker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("P2 must not run")),
+    )
+
+    result = DockerGradeActivityExecutionService().run(
+        _request(activity_path, source_path, language="c")
+    )
+
+    assert result.status == "invalid_payload"
+    assert "function_tests" in result.detail
+    assert "Python" in result.detail

--- a/tests/test_python_function_report_redaction.py
+++ b/tests/test_python_function_report_redaction.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+
+from scripts import student_lab_runner
+
+
+def test_teacher_p2_results_are_redacted_for_student_report() -> None:
+    teacher_report = {
+        "passed": False,
+        "status": "failed",
+        "profile": "python-function-v1",
+        "summary": {"passed": 1, "total": 2},
+        "tests": [
+            {
+                "name": "area hidden oracle",
+                "profile": "python-function-v1",
+                "function": "area",
+                "visibility": "teacher",
+                "passed": True,
+                "status": "passed",
+                "worker_status": "returned",
+                "stdout": "debug segreto",
+                "stderr": "",
+                "actual_return": 12,
+                "actual_exception": None,
+            },
+            {
+                "name": "exception hidden oracle",
+                "profile": "python-function-v1",
+                "function": "reciproco",
+                "visibility": "teacher",
+                "passed": False,
+                "status": "failed",
+                "worker_status": "raised",
+                "stdout": "",
+                "stderr": "",
+                "actual_return": None,
+                "actual_exception": {
+                    "type": "ValueError",
+                    "message": "teacher-only diagnostic",
+                },
+            },
+        ],
+    }
+
+    student = student_lab_runner.redact_student_grading_report(teacher_report)
+
+    assert student["tests"] == [
+        {"name": "Test 1", "passed": True, "status": "passed"},
+        {"name": "Test 2", "passed": False, "status": "failed"},
+    ]
+    serialized = json.dumps(student, ensure_ascii=False)
+    for forbidden in (
+        "area hidden oracle",
+        "exception hidden oracle",
+        "actual_return",
+        "actual_exception",
+        "teacher-only diagnostic",
+        "debug segreto",
+        "reciproco",
+    ):
+        assert forbidden not in serialized
+
+
+def test_explicit_public_p2_result_can_preserve_public_observation() -> None:
+    report = {
+        "tests": [
+            {
+                "name": "esempio pubblico",
+                "visibility": "public",
+                "passed": True,
+                "status": "passed",
+                "worker_status": "returned",
+                "actual_return": 6,
+            }
+        ]
+    }
+    student = student_lab_runner.redact_student_grading_report(report)
+    assert student["tests"][0]["name"] == "esempio pubblico"
+    assert student["tests"][0]["actual_return"] == 6

--- a/tests/test_python_function_student_lab_docker.py
+++ b/tests/test_python_function_student_lab_docker.py
@@ -110,11 +110,12 @@ def test_p2_runs_through_normal_student_lab_and_redacts_teacher_oracles(tmp_path
         encoding="utf-8",
     )
 
+    docker_image = os.environ.get("THEBITLAB_P2_DOCKER_IMAGE", "thebitlab-p2-candidate")
     report = student_lab_runner.run_docker_assignment(
         _assignment(),
         root=tmp_path,
         timeout_seconds=3,
-        docker_image="thebitlab-p2-candidate",
+        docker_image=docker_image,
     )
 
     assert report["backend"] == "docker"

--- a/tests/test_python_function_student_lab_docker.py
+++ b/tests/test_python_function_student_lab_docker.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts import student_lab_runner
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1",
+    reason="set THEBITLAB_RUN_DOCKER_TESTS=1 to exercise the Docker sandbox",
+)
+
+
+def _activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p2-student-lab-001",
+        "title": "Return nel percorso Student Lab",
+        "titolo": "Return nel percorso Student Lab",
+        "kind": "laboratorio",
+        "tipo": "laboratorio",
+        "language": "python",
+        "linguaggio": "python",
+        "source_name": "main.py",
+        "difficulty": "B",
+        "difficolta": "B",
+        "topics": ["funzioni", "return"],
+        "argomenti": ["funzioni", "return"],
+        "instructions": "Implementa le funzioni richieste.",
+        "consegna": "Implementa le funzioni richieste.",
+        "grading_policy": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 10,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "function_tests": [
+            {
+                "profile": "python-function-v1",
+                "name": "doppio positivo",
+                "function": "doppio",
+                "args": [3],
+                "expected_return": 6,
+            },
+            {
+                "profile": "python-function-v1",
+                "name": "doppio zero",
+                "function": "doppio",
+                "args": [0],
+                "expected_return": 0,
+            },
+            {
+                "profile": "python-function-v1",
+                "name": "predicate pari",
+                "function": "pari",
+                "args": [8],
+                "expected_return": True,
+            },
+        ],
+    }
+
+
+def _assignment() -> dict:
+    return {
+        "assignment_id": "assignment-python-p2-student-lab",
+        "activity_id": "python-p2-student-lab-001",
+        "student_id": "rossi-mario",
+        "activity": {"path": "activities/python-p2-student-lab-001.json"},
+        "workspace": {
+            "path": "students/rossi-mario/assignments/python-p2-student-lab-001"
+        },
+    }
+
+
+def test_p2_runs_through_normal_student_lab_and_redacts_teacher_oracles(tmp_path: Path) -> None:
+    activity_path = tmp_path / "activities" / "python-p2-student-lab-001.json"
+    activity_path.parent.mkdir(parents=True)
+    activity_path.write_text(json.dumps(_activity()), encoding="utf-8")
+
+    workspace = (
+        tmp_path
+        / "students"
+        / "rossi-mario"
+        / "assignments"
+        / "python-p2-student-lab-001"
+    )
+    workspace.mkdir(parents=True)
+    (workspace / "main.py").write_text(
+        "def doppio(x):\n"
+        "    return x * 2\n\n"
+        "def pari(n):\n"
+        "    return n % 2 == 0\n",
+        encoding="utf-8",
+    )
+
+    report = student_lab_runner.run_docker_assignment(
+        _assignment(),
+        root=tmp_path,
+        timeout_seconds=3,
+        docker_image="thebitlab-p2-candidate",
+    )
+
+    assert report["backend"] == "docker"
+    assert report["passed"] is True
+    assert report["status"] == "passed"
+    assert report["profile"] == "python-function-v1"
+    assert report["summary"] == {"passed": 3, "total": 3}
+    assert report["tests"] == [
+        {"name": "Test 1", "passed": True, "status": "passed"},
+        {"name": "Test 2", "passed": True, "status": "passed"},
+        {"name": "Test 3", "passed": True, "status": "passed"},
+    ]
+
+    serialized = json.dumps(report, ensure_ascii=False).casefold()
+    for forbidden in (
+        "expected_return",
+        "actual_return",
+        "worker_status",
+        "doppio positivo",
+        "doppio zero",
+        "predicate pari",
+    ):
+        assert forbidden not in serialized

--- a/tests/test_python_function_worker.py
+++ b/tests/test_python_function_worker.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import python_function_profile as p2
+
+
+def write_source(tmp_path: Path, text: str) -> Path:
+    source = tmp_path / "main.py"
+    source.write_text(text, encoding="utf-8")
+    return source
+
+
+def request(function: str, *args, **kwargs) -> dict:
+    return {
+        "schema_version": p2.WORKER_SCHEMA,
+        "function": function,
+        "args": list(args),
+        "kwargs": kwargs,
+    }
+
+
+def test_worker_invokes_top_level_function(tmp_path: Path) -> None:
+    source = write_source(tmp_path, "def area(base, altezza):\n    return base * altezza\n")
+    result = p2.execute_worker_request(request("area", 3, 4), source)
+    assert result == {
+        "schema_version": p2.WORKER_SCHEMA,
+        "status": "returned",
+        "return_value": 12,
+        "stdout": "",
+        "stderr": "",
+    }
+
+
+def test_worker_captures_stdout_without_using_it_as_oracle(tmp_path: Path) -> None:
+    source = write_source(
+        tmp_path,
+        "def saluta(nome):\n    print('debug', nome)\n    return 'ciao ' + nome\n",
+    )
+    result = p2.execute_worker_request(request("saluta", "Ada"), source)
+    assert result["status"] == "returned"
+    assert result["return_value"] == "ciao Ada"
+    assert result["stdout"] == "debug Ada\n"
+
+
+def test_worker_reports_missing_and_non_callable(tmp_path: Path) -> None:
+    missing = write_source(tmp_path, "x = 1\n")
+    assert p2.execute_worker_request(request("area"), missing)["status"] == "missing-function"
+
+    non_callable = write_source(tmp_path, "area = 12\n")
+    assert p2.execute_worker_request(request("area"), non_callable)["status"] == "not-callable"
+
+
+def test_worker_reports_student_exception(tmp_path: Path) -> None:
+    source = write_source(tmp_path, "def reciproco(x):\n    return 1 / x\n")
+    result = p2.execute_worker_request(request("reciproco", 0), source)
+    assert result["status"] == "raised"
+    assert result["exception"]["type"] == "ZeroDivisionError"
+    assert len(result["exception"]["message"]) <= 512
+
+
+def test_import_side_effect_failure_is_not_a_platform_crash(tmp_path: Path) -> None:
+    source = write_source(tmp_path, "raise RuntimeError('boom import')\n")
+    result = p2.execute_worker_request(request("f"), source)
+    assert result["status"] == "import-error"
+    assert "RuntimeError" in result["stderr"]
+
+
+def test_unsupported_return_fails_closed(tmp_path: Path) -> None:
+    source = write_source(tmp_path, "def f():\n    return {1, 2}\n")
+    result = p2.execute_worker_request(request("f"), source)
+    assert result["status"] == "unsupported-return"
+    assert "return_value" not in result
+
+
+def test_stdout_limit_is_enforced_during_import(tmp_path: Path) -> None:
+    source = write_source(tmp_path, f"print('x' * {p2.MAX_STRING_CHARS + 1})\ndef f():\n    return 1\n")
+    result = p2.execute_worker_request(request("f"), source)
+    assert result["status"] == "output-limit"
+    assert len(result["stdout"]) <= p2.MAX_STRING_CHARS
+
+
+def test_stdout_limit_is_enforced_during_function_call(tmp_path: Path) -> None:
+    source = write_source(
+        tmp_path,
+        f"def f():\n    print('x' * {p2.MAX_STRING_CHARS + 1})\n    return 1\n",
+    )
+    result = p2.execute_worker_request(request("f"), source)
+    assert result["status"] == "output-limit"
+    assert len(result["stdout"]) <= p2.MAX_STRING_CHARS
+
+
+def test_worker_request_never_contains_teacher_expectations(tmp_path: Path) -> None:
+    teacher_test = {
+        "profile": p2.PROFILE_ID,
+        "function": "area",
+        "args": [5, 6],
+        "expected_return": 30,
+    }
+    worker = p2.worker_request(teacher_test)
+    assert set(worker) == {"schema_version", "function", "args", "kwargs"}
+    assert "expected_return" not in worker
+    assert "expected_exception" not in worker

--- a/tests/test_python_grading_profiles_integration.py
+++ b/tests/test_python_grading_profiles_integration.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import validate_activity
+from scripts.thebitlab_technical_services import (
+    DockerGradeActivityExecutionService,
+    ExecutionRequest,
+)
+
+
+def base_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-profiles-ambiguous-001",
+        "titolo": "Contratto ambiguo",
+        "tipo": "laboratorio",
+        "difficolta": "B",
+        "argomenti": ["funzioni", "file"],
+        "consegna": "Activity usata soltanto per il gate di integrazione.",
+        "language": "python",
+        "linguaggio": "python",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 10,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "function_tests": [
+            {
+                "profile": "python-function-v1",
+                "function": "f",
+                "expected_return": 1,
+            }
+        ],
+        "filesystem_tests": [
+            {
+                "profile": "python-filesystem-v1",
+                "expected_artifacts": [
+                    {"path": "out.txt", "text": "1\n", "encoding": "utf-8"}
+                ],
+            }
+        ],
+    }
+
+
+def test_validator_rejects_activity_with_both_p2_and_p4_contracts() -> None:
+    errors = validate_activity.validate_activity(base_activity(), "activity.json")
+
+    assert any(
+        "function_tests e filesystem_tests non possono coesistere" in error
+        for error in errors
+    )
+
+
+def test_validator_rejects_python_profiles_on_non_python_activity() -> None:
+    activity = base_activity()
+    activity.pop("filesystem_tests")
+    activity["language"] = "c"
+    activity["linguaggio"] = "c"
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("function_tests" in error and "Python" in error for error in errors)
+
+    activity = base_activity()
+    activity.pop("function_tests")
+    activity["language"] = "c"
+    activity["linguaggio"] = "c"
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("filesystem_tests" in error and "Python" in error for error in errors)
+
+
+def test_docker_dispatcher_rejects_ambiguous_activity_before_running_any_grader(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(json.dumps(base_activity()), encoding="utf-8")
+    source_path.write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    from scripts import grade_activity
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("nessun grader deve partire per Activity ambigua")
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", forbidden)
+    result = DockerGradeActivityExecutionService().run(
+        ExecutionRequest(
+            activity_id="python-profiles-ambiguous-001",
+            student_id="student",
+            files={"main.py": str(source_path)},
+            language="python",
+            metadata={
+                "activity_path": activity_path,
+                "source_path": source_path,
+                "docker_image": "runner:test",
+            },
+        )
+    )
+
+    assert result.status == "invalid_payload"
+    assert "ambigua" in result.detail
+    assert "function_tests" in result.detail
+    assert "filesystem_tests" in result.detail

--- a/tests/test_python_object_profile.py
+++ b/tests/test_python_object_profile.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts import python_object_profile as p3
+
+
+def scenario() -> dict:
+    return {
+        "profile": "python-object-v1",
+        "name": "conto base",
+        "class": "Conto",
+        "construct": {"args": ["Anna", 100], "kwargs": {}},
+        "additional_instances": [
+            {"id": "other", "construct": {"args": ["Luca", 50], "kwargs": {}}}
+        ],
+        "steps": [
+            {
+                "call": "deposita",
+                "args": [20],
+                "expected_return": None,
+            },
+            {"observe": "saldo", "expected": 120},
+            {"instance": "other", "observe": "saldo", "expected": 50},
+        ],
+    }
+
+
+def test_object_contract_normalizes_main_and_additional_instances() -> None:
+    normalized = p3.validate_object_test(scenario())
+
+    assert normalized["class"] == "Conto"
+    assert normalized["construct"] == {"args": ["Anna", 100], "kwargs": {}}
+    assert normalized["additional_instances"][0]["id"] == "other"
+    assert normalized["steps"][0]["instance"] == "main"
+    assert normalized["steps"][2]["instance"] == "other"
+
+
+def test_worker_request_redacts_all_teacher_expectations() -> None:
+    request = p3.worker_request(scenario())
+    serialized = json.dumps(request, ensure_ascii=False).casefold()
+
+    assert request["schema_version"] == p3.WORKER_SCHEMA
+    assert request["class"] == "Conto"
+    assert request["steps"][0] == {
+        "kind": "call",
+        "instance": "main",
+        "member": "deposita",
+        "args": [20],
+        "kwargs": {},
+    }
+    assert request["steps"][1] == {
+        "kind": "observe",
+        "instance": "main",
+        "member": "saldo",
+    }
+    for forbidden in (
+        "expected_return",
+        "expected_exception",
+        '"expected"',
+        "float_tolerance",
+        "120",
+    ):
+        assert forbidden not in serialized
+
+
+def test_private_dunder_and_unknown_instance_are_rejected() -> None:
+    private = scenario()
+    private["steps"] = [{"observe": "_saldo", "expected": 100}]
+    with pytest.raises(p3.ObjectProfileError, match="pubblico"):
+        p3.validate_object_test(private)
+
+    dunder = scenario()
+    dunder["steps"] = [{"observe": "__dict__", "expected": {}}]
+    with pytest.raises(p3.ObjectProfileError, match="pubblico"):
+        p3.validate_object_test(dunder)
+
+    unknown = scenario()
+    unknown["steps"] = [
+        {"instance": "missing", "observe": "saldo", "expected": 100}
+    ]
+    with pytest.raises(p3.ObjectProfileError, match="non dichiarata"):
+        p3.validate_object_test(unknown)
+
+
+def test_constructor_exception_is_teacher_only_and_exclusive() -> None:
+    item = {
+        "profile": "python-object-v1",
+        "class": "Conto",
+        "construct": {"args": ["Anna", -1]},
+        "expected_constructor_exception": "ValueError",
+    }
+    normalized = p3.validate_object_test(item)
+    request = p3.worker_request(item)
+
+    assert normalized["expected_constructor_exception"] == "ValueError"
+    assert "expected_constructor_exception" not in request
+    assert request["steps"] == []
+
+    bad = dict(item)
+    bad["steps"] = [{"observe": "saldo", "expected": 0}]
+    with pytest.raises(p3.ObjectProfileError, match="non puo dichiarare"):
+        p3.validate_object_test(bad)
+
+
+def test_call_must_declare_exactly_one_expected_behavior() -> None:
+    missing = scenario()
+    missing["steps"] = [{"call": "deposita", "args": [1]}]
+    with pytest.raises(p3.ObjectProfileError, match="esattamente uno"):
+        p3.validate_object_test(missing)
+
+    double = scenario()
+    double["steps"] = [
+        {
+            "call": "deposita",
+            "args": [1],
+            "expected_return": None,
+            "expected_exception": "ValueError",
+        }
+    ]
+    with pytest.raises(p3.ObjectProfileError, match="esattamente uno"):
+        p3.validate_object_test(double)
+
+
+def test_comparison_covers_method_state_and_instance_independence() -> None:
+    result = {
+        "schema_version": p3.WORKER_SCHEMA,
+        "status": "completed",
+        "stdout": "",
+        "stderr": "",
+        "steps": [
+            {
+                "kind": "call",
+                "instance": "main",
+                "member": "deposita",
+                "status": "returned",
+                "return_value": None,
+            },
+            {
+                "kind": "observe",
+                "instance": "main",
+                "member": "saldo",
+                "status": "observed",
+                "value": 120,
+            },
+            {
+                "kind": "observe",
+                "instance": "other",
+                "member": "saldo",
+                "status": "observed",
+                "value": 50,
+            },
+        ],
+    }
+
+    compared = p3.compare_worker_result(scenario(), result)
+
+    assert compared["passed"] is True
+    assert [item["passed"] for item in compared["observations"]] == [True, True, True]
+
+    result["steps"][2]["value"] = 70
+    compared = p3.compare_worker_result(scenario(), result)
+    assert compared["passed"] is False
+    assert compared["observations"][2]["passed"] is False
+
+
+def test_expected_method_exception_and_float_tolerance_compare_host_side() -> None:
+    item = {
+        "profile": "python-object-v1",
+        "class": "Termometro",
+        "construct": {},
+        "steps": [
+            {
+                "call": "imposta",
+                "args": [-999],
+                "expected_exception": "ValueError",
+            },
+            {
+                "observe": "valore",
+                "expected": 20.0,
+                "float_tolerance": 0.01,
+            },
+        ],
+    }
+    actual = {
+        "schema_version": p3.WORKER_SCHEMA,
+        "status": "completed",
+        "stdout": "",
+        "stderr": "",
+        "steps": [
+            {
+                "kind": "call",
+                "instance": "main",
+                "member": "imposta",
+                "status": "raised",
+                "exception": {"type": "ValueError", "message": "fuori intervallo"},
+            },
+            {
+                "kind": "observe",
+                "instance": "main",
+                "member": "valore",
+                "status": "observed",
+                "value": 20.005,
+            },
+        ],
+    }
+
+    compared = p3.compare_worker_result(item, actual)
+    assert compared["passed"] is True
+
+
+def test_constructor_exception_comparison_uses_type_not_teacher_message() -> None:
+    item = {
+        "profile": "python-object-v1",
+        "class": "Conto",
+        "construct": {"args": ["Anna", -1]},
+        "expected_constructor_exception": "ValueError",
+    }
+    actual = {
+        "schema_version": p3.WORKER_SCHEMA,
+        "status": "constructor-raised",
+        "stdout": "",
+        "stderr": "",
+        "steps": [],
+        "instance": "main",
+        "exception": {"type": "ValueError", "message": "saldo iniziale negativo"},
+    }
+
+    assert p3.compare_worker_result(item, actual)["passed"] is True

--- a/tests/test_python_object_profile_dispatch.py
+++ b/tests/test_python_object_profile_dispatch.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.thebitlab_technical_services import (
+    DockerGradeActivityExecutionService,
+    ExecutionRequest,
+    RunnerTestResult,
+)
+
+
+def p3_activity() -> dict:
+    return {
+        "id": "python-p3-dispatch-001",
+        "language": "python",
+        "object_tests": [
+            {
+                "profile": "python-object-v1",
+                "name": "saldo dopo deposito",
+                "class": "Conto",
+                "construct": {"args": ["Anna", 100]},
+                "steps": [
+                    {"call": "deposita", "args": [20], "expected_return": None},
+                    {"observe": "saldo", "expected": 120},
+                ],
+            }
+        ],
+    }
+
+
+def request(
+    activity_path: Path,
+    source_path: Path,
+    *,
+    language: str = "python",
+) -> ExecutionRequest:
+    return ExecutionRequest(
+        activity_id="python-p3-dispatch-001",
+        student_id="student",
+        files={"main.py": str(source_path)},
+        language=language,
+        timeout_seconds=6,
+        metadata={
+            "activity_path": activity_path,
+            "source_path": source_path,
+            "docker_image": "p3-candidate:test",
+        },
+    )
+
+
+def test_docker_service_dispatches_object_tests_to_p3_only(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(json.dumps(p3_activity()), encoding="utf-8")
+    source_path.write_text(
+        "class Conto:\n"
+        "    def __init__(self, titolare, saldo):\n"
+        "        self.titolare = titolare\n"
+        "        self.saldo = saldo\n",
+        encoding="utf-8",
+    )
+
+    from scripts import (
+        grade_activity,
+        grade_python_filesystem_activity,
+        grade_python_function_activity,
+        grade_python_object_activity,
+    )
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("solo il grader P3 deve essere eseguito")
+
+    def fake_p3(**kwargs):
+        assert kwargs["activity_path"] == activity_path
+        assert kwargs["source_path"] == source_path
+        assert kwargs["image"] == "p3-candidate:test"
+        assert kwargs["timeout_seconds"] == 6
+        assert kwargs["activity_root"] == tmp_path
+        assert kwargs["source_root"] == tmp_path
+        return {
+            "activity_id": "python-p3-dispatch-001",
+            "language": "python",
+            "profile": "python-object-v1",
+            "passed": True,
+            "status": "passed",
+            "tests": [
+                {
+                    "name": "saldo dopo deposito",
+                    "passed": True,
+                    "status": "passed",
+                    "worker_status": "completed",
+                }
+            ],
+            "summary": {"passed": 1, "total": 1},
+        }
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", forbidden)
+    monkeypatch.setattr(grade_python_function_activity, "grade_in_docker", forbidden)
+    monkeypatch.setattr(grade_python_filesystem_activity, "grade_in_docker", forbidden)
+    monkeypatch.setattr(grade_python_object_activity, "grade_in_docker", fake_p3)
+
+    result = DockerGradeActivityExecutionService().run(
+        request(activity_path, source_path)
+    )
+
+    assert result.status == "passed"
+    assert result.tests == [RunnerTestResult("saldo dopo deposito", True)]
+    assert result.metadata["backend"] == "docker"
+    assert result.metadata["docker_image"] == "p3-candidate:test"
+    assert result.metadata["grading_profile"] == "python-object-v1"
+    assert result.metadata["runner_report"]["profile"] == "python-object-v1"
+
+
+def test_docker_service_rejects_object_profile_for_non_python_request(
+    tmp_path: Path,
+) -> None:
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.c"
+    activity_path.write_text(json.dumps(p3_activity()), encoding="utf-8")
+    source_path.write_text("int main(void){return 0;}\n", encoding="utf-8")
+
+    result = DockerGradeActivityExecutionService().run(
+        request(activity_path, source_path, language="c")
+    )
+
+    assert result.status == "invalid_payload"
+    assert "object_tests" in result.detail
+    assert "Python" in result.detail
+
+
+@pytest.mark.parametrize("other_field", ["function_tests", "filesystem_tests"])
+def test_docker_service_rejects_p3_mixed_with_another_python_profile(
+    monkeypatch,
+    tmp_path: Path,
+    other_field: str,
+) -> None:
+    activity = p3_activity()
+    if other_field == "function_tests":
+        activity[other_field] = [
+            {
+                "profile": "python-function-v1",
+                "function": "f",
+                "expected_return": 1,
+            }
+        ]
+    else:
+        activity[other_field] = [
+            {
+                "profile": "python-filesystem-v1",
+                "expected_artifacts": [
+                    {"path": "out.txt", "text": "ok\n", "encoding": "utf-8"}
+                ],
+            }
+        ]
+
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(json.dumps(activity), encoding="utf-8")
+    source_path.write_text("pass\n", encoding="utf-8")
+
+    from scripts import (
+        grade_activity,
+        grade_python_filesystem_activity,
+        grade_python_function_activity,
+        grade_python_object_activity,
+    )
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("nessun grader deve partire per Activity ambigua")
+
+    monkeypatch.setattr(grade_activity, "grade_activity_in_docker", forbidden)
+    monkeypatch.setattr(grade_python_function_activity, "grade_in_docker", forbidden)
+    monkeypatch.setattr(grade_python_filesystem_activity, "grade_in_docker", forbidden)
+    monkeypatch.setattr(grade_python_object_activity, "grade_in_docker", forbidden)
+
+    result = DockerGradeActivityExecutionService().run(
+        request(activity_path, source_path)
+    )
+
+    assert result.status == "invalid_payload"
+    assert "profili Python incompatibili" in result.detail
+    assert "object_tests" in result.detail
+    assert other_field in result.detail
+
+
+def test_docker_service_rejects_all_three_python_profiles_before_execution(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    activity = p3_activity()
+    activity["function_tests"] = [
+        {
+            "profile": "python-function-v1",
+            "function": "f",
+            "expected_return": 1,
+        }
+    ]
+    activity["filesystem_tests"] = [
+        {
+            "profile": "python-filesystem-v1",
+            "expected_artifacts": [
+                {"path": "out.txt", "text": "ok\n", "encoding": "utf-8"}
+            ],
+        }
+    ]
+    activity_path = tmp_path / "activity.json"
+    source_path = tmp_path / "main.py"
+    activity_path.write_text(json.dumps(activity), encoding="utf-8")
+    source_path.write_text("pass\n", encoding="utf-8")
+
+    from scripts import grade_activity
+
+    monkeypatch.setattr(
+        grade_activity,
+        "grade_activity_in_docker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("legacy non deve partire")
+        ),
+    )
+
+    result = DockerGradeActivityExecutionService().run(
+        request(activity_path, source_path)
+    )
+
+    assert result.status == "invalid_payload"
+    for field in ("function_tests", "filesystem_tests", "object_tests"):
+        assert field in result.detail

--- a/tests/test_python_object_student_lab_docker.py
+++ b/tests/test_python_object_student_lab_docker.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts import student_lab_runner
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1",
+    reason="set THEBITLAB_RUN_DOCKER_TESTS=1 to exercise the Docker sandbox",
+)
+
+
+def _activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p3-student-lab-001",
+        "title": "Oggetti nel percorso Student Lab",
+        "titolo": "Oggetti nel percorso Student Lab",
+        "kind": "laboratorio",
+        "tipo": "laboratorio",
+        "language": "python",
+        "linguaggio": "python",
+        "source_name": "main.py",
+        "difficulty": "B",
+        "difficolta": "B",
+        "topics": ["classi", "stato", "invarianti"],
+        "argomenti": ["classi", "stato", "invarianti"],
+        "instructions": "Implementa Conto con stato e invarianti.",
+        "consegna": "Implementa Conto con stato e invarianti.",
+        "grading_policy": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "object_tests": [
+            {
+                "profile": "python-object-v1",
+                "name": "deposito modifica lo stato",
+                "class": "Conto",
+                "construct": {"args": ["Anna", 100]},
+                "steps": [
+                    {"call": "deposita", "args": [20], "expected_return": None},
+                    {"observe": "saldo", "expected": 120},
+                    {"call": "saldo_corrente", "expected_return": 120},
+                ],
+            },
+            {
+                "profile": "python-object-v1",
+                "name": "deposito invalido preserva lo stato",
+                "class": "Conto",
+                "construct": {"args": ["Anna", 100]},
+                "steps": [
+                    {
+                        "call": "deposita",
+                        "args": [-5],
+                        "expected_exception": "ValueError",
+                    },
+                    {"observe": "saldo", "expected": 100},
+                ],
+            },
+            {
+                "profile": "python-object-v1",
+                "name": "istanze indipendenti",
+                "class": "Conto",
+                "construct": {"args": ["Anna", 100]},
+                "additional_instances": [
+                    {"id": "other", "construct": {"args": ["Luca", 50]}}
+                ],
+                "steps": [
+                    {"call": "deposita", "args": [20], "expected_return": None},
+                    {"observe": "saldo", "expected": 120},
+                    {"instance": "other", "observe": "saldo", "expected": 50},
+                ],
+            },
+            {
+                "profile": "python-object-v1",
+                "name": "costruttore protegge invariante",
+                "class": "Conto",
+                "construct": {"args": ["Anna", -1]},
+                "expected_constructor_exception": "ValueError",
+            },
+        ],
+    }
+
+
+def _assignment() -> dict:
+    return {
+        "assignment_id": "assignment-python-p3-student-lab",
+        "activity_id": "python-p3-student-lab-001",
+        "student_id": "rossi-mario",
+        "activity": {"path": "activities/python-p3-student-lab-001.json"},
+        "workspace": {
+            "path": "students/rossi-mario/assignments/python-p3-student-lab-001"
+        },
+    }
+
+
+def test_p3_runs_through_normal_student_lab_and_redacts_teacher_oracles(
+    tmp_path: Path,
+) -> None:
+    activity_path = tmp_path / "activities" / "python-p3-student-lab-001.json"
+    activity_path.parent.mkdir(parents=True)
+    activity_path.write_text(json.dumps(_activity()), encoding="utf-8")
+
+    workspace = (
+        tmp_path
+        / "students"
+        / "rossi-mario"
+        / "assignments"
+        / "python-p3-student-lab-001"
+    )
+    workspace.mkdir(parents=True)
+    (workspace / "main.py").write_text(
+        "class Conto:\n"
+        "    def __init__(self, titolare, saldo):\n"
+        "        if saldo < 0:\n"
+        "            raise ValueError('saldo iniziale negativo')\n"
+        "        self.titolare = titolare\n"
+        "        self.saldo = saldo\n\n"
+        "    def deposita(self, importo):\n"
+        "        if importo <= 0:\n"
+        "            raise ValueError('importo non valido')\n"
+        "        self.saldo += importo\n\n"
+        "    def saldo_corrente(self):\n"
+        "        return self.saldo\n",
+        encoding="utf-8",
+    )
+
+    docker_image = os.environ.get("THEBITLAB_P3_DOCKER_IMAGE", "thebitlab-p3-candidate")
+    report = student_lab_runner.run_docker_assignment(
+        _assignment(),
+        root=tmp_path,
+        timeout_seconds=3,
+        docker_image=docker_image,
+    )
+
+    assert report["backend"] == "docker"
+    assert report["passed"] is True
+    assert report["status"] == "passed"
+    assert report["profile"] == "python-object-v1"
+    assert report["summary"] == {"passed": 4, "total": 4}
+    assert report["tests"] == [
+        {"name": "Test 1", "passed": True, "status": "passed"},
+        {"name": "Test 2", "passed": True, "status": "passed"},
+        {"name": "Test 3", "passed": True, "status": "passed"},
+        {"name": "Test 4", "passed": True, "status": "passed"},
+    ]
+
+    serialized = json.dumps(report, ensure_ascii=False).casefold()
+    for forbidden in (
+        "object_tests",
+        "expected_return",
+        "expected_exception",
+        "expected_constructor_exception",
+        "observations",
+        "worker_status",
+        "deposito modifica lo stato",
+        "deposito invalido preserva lo stato",
+        "istanze indipendenti",
+        "costruttore protegge invariante",
+        "saldo iniziale negativo",
+        "importo non valido",
+    ):
+        assert forbidden not in serialized

--- a/tests/test_python_object_worker.py
+++ b/tests/test_python_object_worker.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import python_object_profile as p3
+from scripts import python_object_worker as worker
+
+
+def write_source(tmp_path: Path, source: str) -> Path:
+    path = tmp_path / "main.py"
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def execute(tmp_path: Path, source: str, request: dict) -> dict:
+    return worker.execute_worker_request(request, write_source(tmp_path, source))
+
+
+def base_request() -> dict:
+    return {
+        "schema_version": p3.WORKER_SCHEMA,
+        "class": "Conto",
+        "construct": {"args": ["Anna", 100], "kwargs": {}},
+        "additional_instances": [
+            {
+                "id": "other",
+                "construct": {"args": ["Luca", 50], "kwargs": {}},
+            }
+        ],
+        "steps": [
+            {
+                "kind": "call",
+                "instance": "main",
+                "member": "deposita",
+                "args": [20],
+                "kwargs": {},
+            },
+            {
+                "kind": "observe",
+                "instance": "main",
+                "member": "saldo",
+            },
+            {
+                "kind": "observe",
+                "instance": "other",
+                "member": "saldo",
+            },
+        ],
+    }
+
+
+def test_worker_executes_method_state_and_two_instance_independence(tmp_path: Path) -> None:
+    result = execute(
+        tmp_path,
+        "class Conto:\n"
+        "    def __init__(self, nome, saldo):\n"
+        "        self.nome = nome\n"
+        "        self.saldo = saldo\n"
+        "    def deposita(self, valore):\n"
+        "        self.saldo += valore\n",
+        base_request(),
+    )
+
+    assert result["status"] == "completed"
+    assert result["steps"] == [
+        {
+            "kind": "call",
+            "instance": "main",
+            "member": "deposita",
+            "status": "returned",
+            "return_value": None,
+        },
+        {
+            "kind": "observe",
+            "instance": "main",
+            "member": "saldo",
+            "status": "observed",
+            "value": 120,
+        },
+        {
+            "kind": "observe",
+            "instance": "other",
+            "member": "saldo",
+            "status": "observed",
+            "value": 50,
+        },
+    ]
+
+
+def test_worker_reports_missing_class_and_non_class_cleanly(tmp_path: Path) -> None:
+    missing = execute(tmp_path, "x = 1\n", base_request())
+    assert missing["status"] == "missing-class"
+
+    not_class = execute(tmp_path, "Conto = 42\n", base_request())
+    assert not_class["status"] == "not-class"
+
+
+def test_worker_reports_constructor_exception_without_expected_oracle(tmp_path: Path) -> None:
+    request = base_request()
+    request["construct"] = {"args": ["Anna", -1], "kwargs": {}}
+    request["additional_instances"] = []
+    request["steps"] = []
+    result = execute(
+        tmp_path,
+        "class Conto:\n"
+        "    def __init__(self, nome, saldo):\n"
+        "        if saldo < 0:\n"
+        "            raise ValueError('saldo iniziale negativo')\n"
+        "        self.saldo = saldo\n",
+        request,
+    )
+
+    assert result["status"] == "constructor-raised"
+    assert result["instance"] == "main"
+    assert result["exception"]["type"] == "ValueError"
+    assert "expected" not in str(result).casefold()
+
+
+def test_worker_reports_missing_method_and_attribute_without_introspection_dump(tmp_path: Path) -> None:
+    request = base_request()
+    request["additional_instances"] = []
+    request["steps"] = [
+        {
+            "kind": "call",
+            "instance": "main",
+            "member": "preleva",
+            "args": [1],
+            "kwargs": {},
+        },
+        {
+            "kind": "observe",
+            "instance": "main",
+            "member": "proprietario",
+        },
+    ]
+    result = execute(
+        tmp_path,
+        "class Conto:\n"
+        "    def __init__(self, nome, saldo):\n"
+        "        self.saldo = saldo\n",
+        request,
+    )
+
+    assert result["status"] == "completed"
+    assert result["steps"][0]["status"] == "missing-member"
+    assert result["steps"][1]["status"] == "missing-member"
+    serialized = str(result)
+    assert "__dict__" not in serialized
+    assert "__class__" not in serialized
+
+
+def test_worker_observes_property_and_reports_property_exception(tmp_path: Path) -> None:
+    request = base_request()
+    request["additional_instances"] = []
+    request["steps"] = [
+        {"kind": "observe", "instance": "main", "member": "saldo_doppio"},
+        {"kind": "observe", "instance": "main", "member": "rotto"},
+    ]
+    result = execute(
+        tmp_path,
+        "class Conto:\n"
+        "    def __init__(self, nome, saldo):\n"
+        "        self.saldo = saldo\n"
+        "    @property\n"
+        "    def saldo_doppio(self):\n"
+        "        return self.saldo * 2\n"
+        "    @property\n"
+        "    def rotto(self):\n"
+        "        raise ValueError('property non disponibile')\n",
+        request,
+    )
+
+    assert result["steps"][0]["status"] == "observed"
+    assert result["steps"][0]["value"] == 200
+    assert result["steps"][1]["status"] == "access-raised"
+    assert result["steps"][1]["exception"]["type"] == "ValueError"
+
+
+def test_worker_reports_expected_method_exception_as_observation_only(tmp_path: Path) -> None:
+    request = base_request()
+    request["additional_instances"] = []
+    request["steps"] = [
+        {
+            "kind": "call",
+            "instance": "main",
+            "member": "preleva",
+            "args": [1000],
+            "kwargs": {},
+        }
+    ]
+    result = execute(
+        tmp_path,
+        "class Conto:\n"
+        "    def __init__(self, nome, saldo):\n"
+        "        self.saldo = saldo\n"
+        "    def preleva(self, valore):\n"
+        "        if valore > self.saldo:\n"
+        "            raise ValueError('fondi insufficienti')\n"
+        "        self.saldo -= valore\n",
+        request,
+    )
+
+    assert result["status"] == "completed"
+    assert result["steps"][0]["status"] == "raised"
+    assert result["steps"][0]["exception"]["type"] == "ValueError"
+
+
+def test_worker_rejects_unsupported_observed_object_value(tmp_path: Path) -> None:
+    request = base_request()
+    request["additional_instances"] = []
+    request["steps"] = [
+        {"kind": "observe", "instance": "main", "member": "helper"}
+    ]
+    result = execute(
+        tmp_path,
+        "class Helper:\n"
+        "    pass\n"
+        "class Conto:\n"
+        "    def __init__(self, nome, saldo):\n"
+        "        self.helper = Helper()\n",
+        request,
+    )
+
+    assert result["steps"][0]["status"] == "unsupported-value"
+    assert "value" not in result["steps"][0]
+
+
+def test_worker_bounds_stdout(tmp_path: Path) -> None:
+    request = base_request()
+    request["additional_instances"] = []
+    request["steps"] = []
+    result = execute(
+        tmp_path,
+        "print('x' * 5000)\n"
+        "class Conto:\n"
+        "    def __init__(self, nome, saldo):\n"
+        "        self.saldo = saldo\n",
+        request,
+    )
+
+    assert result["status"] == "output-limit"
+    assert len(result["stdout"]) <= p3.p2.MAX_STRING_CHARS

--- a/tests/test_validate_activity_filesystem_profile.py
+++ b/tests/test_validate_activity_filesystem_profile.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from scripts import create_submission_scaffold, validate_activity
+
+
+def p4_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p4-files-001",
+        "titolo": "Somma misure da file",
+        "tipo": "laboratorio",
+        "difficolta": "B",
+        "argomenti": ["file", "pathlib"],
+        "consegna": "Leggi misure.txt e crea risultato.txt.",
+        "language": "python",
+        "linguaggio": "python",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "filesystem_tests": [
+            {
+                "profile": "python-filesystem-v1",
+                "name": "somma base",
+                "fixtures": [
+                    {
+                        "id": "input",
+                        "source": "fixtures/misure.txt",
+                        "target": "misure.txt",
+                        "mode": "read-only",
+                    }
+                ],
+                "expected_artifacts": [
+                    {
+                        "path": "risultato.txt",
+                        "text": "36\n",
+                        "encoding": "utf-8",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_activity_validator_accepts_p4_contract() -> None:
+    assert validate_activity.validate_activity(p4_activity(), "activity.json") == []
+
+
+def test_activity_validator_rejects_p4_on_non_python_activity() -> None:
+    activity = p4_activity()
+    activity["language"] = "c"
+    activity["linguaggio"] = "c"
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("filesystem_tests" in error and "Python" in error for error in errors)
+
+
+def test_activity_validator_rejects_teacher_contract_errors() -> None:
+    activity = p4_activity()
+    activity["filesystem_tests"][0]["expected_artifacts"][0]["path"] = "../out.txt"
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("expected_artifacts" in error for error in errors)
+
+
+def test_student_activity_payload_redacts_filesystem_teacher_contract() -> None:
+    public = create_submission_scaffold.student_activity_payload(p4_activity())
+    assert "filesystem_tests" not in public
+    serialized = repr(public).casefold()
+    assert "fixtures/misure.txt" not in serialized
+    assert "expected_artifacts" not in serialized
+    assert "36\\n" not in serialized
+    # The requested output filename is intentionally public because it is part
+    # of the student-facing assignment text, not a grading oracle.
+    assert "risultato.txt" in serialized

--- a/tests/test_validate_activity_function_profile.py
+++ b/tests/test_validate_activity_function_profile.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from scripts import create_submission_scaffold, validate_activity
+
+
+def base_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-function-test-001",
+        "titolo": "Area rettangolo",
+        "tipo": "laboratorio",
+        "difficolta": "B",
+        "argomenti": ["funzioni", "return"],
+        "consegna": "Completa la funzione area(base, altezza).",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 15,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "function_tests": [
+            {
+                "profile": "python-function-v1",
+                "name": "rettangolo 3x4",
+                "function": "area",
+                "args": [3, 4],
+                "expected_return": 12,
+            }
+        ],
+    }
+
+
+def test_activity_accepts_valid_function_profile_tests() -> None:
+    assert validate_activity.validate_activity(base_activity(), "activity.json") == []
+
+
+def test_activity_rejects_unknown_function_profile_version() -> None:
+    activity = base_activity()
+    activity["function_tests"][0]["profile"] = "python-function-v2"
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("profile deve essere python-function-v1" in error for error in errors)
+
+
+def test_activity_rejects_unknown_function_test_fields() -> None:
+    activity = base_activity()
+    activity["function_tests"][0]["expected_magic"] = 12
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("campi non supportati" in error for error in errors)
+
+
+def test_student_activity_payload_redacts_teacher_function_tests() -> None:
+    public = create_submission_scaffold.student_activity_payload(base_activity())
+    assert "function_tests" not in public
+    serialized = str(public)
+    assert "expected_return" not in serialized
+    assert "rettangolo 3x4" not in serialized

--- a/tests/test_validate_activity_object_profile.py
+++ b/tests/test_validate_activity_object_profile.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from scripts import create_submission_scaffold, validate_activity
+
+
+def p3_activity() -> dict:
+    return {
+        "schema_version": "1.0",
+        "id": "python-p3-object-001",
+        "titolo": "Conto con stato",
+        "tipo": "laboratorio",
+        "difficolta": "B",
+        "argomenti": ["classi", "oggetti", "stato"],
+        "consegna": "Implementa la classe Conto con saldo e metodo deposita.",
+        "language": "python",
+        "linguaggio": "python",
+        "correzione": {
+            "compila": True,
+            "test": True,
+            "sandbox": True,
+            "ai_feedback": False,
+        },
+        "metriche": {
+            "tempo_stimato_minuti": 20,
+            "traccia_tempo_dichiarato": True,
+            "traccia_sessioni_thebitlab": True,
+            "traccia_eventi_didattici": True,
+            "traccia_errori_compilazione": True,
+        },
+        "object_tests": [
+            {
+                "profile": "python-object-v1",
+                "name": "saldo dopo deposito",
+                "class": "Conto",
+                "construct": {"args": ["Anna", 100]},
+                "steps": [
+                    {
+                        "call": "deposita",
+                        "args": [20],
+                        "expected_return": None,
+                    },
+                    {"observe": "saldo", "expected": 120},
+                ],
+            }
+        ],
+    }
+
+
+def test_activity_validator_accepts_p3_object_contract() -> None:
+    assert validate_activity.validate_activity(p3_activity(), "activity.json") == []
+
+
+def test_activity_validator_rejects_p3_on_non_python_activity() -> None:
+    activity = p3_activity()
+    activity["language"] = "c"
+    activity["linguaggio"] = "c"
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("object_tests" in error and "Python" in error for error in errors)
+
+
+def test_activity_validator_rejects_multiple_python_profiles() -> None:
+    activity = p3_activity()
+    activity["function_tests"] = [
+        {
+            "profile": "python-function-v1",
+            "function": "f",
+            "expected_return": 1,
+        }
+    ]
+    errors = validate_activity.validate_activity(activity, "activity.json")
+    assert any("profili Python incompatibili" in error for error in errors)
+
+
+def test_student_activity_payload_redacts_object_scenarios() -> None:
+    public = create_submission_scaffold.student_activity_payload(p3_activity())
+    assert "object_tests" not in public
+    serialized = repr(public).casefold()
+    for forbidden in (
+        "saldo dopo deposito",
+        "expected_return",
+        "expected_exception",
+        "expected_constructor_exception",
+        "'expected': 120",
+    ):
+        assert forbidden not in serialized


### PR DESCRIPTION
Release integration PR to `main` for the exact cumulative source already validated as P2 + P3 + P4 candidate `2026.08.3`.

Exact source snapshot: `3b482fe6a031bd6e7285342e489def786d77d197`.

This branch is byte-identical at creation to the fully green candidate from #768/#769. It exists only because the connected GitHub GraphQL `Ready for review` transition failed on draft #769; no source code was changed to work around that connector issue.

Safety rule: merge this cumulative PR only, never #766/#767/#768 sequentially into `main`, so the main-only publish workflow cannot publish intermediate `2026.08.2` states.

Release boundary:
- candidate `toolchain.json`: `2026.08.3`;
- stable checked-in lock remains real published `2026.07.1`;
- no `2026.08.3` immutable digest exists before publication;
- PR validation must be green before merge;
- after merge, the guarded `main` workflow may publish `2026.08.3`;
- the real GHCR digest must then be captured and used in a separate reviewed stable-lock update.

No digest is invented here.