### PR TITLE
feat: archive student deliveries and grade trusted snapshots

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 *.sh text eol=lf
 doc/architecture/diagrams/*.svg linguist-generated=true
+
+# M04 originals are pinned by byte hashes and the installed policy fingerprint.
+/tests/fixtures/student_delivery_m04/** -text

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,9 @@ private-key.pem
 
 # File privati generati da docenti/studenti
 *_private.json
+teacher-deliveries/
+teacher-delivery-grading/
+student-delivery/
 
 # Artefatti Windows da evitare
 NUL

--- a/doc/ARCHITETTURA_MVP.md
+++ b/doc/ARCHITETTURA_MVP.md
@@ -97,6 +97,8 @@ sequenceDiagram
 
 Il bearer TUI resta in memoria e può essere revocato esattamente. Browser e terminale non si scambiano credenziali dell'altro canale. L'MVP non implementa ancora l'upload autenticato dei report di tentativo da una macchina studente separata: dashboard docente e selezione definitiva vedono i report soltanto quando condividono la root dati o quando un processo esterno li sincronizza. Un pilot distribuito deve definire questa sincronizzazione prima di considerare autorevoli tentativi e grading remoti.
 
+Il percorso distribuito usa l'[archivio delle consegne dai PC](architecture/student-delivery-storage.md): conserva sorgenti immutabili, ricevute server e definitivo separati dal grading. API, workspace/outbox TUI e registro docente sono integrati dietro l'opzione server `--student-deliveries`, con collaudo HTTP locale e root separate. L'opzione richiede auth federata; il default conserva il rehearsal a root unica. Il [grading docente dello snapshot](architecture/student-delivery-grading.md) usa Docker fissato, test originali e revisione esplicita del voto per il profilo stdin/stdout a singolo sorgente senza asset e per l'eccezione M04 con GUIDA.md obbligatoria e byte-identica. La policy M04 è docente, versionata e vincolata ai materiali originali e alla provenienza del job; la ricevuta resta integrale. Restano estensione agli altri profili richiesti dalle classi, quote aggregate, retention/export e collaudi di rilascio: la topologia distribuita non ha ancora GO pilot.
+
 ## Dati e storage
 
 ```mermaid

--- a/doc/PILOT_REHEARSAL.md
+++ b/doc/PILOT_REHEARSAL.md
@@ -26,6 +26,18 @@ Una topologia con host di esecuzione studente separati è **NO-GO** finché non 
 
 In assenza di questa suite, scegliere e registrare la baseline a root unica; un mount o una copia manuale non documentata non conta come sincronizzazione autorevole.
 
+Il percorso sperimentale `--student-deliveries` dispone ora di un
+[collaudo HTTP locale con root separate](architecture/student-delivery-storage.md#integrazione-http-tui-e-registro),
+inclusi pairing reale, menu TUI, invio, perdita della risposta, riavvio,
+definitivo e preview docente. La prova usa un proxy loopback e non attesta TLS,
+VPS. Una prova distinta del [grading docente dello snapshot](architecture/student-delivery-grading.md)
+usa il producer Docker reale per il profilo stdin/stdout a singolo sorgente
+senza asset. Il collaudo M04 aggiunge la policy docente circoscritta per
+`main.py` e `GUIDA.md` obbligatoria e invariata, con tre test originali,
+rifiuti e retry; non certifica tutti i profili delle classi. Il rilascio distribuito resta
+NO-GO. Per eseguire la baseline di questo runbook non attivare tale opzione;
+i gate Docker, backup/restore, attività reali e governance rimangono necessari.
+
 ## Ruoli e scheda della prova
 
 Assegnare persone distinte quando possibile:

--- a/doc/architecture/student-api-authorization.md
+++ b/doc/architecture/student-api-authorization.md
@@ -30,8 +30,16 @@ Il `student_id` restituito per compatibilità TUI è un alias legacy esplicito e
 | `GET /api/student-lab/help-history` | read target | `assignment_id` come selettore | record riletto server-side; ID esatto; `resolve_assignment_target` positivo | record e target autorizzati; log server keyed dal `subject_id` |
 | `POST /api/student-lab/help` | write target | `assignment_id`, tipo, prompt, request id | come help-history; gli eventuali ID identitari aggiuntivi sono ignorati | record e target già autorizzati; chiave lock/log server-side |
 | `POST /api/student-lab/final-attempt` | write target | `assignment_id`, `attempt_id` | come help-history | record e target già autorizzati; tentativo operativo selezionato nella consegna |
+| `GET /api/student-lab/delivery-manifest` | read contratto | `assignment_id` | bearer e record strict riletti sotto lock lifecycle | soli asset pubblici e fingerprint docente |
+| `GET /api/student-lab/deliveries` | read ricevute | `assignment_id` | stesso boundary; snapshot fresco anche nel lock archivio | storico server del soggetto autorizzato |
+| `POST /api/student-lab/deliveries` | write sorgenti | `assignment_id`, `package` | come storico, con rivalidazione bearer prima della scrittura | pacchetto immutabile e ricevuta ungraded |
+| `POST /api/student-lab/delivery-final` | write definitivo ricevuto | `assignment_id`, `attempt_id`, `expected_revision` | stesso boundary e confronto revisione | selezione dello snapshot, senza attribuzione di voto |
 
-Non sono state trovate altre route Student Lab federate: `REMOTE_STUDENT_API_ROUTES` è la allowlist canonica e contiene esattamente le cinque righe sopra. Le API dashboard/docente e i consumer CLI locali non federati restano su boundary separati.
+`REMOTE_STUDENT_API_ROUTES` è la allowlist canonica delle nove operazioni sopra.
+Le quattro route di consegna richiedono l'opzione server `--student-deliveries`,
+disabilitata per default; non ammettono fallback HMAC. Contratto e limiti sono in
+[student-delivery-storage.md](student-delivery-storage.md). Le API dashboard/docente
+e i consumer CLI locali non federati restano su boundary separati.
 
 ## Failure model
 

--- a/doc/architecture/student-delivery-grading.md
+++ b/doc/architecture/student-delivery-grading.md
@@ -1,0 +1,221 @@
+# Grading docente delle ricevute TUI
+
+## Contratto e perimetro v1
+
+`student_delivery_grading.py` valuta i byte della ricevuta immutabile, senza
+usare workspace corrente, report client o artifact GitHub legati solo a commit.
+La ricevuta conserva `grading_authority: ungraded`. Job, risultato e revisione
+del voto sono record privati separati.
+
+Il producer `docker-stdio-host-comparator.v1` riusa `grade_activity` e
+`thebitlab_sandbox_boundary`: non introduce un nuovo sistema di isolamento.
+Ammette un unico sorgente senza asset, da 1 a 64 test stdin/stdout, nei linguaggi
+implementati dal runner: C, Python, JavaScript/Node.js e SQL. Progetti multifile,
+asset diversi dall'eccezione M04 descritta sotto, contratti
+`extensions.thebitlab.runtime` (anche con test stdin/stdout),
+profili Python function/object/filesystem, activity senza test e linguaggi
+non implementati danno `unsupported_profile`; non si valuta un sottoinsieme
+del progetto. Il rifiuto runtime precede la creazione del job e del producer.
+Un errore di compilazione senza tutti gli esiti attesi dà
+`producer_error`, senza voto zero. Estensione dei profili e collaudo delle
+activity reali delle classi restano gate di rilascio aperti.
+
+### Policy accessoria M04 v1
+
+Estensione circoscritta autorizzata il 10 settembre 2026. La policy docente
+`python-m04-stdio-accessory.v1` vive nel codice installato
+`scripts/student_delivery_policies.py`, non nei payload, manifest studente o
+file della root dati. Identifica `TheBitPoets/python-docente`, revisione
+`1bc6d712c9e44d482846cc3c290b66e979c24905`, activity
+`activities/python/py2-activity-b-input-somma-001/activity.json`.
+
+L'ammissione confronta il SHA-256 canonico di `{activity, assets}`: activity
+normalizzata completa e lista ordinata di `{path, sha256}` di tutti gli asset,
+prima validati rispetto ai byte archiviati. Digest approvato:
+`dc16ae5bb215d90a089721afbaf2ec7434d4327ef666209416707867ce1ced5b`.
+Il riferimento Git documenta l'origine verificata dei materiali approvati;
+non è un'attestazione Git del filesystem operativo. Copie degli stessi materiali
+in assegnazioni diverse sono ammesse: l'assegnazione e la revisione privata
+restano vincolate separatamente da `activity_digest` nel job. Il manifest
+originale non viene modificato; il contratto archivio conserva la sua forma
+normalizzata, come nella v1 precedente.
+
+La ricevuta deve contenere esattamente `main.py` e `GUIDA.md`. Solo i byte
+consegnati di `main.py` sono eseguiti, su tutti i tre test stdin/stdout originali.
+`GUIDA.md` è obbligatoria e confrontata byte per byte con `student/GUIDA.md`
+della revisione privata; non è una dipendenza runtime e non entra nel worker.
+Lo starter e `teacher/README.md` restano nella revisione privata. Note docente,
+guida, root docente e aspettative non sono montate nel worker. Nessun file
+viene eliminato dalla ricevuta e nessun asset viene omesso dai fingerprint.
+
+Guida mancante/alterata, file extra e materiali diversi dalla revisione ammessa
+danno `unsupported_profile` prima della costruzione del producer e del job.
+La raccolta resta disponibile per pacchetti validi ma non valutabili e ne
+preserva tutti i byte. Suffix, tipo `fixture`, nome activity o visibilità non
+abilitano altre eccezioni. Function/object/filesystem e runtime restano esclusi.
+
+Per M04 il core aggiunge a `provenance` il campo `grading_policy`, con `id` e
+`digest` SHA-256 canonico dell'intera policy, origine e regole comprese. Il
+codice policy è incluso anche in `comparator_digest`. Il reader verifica la
+policy contro revisione e ricevuta e richiede tutti i tre esiti anche in lettura.
+Le versioni pubblicate della policy vanno
+conservate immutabili per leggere i risultati storici; modifiche richiedono
+una nuova versione e un nuovo incarico.
+
+Gli schemi job/risultato restano v1: per i profili senza asset la provenienza
+non acquisisce il nuovo campo. I risultati v1 già riusciti restano leggibili
+e riusabili senza ricostruire un producer. Un job fallito con provenienza diversa
+non è sovrascritto; i vecchi rifiuti M04 senza job possono essere ritentati con
+la policy nuova, senza cancellare stati o ricevute. Nessuna rivalutazione di
+risultati riusciti con producer diverso è introdotta.
+
+## Revisione privata docente
+
+`teacher_contract` conserva nel contratto interno record assegnazione, activity
+normalizzata e byte degli asset dichiarati, letti insieme ai rispettivi hash.
+L'upload HTTP archivia tale revisione sotto i lock lifecycle prima di confermare
+la consegna. Il manifest pubblico continua a essere una proiezione distinta.
+
+`teacher-delivery-grading/contracts/<activity_digest>.json` usa lo schema
+`thebitlab.delivery-teacher-revision.v1`. In lettura si ricostruiscono entrambi
+i fingerprint precedenti, inclusi ordine e digest asset, e si confrontano con
+la ricevuta. Per ricevute precedenti l'adapter recupera il materiale corrente
+soltanto se entrambi i digest coincidono. Se manca la revisione richiesta:
+`contract_unavailable`, senza usare test nuovi. Materiale storico esatto può
+essere ripristinato tramite il core docente `archive_contract`. Corruzione:
+errore storage, senza fallback. Non esiste un'importazione tramite API studente.
+
+## Job, risultato e retry
+
+Nella directory privata identificata dallo SHA-256 dell'identità server:
+
+| File per attempt | Contratto |
+|---|---|
+| `.job.json` | `thebitlab.delivery-grading-job.v1`: binding, provenienza e ora server; immutabile |
+| `.result.json` | `thebitlab.delivery-grading-result.v1`: binding, digest job, provenienza, ora e conteggi; immutabile |
+| `.state.json` | `running` oppure `error`, binding e codice sanitizzato; atomico |
+| `.review.json` | Digest risultato, voto docente e ora; atomico, separato dal definitivo |
+
+Il binding comprende subject, classe, assegnazione, activity, attempt ID e
+digest package/activity/tests. Il reader verifica binding, schema, legame
+job/risultato e conteggi. Il modello richiede una root privata con writer
+cooperanti, come per le ricevute: non offre firme contro amministratori locali.
+
+La provenienza nasce sul server: producer, riferimento Docker immutabile,
+piattaforma, revisione sorgente toolchain e hash del codice di orchestrazione,
+comparazione e boundary. L'immagine proviene dal lock del codice installato
+`docker/assignment-runner/toolchain.lock.json`, non da root dati o payload.
+Il producer richiede l'immagine già installata per Linux/amd64, senza pull
+impliciti. Motore/immagine mancanti: `producer_unavailable`; timeout o output
+non valido: `producer_error`. Risultati e stato non conservano stdout, stderr,
+aspettative, credenziali o stack trace.
+
+Un lock per identità serializza producer, letture e revisione del voto. I lock
+corso/assegnazione sono rilasciati durante l'esecuzione. Le primitive durevoli
+sono quelle delle ricevute. Retry dopo perdita della risposta riusa il risultato
+pubblicato; senza risultato può rieseguire lo stesso job dopo errore o riavvio.
+Uno stato `running` letto con lock acquisito significa `interrupted`, senza voto.
+Una provenienza cambiata non sovrascrive il job. La v1 conserva un risultato
+riuscito per tentativo; rivalutazioni con producer diverso richiedono un futuro
+contratto versionato, non cancellazioni manuali.
+
+## Boundary di esecuzione
+
+Activity privata e sorgente ricevuto sono preparati in directory temporanee
+distinte. Il runner copia solo il sorgente nel mount `/submission` read-only;
+root docente, asset privati, credenziali e socket Docker non entrano nel worker.
+Il boundary esistente impone utente non root, rete `none`, root read-only,
+capability rimosse, `no-new-privileges`, limiti CPU/memoria/PID, tmpfs limitato,
+timeout e output limitato. La richiesta worker contiene schema, linguaggio e
+input del singolo test. Il server conserva le aspettative e confronta gli output.
+L'input necessario al programma è osservabile dal programma stesso.
+
+Valgono i limiti del runner descritti in [ASSIGNMENT_SUBMISSIONS](../ASSIGNMENT_SUBMISSIONS.md):
+Docker non è un'attestazione hardware né una prova assoluta contro ogni evasione.
+Container e directory temporanee sono rimossi dalle primitive esistenti anche
+su errore; cleanup non confermato è errore, non voto. L'iniezione Python di un
+producer è un seam di test/composizione fidata del core, non un'opzione HTTP.
+
+## Operazioni docente e registro
+
+Con `--student-deliveries`, autenticazione docente e gli stessi controlli
+JSON/origin delle altre API docente:
+
+| POST | Payload chiuso |
+|---|---|
+| `/api/assignment-reports/delivery-grade` | `assignment_id`, `subject_id`, `attempt_id` |
+| `/api/assignment-reports/delivery-grade/review` | Gli stessi campi, `result_digest`, `teacher_grade` |
+
+Il grading è sincrono e restituisce stato, risultato privato e `result_digest`.
+Un timeout client può essere seguito da retry. Errori producer sono esiti
+applicativi `state: error`, distinti dai rifiuti HTTP. Il timeout del client
+operativo deve coprire fino a 64 worker; gli E2E usano activity brevi. Non sono
+ancora presenti una coda asincrona o un bottone dedicato nella dashboard.
+
+La revisione richiede il digest esatto e voto finito 0–10; `null` revoca la
+conferma. Si rigenera il registro tramite l'endpoint esistente. Il punteggio
+automatico 0–10 rimane provvisorio fino alla revisione, indipendentemente dal
+definitivo studente. Il registro legge soltanto il risultato della ricevuta
+selezionata (definitiva o ultima), con autorità `verified_delivery`, aggregati
+e voto docente. A non trasferisce il voto a B se B diventa definitivo mentre
+A è in corso. Preview e ricevuta restano originali; nessun esito protetto o
+stdout entra nel registro. Il default legacy e il comportamento senza consegne
+restano quelli del [contratto storage](student-delivery-storage.md).
+
+Per `verified_delivery`, registro e overview (tabella e matrice) distinguono
+"Tentativo definitivo/Ultimo tentativo" da "Voto da revisionare/confermato".
+La proiezione overview conserva `report_authority` insieme a `report_selection`,
+`grading_provisional` e `teacher_grade`. Il badge del voto segue la revisione
+docente, compreso il voto zero e la revoca con `null`; scegliere il definitivo
+non conferma il voto. Anche la normalizzazione del registro ricava `provisional`
+dal voto docente per `verified_delivery`, senza sovrascriverlo con la selezione
+del tentativo. Le etichette e la normalizzazione dei report legacy restano invariate.
+
+`teacher-delivery-grading` è ignorata da Git e bloccata dal serving statico.
+Appartiene alla root privata da includere nel backup; rehearsal backup/restore
+e verifica fsync Linux restano aperti.
+
+## Verifiche riproducibili
+
+`tests/test_student_delivery_grading.py` e `tests/test_student_delivery_grading_http.py`
+coprono contratto, persistenza, errore, recupero storico, proiezione e API docente.
+I producer simulati non attestano l'isolamento. Con `THEBITLAB_RUN_DOCKER_TESTS=1`
+si eseguono anche Docker reale e HTTP con root separate: upload A, modifica
+workspace e test correnti, grading A, registro e revisione. L'immagine deve
+essere già disponibile al riferimento del lock. Una fixture innocua verifica
+utente non root, assenza di un marker dell'ambiente host e mount contenente
+solo il sorgente. Non sono collaudi TLS/VPS, di tutti i linguaggi/profili o
+prove assolute di isolamento. Completare inoltre le regressioni delivery,
+authorization, TUI e registro.
+
+`tests/test_student_delivery_m04.py` usa i quattro materiali originali in
+`tests/fixtures/student_delivery_m04/`, fissati per SHA-256 e provenienza Git
+in `ORIGIN.md`. La regola `-text` in `.gitattributes`, limitata a questa
+directory e alle sue sottodirectory, disabilita la conversione dei fine riga
+durante add/checkout anche con `core.autocrlf=true` su Windows. I byte originali,
+gli hash attesi e il fingerprint della policy devono restare invariati;
+non normalizzare le fixture per adattarle al checkout locale.
+Verifica ammissione, guida byte-identica, rifiuti prima del
+producer, conservazione, revisione storica, binding della policy, compatibilità
+dei retry e staging. I quattro casi Docker reali hanno attese rispettivamente
+1/3 (starter), 3/3 (somma), 0/3 (somma più uno), 0/3 (prompt); osservano i tre
+input originali e il mount con il solo sorgente.
+
+`tests/test_student_delivery_m04_http.py` esegue pairing, download e invio dalla
+TUI legacy tramite HTTP locale, i quattro grading, definitivo, preview,
+revisione del voto e riavvio con retry senza nuovo producer. Rifiuta il grading
+di tre ricevute raccolte con guida assente/alterata o file extra; cambiare il
+definitivo non trasferisce il voto docente. I materiali e le ricevute restano
+immutati. La variante Docker è opt-in con la stessa variabile ambiente.
+
+Comandi mirati dalla root del repository:
+
+```powershell
+python -B -m pytest tests/test_student_delivery_m04.py tests/test_student_delivery_m04_http.py
+$env:THEBITLAB_RUN_DOCKER_TESTS = '1'
+python -B -m pytest tests/test_student_delivery_m04.py tests/test_student_delivery_m04_http.py
+```
+
+Queste prove non sono una verifica visuale utui, un login Google live o un
+collaudo HTTPS/VPS, backup/restore o durabilità fsync su Linux. Il PASS tecnico
+M04 non approva la distribuzione didattica né gli altri profili dei corsi.

--- a/doc/architecture/student-delivery-storage.md
+++ b/doc/architecture/student-delivery-storage.md
@@ -1,0 +1,243 @@
+# Archivio delle consegne dai PC studenti
+
+## Stato e perimetro
+
+Archivio collegato alle API HTTP, alla TUI e al registro docente, con
+attivazione esplicita tramite `--student-deliveries` sul server. Richiede
+`--enable-google-auth` e il pairing federato; il bearer HMAC locale non abilita
+queste operazioni. Il default conserva il flusso precedente a root unica.
+La topologia richiesta il 9 settembre 2026 è TUI su
+PC Windows degli studenti e server docente online su VPS Hetzner. Lo sviluppo
+e il successivo collaudo HTTP possono usare un server locale con root dati
+diversa da quella della TUI; non occorre accedere al VPS per sviluppare.
+
+I moduli `scripts/student_delivery_store.py`, `student_delivery_service.py`
+e `student_delivery_client.py` implementano persistenza, contratto pubblico,
+workspace, outbox, ricevute e definitivo. Il collaudo automatico usa HTTP reale
+e root Windows separate, incluso il menu TUI. Non costituisce un GO pilot
+o un cambiamento a PR772,
+interlock, bootstrap e requisiti del [rehearsal](../PILOT_REHEARSAL.md).
+
+## Problema verificato sulla base main 758818f1
+
+| Passaggio | Implementazione esistente | Gap per PC separati |
+|---|---|---|
+| Identità e classe | `student_api_authorization`, snapshot SQLite e assignment strict | Riutilizzare questa autorizzazione per ogni operazione di consegna |
+| Workspace | `student_lab_cli.merge_local_operational_paths` unisce path locali già presenti | Non scarica né prepara un workspace su un PC nuovo |
+| Esecuzione | `student_lab_runner.write_student_report`, `student_lab_attempts.persist_standard_report` | Conservano report locali, non snapshot immutabili dei sorgenti |
+| Definitivo | `/api/student-lab/final-attempt` legge lo storage del server | Il server non riceve i tentativi creati su un altro PC |
+| Registro | `track_assignments` collega `submitted` alla presenza di un report | Una ricevuta senza grading deve essere rappresentata come consegnata, ancora da valutare |
+| Preview docente | `course_board_server.read_submission_file` legge file dal repository operativo | Serve lettura dello snapshot del tentativo, anche dopo modifiche al workspace |
+| GitHub | `ArtifactTrackingReportSource` verifica una run vincolata dal docente | Non carica lo storico TUI; l'artifact fidato e il report client hanno autorità diverse |
+
+La raccolta GitHub resta descritta in
+[ASSIGNMENT_SUBMISSIONS.md](../ASSIGNMENT_SUBMISSIONS.md#integrazione-nel-tracking-docente).
+
+## Contratto applicativo implementato
+
+`JsonStudentDeliveryStore` riceve una root server già esistente, un clock UTC
+iniettabile e un `context_loader` fidato per ciascuna operazione. Non effettua
+autenticazione HTTP. Il loader deve risolvere nuovamente utente autenticato,
+binding, membership, assignment, activity e contratto docente; un errore di
+autorizzazione si propaga anche per un retry già noto. Il contesto iniziale
+individua lo storage; il secondo viene letto sotto lock e non può cambiare
+l'identità della partizione.
+
+`DeliveryContext.from_authorized` usa un `AuthorizedStudentAssignment` prodotto
+dal boundary [Student API](student-api-authorization.md). Il chiamante fornisce
+dal lato docente i digest SHA-256 dell'activity e dei test e `closes_at`, deadline
+UTC di ammissione. L'adapter produce questi fingerprint dai record docente
+e dagli asset dichiarati, mai dai valori caricati dallo studente. `closes_at` è distinta
+dalla scadenza didattica `due_at`: consente una futura policy esplicita per
+consegne in ritardo. Nessuna deadline si desume dall'orologio del PC.
+
+Il pacchetto chiuso `thebitlab.student-delivery.v1` contiene esclusivamente:
+
+- `attempt_id`, nel formato già generato da `student_lab_attempts.new_attempt_id`;
+- `activity_digest` e `tests_digest`, da confrontare con il contesto docente;
+- `files`: elenco di `path` relativo portabile, `content_base64` e `sha256`.
+
+Identità, classe, timestamp di consegna, path server e grading client non sono
+campi ammessi. Il digest canonico del pacchetto normalizza ordine dei file e
+base64; due retry con gli stessi contenuti sono equivalenti. Sono rifiutati
+digest errati, path assoluti, traversal, ADS, nomi riservati Windows, componenti
+non NFC, collisioni case-insensitive e sovrapposizioni file/directory.
+
+Limiti iniziali: 64 file, 1 MiB per file, 8 MiB decodificati per pacchetto,
+100 tentativi per partizione. Il reader limita ogni documento a 12 MiB. Lo
+storico valida un documento alla volta e conserva soltanto i riepiloghi.
+Questi limiti devono essere confrontati con le activity reali prima del pilot;
+non attestano il supporto di tutti i progetti o linguaggi delle classi.
+
+## Storage, ordine e ricevuta
+
+La partizione è `teacher-deliveries/<sha256-identità>/`, dove l'identità
+server comprende `subject_id`, `class_id`, `assignment_id`, `activity_id`.
+Ogni file `attempt-….json` contiene insieme sorgenti e ricevuta: non esiste
+una finestra in cui il server confermi un record privo dei relativi file.
+I nomi client restano nel JSON, senza estrazione nel filesystem server.
+La nuova directory è ignorata da Git e appartiene alla root dati privata.
+
+La ricevuta `thebitlab.student-delivery-receipt.v1` registra identità derivata
+dal server, pacchetto, digest canonico, `received_at` UTC, sequenza di ricezione
+e `grading_authority: ungraded`. La selezione definitiva non trasforma questo
+valore in grading autorevole. I namespace `reports/` e `verified_remote` non
+ricevono questi pacchetti.
+
+La pubblicazione esclusiva riusa le primitive di `student_lab_attempts`.
+File e directory sono sincronizzati prima del ritorno positivo, incluse le
+entry dei parent create da un tentativo precedente fallito. Tutte le letture
+e scritture acquisiscono il medesimo lock di processo della partizione.
+Symlink, junction e file speciali nello storage sono rifiutati. Il modello
+presuppone una sola installazione e una root controllata dal server: non
+protegge da amministratori locali malevoli o writer esterni che ignorano i lock.
+
+Un retry dello stesso ID e digest restituisce la ricevuta originale, anche
+dopo la deadline, purché l'autorizzazione sia ancora valida. Un contenuto
+diverso con lo stesso ID produce `conflict`. Un tentativo nuovo oltre la
+deadline produce `closed`; un fingerprint obsoleto produce `contract_changed`.
+Lo storico mantiene l'ordine di ricezione server, distinto dall'ordine dei
+timestamp presenti negli ID client. Errori o corruzione dello storage non
+vengono presentati come storico vuoto.
+
+## Definitivo e lifecycle
+
+`select_final` richiede un tentativo esistente della stessa partizione e una
+`expected_revision`. Aggiorna atomicamente `final.json`, con ID, digest e
+revisione incrementata. Il retry immediato della stessa selezione restituisce
+lo stesso risultato; un retry vecchio non sovrascrive una selezione successiva.
+Lo storico resta intatto. Un fingerprint superato impedisce una nuova
+selezione, ma non elimina le ricevute storiche.
+
+L'adapter HTTP acquisisce il lock del corso e quello del record assegnazione,
+nello stesso ordine dei writer docente. Rilegge il bearer, lo snapshot auth,
+il record strict e il contratto anche dal callback dello store. Cancellazione
+e modifiche docente non possono intercalarsi alla scrittura. Finché manca
+una procedura esplicita di retention/export, la cancellazione di un'assegnazione
+con ricevute è bloccata; le ricevute non vengono eliminate né rese orfane.
+La cancellazione dell'activity resta bloccata dalle dipendenze dell'assegnazione.
+
+Il backup canonico enumera già la nuova cartella e ne include ricevute e
+definitivo; ignora il lock. Il test verifica questa inclusione nell'inventario,
+non certifica un nuovo rehearsal completo di backup/restore. Restano validi
+server fermo e lock esclusivo root previsti da [PILOT_ROOT_BACKUP.md](../PILOT_ROOT_BACKUP.md).
+Su Windows si verifica la persistenza dei file e il riavvio; la garanzia POSIX
+di fsync delle directory richiede esecuzione dei test anche su Linux.
+
+## Integrazione HTTP, TUI e registro
+
+`REMOTE_STUDENT_API_ROUTES` aggiunge quattro operazioni federate:
+
+| Metodo e route `/api/student-lab/…` | Input | Risultato |
+|---|---|---|
+| GET `delivery-manifest` | query `assignment_id` | contratto e asset pubblici |
+| GET `deliveries` | query `assignment_id` | storico, definitivo e stato calcolato server |
+| POST `deliveries` | `assignment_id`, `package` | ricevuta compatta, senza ritrasmettere i sorgenti |
+| POST `delivery-final` | `assignment_id`, `attempt_id`, `expected_revision` | selezione CAS |
+
+Query, framing e content type usano il boundary federato esistente; il JSON
+delle nuove route rifiuta chiavi duplicate e campi aggiuntivi. Corpo upload
+massimo 12 MiB, lettura con deadline; restano i limiti decodificati dello store.
+Risposte no-store; log con sole route allowlisted, senza query, ID o bearer.
+Archivi server e outbox non sono serviti come file statici.
+
+Il manifest è una proiezione del contratto docente corrente sotto lock, non
+un campo modificabile dallo studente. Il fingerprint activity include record
+assegnazione, activity normalizzata e digest di tutti gli asset dichiarati;
+quello test include test, grading policy e digest asset. I test protetti sono
+inclusi nel fingerprint ma esclusi dal download tramite il filtro pubblico
+canonico dello scaffold. Non vengono cercate dipendenze implicite non dichiarate.
+Per questa versione `closes_at = due_at`: le nuove consegne tardive sono chiuse;
+il recupero di una ricevuta già salvata resta ammesso. Le date richiedono timezone.
+
+La collezione federata annuncia `delivery_api` quando l'opzione è attiva.
+La TUI scarica i manifest e prepara workspace sotto `student-delivery/`,
+separati per origin, identità server dell'assegnazione e fingerprint. Conserva
+sempre i file esistenti. Un contratto nuovo crea un workspace nuovo e conserva
+quello precedente; la migrazione dei sorgenti fra revisioni resta esplicita.
+L'activity pubblica è salvata nel workspace per il runner locale.
+
+Nel dettaglio `i` fotografa e invia i sorgenti; se esiste un pacchetto senza
+ricevuta riprova esattamente quello. L'outbox è pubblicata atomicamente prima
+della rete e non contiene credenziali. La risposta è accettata solo se ID,
+digest canonico e autorità `ungraded` corrispondono. La scansione esclude file
+nascosti, metadati activity, cache e directory generate note; rifiuta link,
+junction, file speciali, path non portabili e pacchetti oltre quota.
+Lo studente deve comunque controllare il contenuto dei sorgenti del workspace.
+`n`, dopo conferma, conserva un eventuale pacchetto in attesa in un file
+immutabile `outbox-attempt-….json` e prepara un nuovo invio dei sorgenti
+attuali. Questo permette di riprendere dopo un rifiuto per cambio contratto
+senza riscrivere il pacchetto precedente. Massimo 100 pacchetti locali archiviati.
+
+`t` legge lo storico server e seleziona il definitivo con revisione attesa.
+L'esecuzione `e` rimane locale: mostra i test senza cambiare ricevute, stato
+di consegna o voto. Registro federato e preview usano lo snapshot definitivo,
+oppure l'ultimo ricevuto se il definitivo manca. Il registro mostra consegnato
+e `not_graded` finché manca un risultato docente verificato; vecchi report locali/GitHub non assegnano un voto a
+questo snapshot. La preview verifica identità e digest registrati e legge
+i byte archiviati, anche se workspace o contratto docente sono poi cambiati.
+Il [grading docente delle ricevute](student-delivery-grading.md) conserva
+revisioni private e risultati separati, vincolati allo snapshot selezionato.
+L'upload HTTP archivia i byte del contratto prima della conferma; il registro
+può mostrare aggregati verificati e voto rivisto dal docente. Il definitivo
+studente non conferma automaticamente il voto. Il feedback docente precedente viene conservato nella rigenerazione del
+registro soltanto se il digest del pacchetto ricevuto è rimasto identico.
+
+La generazione del registro riceve `student_delivery_enabled` dal flag del
+server, non dal payload HTTP né dalla presenza degli alias del canale aiuti.
+Il default `False` conserva i report locali/GitHub e non apre l'archivio
+consegne, anche per assegnazioni individuali federate senza classe.
+Quando attivo, richiede assegnazione e identità federate e deriva sempre
+consegna, valutazione e preview dalle ricevute. Con storico vuoto mostra
+`pending` oppure `missing` secondo la scadenza, `submitted: false`, nessun
+voto, sorgente o feedback precedente. I report locali/GitHub non vengono
+consultati in questa modalità; il feedback si conserva soltanto in presenza
+di un digest ricevuto identico.
+
+Collaudo riproducibile:
+
+```powershell
+py -3.12 -m pytest tests/test_student_delivery_client.py tests/test_student_delivery_http_e2e.py tests/test_student_delivery_store.py -o addopts= -q
+```
+
+L'E2E avvia il vero `CourseBoardHandler`, pairing e SQLite nella root docente,
+usa la TUI con il trasporto subprocess reale e una root studente vuota.
+Un proxy HTTP su loopback riproduce il terminatore trusted del deployment;
+solo nel test aggiunge `X-Forwarded-Proto: https`. Non è una prova TLS/VPS.
+La perdita della risposta viene prodotta dal proxy dopo il salvataggio server.
+Server, proxy e TUI sono chiusi al termine, anche in caso di errore.
+
+## Lavoro residuo per il rilascio
+
+Restano verifica delle activity reali di tutte le classi, estensione del grading
+oltre il profilo stdin/stdout a singolo sorgente senza asset, quote aggregate e retention/export,
+migrazione guidata dei sorgenti fra revisioni e gestione operativa dell'archivio
+locale degli invii precedenti. Il recupero tramite `n` conserva il vecchio
+pacchetto, ma non migra automaticamente il lavoro nel nuovo workspace.
+Servono inoltre collaudo Windows → HTTPS/VPS, backup/restore aggiornato,
+verifica POSIX/fsync e gate release residui. Il rilascio resta NO-GO.
+
+### Requisiti del flusso completo (riferimento)
+
+1. Pubblicazione del manifest docente: versione dell'assegnazione, asset
+   pubblici, test protetti, fingerprint e deadline. Download autenticato con
+   workspace Windows separato per assegnazione, senza sovrascrivere lavoro.
+2. Adapter HTTP sulle Student API: bearer, snapshot e record strict, lock
+   lifecycle, parser JSON e corpo limitati, deadline, quote aggregate,
+   errori/audit sanitizzati. Le route richiedono attivazione esplicita.
+3. TUI: snapshot dei file della consegna, outbox durevole senza credenziali,
+   invio, ripresa/retry dello stesso pacchetto e conferma soltanto dopo ricevuta.
+   L'esecuzione locale e la consegna devono avere stati distinti e leggibili.
+4. Storico e definitivo TUI letti dalla copia server; registro docente con
+   `consegnato/da valutare`, preview degli stessi byte e grading separato.
+   Valutazione automatica soltanto da producer fidato sullo snapshot esatto;
+   nessuna riduzione implicita del rilascio alla sola attività manuale HTML.
+5. E2E con server locale reale e root client/server diverse: pairing, più
+   studenti/classi, upload, perdita della risposta, riavvio, revoca, cambio
+   contratto, definitivo e preview. Poi collaudo Windows → HTTPS/VPS,
+   backup/restore, activity reali di tutte le classi e gate release residui.
+
+I test dello storage coprono isolamento dello storage, sorgenti
+immutabili, riavvio, retry, concorrenza, revoca del loader, fingerprint,
+quote, path portabili, corruzione, fault di persistenza, definitivo e
+inventario backup. Le prove HTTP e del menu TUI sono nella suite E2E indicata sopra.

--- a/scripts/course_board_server.py
+++ b/scripts/course_board_server.py
@@ -68,6 +68,8 @@ from scripts import (
     github_app_token_runtime,
     manual_ai_feedback,
     student_api_authorization,
+    student_delivery_service,
+    student_delivery_store,
     student_help_auth,
     student_help_codex_adapter,
     student_help_service,
@@ -181,7 +183,8 @@ HELP_DELETION_SCHEMA_VERSION = "student_help_deletion.v2"
 ASSIGNMENT_TARGET_BINDINGS_OPERATION_ID = "assignment-target-bindings-global"
 STUDENT_HELP_SERVER_ERROR = "Servizio aiuto temporaneamente non disponibile."
 TEACHER_AUTH_REALM = "TheBitLab docente"
-PRIVATE_STATIC_ROOTS = {"teacher-assignments", "teacher-help-events", "teacher-reports"}
+PRIVATE_STATIC_ROOTS = {"teacher-assignments", "teacher-help-events", "teacher-reports",
+                        "teacher-deliveries", "teacher-delivery-grading", "student-delivery"}
 REMOTE_STUDENT_API_ROUTES = frozenset(
     {
         ("GET", "/api/student-lab/me"),
@@ -189,6 +192,10 @@ REMOTE_STUDENT_API_ROUTES = frozenset(
         ("GET", "/api/student-lab/help-history"),
         ("POST", "/api/student-lab/help"),
         ("POST", "/api/student-lab/final-attempt"),
+        ("GET", "/api/student-lab/delivery-manifest"),
+        ("GET", "/api/student-lab/deliveries"),
+        ("POST", "/api/student-lab/deliveries"),
+        ("POST", "/api/student-lab/delivery-final"),
     }
 )
 _ASSIGNMENT_OPERATION_LOCKS: dict[str, dict[str, Any]] = {}
@@ -1687,6 +1694,15 @@ def _delete_assignment_record_locked(payload: dict, *, help_subject_aliases=None
                     class_id=str(assignment.get("class_id", "")),
                     legacy_aliases=help_subject_aliases,
                 ))
+        # Until an explicit receipt retention/export policy exists, deleting
+        # an assignment with received sources would orphan its authoritative
+        # archive and allow the same assignment identity to be reused.
+        deliveries = student_delivery_store.JsonStudentDeliveryStore(ROOT)
+        for student_id in student_ids if assignment.get("class_id") else ():
+            context = student_delivery_service.archive_context(assignment, student_id)
+            directory = deliveries._directory(context)
+            if directory.exists() and any(path.name.startswith("attempt-") for path in directory.iterdir()):
+                raise ValueError("Assegnazione con consegne ricevute: conservare il registro e l'archivio.")
         log_paths = sorted(
             {
                 student_help_service.server_help_log_path(ROOT, student_id, assignment_id)
@@ -2152,6 +2168,11 @@ def preserve_assignment_ai_feedback(previous: dict, generated: dict) -> dict:
             previous_student = by_student_name.get(student_name)
         if previous_student is None:
             continue
+        delivery = student.get("submission", {}).get("delivery")
+        if isinstance(delivery, dict):
+            previous_delivery = previous_student.get("submission", {}).get("delivery", {})
+            if not delivery.get("package_digest") or previous_delivery.get("package_digest") != delivery.get("package_digest"):
+                continue
         feedback = previous_student.get("ai_feedback")
         if not isinstance(feedback, dict):
             continue
@@ -2687,6 +2708,32 @@ def read_submission_file(payload: dict) -> dict:
     student = next((entry for entry in report.get("students", []) if entry.get("student") == student_name), None)
     if student is None:
         raise FileNotFoundError(f"Studente non trovato nel registro: {student_name}")
+    submission = student.get("submission", {})
+    delivery = submission.get("delivery")
+    if isinstance(delivery, dict):
+        requested = normalized_submission_file_reference(payload.get("path", ""))
+        if requested not in registered_submission_file_references(student):
+            raise FileNotFoundError("File consegna non consentito.")
+        assignment_id = report.get("assignment_id", "")
+        with thebitlab_storage.course_storage_lock(ROOT):
+            storage = assignment_record_storage()
+            with assignment_operation_lock(assignment_record_operation_id(storage, assignment_id)):
+                assignment = storage.read_assignment_strict(assignment_id)
+                context = student_delivery_service.archive_context(assignment, delivery.get("subject_id", ""))
+                if any(delivery.get(key) != value for key, value in context.identity().items()):
+                    raise ValueError("Riferimento consegna non valido.")
+                receipt = student_delivery_store.JsonStudentDeliveryStore(ROOT).read(
+                    submission["attempt_id"], context_loader=lambda: context)
+                if receipt["package_digest"] != delivery.get("package_digest"):
+                    raise ValueError("Riferimento consegna non valido.")
+                entry = next((item for item in receipt["package"]["files"] if item["path"] == requested), None)
+                if entry is None:
+                    raise FileNotFoundError("File consegna non disponibile.")
+                content = base64.b64decode(entry["content_base64"], validate=True)
+                if len(content) > MAX_SUBMISSION_FILE_BYTES:
+                    raise ValueError("File troppo grande per l'anteprima nella dashboard.")
+                return {"path": requested, "name": Path(requested).name,
+                        "size": len(content), "content": content.decode("utf-8-sig")}
     path = resolve_submission_file_path(student, payload.get("path", ""))
     size = path.stat().st_size
     if size > MAX_SUBMISSION_FILE_BYTES:
@@ -2976,14 +3023,58 @@ def _distribute_activity_assignment_locked(payload: dict) -> dict:
     }
 
 
-def generate_assignment_report(payload: dict, *, help_subject_aliases=None) -> dict:
+def grade_student_delivery(payload: dict, *, review: bool = False) -> dict:
+    """Teacher-only adapter: freeze the receipt identity before releasing lifecycle locks."""
+    from scripts import student_delivery_grading
+
+    fields = {"assignment_id", "subject_id", "attempt_id"}
+    if review:
+        fields |= {"result_digest", "teacher_grade"}
+    if not isinstance(payload, dict) or payload.keys() != fields:
+        raise student_delivery_store.DeliveryError("invalid")
+    assignment_id = student_delivery_store._text(payload["assignment_id"])
+    attempt_id = student_delivery_store._attempt_id(payload["attempt_id"])
+    grading = student_delivery_grading.JsonDeliveryGradingStore(ROOT)
+    with thebitlab_storage.course_storage_lock(ROOT):
+        records = assignment_record_storage()
+        with assignment_operation_lock(assignment_record_operation_id(records, assignment_id)):
+            assignment = records.read_assignment_strict(assignment_id)
+            context = student_delivery_service.archive_context(assignment, payload["subject_id"])
+            receipt = grading.read(attempt_id, context_loader=lambda: context)
+            if not review:
+                # Legacy receipts may be recovered only from exactly matching material.
+                try:
+                    grading._revision(receipt)
+                except student_delivery_store.DeliveryError as error:
+                    if error.code != "contract_unavailable":
+                        raise
+                    try:
+                        contract = student_delivery_service.teacher_contract(ROOT, assignment)
+                    except (OSError, ValueError, TypeError, KeyError):
+                        contract = None
+                    if contract is not None and all(
+                            contract[key] == receipt["package"][key]
+                            for key in ("activity_digest", "tests_digest")):
+                        grading.archive_contract(contract)
+    # No course/assignment lock is held while a container runs. Final selection
+    # can change independently; publication remains bound to this exact attempt.
+    if review:
+        return grading.review(attempt_id, context_loader=lambda: context,
+            result_digest=payload["result_digest"], teacher_grade=payload["teacher_grade"])
+    return grading.grade(attempt_id, context_loader=lambda: context)
+
+
+def generate_assignment_report(payload: dict, *, help_subject_aliases=None,
+                               student_delivery_enabled: bool = False) -> dict:
     """Generate and persist an assignment tracking report from the local GUI."""
 
     with thebitlab_storage.course_storage_lock(ROOT):
-        return _generate_assignment_report_locked(payload, help_subject_aliases=help_subject_aliases)
+        return _generate_assignment_report_locked(payload, help_subject_aliases=help_subject_aliases,
+            student_delivery_enabled=student_delivery_enabled)
 
 
-def _generate_assignment_report_locked(payload: dict, *, help_subject_aliases=None) -> dict:
+def _generate_assignment_report_locked(payload: dict, *, help_subject_aliases=None,
+                                       student_delivery_enabled: bool = False) -> dict:
     """Persist one report while activity deletion is excluded."""
 
     activity_path = resolve_local_path(payload.get("activity_path", ""), "activity_path")
@@ -3015,8 +3106,9 @@ def _generate_assignment_report_locked(payload: dict, *, help_subject_aliases=No
             github_team=payload.get("github_team") or None,
             assignment_id=canonical_assignment_id or None,
             server_root=ROOT if canonical_assignment_id else None,
-            report_source=grading_tracking_report_source() if canonical_assignment_id else None,
+            report_source=grading_tracking_report_source() if canonical_assignment_id and not student_delivery_enabled else None,
             help_subject_aliases=help_subject_aliases,
+            student_delivery_enabled=student_delivery_enabled,
         )
         with assignment_operation_lock(assignment_report_operation_id(storage, output_name)):
             if output_path.is_file():
@@ -5283,6 +5375,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
     def log_error(self, format, *args) -> None:
         """Redact even malformed OAuth request lines before parser completion."""
 
+        if "/api/student-lab/" in str(getattr(self, "requestline", "")):
+            self.log_message("Student API request non valida")
+            return
         if self._is_sensitive_auth_request_line() or any(
             any(
                 auth_path in str(argument)
@@ -5301,6 +5396,9 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
 
         path = str(getattr(self, "path", ""))
         requestline = str(getattr(self, "requestline", ""))
+        if "/api/student-lab/" in path + " " + requestline:
+            self.log_message('"STUDENT %s HTTP" %s %s', self._student_route_label(), str(code), str(size))
+            return
         if self._is_sensitive_auth_request_line():
             combined = path + " " + requestline
             if "/auth/google/callback" in combined:
@@ -5581,7 +5679,10 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
             self.close_connection = True
             raise thebitlab_http_auth.HttpBadRequestError()
         length = int(lengths[0])
-        if not 1 <= length <= MAX_STUDENT_HELP_REQUEST_BYTES:
+        body_limit = (student_delivery_store.MAX_DOCUMENT_BYTES
+                      if urlparse(self.path).path == "/api/student-lab/deliveries"
+                      else MAX_STUDENT_HELP_REQUEST_BYTES)
+        if not 1 <= length <= body_limit:
             self.close_connection = True
             raise thebitlab_http_auth.HttpBadRequestError()
         content_types = [
@@ -6122,6 +6223,108 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
     def do_CONNECT(self) -> None:  # noqa: N802
         self.do_unsupported_auth_method()
 
+    def dispatch_student_delivery(self, parsed) -> bool:
+        if parsed.path not in {"/api/student-lab/delivery-manifest",
+                               "/api/student-lab/deliveries",
+                               "/api/student-lab/delivery-final"}:
+            return False
+        if not getattr(self.server, "student_delivery_enabled", False):
+            self.close_connection = True
+            self.write_error_json(404, "Servizio consegne non abilitato.")
+            return True
+        # Source transfer requires the federated boundary; never accept HMAC
+        # aliases as authoritative identities for durable teacher receipts.
+        if getattr(self.server, "tui_pairing_http_routes", None) is None:
+            self.close_connection = True
+            self.write_error_json(403, "Accesso studente non consentito.")
+            return True
+        scope = self.authenticated_student_request()
+        if scope is None:
+            return True
+        try:
+            if self.command == "GET":
+                payload = dict(parse_qsl(parsed.query))
+            else:
+                body = self._read_body_with_deadline(
+                    int(self.headers["Content-Length"]), STUDENT_API_BODY_DEADLINE_SECONDS)
+                if body is None:
+                    raise student_delivery_store.DeliveryError("invalid")
+                payload = json.loads(body.decode("utf-8"),
+                                     object_pairs_hook=student_delivery_store._unique_object)
+            expected = {"assignment_id"}
+            if self.command == "POST":
+                expected |= ({"package"} if parsed.path.endswith("/deliveries")
+                             else {"attempt_id", "expected_revision"})
+            if not isinstance(payload, dict) or payload.keys() != expected:
+                raise student_delivery_store.DeliveryError("invalid")
+            assignment_id = student_delivery_store._text(payload["assignment_id"])
+            record_storage = assignment_record_storage()
+            with thebitlab_storage.course_storage_lock(ROOT):
+                with assignment_operation_lock(assignment_record_operation_id(record_storage, assignment_id)):
+                    def context_loader():
+                        routes = self.server.tui_pairing_http_routes
+                        try:
+                            authentication = routes.boundary.authenticate_bearer(self.headers["Authorization"])
+                        except ValueError:
+                            raise student_api_authorization.StudentApiAuthorizationDenied("account") from None
+                        fresh = student_api_authorization.authorize_student_request(
+                            routes.boundary.tui_sessions.storage, authentication.user.user_id)
+                        if fresh.subject_id != scope.subject_id:
+                            raise student_api_authorization.StudentApiAuthorizationDenied("identity_incoherent")
+                        try:
+                            assignment = record_storage.read_assignment_strict(assignment_id)
+                        except FileNotFoundError:
+                            raise student_api_authorization.StudentApiAuthorizationDenied("target_missing") from None
+                        authorized = fresh.authorize_assignment(assignment)
+                        try:
+                            contract = student_delivery_service.teacher_contract(ROOT, authorized.assignment_copy())
+                            if self.command == "POST" and parsed.path.endswith("/deliveries"):
+                                from scripts.student_delivery_grading import JsonDeliveryGradingStore
+                                JsonDeliveryGradingStore(ROOT).archive_contract(contract)
+                        except (OSError, ValueError, TypeError, KeyError):
+                            raise student_api_authorization.StudentApiAuthorizationUnavailable("storage_corrupt") from None
+                        return student_delivery_service.delivery_context(assignment, fresh.subject_id, contract)
+
+                    context = context_loader()
+                    delivery_store = student_delivery_store.JsonStudentDeliveryStore(ROOT)
+                    if parsed.path.endswith("/delivery-manifest"):
+                        contract = student_delivery_service.teacher_contract(
+                            ROOT, record_storage.read_assignment_strict(assignment_id))
+                        result = student_delivery_service.workspace_manifest(ROOT, context, contract)
+                    elif self.command == "GET":
+                        result = delivery_store.history(context_loader=context_loader)
+                        selected = result["final"] or (result["items"][-1] if result["items"] else None)
+                        received = next((item["received_at"] for item in result["items"]
+                                         if selected and item["attempt_id"] == selected["attempt_id"]), None)
+                        status, _ = track_assignments.submission_status(submitted=bool(selected),
+                            submitted_at=received, due_at=context.closes_at.isoformat())
+                        result["status"] = "submitted" if status == "submitted_on_time" else status
+                    elif parsed.path.endswith("/deliveries"):
+                        receipt = delivery_store.receive(payload["package"], context_loader=context_loader)
+                        result = delivery_store._summary(receipt)
+                    else:
+                        result = delivery_store.select_final(payload["attempt_id"],
+                            expected_revision=payload["expected_revision"], context_loader=context_loader)
+            self.write_sensitive_json(result)
+        except student_api_authorization.StudentApiAuthorizationError as error:
+            self._write_student_authorization_error(
+                403 if isinstance(error, student_api_authorization.StudentApiAuthorizationDenied) else 503, error)
+        except thebitlab_http_auth.HttpAuthError as error:
+            self.close_connection = True
+            self.write_error_json(error.status_code, error.public_message)
+        except student_delivery_store.DeliveryError as error:
+            self.close_connection = True
+            status = {"conflict": 409, "contract_changed": 409, "closed": 409,
+                      "missing": 404, "limit": 413, "storage": 503}.get(error.code, 400)
+            self.write_error_json(status, str(error))
+        except (ValueError, TypeError, KeyError, RecursionError):
+            self.close_connection = True
+            self.write_error_json(400, "Richiesta consegna non valida.")
+        except Exception:  # No credentials, identities or paths in errors/logs.
+            self.close_connection = True
+            self.write_error_json(503, "Servizio consegne temporaneamente non disponibile.")
+        return True
+
     def do_GET(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
         if self.dispatch_tui_pairing_http(parsed):
@@ -6147,6 +6350,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 self.serve_login_page()
                 return
         if self.reject_unauthenticated_teacher_api("GET", parsed.path):
+            return
+        if self.dispatch_student_delivery(parsed):
             return
         if parsed.path in {
             "/api/student-lab/me",
@@ -6174,7 +6379,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                         records = assignment_record_storage().list_assignments_strict()
                         authorized = student_request.visible_assignments(records)
                         self.write_json(
-                            student_lab_service.authorized_student_lab_payload(
+                            {"delivery_api": bool(getattr(self.server, "student_delivery_enabled", False)),
+                             **student_lab_service.authorized_student_lab_payload(
                                 root=ROOT,
                                 authorized_assignments=[
                                     (item.assignment_copy(), item.target_copy())
@@ -6183,7 +6389,7 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                                 public_student_id=student_request.public_student_id,
                                 server_student_key=student_request.subject_id,
                                 now=requested_now if self.is_loopback_client() else None,
-                            )
+                            )}
                         )
                     else:
                         self.write_json(
@@ -6387,6 +6593,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
         if self.reject_unauthenticated_teacher_api("POST", parsed.path):
             return
         if self.reject_unsafe_teacher_post(parsed.path):
+            return
+        if self.dispatch_student_delivery(parsed):
             return
         if parsed.path == "/api/student-lab/final-attempt":
             student_request = self.authenticated_student_request()
@@ -6708,6 +6916,16 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(json.dumps({"error": str(error)}, ensure_ascii=False).encode("utf-8"))
             return
+        if parsed.path in {"/api/assignment-reports/delivery-grade", "/api/assignment-reports/delivery-grade/review"}:
+            if not getattr(self.server, "student_delivery_enabled", False):
+                self.write_error_json(404, "Valutazione consegne non abilitata.")
+                return
+            try:
+                result = grade_student_delivery(payload, review=parsed.path.endswith("/review"))
+                self.write_sensitive_json({"ok": True, **result})
+            except (OSError, ValueError, TypeError, KeyError):
+                self.write_error_json(400, "Valutazione consegna non disponibile.")
+            return
         if parsed.path == "/api/assignment-reports/ai-feedback/review":
             try:
                 report = review_assignment_ai_feedback(
@@ -6735,7 +6953,8 @@ class CourseBoardHandler(BaseHTTPRequestHandler):
                     except Exception:
                         self.write_error_json(503, "Registro aiuti temporaneamente non disponibile.")
                         return
-                    self.write_json(generate_assignment_report(payload, help_subject_aliases=aliases))
+                    self.write_json(generate_assignment_report(payload, help_subject_aliases=aliases,
+                        student_delivery_enabled=bool(getattr(self.server, "student_delivery_enabled", False))))
             except Exception as error:  # noqa: BLE001
                 self.send_response(400)
                 self.send_header("Content-Type", "application/json; charset=utf-8")
@@ -7104,6 +7323,8 @@ def main() -> int:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--root", type=Path, default=APP_ROOT, help="Root dati da usare per API e dashboard.")
+    parser.add_argument("--student-deliveries", action="store_true",
+                        help="Abilita consegne da TUI su PC separati; richiede il runtime auth federato.")
     parser.add_argument(
         "--allow-insecure-network-http",
         action="store_true",
@@ -7120,6 +7341,8 @@ def main() -> int:
         help="Genera e rinnova il token GitHub App dalla configurazione esterna protetta.",
     )
     args = parser.parse_args()
+    if args.student_deliveries and not args.enable_google_auth:
+        parser.error("--student-deliveries richiede --enable-google-auth.")
     teacher_token_is_configured = bool(os.environ.get("THEBITLAB_TEACHER_TOKEN", "").strip())
     try:
         validate_server_bind(args.host, args.allow_insecure_network_http)
@@ -7155,6 +7378,7 @@ def main() -> int:
                 parser.error(str(error))
         server = BoundedThreadingHTTPServer((args.host, args.port), CourseBoardHandler)
         server.teacher_token = configured_teacher_token
+        server.student_delivery_enabled = args.student_deliveries
         if auth_runtime is not None:
             server.google_oidc_runtime = auth_runtime
             server.google_oidc_http_routes = auth_runtime.routes

--- a/scripts/student_delivery_client.py
+++ b/scripts/student_delivery_client.py
@@ -1,0 +1,240 @@
+"""Local workspaces and a durable, credential-free delivery outbox."""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+from pathlib import Path
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from scripts import assignment_records
+from scripts import create_submission_scaffold as scaffold
+from scripts import student_delivery_service as service
+from scripts import student_delivery_store as store
+from scripts import student_lab_attempts as attempts
+
+
+def request(route: str, *, server_url: str, server_token: str,
+            allow_insecure_http: bool = False, payload: dict | None = None,
+            assignment_id: str = "") -> dict:
+    from scripts import student_lab_cli as cli
+
+    credential = cli._MemoryBearer(server_token)
+    server_token = ""
+    safe_url = cli.validated_server_url(server_url, allow_insecure_http)
+    url = safe_url + "/api/student-lab/" + route
+    if payload is None:
+        url += "?" + urllib.parse.urlencode({"assignment_id": assignment_id})
+    transport = urllib.request.Request(url,
+        data=store._json_bytes(payload) if payload is not None else None,
+        headers={"Authorization": "Bearer " + credential.value, "Content-Type": "application/json",
+                 "User-Agent": cli._USER_AGENT}, method="POST" if payload is not None else "GET")
+    failed = False
+    try:
+        result = cli._student_api_json(transport, timeout=30)
+        if not isinstance(result, dict) or cli._contains_credential(result, credential.value):
+            failed = True
+    except Exception:
+        failed = True
+    finally:
+        transport = None
+        credential.value = ""
+    if failed:
+        raise ValueError("Consegne non disponibili: verifica connessione, accesso e contratto docente. Riprova l'invio per recuperare la ricevuta.")
+    return result
+
+
+def ensure_directory(root: Path, directory: Path) -> None:
+    store._safe_path(root, directory)
+    assignment_records.create_durable_directory(directory)
+    store._safe_path(root, directory)
+
+
+def local_directory(root: Path, server_url: str, workspace_id: str) -> Path:
+    from scripts import student_lab_cli as cli
+
+    # The origin and server-derived owner both partition local data. The bearer
+    # is deliberately absent from paths, manifests, packages and receipts.
+    safe_url = cli.validated_server_url(server_url, True)
+    key = store.content_digest(store._json_bytes([safe_url, store._digest(workspace_id)]))
+    directory = root / "student-delivery" / key
+    store._safe_path(root, directory)
+    ensure_directory(root, directory)
+    return directory
+
+
+def prepare_workspace(root: Path, server_url: str, manifest: dict) -> dict:
+    if manifest.get("schema_version") != service.MANIFEST_SCHEMA:
+        raise store.DeliveryError("invalid")
+    checked = store.normalize_package({"schema_version": store.PACKAGE_SCHEMA,
+        "attempt_id": "attempt-20000101T000000000000Z-00000000",
+        "activity_digest": manifest["activity_digest"], "tests_digest": manifest["tests_digest"],
+        "files": manifest["files"]})
+    directory = local_directory(root, server_url, manifest["workspace_id"])
+    revision = directory / checked["activity_digest"]
+    activity_id = scaffold.validate_source_name(manifest["activity_id"])
+    workspace = revision / "assignments" / activity_id
+    ensure_directory(root, workspace)
+    for item in checked["files"]:
+        path = workspace / item["path"]
+        store._safe_path(root, path)
+        ensure_directory(root, path.parent)
+        descriptor, temporary_name = tempfile.mkstemp(dir=path.parent, prefix=".download-")
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(base64.b64decode(item["content_base64"], validate=True))
+                stream.flush()
+                os.fsync(stream.fileno())
+            attempts.publish_exclusive(temporary, path)
+            attempts.sync_directory(path.parent)
+        except FileExistsError:
+            pass  # Existing student work is never replaced by a download.
+        finally:
+            temporary.unlink(missing_ok=True)
+    activity_path = workspace / "activity.json"
+    if not activity_path.exists():
+        attempts.write_json_exclusive(activity_path, manifest["activity"], base_dir=root)
+    store._safe_path(root, activity_path)
+    return {"workspace": {"path": str(workspace), "exists": True},
+            "activity": {"path": str(activity_path), "exists": True},
+            "report": {"path": str(revision / "reports" / activity_id / "latest.json")}}
+
+
+def enrich_payload(payload: dict, *, root: Path, server_url: str, server_token: str,
+                   allow_insecure_http: bool) -> dict:
+    transport = dict(server_url=server_url, server_token=server_token,
+                     allow_insecure_http=allow_insecure_http)
+    result = {**payload, "assignments": []}
+    for assignment in payload.get("assignments", []):
+        assignment_id = assignment["assignment_id"]
+        manifest = request("delivery-manifest", assignment_id=assignment_id, **transport)
+        if manifest.get("assignment_id") != assignment_id or manifest.get("activity_id") != assignment["activity_id"]:
+            raise store.DeliveryError("invalid")
+        history = request("deliveries", assignment_id=assignment_id, **transport)
+        paths = prepare_workspace(root, server_url, manifest)
+        current = {**assignment, "delivery": {key: manifest[key] for key in
+                   ("workspace_id", "activity_digest", "tests_digest", "closes_at")}}
+        for section in paths:
+            current[section] = {**current.get(section, {}), **paths[section]}
+        summaries = [{**item, "id": item["attempt_id"], "status": "Da valutare",
+                      "submitted_at": item["received_at"]} for item in reversed(history["items"])]
+        final = history.get("final")
+        current["delivery"]["revision"] = final["revision"] if final else 0
+        current["attempts"] = {"items": summaries, "count": len(summaries), "truncated": False,
+                               "latest": summaries[0] if summaries else None, "best": None,
+                               "final": next((item for item in summaries if final and item["id"] == final["attempt_id"]), None)}
+        current["submitted"] = bool(summaries)
+        current["status"] = history["status"]
+        current["grading"] = {"status": "not_graded", "score": None, "teacher_grade": None}
+        current["report"] = {**paths["report"], "exists": False, "tests": []}
+        current["runner"] = {"status": "not_run", "backend": ""}
+        # Local tests remain visible, but never supply delivery state or grades.
+        local_report_path = Path(paths["report"]["path"])
+        try:
+            from scripts import student_lab_service
+
+            store._safe_path(root, local_report_path)
+            raw = service.bounded_file(root, local_report_path) if local_report_path.is_file() else b"{}"
+            local_report = json.loads(raw, object_pairs_hook=store._unique_object)
+            if not isinstance(local_report, dict):
+                raise ValueError("local report")
+            if (local_report.get("assignment_id") == assignment_id
+                    and local_report.get("activity_id") == assignment["activity_id"]):
+                current["report"].update(exists=True, tests=student_lab_service.report_tests_summary(local_report))
+                current["runner"] = {"status": local_report.get("status"), "backend": local_report.get("backend")}
+        except (ValueError, OSError):
+            current["runner"] = {"status": "error", "backend": ""}
+        result["assignments"].append(current)
+    return result
+
+
+def snapshot_package(assignment: dict, root: Path) -> dict:
+    workspace = Path(assignment["workspace"]["path"])
+    if not workspace.is_absolute():
+        workspace = root / workspace
+    store._safe_path(root, workspace)
+    entries = []
+    total = 0
+    visited = 0
+    # Avoid uploading tools, credentials and generated runner output. Symlinks
+    # and junctions are rejected, including entries that would be excluded.
+    excluded = {".git", ".venv", "venv", "node_modules", "__pycache__", ".pytest_cache", "reports", "build", "dist"}
+    def visit(directory: Path):
+        nonlocal total, visited
+        for index, path in enumerate(directory.iterdir()):
+            visited += 1
+            if index >= 512 or visited > 4096:
+                raise store.DeliveryError("limit")
+            store._safe_path(root, path)
+            if path.name in excluded or path.name.startswith(".") or path == workspace / "activity.json":
+                continue
+            if path.is_dir():
+                if len(path.relative_to(workspace).parts) > 16:
+                    raise store.DeliveryError("limit")
+                visit(path)
+            else:
+                if len(entries) >= store.MAX_FILES:
+                    raise store.DeliveryError("limit")
+                data = service.bounded_file(root, path)
+                total += len(data)
+                if total > store.MAX_TOTAL_BYTES:
+                    raise store.DeliveryError("limit")
+                entries.append(service.file_entry(path.relative_to(workspace).as_posix(), data))
+    visit(workspace)
+    contract = assignment["delivery"]
+    return store.normalize_package({"schema_version": store.PACKAGE_SCHEMA,
+        "attempt_id": attempts.new_attempt_id(), "activity_digest": contract["activity_digest"],
+        "tests_digest": contract["tests_digest"], "files": entries})
+
+
+def send_assignment(assignment: dict, *, root: Path, server_url: str, server_token: str,
+                    allow_insecure_http: bool = False, new_snapshot: bool = False) -> dict:
+    directory = local_directory(root, server_url, assignment["delivery"]["workspace_id"])
+    pending = directory / "outbox.json"
+    store._safe_path(root, pending)
+    store._safe_path(root, directory / ".attempt-history.lock")
+    with attempts.report_history_lock(directory / "history.json", base_dir=root):
+        if pending.exists():
+            with pending.open("rb") as stream:
+                raw = stream.read(store.MAX_DOCUMENT_BYTES + 1)
+            if len(raw) > store.MAX_DOCUMENT_BYTES:
+                raise store.DeliveryError("limit")
+            state = json.loads(raw, object_pairs_hook=store._unique_object)
+        else:
+            state = None
+        if state is not None and new_snapshot and state.get("receipt") is None:
+            previous = store.normalize_package(state["package"])
+            archive = directory / ("outbox-" + previous["attempt_id"] + ".json")
+            store._safe_path(root, archive)
+            if len(list(directory.glob("outbox-*.json"))) >= store.MAX_ATTEMPTS:
+                raise store.DeliveryError("limit")
+            # Keep rejected/unacknowledged bytes before replacing the active
+            # slot. A crash before replacement merely leaves the old slot.
+            try:
+                attempts.write_json_exclusive(archive, state, base_dir=root)
+            except FileExistsError:
+                with archive.open("rb") as stream:
+                    saved = stream.read(store.MAX_DOCUMENT_BYTES + 1)
+                if len(saved) > store.MAX_DOCUMENT_BYTES or json.loads(saved) != state:
+                    raise store.DeliveryError("conflict") from None
+            state = None
+        if state is None or state.get("receipt") is not None:
+            state = {"assignment_id": assignment["assignment_id"], "package": snapshot_package(assignment, root), "receipt": None}
+            attempts.write_json_atomic(pending, state, base_dir=root)
+        if state["assignment_id"] != assignment["assignment_id"]:
+            raise store.DeliveryError("conflict")
+        package = store.normalize_package(state["package"])
+        receipt = request("deliveries", server_url=server_url, server_token=server_token,
+                          allow_insecure_http=allow_insecure_http,
+                          payload={"assignment_id": state["assignment_id"], "package": package})
+        if (receipt.get("attempt_id") != package["attempt_id"]
+                or receipt.get("package_digest") != store.content_digest(store._json_bytes(package))
+                or receipt.get("grading_authority") != "ungraded"):
+            raise store.DeliveryError("invalid")
+        state["receipt"] = receipt
+        attempts.write_json_atomic(pending, state, base_dir=root)
+        return receipt

--- a/scripts/student_delivery_grading.py
+++ b/scripts/student_delivery_grading.py
@@ -1,0 +1,357 @@
+"""Private teacher orchestration for immutable deliveries; never imports client grades.
+
+The producer is the host comparator in grade_activity, using its Docker boundary.
+Only stdio single-source profiles and the pinned M04 accessory policy are admitted.
+See student-delivery-grading.md.
+"""
+from __future__ import annotations
+
+import base64
+from contextlib import contextmanager
+from datetime import datetime
+import json
+import math
+from pathlib import Path
+import subprocess
+import tempfile
+
+from scripts import grade_activity, student_delivery_store as delivery
+from scripts import student_lab_attempts as persistence
+from scripts import thebitlab_runtime_contracts, toolchain_lock
+from scripts import student_delivery_policies as policies
+
+
+DIRECTORY = "teacher-delivery-grading"
+JOB_SCHEMA = "thebitlab.delivery-grading-job.v1"
+RESULT_SCHEMA = "thebitlab.delivery-grading-result.v1"
+REVISION_SCHEMA = "thebitlab.delivery-teacher-revision.v1"
+PRODUCER = "docker-stdio-host-comparator.v1"
+ERRORS = {"contract_unavailable", "unsupported_profile", "producer_unavailable", "producer_error"}
+
+
+def digest(value: dict) -> str:
+    return delivery.content_digest(delivery._json_bytes(value))
+
+
+def binding(receipt: dict) -> dict:
+    package = receipt["package"]
+    return {"identity": receipt["identity"], "attempt_id": package["attempt_id"],
+            "package_digest": receipt["package_digest"],
+            "activity_digest": package["activity_digest"], "tests_digest": package["tests_digest"]}
+
+
+def revision_digests(revision: dict) -> dict:
+    """Reconstruct the original fingerprint, including asset order and bytes."""
+    from scripts import create_submission_scaffold as scaffold
+    try:
+        if revision.keys() != {"assignment", "activity", "assets"}:
+            raise ValueError()
+        activity = revision["activity"]
+        entries = revision["assets"]
+        if len(entries) != len(activity.get("assets", [])) or len(entries) > delivery.MAX_FILES:
+            raise ValueError()
+        asset_digests = []
+        total = len(delivery._json_bytes(revision["activity"]))
+        for declared, entry in zip(activity.get("assets", []), entries):
+            declared_path = scaffold.validate_relative_path(declared["path"], "asset").as_posix()
+            if entry.keys() != {"path", "content_base64", "sha256"} or entry["path"] != declared_path:
+                raise ValueError()
+            content = base64.b64decode(entry["content_base64"], validate=True)
+            total += len(content)
+            if (len(content) > delivery.MAX_FILE_BYTES or total > delivery.MAX_TOTAL_BYTES
+                    or delivery.content_digest(content) != entry["sha256"]):
+                raise ValueError()
+            asset_digests.append({"path": entry["path"], "sha256": entry["sha256"]})
+        return {"activity_digest": digest({"assignment": revision["assignment"],
+                    "activity": activity, "assets": asset_digests}),
+                "tests_digest": digest({"tests": activity.get("test_cases", []),
+                    "assets": asset_digests, "grading_policy": activity.get("grading_policy", {})})}
+    except (ValueError, TypeError, KeyError, AttributeError):
+        raise delivery.DeliveryError("storage") from None
+
+
+def profile(receipt: dict, revision: dict) -> tuple[str, dict]:
+    """Do not silently grade a subset or ignore a runtime/profile contract."""
+    from scripts import create_submission_scaffold as scaffold
+
+    activity = revision["activity"]
+    extensions = activity.get("extensions")
+    if isinstance(extensions, dict) and thebitlab_runtime_contracts.RUNTIME_EXTENSION_KEY in extensions:
+        raise delivery.DeliveryError("unsupported_profile")
+    language = scaffold.language_for(activity)
+    source_name = activity.get("source_name") or scaffold.default_source_name_for(language)
+    files = receipt["package"]["files"]
+    cases = activity.get("test_cases", [])
+    if (grade_activity.SUPPORTED_LANGUAGES.get(language) != "implemented"
+            or any(key in activity for key in ("function_tests", "object_tests", "filesystem_tests"))
+            or "/" in source_name or not cases or len(cases) > 64
+            or grade_activity.validate_test_cases(cases)):
+        raise delivery.DeliveryError("unsupported_profile")
+    if activity.get("assets"):
+        policy = policies.accessory_policy(revision)
+        if policy is None:
+            raise delivery.DeliveryError("unsupported_profile")
+        revision_digests(revision)
+        accessory = policy["required_accessory"]
+        entries = {entry["path"]: entry for entry in files}
+        if (language != policy["language"] or len(cases) != policy["tests_total"]
+                or source_name != policy["source"]["target_path"] or len(files) != 2
+                or set(entries) != {source_name, accessory["target_path"]}):
+            raise delivery.DeliveryError("unsupported_profile")
+        original = next(entry for entry in revision["assets"] if entry["path"] == accessory["asset_path"])
+        if (base64.b64decode(entries[accessory["target_path"]]["content_base64"], validate=True)
+                != base64.b64decode(original["content_base64"], validate=True)):
+            raise delivery.DeliveryError("unsupported_profile")
+        return language, entries[source_name]
+    if len(files) != 1 or files[0]["path"] != source_name:
+        raise delivery.DeliveryError("unsupported_profile")
+    return language, files[0]
+
+
+def policy_provenance(revision: dict) -> dict | None:
+    policy = policies.accessory_policy(revision)
+    return {"id": policy["id"], "digest": digest(policy)} if policy else None
+
+
+class DockerSnapshotProducer:
+    """No client-selected executable, image, environment, path or result channel."""
+
+    def __init__(self) -> None:
+        code_root = Path(__file__).resolve().parents[1]
+        lock = toolchain_lock.load_lock(code_root / "docker/assignment-runner/toolchain.lock.json")
+        self.image = toolchain_lock.immutable_reference(lock)
+        modules = (Path(__file__), Path(policies.__file__), Path(grade_activity.__file__),
+                   code_root / "scripts/thebitlab_sandbox_boundary.py")
+        self.provenance = {"producer": PRODUCER, "image": self.image,
+            "platform": lock["platform"], "toolchain_source": lock["source_revision"],
+            "comparator_digest": delivery.content_digest(b"".join(path.read_bytes() for path in modules))}
+
+    def run(self, receipt: dict, revision: dict) -> dict:
+        language, entry = profile(receipt, revision)
+        # Refuse a missing image; grading must never implicitly pull a mutable tag.
+        inspected = subprocess.run(["docker", "image", "inspect", self.image],
+            capture_output=True, timeout=15, check=False)
+        if inspected.returncode != 0:
+            raise delivery.DeliveryError("producer_unavailable")
+        metadata = json.loads(inspected.stdout)[0]
+        if metadata.get("Os") != "linux" or metadata.get("Architecture") != "amd64":
+            raise delivery.DeliveryError("producer_unavailable")
+        with tempfile.TemporaryDirectory(prefix="thebitlab-delivery-grade-") as name:
+            staging = Path(name)
+            (staging / "private").mkdir()
+            (staging / "source").mkdir()
+            activity_path = staging / "private/activity.json"
+            source_path = staging / "source" / entry["path"]
+            activity_path.write_bytes(delivery._json_bytes(revision["activity"]))
+            source_path.write_bytes(base64.b64decode(entry["content_base64"], validate=True))
+            report, _ = grade_activity.grade_activity_in_docker(activity_path, source_path,
+                timeout_seconds=5, language=language, image=self.image,
+                activity_root=staging, source_root=staging)
+        tests = report.get("tests")
+        if (not isinstance(tests, list) or len(tests) != len(revision["activity"]["test_cases"])
+                or any(type(test.get("passed")) is not bool for test in tests)):
+            raise delivery.DeliveryError("producer_error")
+        return {"tests_passed": sum(test["passed"] for test in tests), "tests_total": len(tests)}
+
+
+class JsonDeliveryGradingStore(delivery.JsonStudentDeliveryStore):
+    """One durable job/result per attempt; retry failures, reuse successful results."""
+
+    def _grading_directory(self, identity: dict | None = None) -> Path:
+        key = digest(identity) if identity is not None else "contracts"
+        return delivery._safe_path(self.root, self.root / DIRECTORY / key)
+
+    @contextmanager
+    def _locked(self, directory: Path):
+        self._prepare_directory(directory)
+        delivery._safe_path(self.root, directory / ".attempt-history.lock")
+        with persistence.report_history_lock(directory / "history.json", base_dir=self.root):
+            yield
+
+    def _write(self, path: Path, record: dict, *, exclusive: bool = False) -> None:
+        delivery._safe_path(self.root, path)
+        if len(delivery._json_bytes(record)) > delivery.MAX_DOCUMENT_BYTES:
+            raise delivery.DeliveryError("limit")
+        writer = persistence.write_json_exclusive if exclusive else persistence.write_json_atomic
+        writer(path, record, base_dir=self.root)
+
+    def archive_contract(self, contract: dict) -> None:
+        revision = contract["revision"]
+        hashes = revision_digests(revision)
+        if any(hashes[key] != contract[key] for key in hashes):
+            raise delivery.DeliveryError("contract_changed")
+        record = {"schema_version": REVISION_SCHEMA, **hashes, "revision": revision}
+        directory = self._grading_directory()
+        with self._locked(directory):
+            path = directory / f"{hashes['activity_digest']}.json"
+            old = self._read(path)
+            if old is not None:
+                if old != record:
+                    raise delivery.DeliveryError("storage")
+                persistence.sync_directory(directory)
+            else:
+                self._write(path, record, exclusive=True)
+
+    def _revision(self, receipt: dict) -> dict:
+        expected = binding(receipt)
+        directory = self._grading_directory()
+        with self._locked(directory):
+            record = self._read(directory / f"{expected['activity_digest']}.json")
+        if record is None:
+            raise delivery.DeliveryError("contract_unavailable")
+        if (record.keys() != {"schema_version", "activity_digest", "tests_digest", "revision"}
+                or record["schema_version"] != REVISION_SCHEMA):
+            raise delivery.DeliveryError("storage")
+        hashes = revision_digests(record["revision"])
+        if any(record[key] != value or expected[key] != value for key, value in hashes.items()):
+            raise delivery.DeliveryError("storage")
+        return record["revision"]
+
+    def _timestamp(self) -> str:
+        return delivery._utc(self.clock()).isoformat()
+
+    def _result(self, directory: Path, receipt: dict) -> dict | None:
+        attempt = receipt["package"]["attempt_id"]
+        result = self._read(directory / f"{attempt}.result.json")
+        if result is None:
+            return None
+        job = self._read(directory / f"{attempt}.job.json")
+        try:
+            if (result.keys() != {"schema_version", "binding", "job_digest", "provenance", "completed_at", "summary"}
+                    or result["schema_version"] != RESULT_SCHEMA or result["binding"] != binding(receipt)
+                    or job is None or job.keys() != {"schema_version", "binding", "provenance", "created_at"}
+                    or job["schema_version"] != JOB_SCHEMA or job["binding"] != binding(receipt)
+                    or digest(job) != result["job_digest"] or job["provenance"] != result["provenance"]
+                    or result["provenance"]["producer"] != PRODUCER):
+                raise ValueError()
+            delivery._utc(datetime.fromisoformat(result["completed_at"]))
+            if "grading_policy" in result["provenance"] or len(receipt["package"]["files"]) != 1:
+                revision = self._revision(receipt)
+                try:
+                    profile(receipt, revision)
+                except delivery.DeliveryError:
+                    raise ValueError() from None
+                expected_policy = policy_provenance(revision)
+                if (expected_policy is None or result["provenance"].get("grading_policy") != expected_policy
+                        or result["summary"]["tests_total"] != len(revision["activity"]["test_cases"])):
+                    raise ValueError()
+            summary = result["summary"]
+            if (summary.keys() != {"tests_passed", "tests_total"}
+                    or type(summary["tests_passed"]) is not int or type(summary["tests_total"]) is not int
+                    or not 0 <= summary["tests_passed"] <= summary["tests_total"] <= 64
+                    or summary["tests_total"] == 0):
+                raise ValueError()
+        except (ValueError, TypeError, KeyError, AttributeError):
+            raise delivery.DeliveryError("storage") from None
+        return result
+
+    def grade(self, attempt_id: str, *, context_loader, producer=None) -> dict:
+        # The loader belongs to the teacher adapter. There is no report-upload API.
+        receipt = self.read(attempt_id, context_loader=context_loader)
+        directory = self._grading_directory(receipt["identity"])
+        with self._locked(directory):
+            result = self._result(directory, receipt)
+            if result is not None:
+                persistence.sync_directory(directory)
+                return {"state": "succeeded", "result": result, "result_digest": digest(result)}
+            state_path = directory / f"{attempt_id}.state.json"
+            job_path = directory / f"{attempt_id}.job.json"
+            try:
+                revision = self._revision(receipt)
+                profile(receipt, revision)
+                producer = producer or DockerSnapshotProducer()
+                provenance = dict(producer.provenance)
+                if "grading_policy" in provenance:
+                    raise ValueError("Policy provenance belongs to the grading core")
+                policy = policy_provenance(revision)
+                if policy is not None:
+                    provenance["grading_policy"] = policy
+                job = self._read(job_path)
+                if job is None:
+                    job = {"schema_version": JOB_SCHEMA, "binding": binding(receipt),
+                           "provenance": provenance, "created_at": self._timestamp()}
+                    self._write(job_path, job, exclusive=True)
+                elif (job.keys() != {"schema_version", "binding", "provenance", "created_at"}
+                        or job.get("schema_version") != JOB_SCHEMA or job.get("binding") != binding(receipt)
+                        or job.get("provenance") != provenance):
+                    raise delivery.DeliveryError("storage")
+                self._write(state_path, {"binding": binding(receipt), "state": "running"})
+                summary = producer.run(receipt, revision)
+                if (not isinstance(summary, dict) or summary.keys() != {"tests_passed", "tests_total"}
+                        or type(summary["tests_passed"]) is not int or type(summary["tests_total"]) is not int
+                        or summary["tests_total"] != len(revision["activity"]["test_cases"])
+                        or not 0 <= summary["tests_passed"] <= summary["tests_total"]):
+                    raise delivery.DeliveryError("producer_error")
+                result = {"schema_version": RESULT_SCHEMA, "binding": binding(receipt),
+                          "job_digest": digest(job), "provenance": provenance,
+                          "completed_at": self._timestamp(), "summary": summary}
+                self._write(directory / f"{attempt_id}.result.json", result, exclusive=True)
+                return {"state": "succeeded", "result": result, "result_digest": digest(result)}
+            except delivery.DeliveryError as error:
+                if error.code not in ERRORS:
+                    raise
+                code = error.code
+            except (FileNotFoundError, toolchain_lock.ToolchainLockError):
+                code = "producer_unavailable"
+            except (ValueError, subprocess.SubprocessError):
+                code = "producer_error"
+            self._write(state_path, {"binding": binding(receipt), "state": "error", "error": code})
+            return {"state": "error", "error": code}
+
+    def lookup(self, receipt: dict) -> dict:
+        directory = self._grading_directory(receipt["identity"])
+        with self._locked(directory):
+            result = self._result(directory, receipt)
+            if result is None:
+                state = self._read(directory / f"{receipt['package']['attempt_id']}.state.json")
+                if state is None:
+                    return {"state": "not_graded"}
+                if (state.get("binding") != binding(receipt) or state.get("state") not in {"running", "error"}
+                        or (state["state"] == "error" and state.get("error") not in ERRORS)):
+                    raise delivery.DeliveryError("storage")
+                # Acquiring this same lock proves no producer is still running.
+                return {"state": "error", "error": state.get("error", "interrupted")}
+            review = self._read(directory / f"{receipt['package']['attempt_id']}.review.json")
+            if review is not None:
+                if (review.keys() != {"result_digest", "teacher_grade", "reviewed_at"}
+                        or review["result_digest"] != digest(result) or not valid_grade(review["teacher_grade"])):
+                    raise delivery.DeliveryError("storage")
+            return {"state": "succeeded", "result": result, "review": review}
+
+    def review(self, attempt_id: str, *, context_loader, result_digest: str, teacher_grade) -> dict:
+        if not valid_grade(teacher_grade):
+            raise delivery.DeliveryError("invalid")
+        receipt = self.read(attempt_id, context_loader=context_loader)
+        directory = self._grading_directory(receipt["identity"])
+        with self._locked(directory):
+            result = self._result(directory, receipt)
+            if result is None or digest(result) != result_digest:
+                raise delivery.DeliveryError("conflict")
+            review = {"result_digest": result_digest, "teacher_grade": teacher_grade,
+                      "reviewed_at": self._timestamp()}
+            self._write(directory / f"{attempt_id}.review.json", review)
+            return review
+
+
+def valid_grade(value) -> bool:
+    return value is None or (type(value) in {int, float} and math.isfinite(value) and 0 <= value <= 10)
+
+
+def project(student: dict, receipt: dict, outcome: dict) -> None:
+    """Publish aggregates only; protected cases, stdout and provenance stay private."""
+    if outcome["state"] != "succeeded":
+        student["grading"]["delivery_grading_state"] = outcome["state"]
+        student["grading"]["report_status"] = outcome.get("error")
+        return
+    result = outcome["result"]
+    if result["binding"] != binding(receipt):
+        raise delivery.DeliveryError("storage")
+    summary = result["summary"]
+    passed, total = summary["tests_passed"], summary["tests_total"]
+    review = outcome.get("review")
+    teacher_grade = review["teacher_grade"] if review else None
+    student["grading"].update({"status": "graded_passed" if passed == total else "graded_failed",
+        "passed": passed == total, **summary, "score": round(10 * passed / total, 2),
+        "teacher_grade": teacher_grade, "provisional": teacher_grade is None,
+        "report_status": "passed" if passed == total else "failed", "delivery_grading_state": "succeeded"})
+    student["submission"]["report_authority"] = "verified_delivery"

--- a/scripts/student_delivery_policies.py
+++ b/scripts/student_delivery_policies.py
@@ -1,0 +1,31 @@
+"""Teacher-approved, installed-code policies; never loaded from a delivery/root.
+
+Published policy versions must remain immutable for historical result readers.
+Callers validate revision bytes before matching the material fingerprint.
+"""
+from scripts import student_delivery_store as delivery
+
+
+def accessory_policy(revision: dict) -> dict | None:
+    materials = {"activity": revision["activity"], "assets": [
+        {"path": entry["path"], "sha256": entry["sha256"]} for entry in revision["assets"]]}
+    fingerprint = delivery.content_digest(delivery._json_bytes(materials))
+    if fingerprint != "dc16ae5bb215d90a089721afbaf2ec7434d4327ef666209416707867ce1ced5b":
+        return None
+    # A fresh value prevents callers from mutating the installed policy in place.
+    return {
+        "id": "python-m04-stdio-accessory.v1",
+        "origin": {
+            "repository": "TheBitPoets/python-docente",
+            "revision": "1bc6d712c9e44d482846cc3c290b66e979c24905",
+            "activity_path": "activities/python/py2-activity-b-input-somma-001/activity.json",
+        },
+        "materials_digest": fingerprint,
+        "language": "python",
+        "tests_total": 3,
+        "source": {"asset_path": "starter/main.py", "target_path": "main.py"},
+        "required_accessory": {"asset_path": "student/GUIDA.md", "target_path": "GUIDA.md",
+                               "comparison": "identical_bytes", "worker": False},
+        "private_assets": ["teacher/README.md"],
+        "extra_files": "reject",
+    }

--- a/scripts/student_delivery_service.py
+++ b/scripts/student_delivery_service.py
@@ -1,0 +1,133 @@
+"""Teacher-owned contracts and presentation for received source snapshots.
+
+Callers hold the course and assignment lifecycle locks. Network callers also
+reload bearer authorization through the store's context loader.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts import create_submission_scaffold as scaffold
+from scripts import student_delivery_store as store
+from scripts.thebitlab_contracts import normalize_activity
+
+
+MANIFEST_SCHEMA = "thebitlab.student-workspace.v1"
+
+
+def file_entry(name: str, content: bytes) -> dict:
+    return {"path": name, "content_base64": base64.b64encode(content).decode("ascii"),
+            "sha256": store.content_digest(content)}
+
+
+def bounded_file(root: Path, path: Path) -> bytes:
+    store._safe_path(root, path)
+    with path.open("rb") as stream:
+        data = stream.read(store.MAX_FILE_BYTES + 1)
+    if len(data) > store.MAX_FILE_BYTES:
+        raise store.DeliveryError("limit")
+    return data
+
+
+def teacher_contract(root: Path, assignment: dict) -> dict:
+    """Fingerprint teacher metadata and every declared asset, including tests."""
+    relative = scaffold.validate_relative_path(assignment["activity_path"], "activity_path")
+    activity_path = root / relative
+    raw = bounded_file(root, activity_path)
+    activity = normalize_activity(json.loads(raw.decode("utf-8-sig"), object_pairs_hook=store._unique_object))
+    if activity["id"] != assignment["activity_id"]:
+        raise store.DeliveryError("contract_changed")
+    assets = activity.get("assets", [])
+    if len(assets) > store.MAX_FILES:
+        raise store.DeliveryError("limit")
+    asset_digests = []
+    private_assets = []
+    total = len(raw)
+    for asset in assets:
+        relative = scaffold.validate_relative_path(asset.get("path"), "asset")
+        content = bounded_file(root, activity_path.parent / relative)
+        total += len(content)
+        if total > store.MAX_TOTAL_BYTES:
+            raise store.DeliveryError("limit")
+        asset_digests.append({"path": relative.as_posix(), "sha256": store.content_digest(content)})
+        private_assets.append(file_entry(relative.as_posix(), content))
+    closes_at = datetime.fromisoformat(assignment["due_at"].replace("Z", "+00:00"))
+    store._utc(closes_at)
+    activity_digest = store.content_digest(store._json_bytes({
+        "assignment": assignment, "activity": activity, "assets": asset_digests}))
+    tests_digest = store.content_digest(store._json_bytes({
+        "tests": activity.get("test_cases", []), "assets": asset_digests,
+        "grading_policy": activity.get("grading_policy", {})}))
+    return {"activity_digest": activity_digest, "tests_digest": tests_digest,
+            "closes_at": closes_at, "activity": activity, "activity_path": activity_path,
+            "revision": {"assignment": assignment, "activity": activity, "assets": private_assets}}
+
+
+def delivery_context(assignment: dict, subject_id: str, contract: dict) -> store.DeliveryContext:
+    return store.DeliveryContext(assignment["id"], assignment["class_id"], subject_id,
+                                 assignment["activity_id"], contract["activity_digest"],
+                                 contract["tests_digest"], contract["closes_at"])
+
+
+def archive_context(assignment: dict, subject_id: str) -> store.DeliveryContext:
+    """Teacher read capability; no current assets needed to read old bytes."""
+    return store.DeliveryContext(assignment["id"], assignment["class_id"], subject_id,
+        assignment["activity_id"], "0" * 64, "0" * 64, datetime.min.replace(tzinfo=timezone.utc))
+
+
+def workspace_manifest(root: Path, context: store.DeliveryContext, contract: dict) -> dict:
+    activity = contract["activity"]
+    public = scaffold.student_activity_payload(activity)
+    language = scaffold.language_for(activity)
+    public["language"] = language
+    source_name = scaffold.validate_source_name(
+        activity.get("source_name") or scaffold.default_source_name_for(language))
+    public["source_name"] = source_name
+    files = [file_entry(target.as_posix(), bounded_file(root, source))
+             for source, target in scaffold.student_asset_copy_plan(contract["activity_path"], activity)]
+    if not any(entry["path"] == source_name for entry in files):
+        files.append(file_entry(source_name, scaffold.starter_source(language).encode("utf-8")))
+    # Reuse exactly the portable paths and size limits of uploaded packages.
+    checked = store.normalize_package({"schema_version": store.PACKAGE_SCHEMA,
+        "attempt_id": "attempt-20000101T000000000000Z-00000000", **context.contract(), "files": files})
+    return {"schema_version": MANIFEST_SCHEMA, "assignment_id": context.assignment_id,
+            "activity_id": context.activity_id,
+            "workspace_id": store.content_digest(store._json_bytes(context.identity())),
+            **context.contract(), "closes_at": context.closes_at.isoformat(),
+            "activity": public, "files": checked["files"]}
+
+
+def apply_delivery_to_student(student: dict, receipt: dict | None, final: dict | None,
+                              context: store.DeliveryContext, *, now: str | None = None) -> None:
+    """Project only archived receipts, including an empty, ungraded history."""
+    from scripts import track_assignments
+
+    student["submitted"] = receipt is not None
+    student["status"], student["late"] = track_assignments.submission_status(
+        submitted=receipt is not None, submitted_at=receipt["received_at"] if receipt else None,
+        due_at=student.get("due_at"), now=now)
+    student["grading"] = {**track_assignments.grading_summary(None), "provisional": receipt is not None}
+    student["report_path"] = None
+    student["ai_feedback"] = track_assignments.ai_feedback_placeholder()
+    if receipt is None:
+        student["submission"] = {
+            "source_path": None, "files": [], "local_preview_status": "unavailable",
+            "submitted_at": None, "attempt_id": None, "final_selected": False,
+            "report_authority": "ungraded", "report_selection": None,
+            "delivery": context.identity(),
+        }
+        return
+    package = receipt["package"]
+    student["submission"] = {
+        "source_path": package["files"][0]["path"],
+        "files": [{"path": item["path"], "name": Path(item["path"]).name,
+                   "size": len(base64.b64decode(item["content_base64"])), "role": "source"}
+                  for item in package["files"]],
+        "local_preview_status": "available", "submitted_at": receipt["received_at"],
+        "attempt_id": package["attempt_id"], "final_selected": final is not None,
+        "report_authority": "ungraded", "report_selection": "final" if final else "latest",
+        "delivery": {**context.identity(), "package_digest": receipt["package_digest"]},
+    }

--- a/scripts/student_delivery_store.py
+++ b/scripts/student_delivery_store.py
@@ -1,0 +1,405 @@
+"""Durable, ungraded source submissions for the distributed student workflow.
+
+This is an application port, not an HTTP endpoint. A trusted caller must reload
+authorization and the teacher's delivery contract through ``context_loader``.
+Client reports never enter the local/verified grading report namespaces.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import re
+import stat
+from typing import Any, Callable
+
+from scripts import assignment_records, create_submission_scaffold, student_lab_attempts
+from scripts.student_api_authorization import AuthorizedStudentAssignment
+
+
+PACKAGE_SCHEMA = "thebitlab.student-delivery.v1"
+RECEIPT_SCHEMA = "thebitlab.student-delivery-receipt.v1"
+FINAL_SCHEMA = "thebitlab.student-delivery-final.v1"
+STORAGE_DIRECTORY = "teacher-deliveries"
+MAX_FILES = 64
+MAX_FILE_BYTES = 1024 * 1024
+MAX_TOTAL_BYTES = 8 * 1024 * 1024
+MAX_DOCUMENT_BYTES = 12 * 1024 * 1024
+MAX_ATTEMPTS = 100
+ATTEMPT_ID = re.compile(r"attempt-[0-9]{8}T[0-9]{12}Z-[0-9a-f]{8}\Z")
+DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class DeliveryError(ValueError):
+    """Bounded errors safe for a future transport adapter to classify."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(f"Consegna non disponibile ({code}).")
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=True, allow_nan=False).encode("ascii")
+
+
+def content_digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _text(value: Any, *, limit: int = 256) -> str:
+    if not isinstance(value, str) or not value or len(value) > limit:
+        raise DeliveryError("invalid")
+    return value
+
+
+def _digest(value: Any) -> str:
+    if not isinstance(value, str) or not DIGEST.fullmatch(value):
+        raise DeliveryError("invalid")
+    return value
+
+
+def _attempt_id(value: Any) -> str:
+    if not isinstance(value, str) or not ATTEMPT_ID.fullmatch(value):
+        raise DeliveryError("invalid")
+    return value
+
+
+def _utc(value: datetime) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise DeliveryError("invalid")
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class DeliveryContext:
+    """Server-derived identity and pinned teacher contract, reloaded per call.
+
+    ``closes_at`` is a delivery admission deadline, distinct from the teaching
+    due date: a late submission can be admitted before this deadline.
+    """
+
+    assignment_id: str
+    class_id: str
+    subject_id: str
+    activity_id: str
+    activity_digest: str
+    tests_digest: str
+    closes_at: datetime
+
+    def __post_init__(self) -> None:
+        for value in (self.assignment_id, self.class_id, self.subject_id, self.activity_id):
+            _text(value)
+        _digest(self.activity_digest)
+        _digest(self.tests_digest)
+        _utc(self.closes_at)
+
+    @classmethod
+    def from_authorized(
+        cls, authorized: AuthorizedStudentAssignment, *, activity_digest: str,
+        tests_digest: str, closes_at: datetime,
+    ) -> "DeliveryContext":
+        return cls(authorized.assignment_id, authorized.class_id, authorized.subject_id,
+                   authorized.assignment_copy().get("activity_id"), activity_digest,
+                   tests_digest, closes_at)
+
+    def identity(self) -> dict[str, str]:
+        return {name: getattr(self, name) for name in
+                ("assignment_id", "class_id", "subject_id", "activity_id")}
+
+    def contract(self) -> dict[str, str]:
+        return {"activity_digest": self.activity_digest, "tests_digest": self.tests_digest}
+
+
+def normalize_package(payload: Any) -> dict[str, Any]:
+    """Validate a bounded file manifest without ever extracting client paths."""
+
+    fields = {"schema_version", "attempt_id", "activity_digest", "tests_digest", "files"}
+    if not isinstance(payload, dict) or payload.keys() != fields:
+        raise DeliveryError("invalid")
+    if payload["schema_version"] != PACKAGE_SCHEMA:
+        raise DeliveryError("invalid")
+    attempt_id = _attempt_id(payload["attempt_id"])
+    activity_digest = _digest(payload["activity_digest"])
+    tests_digest = _digest(payload["tests_digest"])
+    files = payload["files"]
+    if not isinstance(files, list) or not 1 <= len(files) <= MAX_FILES:
+        raise DeliveryError("limit")
+    normalized = []
+    paths: list[Path] = []
+    total = 0
+    for entry in files:
+        if not isinstance(entry, dict) or entry.keys() != {"path", "content_base64", "sha256"}:
+            raise DeliveryError("invalid")
+        name = _text(entry["path"], limit=240)
+        try:
+            path = create_submission_scaffold.validate_relative_path(name, "file")
+        except ValueError:
+            raise DeliveryError("path") from None
+        if any(create_submission_scaffold.portable_paths_overlap(path, old) for old in paths):
+            raise DeliveryError("path")
+        paths.append(path)
+        encoded = entry["content_base64"]
+        if not isinstance(encoded, str) or len(encoded) > 4 * ((MAX_FILE_BYTES + 2) // 3):
+            raise DeliveryError("limit")
+        try:
+            content = base64.b64decode(encoded, validate=True)
+        except (ValueError, binascii.Error):
+            raise DeliveryError("invalid") from None
+        total += len(content)
+        if len(content) > MAX_FILE_BYTES or total > MAX_TOTAL_BYTES:
+            raise DeliveryError("limit")
+        if content_digest(content) != _digest(entry["sha256"]):
+            raise DeliveryError("digest")
+        normalized.append({"path": path.as_posix(), "sha256": entry["sha256"],
+                           "content_base64": base64.b64encode(content).decode("ascii")})
+    return {"schema_version": PACKAGE_SCHEMA, "attempt_id": attempt_id,
+            "activity_digest": activity_digest, "tests_digest": tests_digest,
+            "files": sorted(normalized, key=lambda item: item["path"])}
+
+
+def _safe_path(root: Path, path: Path) -> Path:
+    """Reject symlinks, junctions and special files, including dangling links."""
+
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        raise DeliveryError("storage") from None
+    current = root
+    for part in (None, *relative.parts):
+        if part is not None:
+            current /= part
+        try:
+            info = current.lstat()
+        except FileNotFoundError:
+            continue
+        if (stat.S_ISLNK(info.st_mode)
+                or getattr(info, "st_file_attributes", 0) & stat.FILE_ATTRIBUTE_REPARSE_POINT
+                or not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode))):
+            raise DeliveryError("storage")
+        if current != path and not stat.S_ISDIR(info.st_mode):
+            raise DeliveryError("storage")
+    return path
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise DeliveryError("storage")
+        result[key] = value
+    return result
+
+
+class JsonStudentDeliveryStore:
+    """One controlled server root; receipts are immutable, final is CAS-updated.
+
+    The loader must read current identity, assignment and pinned contract. It is
+    invoked again inside the process lock; its authorization errors propagate.
+    No client-provided path, timestamp or grade determines server state.
+    """
+
+    def __init__(self, root: Path, *, clock: Callable[[], datetime] | None = None) -> None:
+        self.root = root.absolute()
+        _safe_path(self.root, self.root)
+        if not self.root.is_dir():
+            raise DeliveryError("storage")
+        self.clock = clock or (lambda: datetime.now(timezone.utc))
+
+    def _directory(self, context: DeliveryContext) -> Path:
+        key = content_digest(_json_bytes(context.identity()))
+        return _safe_path(self.root, self.root / STORAGE_DIRECTORY / key)
+
+    def _prepare_directory(self, directory: Path) -> None:
+        _safe_path(self.root, directory)
+        assignment_records.create_durable_directory(directory)
+        _safe_path(self.root, directory)
+        # A previous mkdir may have succeeded before its parent fsync failed.
+        # Repeat every link's sync even when the directories already exist.
+        student_lab_attempts.sync_directory(self.root)
+        student_lab_attempts.sync_directory(directory.parent)
+        student_lab_attempts.sync_directory(directory)
+
+    def _read(self, path: Path) -> dict[str, Any] | None:
+        _safe_path(self.root, path)
+        try:
+            with path.open("rb") as stream:
+                raw = stream.read(MAX_DOCUMENT_BYTES + 1)
+        except FileNotFoundError:
+            return None
+        if len(raw) > MAX_DOCUMENT_BYTES:
+            raise DeliveryError("storage")
+        try:
+            result = json.loads(raw, object_pairs_hook=_unique_object)
+        except (ValueError, UnicodeError, RecursionError):
+            raise DeliveryError("storage") from None
+        if not isinstance(result, dict):
+            raise DeliveryError("storage")
+        return result
+
+    def _receipt(self, directory: Path, context: DeliveryContext, attempt_id: str) -> dict[str, Any] | None:
+        receipt = self._read(directory / f"{_attempt_id(attempt_id)}.json")
+        if receipt is None:
+            return None
+        fields = {"schema_version", "identity", "received_at", "sequence", "package_digest",
+                  "package", "grading_authority"}
+        try:
+            if receipt.keys() != fields or receipt["schema_version"] != RECEIPT_SCHEMA:
+                raise DeliveryError("storage")
+            package = normalize_package(receipt["package"])
+            timestamp = _utc(datetime.fromisoformat(receipt["received_at"]))
+            if (receipt["identity"] != context.identity()
+                    or package["attempt_id"] != attempt_id
+                    or content_digest(_json_bytes(package)) != receipt["package_digest"]
+                    or receipt["grading_authority"] != "ungraded"
+                    or type(receipt["sequence"]) is not int
+                    or not 1 <= receipt["sequence"] <= MAX_ATTEMPTS
+                    or timestamp.isoformat() != receipt["received_at"]):
+                raise DeliveryError("storage")
+        except (ValueError, TypeError, KeyError):
+            raise DeliveryError("storage") from None
+        return receipt
+
+    def _reload(self, loader: Callable[[], DeliveryContext], original: DeliveryContext) -> DeliveryContext:
+        current = loader()
+        if current.identity() != original.identity():
+            raise DeliveryError("scope_changed")
+        return current
+
+    def receive(self, payload: Any, *, context_loader: Callable[[], DeliveryContext]) -> dict[str, Any]:
+        package = normalize_package(payload)
+        digest = content_digest(_json_bytes(package))
+        context = context_loader()
+        directory = self._directory(context)
+        self._prepare_directory(directory)
+        lock = directory / "history.json"
+        _safe_path(self.root, directory / ".attempt-history.lock")
+        with student_lab_attempts.report_history_lock(lock, base_dir=self.root):
+            context = self._reload(context_loader, context)
+            old = self._receipt(directory, context, package["attempt_id"])
+            if old is not None:
+                if old["package_digest"] != digest:
+                    raise DeliveryError("conflict")
+                # Recover an acknowledgement after a failed/lost response,
+                # including a previous directory fsync failure.
+                student_lab_attempts.sync_directory(directory)
+                return old
+            now = _utc(self.clock())
+            if now > _utc(context.closes_at):
+                raise DeliveryError("closed")
+            if any(package[key] != value for key, value in context.contract().items()):
+                raise DeliveryError("contract_changed")
+            history = self._history(directory, context)
+            if len(history) >= MAX_ATTEMPTS:
+                raise DeliveryError("limit")
+            receipt = {"schema_version": RECEIPT_SCHEMA, "identity": context.identity(),
+                       "received_at": now.isoformat(), "sequence": len(history) + 1,
+                       "package_digest": digest, "package": package,
+                       "grading_authority": "ungraded"}
+            output = _safe_path(self.root, directory / f"{package['attempt_id']}.json")
+            student_lab_attempts.write_json_exclusive(output, receipt, base_dir=self.root)
+            return receipt
+
+    def _history(self, directory: Path, context: DeliveryContext) -> list[dict[str, Any]]:
+        result = []
+        if not directory.exists():
+            return result
+        for index, path in enumerate(directory.iterdir()):
+            # Lock, final marker, interrupted atomic writes; bounded even if
+            # the controlled storage is unexpectedly populated with junk.
+            if index >= MAX_ATTEMPTS + 16:
+                raise DeliveryError("storage")
+            if path.name.startswith(".") or path.name == "final.json":
+                continue
+            if path.suffix != ".json" or not ATTEMPT_ID.fullmatch(path.stem):
+                raise DeliveryError("storage")
+            receipt = self._receipt(directory, context, path.stem)
+            if receipt is None:
+                raise DeliveryError("storage")
+            # Validate one bounded receipt at a time; do not retain all source
+            # packages in memory while listing or counting the history.
+            result.append(self._summary(receipt))
+            if len(result) > MAX_ATTEMPTS:
+                raise DeliveryError("storage")
+        result.sort(key=lambda item: item["sequence"])
+        if [item["sequence"] for item in result] != list(range(1, len(result) + 1)):
+            raise DeliveryError("storage")
+        return result
+
+    @staticmethod
+    def _summary(receipt: dict[str, Any]) -> dict[str, Any]:
+        return {"attempt_id": receipt["package"]["attempt_id"],
+                "received_at": receipt["received_at"], "sequence": receipt["sequence"],
+                "package_digest": receipt["package_digest"], "grading_authority": "ungraded"}
+
+    def _final(self, directory: Path, context: DeliveryContext) -> dict[str, Any] | None:
+        marker = self._read(directory / "final.json")
+        if marker is None:
+            return None
+        if (marker.keys() != {"schema_version", "attempt_id", "package_digest", "revision"}
+                or marker.get("schema_version") != FINAL_SCHEMA
+                or type(marker.get("revision")) is not int or marker["revision"] < 1):
+            raise DeliveryError("storage")
+        receipt = self._receipt(directory, context, marker["attempt_id"])
+        if receipt is None or receipt["package_digest"] != marker["package_digest"]:
+            raise DeliveryError("storage")
+        return marker
+
+    def history(self, *, context_loader: Callable[[], DeliveryContext]) -> dict[str, Any]:
+        context = context_loader()
+        directory = self._directory(context)
+        self._prepare_directory(directory)
+        _safe_path(self.root, directory / ".attempt-history.lock")
+        with student_lab_attempts.report_history_lock(directory / "history.json", base_dir=self.root):
+            context = self._reload(context_loader, context)
+            receipts = self._history(directory, context)
+            return {"items": receipts,
+                    "final": self._final(directory, context)}
+
+    def read(self, attempt_id: str, *, context_loader: Callable[[], DeliveryContext]) -> dict[str, Any]:
+        context = context_loader()
+        directory = self._directory(context)
+        self._prepare_directory(directory)
+        _safe_path(self.root, directory / ".attempt-history.lock")
+        with student_lab_attempts.report_history_lock(directory / "history.json", base_dir=self.root):
+            context = self._reload(context_loader, context)
+            receipt = self._receipt(directory, context, attempt_id)
+            if receipt is None:
+                raise DeliveryError("missing")
+            return receipt
+
+    def select_final(self, attempt_id: str, *, expected_revision: int,
+                     context_loader: Callable[[], DeliveryContext]) -> dict[str, Any]:
+        _attempt_id(attempt_id)
+        if type(expected_revision) is not int or expected_revision < 0:
+            raise DeliveryError("invalid")
+        context = context_loader()
+        directory = self._directory(context)
+        self._prepare_directory(directory)
+        _safe_path(self.root, directory / ".attempt-history.lock")
+        with student_lab_attempts.report_history_lock(directory / "history.json", base_dir=self.root):
+            context = self._reload(context_loader, context)
+            receipt = self._receipt(directory, context, attempt_id)
+            if receipt is None:
+                raise DeliveryError("missing")
+            old = self._final(directory, context)
+            revision = old["revision"] if old is not None else 0
+            if old and revision == expected_revision + 1 and old["attempt_id"] == attempt_id:
+                student_lab_attempts.sync_directory(directory)
+                return old
+            if revision != expected_revision:
+                raise DeliveryError("conflict")
+            if _utc(self.clock()) > _utc(context.closes_at):
+                raise DeliveryError("closed")
+            if any(receipt["package"][key] != value for key, value in context.contract().items()):
+                raise DeliveryError("contract_changed")
+            marker = {"schema_version": FINAL_SCHEMA, "attempt_id": attempt_id,
+                      "package_digest": receipt["package_digest"], "revision": revision + 1}
+            _safe_path(self.root, directory / "final.json")
+            student_lab_attempts.write_json_atomic(directory / "final.json", marker, base_dir=self.root)
+            return marker

--- a/scripts/student_lab_cli.py
+++ b/scripts/student_lab_cli.py
@@ -24,6 +24,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts import (
+    student_delivery_client,
     student_help_auth,
     student_help_service,
     student_lab_layout,
@@ -39,7 +40,8 @@ PrintFn = Callable[[str], None]
 DEFAULT_SERVER_URL = "http://127.0.0.1:8765"
 _USER_AGENT = "TheBitLab-TUI/1.0"
 HELP_REQUEST_TIMEOUT_SECONDS = 150
-MAX_STUDENT_API_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_STUDENT_API_RESPONSE_BYTES = 12 * 1024 * 1024
+MAX_STUDENT_API_WORKER_BYTES = 17 * 1024 * 1024
 TUI_RENDERERS = {"auto", "legacy", "utui"}
 
 
@@ -1056,6 +1058,11 @@ def select_final_attempt_from_server(
 ) -> dict[str, Any]:
     """Select one final attempt through the authenticated student API."""
 
+    if isinstance(assignment.get("delivery"), dict):
+        return student_delivery_client.request("delivery-final", server_url=server_url,
+            server_token=server_token, allow_insecure_http=allow_insecure_http,
+            payload={"assignment_id": assignment["assignment_id"], "attempt_id": attempt_id,
+                     "expected_revision": assignment["delivery"]["revision"]})
     credential = _MemoryBearer(server_token)
     server_token = ""
     assignment_id = clean_text(assignment.get("assignment_id"), "")
@@ -1219,8 +1226,8 @@ def _run_student_api_worker() -> int:
     raw = None
     outcome = ["error", None]
     try:
-        raw = sys.stdin.buffer.read(65537)
-        if len(raw) > 65536:
+        raw = sys.stdin.buffer.read(MAX_STUDENT_API_WORKER_BYTES + 1)
+        if len(raw) > MAX_STUDENT_API_WORKER_BYTES:
             raise ValueError("specification")
         specification = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_json_object)
         if type(specification) is not dict or set(specification) != {
@@ -1628,6 +1635,10 @@ def load_current_payload(
             now=now,
             allow_insecure_http=allow_insecure_http,
         )
+        if remote_payload.get("delivery_api") is True:
+            return student_delivery_client.enrich_payload(remote_payload, root=root,
+                server_url=server_url, server_token=credential.value,
+                allow_insecure_http=allow_insecure_http)
         try:
             local_payload = load_payload(root, student_id, now)
         except Exception:  # Local paths are an optional operational enhancement.
@@ -1789,6 +1800,9 @@ def run_tui(
                 selected_renderer = "legacy"
             if actual_renderer == "utui":
                 print_fn(render_utui_detail_commands())
+            if assignment.get("delivery"):
+                print_fn("Consegna: i = invia / riprova | n = nuovo invio | t = storico server e definitivo")
+                print_fn("Valutazione docente: Da valutare" if assignment.get("submitted") else "Nessuna consegna ricevuta")
             action = input_fn("\nDettaglio: ").strip().lower()
             if action in {"", "b", "back", "indietro"}:
                 break
@@ -1799,6 +1813,21 @@ def run_tui(
                 continue
             if actual_renderer == "utui" and action in {"k", "up", "su"}:
                 dashboard_offset = max(0, dashboard_offset - 5)
+                continue
+            if action in {"i", "n"} and assignment.get("delivery"):
+                if action == "n" and input_fn("Conservare il tentativo in attesa e inviare i sorgenti attuali? s/N: ").strip().lower() != "s":
+                    continue
+                try:
+                    receipt = student_delivery_client.send_assignment(assignment, root=root,
+                        server_url=server_url, server_token=memory_bearer.value,
+                        allow_insecure_http=allow_insecure_http, new_snapshot=action == "n")
+                    print_fn(f"Consegna ricevuta dal docente: {receipt['attempt_id']}. Da valutare.")
+                    payload = load_current_payload(root=root, student_id=student_id, now=now,
+                        server_url=server_url, server_token=memory_bearer.value,
+                        allow_insecure_http=allow_insecure_http)
+                except (ValueError, OSError) as error:
+                    print_fn(f"Invio o aggiornamento non completato:\n{error}")
+                input_fn("Premi invio per continuare...")
                 continue
             if action == "o":
                 workspace = assignment.get("workspace") if isinstance(assignment.get("workspace"), dict) else {}

--- a/scripts/thebitlab_contracts.py
+++ b/scripts/thebitlab_contracts.py
@@ -247,6 +247,9 @@ def normalize_register_student(payload: dict[str, Any]) -> dict[str, Any]:
     else:
         normalized_submission["final_selected"] = False
         normalized_grading["provisional"] = bool(normalized["submitted"])
+    if normalized_submission.get("report_authority") == "verified_delivery":
+        # Delivery review belongs to the result, independently of attempt selection.
+        normalized_grading["provisional"] = normalized_grading["teacher_grade"] is None
     normalized["submission"] = normalized_submission
     normalized["grading"] = normalized_grading
     normalized["ai_feedback"] = normalize_ai_feedback(ai_feedback)

--- a/scripts/thebitlab_services.py
+++ b/scripts/thebitlab_services.py
@@ -217,6 +217,7 @@ class AssignmentOverviewService:
                         "source_path": submission.get("source_path"),
                         "attempt_id": submission.get("attempt_id"),
                         "report_selection": submission.get("report_selection"),
+                        "report_authority": submission.get("report_authority"),
                         "final_selected": bool(submission.get("final_selected", False)),
                         "grading_provisional": bool(grading.get("provisional", False)),
                         "grading_status": grading.get("status", ""),

--- a/scripts/track_assignments.py
+++ b/scripts/track_assignments.py
@@ -523,6 +523,7 @@ def track_assignments(
     server_root: Path | None = None,
     report_source: thebitlab_tracking_reports.TrackingReportSource | None = None,
     help_subject_aliases: tuple[LegacySubjectAlias, ...] | None = None,
+    student_delivery_enabled: bool = False,
 ) -> dict[str, Any]:
     """Build a teacher-facing tracking index for one activity."""
     activity = create_submission_scaffold.load_activity(activity_path)
@@ -541,6 +542,8 @@ def track_assignments(
     normalized_github_team = clean_metadata(github_team) or clean_metadata(normalized_activity.get("github_team"))
     assignment = None
     same_activity_assignments: list[dict[str, Any]] = []
+    if student_delivery_enabled and (not assignment_id or server_root is None or help_subject_aliases is None):
+        raise ValueError("Il registro consegne richiede un'assegnazione e identita federate.")
     if assignment_id and server_root is None:
         raise ValueError("server_root obbligatorio quando assignment_id e specificato.")
     if assignment_id:
@@ -581,7 +584,7 @@ def track_assignments(
         report = None
         report_selection = None
         remote_report_result = None
-        if assignment_id:
+        if assignment_id and not student_delivery_enabled:
             if report_source is not None:
                 remote_report_result = (
                     thebitlab_tracking_reports.canonical_tracking_report_result(
@@ -631,7 +634,7 @@ def track_assignments(
                         assignment_report_path,
                     )
                     uses_assignment_report = safe_report_path is not None
-        if report is None and report_selection not in {"invalid_final", "remote_error"}:
+        if not student_delivery_enabled and report is None and report_selection not in {"invalid_final", "remote_error"}:
             if safe_report_path is None:
                 safe_report_path = student_identity.confined_regular_file(target.path, report_path)
             report = load_report(safe_report_path) if safe_report_path is not None else None
@@ -689,7 +692,7 @@ def track_assignments(
             and remote_report_result.configured
             and report is not None
         )
-        local_preview_allowed = not remote_report
+        local_preview_allowed = not remote_report and not student_delivery_enabled
         source_file_path = (
             report_source_path(target, report.get("source"))
             if report and local_preview_allowed
@@ -767,6 +770,26 @@ def track_assignments(
                 "report_path": relative_report_path,
             }
         )
+
+    if student_delivery_enabled:
+        from scripts import student_delivery_service, student_delivery_store, student_delivery_grading
+
+        deliveries = student_delivery_store.JsonStudentDeliveryStore(server_root)
+        grading_store = student_delivery_grading.JsonDeliveryGradingStore(server_root)
+        for student in students:
+            subject_id = student.get("help", {}).get("subject_id")
+            if not subject_id:
+                raise ValueError("Identita consegna federata non disponibile.")
+            context = student_delivery_service.archive_context(assignment, subject_id)
+            history = deliveries.history(context_loader=lambda: context)
+            receipt = None
+            if history["items"]:
+                selected = history["final"] or history["items"][-1]
+                receipt = deliveries.read(selected["attempt_id"], context_loader=lambda: context)
+            student_delivery_service.apply_delivery_to_student(
+                student, receipt, history["final"], context, now=normalized_now)
+            if receipt is not None:
+                student_delivery_grading.project(student, receipt, grading_store.lookup(receipt))
 
     result = {
         "activity_id": activity_id,

--- a/tests/fixtures/student_delivery_m04/ORIGIN.md
+++ b/tests/fixtures/student_delivery_m04/ORIGIN.md
@@ -1,0 +1,13 @@
+# Materiali originali M04 per regressioni grading
+
+Copie byte-identiche da `TheBitPoets/python-docente`, revisione
+`1bc6d712c9e44d482846cc3c290b66e979c24905`, directory
+`activities/python/py2-activity-b-input-somma-001/`.
+
+I quattro file originali sono `activity.json`, `starter/main.py`,
+`student/GUIDA.md` e `teacher/README.md`. SHA-256 e Git blob verificati prima
+della copia; i test fissano i quattro SHA-256. Questa directory è una fixture
+docente per i test, non un pacchetto da distribuire agli studenti.
+
+Policy e contratto: `scripts/student_delivery_policies.py` e
+`doc/architecture/student-delivery-grading.md`.

--- a/tests/fixtures/student_delivery_m04/activity.json
+++ b/tests/fixtures/student_delivery_m04/activity.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "id": "py2-activity-b-input-somma-001",
+  "title": "Completa la somma",
+  "titolo": "Completa la somma",
+  "kind": "laboratorio",
+  "tipo": "laboratorio",
+  "language": "python",
+  "linguaggio": "python",
+  "source_name": "main.py",
+  "difficulty": "B",
+  "difficolta": "B",
+  "topics": [
+    "input-output",
+    "variabili",
+    "conversione-tipi",
+    "operatori-aritmetici"
+  ],
+  "argomenti": [
+    "input-output",
+    "variabili",
+    "conversione-tipi",
+    "operatori-aritmetici"
+  ],
+  "instructions": "Completa il programma starter: legge due numeri interi, uno per riga, e deve stampare soltanto la loro somma.",
+  "consegna": "Completa il programma starter: legge due numeri interi, uno per riga, e deve stampare soltanto la loro somma.",
+  "student_support_mode": "feedback-tecnico",
+  "grading_policy": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": false
+  },
+  "correzione": {
+    "compila": true,
+    "test": true,
+    "sandbox": true,
+    "ai_feedback": false
+  },
+  "metriche": {
+    "tempo_stimato_minuti": 15,
+    "traccia_tempo_dichiarato": true,
+    "traccia_sessioni_thebitlab": true,
+    "traccia_eventi_didattici": true,
+    "traccia_errori_compilazione": true
+  },
+  "test_cases": [
+    {
+      "name": "positivi",
+      "stdin": "2\n3\n",
+      "expected_stdout": "5\n"
+    },
+    {
+      "name": "zeri",
+      "stdin": "0\n0\n",
+      "expected_stdout": "0\n"
+    },
+    {
+      "name": "negativo e positivo",
+      "stdin": "-4\n10\n",
+      "expected_stdout": "6\n"
+    }
+  ],
+  "source_refs": [
+    {
+      "source_id": "python-course-content",
+      "href": "content/python/04_INTERPRETE_REPL_VALORI_IO.md#m04-interprete-repl-script-valori-e-inputoutput"
+    },
+    {
+      "source_id": "python-secondo-design",
+      "href": "tracks/secondo/PY2_02_SPEC.md#activity-candidate"
+    }
+  ],
+  "assets": [
+    {
+      "type": "starter",
+      "path": "starter/main.py",
+      "target_path": "main.py",
+      "visibility": "student",
+      "description": "Programma incompleto da correggere"
+    },
+    {
+      "type": "fixture",
+      "path": "student/GUIDA.md",
+      "target_path": "GUIDA.md",
+      "visibility": "student",
+      "description": "Guida breve allo svolgimento"
+    },
+    {
+      "type": "teacher_only",
+      "path": "teacher/README.md",
+      "visibility": "teacher",
+      "description": "Note docente e criteri del vertical slice"
+    }
+  ],
+  "contesto": {
+    "percorso": "python-secondo-2026-2027",
+    "uda": "py2-02"
+  }
+}

--- a/tests/fixtures/student_delivery_m04/starter/main.py
+++ b/tests/fixtures/student_delivery_m04/starter/main.py
@@ -1,0 +1,9 @@
+# Leggi due numeri interi, uno per riga.
+primo = int(input())
+secondo = int(input())
+
+# TODO: sostituisci il valore qui sotto con il calcolo corretto.
+risultato = 0
+
+# Non aggiungere altri messaggi: stampa soltanto il risultato.
+print(risultato)

--- a/tests/fixtures/student_delivery_m04/student/GUIDA.md
+++ b/tests/fixtures/student_delivery_m04/student/GUIDA.md
@@ -1,0 +1,70 @@
+# Activity B — Completa la somma
+
+## Obiettivo
+
+Completa un piccolo programma Python già iniziato.
+
+Il programma deve:
+
+1. leggere un primo numero intero;
+2. leggere un secondo numero intero;
+3. calcolare la loro somma;
+4. stampare **soltanto** il risultato.
+
+## Cosa trovi già pronto
+
+Nel file `main.py` sono già presenti:
+
+- i due `input()`;
+- la conversione con `int()`;
+- la stampa finale.
+
+Devi modificare il calcolo di `risultato`.
+
+## Prima di modificare
+
+Per questi input:
+
+```text
+2
+3
+```
+
+scrivi su carta quale output ti aspetti.
+
+Ripeti mentalmente con:
+
+```text
+-4
+10
+```
+
+## Regola importante
+
+Non aggiungere messaggi come:
+
+```text
+Inserisci il primo numero:
+```
+
+In questa Activity il contratto di output richiede soltanto il valore numerico finale.
+
+## Se il test fallisce
+
+Controlla nell'ordine:
+
+1. hai salvato `main.py`?
+2. stai sommando `primo` e `secondo`?
+3. hai lasciato i due `int(input())`?
+4. stai stampando `risultato`?
+5. hai aggiunto testo extra nell'output?
+
+Non cambiare più righe del necessario.
+
+## Quando hai finito
+
+Devi saper spiegare a voce:
+
+- perché `input()` viene convertito con `int()`;
+- quale riga esegue il calcolo;
+- perché il test prova più di una coppia di numeri.

--- a/tests/fixtures/student_delivery_m04/teacher/README.md
+++ b/tests/fixtures/student_delivery_m04/teacher/README.md
@@ -1,0 +1,88 @@
+# Note docente — py2-activity-b-input-somma-001
+
+## Ruolo didattico
+
+Prima Activity Python autogradata del track di seconda.
+
+Non misura problem solving complesso. Serve a consolidare:
+
+- `input()`;
+- `int()`;
+- variabili;
+- operatore `+`;
+- `print()`;
+- lettura del report TheBitLab;
+- disciplina sul contratto di input/output.
+
+## Perché difficoltà B
+
+Lo studente non scrive il programma da zero. Riceve uno starter corretto nella struttura e modifica soltanto il calcolo di `risultato`.
+
+Questo riduce il carico cognitivo mentre viene introdotto il workflow TheBitLab.
+
+## Test deterministici
+
+I tre casi coprono:
+
+1. numeri positivi;
+2. zeri;
+3. numero negativo + positivo.
+
+Il test non deve essere presentato come prova esaustiva della correttezza di qualsiasi programma: è una prima introduzione al concetto di casi differenti.
+
+## Domande diagnostiche
+
+Dopo la consegna chiedere a campione:
+
+- Che tipo restituisce `input()`?
+- Perché qui usiamo `int()`?
+- Cosa accadrebbe con `"2" + "3"`?
+- Perché il test non usa soltanto `2` e `3`?
+- Perché non aggiungiamo `Inserisci un numero:` all'output?
+
+## Misconception attese
+
+- lasciare `risultato = 0`;
+- scrivere `primo + secondo` senza assegnarlo o stamparlo;
+- concatenare stringhe rimuovendo `int()`;
+- aggiungere output extra;
+- modificare righe non necessarie;
+- pensare che un singolo test positivo sia sufficiente.
+
+## Grading boundary
+
+Autograde:
+
+- processo termina;
+- output corrisponde ai casi previsti.
+
+Manuale/formativo:
+
+- capacità di spiegare la conversione;
+- comprensione del flusso dati;
+- capacità di leggere un errore;
+- qualità della modifica minima.
+
+## AI policy
+
+`ai_feedback=false`.
+
+Questa Activity appartiene ai fondamenti e non prevede generazione AI della soluzione.
+
+## Vertical slice tecnico
+
+Prima di usare questa Activity come modello per la produzione massiva verificare end-to-end:
+
+```text
+validate Activity
+→ create scaffold
+→ student bundle senza test/solution/teacher leakage
+→ main.py modificato
+→ Python runner
+→ Docker sandbox
+→ 3 test
+→ report
+→ tentativo/persistenza/dashboard secondo contratto TheBitLab
+```
+
+Un PASS del JSON/schema da solo non equivale a certificazione del vertical slice.

--- a/tests/test_assignment_dashboard_frontend.py
+++ b/tests/test_assignment_dashboard_frontend.py
@@ -397,6 +397,8 @@ const assignmentStepNames = ["activity", "ai", "review", "targets", "dates", "pr
         reportSelectionState,
         reportSelectionBadge,
         reportSelectionCompactBadge,
+        gradeReviewBadge,
+        renderOverview,
         aiFeedbackState,
         aiFeedbackDetails,
         aiFeedbackReviewDetails,
@@ -614,6 +616,61 @@ def test_report_selection_badges_distinguish_final_provisional_and_invalid() -> 
         assert.match(compactInvalid, />ERR</);
         assert.match(compactInvalid, /tabindex="0"/);
         assert.match(compactInvalid, /aria-label="Finale non valido[.]/);
+        """
+    )
+
+
+def test_delivery_attempt_and_grade_review_are_separate_in_all_teacher_views() -> None:
+    run_dashboard_js(
+        """
+        for (const selection of ["final", "latest"]) {
+          // Include confirmation at zero and revocation after confirmation.
+          for (const teacherGrade of [null, 8, 0, null]) {
+            const provisional = teacherGrade === null;
+            const student = {
+              student: "student-one", submitted: true, status: "submitted_on_time",
+              submission: { report_authority: "verified_delivery", report_selection: selection,
+                final_selected: selection === "final" },
+              grading: { status: "graded_passed", score: 10, teacher_grade: teacherGrade, provisional },
+            };
+            const row = {
+              student: student.student, submitted: true, status: student.status,
+              activity_id: "demo", report_name: "demo.json", ...student.submission,
+              grading_status: "graded_passed", grading_provisional: provisional,
+              score: 10, teacher_grade: teacherGrade,
+            };
+            const attemptLabel = selection === "final" ? "Tentativo definitivo" : "Ultimo tentativo";
+            const gradeLabel = provisional ? "Voto da revisionare" : "Voto confermato";
+            for (const value of [student, row]) {
+              assert.equal(tested.reportSelectionState(value).label, attemptLabel);
+              const badge = tested.gradeReviewBadge(value);
+              assert.ok(badge.includes(gradeLabel));
+              assert.match(badge, provisional ? /badgeWarn/ : /badgeOk/);
+              assert.match(badge, /tabindex="0"/);
+            }
+            tested.state.report = { activity_id: "demo", students: [student] };
+            tested.els.studentsBody.children = [];
+            tested.renderStudents([student]);
+            const register = tested.els.studentsBody.children[0].innerHTML;
+            assert.ok(register.includes(attemptLabel));
+            assert.match(register, new RegExp(`<code>${teacherGrade ?? 10}</code>.*${gradeLabel}`));
+
+            tested.state.overviewRows = [row];
+            tested.els.overviewBody.children = [];
+            tested.els.overviewMatrixBody.children = [];
+            tested.renderOverview();
+            const table = tested.els.overviewBody.children[0].innerHTML;
+            const matrix = tested.els.overviewMatrixBody.children[0].innerHTML;
+            assert.ok(table.includes(attemptLabel));
+            assert.match(table, new RegExp(`<code>${teacherGrade ?? 10}</code>.*${gradeLabel}`));
+            assert.ok(matrix.includes(attemptLabel));
+            assert.ok(matrix.includes(gradeLabel));
+            assert.match(matrix, provisional ? />REV</ : />CONF</);
+          }
+        }
+        for (const authority of [undefined, "ungraded", "verified_remote"]) {
+          assert.equal(tested.gradeReviewBadge({ report_authority: authority, score: 10 }), "");
+        }
         """
     )
 

--- a/tests/test_course_board_server.py
+++ b/tests/test_course_board_server.py
@@ -3786,7 +3786,8 @@ def test_delete_activity_record_rejects_non_draft_activity(tmp_path, monkeypatch
     assert activity_path.exists()
 
 
-def test_generate_assignment_report_preserves_assignment_id(tmp_path, monkeypatch) -> None:
+@pytest.mark.parametrize("help_subject_aliases", [None, ()])
+def test_generate_assignment_report_preserves_assignment_id(tmp_path, monkeypatch, help_subject_aliases) -> None:
     monkeypatch.setattr(course_board_server, "ROOT", tmp_path)
     monkeypatch.setattr(course_board_server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
     monkeypatch.setattr(course_board_server, "TEACHER_ASSIGNMENTS_DIR", tmp_path / "teacher-assignments")
@@ -3830,7 +3831,8 @@ def test_generate_assignment_report_preserves_assignment_id(tmp_path, monkeypatc
             target_type="student",
             assigned_at="2026-10-12T09:00:00+02:00",
             due_at="2026-10-19T23:59:00+02:00",
-            targets=[{"student_id": "rossi-mario", "path": str(student_repo)}],
+            targets=[{"student_id": "rossi-mario", "path": str(student_repo),
+                      "subject_id": "subject:11111111111111111111111111111111"}],
         )
     )
 
@@ -3845,9 +3847,10 @@ def test_generate_assignment_report_preserves_assignment_id(tmp_path, monkeypatc
         "now": "2026-10-20T08:00:00+02:00",
         "targets_text": str(student_repo),
         "assignment_id": "assignment-python-base-somma-001-3a",
-    })
+    }, help_subject_aliases=help_subject_aliases)
 
     assert result["report"]["assignment_id"] == "assignment-python-base-somma-001-3a"
+    assert result["report"]["students"][0]["submitted"] is False
     saved_payload = json.loads((tmp_path / "teacher-reports" / "demo" / "report.json").read_text(encoding="utf-8"))
     assert saved_payload["assignment_id"] == "assignment-python-base-somma-001-3a"
 

--- a/tests/test_student_delivery_client.py
+++ b/tests/test_student_delivery_client.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import student_delivery_client as client
+from scripts import student_delivery_service as service
+from scripts import student_delivery_store as store
+
+
+def manifest():
+    return {"schema_version": service.MANIFEST_SCHEMA, "workspace_id": "a" * 64,
+            "assignment_id": "assignment-one", "activity_id": "activity-one",
+            "activity_digest": "b" * 64, "tests_digest": "c" * 64,
+            "closes_at": "2030-01-01T00:00:00+00:00",
+            "activity": {"id": "activity-one", "source_name": "main.py", "language": "python"},
+            "files": [service.file_entry("main.py", b"print(42)\n")]}
+
+
+def assignment(root):
+    description = manifest()
+    paths = client.prepare_workspace(root, "http://localhost:8765", description)
+    return {"assignment_id": "assignment-one", "activity_id": "activity-one", **paths,
+            "delivery": {key: description[key] for key in ("workspace_id", "activity_digest", "tests_digest")}}
+
+
+def test_workspace_preserves_edits_and_partitions_contract_server_owner(tmp_path):
+    description = manifest()
+    paths = client.prepare_workspace(tmp_path, "http://localhost:8765", description)
+    source = Path(paths["workspace"]["path"]) / "main.py"
+    source.write_bytes(b"student's work")
+    assert client.prepare_workspace(tmp_path, "http://localhost:8765", description) == paths
+    assert source.read_bytes() == b"student's work"
+    for origin, changed in (("http://localhost:8766", description),
+                            ("http://localhost:8765", {**description, "workspace_id": "d" * 64}),
+                            ("http://localhost:8765", {**description, "activity_digest": "e" * 64})):
+        other = client.prepare_workspace(tmp_path, origin, changed)
+        assert other["workspace"]["path"] != paths["workspace"]["path"]
+        assert (Path(other["workspace"]["path"]) / "main.py").read_bytes() == b"print(42)\n"
+
+
+@pytest.mark.parametrize("path", ["../secret", "C:/secret", "file:stream", "CON.txt"])
+def test_untrusted_download_paths_rejected_before_writes(tmp_path, path):
+    description = {**manifest(), "files": [service.file_entry(path, b"secret")]}
+    with pytest.raises(store.DeliveryError):
+        client.prepare_workspace(tmp_path, "http://localhost:8765", description)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_snapshot_excludes_metadata_hidden_and_generated_files_and_enforces_limits(tmp_path):
+    current = assignment(tmp_path)
+    workspace = Path(current["workspace"]["path"])
+    (workspace / ".env").write_bytes(b"credential")
+    (workspace / "__pycache__").mkdir()
+    (workspace / "__pycache__" / "code.pyc").write_bytes(b"compiled")
+    package = client.snapshot_package(current, tmp_path)
+    assert [entry["path"] for entry in package["files"]] == ["main.py"]
+    (workspace / "large.bin").write_bytes(b"x" * (store.MAX_FILE_BYTES + 1))
+    with pytest.raises(store.DeliveryError, match="limit"):
+        client.snapshot_package(current, tmp_path)
+
+
+def test_bad_ack_keeps_original_outbox_after_source_edit(tmp_path, monkeypatch):
+    current = assignment(tmp_path)
+    source = Path(current["workspace"]["path"]) / "main.py"
+    calls = []
+    def transport(route, **kwargs):
+        package = kwargs["payload"]["package"]
+        calls.append(package)
+        return {"attempt_id": package["attempt_id"], "package_digest": "f" * 64,
+                "grading_authority": "ungraded"}
+    monkeypatch.setattr(client, "request", transport)
+    for content in (b"first", b"second"):
+        source.write_bytes(content)
+        with pytest.raises(store.DeliveryError, match="invalid"):
+            client.send_assignment(current, root=tmp_path, server_url="http://localhost:8765",
+                                   server_token="do-not-persist", allow_insecure_http=True)
+    assert calls[0] == calls[1]
+    outbox = next(tmp_path.rglob("outbox.json")).read_text()
+    assert "do-not-persist" not in outbox and json.loads(outbox)["receipt"] is None
+
+
+def test_failure_to_persist_outbox_prevents_network_send(tmp_path, monkeypatch):
+    current = assignment(tmp_path)
+    def fail(*args, **kwargs):
+        raise OSError("disk unavailable")
+    def unexpected(*args, **kwargs):
+        pytest.fail("network called before durable outbox")
+    monkeypatch.setattr(client.attempts, "write_json_atomic", fail)
+    monkeypatch.setattr(client, "request", unexpected)
+    with pytest.raises(OSError):
+        client.send_assignment(current, root=tmp_path, server_url="http://localhost:8765",
+                               server_token="do-not-persist", allow_insecure_http=True)
+
+
+def test_explicit_new_snapshot_preserves_rejected_pending_package(tmp_path, monkeypatch):
+    current = assignment(tmp_path)
+    calls = []
+    def reject(route, **kwargs):
+        calls.append(kwargs["payload"]["package"])
+        raise ValueError("contract changed")
+    monkeypatch.setattr(client, "request", reject)
+    for fresh in (False, True):
+        (Path(current["workspace"]["path"]) / "main.py").write_bytes(str(fresh).encode())
+        with pytest.raises(ValueError, match="contract changed"):
+            client.send_assignment(current, root=tmp_path, server_url="http://localhost:8765",
+                                   server_token="do-not-persist", allow_insecure_http=True,
+                                   new_snapshot=fresh)
+    assert calls[0]["attempt_id"] != calls[1]["attempt_id"]
+    archived = list(tmp_path.rglob("outbox-attempt-*.json"))
+    assert len(archived) == 1
+    assert json.loads(archived[0].read_text())["package"] == calls[0]
+    assert json.loads(next(tmp_path.rglob("outbox.json")).read_text())["package"] == calls[1]
+
+
+def test_teacher_feedback_is_preserved_only_for_same_received_snapshot():
+    from copy import deepcopy
+    from scripts import course_board_server
+
+    previous = {"activity_id": "activity-one", "assignment_id": "assignment-one",
+        "students": [{"student_id": "one", "student": "One",
+        "submission": {"delivery": {"package_digest": "a" * 64}},
+        "ai_feedback": {"status": "approved", "feedback": "Previous snapshot"}}]}
+    generated = deepcopy(previous)
+    generated["students"][0]["ai_feedback"] = {"status": "not_generated"}
+    same = course_board_server.preserve_assignment_ai_feedback(previous, deepcopy(generated))
+    assert same["students"][0]["ai_feedback"]["status"] == "approved"
+    generated["students"][0]["submission"]["delivery"]["package_digest"] = "b" * 64
+    changed = course_board_server.preserve_assignment_ai_feedback(previous, generated)
+    assert changed["students"][0]["ai_feedback"]["status"] == "not_generated"
+
+
+@pytest.mark.parametrize("corrupt", [False, True])
+def test_local_report_cannot_create_delivery_or_teacher_grade(tmp_path, monkeypatch, corrupt):
+    current = assignment(tmp_path)
+    report = Path(current["report"]["path"])
+    report.parent.mkdir(parents=True)
+    report.write_text("invalid" if corrupt else json.dumps({
+        "assignment_id": "assignment-one", "activity_id": "activity-one",
+        "score": 100, "teacher_grade": 10, "passed": True, "status": "passed",
+        "backend": "local", "tests": [{"name": "local-only", "passed": True}]}))
+    monkeypatch.setattr(client, "request", lambda route, **kwargs: manifest() if route == "delivery-manifest"
+                        else {"items": [], "final": None, "status": "pending"})
+    payload = client.enrich_payload({"assignments": [current]}, root=tmp_path,
+        server_url="http://localhost:8765", server_token="memory-only", allow_insecure_http=True)
+    result = payload["assignments"][0]
+    assert result["submitted"] is False and result["status"] == "pending"
+    assert result["grading"]["teacher_grade"] is None and result["grading"]["score"] is None
+    assert result["attempts"]["items"] == []
+    assert result["runner"]["status"] == ("error" if corrupt else "passed")

--- a/tests/test_student_delivery_grading.py
+++ b/tests/test_student_delivery_grading.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+import json
+import os
+import subprocess
+
+import pytest
+
+from scripts import student_delivery_grading as grading
+from scripts import student_delivery_service as service
+from scripts import student_delivery_store as delivery
+
+
+FIRST = "attempt-20260909T120000000000Z-11111111"
+SECOND = "attempt-20260909T120000000000Z-22222222"
+SUBJECT = "subject:11111111111111111111111111111111"
+
+
+class Producer:
+    provenance = {"producer": grading.PRODUCER, "image": "test-only", "comparator_digest": "a" * 64}
+
+    def __init__(self, callback=None):
+        self.calls = []
+        self.callback = callback
+
+    def run(self, receipt, revision):
+        self.calls.append((deepcopy(receipt), deepcopy(revision)))
+        if self.callback:
+            return self.callback(receipt, revision)
+        return {"tests_passed": 1, "tests_total": 1}
+
+
+@pytest.fixture
+def setup(tmp_path):
+    activity = {"schema_version": "1.0", "id": "python-snapshot", "title": "Snapshot",
+        "kind": "laboratorio", "difficulty": "B", "topics": ["python"],
+        "language": "python", "source_name": "main.py", "instructions": "Print 42",
+        "test_cases": [{"name": "private case", "stdin": "", "expected_stdout": "42\n",
+                        "visibility": "teacher"}]}
+    (tmp_path / "activity.json").write_text(json.dumps(activity), encoding="utf-8")
+    assignment = {"id": "assignment-one", "class_id": "class-one", "activity_id": activity["id"],
+                  "activity_path": "activity.json",
+                  "due_at": (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()}
+    contract = service.teacher_contract(tmp_path, assignment)
+    context = service.delivery_context(assignment, SUBJECT, contract)
+    store = grading.JsonDeliveryGradingStore(tmp_path)
+    store.archive_contract(contract)
+    package = {"schema_version": delivery.PACKAGE_SCHEMA, "attempt_id": FIRST, **context.contract(),
+               "files": [service.file_entry("main.py", b"print(42)\n")]}
+    receipt = store.receive(package, context_loader=lambda: context)
+    return store, context, contract, receipt
+
+
+def row_for(store, context, receipt, final=None):
+    row = {"due_at": context.closes_at.isoformat()}
+    service.apply_delivery_to_student(row, receipt, final, context)
+    grading.project(row, receipt, store.lookup(receipt))
+    return row
+
+
+def test_snapshot_and_original_contract_survive_changes_restart_and_retry(setup):
+    store, context, contract, receipt = setup
+    (store.root / "main.py").write_text("print(999)", encoding="utf-8")
+    (store.root / "activity.json").write_text("{}", encoding="utf-8")
+    producer = Producer()
+    result = store.grade(FIRST, context_loader=lambda: context, producer=producer)
+    assert result["state"] == "succeeded"
+    assert producer.calls == [(receipt, contract["revision"])]
+    restarted = grading.JsonDeliveryGradingStore(store.root)
+    assert restarted.grade(FIRST, context_loader=lambda: context, producer=producer) == result
+    assert len(producer.calls) == 1
+    assert restarted.read(FIRST, context_loader=lambda: context) == receipt
+    row = row_for(restarted, context, receipt)
+    assert row["grading"]["score"] == 10
+    assert row["grading"]["provisional"] is True
+    assert row["grading"]["teacher_grade"] is None
+    assert row["submission"]["report_authority"] == "verified_delivery"
+    assert "private case" not in json.dumps(row)
+
+
+@pytest.mark.parametrize("select_final", [False, True])
+@pytest.mark.parametrize("teacher_grade", [0, 8])
+def test_teacher_review_is_bound_to_result_and_separate_from_final(setup, select_final, teacher_grade):
+    from scripts.thebitlab_services import AssignmentOverviewService
+    from scripts.thebitlab_storage import JsonAssignmentStorage
+
+    store, context, _, receipt = setup
+    result = store.grade(FIRST, context_loader=lambda: context, producer=Producer())["result"]
+    final = store.select_final(FIRST, expected_revision=0, context_loader=lambda: context) if select_final else None
+
+    def check(expected_grade):
+        row = row_for(store, context, receipt, final)
+        assert row["grading"]["provisional"] is (expected_grade is None)
+        assert row["grading"]["teacher_grade"] == expected_grade
+        storage = JsonAssignmentStorage(store.root, store.root / "teacher-reports", [])
+        storage.write_assignment_report("delivery.json", {"students": [row]})
+        saved = storage.read_assignment_report("delivery.json")["students"][0]
+        assert saved["grading"]["provisional"] is (expected_grade is None)
+        assert saved["grading"]["teacher_grade"] == expected_grade
+        overview = AssignmentOverviewService(storage).assignment_overview()[0]
+        assert overview["report_authority"] == "verified_delivery"
+        assert overview["report_selection"] == ("final" if select_final else "latest")
+        assert overview["final_selected"] is select_final
+        assert overview["grading_provisional"] is (expected_grade is None)
+        assert overview["teacher_grade"] == expected_grade
+        assert overview["score"] == 10
+
+    check(None)
+    with pytest.raises(delivery.DeliveryError, match="conflict"):
+        store.review(FIRST, context_loader=lambda: context, result_digest="b" * 64, teacher_grade=8)
+    store.review(FIRST, context_loader=lambda: context, result_digest=grading.digest(result), teacher_grade=teacher_grade)
+    check(teacher_grade)
+    store.review(FIRST, context_loader=lambda: context, result_digest=grading.digest(result), teacher_grade=None)
+    check(None)
+
+
+def test_selecting_b_while_a_runs_does_not_transfer_grade(setup):
+    store, context, _, first = setup
+    package = deepcopy(first["package"])
+    package["attempt_id"] = SECOND
+    package["files"] = [service.file_entry("main.py", b"print(0)\n")]
+    second = store.receive(package, context_loader=lambda: context)
+
+    def run(*args):
+        store.select_final(SECOND, expected_revision=0, context_loader=lambda: context)
+        return {"tests_passed": 1, "tests_total": 1}
+
+    store.grade(FIRST, context_loader=lambda: context, producer=Producer(run))
+    history = store.history(context_loader=lambda: context)
+    row = row_for(store, context, second, history["final"])
+    assert row["grading"]["status"] == "not_graded"
+    assert row["grading"]["score"] is None
+    assert store.lookup(first)["state"] == "succeeded"
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        grading.project(row, second, store.lookup(first))
+
+
+@pytest.mark.parametrize("field", ["identity", "attempt_id", "package_digest", "activity_digest", "tests_digest"])
+def test_wrong_binding_in_private_result_fails_closed(setup, field):
+    store, context, _, receipt = setup
+    store.grade(FIRST, context_loader=lambda: context, producer=Producer())
+    path = store._grading_directory(receipt["identity"]) / f"{FIRST}.result.json"
+    result = json.loads(path.read_text())
+    result["binding"][field] = "different"
+    path.write_text(json.dumps(result))
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        store.lookup(receipt)
+
+
+def test_report_from_client_cannot_be_used_as_result(setup):
+    store, context, _, receipt = setup
+    path = store._grading_directory(receipt["identity"])
+    path.mkdir(parents=True)
+    (path / f"{FIRST}.result.json").write_text(json.dumps({"passed": True, "score": 10,
+        "binding": grading.binding(receipt), "provenance": {"producer": grading.PRODUCER}}))
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        store.lookup(receipt)
+
+
+def test_missing_contract_does_not_use_new_tests(setup):
+    store, context, contract, receipt = setup
+    path = store._grading_directory() / f"{context.activity_digest}.json"
+    path.unlink()
+    activity = deepcopy(contract["activity"])
+    activity["test_cases"][0]["expected_stdout"] = "999"
+    (store.root / "activity.json").write_text(json.dumps(activity))
+    changed = service.teacher_contract(store.root, contract["revision"]["assignment"])
+    store.archive_contract(changed)
+    producer = Producer()
+    assert store.grade(FIRST, context_loader=lambda: context, producer=producer) == {
+        "state": "error", "error": "contract_unavailable"}
+    assert producer.calls == []
+    assert row_for(store, context, receipt)["grading"]["score"] is None
+    # Exact historical material can be recovered, independent of current files.
+    store.archive_contract(contract)
+    assert store.grade(FIRST, context_loader=lambda: context, producer=producer)["state"] == "succeeded"
+
+
+def test_corrupted_revision_is_not_graded(setup):
+    store, context, _, _ = setup
+    path = store._grading_directory() / f"{context.activity_digest}.json"
+    record = json.loads(path.read_text())
+    record["revision"]["activity"]["test_cases"][0]["expected_stdout"] = "999"
+    path.write_text(json.dumps(record))
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        store.grade(FIRST, context_loader=lambda: context, producer=Producer())
+
+
+def test_producer_error_and_interrupted_job_retry_without_zero_grade(setup):
+    store, context, _, receipt = setup
+
+    def fail(*args):
+        raise subprocess.TimeoutExpired("docker", 1)
+
+    result = store.grade(FIRST, context_loader=lambda: context, producer=Producer(fail))
+    assert result == {"state": "error", "error": "producer_error"}
+    assert row_for(store, context, receipt)["grading"]["score"] is None
+    directory = store._grading_directory(receipt["identity"])
+    store._write(directory / f"{FIRST}.state.json", {"binding": grading.binding(receipt), "state": "running"})
+    assert store.lookup(receipt) == {"state": "error", "error": "interrupted"}
+    restarted = grading.JsonDeliveryGradingStore(store.root)
+    assert restarted.grade(FIRST, context_loader=lambda: context, producer=Producer())["state"] == "succeeded"
+    assert restarted.read(FIRST, context_loader=lambda: context) == receipt
+
+
+def test_lost_result_ack_reuses_published_result(setup, monkeypatch):
+    store, context, _, receipt = setup
+    original = store._write
+
+    def write(path, record, **kwargs):
+        original(path, record, **kwargs)
+        if path.name.endswith(".result.json"):
+            raise OSError("simulated fsync failure after publication")
+
+    monkeypatch.setattr(store, "_write", write)
+    producer = Producer()
+    with pytest.raises(OSError):
+        store.grade(FIRST, context_loader=lambda: context, producer=producer)
+    restarted = grading.JsonDeliveryGradingStore(store.root)
+    assert restarted.grade(FIRST, context_loader=lambda: context, producer=producer)["state"] == "succeeded"
+    assert len(producer.calls) == 1
+    assert restarted.read(FIRST, context_loader=lambda: context) == receipt
+
+
+def test_concurrent_retries_run_only_one_producer(setup):
+    store, context, _, receipt = setup
+    producer = Producer()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(store.grade, FIRST, context_loader=lambda: context, producer=producer)
+                   for _ in range(2)]
+        results = [future.result(timeout=10) for future in futures]
+    assert results[0] == results[1]
+    assert len(producer.calls) == 1
+    assert store.read(FIRST, context_loader=lambda: context) == receipt
+
+
+@pytest.mark.parametrize("summary", [
+    {"tests_passed": True, "tests_total": 1},
+    {"tests_passed": 2, "tests_total": 2},
+    {"tests_passed": 0, "tests_total": 0},
+])
+def test_invalid_producer_summary_never_assigns_a_grade(setup, summary):
+    store, context, _, receipt = setup
+    result = store.grade(FIRST, context_loader=lambda: context, producer=Producer(lambda *args: summary))
+    assert result == {"state": "error", "error": "producer_error"}
+    assert row_for(store, context, receipt)["grading"]["score"] is None
+
+
+def test_zero_is_a_completed_evaluation_not_a_producer_error(setup):
+    store, context, _, receipt = setup
+    result = store.grade(FIRST, context_loader=lambda: context,
+                         producer=Producer(lambda *args: {"tests_passed": 0, "tests_total": 1}))
+    assert result["state"] == "succeeded"
+    row = row_for(store, context, receipt)
+    assert row["grading"]["score"] == 0
+    assert row["grading"]["status"] == "graded_failed"
+
+
+@pytest.mark.parametrize("change", ["extra_source", "profile", "assets", "no_tests"])
+def test_unsupported_profiles_never_run_a_subset(setup, change):
+    _, _, contract, receipt = setup
+    if change == "extra_source":
+        receipt["package"]["files"].append(service.file_entry("helper.py", b""))
+    elif change == "profile":
+        contract["revision"]["activity"]["function_tests"] = []
+    elif change == "assets":
+        contract["revision"]["activity"]["assets"] = [{"path": "extra.txt"}]
+    else:
+        contract["revision"]["activity"]["test_cases"] = []
+    with pytest.raises(delivery.DeliveryError, match="unsupported_profile"):
+        grading.profile(receipt, contract["revision"])
+
+
+def test_runtime_with_stdio_tests_is_rejected_before_job_or_producer(setup, monkeypatch):
+    from scripts import thebitlab_runtime_contracts as runtime
+
+    store, _, contract, original = setup
+    activity = deepcopy(contract["activity"])
+    activity["extensions"] = {runtime.RUNTIME_EXTENSION_KEY: {
+        "schema_version": "runtime_activity.v1", "runtime_id": "example-runtime",
+        "submission": {"artifacts": [{"id": "answer", "path": "main.py"}]},
+    }}
+    assert runtime.validate_runtime_extension(activity) == []
+    assert runtime.normalize_runtime_extension(activity) is not None
+    (store.root / "activity.json").write_text(json.dumps(activity), encoding="utf-8")
+    contract = service.teacher_contract(store.root, contract["revision"]["assignment"])
+    context = service.delivery_context(contract["revision"]["assignment"], SUBJECT, contract)
+    store.archive_contract(contract)
+    package = {**original["package"], **context.contract(), "attempt_id": SECOND}
+    receipt = store.receive(package, context_loader=lambda: context)
+    producer = Producer()
+
+    def unexpected_producer():
+        pytest.fail("Unsupported runtime must be rejected before constructing a producer")
+
+    monkeypatch.setattr(grading, "DockerSnapshotProducer", unexpected_producer)
+    for injected in (producer, None):
+        assert store.grade(SECOND, context_loader=lambda: context, producer=injected) == {
+            "state": "error", "error": "unsupported_profile"}
+    assert producer.calls == []
+    directory = store._grading_directory(receipt["identity"])
+    assert not (directory / f"{SECOND}.job.json").exists()
+    assert not (directory / f"{SECOND}.result.json").exists()
+    row = row_for(store, context, receipt)
+    assert row["grading"]["score"] is None
+    assert row["grading"]["report_status"] == "unsupported_profile"
+    assert row["submission"]["report_authority"] == "ungraded"
+
+
+def test_private_asset_bytes_are_preserved_and_checked(setup):
+    store, _, contract, _ = setup
+    activity = contract["activity"]
+    activity["assets"] = [{"path": "secret.txt", "role": "test", "visibility": "teacher"}]
+    (store.root / "activity.json").write_text(json.dumps(activity))
+    (store.root / "secret.txt").write_bytes(b"private teacher fixture")
+    private = service.teacher_contract(store.root, contract["revision"]["assignment"])
+    store.archive_contract(private)
+    archived = store._read(store._grading_directory() / f"{private['activity_digest']}.json")
+    assert archived["revision"]["assets"] == [service.file_entry("secret.txt", b"private teacher fixture")]
+    archived["revision"]["assets"][0]["content_base64"] = "eA=="
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        grading.revision_digests(archived["revision"])
+
+
+@pytest.mark.skipif(os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1", reason="requires real Docker")
+def test_real_docker_snapshot_host_comparator_and_boundary(setup, monkeypatch):
+    store, context, _, receipt = setup
+    producer = grading.DockerSnapshotProducer()
+    observed = []
+    original = grading.grade_activity.run_bounded_process
+
+    def observe(command, **kwargs):
+        request = json.loads(kwargs["input_text"])
+        assert set(request) == {"schema_version", "language", "stdin"}
+        assert "expected_stdout" not in kwargs["input_text"]
+        assert command[command.index("--network") + 1] == "none"
+        assert "--read-only" in command and "--cap-drop" in command
+        observed.append(command)
+        return original(command, **kwargs)
+
+    monkeypatch.setattr(grading.grade_activity, "run_bounded_process", observe)
+    (store.root / "main.py").write_bytes(b"print(999)\n")
+    (store.root / "activity.json").write_text("{}")
+    result = store.grade(FIRST, context_loader=lambda: context, producer=producer)
+    assert result["state"] == "succeeded", result
+    assert result["result"]["summary"] == {"tests_passed": 1, "tests_total": 1}
+    assert observed
+    assert store.read(FIRST, context_loader=lambda: context) == receipt
+    assert row_for(store, context, receipt)["grading"]["score"] == 10

--- a/tests/test_student_delivery_grading_http.py
+++ b/tests/test_student_delivery_grading_http.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import base64
+from http.client import HTTPConnection
+import json
+import os
+
+import pytest
+
+from scripts import student_delivery_grading as grading
+from scripts import student_delivery_service as service
+from scripts import student_delivery_store as delivery
+from scripts.assignment_records import JsonAssignmentRecordStorage
+from tests.test_student_delivery_grading import FIRST, Producer
+from tests.test_student_delivery_http_e2e import prepare_roots
+from tests.test_student_api_authorization_pilot_root_e2e import (
+    _running_pilot, _authorization_header, STUDENT_USER_ID, STUDENT_SUBJECT_ID,
+)
+from scripts import course_board_server as server
+
+
+TEACHER = {"Authorization": "Basic " + base64.b64encode(b"teacher:teacher-demo-only-706").decode("ascii")}
+
+
+@pytest.mark.parametrize("real", [False, pytest.param(True, marks=pytest.mark.skipif(
+    os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1", reason="requires real Docker"))])
+def test_http_upload_grade_review_and_register_are_bound_to_snapshot(tmp_path, monkeypatch, real):
+    teacher, student, own, _, _ = prepare_roots(tmp_path)
+    monkeypatch.setattr(server.BoundedThreadingHTTPServer, "student_delivery_enabled", True, raising=False)
+    record = JsonAssignmentRecordStorage(teacher).read_assignment_strict(own)
+    target = next(item for item in record["targets"] if item["subject_id"] == STUDENT_SUBJECT_ID)
+    activity_path = teacher / record["activity_path"]
+    activity = json.loads(activity_path.read_text(encoding="utf-8"))
+    activity.update(language="python", source_name="main.py", assets=[], test_cases=[{
+        "name": "PRIVATE_EXPECTATION", "visibility": "teacher", "stdin": "", "expected_stdout": "42\n"}])
+    activity_path.write_text(json.dumps(activity), encoding="utf-8")
+    producer = Producer()
+    if not real:
+        monkeypatch.setattr(grading, "DockerSnapshotProducer", lambda: producer)
+    # A harmless fixture observes the execution environment without any external access.
+    monkeypatch.setenv("DELIVERY_TEST_PRIVATE_SENTINEL", "host-only-dummy-value")
+    source = student / "main.py"
+    source.write_bytes(b"import os\nfrom pathlib import Path\n"
+        b"assert os.getuid() != 0\n"
+        b"assert 'DELIVERY_TEST_PRIVATE_SENTINEL' not in os.environ\n"
+        b"assert sorted(str(p.relative_to('/submission')) for p in Path('/submission').rglob('*') if p.is_file()) == ['source/main.py']\n"
+        b"print(42)\n")
+    with _running_pilot(teacher) as (http, _, sessions):
+        bearer, _ = http.pair(STUDENT_USER_ID, sessions)
+        auth = _authorization_header(bearer)
+        status, manifest = http.exchange(f"/api/student-lab/delivery-manifest?assignment_id={own}", headers=auth)
+        assert status == 200, manifest
+        assert "PRIVATE_EXPECTATION" not in json.dumps(manifest)
+        package = {"schema_version": delivery.PACKAGE_SCHEMA, "attempt_id": FIRST,
+            "activity_digest": manifest["activity_digest"], "tests_digest": manifest["tests_digest"],
+            "files": [service.file_entry("main.py", source.read_bytes())]}
+        status, ack = http.exchange("/api/student-lab/deliveries", method="POST", headers=auth,
+            payload={"assignment_id": own, "package": package})
+        assert status == 200, ack
+        source.write_bytes(b"print(999)\n")
+        activity["test_cases"][0]["expected_stdout"] = "999\n"
+        activity_path.write_text(json.dumps(activity), encoding="utf-8")
+        request = {"assignment_id": own, "subject_id": STUDENT_SUBJECT_ID, "attempt_id": FIRST}
+        status, _ = http.exchange("/api/assignment-reports/delivery-grade", method="POST", headers=auth, payload=request)
+        assert status in {401, 403}
+        status, result = http.exchange("/api/assignment-reports/delivery-grade", method="POST",
+            headers=TEACHER, payload=request)
+        assert status == 200 and result["state"] == "succeeded", result
+        assert result["result"]["binding"]["package_digest"] == ack["package_digest"]
+        assert result["result"]["summary"] == {"tests_passed": 1, "tests_total": 1}
+        if not real:
+            assert producer.calls[0][1]["activity"]["test_cases"][0]["expected_stdout"] == "42\n"
+        report_request = {"assignment_id": own, "activity_path": record["activity_path"],
+            "targets_text": str(teacher / target["path"]), "due_at": record["due_at"], "output_name": "graded.json"}
+        status, register = http.exchange("/api/assignment-reports/generate", method="POST",
+            headers=TEACHER, payload=report_request)
+        assert status == 200, register
+        row = register["report"]["students"][0]
+        assert row["grading"]["score"] == 10 and row["grading"]["provisional"] is True
+        assert row["submission"]["delivery"]["package_digest"] == ack["package_digest"]
+        status, reviewed = http.exchange("/api/assignment-reports/delivery-grade/review", method="POST",
+            headers=TEACHER, payload={**request, "result_digest": result["result_digest"], "teacher_grade": 8})
+        assert status == 200, reviewed
+        status, register = http.exchange("/api/assignment-reports/generate", method="POST",
+            headers=TEACHER, payload=report_request)
+        assert status == 200, register
+        row = register["report"]["students"][0]
+        assert row["grading"]["teacher_grade"] == 8 and row["grading"]["provisional"] is False
+        assert "PRIVATE_EXPECTATION" not in json.dumps(register)
+        status, history = http.exchange(f"/api/student-lab/deliveries?assignment_id={own}", headers=auth)
+        assert status == 200, history
+        assert history["items"][0]["grading_authority"] == "ungraded"
+        assert "teacher_grade" not in json.dumps(history)
+        connection = HTTPConnection("127.0.0.1", http.port, timeout=10)
+        try:
+            connection.request("GET", f"/teacher-delivery-grading/contracts/{manifest['activity_digest']}.json",
+                               headers={**TEACHER, "X-Forwarded-Proto": "https"})
+            response = connection.getresponse()
+            assert response.status in {403, 404}
+            assert b"PRIVATE_EXPECTATION" not in response.read()
+        finally:
+            connection.close()
+
+
+def test_teacher_adapter_recovers_only_exact_legacy_revision(tmp_path, monkeypatch):
+    teacher, _, own, _, _ = prepare_roots(tmp_path)
+    record = JsonAssignmentRecordStorage(teacher).read_assignment_strict(own)
+    contract = service.teacher_contract(teacher, record)
+    context = service.delivery_context(record, STUDENT_SUBJECT_ID, contract)
+    store = grading.JsonDeliveryGradingStore(teacher)
+    package = {"schema_version": delivery.PACKAGE_SCHEMA, "attempt_id": FIRST, **context.contract(),
+               "files": [service.file_entry("main.py", b"print(42)\n")]}
+    receipt = store.receive(package, context_loader=lambda: context)
+    request = {"assignment_id": own, "subject_id": STUDENT_SUBJECT_ID, "attempt_id": FIRST}
+    monkeypatch.setattr(server, "ROOT", teacher)
+    monkeypatch.setattr(server, "TEACHER_ASSIGNMENTS_DIR", teacher / "teacher-assignments")
+    monkeypatch.setattr(grading, "DockerSnapshotProducer", Producer)
+    server.grade_student_delivery(request)
+    assert store._revision(receipt) == contract["revision"]
+    (store._grading_directory() / f"{context.activity_digest}.json").unlink()
+    activity_path = teacher / record["activity_path"]
+    activity_path.write_text("{}", encoding="utf-8")
+    assert server.grade_student_delivery(request) == {"state": "error", "error": "contract_unavailable"}

--- a/tests/test_student_delivery_http_e2e.py
+++ b/tests/test_student_delivery_http_e2e.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import base64
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+import http.client
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+from pathlib import Path
+import threading
+
+import pytest
+
+from scripts import course_board_server as server
+from scripts import pilot_data_root, student_delivery_client as client
+from scripts import student_delivery_service as service, student_delivery_store as store
+from scripts import student_lab_cli as cli
+from scripts.assignment_records import JsonAssignmentRecordStorage
+from tests.test_student_api_authorization_pilot_root_e2e import (
+    _running_pilot, _authorization_header, _write_negative_assignments,
+    STUDENT_USER_ID, OTHER_USER_ID, STUDENT_SUBJECT_ID,
+)
+
+
+@pytest.fixture(autouse=True)
+def enable_deliveries(monkeypatch):
+    monkeypatch.setattr(server.BoundedThreadingHTTPServer, "student_delivery_enabled", True, raising=False)
+
+
+@contextmanager
+def local_proxy(upstream_port):
+    """Real loopback proxy, representing the existing trusted TLS terminator.
+
+    Only the test client->proxy hop uses explicitly permitted insecure HTTP.
+    The application auth boundary and killable TUI transport remain real.
+    """
+    state = {"upstream_port": upstream_port, "drop_next_upload": False}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.forward()
+
+        def do_POST(self):
+            self.forward()
+
+        def log_message(self, *args):
+            pass
+
+        def forward(self):
+            connection = http.client.HTTPConnection("127.0.0.1", state["upstream_port"], timeout=10)
+            try:
+                body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                headers = {key: value for key, value in self.headers.items()
+                           if key.lower() not in {"host", "x-forwarded-proto", "connection"}}
+                headers["X-Forwarded-Proto"] = "https"
+                connection.request(self.command, self.path, body=body, headers=headers)
+                response = connection.getresponse()
+                result = response.read()
+                if self.command == "POST" and self.path.endswith("/deliveries") and state["drop_next_upload"]:
+                    assert response.status == 200
+                    state["drop_next_upload"] = False
+                    self.close_connection = True
+                    return
+                self.send_response(response.status)
+                self.send_header("Content-Length", str(len(result)))
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(result)
+            finally:
+                connection.close()
+
+    proxy = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=proxy.serve_forever)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{proxy.server_port}", state
+    finally:
+        proxy.shutdown()
+        proxy.server_close()
+        thread.join(10)
+        assert not thread.is_alive()
+
+
+def prepare_roots(tmp_path):
+    teacher = tmp_path / "teacher"
+    student = tmp_path / "student"
+    student.mkdir()
+    assert pilot_data_root.bootstrap(pilot_data_root.topology_from_paths(teacher))["ok"]
+    own, cross, other = _write_negative_assignments(teacher)
+    records = JsonAssignmentRecordStorage(teacher)
+    for assignment in records.list_assignments_strict():
+        assignment["due_at"] = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+        records.write_assignment(assignment, overwrite=True)
+    return teacher, student, own, cross, other
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_teacher_http_register_uses_server_delivery_mode(tmp_path, monkeypatch, enabled):
+    teacher, _, own, _, _ = prepare_roots(tmp_path)
+    records = JsonAssignmentRecordStorage(teacher)
+    record = records.read_assignment_strict(own)
+    target = next(item for item in record["targets"] if item["subject_id"] == STUDENT_SUBJECT_ID)
+    if not enabled:
+        record.update(target_type="student", class_id="", targets=[target])
+        records.write_assignment(record, overwrite=True)
+    report_path = teacher / target["path"] / "reports" / record["activity_id"] / "latest.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps({"activity_id": record["activity_id"],
+        "assignment_id": own, "status": "passed", "passed": True,
+        "submitted_at": datetime.now(timezone.utc).isoformat()}), encoding="utf-8")
+    monkeypatch.setattr(server.BoundedThreadingHTTPServer, "student_delivery_enabled", enabled)
+    with _running_pilot(teacher) as (http, _, _):
+        status, result = http.exchange("/api/assignment-reports/generate", method="POST",
+            headers={"Authorization": "Basic " + base64.b64encode(b"teacher:teacher-demo-only-706").decode("ascii")},
+            payload={"assignment_id": own, "activity_path": record["activity_path"],
+                     "targets_text": str(teacher / target["path"]), "due_at": record["due_at"],
+                     "output_name": "mode.json", "student_delivery_enabled": not enabled})
+        assert status == 200, result
+        row = result["report"]["students"][0]
+        assert row["submitted"] is (not enabled)
+        assert row["grading"]["status"] == ("not_graded" if enabled else "graded_passed")
+        assert row["help"]["subject_id"] == STUDENT_SUBJECT_ID
+
+
+def test_tui_real_http_separate_roots_lost_ack_restart_final_register_preview(tmp_path):
+    teacher, student, own, cross, other = prepare_roots(tmp_path)
+    with local_proxy(0) as (url, proxy):
+        with _running_pilot(teacher) as (http, identities, sessions):
+            proxy["upstream_port"] = http.port
+            bearer, _ = http.pair(STUDENT_USER_ID, sessions)
+            transport = dict(server_url=url, server_token=bearer, allow_insecure_http=True)
+            payload = cli.load_current_payload(root=student, student_id="rossi-mario", now=None, **transport)
+            assignment = payload["assignments"][0]
+            assert assignment["assignment_id"] == own
+            workspace = Path(assignment["workspace"]["path"])
+            assert workspace.is_relative_to(student) and not workspace.is_relative_to(teacher)
+            source = workspace / assignment["activity"]["source_name"]
+            source.write_bytes(b"print('first delivery')\n")
+            # More than the old 64 KiB transport envelope: actual subprocess upload.
+            (workspace / "large.txt").write_bytes(b"x" * 70000)
+            proxy["drop_next_upload"] = True
+            with pytest.raises(ValueError, match="Riprova"):
+                client.send_assignment(assignment, root=student, **transport)
+            source.write_bytes(b"print('changed after loss')\n")
+            assert not proxy["drop_next_upload"]
+            pending = list(student.rglob("outbox.json"))
+            assert len(pending) == 1 and bearer not in pending[0].read_text()
+            first_id = json.loads(pending[0].read_text())["package"]["attempt_id"]
+
+        # Both application and transport really restart; durable auth/storage survives.
+        with _running_pilot(teacher) as (http, identities, sessions):
+            proxy["upstream_port"] = http.port
+            receipt = client.send_assignment(assignment, root=student, **transport)
+            assert receipt["attempt_id"] == first_id and receipt["sequence"] == 1
+            history = client.request("deliveries", assignment_id=own, **transport)
+            assert len(history["items"]) == 1
+            commands = iter(["1", "i", "", "t", "2", "", "q"])
+            displayed = []
+            assert cli.run_tui(student_id="rossi-mario", root=student, **transport,
+                input_fn=lambda _: next(commands), print_fn=displayed.append,
+                clear=False, renderer="legacy") == 0
+            assert any("Consegna ricevuta dal docente" in text for text in displayed)
+            assert any("Tentativo definitivo salvato" in text for text in displayed)
+            history = client.request("deliveries", assignment_id=own, **transport)
+            assert history["items"][-1]["sequence"] == 2
+            assert history["final"]["attempt_id"] == first_id
+            payload = cli.load_current_payload(root=student, student_id="rossi-mario", now=None, **transport)
+            assignment = payload["assignments"][0]
+            assert assignment["delivery"]["revision"] == 1
+            records = JsonAssignmentRecordStorage(teacher)
+            record = records.read_assignment_strict(own)
+            status, result = http.exchange("/api/assignment-reports/generate", method="POST",
+                headers={"Authorization": "Basic " + base64.b64encode(b"teacher:teacher-demo-only-706").decode("ascii")},
+                payload={
+                "assignment_id": own, "activity_path": record["activity_path"],
+                "targets_text": "\n".join(target["path"] for target in record["targets"]),
+                "due_at": record["due_at"], "output_name": "delivery-e2e.json",
+            })
+            assert status == 200, result
+            received = next(row for row in result["report"]["students"] if row["student_id"] == "rossi-mario")
+            assert received["submitted"] is True
+            assert received["grading"]["status"] == "not_graded"
+            assert received["grading"]["teacher_grade"] is None
+            assert received["submission"]["report_authority"] == "ungraded"
+            assert received["submission"]["final_selected"] is True
+            preview = server.read_submission_file({"report_name": result["saved"]["name"],
+                "student": received["student"], "path": source.name})
+            assert preview["content"] == "print('first delivery')\n"
+            with pytest.raises(ValueError, match="consegne ricevute"):
+                server.delete_assignment_record({"assignment_id": own}, help_subject_aliases=())
+            # Pair a second student; their archive and workspace cannot alias ours.
+            other_bearer, _ = http.pair(OTHER_USER_ID, sessions)
+            other_transport = {**transport, "server_token": other_bearer}
+            other_history = client.request("deliveries", assignment_id=own, **other_transport)
+            assert other_history["items"] == []
+            other_manifest = client.request("delivery-manifest", assignment_id=own, **other_transport)
+            assert other_manifest["workspace_id"] != assignment["delivery"]["workspace_id"]
+            status, _ = http.exchange("/api/student-lab/delivery-final", method="POST",
+                headers=_authorization_header(other_bearer),
+                payload={"assignment_id": own, "attempt_id": first_id, "expected_revision": 0})
+            assert status == 404
+            for denied in (cross, other):
+                status, _ = http.exchange(f"/api/student-lab/deliveries?assignment_id={denied}",
+                                           headers=_authorization_header(bearer))
+                assert status == 403
+            membership = identities.list_user_memberships(STUDENT_USER_ID)[0]
+            identities.delete_membership(STUDENT_USER_ID, membership.class_id, membership.role)
+            status, _ = http.exchange(f"/api/student-lab/deliveries?assignment_id={own}",
+                                       headers=_authorization_header(bearer))
+            assert status == 403
+        assert {"teacher-deliveries", "student-delivery"} <= server.PRIVATE_STATIC_ROOTS
+
+
+def test_http_contract_change_parser_and_deadline(tmp_path, monkeypatch):
+    teacher, student, own, _, _ = prepare_roots(tmp_path)
+    with _running_pilot(teacher) as (http, identities, sessions):
+        bearer, _ = http.pair(STUDENT_USER_ID, sessions)
+        auth = _authorization_header(bearer)
+        status, manifest = http.exchange(f"/api/student-lab/delivery-manifest?assignment_id={own}", headers=auth)
+        assert status == 200
+        record = JsonAssignmentRecordStorage(teacher).read_assignment_strict(own)
+        activity_path = teacher / record["activity_path"]
+        activity = json.loads(activity_path.read_text(encoding="utf-8-sig"))
+        activity["test_cases"] = [{"name": "private", "stdin": "hidden-input", "expected_stdout": "secret-result"}]
+        activity_path.write_text(json.dumps(activity), encoding="utf-8")
+        package = {"schema_version": store.PACKAGE_SCHEMA, "attempt_id": "attempt-20260909T120000000000Z-11111111",
+                   "activity_digest": manifest["activity_digest"], "tests_digest": manifest["tests_digest"],
+                   "files": [service.file_entry("main.py", b"print(42)\n")]}
+        status, _ = http.exchange("/api/student-lab/deliveries", method="POST", headers=auth,
+                                  payload={"assignment_id": own, "package": package})
+        assert status == 409
+        status, updated = http.exchange(f"/api/student-lab/delivery-manifest?assignment_id={own}", headers=auth)
+        assert status == 200 and "secret-result" not in json.dumps(updated)
+        package.update(activity_digest=updated["activity_digest"], tests_digest=updated["tests_digest"])
+        status, receipt = http.exchange("/api/student-lab/deliveries", method="POST", headers=auth,
+                                       payload={"assignment_id": own, "package": package})
+        assert status == 200
+        record["due_at"] = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+        JsonAssignmentRecordStorage(teacher).write_assignment(record, overwrite=True)
+        status, retry = http.exchange("/api/student-lab/deliveries", method="POST", headers=auth,
+                                     payload={"assignment_id": own, "package": package})
+        assert status == 200 and retry == receipt
+        package["attempt_id"] = "attempt-20260909T120000000000Z-22222222"
+        status, _ = http.exchange("/api/student-lab/deliveries", method="POST", headers=auth,
+                                  payload={"assignment_id": own, "package": package})
+        assert status == 409
+        for suffix in ("?assignment_id=" + own + "&assignment_id=" + own, "?assignment_id=" + own + "&subject_id=x"):
+            status, _ = http.exchange("/api/student-lab/deliveries" + suffix, headers=auth)
+            assert status == 400
+        status, _ = http.exchange("/api/student-lab/deliveries", method="POST", headers=auth,
+                                  payload={"assignment_id": own, "package": package, "subject_id": STUDENT_SUBJECT_ID})
+        assert status == 400
+        # Revocation after initial authentication must still win before a write.
+        original_receive = store.JsonStudentDeliveryStore.receive
+        def revoked_receive(self, payload, *, context_loader):
+            membership = identities.list_user_memberships(STUDENT_USER_ID)[0]
+            identities.delete_membership(STUDENT_USER_ID, membership.class_id, membership.role)
+            return original_receive(self, payload, context_loader=context_loader)
+        monkeypatch.setattr(store.JsonStudentDeliveryStore, "receive", revoked_receive)
+        status, _ = http.exchange("/api/student-lab/deliveries", method="POST", headers=auth,
+                                  payload={"assignment_id": own, "package": package})
+        assert status == 403

--- a/tests/test_student_delivery_m04.py
+++ b/tests/test_student_delivery_m04.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import base64
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from scripts import student_delivery_grading as grading
+from scripts import student_delivery_service as service
+from scripts import student_delivery_store as delivery
+from tests.test_student_delivery_grading import FIRST, SECOND, SUBJECT, Producer, row_for
+
+
+FIXTURE = Path(__file__).parent / "fixtures/student_delivery_m04"
+SOURCE = b"a = int(input())\nb = int(input())\nprint(a + b)\n"
+ORIGINAL_HASHES = {
+    "activity.json": "5502bb0b7fd4d1ecca394da8c679ec4f1b4b414fb43a1ebffaf24fed7eda956b",
+    "starter/main.py": "2fb9eda529a89211a82f8b458c7444e7f59b39811255f68b14db7bbd69e82695",
+    "student/GUIDA.md": "ba0299aa11b043934f207c0ec4c989c7860737aad648fa7a7f8586e15371166c",
+    "teacher/README.md": "d7a3bf56523213771026a0e24ee408b5116ff590ac68fb634e8aa6f031b14107",
+}
+
+
+@pytest.fixture
+def m04(tmp_path):
+    teacher = tmp_path / "teacher"
+    shutil.copytree(FIXTURE, teacher)
+    assignment = {"id": "m04-assignment", "class_id": "m04-class",
+                  "activity_id": "py2-activity-b-input-somma-001", "activity_path": "activity.json",
+                  "due_at": (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()}
+    contract = service.teacher_contract(teacher, assignment)
+    context = service.delivery_context(assignment, SUBJECT, contract)
+    store = grading.JsonDeliveryGradingStore(teacher)
+    store.archive_contract(contract)
+    package = {"schema_version": delivery.PACKAGE_SCHEMA, "attempt_id": FIRST, **context.contract(),
+               "files": [service.file_entry("main.py", SOURCE),
+                         service.file_entry("GUIDA.md", (teacher / "student/GUIDA.md").read_bytes())]}
+    receipt = store.receive(package, context_loader=lambda: context)
+    return store, context, contract, receipt
+
+
+def m04_producer(callback=None):
+    return Producer(callback or (lambda *_: {"tests_passed": 3, "tests_total": 3}))
+
+
+def test_original_fixture_and_three_cases_are_pinned(m04):
+    _, _, contract, receipt = m04
+    for path, sha in ORIGINAL_HASHES.items():
+        assert hashlib.sha256((FIXTURE / path).read_bytes()).hexdigest() == sha
+    assert contract["activity"]["test_cases"] == [
+        {"name": "positivi", "stdin": "2\n3\n", "expected_stdout": "5\n"},
+        {"name": "zeri", "stdin": "0\n0\n", "expected_stdout": "0\n"},
+        {"name": "negativo e positivo", "stdin": "-4\n10\n", "expected_stdout": "6\n"}]
+    language, entry = grading.profile(receipt, contract["revision"])
+    assert language == "python" and entry == service.file_entry("main.py", SOURCE)
+
+
+def test_m04_archived_materials_receipt_policy_and_successful_retry(m04):
+    store, context, contract, receipt = m04
+    before = {p: p.read_bytes() for p in store.root.rglob("*.json")}
+    # Current teacher files and the student's working copy are not the grading input.
+    for path in ORIGINAL_HASHES:
+        (store.root / path).write_bytes(b"changed current material")
+    (store.root / "main.py").write_bytes(b"print(999)\n")
+    producer = m04_producer()
+    outcome = store.grade(FIRST, context_loader=lambda: context, producer=producer)
+    assert outcome["state"] == "succeeded"
+    result = outcome["result"]
+    policy = grading.policies.accessory_policy(contract["revision"])
+    assert result["provenance"]["grading_policy"] == {"id": "python-m04-stdio-accessory.v1",
+                                                    "digest": grading.digest(policy)}
+    assert "grading_policy" not in producer.provenance
+    assert result["binding"] == grading.binding(receipt)
+    assert producer.calls == [(receipt, contract["revision"])]
+    assert [e["path"] for e in producer.calls[0][1]["assets"]] == [
+        "starter/main.py", "student/GUIDA.md", "teacher/README.md"]
+    restarted = grading.JsonDeliveryGradingStore(store.root)
+    different = m04_producer()
+    different.provenance = {**different.provenance, "comparator_digest": "b" * 64}
+    assert restarted.grade(FIRST, context_loader=lambda: context, producer=different) == outcome
+    assert different.calls == []
+    assert restarted.read(FIRST, context_loader=lambda: context) == receipt
+    for path, content in before.items():
+        if path != store.root / "activity.json":
+            assert path.read_bytes() == content
+    row = row_for(restarted, context, receipt)
+    assert row["grading"]["score"] == 10 and row["grading"]["provisional"] is True
+    assert "grading_policy" not in json.dumps(row)
+
+
+@pytest.mark.parametrize("change", ["missing_guide", "altered_guide", "line_endings", "extra_source",
+                                    "extra_document", "teacher_notes", "guide_case", "missing_source"])
+def test_m04_rejects_invalid_packages_before_producer_and_preserves_receipt(m04, monkeypatch, change):
+    store, context, _, receipt = m04
+    entries = {e["path"]: e for e in receipt["package"]["files"]}
+    if change == "missing_guide":
+        del entries["GUIDA.md"]
+    elif change in {"altered_guide", "line_endings"}:
+        guide = base64.b64decode(entries["GUIDA.md"]["content_base64"])
+        guide = guide + b"\n" if change == "altered_guide" else guide.replace(b"\n", b"\r\n")
+        entries["GUIDA.md"] = service.file_entry("GUIDA.md", guide)
+    elif change == "guide_case":
+        entries["guida.md"] = {**entries.pop("GUIDA.md"), "path": "guida.md"}
+    elif change == "missing_source":
+        del entries["main.py"]
+    else:
+        path = {"extra_source": "helper.py", "extra_document": "notes.md", "teacher_notes": "README.md"}[change]
+        entries[path] = service.file_entry(path, b"extra")
+    package = {**receipt["package"], "attempt_id": SECOND, "files": list(entries.values())}
+    rejected = store.receive(package, context_loader=lambda: context)
+    monkeypatch.setattr(grading, "DockerSnapshotProducer", lambda: pytest.fail("Producer constructed on refusal"))
+    assert store.grade(SECOND, context_loader=lambda: context) == {"state": "error", "error": "unsupported_profile"}
+    assert store.read(SECOND, context_loader=lambda: context) == rejected
+    directory = store._grading_directory(rejected["identity"])
+    assert not (directory / f"{SECOND}.job.json").exists()
+    assert not (directory / f"{SECOND}.result.json").exists()
+    assert row_for(store, context, rejected)["grading"]["score"] is None
+
+
+@pytest.mark.parametrize("change", ["test_output", "test_count", "instructions", "source_name", "asset_role",
+                                    "guide", "starter", "teacher_notes", "extra_asset"])
+def test_m04_policy_does_not_admit_different_materials(m04, monkeypatch, change):
+    store, _, contract, original = m04
+    activity = deepcopy(contract["activity"])
+    if change == "test_output":
+        activity["test_cases"][0]["expected_stdout"] = "999\n"
+    elif change == "test_count":
+        activity["test_cases"].pop()
+    elif change == "instructions":
+        activity["instructions"] += " changed"
+    elif change == "source_name":
+        activity["source_name"] = "other.py"
+    elif change == "asset_role":
+        activity["assets"][1]["type"] = "starter"
+    elif change == "extra_asset":
+        activity["assets"].append({"type": "fixture", "visibility": "student", "path": "runtime.txt"})
+        (store.root / "runtime.txt").write_bytes(b"runtime dependency")
+    else:
+        path = {"guide": "student/GUIDA.md", "starter": "starter/main.py", "teacher_notes": "teacher/README.md"}[change]
+        with (store.root / path).open("ab") as stream:
+            stream.write(b"\nchanged")
+    (store.root / "activity.json").write_text(json.dumps(activity), encoding="utf-8")
+    updated = service.teacher_contract(store.root, contract["revision"]["assignment"])
+    context = service.delivery_context(updated["revision"]["assignment"], SUBJECT, updated)
+    store.archive_contract(updated)
+    receipt = store.receive({**original["package"], **context.contract(), "attempt_id": SECOND},
+                            context_loader=lambda: context)
+    monkeypatch.setattr(grading, "DockerSnapshotProducer", lambda: pytest.fail("Producer constructed on refusal"))
+    assert store.grade(SECOND, context_loader=lambda: context) == {"state": "error", "error": "unsupported_profile"}
+    assert store.read(SECOND, context_loader=lambda: context) == receipt
+    assert not (store._grading_directory(receipt["identity"]) / f"{SECOND}.job.json").exists()
+
+
+def test_old_m04_refusal_without_job_can_be_retried(m04):
+    store, context, _, receipt = m04
+    directory = store._grading_directory(receipt["identity"])
+    with store._locked(directory):
+        store._write(directory / f"{FIRST}.state.json", {"binding": grading.binding(receipt),
+                     "state": "error", "error": "unsupported_profile"})
+    assert store.grade(FIRST, context_loader=lambda: context, producer=m04_producer())["state"] == "succeeded"
+    assert store.read(FIRST, context_loader=lambda: context) == receipt
+
+
+def test_m04_lost_result_ack_reuses_policy_bound_result(m04, monkeypatch):
+    store, context, _, receipt = m04
+    original_write = store._write
+
+    def write(path, record, **kwargs):
+        original_write(path, record, **kwargs)
+        if path.name.endswith(".result.json"):
+            raise OSError("simulated lost acknowledgement after publication")
+
+    monkeypatch.setattr(store, "_write", write)
+    producer = m04_producer()
+    with pytest.raises(OSError):
+        store.grade(FIRST, context_loader=lambda: context, producer=producer)
+    restarted = grading.JsonDeliveryGradingStore(store.root)
+    result = restarted.grade(FIRST, context_loader=lambda: context, producer=producer)
+    assert result["state"] == "succeeded" and len(producer.calls) == 1
+    assert restarted.read(FIRST, context_loader=lambda: context) == receipt
+
+
+def test_m04_partial_summary_is_rejected_on_write_and_read(m04):
+    store, context, _, receipt = m04
+    subset = m04_producer(lambda *_: {"tests_passed": 2, "tests_total": 2})
+    assert store.grade(FIRST, context_loader=lambda: context, producer=subset) == {
+        "state": "error", "error": "producer_error"}
+    path = store._grading_directory(receipt["identity"]) / f"{FIRST}.result.json"
+    assert not path.exists()
+    assert store.grade(FIRST, context_loader=lambda: context, producer=m04_producer())["state"] == "succeeded"
+    result = json.loads(path.read_bytes())
+    result["summary"] = {"tests_passed": 2, "tests_total": 2}
+    path.write_text(json.dumps(result), encoding="utf-8")
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        store.lookup(receipt)
+
+
+def test_m04_failed_job_retries_same_provenance_and_refuses_changed_provenance(m04):
+    store, context, _, receipt = m04
+
+    def fail(*_):
+        raise subprocess.TimeoutExpired("docker", 1)
+
+    assert store.grade(FIRST, context_loader=lambda: context, producer=m04_producer(fail))["error"] == "producer_error"
+    path = store._grading_directory(receipt["identity"]) / f"{FIRST}.job.json"
+    job_bytes = path.read_bytes()
+    changed = m04_producer()
+    changed.provenance = {**changed.provenance, "comparator_digest": "b" * 64}
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        store.grade(FIRST, context_loader=lambda: context, producer=changed)
+    assert path.read_bytes() == job_bytes and changed.calls == []
+    restarted = grading.JsonDeliveryGradingStore(store.root)
+    assert restarted.grade(FIRST, context_loader=lambda: context, producer=m04_producer())["state"] == "succeeded"
+    assert path.read_bytes() == job_bytes
+
+
+@pytest.mark.parametrize("change", ["missing", "id", "digest"])
+def test_m04_reader_rejects_unbound_policy_even_with_consistent_job_digest(m04, change):
+    store, context, _, receipt = m04
+    store.grade(FIRST, context_loader=lambda: context, producer=m04_producer())
+    directory = store._grading_directory(receipt["identity"])
+    job_path, result_path = directory / f"{FIRST}.job.json", directory / f"{FIRST}.result.json"
+    job, result = json.loads(job_path.read_bytes()), json.loads(result_path.read_bytes())
+    if change == "missing":
+        job["provenance"].pop("grading_policy")
+    else:
+        job["provenance"]["grading_policy"][change] = "different"
+    result.update(provenance=job["provenance"], job_digest=grading.digest(job))
+    job_path.write_text(json.dumps(job), encoding="utf-8")
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        store.lookup(receipt)
+
+
+def test_m04_producer_stages_only_delivered_source_and_all_original_cases(m04, monkeypatch):
+    _, _, contract, receipt = m04
+    producer = grading.DockerSnapshotProducer()
+    monkeypatch.setattr(grading.subprocess, "run", lambda *a, **kw: subprocess.CompletedProcess(
+        a, 0, stdout=b'[{"Os":"linux","Architecture":"amd64"}]'))
+    observed = []
+
+    def run(activity_path, source_path, **kwargs):
+        observed.append(source_path)
+        assert source_path.read_bytes() == SOURCE
+        assert list(source_path.parent.iterdir()) == [source_path]
+        assert sorted(p.relative_to(source_path.parent.parent).as_posix()
+                      for p in source_path.parent.parent.rglob("*") if p.is_file()) == [
+                          "private/activity.json", "source/main.py"]
+        assert json.loads(activity_path.read_bytes()) == contract["activity"]
+        return {"tests": [{"passed": True}] * 3}, 0
+
+    monkeypatch.setattr(grading.grade_activity, "grade_activity_in_docker", run)
+    assert producer.run(receipt, contract["revision"]) == {"tests_passed": 3, "tests_total": 3}
+    assert len(observed) == 1 and not observed[0].exists()
+
+
+@pytest.mark.skipif(os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1", reason="requires real Docker")
+@pytest.mark.parametrize("case,expected", [("starter", 1), ("sum", 3), ("plus_one", 0), ("prompt", 0)])
+def test_real_m04_docker_three_original_cases(m04, monkeypatch, case, expected):
+    store, context, _, original = m04
+    sources = {"starter": (FIXTURE / "starter/main.py").read_bytes(), "sum": SOURCE,
+               "plus_one": SOURCE.replace(b"a + b", b"a + b + 1"),
+               "prompt": SOURCE.replace(b"input()", b"input('numero: ')")}
+    package = deepcopy(original["package"])
+    package.update(attempt_id=SECOND, files=[service.file_entry("main.py", sources[case]),
+        next(e for e in package["files"] if e["path"] == "GUIDA.md")])
+    receipt = store.receive(package, context_loader=lambda: context)
+    original_run = grading.grade_activity.run_bounded_process
+    observed = []
+
+    def observe(command, **kwargs):
+        if command[0] == "docker" and "run" in command:
+            request = json.loads(kwargs["input_text"])
+            assert set(request) == {"schema_version", "language", "stdin"}
+            assert command[command.index("--network") + 1] == "none"
+            assert "--read-only" in command and "--cap-drop" in command
+            mount = command[command.index("-v") + 1]
+            source_dir = Path(mount.removesuffix(":/submission:ro"))
+            assert sorted(p.relative_to(source_dir).as_posix() for p in source_dir.rglob("*")
+                          if p.is_file()) == ["source/main.py"]
+            observed.append(request["stdin"])
+        return original_run(command, **kwargs)
+
+    monkeypatch.setattr(grading.grade_activity, "run_bounded_process", observe)
+    outcome = store.grade(SECOND, context_loader=lambda: context)
+    assert outcome["state"] == "succeeded", outcome
+    assert outcome["result"]["summary"] == {"tests_passed": expected, "tests_total": 3}
+    assert observed == ["2\n3\n", "0\n0\n", "-4\n10\n"]
+    assert store.read(SECOND, context_loader=lambda: context) == receipt

--- a/tests/test_student_delivery_m04_http.py
+++ b/tests/test_student_delivery_m04_http.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import base64
+from copy import deepcopy
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import threading
+
+import pytest
+
+from scripts import course_board_server as server
+from scripts import student_delivery_client as client
+from scripts import student_delivery_grading as grading
+from scripts import student_delivery_service as service
+from scripts import student_lab_cli as cli
+from scripts.assignment_records import JsonAssignmentRecordStorage
+from tests.test_student_delivery_grading import SECOND
+from tests.test_student_delivery_grading_http import TEACHER
+from tests.test_student_delivery_http_e2e import prepare_roots, local_proxy
+from tests.test_student_delivery_m04 import FIXTURE, ORIGINAL_HASHES, SOURCE, m04_producer
+from tests.test_student_api_authorization_pilot_root_e2e import (
+    _running_pilot, _authorization_header, STUDENT_USER_ID, STUDENT_SUBJECT_ID,
+)
+
+
+@pytest.mark.parametrize("real", [False, pytest.param(True, marks=pytest.mark.skipif(
+    os.environ.get("THEBITLAB_RUN_DOCKER_TESTS") != "1", reason="requires real Docker"))])
+def test_m04_tui_http_grading_restart_review_and_invalid_receipts(tmp_path, monkeypatch, real):
+    baseline_threads = set(threading.enumerate())
+    teacher, student, own, _, _ = prepare_roots(tmp_path)
+    material_root = teacher / "m04-original"
+    shutil.copytree(FIXTURE, material_root)
+    records = JsonAssignmentRecordStorage(teacher)
+    record = records.read_assignment_strict(own)
+    record.update(activity_id="py2-activity-b-input-somma-001", activity_path="m04-original/activity.json")
+    records.write_assignment(record, overwrite=True)
+    monkeypatch.setattr(server.BoundedThreadingHTTPServer, "student_delivery_enabled", True, raising=False)
+    sources = [("starter", (FIXTURE / "starter/main.py").read_bytes(), 1), ("sum", SOURCE, 3),
+               ("plus_one", SOURCE.replace(b"a + b", b"a + b + 1"), 0),
+               ("prompt", SOURCE.replace(b"input()", b"input('numero: ')"), 0)]
+    expected = {source: count for _, source, count in sources}
+    actual_factory = grading.DockerSnapshotProducer
+    producers = []
+
+    def producer_factory():
+        def run(receipt, revision):
+            language, source = grading.profile(receipt, revision)
+            assert language == "python" and len(revision["activity"]["test_cases"]) == 3
+            return {"tests_passed": expected[base64.b64decode(source["content_base64"])], "tests_total": 3}
+
+        result = actual_factory() if real else m04_producer(run)
+        producers.append(result)
+        return result
+
+    monkeypatch.setattr(grading, "DockerSnapshotProducer", producer_factory)
+    receipts, outcomes, receipt_files = {}, {}, {}
+
+    def menu(commands):
+        pending = iter(commands)
+        output = []
+        assert cli.run_tui(student_id="rossi-mario", root=student, **transport,
+            input_fn=lambda _: next(pending), print_fn=output.append, clear=False, renderer="legacy") == 0
+        assert next(pending, None) is None
+        return "\n".join(output)
+
+    def load():
+        payload = cli.load_current_payload(root=student, student_id="rossi-mario", now=None, **transport)
+        return next(a for a in payload["assignments"] if a["assignment_id"] == own)
+
+    def history():
+        return client.request("deliveries", assignment_id=own, **transport)
+
+    def request_for(receipt):
+        return {"assignment_id": own, "subject_id": STUDENT_SUBJECT_ID, "attempt_id": receipt["attempt_id"]}
+
+    def register(http):
+        status, body = http.exchange("/api/assignment-reports/generate", method="POST", headers=TEACHER,
+            payload={"assignment_id": own, "activity_path": record["activity_path"],
+                     "targets_text": "\n".join(t["path"] for t in record["targets"]),
+                     "due_at": record["due_at"], "output_name": "m04-graded.json"})
+        assert status == 200, body
+        row = next(r for r in body["report"]["students"] if r["student_id"] == "rossi-mario")
+        assert "grading_policy" not in json.dumps(body)
+        return body, row
+
+    with local_proxy(0) as (url, proxy):
+        with _running_pilot(teacher) as (http, _, sessions):
+            proxy["upstream_port"] = http.port
+            bearer, _ = http.pair(STUDENT_USER_ID, sessions)
+            transport = dict(server_url=url, server_token=bearer, allow_insecure_http=True)
+            menu(["1", "q"])
+            workspace = Path(load()["workspace"]["path"])
+            assert workspace.is_relative_to(student)
+            assert (workspace / "GUIDA.md").read_bytes() == (FIXTURE / "student/GUIDA.md").read_bytes()
+            assert {p.name for p in workspace.iterdir()} == {"activity.json", "main.py", "GUIDA.md"}
+            public = json.loads((workspace / "activity.json").read_bytes())
+            assert not public.get("test_cases") and "teacher/README.md" not in json.dumps(public)
+            for index, (case, source, count) in enumerate(sources):
+                (workspace / "main.py").write_bytes(source)
+                command = ["1", "i", "", "q"] if index == 0 else ["1", "n", "s", "", "q"]
+                assert "Consegna ricevuta dal docente" in menu(command)
+                receipt = history()["items"][-1]
+                receipts[case] = receipt
+                assert receipt["sequence"] == index + 1 and receipt["grading_authority"] == "ungraded"
+                receipt_path = next((teacher / "teacher-deliveries").glob(f"*/{receipt['attempt_id']}.json"))
+                receipt_files[receipt_path] = receipt_path.read_bytes()
+                stored = json.loads(receipt_files[receipt_path])
+                assert {e["path"] for e in stored["package"]["files"]} == {"main.py", "GUIDA.md"}
+                assert base64.b64decode(next(e for e in stored["package"]["files"]
+                                            if e["path"] == "main.py")["content_base64"]) == source
+                status, _ = http.exchange("/api/assignment-reports/delivery-grade", method="POST",
+                    headers=_authorization_header(bearer), payload=request_for(receipt))
+                assert status in {401, 403}
+                status, outcome = http.exchange("/api/assignment-reports/delivery-grade", method="POST",
+                    headers=TEACHER, payload=request_for(receipt))
+                assert status == 200 and outcome["state"] == "succeeded", outcome
+                assert outcome["result"]["summary"] == {"tests_passed": count, "tests_total": 3}
+                assert outcome["result"]["binding"]["package_digest"] == receipt["package_digest"]
+                assert outcome["result"]["provenance"]["grading_policy"]["id"] == "python-m04-stdio-accessory.v1"
+                outcomes[case] = outcome
+            assert len(producers) == 4
+            all_items = history()["items"]
+            assignment = load()
+            final_index = next(i for i, item in enumerate(cli.selectable_attempts(assignment), 1)
+                               if item["id"] == receipts["sum"]["attempt_id"])
+            assert "Tentativo definitivo salvato" in menu(["1", "t", str(final_index), "", "q"])
+            final = history()["final"]
+            (workspace / "main.py").write_bytes(b"print('later local edit')\n")
+            report, row = register(http)
+            assert row["grading"]["score"] == 10 and row["grading"]["teacher_grade"] is None
+            assert row["submission"]["report_authority"] == "verified_delivery"
+            status, preview = http.exchange("/api/assignment-submissions/read", method="POST", headers=TEACHER,
+                payload={"report_name": report["saved"]["name"], "student": row["student"], "path": "main.py"})
+            assert status == 200 and preview["file"]["content"].encode() == SOURCE
+            status, _ = http.exchange("/api/assignment-reports/delivery-grade/review", method="POST", headers=TEACHER,
+                payload={**request_for(receipts["sum"]), "result_digest": "0" * 64, "teacher_grade": 8})
+            assert status == 400
+            status, reviewed = http.exchange("/api/assignment-reports/delivery-grade/review", method="POST", headers=TEACHER,
+                payload={**request_for(receipts["sum"]), "result_digest": outcomes["sum"]["result_digest"], "teacher_grade": 8})
+            assert status == 200, reviewed
+            assert history()["final"] == final
+
+        with _running_pilot(teacher) as (http, _, _):
+            proxy["upstream_port"] = http.port
+            for case, receipt in receipts.items():
+                status, retry = http.exchange("/api/assignment-reports/delivery-grade", method="POST", headers=TEACHER,
+                    payload=request_for(receipt))
+                assert status == 200 and retry == outcomes[case]
+            assert len(producers) == 4
+            assert history()["items"] == all_items and history()["final"] == final
+            _, row = register(http)
+            assert row["grading"]["teacher_grade"] == 8 and row["grading"]["provisional"] is False
+            assert row["submission"]["delivery"]["package_digest"] == receipts["sum"]["package_digest"]
+            assert "teacher_grade" not in json.dumps(history())
+
+            original = json.loads(next(iter(receipt_files.values())))["package"]
+            for index, change in enumerate(("missing", "altered", "extra"), 1):
+                package = deepcopy(original)
+                package["attempt_id"] = SECOND.replace("22222222", f"eeeeeee{index}")
+                if change == "missing":
+                    package["files"] = [e for e in package["files"] if e["path"] != "GUIDA.md"]
+                elif change == "altered":
+                    package["files"] = [e if e["path"] != "GUIDA.md" else service.file_entry("GUIDA.md", b"changed")
+                                        for e in package["files"]]
+                else:
+                    package["files"].append(service.file_entry("extra.py", b"print(1)\n"))
+                ack = client.request("deliveries", payload={"assignment_id": own, "package": package}, **transport)
+                # Upload succeeded; grading refusal must not remove any uploaded byte.
+                rejected_path = next((teacher / "teacher-deliveries").glob(f"*/{package['attempt_id']}.json"))
+                saved = rejected_path.read_bytes()
+                status, refused = http.exchange("/api/assignment-reports/delivery-grade", method="POST", headers=TEACHER,
+                    payload=request_for(ack))
+                assert status == 200 and refused == {"ok": True, "state": "error", "error": "unsupported_profile"}
+                assert rejected_path.read_bytes() == saved
+                assert not list((teacher / "teacher-delivery-grading").glob(f"*/{package['attempt_id']}.job.json"))
+            assert len(producers) == 4
+            assert history()["final"] == final
+            _, row = register(http)
+            assert row["grading"]["teacher_grade"] == 8 and row["grading"]["score"] == 10
+            assignment = load()
+            other_index = next(i for i, item in enumerate(cli.selectable_attempts(assignment), 1)
+                               if item["id"] == receipts["prompt"]["attempt_id"])
+            assert "Tentativo definitivo salvato" in menu(["1", "t", str(other_index), "", "q"])
+            _, row = register(http)
+            assert row["grading"]["score"] == 0 and row["grading"]["teacher_grade"] is None
+            assert row["grading"]["provisional"] is True
+            assert all(p.read_bytes() == data for p, data in receipt_files.items())
+            for path, expected_hash in ORIGINAL_HASHES.items():
+                assert hashlib.sha256((material_root / path).read_bytes()).hexdigest() == expected_hash
+            (tmp_path / "m04-outcomes.json").write_text(json.dumps({"real_docker": real,
+                "outcomes": outcomes, "receipt_hashes": {p.name: hashlib.sha256(data).hexdigest()
+                    for p, data in receipt_files.items()}}, indent=2), encoding="utf-8")
+    assert not [t for t in threading.enumerate() if t not in baseline_threads and t.is_alive()]

