### PR TITLE
Promote published 2026.08.3 runner lock

### DIFF
--- a/.github/workflows/publish-assignment-runner.yml
+++ b/.github/workflows/publish-assignment-runner.yml
@@ -12,6 +12,7 @@ on:
       - "docker/assignment-runner/**"
       - "scripts/build_assignment_runner.py"
       - "scripts/publish_assignment_runner.py"
+      - "scripts/toolchain_lock.py"
       - "scripts/grade_activity.py"
       - "scripts/python_function_profile.py"
       - "scripts/python_function_worker.py"
@@ -26,6 +27,8 @@ on:
       - "scripts/validate_activity.py"
       - "scripts/create_submission_scaffold.py"
       - "scripts/student_lab_runner.py"
+      - "tests/test_grading_workflows.py"
+      - "tests/test_toolchain_lock.py"
       - "tests/test_python_grading_profiles_integration.py"
       - "tests/test_python_function_profile.py"
       - "tests/test_python_function_worker.py"
@@ -47,42 +50,7 @@ on:
     branches:
       - main
     paths:
-      - ".dockerignore"
-      - ".github/workflows/publish-assignment-runner.yml"
-      - "docker/assignment-runner/**"
-      - "scripts/build_assignment_runner.py"
-      - "scripts/publish_assignment_runner.py"
-      - "scripts/grade_activity.py"
-      - "scripts/python_function_profile.py"
-      - "scripts/python_function_worker.py"
-      - "scripts/grade_python_function_activity.py"
-      - "scripts/python_object_profile.py"
-      - "scripts/python_object_worker.py"
-      - "scripts/grade_python_object_activity.py"
-      - "scripts/python_filesystem_profile.py"
-      - "scripts/python_filesystem_worker.py"
-      - "scripts/grade_python_filesystem_activity.py"
-      - "scripts/thebitlab_technical_services.py"
-      - "scripts/validate_activity.py"
-      - "scripts/create_submission_scaffold.py"
-      - "scripts/student_lab_runner.py"
-      - "tests/test_python_grading_profiles_integration.py"
-      - "tests/test_python_function_profile.py"
-      - "tests/test_python_function_worker.py"
-      - "tests/test_python_function_profile_dispatch.py"
-      - "tests/test_python_function_student_lab_docker.py"
-      - "tests/test_validate_activity_function_profile.py"
-      - "tests/test_python_object_profile.py"
-      - "tests/test_python_object_worker.py"
-      - "tests/test_python_object_profile_dispatch.py"
-      - "tests/test_python_object_student_lab_docker.py"
-      - "tests/test_validate_activity_object_profile.py"
-      - "tests/test_python_filesystem_profile.py"
-      - "tests/test_python_filesystem_worker.py"
-      - "tests/test_python_filesystem_profile_dispatch.py"
-      - "tests/test_python_filesystem_student_lab_docker.py"
-      - "tests/test_validate_activity_filesystem_profile.py"
-      - "tests/test_p2_release_candidate.py"
+      - "docker/assignment-runner/toolchain.json"
 
 concurrency:
   group: assignment-runner-toolchain
@@ -103,11 +71,13 @@ jobs:
       - name: Install validation dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Validate combined P2 P3 P4 contracts dispatch and release identity
+      - name: Validate combined P2 P3 P4 contracts dispatch release identity and publish guards
         run: >-
           python -m pytest -q
           tests/test_build_assignment_runner.py
           tests/test_p2_release_candidate.py
+          tests/test_toolchain_lock.py
+          tests/test_grading_workflows.py
           tests/test_python_grading_profiles_integration.py
           tests/test_python_function_profile.py
           tests/test_python_function_worker.py

--- a/docker/assignment-runner/toolchain.lock.json
+++ b/docker/assignment-runner/toolchain.lock.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "thebitlab.grading-toolchain-lock.v1",
-  "version": "2026.07.1",
+  "version": "2026.08.3",
   "platform": "linux/amd64",
   "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