--- a/tests/test_student_delivery_store.py
+++ b/tests/test_student_delivery_store.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import base64
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import threading
+
+import pytest
+
+from scripts import student_delivery_store as delivery, student_lab_attempts
+
+
+NOW = datetime(2026, 9, 9, 12, tzinfo=timezone.utc)
+FIRST = "attempt-20260909T120000000000Z-11111111"
+SECOND = "attempt-20260909T110000000000Z-22222222"
+
+
+@pytest.fixture
+def context():
+    return delivery.DeliveryContext(
+        "assignment-one", "class-one", "subject:11111111111111111111111111111111",
+        "activity-one", "a" * 64, "b" * 64, NOW + timedelta(days=1),
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    root = tmp_path / "server"
+    root.mkdir()
+    return delivery.JsonStudentDeliveryStore(root, clock=lambda: NOW)
+
+
+def file_entry(path="main.py", content=b"print(42)\n"):
+    return {"path": path, "content_base64": base64.b64encode(content).decode("ascii"),
+            "sha256": delivery.content_digest(content)}
+
+
+def package(attempt_id=FIRST, files=None):
+    return {"schema_version": delivery.PACKAGE_SCHEMA, "attempt_id": attempt_id,
+            "activity_digest": "a" * 64, "tests_digest": "b" * 64,
+            "files": files if files is not None else [file_entry()]}
+
+
+def test_immutable_sources_survive_client_changes_and_server_restart(tmp_path, store, context):
+    client = tmp_path / "client"
+    client.mkdir()
+    source = client / "main.py"
+    source.write_bytes(b"print(42)\n")
+    payload = package(files=[file_entry(content=source.read_bytes())])
+    receipt = store.receive(payload, context_loader=lambda: context)
+    source.write_bytes(b"print(99)\n")
+    payload["files"][0]["content_base64"] = "corrupted after call"
+
+    restarted = delivery.JsonStudentDeliveryStore(store.root)
+    saved = restarted.read(FIRST, context_loader=lambda: context)
+    assert saved == receipt
+    assert base64.b64decode(saved["package"]["files"][0]["content_base64"]) == b"print(42)\n"
+    assert saved["received_at"] == NOW.isoformat()
+    assert saved["grading_authority"] == "ungraded"
+    assert not list(store.root.rglob("reports"))
+
+
+def test_lost_ack_retry_is_identical_even_after_admission_closes(store, context):
+    first = store.receive(package(), context_loader=lambda: context)
+    closed = replace(context, closes_at=NOW - timedelta(seconds=1))
+    assert store.receive(package(), context_loader=lambda: closed) == first
+    with pytest.raises(delivery.DeliveryError, match="closed"):
+        store.receive(package(SECOND), context_loader=lambda: closed)
+    assert len(store.history(context_loader=lambda: context)["items"]) == 1
+
+
+def test_retry_normalizes_file_order_but_rejects_changed_bytes(store, context):
+    files = [file_entry("a.py"), file_entry("b.py")]
+    receipt = store.receive(package(files=files), context_loader=lambda: context)
+    assert store.receive(package(files=files[::-1]), context_loader=lambda: context) == receipt
+    with pytest.raises(delivery.DeliveryError, match="conflict"):
+        store.receive(package(files=[file_entry(content=b"changed")]), context_loader=lambda: context)
+    assert store.read(FIRST, context_loader=lambda: context) == receipt
+
+
+def test_out_of_order_attempts_use_server_receipt_sequence_and_explicit_final(store, context):
+    store.receive(package(), context_loader=lambda: context)
+    store.receive(package(SECOND), context_loader=lambda: context)
+    final = store.select_final(FIRST, expected_revision=0, context_loader=lambda: context)
+    assert final["revision"] == 1
+    assert store.select_final(FIRST, expected_revision=0, context_loader=lambda: context) == final
+    history = store.history(context_loader=lambda: context)
+    assert [item["attempt_id"] for item in history["items"]] == [FIRST, SECOND]
+    assert history["final"]["attempt_id"] == FIRST
+    store.select_final(SECOND, expected_revision=1, context_loader=lambda: context)
+    with pytest.raises(delivery.DeliveryError, match="conflict"):
+        store.select_final(FIRST, expected_revision=0, context_loader=lambda: context)
+    assert len(store.history(context_loader=lambda: context)["items"]) == 2
+
+
+@pytest.mark.parametrize("field,value", [
+    ("subject_id", "subject:22222222222222222222222222222222"),
+    ("class_id", "class-two"), ("assignment_id", "assignment-two"),
+    ("activity_id", "activity-two"),
+])
+def test_namespaces_do_not_share_attempts_even_for_identical_ids(store, context, field, value):
+    store.receive(package(), context_loader=lambda: context)
+    other = replace(context, **{field: value})
+    with pytest.raises(delivery.DeliveryError, match="missing"):
+        store.read(FIRST, context_loader=lambda: other)
+    assert store.history(context_loader=lambda: other)["items"] == []
+    store.receive(package(files=[file_entry(content=b"other")]), context_loader=lambda: other)
+    assert store.read(FIRST, context_loader=lambda: context)["package"] != store.read(
+        FIRST, context_loader=lambda: other)["package"]
+
+
+@pytest.mark.parametrize("operation", ["receive", "history", "final", "read"])
+def test_revocation_while_waiting_for_lock_prevents_operation(store, context, operation):
+    calls = 0
+
+    def loader():
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise PermissionError("revoked")
+        return context
+
+    with pytest.raises(PermissionError, match="revoked"):
+        if operation == "receive":
+            store.receive(package(), context_loader=loader)
+        elif operation == "history":
+            store.history(context_loader=loader)
+        elif operation == "read":
+            store.read(FIRST, context_loader=loader)
+        else:
+            store.select_final(FIRST, expected_revision=0, context_loader=loader)
+    assert calls == 2
+    assert not list(store.root.rglob("attempt-*.json"))
+    assert not list(store.root.rglob("final.json"))
+
+
+def test_retry_after_revocation_is_denied_not_served_from_cache(store, context):
+    store.receive(package(), context_loader=lambda: context)
+
+    def revoked():
+        raise PermissionError("revoked")
+
+    with pytest.raises(PermissionError):
+        store.receive(package(), context_loader=revoked)
+
+
+def test_changed_teacher_contract_rejects_new_upload_and_final_but_retains_history(store, context):
+    store.receive(package(), context_loader=lambda: context)
+    changed = replace(context, tests_digest="c" * 64)
+    with pytest.raises(delivery.DeliveryError, match="contract_changed"):
+        store.receive(package(SECOND), context_loader=lambda: changed)
+    with pytest.raises(delivery.DeliveryError, match="contract_changed"):
+        store.select_final(FIRST, expected_revision=0, context_loader=lambda: changed)
+    assert store.read(FIRST, context_loader=lambda: changed)["package"]["tests_digest"] == "b" * 64
+
+
+@pytest.mark.parametrize("path", [
+    "../x", "x/../../y", "/absolute", "C:/file", "x\\y", "x:stream", "CON", "aux.txt",
+    "x.", "x ", "x//y", "x/./y", "x/../y", "e\u0301.py", "a\x00.py",
+])
+def test_nonportable_or_traversal_file_paths_rejected(path):
+    with pytest.raises(delivery.DeliveryError):
+        delivery.normalize_package(package(files=[file_entry(path)]))
+
+
+@pytest.mark.parametrize("paths", [["a", "A"], ["a", "a/b"], ["a/b", "a"], ["Straße", "STRASSE"]])
+def test_windows_aliases_and_parent_child_collisions_rejected(paths):
+    with pytest.raises(delivery.DeliveryError, match="path"):
+        delivery.normalize_package(package(files=[file_entry(path) for path in paths]))
+
+
+@pytest.mark.parametrize("field,value", [
+    ("subject_id", "attacker"), ("class_id", "other"), ("submitted_at", "2000-01-01"),
+    ("grading", {"passed": True}), ("local_report", {"status": "passed"}),
+])
+def test_client_cannot_supply_identity_time_or_grading(field, value):
+    payload = package()
+    payload[field] = value
+    with pytest.raises(delivery.DeliveryError, match="invalid"):
+        delivery.normalize_package(payload)
+
+
+def test_limits_and_corrupt_base64_or_digest(monkeypatch):
+    with pytest.raises(delivery.DeliveryError, match="limit"):
+        delivery.normalize_package(package(files=[]))
+    with pytest.raises(delivery.DeliveryError, match="limit"):
+        delivery.normalize_package(package(files=[file_entry(str(n)) for n in range(65)]))
+    entry = file_entry()
+    entry["content_base64"] = "not base64!"
+    with pytest.raises(delivery.DeliveryError, match="invalid"):
+        delivery.normalize_package(package(files=[entry]))
+    entry = file_entry()
+    entry["sha256"] = "0" * 64
+    with pytest.raises(delivery.DeliveryError, match="digest"):
+        delivery.normalize_package(package(files=[entry]))
+    monkeypatch.setattr(delivery, "MAX_FILE_BYTES", 2)
+    with pytest.raises(delivery.DeliveryError, match="limit"):
+        delivery.normalize_package(package())
+    monkeypatch.setattr(delivery, "MAX_FILE_BYTES", 100)
+    monkeypatch.setattr(delivery, "MAX_TOTAL_BYTES", 3)
+    with pytest.raises(delivery.DeliveryError, match="limit"):
+        delivery.normalize_package(package(files=[file_entry("a", b"ab"), file_entry("b", b"cd")]))
+
+
+def test_concurrent_duplicate_receive_commits_once(store, context):
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        receipts = list(executor.map(lambda _: store.receive(package(), context_loader=lambda: context), range(4)))
+    assert all(receipt == receipts[0] for receipt in receipts)
+    assert len(store.history(context_loader=lambda: context)["items"]) == 1
+
+
+def test_quota_keeps_old_retry_and_history_available(store, context, monkeypatch):
+    monkeypatch.setattr(delivery, "MAX_ATTEMPTS", 1)
+    receipt = store.receive(package(), context_loader=lambda: context)
+    with pytest.raises(delivery.DeliveryError, match="limit"):
+        store.receive(package(SECOND), context_loader=lambda: context)
+    assert store.receive(package(), context_loader=lambda: context) == receipt
+
+
+def test_corrupt_storage_never_looks_like_missing_or_unsubmitted(store, context):
+    store.receive(package(), context_loader=lambda: context)
+    path = next(store.root.rglob("attempt-*.json"))
+    payload = json.loads(path.read_text())
+    payload["package"]["files"][0]["content_base64"] = base64.b64encode(b"tampered").decode()
+    path.write_text(json.dumps(payload))
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        store.history(context_loader=lambda: context)
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        store.receive(package(), context_loader=lambda: context)
+
+
+def test_interrupted_atomic_publish_has_no_ack_and_retry_recovers(store, context, monkeypatch):
+    original = student_lab_attempts.publish_exclusive
+
+    def fail(*args):
+        raise OSError("simulated publish failure")
+
+    monkeypatch.setattr(student_lab_attempts, "publish_exclusive", fail)
+    with pytest.raises(OSError):
+        store.receive(package(), context_loader=lambda: context)
+    assert not list(store.root.rglob("attempt-*.json"))
+    monkeypatch.setattr(student_lab_attempts, "publish_exclusive", original)
+    assert store.receive(package(), context_loader=lambda: context)["sequence"] == 1
+
+
+def test_final_fsync_failure_is_recovered_by_same_retry(store, context, monkeypatch):
+    store.receive(package(), context_loader=lambda: context)
+    original = student_lab_attempts.sync_directory
+
+    def fail(path):
+        if (path / "final.json").exists():
+            raise OSError("simulated fsync failure")
+        original(path)
+
+    monkeypatch.setattr(student_lab_attempts, "sync_directory", fail)
+    with pytest.raises(OSError):
+        store.select_final(FIRST, expected_revision=0, context_loader=lambda: context)
+    monkeypatch.setattr(student_lab_attempts, "sync_directory", original)
+    assert store.select_final(FIRST, expected_revision=0, context_loader=lambda: context)["revision"] == 1
+
+
+def test_symlink_storage_is_rejected(tmp_path, store, context):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    try:
+        (store.root / delivery.STORAGE_DIRECTORY).symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks unavailable")
+    with pytest.raises(delivery.DeliveryError, match="storage"):
+        store.receive(package(), context_loader=lambda: context)
+    assert list(outside.iterdir()) == []
+
+
+def test_retry_syncs_existing_parent_entries_after_mkdir_failure(store, context, monkeypatch):
+    original_create = delivery.assignment_records.create_durable_directory
+
+    def mkdir_then_fail(directory):
+        directory.mkdir(parents=True, exist_ok=True)
+        raise OSError("simulated directory fsync failure")
+
+    monkeypatch.setattr(delivery.assignment_records, "create_durable_directory", mkdir_then_fail)
+    with pytest.raises(OSError):
+        store.receive(package(), context_loader=lambda: context)
+    monkeypatch.setattr(delivery.assignment_records, "create_durable_directory", original_create)
+    synced = []
+    original_sync = student_lab_attempts.sync_directory
+
+    def sync(path):
+        synced.append(path)
+        original_sync(path)
+
+    monkeypatch.setattr(student_lab_attempts, "sync_directory", sync)
+    store.receive(package(), context_loader=lambda: context)
+    assert store.root in synced
+    assert store.root / delivery.STORAGE_DIRECTORY in synced
+
+
+def test_history_retains_only_summaries(store, context):
+    store.receive(package(), context_loader=lambda: context)
+    history = store.history(context_loader=lambda: context)
+    assert "content_base64" not in json.dumps(history)
+    assert "package" not in history["items"][0]
+
+
+def test_read_waits_for_writer_rollback_instead_of_returning_transient_receipt(store, context, monkeypatch):
+    published = threading.Event()
+    release_writer = threading.Event()
+    reader_started = threading.Event()
+    original_sync = student_lab_attempts.sync_directory
+    writer_id = None
+
+    def fail_after_publish(path):
+        if threading.get_ident() == writer_id and list(path.glob("attempt-*.json")):
+            published.set()
+            assert release_writer.wait(timeout=10)
+            raise OSError("simulated fsync failure after publication")
+        original_sync(path)
+
+    def write():
+        nonlocal writer_id
+        writer_id = threading.get_ident()
+        with pytest.raises(OSError):
+            store.receive(package(), context_loader=lambda: context)
+
+    def read_context():
+        reader_started.set()
+        return context
+
+    monkeypatch.setattr(student_lab_attempts, "sync_directory", fail_after_publish)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        writer = executor.submit(write)
+        try:
+            assert published.wait(timeout=10)
+            reader = executor.submit(store.read, FIRST, context_loader=read_context)
+            assert reader_started.wait(timeout=10)
+        finally:
+            release_writer.set()
+        writer.result(timeout=10)
+        with pytest.raises(delivery.DeliveryError, match="missing"):
+            reader.result(timeout=10)
+
+
+def test_backup_inventory_covers_receipts_and_final_without_client_path_side_effects(store, context):
+    from scripts import pilot_data_root
+
+    # Logical filenames never become physical backup entries.
+    store.receive(package(files=[file_entry("token-example.py")]), context_loader=lambda: context)
+    store.select_final(FIRST, expected_revision=0, context_loader=lambda: context)
+    entries = pilot_data_root._root_files(store.root, pilot_data_root.DEFAULT_AUTH_DB_PATH)
+    names = {path.name for path, _relative in entries}
+    assert names == {FIRST + ".json", "final.json"}
+    assert all(relative.parts[0] == delivery.STORAGE_DIRECTORY for _path, relative in entries)

--- a/tests/test_thebitlab_services.py
+++ b/tests/test_thebitlab_services.py
@@ -187,6 +187,7 @@ def test_assignment_overview_lists_student_rows(tmp_path) -> None:
             "source_path": None,
             "attempt_id": None,
             "report_selection": None,
+            "report_authority": None,
             "final_selected": False,
             "grading_provisional": True,
             "grading_status": "graded_passed",

--- a/tests/test_track_assignments.py
+++ b/tests/test_track_assignments.py
@@ -1326,6 +1326,110 @@ class StaticTrackingReportSource:
         return self.result
 
 
+def write_federated_tracking_assignment(tmp_path, *, class_id):
+    activity_path = write_activity(tmp_path)
+    student = target(tmp_path, "rossi-mario")
+    student.path.mkdir()
+    record = assignment_records.build_assignment_record(
+        assignment_id="assignment-delivery", activity_id=activity()["id"],
+        activity_path="activity.json", target_type="student", class_id=class_id,
+        assigned_at="2026-10-12T09:00:00+02:00", due_at="2026-10-21T08:00:00+02:00",
+        targets=[{"student_id": student.student, "subject_id": "subject:11111111111111111111111111111111",
+                  "repo_ref": student.repo, "path": student.student}],
+    )
+    assignment_records.JsonAssignmentRecordStorage(tmp_path).write_assignment(record)
+    return activity_path, student, record
+
+
+@pytest.mark.parametrize("class_id", ["", "3A-TPSI"])
+@pytest.mark.parametrize("has_report", [False, True])
+def test_federated_tracking_default_never_opens_delivery_archive(tmp_path, monkeypatch, class_id, has_report):
+    from scripts import student_delivery_store
+
+    activity_path, student, record = write_federated_tracking_assignment(tmp_path, class_id=class_id)
+    if has_report:
+        write_report(student.path, "2026-10-20T08:00:00+02:00")
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("Legacy tracking must not open the delivery archive")
+
+    monkeypatch.setattr(student_delivery_store, "JsonStudentDeliveryStore", forbidden)
+    row = track_assignments.track_assignments(
+        activity_path=activity_path, targets=[student], assignment_id=record["id"],
+        server_root=tmp_path, help_subject_aliases=(), due_at=record["due_at"],
+        now="2026-10-20T09:00:00+02:00",
+    )["students"][0]
+    assert row["submitted"] is has_report
+    assert row["grading"]["status"] == ("graded_passed" if has_report else "not_graded")
+    assert row["help"]["subject_id"] == record["targets"][0]["subject_id"]
+
+
+@pytest.mark.parametrize("backend", ["local", "github"])
+@pytest.mark.parametrize("now, status", [
+    ("2026-10-20T09:00:00+02:00", "pending"),
+    ("2026-10-22T09:00:00+02:00", "missing"),
+])
+def test_delivery_register_without_receipts_discards_previous_report(
+    tmp_path, monkeypatch, backend, now, status,
+):
+    from scripts import course_board_server as server
+    from scripts import student_delivery_client as client
+    from tests.test_student_delivery_client import manifest
+
+    activity_path, student, record = write_federated_tracking_assignment(tmp_path, class_id="3A-TPSI")
+    write_report(student.path, "2026-10-20T08:00:00+02:00")
+    source = StaticTrackingReportSource(thebitlab_tracking_reports.TrackingReportResult(
+        configured=True, report=attempt_report(record["id"], "attempt-old", passed=True,
+            submitted_at="2026-10-20T08:00:00+02:00"),
+        selection="github_actions_artifact", authority="verified_remote", provisional=True,
+        provenance={"repository": student.repo},
+    )) if backend == "github" else None
+    monkeypatch.setattr(server, "ROOT", tmp_path)
+    monkeypatch.setattr(server, "TEACHER_REPORTS_DIR", tmp_path / "teacher-reports")
+    monkeypatch.setattr(server, "TEACHER_ASSIGNMENTS_DIR", tmp_path / "teacher-assignments")
+    monkeypatch.setattr(server, "grading_tracking_report_source", lambda: source)
+    payload = {"activity_path": str(activity_path), "assignment_id": record["id"],
+               "targets_text": str(student.path), "due_at": record["due_at"],
+               "now": now, "output_name": "delivery.json"}
+    legacy = server.generate_assignment_report(payload, help_subject_aliases=())["report"]
+    old = legacy["students"][0]
+    assert old["submitted"] is True
+    assert old["grading"]["status"] == "graded_passed"
+    old["ai_feedback"] = {"status": "approved", "suggested_grade": 10, "summary": "Old report"}
+    track_assignments.write_tracking_index(legacy, tmp_path / "teacher-reports" / "delivery.json")
+    if source:
+        source.requests.clear()
+
+    result = server.generate_assignment_report(
+        payload, help_subject_aliases=(), student_delivery_enabled=True,
+    )["report"]["students"][0]
+    assert result["submitted"] is False
+    assert result["status"] == status
+    assert result["late"] is (status == "missing")
+    assert result["grading"]["status"] == "not_graded"
+    assert result["grading"]["score"] is None and result["grading"]["teacher_grade"] is None
+    assert result["report_path"] is None
+    assert result["submission"]["source_path"] is None
+    assert result["submission"]["files"] == []
+    assert result["submission"]["local_preview_status"] == "unavailable"
+    assert result["submission"]["submitted_at"] is None
+    assert not result["submission"].get("final_selected")
+    assert not result["submission"].get("report_provenance")
+    assert result["ai_feedback"]["status"] == "not_generated"
+    if source:
+        assert source.requests == []
+
+    description = {**manifest(), "assignment_id": record["id"], "activity_id": activity()["id"]}
+    monkeypatch.setattr(client, "request", lambda route, **kwargs: description
+        if route == "delivery-manifest" else {"items": [], "final": None, "status": status})
+    tui = client.enrich_payload({"assignments": [{"assignment_id": record["id"],
+        "activity_id": activity()["id"], "submitted": True, "grading": old["grading"]}]},
+        root=tmp_path, server_url="http://localhost:8765", server_token="test-only",
+        allow_insecure_http=True)["assignments"][0]
+    assert (result["submitted"], result["status"]) == (tui["submitted"], tui["status"])
+    assert result["grading"]["teacher_grade"] == tui["grading"]["teacher_grade"]
+
+
 def test_track_assignments_uses_verified_remote_report_and_provenance(tmp_path) -> None:
     activity_path = write_activity(tmp_path)
     student_path = tmp_path / "rossi-mario"

--- a/tools/assignment_dashboard.css
+++ b/tools/assignment_dashboard.css
@@ -2154,7 +2154,13 @@ button.matrixCell:disabled:focus-visible {
   font-weight: 800;
 }
 
-.matrixSelectionState {
+.gradeReviewState {
+  display: block;
+  margin-top: .25rem;
+}
+
+.matrixSelectionState,
+.matrixGradeReviewState .badge {
   min-width: 3.7rem;
   justify-content: center;
   font-size: .58rem;

--- a/tools/assignment_dashboard.js
+++ b/tools/assignment_dashboard.js
@@ -2823,6 +2823,7 @@ function renderOverviewMatrix(rows) {
                   ${score !== "" ? `<small>${escapeHtml(score)}</small>` : ""}
                 </button>
                 ${selection ? reportSelectionCompactBadge(row) : ""}
+                ${gradeReviewBadge(row, true)}
               ` : '<span class="matrixCell matrixCellEmpty">-</span>'}
             </div>
           </td>
@@ -2905,7 +2906,7 @@ function renderOverview() {
             }, { detailsKey: testDetailsKey })
           : ""}
       </td>
-      <td><code>${escapeHtml(grade)}</code></td>
+      <td><code>${escapeHtml(grade)}</code>${gradeReviewBadge(row)}</td>
       <td>
         <button type="button" class="smallButton" data-overview-report="${escapeHtml(row.report_name)}" data-overview-student="${escapeHtml(row.student || "")}" title="${submissionTitle}" ${hasSubmission ? "" : "disabled"}>
           Consegna
@@ -4002,6 +4003,21 @@ function badge(text, kind = "muted", title = "") {
   return `<span class="badge ${className}${title ? " hasTooltip" : ""}"${tooltipAttributes(label, title)}>${escapeHtml(label)}</span>`;
 }
 
+function gradeReviewBadge(value, compact = false) {
+  const submission = value?.submission || value || {};
+  if (submission.report_authority !== "verified_delivery") return "";
+  const grading = value?.grading || value || {};
+  const provisional = grading.provisional ?? value?.grading_provisional;
+  const confirmed = provisional === false && grading.teacher_grade != null;
+  const label = confirmed ? "Voto confermato" : "Voto da revisionare";
+  const tooltip = confirmed
+    ? "Il docente ha confermato il voto di questo tentativo."
+    : "Il punteggio automatico resta provvisorio fino alla revisione docente, anche per un tentativo definitivo.";
+  return `<span class="${compact ? "matrixGradeReviewState" : "gradeReviewState"}">${badge(
+    compact ? (confirmed ? "CONF" : "REV") : label,
+    confirmed ? "ok" : "warn", `${label}. ${tooltip}`)}</span>`;
+}
+
 function reportSelectionState(value) {
   const submission = value?.submission || value || {};
   const grading = value?.grading || value || {};
@@ -4015,6 +4031,16 @@ function reportSelectionState(value) {
       compactLabel: "ERR",
       kind: "bad",
       tooltip: "La selezione definitiva non e valida: il registro non usa un altro tentativo al suo posto.",
+    };
+  }
+  if (submission.report_authority === "verified_delivery" && ["final", "latest"].includes(selection)) {
+    return {
+      label: selection === "final" ? "Tentativo definitivo" : "Ultimo tentativo",
+      compactLabel: selection === "final" ? "DEF" : "ULT",
+      kind: "muted",
+      tooltip: selection === "final"
+        ? "Lo studente ha scelto questa consegna come definitiva. La revisione del voto e indicata separatamente."
+        : "Il registro usa l'ultima consegna ricevuta. La revisione del voto e indicata separatamente.",
     };
   }
   if (selection === "final") {
@@ -4761,7 +4787,7 @@ function renderStudents(students) {
         <small>Test: ${escapeHtml(grading.tests_passed ?? "-")}/${escapeHtml(grading.tests_total ?? "-")}</small>
         ${gradingDetails(grading, { detailsKey: testDetailsKey })}
       </td>
-      <td><code>${escapeHtml(grading.teacher_grade ?? grading.score ?? "-")}</code></td>
+      <td><code>${escapeHtml(grading.teacher_grade ?? grading.score ?? "-")}</code>${gradeReviewBadge(student)}</td>
       <td>
         <div data-ai-feedback-student="${escapeHtml(student.student_id || student.student)}">
           ${aiFeedbackDetails(ai)}


### PR DESCRIPTION
Students using separate PCs can now download assignment workspaces and submit immutable source snapshots to the teacher server. With `--student-deliveries` and federated Google authentication enabled, the TUI persists an outbox for retries, receives server receipts, and selects a final attempt with revision checks. The teacher register and source preview use the archived attempt.

Teacher-triggered grading runs the received source against the archived teacher contract in the existing Docker boundary. Results and teacher grade confirmation are bound to the attempt; choosing a final attempt does not confirm its grade. The versioned M04 policy admits only the approved materials, requires the original guide, and runs the source against all three original stdin/stdout tests. Git attributes preserve the fixture bytes.

Validation before publication: 64 passed / 0 skipped for grading and M04 integration, 434 passed / 5 skipped for consumer regressions, and 18 passed / 0 skipped for the fixture fix. Counts overlap. Four skips concern Windows filesystem behavior; the Docker HTTP skip passed in the final suite. XML hashes and the 35-file snapshot were rechecked before commit. Staging preserved all fixture bytes and only normalized CRLF to LF in 16 existing text files. PR CI supplies the fresh committed-tree checks.

Contracts: `doc/architecture/student-delivery-storage.md` and `doc/architecture/student-delivery-grading.md`. Release remains NO-GO pending teaching readiness, other profiles/courses, standalone manual assessment, packaging, quotas/retention/export, HTTPS/VPS, backup/restore, and Linux durability rehearsal. This PR enables code integration, not deployment or teaching distribution.

The two clean local M04 reviews covered that extension. Review of the complete published diff starts at this PR HEAD and must reach two consecutive clean rounds before merge, as required by `AGENTS.md`.