-  "source_revision": "bd102146a684a9b06835204ec1b7f668f7655a03",
-  "immutable_reference": "ghcr.io/thebitpoets/2cornot2c-assignment-runner@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+  "source_revision": "23bc1d36c7eb8c1b10a11cbde5f226ce7554f85e",
+  "immutable_reference": "ghcr.io/thebitpoets/2cornot2c-assignment-runner@sha256:c0594df833925044831463a9ee631aba2688929951a7dbcb53612b86d221ed51"
 }

--- a/tests/test_grading_workflows.py
+++ b/tests/test_grading_workflows.py
@@ -65,6 +65,12 @@ def test_publish_workflow_only_publishes_reviewed_main_toolchains() -> None:
     ).read_text(encoding="utf-8")
 
     validate_block, publish_block = source.split("  publish:\n", maxsplit=1)
+    trigger_block = source.split("\nconcurrency:\n", maxsplit=1)[0]
+    pull_request_block = trigger_block.split("  pull_request:\n", maxsplit=1)[1].split(
+        "  push:\n", maxsplit=1
+    )[0]
+    push_block = trigger_block.split("  push:\n", maxsplit=1)[1].strip()
+
     assert "pull_request:" in source
     assert "branches:\n      - main" in source
     assert "if: github.ref == 'refs/heads/main'" in publish_block
@@ -77,7 +83,11 @@ def test_publish_workflow_only_publishes_reviewed_main_toolchains() -> None:
     assert "THEBITLAB_RUN_DOCKER_TESTS" in validate_block
     assert "tests/test_student_lab_runner_docker.py" in validate_block
     assert "tests/test_python_function_student_lab_docker.py" in validate_block
+    assert "tests/test_python_object_student_lab_docker.py" in validate_block
+    assert "tests/test_python_filesystem_student_lab_docker.py" in validate_block
     assert "tests/test_p2_release_candidate.py" in validate_block
+    assert "tests/test_toolchain_lock.py" in validate_block
+    assert "tests/test_grading_workflows.py" in validate_block
     assert "image_id: ${{ steps.image-digest.outputs.image_id }}" in validate_block
     assert "VALIDATED_IMAGE_ID: ${{ needs.validate.outputs.image_id }}" in publish_block
     assert "actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16" in publish_block
@@ -87,11 +97,30 @@ def test_publish_workflow_only_publishes_reviewed_main_toolchains() -> None:
     assert "gunzip" in publish_block
     assert ":latest" not in source
     assert source.count("tests/test_student_lab_runner_docker.py") == 1
-    assert '".github/workflows/publish-assignment-runner.yml"' in source
+    assert '".github/workflows/publish-assignment-runner.yml"' in pull_request_block
+    assert '"docker/assignment-runner/**"' in pull_request_block
+    assert '"tests/test_toolchain_lock.py"' in pull_request_block
     assert "actions/checkout@v4" not in source
     assert "actions/upload-artifact@v4" not in source
     assert "actions/checkout@11d5960a326750d5838078e36cf38b85af677262" in source
     assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in source
+
+    # A push to main is a publication trigger, not a generic validation trigger.
+    # Only a reviewed release-manifest/version bump may start an automatic publish.
+    assert push_block == (
+        "branches:\n"
+        "      - main\n"
+        "    paths:\n"
+        '      - "docker/assignment-runner/toolchain.json"'
+    )
+    for forbidden in (
+        "toolchain.lock.json",
+        "docker/assignment-runner/**",
+        ".github/workflows/publish-assignment-runner.yml",
+        "scripts/",
+        "tests/",
+    ):
+        assert forbidden not in push_block
 
 
 def test_student_preview_workflow_does_not_interpolate_inputs_in_shell() -> None:

--- a/tests/test_p2_release_candidate.py
+++ b/tests/test_p2_release_candidate.py
@@ -10,6 +10,11 @@ LOCK = ROOT / "docker" / "assignment-runner" / "toolchain.lock.json"
 DOCKERFILE = ROOT / "docker" / "assignment-runner" / "Dockerfile"
 DOCKERIGNORE = ROOT / ".dockerignore"
 
+PUBLISHED_VERSION = "2026.08.3"
+PUBLISHED_SOURCE = "23bc1d36c7eb8c1b10a11cbde5f226ce7554f85e"
+PUBLISHED_DIGEST = "sha256:c0594df833925044831463a9ee631aba2688929951a7dbcb53612b86d221ed51"
+IMAGE_REPOSITORY = "ghcr.io/thebitpoets/2cornot2c-assignment-runner"
+
 
 def load(path: Path) -> dict:
     value = json.loads(path.read_text(encoding="utf-8"))
@@ -17,28 +22,25 @@ def load(path: Path) -> dict:
     return value
 
 
-def test_combined_p2_p3_p4_candidate_has_distinct_version_without_faking_published_lock() -> None:
+def test_combined_p2_p3_p4_release_is_locked_to_published_2026_08_3() -> None:
     manifest = load(MANIFEST)
     lock = load(LOCK)
 
-    assert manifest["version"] == "2026.08.3"
-    assert manifest["platform"] == "linux/amd64"
+    assert manifest["version"] == PUBLISHED_VERSION
+    assert lock["version"] == PUBLISHED_VERSION
+    assert manifest["platform"] == lock["platform"] == "linux/amd64"
+    assert manifest["image_repository"] == lock["image_repository"] == IMAGE_REPOSITORY
+    assert lock["source_revision"] == PUBLISHED_SOURCE
+    assert lock["immutable_reference"] == f"{IMAGE_REPOSITORY}@{PUBLISHED_DIGEST}"
+
+
+def test_manifest_and_stable_lock_share_the_reviewed_release_identity() -> None:
+    manifest = load(MANIFEST)
+    lock = load(LOCK)
+
+    assert manifest["version"] == lock["version"] == PUBLISHED_VERSION
     assert manifest["image_repository"] == lock["image_repository"]
-
-    # Until the combined P2/P3/P4 release is actually reviewed, merged and
-    # published, the checked-in immutable lock remains the previous stable release.
-    assert lock["version"] == "2026.07.1"
-    assert lock["source_revision"] == "bd102146a684a9b06835204ec1b7f668f7655a03"
-    assert lock["immutable_reference"].endswith(
-        "@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
-    )
-
-
-def test_candidate_and_stable_lock_are_deliberately_different_release_identities() -> None:
-    manifest = load(MANIFEST)
-    lock = load(LOCK)
-
-    assert manifest["version"] != lock["version"]
+    assert "@sha256:" in lock["immutable_reference"]
 
 
 def test_combined_runner_packages_all_three_python_profile_workers() -> None:

--- a/tests/test_toolchain_lock.py
+++ b/tests/test_toolchain_lock.py
@@ -8,17 +8,20 @@ import pytest
 from scripts import toolchain_lock
 
 
+PUBLISHED_VERSION = "2026.08.3"
+PUBLISHED_SOURCE = "23bc1d36c7eb8c1b10a11cbde5f226ce7554f85e"
+PUBLISHED_DIGEST = "sha256:c0594df833925044831463a9ee631aba2688929951a7dbcb53612b86d221ed51"
+IMAGE_REPOSITORY = "ghcr.io/thebitpoets/2cornot2c-assignment-runner"
+
+
 def lock_payload() -> dict:
     return {
         "schema_version": "thebitlab.grading-toolchain-lock.v1",
-        "version": "2026.07.1",
+        "version": PUBLISHED_VERSION,
         "platform": "linux/amd64",
-        "image_repository": "ghcr.io/thebitpoets/2cornot2c-assignment-runner",
-        "source_revision": "bd102146a684a9b06835204ec1b7f668f7655a03",
-        "immutable_reference": (
-            "ghcr.io/thebitpoets/2cornot2c-assignment-runner"
-            "@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
-        ),
+        "image_repository": IMAGE_REPOSITORY,
+        "source_revision": PUBLISHED_SOURCE,
+        "immutable_reference": f"{IMAGE_REPOSITORY}@{PUBLISHED_DIGEST}",
     }
 
 
@@ -28,17 +31,14 @@ def write_lock(tmp_path: Path, payload: dict) -> Path:
     return path
 
 
-def test_load_lock_accepts_checked_in_reference(tmp_path: Path) -> None:
-    lock = toolchain_lock.load_lock(
-        write_lock(tmp_path, lock_payload())
-    )
+def test_load_lock_accepts_checked_in_published_reference(tmp_path: Path) -> None:
+    lock = toolchain_lock.load_lock(write_lock(tmp_path, lock_payload()))
 
-    assert lock["version"] == "2026.07.1"
+    assert lock["version"] == PUBLISHED_VERSION
     assert lock["platform"] == "linux/amd64"
-    assert lock["image_repository"] == "ghcr.io/thebitpoets/2cornot2c-assignment-runner"
-    assert lock["digest"] == (
-        "sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
-    )
+    assert lock["image_repository"] == IMAGE_REPOSITORY
+    assert lock["source_revision"] == PUBLISHED_SOURCE
+    assert lock["digest"] == PUBLISHED_DIGEST
     assert toolchain_lock.immutable_reference(lock) == lock_payload()["immutable_reference"]
 
 
@@ -48,17 +48,14 @@ def test_load_lock_accepts_checked_in_reference(tmp_path: Path) -> None:
         ({"schema_version": "other"}, "Schema"),
         ({"version": "latest"}, "Versione"),
         ({"platform": "linux/arm64"}, "Piattaforma"),
-        (
-            {"image_repository": "ghcr.io/thebitpoets/other-runner"},
-            "Repository",
-        ),
+        ({"image_repository": "ghcr.io/thebitpoets/other-runner"}, "Repository"),
         ({"source_revision": "short"}, "Revisione"),
         ({"immutable_reference": "missing-digest"}, "digest"),
         (
             {
                 "immutable_reference": (
                     "ghcr.io/thebitpoets/other-runner"
-                    "@sha256:62f0f7b7bc1d48d01b7f8e5fa765e0b43be3622e70a614033b1bb4a4e522e159"
+                    "@sha256:c0594df833925044831463a9ee631aba2688929951a7dbcb53612b86d221ed51"
                 )
             },
             "coerenti",


### PR DESCRIPTION
Promotes the already-published unified P2 + P3 + P4 runner `2026.08.3` to the checked-in stable toolchain lock using the **real GHCR digest produced by the successful main release workflow**.

Authoritative release evidence:

- release workflow: `Publish assignment runner toolchain` run `33293976574` / #30 — SUCCESS;
- published source revision: `23bc1d36c7eb8c1b10a11cbde5f226ce7554f85e`;
- version: `2026.08.3`;
- immutable reference: `ghcr.io/thebitpoets/2cornot2c-assignment-runner@sha256:c0594df833925044831463a9ee631aba2688929951a7dbcb53612b86d221ed51`.

This PR also closes a release-safety gap discovered before lock promotion: automatic publication on `main` is now triggered **only by a change to `docker/assignment-runner/toolchain.json`**. A lock/test/workflow-only merge must not publish the same version again from a different commit.

PR validation remains broad and still exercises release identity, lock parsing, workflow guards, legacy Docker paths and P2/P3/P4 Student Lab paths. The publish job remains main-only.

Expected post-merge behavior:

1. stable lock becomes `2026.08.3` at the real immutable digest above;
2. this lock-only merge does **not** trigger a second `2026.08.3` publication;
3. `python-docente` can then be repinned from source-built candidate grading to this immutable stable runner.

No digest is invented and `toolchain.json` is not changed in this PR.